### PR TITLE
added dependency to javafx maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,13 @@
                 <configuration>
                     <mainClass>io.bitsquare.BitSquare</mainClass>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.twdata.maven</groupId>
+                        <artifactId>mojo-executor</artifactId>
+                        <version>2.1.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
This is to get around javafx-maven-plugin issue with latest maven
version. see:
http://stackoverflow.com/questions/19407959/javafx-maven-plugin-and-api-
incompatibility
