### PR TITLE
Escape vertical bar when splitting seed node addresses in command line

### DIFF
--- a/network/src/main/java/io/bitsquare/p2p/seed/SeedNode.java
+++ b/network/src/main/java/io/bitsquare/p2p/seed/SeedNode.java
@@ -82,7 +82,7 @@ public class SeedNode {
                         String arg4 = args[4];
                         checkArgument(arg4.contains(":") && arg4.split(":").length > 1 && arg4.split(":")[1].length() > 3,
                                 "Wrong program argument");
-                        List<String> list = Arrays.asList(arg4.split("|"));
+                        List<String> list = Arrays.asList(arg4.split("\\|"));
                         progArgSeedNodes = new HashSet<>();
                         list.forEach(e -> {
                             checkArgument(e.contains(":") && e.split(":").length == 2 && e.split(":")[1].length() == 4,


### PR DESCRIPTION
Otherwise it is interpreted as a special regular expression character and all characters are splitted apart, causing a `NullPointerException` after further splitting on `:`.

The fix allows using `NODE1_ADDR.onion:PORT1|NODE2_ADDR.onion:PORT2|…` to indicate nodes to connect to when running `SeedNode.jar`.
