### PR TITLE
Add support for $HOME/.bitsquare/bitsquare.properties

### DIFF
--- a/src/main/java/io/bitsquare/app/BitsquareEnvironment.java
+++ b/src/main/java/io/bitsquare/app/BitsquareEnvironment.java
@@ -57,10 +57,11 @@ public class BitsquareEnvironment extends StandardEnvironment {
     public static final String APP_DATA_DIR_CLEAN_KEY = "app.data.dir.clean";
     public static final String DEFAULT_APP_DATA_DIR_CLEAN = "false";
 
-    static final String BITSQUARE_DEFAULT_PROPERTY_SOURCE_NAME = "bitsquareDefaultProperties";
-    static final String BITSQUARE_CLASSPATH_PROPERTY_SOURCE_NAME = "bitsquareClasspathProperties";
-    static final String BITSQUARE_FILESYSTEM_PROPERTY_SOURCE_NAME = "bitsquareFilesystemProperties";
     static final String BITSQUARE_COMMANDLINE_PROPERTY_SOURCE_NAME = "bitsquareCommandLineProperties";
+    static final String BITSQUARE_APP_DIR_PROPERTY_SOURCE_NAME = "bitsquareAppDirProperties";
+    static final String BITSQUARE_HOME_DIR_PROPERTY_SOURCE_NAME = "bitsquareHomeDirProperties";
+    static final String BITSQUARE_CLASSPATH_PROPERTY_SOURCE_NAME = "bitsquareClasspathProperties";
+    static final String BITSQUARE_DEFAULT_PROPERTY_SOURCE_NAME = "bitsquareDefaultProperties";
 
     private final ResourceLoader resourceLoader = new DefaultResourceLoader();
 
@@ -87,7 +88,8 @@ public class BitsquareEnvironment extends StandardEnvironment {
         MutablePropertySources propertySources = this.getPropertySources();
         propertySources.addFirst(commandLineProperties);
         try {
-            propertySources.addLast(filesystemProperties());
+            propertySources.addLast(appDirProperties());
+            propertySources.addLast(homeDirProperties());
             propertySources.addLast(classpathProperties());
             propertySources.addLast(defaultProperties());
         } catch (Exception ex) {
@@ -96,14 +98,24 @@ public class BitsquareEnvironment extends StandardEnvironment {
     }
 
 
-    PropertySource<?> filesystemProperties() throws Exception {
+    PropertySource<?> appDirProperties() throws Exception {
         String location = String.format("file:%s/bitsquare.properties", appDataDir);
         Resource resource = resourceLoader.getResource(location);
 
         if (!resource.exists())
-            return new PropertySource.StubPropertySource(BITSQUARE_FILESYSTEM_PROPERTY_SOURCE_NAME);
+            return new PropertySource.StubPropertySource(BITSQUARE_APP_DIR_PROPERTY_SOURCE_NAME);
 
-        return new ResourcePropertySource(BITSQUARE_FILESYSTEM_PROPERTY_SOURCE_NAME, resource);
+        return new ResourcePropertySource(BITSQUARE_APP_DIR_PROPERTY_SOURCE_NAME, resource);
+    }
+
+    PropertySource<?> homeDirProperties() throws Exception {
+        String location = String.format("file:%s/.bitsquare/bitsquare.properties", getProperty("user.home"));
+        Resource resource = resourceLoader.getResource(location);
+
+        if (!resource.exists())
+            return new PropertySource.StubPropertySource(BITSQUARE_HOME_DIR_PROPERTY_SOURCE_NAME);
+
+        return new ResourcePropertySource(BITSQUARE_HOME_DIR_PROPERTY_SOURCE_NAME, resource);
     }
 
     PropertySource<?> classpathProperties() throws Exception {

--- a/src/test/java/io/bitsquare/app/BitsquareEnvironmentTests.java
+++ b/src/test/java/io/bitsquare/app/BitsquareEnvironmentTests.java
@@ -41,13 +41,13 @@ public class BitsquareEnvironmentTests {
         PropertySource commandlineProps = new MockPropertySource(BITSQUARE_COMMANDLINE_PROPERTY_SOURCE_NAME)
                 .withProperty("key.x", "x.commandline");
 
-        PropertySource filesystemProps = new MockPropertySource(BITSQUARE_FILESYSTEM_PROPERTY_SOURCE_NAME)
+        PropertySource filesystemProps = new MockPropertySource(BITSQUARE_APP_DIR_PROPERTY_SOURCE_NAME)
                 .withProperty("key.x", "x.env")
                 .withProperty("key.y", "y.env");
 
         ConfigurableEnvironment env = new BitsquareEnvironment(commandlineProps) {
             @Override
-            PropertySource<?> filesystemProperties() {
+            PropertySource<?> appDirProperties() {
                 return filesystemProps;
             }
         };
@@ -56,10 +56,11 @@ public class BitsquareEnvironmentTests {
         assertThat(propertySources.precedenceOf(named(BITSQUARE_COMMANDLINE_PROPERTY_SOURCE_NAME)), equalTo(0));
         assertThat(propertySources.precedenceOf(named(SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME)), equalTo(1));
         assertThat(propertySources.precedenceOf(named(SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME)), equalTo(2));
-        assertThat(propertySources.precedenceOf(named(BITSQUARE_FILESYSTEM_PROPERTY_SOURCE_NAME)), equalTo(3));
-        assertThat(propertySources.precedenceOf(named(BITSQUARE_CLASSPATH_PROPERTY_SOURCE_NAME)), equalTo(4));
-        assertThat(propertySources.precedenceOf(named(BITSQUARE_DEFAULT_PROPERTY_SOURCE_NAME)), equalTo(5));
-        assertThat(propertySources.size(), equalTo(6));
+        assertThat(propertySources.precedenceOf(named(BITSQUARE_APP_DIR_PROPERTY_SOURCE_NAME)), equalTo(3));
+        assertThat(propertySources.precedenceOf(named(BITSQUARE_HOME_DIR_PROPERTY_SOURCE_NAME)), equalTo(4));
+        assertThat(propertySources.precedenceOf(named(BITSQUARE_CLASSPATH_PROPERTY_SOURCE_NAME)), equalTo(5));
+        assertThat(propertySources.precedenceOf(named(BITSQUARE_DEFAULT_PROPERTY_SOURCE_NAME)), equalTo(6));
+        assertThat(propertySources.size(), equalTo(7));
 
         assertThat(env.getProperty("key.x"), equalTo("x.commandline")); // commandline value wins due to precedence
         assertThat(env.getProperty("key.y"), equalTo("y.env")); // env value wins because it's the only one available


### PR DESCRIPTION
This change allows users to place a bitsquare.properties file within
a `.bitsquare` directory under their home directory. This makes it
possible to specify property values (such as
node.useManualPortForwarding=true) that will survive cleaning the
application data dir (e.g. with `--clean=true` flag as introduced
in #291).

The precedence of this new "homeDirProperties" property source is lower
than the "appDirProperties" property source.

This means that if a user has a `bitsquare.properties` file both in his
home directory and in his application data directory, both files will be
processed, but for any properties that exist in both files, the property
specified in the application data directory file will take precedence.
This arrangement allows users to customize settings on an app-by-app
basis, which is especially useful in local testing scenarios where more
than one Bitsquare instance is running.
