### PR TITLE
Demote keepalive warning to debug entry

### DIFF
--- a/network/src/main/java/io/bitsquare/p2p/peers/keepalive/KeepAliveManager.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/keepalive/KeepAliveManager.java
@@ -189,7 +189,8 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
                             handlerMap.put(uid, keepAliveHandler);
                             keepAliveHandler.sendPingAfterRandomDelay(connection);
                         } else {
-                            log.warn("Connection with id {} has not completed and is still in our map. " +
+                            // TODO check if this situation causes any issues
+                            log.debug("Connection with id {} has not completed and is still in our map. " +
                                     "We will try to ping that peer at the next schedule.", uid);
                         }
                     });


### PR DESCRIPTION
The error is pretty obscure for a normal user to see in console, and it just reflects a network condition or some delay in the communication with another node, which may be relatively frequent.

Leaving a TODO comment to check if this can cause issues.
