### PR TITLE
Add copy column to transaction view

### DIFF
--- a/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsView.fxml
+++ b/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsView.fxml
@@ -44,7 +44,7 @@
                     <PropertyValueFactory property="amount"/>
                 </cellValueFactory>
             </TableColumn>
-
+            <TableColumn text="Copy" fx:id="copyColumn" minWidth="30" sortable="false"/>
             <TableColumn text="Status" fx:id="confidenceColumn" minWidth="30" sortable="false"/>
         </columns>
     </TableView>

--- a/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsView.java
+++ b/src/main/java/io/bitsquare/gui/main/funds/transactions/TransactionsView.java
@@ -39,12 +39,15 @@ import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.util.Callback;
 
+import de.jensd.fx.fontawesome.AwesomeDude;
+import de.jensd.fx.fontawesome.AwesomeIcon;
+
 @FxmlView
 public class TransactionsView extends ActivatableViewAndModel {
 
     @FXML TableView<TransactionsListItem> table;
     @FXML TableColumn<TransactionsListItem, TransactionsListItem> dateColumn, addressColumn, amountColumn, typeColumn,
-            confidenceColumn;
+            confidenceColumn, copyColumn;
 
     private ObservableList<TransactionsListItem> transactionsListItems;
 
@@ -64,6 +67,7 @@ public class TransactionsView extends ActivatableViewAndModel {
 
         setAddressColumnCellFactory();
         setConfidenceColumnCellFactory();
+        setCopyColumnCellFactory();
     }
 
     @Override
@@ -146,6 +150,43 @@ public class TransactionsView extends ActivatableViewAndModel {
 
                                 if (item != null && !empty) {
                                     setGraphic(item.getProgressIndicator());
+                                }
+                                else {
+                                    setGraphic(null);
+                                }
+                            }
+                        };
+                    }
+                });
+    }
+
+    private void setCopyColumnCellFactory() {
+        copyColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
+        copyColumn.setCellFactory(
+                new Callback<TableColumn<TransactionsListItem, TransactionsListItem>, TableCell<TransactionsListItem,
+                        TransactionsListItem>>() {
+
+                    @Override
+                    public TableCell<TransactionsListItem, TransactionsListItem> call(TableColumn<TransactionsListItem,
+                            TransactionsListItem> column) {
+                        return new TableCell<TransactionsListItem, TransactionsListItem>() {
+                            final Label copyIcon = new Label();
+
+                            {
+                                copyIcon.getStyleClass().add("copy-icon");
+                                AwesomeDude.setIcon(copyIcon, AwesomeIcon.COPY);
+                                Tooltip.install(copyIcon, new Tooltip("Copy address to clipboard"));
+                            }
+
+                            @Override
+                            public void updateItem(final TransactionsListItem item, boolean empty) {
+                                super.updateItem(item, empty);
+
+                                if (item != null && !empty) {
+                                    setGraphic(copyIcon);
+                                    copyIcon.setOnMouseClicked(e -> Utilities.copyToClipboard(item
+                                            .getAddressString()));
+
                                 }
                                 else {
                                     setGraphic(null);


### PR DESCRIPTION
Adds copy button to the transaction view. 

I missed the fact that the other views have a button that copies the address to the clipboard! In my opinion the copy button is not very intuitive. It's not immediately obvious what it does: Copy the address to the clipboard? copy the balance /  amount or something else? It has a mouse over explanation but the text is invisible when the row is selected.

After 15 years of using web apps, it's strange that everything is not selectable / copy pastable. So if I could choose, I would do away with all the copy buttons and make all the addresses / amounts selectable. Would you accept a pull request that did that to all the views?
