### PR TITLE
New timer race conditions

### DIFF
--- a/network/src/main/java/io/bitsquare/p2p/peers/BroadcastHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/BroadcastHandler.java
@@ -133,6 +133,8 @@ public class BroadcastHandler implements PeerManager.Listener {
 
             log.info("Broadcast message to {} peers out of {} total connected peers.", numOfPeers, connectedPeersSet.size());
             for (int i = 0; i < numOfPeers; i++) {
+                if (stopped)
+                    break;  // do not continue sending after a timeout or a cancellation
                 final long minDelay = i * 30 * factor + 1;
                 final long maxDelay = minDelay * 2 + 30 * factor;
                 final Connection connection = connectedPeersList.get(i);

--- a/network/src/main/java/io/bitsquare/p2p/peers/BroadcastHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/BroadcastHandler.java
@@ -116,16 +116,9 @@ public class BroadcastHandler implements PeerManager.Listener {
                 numOfPeers = Math.min(5, connectedPeersList.size());
                 factor = 2;
             }
-            log.info("Broadcast message to {} peers out of {} total connected peers.", numOfPeers, connectedPeersSet.size());
-            for (int i = 0; i < numOfPeers; i++) {
-                final long minDelay = i * 30 * factor + 1;
-                final long maxDelay = minDelay * 2 + 30 * factor;
-                final Connection connection = connectedPeersList.get(i);
-                UserThread.runAfterRandomDelay(() -> sendToPeer(connection, message), minDelay, maxDelay, TimeUnit.MILLISECONDS);
-            }
 
             long timeoutDelay = TIMEOUT_PER_PEER_SEC * numOfPeers;
-            timeoutTimer = UserThread.runAfter(() -> {
+            timeoutTimer = UserThread.runAfter(() -> {  // setup before sending to avoid race conditions
                 String errorMessage = "Timeout: Broadcast did not complete after " + timeoutDelay + " sec.";
 
                 log.warn(errorMessage + "\n\t" +
@@ -137,6 +130,14 @@ public class BroadcastHandler implements PeerManager.Listener {
                         "broadcastQueue=" + broadcastQueue);
                 onFault(errorMessage);
             }, timeoutDelay);
+
+            log.info("Broadcast message to {} peers out of {} total connected peers.", numOfPeers, connectedPeersSet.size());
+            for (int i = 0; i < numOfPeers; i++) {
+                final long minDelay = i * 30 * factor + 1;
+                final long maxDelay = minDelay * 2 + 30 * factor;
+                final Connection connection = connectedPeersList.get(i);
+                UserThread.runAfterRandomDelay(() -> sendToPeer(connection, message), minDelay, maxDelay, TimeUnit.MILLISECONDS);
+            }
         } else {
             onFault("Message not broadcasted because we have no available peers yet.\n\t" +
                     "message = " + StringUtils.abbreviate(message.toString(), 100), false);

--- a/network/src/main/java/io/bitsquare/p2p/peers/getdata/GetDataRequestHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/getdata/GetDataRequestHandler.java
@@ -67,8 +67,8 @@ public class GetDataRequestHandler {
         GetDataResponse getDataResponse = new GetDataResponse(new HashSet<>(dataStorage.getMap().values()),
                 getDataRequest.getNonce());
 
-        if (timeoutTimer == null) {  // setup before sending to avoid race conditions
-            timeoutTimer = UserThread.runAfter(() -> {
+        if (timeoutTimer == null) {
+            timeoutTimer = UserThread.runAfter(() -> {  // setup before sending to avoid race conditions
                         String errorMessage = "A timeout occurred for getDataResponse:" + getDataResponse +
                                 " on connection:" + connection;
                         handleFault(errorMessage, CloseConnectionReason.SEND_MSG_TIMEOUT, connection);

--- a/network/src/main/java/io/bitsquare/p2p/peers/getdata/GetDataRequestHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/getdata/GetDataRequestHandler.java
@@ -80,18 +80,26 @@ public class GetDataRequestHandler {
         Futures.addCallback(future, new FutureCallback<Connection>() {
             @Override
             public void onSuccess(Connection connection) {
-                log.trace("Send DataResponse to {} succeeded. getDataResponse={}",
-                        connection.getPeersNodeAddressOptional(), getDataResponse);
-                cleanup();
-                listener.onComplete();
+                if (!stopped) {
+                    log.trace("Send DataResponse to {} succeeded. getDataResponse={}",
+                            connection.getPeersNodeAddressOptional(), getDataResponse);
+                    cleanup();
+                    listener.onComplete();
+                } else {
+                    log.trace("We have stopped already. We ignore that networkNode.sendMessage.onSuccess call.");
+                }
             }
 
             @Override
             public void onFailure(@NotNull Throwable throwable) {
-                String errorMessage = "Sending getDataRequest to " + connection +
-                        " failed. That is expected if the peer is offline. getDataResponse=" + getDataResponse + "." +
-                        "Exception: " + throwable.getMessage();
-                handleFault(errorMessage, CloseConnectionReason.SEND_MSG_FAILURE, connection);
+                if (!stopped) {
+                    String errorMessage = "Sending getDataRequest to " + connection +
+                            " failed. That is expected if the peer is offline. getDataResponse=" + getDataResponse + "." +
+                            "Exception: " + throwable.getMessage();
+                    handleFault(errorMessage, CloseConnectionReason.SEND_MSG_FAILURE, connection);
+                } else {
+                    log.trace("We have stopped already. We ignore that networkNode.sendMessage.onFailure call.");
+                }
             }
         });
     }

--- a/network/src/main/java/io/bitsquare/p2p/peers/getdata/RequestDataHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/getdata/RequestDataHandler.java
@@ -88,8 +88,6 @@ public class RequestDataHandler implements MessageListener {
             else
                 getDataRequest = new GetUpdatedDataRequest(networkNode.getNodeAddress(), nonce);
 
-            log.info("We send a {} to peer {}. ", getDataRequest.getClass().getSimpleName(), nodeAddress);
-
             if (timeoutTimer == null) {  // setup before sending to avoid race conditions
                 timeoutTimer = UserThread.runAfter(() -> {
                             if (!stopped) {
@@ -105,6 +103,7 @@ public class RequestDataHandler implements MessageListener {
                         TIME_OUT_SEC);
             }
 
+            log.info("We send a {} to peer {}. ", getDataRequest.getClass().getSimpleName(), nodeAddress);
             SettableFuture<Connection> future = networkNode.sendMessage(nodeAddress, getDataRequest);
             Futures.addCallback(future, new FutureCallback<Connection>() {
                 @Override

--- a/network/src/main/java/io/bitsquare/p2p/peers/getdata/RequestDataHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/getdata/RequestDataHandler.java
@@ -88,8 +88,8 @@ public class RequestDataHandler implements MessageListener {
             else
                 getDataRequest = new GetUpdatedDataRequest(networkNode.getNodeAddress(), nonce);
 
-            if (timeoutTimer == null) {  // setup before sending to avoid race conditions
-                timeoutTimer = UserThread.runAfter(() -> {
+            if (timeoutTimer == null) {
+                timeoutTimer = UserThread.runAfter(() -> {  // setup before sending to avoid race conditions
                             if (!stopped) {
                                 String errorMessage = "A timeout occurred at sending getDataRequest:" + getDataRequest +
                                         " on nodeAddress:" + nodeAddress;

--- a/network/src/main/java/io/bitsquare/p2p/peers/peerexchange/PeerExchangeHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/peerexchange/PeerExchangeHandler.java
@@ -85,8 +85,8 @@ class PeerExchangeHandler implements MessageListener {
             if (networkNode.getNodeAddress() != null) {
                 GetPeersRequest getPeersRequest = new GetPeersRequest(networkNode.getNodeAddress(), nonce, peerManager.getConnectedNonSeedNodeReportedPeers(nodeAddress));
 
-                if (timeoutTimer == null) {  // setup before sending to avoid race conditions
-                    timeoutTimer = UserThread.runAfter(() -> {
+                if (timeoutTimer == null) {
+                    timeoutTimer = UserThread.runAfter(() -> {  // setup before sending to avoid race conditions
                                 if (!stopped) {
                                     String errorMessage = "A timeout occurred at sending getPeersRequest:" + getPeersRequest + " for nodeAddress:" + nodeAddress;
                                     log.info(errorMessage + " / PeerExchangeHandler=" +

--- a/network/src/main/java/io/bitsquare/p2p/peers/peerexchange/PeerExchangeHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/peerexchange/PeerExchangeHandler.java
@@ -84,6 +84,22 @@ class PeerExchangeHandler implements MessageListener {
         if (!stopped) {
             if (networkNode.getNodeAddress() != null) {
                 GetPeersRequest getPeersRequest = new GetPeersRequest(networkNode.getNodeAddress(), nonce, peerManager.getConnectedNonSeedNodeReportedPeers(nodeAddress));
+
+                if (timeoutTimer == null) {  // setup before sending to avoid race conditions
+                    timeoutTimer = UserThread.runAfter(() -> {
+                                if (!stopped) {
+                                    String errorMessage = "A timeout occurred at sending getPeersRequest:" + getPeersRequest + " for nodeAddress:" + nodeAddress;
+                                    log.info(errorMessage + " / PeerExchangeHandler=" +
+                                            PeerExchangeHandler.this);
+                                    log.info("timeoutTimer called on " + this);
+                                    handleFault(errorMessage, CloseConnectionReason.SEND_MSG_TIMEOUT, nodeAddress);
+                                } else {
+                                    log.trace("We have stopped that handler already. We ignore that timeoutTimer.run call.");
+                                }
+                            },
+                            TIME_OUT_SEC, TimeUnit.SECONDS);
+                }
+
                 SettableFuture<Connection> future = networkNode.sendMessage(nodeAddress, getPeersRequest);
                 Futures.addCallback(future, new FutureCallback<Connection>() {
                     @Override
@@ -116,21 +132,6 @@ class PeerExchangeHandler implements MessageListener {
                         }
                     }
                 });
-
-                if (timeoutTimer == null) {
-                    timeoutTimer = UserThread.runAfter(() -> {
-                                if (!stopped) {
-                                    String errorMessage = "A timeout occurred at sending getPeersRequest:" + getPeersRequest + " for nodeAddress:" + nodeAddress;
-                                    log.info(errorMessage + " / PeerExchangeHandler=" +
-                                            PeerExchangeHandler.this);
-                                    log.info("timeoutTimer called on " + this);
-                                    handleFault(errorMessage, CloseConnectionReason.SEND_MSG_TIMEOUT, nodeAddress);
-                                } else {
-                                    log.trace("We have stopped that handler already. We ignore that timeoutTimer.run call.");
-                                }
-                            },
-                            TIME_OUT_SEC, TimeUnit.SECONDS);
-                }
             } else {
                 log.debug("My node address is still null at sendGetPeersRequest. We ignore that call.");
             }


### PR DESCRIPTION
I found some race conditions in message handlers. Basically, they do a `networkNode.sendMessage()`, then add callbacks to the resulting future, and then create a timeout timer.

The problem is that the message exchange may actually run, cleanup and set stop before timer creation (e.g. when testing in a single machine), which goes on to create the timer anyway.  The timer does trigger of course (since the operation completed before) and when it runs some cleanup method it uses to check `stopped` (which is already true) and complain about that.

This PR fixes the issue by creating the timer before sending the message.  I ran the network stress test on this and some warnings have gone away.

I also added some missing checks for `stopped` in `GetDataRequestHandler.handle()` and `BroadcastHandler.broadcast()`.
