### PR TITLE
Upgrade to BitcoinJ 0.12

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -18,7 +18,7 @@
           <value>
             <package name="io.bitsquare" withSubpackages="true" static="false" />
             <emptyLine />
-            <package name="com.google.bitcoin" withSubpackages="true" static="false" />
+            <package name="org.bitcoinj" withSubpackages="true" static="false" />
             <emptyLine />
             <package name="com.google.common" withSubpackages="true" static="false" />
             <emptyLine />

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,11 @@ task executableJar(type: OneJar) {
 
 repositories {
     jcenter()
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     maven { url 'http://partnerdemo.artifactoryonline.com/partnerdemo/libs-snapshots-local' }
 }
 
 dependencies {
-    compile 'org.bitcoinj:bitcoinj-core:0.12-SNAPSHOT'
+    compile 'org.bitcoinj:bitcoinj-core:0.12'
     compile 'net.tomp2p:tomp2p-all:5.0-Alpha24.805623c-SNAPSHOT'
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'ch.qos.logback:logback-core:1.1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,12 @@ task executableJar(type: OneJar) {
 
 repositories {
     jcenter()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     maven { url 'http://partnerdemo.artifactoryonline.com/partnerdemo/libs-snapshots-local' }
 }
 
 dependencies {
-    compile 'com.google:bitcoinj:0.12.308de4e-SNAPSHOT'
+    compile 'org.bitcoinj:bitcoinj-core:0.12-SNAPSHOT'
     compile 'net.tomp2p:tomp2p-all:5.0-Alpha24.805623c-SNAPSHOT'
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'ch.qos.logback:logback-core:1.1.2'

--- a/src/main/java/io/bitsquare/btc/AddressBasedCoinSelector.java
+++ b/src/main/java/io/bitsquare/btc/AddressBasedCoinSelector.java
@@ -17,15 +17,15 @@
 
 package io.bitsquare.btc;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.NetworkParameters;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.TransactionConfidence;
-import com.google.bitcoin.core.TransactionOutput;
-import com.google.bitcoin.params.RegTestParams;
-import com.google.bitcoin.wallet.CoinSelection;
-import com.google.bitcoin.wallet.DefaultCoinSelector;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.wallet.CoinSelection;
+import org.bitcoinj.wallet.DefaultCoinSelector;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class implements a {@link com.google.bitcoin.wallet.CoinSelector} which attempts to get the highest priority
+ * This class implements a {@link org.bitcoinj.wallet.CoinSelector} which attempts to get the highest priority
  * possible. This means that the transaction is the most likely to get confirmed. Note that this means we may end up
  * "spending" more priority than would be required to get the transaction we are creating confirmed.
  */

--- a/src/main/java/io/bitsquare/btc/AddressEntry.java
+++ b/src/main/java/io/bitsquare/btc/AddressEntry.java
@@ -17,10 +17,10 @@
 
 package io.bitsquare.btc;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.NetworkParameters;
-import com.google.bitcoin.core.Utils;
-import com.google.bitcoin.crypto.DeterministicKey;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Utils;
+import org.bitcoinj.crypto.DeterministicKey;
 
 import java.io.Serializable;
 

--- a/src/main/java/io/bitsquare/btc/FeePolicy.java
+++ b/src/main/java/io/bitsquare/btc/FeePolicy.java
@@ -17,11 +17,11 @@
 
 package io.bitsquare.btc;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.AddressFormatException;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.NetworkParameters;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.AddressFormatException;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 

--- a/src/main/java/io/bitsquare/btc/Restrictions.java
+++ b/src/main/java/io/bitsquare/btc/Restrictions.java
@@ -17,8 +17,8 @@
 
 package io.bitsquare.btc;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
 
 // Lets see if we get more restriction otherwise move it to other class
 public class Restrictions {

--- a/src/main/java/io/bitsquare/btc/WalletFacade.java
+++ b/src/main/java/io/bitsquare/btc/WalletFacade.java
@@ -24,31 +24,31 @@ import io.bitsquare.btc.listeners.TxConfidenceListener;
 import io.bitsquare.crypto.CryptoFacade;
 import io.bitsquare.persistence.Persistence;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.AddressFormatException;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.ECKey;
-import com.google.bitcoin.core.InsufficientMoneyException;
-import com.google.bitcoin.core.NetworkParameters;
-import com.google.bitcoin.core.ScriptException;
-import com.google.bitcoin.core.Sha256Hash;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.TransactionConfidence;
-import com.google.bitcoin.core.TransactionInput;
-import com.google.bitcoin.core.TransactionOutPoint;
-import com.google.bitcoin.core.TransactionOutput;
-import com.google.bitcoin.core.Utils;
-import com.google.bitcoin.core.VerificationException;
-import com.google.bitcoin.core.Wallet;
-import com.google.bitcoin.core.WalletEventListener;
-import com.google.bitcoin.crypto.DeterministicKey;
-import com.google.bitcoin.crypto.TransactionSignature;
-import com.google.bitcoin.kits.WalletAppKit;
-import com.google.bitcoin.params.MainNetParams;
-import com.google.bitcoin.params.RegTestParams;
-import com.google.bitcoin.script.Script;
-import com.google.bitcoin.script.ScriptBuilder;
-import com.google.bitcoin.utils.Threading;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.AddressFormatException;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.ScriptException;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.core.Utils;
+import org.bitcoinj.core.VerificationException;
+import org.bitcoinj.core.Wallet;
+import org.bitcoinj.core.WalletEventListener;
+import org.bitcoinj.crypto.DeterministicKey;
+import org.bitcoinj.crypto.TransactionSignature;
+import org.bitcoinj.kits.WalletAppKit;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.script.Script;
+import org.bitcoinj.script.ScriptBuilder;
+import org.bitcoinj.utils.Threading;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
@@ -81,7 +81,7 @@ import org.slf4j.LoggerFactory;
 
 import lighthouse.files.AppDirectory;
 
-import static com.google.bitcoin.script.ScriptOpCodes.OP_RETURN;
+import static org.bitcoinj.script.ScriptOpCodes.OP_RETURN;
 
 /**
  * TODO: use walletextension (with protobuffer) instead of saving addressEntryList via storage
@@ -802,7 +802,7 @@ public class WalletFacade {
         }
 
         log.trace("check if it can be correctly spent for input 1");
-        input.getScriptSig().correctlySpends(tx, 1, scriptPubKey, false);
+        input.getScriptSig().correctlySpends(tx, 1, scriptPubKey);
 
         log.trace("verify tx");
         tx.verify();
@@ -917,12 +917,12 @@ public class WalletFacade {
             throw new ScriptException("Don't know how to sign for this kind of scriptPubKey: " + scriptPubKey);
         }
 
-        input.getScriptSig().correctlySpends(tx, 0, scriptPubKey, false);
+        input.getScriptSig().correctlySpends(tx, 0, scriptPubKey);
         log.trace("check if it can be correctly spent for input 0 OK");
 
         TransactionInput input1 = tx.getInput(1);
         scriptPubKey = input1.getConnectedOutput().getScriptPubKey();
-        input1.getScriptSig().correctlySpends(tx, 1, scriptPubKey, false);
+        input1.getScriptSig().correctlySpends(tx, 1, scriptPubKey);
         log.trace("check if it can be correctly spent for input 1 OK");
 
          /*
@@ -1053,7 +1053,7 @@ public class WalletFacade {
         tx.verify();
 
         log.trace("check if it can be correctly spent for ms input");
-        tx.getInput(0).getScriptSig().correctlySpends(tx, 0, multiSigScript, false);
+        tx.getInput(0).getScriptSig().correctlySpends(tx, 0, multiSigScript);
 
         log.trace("verify multiSigOutput");
         tx.getInput(0).verify(multiSigOutput);
@@ -1140,7 +1140,7 @@ public class WalletFacade {
         void downloadComplete();
     }
 
-    private class BlockChainDownloadListener extends com.google.bitcoin.core.DownloadListener {
+    private class BlockChainDownloadListener extends org.bitcoinj.core.DownloadListener {
         @Override
         protected void progress(double percent, int blocksSoFar, Date date) {
             super.progress(percent, blocksSoFar, date);

--- a/src/main/java/io/bitsquare/btc/listeners/AddressConfidenceListener.java
+++ b/src/main/java/io/bitsquare/btc/listeners/AddressConfidenceListener.java
@@ -17,8 +17,8 @@
 
 package io.bitsquare.btc.listeners;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.TransactionConfidence;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.TransactionConfidence;
 
 public class AddressConfidenceListener {
     private final Address address;

--- a/src/main/java/io/bitsquare/btc/listeners/BalanceListener.java
+++ b/src/main/java/io/bitsquare/btc/listeners/BalanceListener.java
@@ -17,8 +17,8 @@
 
 package io.bitsquare.btc.listeners;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
 
 public class BalanceListener {
     private Address address;

--- a/src/main/java/io/bitsquare/btc/listeners/TxConfidenceListener.java
+++ b/src/main/java/io/bitsquare/btc/listeners/TxConfidenceListener.java
@@ -17,7 +17,7 @@
 
 package io.bitsquare.btc.listeners;
 
-import com.google.bitcoin.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionConfidence;
 
 public class TxConfidenceListener {
     private final String txID;

--- a/src/main/java/io/bitsquare/crypto/CryptoFacade.java
+++ b/src/main/java/io/bitsquare/crypto/CryptoFacade.java
@@ -17,10 +17,10 @@
 
 package io.bitsquare.crypto;
 
-import com.google.bitcoin.core.ECKey;
-import com.google.bitcoin.core.Sha256Hash;
-import com.google.bitcoin.core.Utils;
-import com.google.bitcoin.crypto.KeyCrypterException;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Utils;
+import org.bitcoinj.crypto.KeyCrypterException;
 
 import com.google.common.base.Charsets;
 

--- a/src/main/java/io/bitsquare/di/BitSquareModule.java
+++ b/src/main/java/io/bitsquare/di/BitSquareModule.java
@@ -41,10 +41,10 @@ import io.bitsquare.trade.TradeManager;
 import io.bitsquare.user.User;
 import io.bitsquare.util.ConfigLoader;
 
-import com.google.bitcoin.core.NetworkParameters;
-import com.google.bitcoin.params.MainNetParams;
-import com.google.bitcoin.params.RegTestParams;
-import com.google.bitcoin.params.TestNet3Params;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.TestNet3Params;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provider;

--- a/src/main/java/io/bitsquare/gui/components/AddressTextField.java
+++ b/src/main/java/io/bitsquare/gui/components/AddressTextField.java
@@ -19,8 +19,8 @@ package io.bitsquare.gui.components;
 
 import io.bitsquare.gui.OverlayManager;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.uri.BitcoinURI;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.uri.BitcoinURI;
 
 import java.awt.*;
 

--- a/src/main/java/io/bitsquare/gui/components/BalanceTextField.java
+++ b/src/main/java/io/bitsquare/gui/components/BalanceTextField.java
@@ -23,9 +23,9 @@ import io.bitsquare.btc.listeners.BalanceListener;
 import io.bitsquare.gui.components.confidence.ConfidenceProgressIndicator;
 import io.bitsquare.gui.util.BSFormatter;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.TransactionConfidence;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.TransactionConfidence;
 
 import javafx.scene.control.*;
 import javafx.scene.effect.*;

--- a/src/main/java/io/bitsquare/gui/components/Popups.java
+++ b/src/main/java/io/bitsquare/gui/components/Popups.java
@@ -21,7 +21,7 @@ import io.bitsquare.BitSquare;
 import io.bitsquare.gui.OverlayManager;
 import io.bitsquare.locale.BSResources;
 
-import com.google.bitcoin.store.BlockStoreException;
+import org.bitcoinj.store.BlockStoreException;
 
 import com.google.common.base.Throwables;
 

--- a/src/main/java/io/bitsquare/gui/components/TxIdTextField.java
+++ b/src/main/java/io/bitsquare/gui/components/TxIdTextField.java
@@ -21,7 +21,7 @@ import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.btc.listeners.TxConfidenceListener;
 import io.bitsquare.gui.components.confidence.ConfidenceProgressIndicator;
 
-import com.google.bitcoin.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionConfidence;
 
 import java.awt.*;
 

--- a/src/main/java/io/bitsquare/gui/main/account/arbitrator/registration/ArbitratorRegistrationViewCB.java
+++ b/src/main/java/io/bitsquare/gui/main/account/arbitrator/registration/ArbitratorRegistrationViewCB.java
@@ -31,12 +31,12 @@ import io.bitsquare.persistence.Persistence;
 import io.bitsquare.user.User;
 import io.bitsquare.util.DSAKeyUtil;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.ECKey;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.Wallet;
-import com.google.bitcoin.core.WalletEventListener;
-import com.google.bitcoin.script.Script;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+import org.bitcoinj.core.WalletEventListener;
+import org.bitcoinj.script.Script;
 
 import java.net.URL;
 

--- a/src/main/java/io/bitsquare/gui/main/account/content/registration/RegistrationModel.java
+++ b/src/main/java/io/bitsquare/gui/main/account/content/registration/RegistrationModel.java
@@ -25,9 +25,9 @@ import io.bitsquare.gui.UIModel;
 import io.bitsquare.persistence.Persistence;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.InsufficientMoneyException;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
 
 import com.google.common.util.concurrent.FutureCallback;
 

--- a/src/main/java/io/bitsquare/gui/main/account/content/registration/RegistrationPM.java
+++ b/src/main/java/io/bitsquare/gui/main/account/content/registration/RegistrationPM.java
@@ -22,8 +22,8 @@ import io.bitsquare.gui.PresentationModel;
 import io.bitsquare.gui.util.BSFormatter;
 import io.bitsquare.locale.BSResources;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
 
 import com.google.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/account/content/restrictions/RestrictionsModel.java
+++ b/src/main/java/io/bitsquare/gui/main/account/content/restrictions/RestrictionsModel.java
@@ -30,8 +30,8 @@ import io.bitsquare.settings.Settings;
 import io.bitsquare.user.User;
 import io.bitsquare.util.DSAKeyUtil;
 
-import com.google.bitcoin.core.ECKey;
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Utils;
 
 import com.google.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsListItem.java
+++ b/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsListItem.java
@@ -22,11 +22,11 @@ import io.bitsquare.btc.listeners.AddressConfidenceListener;
 import io.bitsquare.gui.components.confidence.ConfidenceProgressIndicator;
 import io.bitsquare.gui.util.BSFormatter;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.TransactionConfidence;
-import com.google.bitcoin.core.TransactionOutput;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionOutput;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;

--- a/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsViewCB.java
+++ b/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsViewCB.java
@@ -22,7 +22,7 @@ import io.bitsquare.gui.CachedViewCB;
 import io.bitsquare.gui.components.Popups;
 import io.bitsquare.gui.util.BSFormatter;
 
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Transaction;
 
 import java.net.URL;
 

--- a/src/main/java/io/bitsquare/gui/main/funds/withdrawal/WithdrawalListItem.java
+++ b/src/main/java/io/bitsquare/gui/main/funds/withdrawal/WithdrawalListItem.java
@@ -24,9 +24,9 @@ import io.bitsquare.btc.listeners.BalanceListener;
 import io.bitsquare.gui.components.confidence.ConfidenceProgressIndicator;
 import io.bitsquare.gui.util.BSFormatter;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.TransactionConfidence;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.TransactionConfidence;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;

--- a/src/main/java/io/bitsquare/gui/main/funds/withdrawal/WithdrawalViewCB.java
+++ b/src/main/java/io/bitsquare/gui/main/funds/withdrawal/WithdrawalViewCB.java
@@ -26,10 +26,10 @@ import io.bitsquare.gui.CachedViewCB;
 import io.bitsquare.gui.components.Popups;
 import io.bitsquare.gui.util.BSFormatter;
 
-import com.google.bitcoin.core.AddressFormatException;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.InsufficientMoneyException;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.AddressFormatException;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
 
 import com.google.common.util.concurrent.FutureCallback;
 

--- a/src/main/java/io/bitsquare/gui/main/orders/pending/PendingTradesModel.java
+++ b/src/main/java/io/bitsquare/gui/main/orders/pending/PendingTradesModel.java
@@ -28,11 +28,11 @@ import io.bitsquare.trade.Trade;
 import io.bitsquare.trade.TradeManager;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.AddressFormatException;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.InsufficientMoneyException;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.TransactionConfidence;
+import org.bitcoinj.core.AddressFormatException;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
 
 import com.google.common.util.concurrent.FutureCallback;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/TradeNavigator.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/TradeNavigator.java
@@ -19,8 +19,8 @@ package io.bitsquare.gui.main.trade;
 
 import io.bitsquare.trade.Offer;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
 
 public interface TradeNavigator {
     void createOffer(Coin amount, Fiat price);

--- a/src/main/java/io/bitsquare/gui/main/trade/TradeViewCB.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/TradeViewCB.java
@@ -27,8 +27,8 @@ import io.bitsquare.trade.Direction;
 import io.bitsquare.trade.Offer;
 import io.bitsquare.util.ViewLoader;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
 
 import java.io.IOException;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferModel.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferModel.java
@@ -32,9 +32,9 @@ import io.bitsquare.trade.Direction;
 import io.bitsquare.trade.TradeManager;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.ExchangeRate;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.ExchangeRate;
+import org.bitcoinj.utils.Fiat;
 
 import com.google.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferPM.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferPM.java
@@ -26,9 +26,9 @@ import io.bitsquare.gui.util.validation.InputValidator;
 import io.bitsquare.locale.BSResources;
 import io.bitsquare.trade.Direction;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
 
 import javax.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferViewCB.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferViewCB.java
@@ -33,8 +33,8 @@ import io.bitsquare.gui.util.ImageUtil;
 import io.bitsquare.locale.BSResources;
 import io.bitsquare.trade.Direction;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
 
 import java.net.URL;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/orderbook/OrderBookModel.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/orderbook/OrderBookModel.java
@@ -28,9 +28,9 @@ import io.bitsquare.trade.Offer;
 import io.bitsquare.trade.TradeManager;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.ExchangeRate;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.ExchangeRate;
+import org.bitcoinj.utils.Fiat;
 
 import com.google.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/orderbook/OrderBookPM.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/orderbook/OrderBookPM.java
@@ -26,8 +26,8 @@ import io.bitsquare.locale.BSResources;
 import io.bitsquare.trade.Direction;
 import io.bitsquare.trade.Offer;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
 
 import com.google.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/takeoffer/TakeOfferModel.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/takeoffer/TakeOfferModel.java
@@ -27,9 +27,9 @@ import io.bitsquare.trade.Offer;
 import io.bitsquare.trade.Trade;
 import io.bitsquare.trade.TradeManager;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.ExchangeRate;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.ExchangeRate;
+import org.bitcoinj.utils.Fiat;
 
 import com.google.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/takeoffer/TakeOfferPM.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/takeoffer/TakeOfferPM.java
@@ -26,8 +26,8 @@ import io.bitsquare.locale.BSResources;
 import io.bitsquare.trade.Direction;
 import io.bitsquare.trade.Offer;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
 
 import javax.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/main/trade/takeoffer/TakeOfferViewCB.java
+++ b/src/main/java/io/bitsquare/gui/main/trade/takeoffer/TakeOfferViewCB.java
@@ -35,7 +35,7 @@ import io.bitsquare.locale.BSResources;
 import io.bitsquare.trade.Direction;
 import io.bitsquare.trade.Offer;
 
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Coin;
 
 import java.net.URL;
 

--- a/src/main/java/io/bitsquare/gui/util/BSFormatter.java
+++ b/src/main/java/io/bitsquare/gui/util/BSFormatter.java
@@ -24,9 +24,9 @@ import io.bitsquare.trade.Direction;
 import io.bitsquare.trade.Offer;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.CoinFormat;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
+import org.bitcoinj.utils.MonetaryFormat;
 
 import java.math.BigDecimal;
 
@@ -59,19 +59,19 @@ public class BSFormatter {
     private boolean useMilliBit;
     private int scale = 3;
 
-    // Format use 2 min decimal places and 2 more optional: 1.00 or 1.0010  
+    // Format use 2 min decimal places and 2 more optional: 1.00 or 1.0010
     // There are not more then 4 decimals allowed.
     // We don't support localized formatting. Format is always using "." as decimal mark and no grouping separator.
     // Input of "," as decimal mark (like in german locale) will be replaced with ".".
     // Input of a group separator (1,123,45) lead to an validation error.
-    // Note: BtcFormat was intended to be used, but it lead to many problems (automatic format to mBit, 
+    // Note: BtcFormat was intended to be used, but it lead to many problems (automatic format to mBit,
     // no way to remove grouping separator). It seems to be not optimal for user input formatting.
-    private CoinFormat coinFormat = CoinFormat.BTC.repeatOptionalDecimals(2, 1);
+    private MonetaryFormat coinFormat = MonetaryFormat.BTC.repeatOptionalDecimals(2, 1);
 
     private String currencyCode = Currency.getInstance(Locale.getDefault()).getCurrencyCode();
 
-    // format is like: 1,00  never more then 2 decimals 
-    private final CoinFormat fiatFormat = CoinFormat.FIAT.repeatOptionalDecimals(0, 0).code(0, currencyCode);
+    // format is like: 1,00  never more then 2 decimals
+    private final MonetaryFormat fiatFormat = MonetaryFormat.FIAT.repeatOptionalDecimals(0, 0).code(0, currencyCode);
 
 
     @Inject
@@ -95,7 +95,7 @@ public class BSFormatter {
 
     public void useMilliBitFormat(boolean useMilliBit) {
         this.useMilliBit = useMilliBit;
-        coinFormat = getCoinFormat();
+        coinFormat = getMonetaryFormat();
         scale = useMilliBit ? 0 : 3;
     }
 
@@ -106,11 +106,11 @@ public class BSFormatter {
         this.locale = locale;
     }
 
-    private CoinFormat getCoinFormat() {
+    private MonetaryFormat getMonetaryFormat() {
         if (useMilliBit)
-            return CoinFormat.MBTC.repeatOptionalDecimals(2, 1);
+            return MonetaryFormat.MBTC.repeatOptionalDecimals(2, 1);
         else
-            return CoinFormat.BTC.repeatOptionalDecimals(2, 1);
+            return MonetaryFormat.BTC.repeatOptionalDecimals(2, 1);
     }
 
     public void setFiatCurrencyCode(String currencyCode) {
@@ -134,7 +134,7 @@ public class BSFormatter {
 
     public String formatCoinWithCode(Coin coin) {
         try {
-            // we don't use the code feature from coinFormat as it does automatic switching between mBTC and BTC and 
+            // we don't use the code feature from coinFormat as it does automatic switching between mBTC and BTC and
             // pre and post fixing
             return coinFormat.postfixCode().format(coin).toString();
         } catch (Throwable t) {
@@ -314,7 +314,7 @@ public class BSFormatter {
 
     private String cleanInput(String input) {
         input = input.replace(",", ".");
-        // don't use String.valueOf(Double.parseDouble(input)) as return value as it gives scientific 
+        // don't use String.valueOf(Double.parseDouble(input)) as return value as it gives scientific
         // notation (1.0E-6) which screw up coinFormat.parse
         //noinspection ResultOfMethodCallIgnored
         Double.parseDouble(input);

--- a/src/main/java/io/bitsquare/gui/util/validation/BtcAddressValidator.java
+++ b/src/main/java/io/bitsquare/gui/util/validation/BtcAddressValidator.java
@@ -17,9 +17,9 @@
 
 package io.bitsquare.gui.util.validation;
 
-import com.google.bitcoin.core.Address;
-import com.google.bitcoin.core.AddressFormatException;
-import com.google.bitcoin.core.NetworkParameters;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.AddressFormatException;
+import org.bitcoinj.core.NetworkParameters;
 
 import javax.inject.Inject;
 

--- a/src/main/java/io/bitsquare/gui/util/validation/BtcValidator.java
+++ b/src/main/java/io/bitsquare/gui/util/validation/BtcValidator.java
@@ -19,7 +19,7 @@ package io.bitsquare.gui.util.validation;
 
 import io.bitsquare.locale.BSResources;
 
-import com.google.bitcoin.core.NetworkParameters;
+import org.bitcoinj.core.NetworkParameters;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/io/bitsquare/gui/util/validation/OptionalBtcValidator.java
+++ b/src/main/java/io/bitsquare/gui/util/validation/OptionalBtcValidator.java
@@ -19,7 +19,7 @@ package io.bitsquare.gui.util.validation;
 
 import io.bitsquare.locale.BSResources;
 
-import com.google.bitcoin.core.NetworkParameters;
+import org.bitcoinj.core.NetworkParameters;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/io/bitsquare/persistence/Persistence.java
+++ b/src/main/java/io/bitsquare/persistence/Persistence.java
@@ -20,7 +20,7 @@ package io.bitsquare.persistence;
 import io.bitsquare.BitSquare;
 import io.bitsquare.util.FileUtil;
 
-import com.google.bitcoin.utils.Threading;
+import org.bitcoinj.utils.Threading;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/main/java/io/bitsquare/settings/Settings.java
+++ b/src/main/java/io/bitsquare/settings/Settings.java
@@ -20,7 +20,7 @@ package io.bitsquare.settings;
 import io.bitsquare.arbitrator.Arbitrator;
 import io.bitsquare.locale.Country;
 
-import com.google.bitcoin.utils.CoinFormat;
+import org.bitcoinj.utils.MonetaryFormat;
 
 import java.io.Serializable;
 
@@ -42,8 +42,8 @@ public class Settings implements Serializable {
     // which will be used for multiplying with the amount to get the collateral size in BTC.
 
 
-    private String btcDenominationString = CoinFormat.CODE_BTC;
-    final transient StringProperty btcDenomination = new SimpleStringProperty(CoinFormat.CODE_BTC);
+    private String btcDenominationString = MonetaryFormat.CODE_BTC;
+    final transient StringProperty btcDenomination = new SimpleStringProperty(MonetaryFormat.CODE_BTC);
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor

--- a/src/main/java/io/bitsquare/trade/Contract.java
+++ b/src/main/java/io/bitsquare/trade/Contract.java
@@ -20,7 +20,7 @@ package io.bitsquare.trade;
 import io.bitsquare.bank.BankAccount;
 import io.bitsquare.util.DSAKeyUtil;
 
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Coin;
 
 import java.io.Serializable;
 

--- a/src/main/java/io/bitsquare/trade/Offer.java
+++ b/src/main/java/io/bitsquare/trade/Offer.java
@@ -21,9 +21,9 @@ import io.bitsquare.arbitrator.Arbitrator;
 import io.bitsquare.bank.BankAccountType;
 import io.bitsquare.locale.Country;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.ExchangeRate;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.ExchangeRate;
+import org.bitcoinj.utils.Fiat;
 
 import java.io.Serializable;
 

--- a/src/main/java/io/bitsquare/trade/Trade.java
+++ b/src/main/java/io/bitsquare/trade/Trade.java
@@ -17,9 +17,9 @@
 
 package io.bitsquare.trade;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.utils.Fiat;
 
 import java.io.Serializable;
 

--- a/src/main/java/io/bitsquare/trade/TradeManager.java
+++ b/src/main/java/io/bitsquare/trade/TradeManager.java
@@ -41,9 +41,9 @@ import io.bitsquare.trade.protocol.trade.taker.messages.RequestTakeOfferMessage;
 import io.bitsquare.trade.protocol.trade.taker.messages.TakeOfferFeePayedMessage;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.utils.Fiat;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/io/bitsquare/trade/handlers/TransactionResultHandler.java
+++ b/src/main/java/io/bitsquare/trade/handlers/TransactionResultHandler.java
@@ -17,7 +17,7 @@
 
 package io.bitsquare.trade.handlers;
 
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Transaction;
 
 public interface TransactionResultHandler {
     void onResult(Transaction transaction);

--- a/src/main/java/io/bitsquare/trade/protocol/createoffer/CreateOfferCoordinator.java
+++ b/src/main/java/io/bitsquare/trade/protocol/createoffer/CreateOfferCoordinator.java
@@ -28,7 +28,7 @@ import io.bitsquare.trade.protocol.createoffer.tasks.CreateOfferFeeTx;
 import io.bitsquare.trade.protocol.createoffer.tasks.PublishOfferToDHT;
 import io.bitsquare.trade.protocol.createoffer.tasks.VerifyOffer;
 
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Transaction;
 
 import java.io.Serializable;
 

--- a/src/main/java/io/bitsquare/trade/protocol/createoffer/tasks/BroadCastOfferFeeTx.java
+++ b/src/main/java/io/bitsquare/trade/protocol/createoffer/tasks/BroadCastOfferFeeTx.java
@@ -21,7 +21,7 @@ import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.trade.handlers.FaultHandler;
 import io.bitsquare.trade.handlers.ResultHandler;
 
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Transaction;
 
 import com.google.common.util.concurrent.FutureCallback;
 

--- a/src/main/java/io/bitsquare/trade/protocol/createoffer/tasks/CreateOfferFeeTx.java
+++ b/src/main/java/io/bitsquare/trade/protocol/createoffer/tasks/CreateOfferFeeTx.java
@@ -21,7 +21,7 @@ import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.trade.handlers.FaultHandler;
 import io.bitsquare.trade.handlers.TransactionResultHandler;
 
-import com.google.bitcoin.core.InsufficientMoneyException;
+import org.bitcoinj.core.InsufficientMoneyException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/BuyerAcceptsOfferProtocol.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/BuyerAcceptsOfferProtocol.java
@@ -41,10 +41,10 @@ import io.bitsquare.trade.protocol.trade.taker.messages.RequestOffererPublishDep
 import io.bitsquare.trade.protocol.trade.taker.messages.TakeOfferFeePayedMessage;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.ECKey;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Utils;
 
 import java.security.PublicKey;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/BuyerAcceptsOfferProtocolListener.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/BuyerAcceptsOfferProtocolListener.java
@@ -19,7 +19,7 @@ package io.bitsquare.trade.protocol.trade.offerer;
 
 import io.bitsquare.trade.Offer;
 
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Transaction;
 
 public interface BuyerAcceptsOfferProtocolListener {
     void onOfferAccepted(Offer offer);

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/messages/BankTransferInitedMessage.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/messages/BankTransferInitedMessage.java
@@ -19,7 +19,7 @@ package io.bitsquare.trade.protocol.trade.offerer.messages;
 
 import io.bitsquare.trade.protocol.trade.TradeMessage;
 
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Coin;
 
 import java.io.Serializable;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/CreateDepositTx.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/CreateDepositTx.java
@@ -20,10 +20,10 @@ package io.bitsquare.trade.protocol.trade.offerer.tasks;
 import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.trade.handlers.ExceptionHandler;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.InsufficientMoneyException;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SendDepositTxIdToTaker.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SendDepositTxIdToTaker.java
@@ -23,8 +23,8 @@ import io.bitsquare.trade.handlers.ExceptionHandler;
 import io.bitsquare.trade.handlers.ResultHandler;
 import io.bitsquare.trade.protocol.trade.offerer.messages.DepositTxPublishedMessage;
 
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Utils;
 
 import net.tomp2p.peers.PeerAddress;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SendSignedPayoutTx.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SendSignedPayoutTx.java
@@ -24,8 +24,8 @@ import io.bitsquare.trade.handlers.ExceptionHandler;
 import io.bitsquare.trade.handlers.ResultHandler;
 import io.bitsquare.trade.protocol.trade.offerer.messages.BankTransferInitedMessage;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.ECKey;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
 
 import javafx.util.Pair;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SetupListenerForBlockChainConfirmation.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SetupListenerForBlockChainConfirmation.java
@@ -20,8 +20,8 @@ package io.bitsquare.trade.protocol.trade.offerer.tasks;
 import io.bitsquare.trade.handlers.ResultHandler;
 import io.bitsquare.trade.protocol.trade.offerer.BuyerAcceptsOfferProtocolListener;
 
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.TransactionConfidence;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SignAndPublishDepositTx.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/SignAndPublishDepositTx.java
@@ -20,7 +20,7 @@ package io.bitsquare.trade.protocol.trade.offerer.tasks;
 import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.trade.handlers.ExceptionHandler;
 
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Transaction;
 
 import com.google.common.util.concurrent.FutureCallback;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/VerifyAndSignContract.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/offerer/tasks/VerifyAndSignContract.java
@@ -24,8 +24,8 @@ import io.bitsquare.trade.Offer;
 import io.bitsquare.trade.handlers.ExceptionHandler;
 import io.bitsquare.util.Utilities;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.ECKey;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
 
 import java.security.PublicKey;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/SellerTakesOfferProtocol.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/SellerTakesOfferProtocol.java
@@ -41,9 +41,9 @@ import io.bitsquare.trade.protocol.trade.taker.tasks.SignAndPublishPayoutTx;
 import io.bitsquare.trade.protocol.trade.taker.tasks.VerifyOffererAccount;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.ECKey;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Transaction;
 
 import java.security.PublicKey;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/SellerTakesOfferProtocolListener.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/SellerTakesOfferProtocolListener.java
@@ -19,7 +19,7 @@ package io.bitsquare.trade.protocol.trade.taker;
 
 import io.bitsquare.trade.Trade;
 
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Transaction;
 
 public interface SellerTakesOfferProtocolListener {
     void onDepositTxPublished(Transaction depositTx);

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/messages/TakeOfferFeePayedMessage.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/messages/TakeOfferFeePayedMessage.java
@@ -19,7 +19,7 @@ package io.bitsquare.trade.protocol.trade.taker.messages;
 
 import io.bitsquare.trade.protocol.trade.TradeMessage;
 
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Coin;
 
 import java.io.Serializable;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/CreateAndSignContract.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/CreateAndSignContract.java
@@ -24,8 +24,8 @@ import io.bitsquare.trade.Offer;
 import io.bitsquare.trade.handlers.ExceptionHandler;
 import io.bitsquare.util.Utilities;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.ECKey;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
 
 import java.security.PublicKey;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/PayDeposit.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/PayDeposit.java
@@ -20,9 +20,9 @@ package io.bitsquare.trade.protocol.trade.taker.tasks;
 import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.trade.handlers.ExceptionHandler;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.InsufficientMoneyException;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/PayTakeOfferFee.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/PayTakeOfferFee.java
@@ -20,8 +20,8 @@ package io.bitsquare.trade.protocol.trade.taker.tasks;
 import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.trade.handlers.ExceptionHandler;
 
-import com.google.bitcoin.core.InsufficientMoneyException;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
 
 import com.google.common.util.concurrent.FutureCallback;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/SendSignedTakerDepositTxAsHex.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/SendSignedTakerDepositTxAsHex.java
@@ -25,8 +25,8 @@ import io.bitsquare.trade.handlers.ExceptionHandler;
 import io.bitsquare.trade.handlers.ResultHandler;
 import io.bitsquare.trade.protocol.trade.taker.messages.RequestOffererPublishDepositTxMessage;
 
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Utils;
 
 import java.security.PublicKey;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/SendTakeOfferFeePayedTxId.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/SendTakeOfferFeePayedTxId.java
@@ -23,7 +23,7 @@ import io.bitsquare.trade.handlers.ExceptionHandler;
 import io.bitsquare.trade.handlers.ResultHandler;
 import io.bitsquare.trade.protocol.trade.taker.messages.TakeOfferFeePayedMessage;
 
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Coin;
 
 import net.tomp2p.peers.PeerAddress;
 

--- a/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/SignAndPublishPayoutTx.java
+++ b/src/main/java/io/bitsquare/trade/protocol/trade/taker/tasks/SignAndPublishPayoutTx.java
@@ -20,9 +20,9 @@ package io.bitsquare.trade.protocol.trade.taker.tasks;
 import io.bitsquare.btc.WalletFacade;
 import io.bitsquare.trade.handlers.ExceptionHandler;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Utils;
 
 import com.google.common.util.concurrent.FutureCallback;
 

--- a/src/main/java/io/bitsquare/util/DSAKeyUtil.java
+++ b/src/main/java/io/bitsquare/util/DSAKeyUtil.java
@@ -17,7 +17,7 @@
 
 package io.bitsquare.util;
 
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.Utils;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;

--- a/src/main/java/io/bitsquare/util/FileUtil.java
+++ b/src/main/java/io/bitsquare/util/FileUtil.java
@@ -17,7 +17,7 @@
 
 package io.bitsquare.util;
 
-import com.google.bitcoin.core.Utils;
+import org.bitcoinj.core.Utils;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/io/bitsquare/util/Utilities.java
+++ b/src/main/java/io/bitsquare/util/Utilities.java
@@ -63,7 +63,7 @@ public class Utilities {
         Object result = null;
         try {
             ByteArrayInputStream byteInputStream =
-                    new ByteArrayInputStream(com.google.bitcoin.core.Utils.parseAsHexOrBase58(serializedHexString));
+                    new ByteArrayInputStream(org.bitcoinj.core.Utils.parseAsHexOrBase58(serializedHexString));
 
             try (ObjectInputStream objectInputStream = new ObjectInputStream(byteInputStream)) {
                 result = objectInputStream.readObject();
@@ -88,7 +88,7 @@ public class Utilities {
             ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
             objectOutputStream.writeObject(serializable);
 
-            result = com.google.bitcoin.core.Utils.HEX.encode(byteArrayOutputStream.toByteArray());
+            result = org.bitcoinj.core.Utils.HEX.encode(byteArrayOutputStream.toByteArray());
             byteArrayOutputStream.close();
             objectOutputStream.close();
 

--- a/src/main/java/io/bitsquare/util/Validator.java
+++ b/src/main/java/io/bitsquare/util/Validator.java
@@ -17,7 +17,7 @@
 
 package io.bitsquare.util;
 
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Coin;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -25,7 +25,7 @@
 
     <logger name="io.bitsquare" level="TRACE"/>
 
-    <logger name="com.google.bitcoin" level="WARN"/>
+    <logger name="org.bitcoinj" level="WARN"/>
     <logger name="net.tomp2p" level="WARN"/>
 
     <logger name="io.netty.util" level="WARN"/>
@@ -37,16 +37,16 @@
     <logger name="io.bitsquare.gui.util.Profiler" level="TRACE"/>
 
     <!--
-    <logger name="com.google.bitcoin.core.Wallet" level="OFF"/>
-    <logger name="com.google.bitcoin.core.MemoryPool" level="OFF"/>
-    <logger name="com.google.bitcoin.net.discovery.DnsDiscovery" level="OFF"/>
-    <logger name="com.google.bitcoin.core.DownloadListener" level="OFF"/>
-    <logger name="com.google.bitcoin.core.TransactionOutput" level="OFF"/>
-    <logger name="com.google.bitcoin.core.BitcoinSerializer" level="OFF"/>
-    <logger name="com.google.bitcoin.core.Peer" level="OFF"/>
-    <logger name="com.google.bitcoin.core.PeerGroup" level="OFF"/>
-    <logger name="com.google.bitcoin.core.PeerSocketHandler" level="OFF"/>
-    <logger name="com.google.bitcoin.net.NioClientManager" level="OFF"/>
-    <logger name="com.google.bitcoin.net.ConnectionHandler" level="OFF"/>
+    <logger name="org.bitcoinj.core.Wallet" level="OFF"/>
+    <logger name="org.bitcoinj.core.MemoryPool" level="OFF"/>
+    <logger name="org.bitcoinj.net.discovery.DnsDiscovery" level="OFF"/>
+    <logger name="org.bitcoinj.core.DownloadListener" level="OFF"/>
+    <logger name="org.bitcoinj.core.TransactionOutput" level="OFF"/>
+    <logger name="org.bitcoinj.core.BitcoinSerializer" level="OFF"/>
+    <logger name="org.bitcoinj.core.Peer" level="OFF"/>
+    <logger name="org.bitcoinj.core.PeerGroup" level="OFF"/>
+    <logger name="org.bitcoinj.core.PeerSocketHandler" level="OFF"/>
+    <logger name="org.bitcoinj.net.NioClientManager" level="OFF"/>
+    <logger name="org.bitcoinj.net.ConnectionHandler" level="OFF"/>
     -->
 </configuration>

--- a/src/test/java/io/bitsquare/btc/RestrictionsTest.java
+++ b/src/test/java/io/bitsquare/btc/RestrictionsTest.java
@@ -17,8 +17,8 @@
 
 package io.bitsquare.btc;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.Transaction;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
 
 import org.junit.Test;
 

--- a/src/test/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferPMTest.java
+++ b/src/test/java/io/bitsquare/gui/main/trade/createoffer/CreateOfferPMTest.java
@@ -24,8 +24,8 @@ import io.bitsquare.gui.util.validation.FiatValidator;
 import io.bitsquare.locale.Country;
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.utils.Fiat;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
 
 import java.util.Locale;
 

--- a/src/test/java/io/bitsquare/gui/util/BSFormatterTest.java
+++ b/src/test/java/io/bitsquare/gui/util/BSFormatterTest.java
@@ -19,7 +19,7 @@ package io.bitsquare.gui.util;
 
 import io.bitsquare.user.User;
 
-import com.google.bitcoin.core.Coin;
+import org.bitcoinj.core.Coin;
 
 import java.util.Locale;
 

--- a/src/test/java/io/bitsquare/gui/util/validation/BtcValidatorTest.java
+++ b/src/test/java/io/bitsquare/gui/util/validation/BtcValidatorTest.java
@@ -17,8 +17,8 @@
 
 package io.bitsquare.gui.util.validation;
 
-import com.google.bitcoin.core.Coin;
-import com.google.bitcoin.core.NetworkParameters;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.NetworkParameters;
 
 import org.junit.Test;
 


### PR DESCRIPTION
- Update imports to reflect BitcoinJ's repackaging, including:
  
  git grep -l 'import com.google.bitcoin' | \
  xargs perl -p -i -e 's/import com.google.bitcoin/import org.bitcoinj/'
  
  git grep -l 'com.google.bitcoin' | \
  xargs perl -p -i -e 's/com.google.bitcoin/org.bitcoinj/'
  - Replace use of BitcoinJ's CoinFormat, which has now been renamed to
    MonetaryFormat, using:
  
  git grep -l 'CoinFormat' | \
  xargs perl -p -i -e 's/CoinFormat/MonetaryFormat/g'
  - Fix calls to BitcoinJ's Script#correctlySpends, whose signature has
    changed from 0.11 => 0.12.

See #98
