### PR TITLE
Per-instance max connections in PeerManager

### DIFF
--- a/network/src/main/java/io/bitsquare/p2p/P2PService.java
+++ b/network/src/main/java/io/bitsquare/p2p/P2PService.java
@@ -55,9 +55,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class P2PService implements SetupListener, MessageListener, ConnectionListener, RequestDataManager.Listener,
         HashMapChangedListener {
     private static final Logger log = LoggerFactory.getLogger(P2PService.class);
+    public static final int MAX_CONNECTIONS_DEFAULT = 12;
 
     private final SeedNodesRepository seedNodesRepository;
     private final int port;
+    private final int maxConnections;
     private final File torDir;
     private Clock clock;
     private final Optional<EncryptionService> optionalEncryptionService;
@@ -104,8 +106,32 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                       Clock clock,
                       @Nullable EncryptionService encryptionService,
                       @Nullable KeyRing keyRing) {
+        this(
+                seedNodesRepository,
+                port, MAX_CONNECTIONS_DEFAULT,
+                torDir,
+                useLocalhost,
+                networkId,
+                storageDir,
+                clock,
+                encryptionService,
+                keyRing
+        );
+    }
+
+    @VisibleForTesting
+    public P2PService(SeedNodesRepository seedNodesRepository,
+                      int port, int maxConnections,
+                      File torDir,
+                      boolean useLocalhost,
+                      int networkId,
+                      File storageDir,
+                      Clock clock,
+                      @Nullable EncryptionService encryptionService,
+                      @Nullable KeyRing keyRing) {
         this.seedNodesRepository = seedNodesRepository;
         this.port = port;
+        this.maxConnections = maxConnections;
         this.torDir = torDir;
         this.clock = clock;
 

--- a/network/src/main/java/io/bitsquare/p2p/P2PService.java
+++ b/network/src/main/java/io/bitsquare/p2p/P2PService.java
@@ -150,7 +150,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
         networkNode.addMessageListener(this);
 
         Set<NodeAddress> seedNodeAddresses = seedNodesRepository.getSeedNodeAddresses(useLocalhost, networkId);
-        peerManager = new PeerManager(networkNode, seedNodeAddresses, storageDir, clock);
+        peerManager = new PeerManager(networkNode, maxConnections, seedNodeAddresses, storageDir, clock);
 
         broadcaster = new Broadcaster(networkNode, peerManager);
 

--- a/network/src/main/java/io/bitsquare/p2p/peers/PeerManager.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/PeerManager.java
@@ -346,7 +346,7 @@ public class PeerManager implements ConnectionListener {
         printNewReportedPeers(reportedPeersToAdd);
 
         // We check if the reported msg is not violating our rules
-        if (reportedPeersToAdd.size() <= (MAX_REPORTED_PEERS + PeerManager.MAX_CONNECTIONS_ABSOLUTE + 10)) {
+        if (reportedPeersToAdd.size() <= (MAX_REPORTED_PEERS + MAX_CONNECTIONS_ABSOLUTE + 10)) {
             reportedPeers.addAll(reportedPeersToAdd);
             purgeReportedPeersIfExceeds();
 

--- a/network/src/main/java/io/bitsquare/p2p/peers/PeerManager.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/PeerManager.java
@@ -28,16 +28,20 @@ public class PeerManager implements ConnectionListener {
     // Use a long delay as the bootstrapping peer might need a while until it knows its onion address
     private static final long REMOVE_ANONYMOUS_PEER_SEC = Timer.STRESS_TEST ? 10 : 120;
 
+    private static final int MAX_REPORTED_PEERS = 1000;
+    private static final int MAX_PERSISTED_PEERS = 500;
+    private static final long MAX_AGE = TimeUnit.DAYS.toMillis(14); // max age for reported peers is 14 days
+
+    private final boolean printReportedPeersDetails = true;
+    private boolean lostAllConnections;
+
     private int MAX_CONNECTIONS;
     private int MIN_CONNECTIONS;
     private int MAX_CONNECTIONS_PEER;
     private int MAX_CONNECTIONS_NON_DIRECT;
-
-
     private int MAX_CONNECTIONS_ABSOLUTE;
-    private final boolean printReportedPeersDetails = true;
-    private boolean lostAllConnections;
 
+    // Modify this to change the relationships between connection limits.
     private void setMaxConnections(int maxConnections) {
         MAX_CONNECTIONS = maxConnections;
         MIN_CONNECTIONS = Math.max(1, maxConnections - 4);
@@ -45,10 +49,6 @@ public class PeerManager implements ConnectionListener {
         MAX_CONNECTIONS_NON_DIRECT = MAX_CONNECTIONS + 8;
         MAX_CONNECTIONS_ABSOLUTE = MAX_CONNECTIONS + 18;
     }
-
-    private static final int MAX_REPORTED_PEERS = 1000;
-    private static final int MAX_PERSISTED_PEERS = 500;
-    private static final long MAX_AGE = TimeUnit.DAYS.toMillis(14); // max age for reported peers is 14 days
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -88,8 +88,8 @@ public class PeerManager implements ConnectionListener {
 
     public PeerManager(NetworkNode networkNode, int maxConnections, Set<NodeAddress> seedNodeAddresses,
                        File storageDir, Clock clock) {
-        this.networkNode = networkNode;
         setMaxConnections(maxConnections);
+        this.networkNode = networkNode;
         this.clock = clock;
         // seedNodeAddresses can be empty (in case there is only 1 seed node, the seed node starting up has no other seed nodes)
         this.seedNodeAddresses = new HashSet<>(seedNodeAddresses);

--- a/network/src/main/java/io/bitsquare/p2p/peers/PeerManager.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/PeerManager.java
@@ -28,26 +28,22 @@ public class PeerManager implements ConnectionListener {
     // Use a long delay as the bootstrapping peer might need a while until it knows its onion address
     private static final long REMOVE_ANONYMOUS_PEER_SEC = Timer.STRESS_TEST ? 10 : 120;
 
-    private static int MAX_CONNECTIONS;
-    private static int MIN_CONNECTIONS;
-    private static int MAX_CONNECTIONS_PEER;
-    private static int MAX_CONNECTIONS_NON_DIRECT;
+    private int MAX_CONNECTIONS;
+    private int MIN_CONNECTIONS;
+    private int MAX_CONNECTIONS_PEER;
+    private int MAX_CONNECTIONS_NON_DIRECT;
 
 
-    private static int MAX_CONNECTIONS_ABSOLUTE;
+    private int MAX_CONNECTIONS_ABSOLUTE;
     private final boolean printReportedPeersDetails = true;
     private boolean lostAllConnections;
 
-    public static void setMaxConnections(int maxConnections) {
+    private void setMaxConnections(int maxConnections) {
         MAX_CONNECTIONS = maxConnections;
         MIN_CONNECTIONS = Math.max(1, maxConnections - 4);
         MAX_CONNECTIONS_PEER = MAX_CONNECTIONS + 4;
         MAX_CONNECTIONS_NON_DIRECT = MAX_CONNECTIONS + 8;
         MAX_CONNECTIONS_ABSOLUTE = MAX_CONNECTIONS + 18;
-    }
-
-    static {
-        setMaxConnections(12);
     }
 
     private static final int MAX_REPORTED_PEERS = 1000;
@@ -90,8 +86,10 @@ public class PeerManager implements ConnectionListener {
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public PeerManager(NetworkNode networkNode, Set<NodeAddress> seedNodeAddresses, File storageDir, Clock clock) {
+    public PeerManager(NetworkNode networkNode, int maxConnections, Set<NodeAddress> seedNodeAddresses,
+                       File storageDir, Clock clock) {
         this.networkNode = networkNode;
+        setMaxConnections(maxConnections);
         this.clock = clock;
         // seedNodeAddresses can be empty (in case there is only 1 seed node, the seed node starting up has no other seed nodes)
         this.seedNodeAddresses = new HashSet<>(seedNodeAddresses);

--- a/network/src/main/java/io/bitsquare/p2p/seed/SeedNode.java
+++ b/network/src/main/java/io/bitsquare/p2p/seed/SeedNode.java
@@ -30,6 +30,7 @@ public class SeedNode {
     public static final int MAX_CONNECTIONS_DEFAULT = 50;
 
     private NodeAddress mySeedNodeAddress = new NodeAddress("localhost:8001");
+    private int maxConnections = MAX_CONNECTIONS_DEFAULT;  // we keep default a higher connection size for seed nodes
     private boolean useLocalhost = false;
     private Set<NodeAddress> progArgSeedNodes;
     private P2PService seedNodeP2PService;
@@ -67,13 +68,10 @@ public class SeedNode {
                     Version.setBtcNetworkId(networkId);
                     if (args.length > 2) {
                         String arg2 = args[2];
-                        int maxConnections = Integer.parseInt(arg2);
+                        maxConnections = Integer.parseInt(arg2);
                         log.info("From processArgs: maxConnections=" + maxConnections);
                         checkArgument(maxConnections < MAX_CONNECTIONS_LIMIT, "maxConnections seems to be a bit too high...");
                         PeerManager.setMaxConnections(maxConnections);
-                    } else {
-                        // we keep default a higher connection size for seed nodes
-                        PeerManager.setMaxConnections(MAX_CONNECTIONS_DEFAULT);
                     }
                     if (args.length > 3) {
                         String arg3 = args[3];
@@ -107,11 +105,13 @@ public class SeedNode {
     }
 
     public void createAndStartP2PService(boolean useDetailedLogging) {
-        createAndStartP2PService(mySeedNodeAddress, useLocalhost, Version.getBtcNetworkId(), useDetailedLogging, progArgSeedNodes, null);
+        createAndStartP2PService(mySeedNodeAddress, maxConnections, useLocalhost,
+                Version.getBtcNetworkId(), useDetailedLogging, progArgSeedNodes, null);
     }
 
     @VisibleForTesting
     public void createAndStartP2PService(NodeAddress mySeedNodeAddress,
+                                         int maxConnections,
                                          boolean useLocalhost,
                                          int networkId,
                                          boolean useDetailedLogging,
@@ -144,7 +144,8 @@ public class SeedNode {
             log.info("Created torDir at " + torDir.getAbsolutePath());
 
         seedNodesRepository.setNodeAddressToExclude(mySeedNodeAddress);
-        seedNodeP2PService = new P2PService(seedNodesRepository, mySeedNodeAddress.port, torDir, useLocalhost, networkId, storageDir, new Clock(), null, null);
+        seedNodeP2PService = new P2PService(seedNodesRepository, mySeedNodeAddress.port, maxConnections,
+                torDir, useLocalhost, networkId, storageDir, new Clock(), null, null);
         seedNodeP2PService.start(listener);
     }
 

--- a/network/src/main/java/io/bitsquare/p2p/seed/SeedNode.java
+++ b/network/src/main/java/io/bitsquare/p2p/seed/SeedNode.java
@@ -71,7 +71,6 @@ public class SeedNode {
                         maxConnections = Integer.parseInt(arg2);
                         log.info("From processArgs: maxConnections=" + maxConnections);
                         checkArgument(maxConnections < MAX_CONNECTIONS_LIMIT, "maxConnections seems to be a bit too high...");
-                        PeerManager.setMaxConnections(maxConnections);
                     }
                     if (args.length > 3) {
                         String arg3 = args[3];

--- a/network/src/test/java/io/bitsquare/p2p/PeerServiceTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/PeerServiceTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CountDownLatch;
 // Run it once then lookup for onion address at: tor/hiddenservice/hostname and use that for the NodeAddress param.
 public class PeerServiceTest {
     private static final Logger log = LoggerFactory.getLogger(PeerServiceTest.class);
+    public static final int MAX_CONNECTIONS = 100;
 
     final boolean useLocalhost = true;
     private CountDownLatch latch;
@@ -37,7 +38,7 @@ public class PeerServiceTest {
     public void setup() throws InterruptedException {
         LocalhostNetworkNode.setSimulateTorDelayTorNode(50);
         LocalhostNetworkNode.setSimulateTorDelayHiddenService(8);
-        PeerManager.setMaxConnections(100);
+        PeerManager.setMaxConnections(MAX_CONNECTIONS);
 
         if (useLocalhost) {
             seedNodeAddresses.add(new NodeAddress("localhost:8001"));
@@ -127,7 +128,7 @@ public class PeerServiceTest {
         
        /* latch = new CountDownLatch(2);
         
-        seedNode.createAndStartP2PService(nodeAddress, useLocalhost, 2, true,
+        seedNode.createAndStartP2PService(nodeAddress, MAX_CONNECTIONS, useLocalhost, 2, true,
                 seedNodeAddresses, new P2PServiceListener() {
                     @Override
                     public void onRequestingDataCompleted() {
@@ -181,7 +182,7 @@ public class PeerServiceTest {
         latch = new CountDownLatch(6);
 
         seedNode1 = new SeedNode("test_dummy_dir");
-        seedNode1.createAndStartP2PService(nodeAddress1, useLocalhost, 2, true, seedNodeAddresses, new P2PServiceListener() {
+        seedNode1.createAndStartP2PService(nodeAddress1, MAX_CONNECTIONS, useLocalhost, 2, true, seedNodeAddresses, new P2PServiceListener() {
             @Override
             public void onRequestingDataCompleted() {
                 latch.countDown();
@@ -219,7 +220,7 @@ public class PeerServiceTest {
         Thread.sleep(500);
 
         seedNode2 = new SeedNode("test_dummy_dir");
-        seedNode2.createAndStartP2PService(nodeAddress2, useLocalhost, 2, true, seedNodeAddresses, new P2PServiceListener() {
+        seedNode2.createAndStartP2PService(nodeAddress2, MAX_CONNECTIONS, useLocalhost, 2, true, seedNodeAddresses, new P2PServiceListener() {
             @Override
             public void onRequestingDataCompleted() {
                 latch.countDown();
@@ -456,7 +457,7 @@ public class PeerServiceTest {
         SeedNode seedNode = new SeedNode("test_dummy_dir");
 
         latch = new CountDownLatch(1);
-        seedNode.createAndStartP2PService(new NodeAddress("localhost", port), useLocalhost, 2, true, seedNodeAddresses, new P2PServiceListener() {
+        seedNode.createAndStartP2PService(new NodeAddress("localhost", port), MAX_CONNECTIONS, useLocalhost, 2, true, seedNodeAddresses, new P2PServiceListener() {
             @Override
             public void onRequestingDataCompleted() {
                 latch.countDown();

--- a/network/src/test/java/io/bitsquare/p2p/PeerServiceTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/PeerServiceTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CountDownLatch;
 // Run it once then lookup for onion address at: tor/hiddenservice/hostname and use that for the NodeAddress param.
 public class PeerServiceTest {
     private static final Logger log = LoggerFactory.getLogger(PeerServiceTest.class);
-    public static final int MAX_CONNECTIONS = 100;
+    private static final int MAX_CONNECTIONS = 100;
 
     final boolean useLocalhost = true;
     private CountDownLatch latch;

--- a/network/src/test/java/io/bitsquare/p2p/PeerServiceTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/PeerServiceTest.java
@@ -38,7 +38,6 @@ public class PeerServiceTest {
     public void setup() throws InterruptedException {
         LocalhostNetworkNode.setSimulateTorDelayTorNode(50);
         LocalhostNetworkNode.setSimulateTorDelayHiddenService(8);
-        PeerManager.setMaxConnections(MAX_CONNECTIONS);
 
         if (useLocalhost) {
             seedNodeAddresses.add(new NodeAddress("localhost:8001"));

--- a/network/src/test/java/io/bitsquare/p2p/TestUtils.java
+++ b/network/src/test/java/io/bitsquare/p2p/TestUtils.java
@@ -82,7 +82,7 @@ public class TestUtils {
         }
 
         CountDownLatch latch = new CountDownLatch(1);
-        seedNode.createAndStartP2PService(new NodeAddress("localhost", port), useLocalhost, 2, true,
+        seedNode.createAndStartP2PService(new NodeAddress("localhost", port), SeedNode.MAX_CONNECTIONS_DEFAULT, useLocalhost, 2, true,
                 seedNodes, new P2PServiceListener() {
                     @Override
                     public void onRequestingDataCompleted() {

--- a/network/src/test/java/io/bitsquare/p2p/routing/PeerManagerTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/routing/PeerManagerTest.java
@@ -38,7 +38,6 @@ public class PeerManagerTest {
     public void setup() throws InterruptedException {
         LocalhostNetworkNode.setSimulateTorDelayTorNode(50);
         LocalhostNetworkNode.setSimulateTorDelayHiddenService(8);
-        PeerManager.setMaxConnections(MAX_CONNECTIONS);
 
         seedNodes = new HashSet<>();
         if (useLocalhost) {

--- a/network/src/test/java/io/bitsquare/p2p/routing/PeerManagerTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/routing/PeerManagerTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 @Ignore
 public class PeerManagerTest {
     private static final Logger log = LoggerFactory.getLogger(PeerManagerTest.class);
+    public static final int MAX_CONNECTIONS = 100;
 
     final boolean useLocalhost = true;
     private CountDownLatch latch;
@@ -37,7 +38,7 @@ public class PeerManagerTest {
     public void setup() throws InterruptedException {
         LocalhostNetworkNode.setSimulateTorDelayTorNode(50);
         LocalhostNetworkNode.setSimulateTorDelayHiddenService(8);
-        PeerManager.setMaxConnections(100);
+        PeerManager.setMaxConnections(MAX_CONNECTIONS);
 
         seedNodes = new HashSet<>();
         if (useLocalhost) {
@@ -84,7 +85,7 @@ public class PeerManagerTest {
         seedNodes.add(nodeAddress);
         seedNode1 = new SeedNode("test_dummy_dir");
         latch = new CountDownLatch(2);
-        seedNode1.createAndStartP2PService(nodeAddress, useLocalhost, 2, true,
+        seedNode1.createAndStartP2PService(nodeAddress, MAX_CONNECTIONS, useLocalhost, 2, true,
                 seedNodes, new P2PServiceListener() {
                     @Override
                     public void onRequestingDataCompleted() {
@@ -136,7 +137,7 @@ public class PeerManagerTest {
         latch = new CountDownLatch(6);
 
         seedNode1 = new SeedNode("test_dummy_dir");
-        seedNode1.createAndStartP2PService(nodeAddress1, useLocalhost, 2, true, seedNodes, new P2PServiceListener() {
+        seedNode1.createAndStartP2PService(nodeAddress1, MAX_CONNECTIONS, useLocalhost, 2, true, seedNodes, new P2PServiceListener() {
             @Override
             public void onRequestingDataCompleted() {
                 latch.countDown();
@@ -174,7 +175,7 @@ public class PeerManagerTest {
         Thread.sleep(500);
 
         seedNode2 = new SeedNode("test_dummy_dir");
-        seedNode2.createAndStartP2PService(nodeAddress2, useLocalhost, 2, true, seedNodes, new P2PServiceListener() {
+        seedNode2.createAndStartP2PService(nodeAddress2, MAX_CONNECTIONS, useLocalhost, 2, true, seedNodes, new P2PServiceListener() {
             @Override
             public void onRequestingDataCompleted() {
                 latch.countDown();
@@ -411,7 +412,7 @@ public class PeerManagerTest {
         SeedNode seedNode = new SeedNode("test_dummy_dir");
 
         latch = new CountDownLatch(1);
-        seedNode.createAndStartP2PService(new NodeAddress("localhost", port), useLocalhost, 2, true, seedNodes, new P2PServiceListener() {
+        seedNode.createAndStartP2PService(new NodeAddress("localhost", port), MAX_CONNECTIONS, useLocalhost, 2, true, seedNodes, new P2PServiceListener() {
             @Override
             public void onRequestingDataCompleted() {
                 latch.countDown();

--- a/network/src/test/java/io/bitsquare/p2p/routing/PeerManagerTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/routing/PeerManagerTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CountDownLatch;
 @Ignore
 public class PeerManagerTest {
     private static final Logger log = LoggerFactory.getLogger(PeerManagerTest.class);
-    public static final int MAX_CONNECTIONS = 100;
+    private static final int MAX_CONNECTIONS = 100;
 
     final boolean useLocalhost = true;
     private CountDownLatch latch;


### PR DESCRIPTION
The `PeerManager` class sets some static limits for connections, which are shared by all instances.  This is a problem for tests where the same process can run seed nodes along normal peers, all of them being forced to use the same numbers for connections limits, which makes the test unrealistic since seed nodes use to allow many more connections than normal peers.

This PR makes connection limits configurable for each `PeerManager` instace by providing a `maxConnections` argument to its constructor.  This replaces the old mechanism that used `PeerManager.setMaxConnections()` to set global connection limits.  `SeedNode` now uses this mechanism to set its maximum connections, with `P2PService` having a second constructor which allows max connections (since such command line argument doesn't probably make sense for normal peers and thus can't be injected from CLI arguments).  Existing tests have also been updated.

I've built the whole seed node and Bitsquare apps and performed a sample transaction without problems.

Thanks!
