### PR TITLE
Updated project to use 5.0-Beta2 of tomp2p

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,12 @@ processResources {
 
 repositories {
     jcenter()
-    maven { url 'https://partnerdemo.artifactoryonline.com/partnerdemo/libs-snapshots-local' }
+    maven { url 'http://tomp2p.net/dev/mvn/' }
 }
 
 dependencies {
     compile 'org.bitcoinj:bitcoinj-core:0.12.2'
-    compile 'net.tomp2p:tomp2p-all:5.0-Alpha.8f1cafb-SNAPSHOT'
+    compile 'net.tomp2p:tomp2p-all:5.0-Beta2'
     compile 'io.reactivex:rxjava:1.0.0'
     compile 'org.springframework:spring-core:4.1.1.RELEASE'
     compile 'net.sf.jopt-simple:jopt-simple:4.8'


### PR DESCRIPTION
I don't have a lot of background on the project yet so I might be missing some history, but I've updated build.gradle to use the latest release of tomp2p (5.0 Beta 2 which came out on Jan 8, 2015) and switched to use the tomp2p maven repository. I do see that bitsquare has its own fork of tomp2p, but it looked to me like there weren't substantial changes in that fork. (I did see some changes to examples, etc.) Again, I might be missing some important history so feel free to reject this PR if it's not helpful. Even if accepted, we should probably stick this on a branch so that it can be tested before being merged into master.

Note that this has not been thoroughly tested and, in particular, my router does not support UPnP so I've only been able to test with --node.useManualPortForwarding=true  The project does compile and Bitsquare does run successfully though. With manual port forwarding I'm able to connect to the p2p network and view open offers successfully.

This will obviously need thorough testing before being incorporated into an actual release!
