### PR TITLE
Seed node monitor

### DIFF
--- a/doc/bitsquare-sn.cron.sh
+++ b/doc/bitsquare-sn.cron.sh
@@ -8,7 +8,7 @@
 # Exit with status 2 if there were restarted daemons.
 #
 # Author: Ivan Vilata-i-Balaguer <ivan@selidor.net>
-MAX_RSS_MiB=350
+MAX_RSS_MiB=400
 
 PIDDIR=/var/run/bitsquare-sn
 INITDIR=/etc/init.d

--- a/doc/bitsquare-sn.init.sh
+++ b/doc/bitsquare-sn.init.sh
@@ -25,7 +25,7 @@ SN_ADDRESS=1a2b3c4d5e6f7g8h.onion:8000
 # Bitcoin network: 0=mainnet, 1=testnet, 2=regtest.
 SN_NETWORK_ID=0
 # Maximum number of connecitions to allow.
-SN_MAX_CONNECTIONS=50
+SN_MAX_CONNECTIONS=100
 
 # Location of the seed node jar file.  Use to select a particular version.
 SN_JAR=~bsqsn/SeedNode-0.4.4.jar

--- a/doc/bitsquare-sn.init.sh
+++ b/doc/bitsquare-sn.init.sh
@@ -28,7 +28,7 @@ SN_NETWORK_ID=0
 SN_MAX_CONNECTIONS=50
 
 # Location of the seed node jar file.  Use to select a particular version.
-SN_JAR=~bsqsn/SeedNode-0.4.2.jar
+SN_JAR=~bsqsn/SeedNode-0.4.4.jar
 # User to run the seed node as.
 SN_USER=bsqsn
 ## END CONFIGURATION

--- a/doc/monitor-bitsquare-sn.cron.sh
+++ b/doc/monitor-bitsquare-sn.cron.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Report by email failing connections to Bitsquare seed nodes.
+#
+# Exit with status 2 if unreachable nodes were detected.
+#
+# You may drop this under ``/etc/cron.hourly``.
+# Please make sure that your system can send emails.
+#
+# Requirements: coreutils, torify, netcat, mail.
+#
+# Author: Ivan Vilata-i-Balaguer <ivan@selidor.net>
+
+
+## BEGIN CONFIGURATION
+# Email addresses to report failing nodes to, white-separated.
+REPORT_TO_EMAILS='
+bsqsn@example.com
+'
+
+# Seed node addresses to check as ONION_ADDRESS:PORT, white-separated.
+# Addresses from ``SeedNodesRepository`` v0.4.4.
+SEED_NODES='
+uadzuib66jupaept.onion:8000
+hbma455xxbqhcuqh.onion:8000
+wgthuiqn3aoiovbm.onion:8000
+2zxtnprnx5wqr7a3.onion:8000
+'
+## END CONFIGURATION
+
+
+failing_seed_nodes=''
+for sn in $SEED_NODES; do
+    true | torify nc $(echo "$sn" | tr ':' ' ') > /dev/null 2>&1
+    if [ $? != 0 ]; then
+        failing_seed_nodes="$failing_seed_nodes $sn"
+    fi
+done
+
+if [ "$failing_seed_nodes" ]; then
+    cat <<- EOF | mail -s "Failing Bitsquare seed nodes" -- $REPORT_TO_EMAILS
+	The following Bitsquare seed nodes failed to accept a new connection:
+
+	$(echo $failing_seed_nodes | tr ' ' '\n' | sed 's/^/    /')
+
+	Please check if they have issues, thank you.
+
+	-- 
+	The Bitsquare seed monitor running at $(hostname -f)
+	EOF
+	exit 2
+fi

--- a/doc/seed-node-daemon.md
+++ b/doc/seed-node-daemon.md
@@ -32,10 +32,10 @@ configuration directory to the ``~bsqsb/.local/share``  directory.
 ## Testing the seed node
 
 You need to check that the seed node can actually run in your system.  For
-instance, if you are using version 0.4.2 and your seed node's Tor address is
+instance, if you are using version 0.4.4 and your seed node's Tor address is
 ``1a2b3c4d5e6f7g8h.onion:8000``, try to run this as the ``bsqsn`` user:
 
-    $ java -jar ~bsqsn/SeedNode-0.4.2.jar 1a2b3c4d5e6f7g8h.onion:8000 0 50
+    $ java -jar ~bsqsn/SeedNode-0.4.4.jar 1a2b3c4d5e6f7g8h.onion:8000 0 50
 
 Please check error messages if it fails to run.  Do note that you will need
 OpenJDK and OpenJFX in the server.  In Debian-like systems you may install the
@@ -53,7 +53,7 @@ configuration variables to your needs, especially ``SN_ADDRESS``, ``SN_JAR``
 and ``SN_USER``.  In the previous example, the values would be:
 
     SN_ADDRESS=1a2b3c4d5e6f7g8h.onion:8000
-    SN_JAR=~bsqsn/SeedNode-0.4.2.jar
+    SN_JAR=~bsqsn/SeedNode-0.4.4.jar
     SN_USER=bsqsn
 
 Put the customized script under ``/etc/init.d`` using a name without

--- a/doc/seed-node-daemon.md
+++ b/doc/seed-node-daemon.md
@@ -83,3 +83,23 @@ executable:
 
 The check will be run every hour.  For more sophisticated checks, use a proper
 monitor like [Monit](https://mmonit.com/monit/).
+
+## Monitor script
+
+The attached [monitor script](monitor-bitsquare-sn.cron.sh) can be used to
+watch several seed nodes by connecting to them over Tor, and report by email
+if there were any failed connection attempts.  The script uses the ``torify``
+and ``nc``  tools, so make sure that you have the ``tor`` and some ``netcat``
+package installed in your system.  Also make sure that it is able to send
+messages using the ``mail``  utility.
+
+To enable the monitor, first edit the script and set the email addresses you
+want to report to in ``REPORT_TO_EMAILS``; if you want to specify the set of
+seed nodes to check, change the value of ``SEED_NODES``.  Then copy the script
+to ``/etc/cron.hourly`` and make it executable:
+
+    # cp /path/to/monitor-bitsquare-sn.cron.sh /etc/cron.hourly/monitor-bitsquare-sn
+    # chmod a+rx /etc/cron.hourly/monitor-bitsquare-sn
+
+Since this script requires no special permissions, you may instead want to run
+it from a normal user's crontab (e.g. the ``bsqsn`` user above).


### PR DESCRIPTION
This adds a script that can be used with Cron to check that a set of seed nodes are available over Tor. If not, an email is sent to a set of addresses. Documentation is included.

The PR also adjusts some version references in init and Cron scripts, as well as adjusting some parameters.
