### PR TITLE
Support code coverage using JaCoCo and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,9 @@ notifications:
     on_failure: always
     use_notice: true
     skip_join: true
+
+env:
+  - TERM=dumb
+
+after_success:
+  - ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://bitsquare.io/images/logo.png" width="240"/>
 
 [![Build Status](https://travis-ci.org/bitsquare/bitsquare.svg?branch=master)](https://travis-ci.org/bitsquare/bitsquare)
+[![Coverage Status](https://img.shields.io/coveralls/bitsquare/bitsquare.svg)](https://coveralls.io/r/bitsquare/bitsquare)
 
 
 What is Bitsquare?

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,15 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
   id "com.github.johnrengelman.shadow" version "1.1.2"
+  id "com.github.kt3k.coveralls" version "2.0.1x"
 }
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'application'
+apply plugin: 'jacoco'
+
+wrapper.gradleVersion = '2.1'
 
 version = '0.1.0-SNAPSHOT'
 sourceCompatibility = 1.8
@@ -60,4 +64,9 @@ task packageNative(type:Exec, dependsOn:shadowJar) {
     args project.version, shadowJar.archivePath, mainClassName
 }
 
-wrapper.gradleVersion = '2.1'
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+}


### PR DESCRIPTION
The Gradle build now supports generating code coverage reports using
JaCoCo. The reports can be run with:

```
./gradle jacocoTestReport
```

and then view the HTML output at:

```
build/reports/jacoco/test/html/index.html
```

The bitsquare repository has now also been registered with a (free)
account at http://coveralls.io. Our Travis CI configuration has been
updated to publish JaCoCo XML test report data to coveralls.io, which
results in the reports found at:
- https://coveralls.io/r/bitsquare/bitsquare

For more information on the JaCoCo and Coveralls Gradle plugins, see:
- http://www.gradle.org/docs/current/userguide/jacoco_plugin.html
- https://github.com/kt3k/coveralls-gradle-plugin
