### PR TITLE
Use https URL for artifactoryonline.com

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ processResources {
 
 repositories {
     jcenter()
-    maven { url 'http://partnerdemo.artifactoryonline.com/partnerdemo/libs-snapshots-local' }
+    maven { url 'https://partnerdemo.artifactoryonline.com/partnerdemo/libs-snapshots-local' }
 }
 
 dependencies {


### PR DESCRIPTION
It's a best practice to use `https://` URLs for all maven repositories. (I was just trying a `./gradlew run` and noticed an `http://` URL in the output.)
