### PR TITLE
Network stress tests

### DIFF
--- a/network/src/main/java/io/bitsquare/p2p/P2PService.java
+++ b/network/src/main/java/io/bitsquare/p2p/P2PService.java
@@ -776,8 +776,9 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     @VisibleForTesting
+    @Nullable
     public KeyRing getKeyRing() {
-        return optionalKeyRing.get();
+        return optionalKeyRing.isPresent()? optionalKeyRing.get() : null;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/network/src/main/java/io/bitsquare/p2p/P2PService.java
+++ b/network/src/main/java/io/bitsquare/p2p/P2PService.java
@@ -775,6 +775,11 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
         return peerManager;
     }
 
+    @VisibleForTesting
+    public KeyRing getKeyRing() {
+        return optionalKeyRing.get();
+    }
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/network/src/main/java/io/bitsquare/p2p/network/Connection.java
+++ b/network/src/main/java/io/bitsquare/p2p/network/Connection.java
@@ -62,10 +62,11 @@ public class Connection implements MessageListener {
     // Static
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private static final int MAX_MSG_SIZE = 500 * 1024;              // 500 kb
+    // Leaving some constants package-private for tests to know limits.
+    static final int MAX_MSG_SIZE = 500 * 1024;              // 500 kb
     //TODO decrease limits again after testing
-    private static final int MSG_THROTTLE_PER_SEC = 70;              // With MAX_MSG_SIZE of 500kb results in bandwidth of 35 mbit/sec 
-    private static final int MSG_THROTTLE_PER_10_SEC = 500;           // With MAX_MSG_SIZE of 100kb results in bandwidth of 50 mbit/sec for 10 sec 
+    static final int MSG_THROTTLE_PER_SEC = 70;              // With MAX_MSG_SIZE of 500kb results in bandwidth of 35 mbit/sec
+    static final int MSG_THROTTLE_PER_10_SEC = 500;           // With MAX_MSG_SIZE of 100kb results in bandwidth of 50 mbit/sec for 10 sec
     private static final int SOCKET_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(60);
 
     public static int getMaxMsgSize() {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -27,13 +27,14 @@ public class NetworkStressTest {
         tempDir = createTempDirectory();
         seedNode = new SeedNode(tempDir.toString());
         final NodeAddress seedNodeAddress = new NodeAddress("localhost:8002");
+        final boolean useLocalhost = true;
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
         seedNodes.add(seedNodeAddress);  // the only seed node in tests
 
         // Use as a barrier to wait for concurrent tasks.
         final CountDownLatch latch = new CountDownLatch(1 /*seed node*/);
         // Start the seed node.
-        seedNode.createAndStartP2PService(seedNodeAddress, true /*localhost*/,
+        seedNode.createAndStartP2PService(seedNodeAddress, useLocalhost,
                 2 /*regtest*/, true /*detailed logging*/, seedNodes,
                 new P2PServiceListener() {
                     @Override

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -269,7 +269,7 @@ public class NetworkStressTest {
         final long idealMaxDirectDelay = MAX_DIRECT_DELAY_MILLIS * directCount;
         // Wait for peers to complete receiving.  We are generous here.
         assertLatch("timed out while receiving direct messages",
-                receivedDirectLatch, 2 * idealMaxDirectDelay, TimeUnit.MILLISECONDS);
+                receivedDirectLatch, 10 * idealMaxDirectDelay, TimeUnit.MILLISECONDS);
         print("receiving %d direct messages per peer took %ss", directCount,
                 (System.currentTimeMillis() - sendStartMillis)/1000.0);
         // Wait for peers to complete sending.

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +94,8 @@ public class NetworkStressTest {
                 : Request.method(NetworkStressTest.class, args[0]);
 
         Result result = new JUnitCore().run(request);
+        for (Failure f : result.getFailures())
+            System.err.printf("\n%s\n%s", f, f.getTrace());
         System.exit(result.wasSuccessful() ? 0 : 1);
     }
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -130,35 +130,27 @@ public class NetworkStressTest {
         printProgress(c, (int)latch.getCount());
     }
 
+    /** Parse an integer value from the given environment variable, with default and minimum values. */
+    private int parseEnvInt(String envVar, int defValue, int minValue) {
+        int value = defValue;
+        final String envValue = System.getenv(envVar);
+        if (envValue != null && !envValue.equals(""))
+            value = Integer.parseInt(envValue);
+        if (value < minValue)
+            throw new IllegalArgumentException(
+                    String.format("%s must be at least %d: %d", envVar, minValue, value)
+            );
+        return value;
+    }
+
     @Before
     public void setUp() throws Exception {
         // Parse test parameter environment variables.
 
         /** Number of peer nodes to create. */
-        int nPeers = NPEERS_DEFAULT;
-        final String nPeersEnv = System.getenv(NPEERS_ENVVAR);
-        if (nPeersEnv != null && !nPeersEnv.equals(""))
-            nPeers = Integer.parseInt(nPeersEnv);
-        if (nPeers < NPEERS_MIN)
-            throw new IllegalArgumentException(
-                    String.format("Test needs at least %d peer nodes to work: %d", NPEERS_MIN, nPeers)
-            );
-
-        final String nDirectEnv = System.getenv(DIRECT_COUNT_ENVVAR);
-        if (nDirectEnv != null && !nDirectEnv.equals(""))
-            directCount = Integer.parseInt(nDirectEnv);
-        if (directCount < 0)
-            throw new IllegalArgumentException(
-                    String.format("Direct messages sent per peer must not be negative: %d", directCount)
-            );
-
-        final String nMailboxEnv = System.getenv(MAILBOX_COUNT_ENVVAR);
-        if (nMailboxEnv != null && !nMailboxEnv.equals(""))
-            mailboxCount = Integer.parseInt(nMailboxEnv);
-        if (mailboxCount < 0)
-            throw new IllegalArgumentException(
-                    String.format("Mailbox messages sent per peer must not be negative: %d", mailboxCount)
-            );
+        final int nPeers = parseEnvInt(NPEERS_ENVVAR, NPEERS_DEFAULT, NPEERS_MIN);
+        directCount = parseEnvInt(DIRECT_COUNT_ENVVAR, DIRECT_COUNT_DEFAULT, 0);
+        mailboxCount = parseEnvInt(MAILBOX_COUNT_ENVVAR, MAILBOX_COUNT_DEFAULT, 0);
 
         /** A property where threads can indicate setup failure of local services (Tor node, hidden service). */
         final BooleanProperty localServicesFailed = new SimpleBooleanProperty(false);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -164,6 +164,16 @@ public class NetworkStressTest {
         }
 
         print("all local nodes started");
+
+        // Wait for peers to get their preliminary data.
+        assertLatch("timed out while waiting for preliminary data",
+                prelimDataLatch, 30, TimeUnit.SECONDS);
+        print("preliminary data received");
+
+        // Wait for peers to complete their bootstrapping.
+        assertLatch("timed out while waiting for bootstrap",
+                bootstrapLatch, 30, TimeUnit.SECONDS);
+        print("bootstrap complete");
     }
 
     @NotNull
@@ -221,15 +231,6 @@ public class NetworkStressTest {
 
     @Test
     public void test() throws InterruptedException {
-        // Wait for peers to get their preliminary data.
-        assertLatch("timed out while waiting for preliminary data",
-                prelimDataLatch, 30, TimeUnit.SECONDS);
-        print("preliminary data received");
-        // Wait for peers to complete their bootstrapping.
-        assertLatch("timed out while waiting for bootstrap",
-                bootstrapLatch, 30, TimeUnit.SECONDS);
-        print("bootstrap complete");
-
         // Test each peer sending a direct message to another random peer.
         final int nPeers = peerNodes.size();
         BooleanProperty sentDirectFailed = new SimpleBooleanProperty(false);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -140,9 +140,9 @@ public class NetworkStressTest {
         // Wait for concurrent tasks to finish.
         shutdownLatch.await();
 
-        // Cleanup directory if not given explicitly.
-        if (tempDir != null && System.getenv(TEST_DIR_ENVVAR) == null) {
-            deleteRecursively(tempDir);
+        // Cleanup temporary directory.
+        if (tempDir != null) {
+            deleteTempDirectory();
         }
     }
 
@@ -173,9 +173,11 @@ public class NetworkStressTest {
         return stressTestDirPath;
     }
 
-    private static void deleteRecursively(@NotNull final Path path) throws IOException {
+    private void deleteTempDirectory() throws IOException {
         // Based on <https://stackoverflow.com/a/27917071/6239236> by Tomasz Dzięcielewski.
-        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+        if (System.getenv(TEST_DIR_ENVVAR) != null)
+            return;  // do not remove if given explicitly
+        Files.walkFileTree(tempDir, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 Files.delete(file);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -228,6 +228,8 @@ public class NetworkStressTest {
 
     @After
     public void tearDown() throws InterruptedException, IOException {
+        print("stopping all local nodes");
+
         /** A barrier to wait for concurrent shutdown of services. */
         final CountDownLatch shutdownLatch = new CountDownLatch((seedNode != null? 1 : 0) + peerNodes.size());
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -35,6 +35,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.security.Security;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class NetworkStressTest {
@@ -136,6 +137,12 @@ public class NetworkStressTest {
         // Create the test data directory.
         testDataDir = createTestDataDirectory();
         print("test data directory: " + testDataDir);
+
+        // Setting the executor seems to make tests more stable against ``ConcurrentModificationException``
+        // (see #443).  However it make it use more open files, so you may need to use ``ulimit -n NUMBER``
+        // or run ``prlimit -nNUMBER -pPID`` (as root) on your shell's PID if you get too many open files errors.
+        // NUMBER=16384 seems to be enough for 100 peers in Debian GNU/Linux.
+        UserThread.setExecutor(Executors.newSingleThreadExecutor());
 
         // Create and start the seed node.
         seedNode = new SeedNode(testDataDir.toString());

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -55,6 +55,8 @@ public class NetworkStressTest {
 
     /** A barrier to wait for concurrent reception of preliminary data in peers. */
     private CountDownLatch prelimDataLatch = new CountDownLatch(NPEERS);
+    /** A barrier to wait for concurrent bootstrap of peers. */
+    private CountDownLatch bootstrapLatch = new CountDownLatch(NPEERS);
 
     @Before
     public void setUp() throws Exception {
@@ -146,7 +148,8 @@ public class NetworkStressTest {
 
             @Override
             public void onBootstrapComplete() {
-                // do nothing
+                // successful result
+                NetworkStressTest.this.bootstrapLatch.countDown();
             }
 
             @Override
@@ -195,6 +198,9 @@ public class NetworkStressTest {
         // Wait for peers to get their preliminary data.
         org.junit.Assert.assertTrue("timed out while waiting for preliminary data",
                 prelimDataLatch.await(30, TimeUnit.SECONDS));
+        // Wait for peers to complete their bootstrapping.
+        org.junit.Assert.assertTrue("timed out while waiting for bootstrap",
+                bootstrapLatch.await(30, TimeUnit.SECONDS));
     }
 
     private Path createTempDirectory() throws IOException {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -35,6 +35,8 @@ public class NetworkStressTest {
 
     /** Number of peer nodes to create. */
     private static final int NPEERS = 4;
+    /** Whether to log messages less important than warnings. */
+    private static final boolean USE_DETAILED_LOGGING = false;
 
     // Constants
 
@@ -77,7 +79,7 @@ public class NetworkStressTest {
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
         seedNodes.add(seedNodeAddress);  // the only seed node in tests
         seedNode.createAndStartP2PService(seedNodeAddress, useLocalhost,
-                REGTEST_NETWORK_ID, true /*detailed logging*/, seedNodes,
+                REGTEST_NETWORK_ID, USE_DETAILED_LOGGING, seedNodes,
                 new SeedServiceListener(localServicesLatch, localServicesFailed));
 
         // Create and start peer nodes.

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -304,6 +304,7 @@ public class NetworkStressTest {
             long nextSendMillis = System.currentTimeMillis();
             for (int i = 0; i < directCount; i++) {
                 // Select a random peer and send a direct message to it...
+                // TODO: Do not send the message to oneself.
                 final int dstPeerIdx = (int) (Math.random() * nPeers);
                 final P2PService dstPeer = peerNodes.get(dstPeerIdx);
                 final NodeAddress dstPeerAddress = dstPeer.getAddress();

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -200,7 +200,7 @@ public class NetworkStressTest {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 final String fileName = file.getFileName().toString();
-                if (!(keep && (fileName.equals("enc.key") || fileName.equals("sig.key"))))
+                if (!(keep && (fileName.matches("enc\\.key|sig\\.key|private_key"))))  // peer and tor keys
                     Files.delete(file);
                 return FileVisitResult.CONTINUE;
             }

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -102,15 +102,7 @@ public class NetworkStressTest {
         System.exit(result.wasSuccessful() ? 0 : 1);
     }
 
-    /** Return a string of a character repeated a number of times. */
-    private static String nChars(char c, int n) {
-        String ret = "";
-        for (int i = 0; i < n; i++)
-            ret += c;
-        return ret;
-    }
-
-    /** Print a progress bar based on the given character. */
+    /** Print a progress indicator based on the given character. */
     private void printProgress(char c, int n) {
         if (n < 1)
             return;  // nothing to represent
@@ -124,7 +116,7 @@ public class NetworkStressTest {
         System.out.flush();
     }
 
-    /** Decrease latch count and print pending as a progress bar based on the given character. */
+    /** Decrease latch count and print a progress indicator based on the given character. */
     private void countDownAndPrint(CountDownLatch latch, char c) {
         latch.countDown();
         printProgress(c, (int)latch.getCount());

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -70,8 +70,6 @@ public class NetworkStressTest {
 
     // Instance fields
 
-    /** Number of columns in terminal (for progress reporting). */
-    private int terminalColumns = 80;
     /** The last time a progress bar update was printed (to throttle message printing). */
     private long lastProgressUpdateMillis = 0;
     /** A directory to (temporarily) hold seed and normal nodes' configuration and state files. */
@@ -118,17 +116,11 @@ public class NetworkStressTest {
             return;  // nothing to represent
 
         long now = System.currentTimeMillis();
-        if ((n != 1) && ((now - lastProgressUpdateMillis) < 500))
-            return;  // throttle message printing below half a second (but last one is always printed)
+        if ((now - lastProgressUpdateMillis) < 500)
+            return;  // throttle message printing below half a second
         lastProgressUpdateMillis = now;
 
-        String hdr = String.format("\r%s> ", this.getClass().getSimpleName());
-        String msg = (hdr.length() - 1/*carriage return*/ + n + 1/*final space*/ > terminalColumns)
-                ? String.format("%c*%d", c, n)
-                : nChars(c, n);
-        System.out.print(hdr + msg + ' ');
-        if (n == 1)
-            System.out.print('\n');
+        System.out.print(String.format("\r%s> %c*%-6d ", this.getClass().getSimpleName(), c, n));
         System.out.flush();
     }
 
@@ -159,10 +151,6 @@ public class NetworkStressTest {
             throw new IllegalArgumentException(
                     String.format("Direct messages sent per peer must not be negative: %d", directCount)
             );
-
-        final String terminalColumnsEnv = System.getenv("COLUMNS");
-        if (terminalColumnsEnv != null && !terminalColumnsEnv.equals(""))
-            terminalColumns = Integer.parseInt(terminalColumnsEnv);
 
         /** A property where threads can indicate setup failure of local services (Tor node, hidden service). */
         final BooleanProperty localServicesFailed = new SimpleBooleanProperty(false);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -60,7 +60,6 @@ public class NetworkStressTest {
                     @Override
                     public void onTorNodeReady() {
                         // do nothing
-                        System.out.println("TOR NODE READY");
                     }
 
                     @Override
@@ -96,8 +95,9 @@ public class NetworkStressTest {
     }
 
     @Test
-    public void test() {
+    public void test() throws InterruptedException {
         // do nothing
+        Thread.sleep(30_000);
     }
 
     private Path createTempDirectory() throws IOException {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -53,8 +53,8 @@ public class NetworkStressTest {
 
     /** Default number of peers in the test. */
     private static final int NPEERS_DEFAULT = 4;
-    /** Minimum number of peers for the test to work. */
-    private static final int NPEERS_MIN = 2;
+    /** Minimum number of peers for the test to work (2 for direct messages, 3 for mailbox messages). */
+    private static final int NPEERS_MIN = 3;
     /** Default number of direct messages to be sent by each peer. */
     private static final int DIRECT_COUNT_DEFAULT = 100;
 
@@ -293,6 +293,20 @@ public class NetworkStressTest {
                 directCount, (System.currentTimeMillis() - sendStartMillis)/1000.0,
                 mma.first, mma.second, mma.third);
         org.junit.Assert.assertFalse("some peer(s) failed to send a direct message", sentDirectFailed.get());
+
+        // Test sending and receiving mailbox messages.
+        // We start by putting the first half of peers online and the second one offline.
+        // Then the first online peer sends a number of messages to random peers (regardless of their state),
+        // so that some messages are delivered directly and others into a mailbox.
+        // Then the first online peer is put offline and the last offline peer is put online
+        // (so it can get its mailbox messages),
+        // and the new first online node sends messages.
+        // This is repeated until all nodes have been online and offline.
+        for (int firstOnline = 0, firstOffline = (int)Math.ceil(nPeers/2.0);
+                firstOnline < nPeers;
+                firstOnline++, firstOffline = ++firstOffline%nPeers) {
+            System.out.println("firstOnline "+firstOnline+" firstOffline "+firstOffline);
+        }
     }
 
     private void print(String message, Object... args) {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -187,7 +187,7 @@ public class NetworkStressTest {
         Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(path);
+                Files.delete(file);
                 return FileVisitResult.CONTINUE;
             }
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -116,6 +116,7 @@ public class NetworkStressTest {
 
         // Create the test data directory.
         testDataDir = createTestDataDirectory();
+        print("test data directory: " + testDataDir);
 
         // Create and start the seed node.
         seedNode = new SeedNode(testDataDir.toString());
@@ -126,6 +127,7 @@ public class NetworkStressTest {
         seedNode.createAndStartP2PService(seedNodeAddress, useLocalhost,
                 REGTEST_NETWORK_ID, USE_DETAILED_LOGGING, seedNodes,
                 new SeedServiceListener(localServicesLatch, localServicesFailed));
+        print("created seed node");
 
         // Create and start peer nodes.
         SeedNodesRepository seedNodesRepository = new SeedNodesRepository();
@@ -151,6 +153,7 @@ public class NetworkStressTest {
             peerNodes.add(peer);
             peer.start(new PeerServiceListener(localServicesLatch, localServicesFailed));
         }
+        print("created peer nodes");
 
         // Wait for concurrent tasks to finish.
         localServicesLatch.await();
@@ -159,6 +162,8 @@ public class NetworkStressTest {
         if (localServicesFailed.get()) {
             throw new Exception("nodes failed to start");
         }
+
+        print("all local nodes started");
     }
 
     @NotNull
@@ -187,6 +192,7 @@ public class NetworkStressTest {
         }
         // Wait for concurrent tasks to finish.
         shutdownLatch.await();
+        print("all local nodes stopped");
 
         // Cleanup test data directory.
         if (testDataDir != null) {
@@ -199,9 +205,11 @@ public class NetworkStressTest {
         // Wait for peers to get their preliminary data.
         assertLatch("timed out while waiting for preliminary data",
                 prelimDataLatch, 30, TimeUnit.SECONDS);
+        print("preliminary data received");
         // Wait for peers to complete their bootstrapping.
         assertLatch("timed out while waiting for bootstrap",
                 bootstrapLatch, 30, TimeUnit.SECONDS);
+        print("bootstrap complete");
 
         // Test each peer sending a direct message to another random peer.
         final int nPeers = peerNodes.size();
@@ -247,6 +255,7 @@ public class NetworkStressTest {
                 );
             }
         }
+        print("%d direct messages scheduled to be sent by each of %d peers", directCount, nPeers);
         // Since receiving is completed before sending is reported to be complete,
         // all receiving checks should end before all sending checks to avoid deadlocking.
         /** Time to transmit all messages in the worst random case, and with no computation delays. */

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -72,6 +72,8 @@ public class NetworkStressTest {
 
     /** Number of columns in terminal (for progress reporting). */
     private int terminalColumns = 80;
+    /** The last time a progress bar update was printed (to throttle message printing). */
+    private long lastProgressUpdateMillis = 0;
     /** A directory to (temporarily) hold seed and normal nodes' configuration and state files. */
     private Path testDataDir;
     /** Whether to use localhost addresses instead of Tor hidden services. */
@@ -114,6 +116,10 @@ public class NetworkStressTest {
     private void countDownAndPrint(CountDownLatch latch, char c) {
         latch.countDown();
         int remaining = (int)latch.getCount();
+        long now = System.currentTimeMillis();
+        if (now - lastProgressUpdateMillis < 500)
+            return;  // throttle message printing below half a second
+        lastProgressUpdateMillis = now;
         if (remaining > 0) {
             String hdr = String.format("\r%s> ", this.getClass().getSimpleName());
             String msg = (hdr.length() - 1/*carriage return*/ + remaining + 1/*final space*/ > terminalColumns)

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -25,7 +25,7 @@ public class NetworkStressTest {
     private SeedNode seedNode;
 
     @Before
-    public void setup() throws IOException, InterruptedException {
+    public void setUp() throws IOException, InterruptedException {
         /** A barrier to wait for concurrent tasks. */
         final CountDownLatch pendingTasks = new CountDownLatch(1 /*seed node*/);
 
@@ -87,6 +87,7 @@ public class NetworkStressTest {
     public void tearDown() throws InterruptedException, IOException {
         /** A barrier to wait for concurrent tasks. */
         final CountDownLatch pendingTasks = new CountDownLatch(seedNode != null? 1 : 0);
+
         // Stop the seed node.
         if (seedNode != null) {
             seedNode.shutDown(pendingTasks::countDown);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -124,7 +124,7 @@ public class NetworkStressTest {
         final boolean useLocalhost = seedNodeAddress.hostName.equals("localhost");
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
         seedNodes.add(seedNodeAddress);  // the only seed node in tests
-        seedNode.createAndStartP2PService(seedNodeAddress, useLocalhost,
+        seedNode.createAndStartP2PService(seedNodeAddress, SeedNode.MAX_CONNECTIONS_DEFAULT, useLocalhost,
                 REGTEST_NETWORK_ID, USE_DETAILED_LOGGING, seedNodes,
                 new SeedServiceListener(localServicesLatch, localServicesFailed));
         print("created seed node");

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -451,6 +451,7 @@ public class NetworkStressTest {
         // TODO: Use meaningful timeout.
         assertLatch("timed out while receiving mailbox messages",
                 receivedMailboxLatch, 120, TimeUnit.SECONDS);
+        org.junit.Assert.assertFalse("some peer(s) failed to send a message", sentMailboxFailed.get());
     }
 
     /** Configure the peer to decrease the latch on receipt of mailbox message (direct or via mailbox). */

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -38,6 +38,17 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Bitsquare network stress tests.
+ *
+ * You can invoke this class directly from the command line.
+ * If the name of a single test is given as an argument, only that test is run.
+ * Otherwise all tests in the class are run.
+ *
+ * You can also set some {@code STRESS_TEST_*} environment variables to
+ * customize the execution of tests.
+ * See the {@code *_ENVVAR} constants for the names of these variables.
+ */
 public class NetworkStressTest {
     // Test parameters
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -270,8 +270,9 @@ public class NetworkStressTest {
         // Wait for peers to complete receiving.  We are generous here.
         assertLatch("timed out while receiving direct messages",
                 receivedDirectLatch, 10 * idealMaxDirectDelay, TimeUnit.MILLISECONDS);
-        print("receiving %d direct messages per peer took %ss", directCount,
-                (System.currentTimeMillis() - sendStartMillis)/1000.0);
+        final long recvMillis = System.currentTimeMillis() - sendStartMillis;
+        print("receiving %d direct messages per peer took %ss (%.2f x ideal max)",
+                directCount, recvMillis/1000.0, recvMillis/(float)idealMaxDirectDelay);
         // Wait for peers to complete sending.
         // This should be nearly instantaneous after waiting for reception is completed.
         assertLatch("timed out while sending direct messages",

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -218,12 +218,12 @@ public class NetworkStressTest {
 
         // Wait for peers to get their preliminary data.
         assertLatch("timed out while waiting for preliminary data",
-                prelimDataLatch, 2 * nPeers, TimeUnit.SECONDS);
+                prelimDataLatch, 5 * nPeers, TimeUnit.SECONDS);
         print("preliminary data received");
 
         // Wait for peers to complete their bootstrapping.
         assertLatch("timed out while waiting for bootstrap",
-                bootstrapLatch, 2 * nPeers, TimeUnit.SECONDS);
+                bootstrapLatch, 5 * nPeers, TimeUnit.SECONDS);
         print("bootstrap complete");
     }
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -90,7 +90,7 @@ public class NetworkStressTest {
         }
         for (int p = 0; p < NPEERS; p++) {
             final int peerPort = Utils.findFreeSystemPort();
-            final File peerDir = new File(tempDir.toFile(), "Bitsquare_peer_" + peerPort);
+            final File peerDir = new File(tempDir.toFile(), String.format("peer-%06d", p));
             final File peerTorDir = new File(peerDir, "tor");
             final File peerStorageDir = new File(peerDir, "db");
             final File peerKeysDir = new File(peerDir, "keys");

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -310,7 +310,7 @@ public class NetworkStressTest {
         final long idealMaxDirectDelay = MAX_DIRECT_DELAY_MILLIS * directCount;
         // Wait for peers to complete receiving.  We are generous here.
         assertLatch("timed out while receiving direct messages",
-                receivedDirectLatch, 10 * idealMaxDirectDelay, TimeUnit.MILLISECONDS);
+                receivedDirectLatch, 25 * idealMaxDirectDelay, TimeUnit.MILLISECONDS);
         final long recvMillis = System.currentTimeMillis() - sendStartMillis;
         print("receiving %d direct messages per peer took %ss (%.2f x ideal max)",
                 directCount, recvMillis / 1000.0, recvMillis / (float) idealMaxDirectDelay);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -469,7 +469,7 @@ public class NetworkStressTest {
                     return;
                 StressTestMailboxMessage msg = (StressTestMailboxMessage) (decryptedMsgWithPubKey.message);
                 if ((msg.getData().equals("test/" + peer.getAddress())))
-                    receivedMailboxLatch.countDown();
+                    countDownAndPrint(receivedMailboxLatch, 'm');
             }
 
             @Override

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -309,13 +309,13 @@ public class NetworkStressTest {
                                         @Override
                                         public void onArrived() {
                                             sentDelays.add(System.currentTimeMillis() - sendMillis);
-                                            sentDirectLatch.countDown();
+                                            countDownAndPrint(sentDirectLatch, 'd');
                                         }
 
                                         @Override
                                         public void onFault() {
                                             sentDirectFailed.set(true);
-                                            sentDirectLatch.countDown();
+                                            countDownAndPrint(sentDirectLatch, 'd');
                                         }
                                     });
                         }, sendAfterMillis, TimeUnit.MILLISECONDS

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -69,8 +69,12 @@ public class NetworkStressTest {
     private Path testDataDir;
     /** A single seed node that other nodes will contact to request initial data. */
     private SeedNode seedNode;
+    /** The repository of seed nodes used in the test. */
+    private SeedNodesRepository seedNodesRepository = new SeedNodesRepository();
     /** A list of peer nodes represented as P2P services. */
     private List<P2PService> peerNodes = new ArrayList<>();
+    /** A list of peer node's service ports. */
+    private List<Integer> peerPorts = new ArrayList<>();
     /** A list of peer node's public key rings. */
     private List<PubKeyRing> peerPKRings = new ArrayList<>();
 
@@ -131,7 +135,6 @@ public class NetworkStressTest {
         print("created seed node");
 
         // Create and start peer nodes, all connecting to the seed node above.
-        SeedNodesRepository seedNodesRepository = new SeedNodesRepository();
         if (useLocalhost) {
             seedNodesRepository.setLocalhostSeedNodeAddresses(seedNodes);
         } else {
@@ -140,8 +143,10 @@ public class NetworkStressTest {
         for (int p = 0; p < nPeers; p++) {
             // peer network port
             final int peerPort = Utils.findFreeSystemPort();
+            peerPorts.add(peerPort);
             // create, save and start peer
-            final P2PService peer = createPeerNode(p, peerPort, useLocalhost, seedNodesRepository);
+            final P2PService peer = createPeerNode(p, peerPort, useLocalhost);
+            //noinspection ConstantConditions
             peerPKRings.add(peer.getKeyRing().getPubKeyRing());
             peerNodes.add(peer);
             peer.start(new PeerServiceListener(localServicesLatch, localServicesFailed));
@@ -171,7 +176,7 @@ public class NetworkStressTest {
     }
 
     @NotNull
-    private P2PService createPeerNode(int n, int port, boolean useLocalhost, SeedNodesRepository seedNodesRepository) {
+    private P2PService createPeerNode(int n, int port, boolean useLocalhost) {
         // peer data directories
         final File peerDir = new File(testDataDir.toFile(), String.format("peer-%06d", n));
         final File peerTorDir = new File(peerDir, "tor");

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -186,7 +186,7 @@ public class NetworkStressTest {
         final CountDownLatch receivedDirectLatch = new CountDownLatch(nPeers);
         final Instant sendStart = Instant.now();
         for (final P2PService srcPeer : peerNodes) {
-            // Make peer ready for receiving direct messages.
+            // Make the peer ready for receiving direct messages.
             srcPeer.addDecryptedDirectMessageListener((decryptedMsgWithPubKey, peerNodeAddress) -> {
                 if (!(decryptedMsgWithPubKey.message instanceof StressTestDirectMessage))
                     return;
@@ -218,12 +218,12 @@ public class NetworkStressTest {
         // Wait for peers to complete receiving.
         org.junit.Assert.assertTrue("timed out while receiving direct messages",
                 receivedDirectLatch.await(30, TimeUnit.SECONDS));
-        print("receiving 1 direct message per node took %ss",
+        print("receiving 1 direct message per peer took %ss",
                 Duration.between(sendStart, Instant.now()).toMillis()/1000.0);
         // Wait for peers to complete sending.
         org.junit.Assert.assertTrue("timed out while sending direct messages",
                 sentDirectLatch.await(30, TimeUnit.SECONDS));
-        print("sending 1 direct message per node took %ss",
+        print("sending 1 direct message per peer took %ss",
                 Duration.between(sendStart, Instant.now()).toMillis()/1000.0);
         org.junit.Assert.assertFalse("some peer(s) failed to send a direct message", sentDirectFailed.get());
     }

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -197,11 +197,11 @@ public class NetworkStressTest {
     @Test
     public void test() throws InterruptedException {
         // Wait for peers to get their preliminary data.
-        org.junit.Assert.assertTrue("timed out while waiting for preliminary data",
-                prelimDataLatch.await(30, TimeUnit.SECONDS));
+        assertLatch("timed out while waiting for preliminary data",
+                prelimDataLatch, 30, TimeUnit.SECONDS);
         // Wait for peers to complete their bootstrapping.
-        org.junit.Assert.assertTrue("timed out while waiting for bootstrap",
-                bootstrapLatch.await(30, TimeUnit.SECONDS));
+        assertLatch("timed out while waiting for bootstrap",
+                bootstrapLatch, 30, TimeUnit.SECONDS);
 
         // Test each peer sending a direct message to another random peer.
         final int nPeers = peerNodes.size();
@@ -252,14 +252,14 @@ public class NetworkStressTest {
         /** Time to transmit all messages in the worst random case, and with no computation delays. */
         final long idealMaxDirectDelay = MAX_DIRECT_DELAY_MILLIS * directCount;
         // Wait for peers to complete receiving.  We are generous here.
-        org.junit.Assert.assertTrue("timed out while receiving direct messages",
-                receivedDirectLatch.await(2 * idealMaxDirectDelay, TimeUnit.MILLISECONDS));
+        assertLatch("timed out while receiving direct messages",
+                receivedDirectLatch, 2 * idealMaxDirectDelay, TimeUnit.MILLISECONDS);
         print("receiving %d direct messages per peer took %ss", directCount,
                 (System.currentTimeMillis() - sendStartMillis)/1000.0);
         // Wait for peers to complete sending.
         // This should be nearly instantaneous after waiting for reception is completed.
-        org.junit.Assert.assertTrue("timed out while sending direct messages",
-                sentDirectLatch.await(idealMaxDirectDelay / 10, TimeUnit.MILLISECONDS));
+        assertLatch("timed out while sending direct messages",
+                sentDirectLatch, idealMaxDirectDelay / 10, TimeUnit.MILLISECONDS);
         print("sending %d direct messages per peer took %ss", directCount,
                 (System.currentTimeMillis() - sendStartMillis)/1000.0);
         org.junit.Assert.assertFalse("some peer(s) failed to send a direct message", sentDirectFailed.get());
@@ -268,6 +268,12 @@ public class NetworkStressTest {
     private void print(String message, Object... args) {
         System.out.println(this.getClass().getSimpleName() + ": "
             + String.format(message, args));
+    }
+
+    private static void assertLatch(String message, CountDownLatch latch, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        if (!latch.await(timeout, unit))
+            org.junit.Assert.fail(String.format("%s (%d pending in latch)", message, latch.getCount()));
     }
 
     private Path createTestDataDirectory() throws IOException {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -45,8 +45,8 @@ public class NetworkStressTest {
 
     // Instance fields
 
-    /** A directory to temporarily hold seed and normal nodes' configuration and state files. */
-    private Path tempDir;
+    /** A directory to (temporarily) hold seed and normal nodes' configuration and state files. */
+    private Path testDataDir;
     /** A single seed node that other nodes will contact to request initial data. */
     private SeedNode seedNode;
     /** A list of peer nodes represented as P2P services. */
@@ -67,11 +67,11 @@ public class NetworkStressTest {
         // Set a security provider to allow key generation.
         Security.addProvider(new BouncyCastleProvider());
 
-        // Create the temporary directory.
-        tempDir = createTempDirectory();
+        // Create the test data directory.
+        testDataDir = createTestDataDirectory();
 
         // Create and start the seed node.
-        seedNode = new SeedNode(tempDir.toString());
+        seedNode = new SeedNode(testDataDir.toString());
         final NodeAddress seedNodeAddress = getSeedNodeAddress();
         final boolean useLocalhost = seedNodeAddress.hostName.equals("localhost");
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
@@ -89,7 +89,7 @@ public class NetworkStressTest {
         }
         for (int p = 0; p < NPEERS; p++) {
             final int peerPort = Utils.findFreeSystemPort();
-            final File peerDir = new File(tempDir.toFile(), String.format("peer-%06d", p));
+            final File peerDir = new File(testDataDir.toFile(), String.format("peer-%06d", p));
             final File peerTorDir = new File(peerDir, "tor");
             final File peerStorageDir = new File(peerDir, "db");
             final File peerKeysDir = new File(peerDir, "keys");
@@ -140,9 +140,9 @@ public class NetworkStressTest {
         // Wait for concurrent tasks to finish.
         shutdownLatch.await();
 
-        // Cleanup temporary directory.
-        if (tempDir != null) {
-            deleteTempDirectory();
+        // Cleanup test data directory.
+        if (testDataDir != null) {
+            deleteTestDataDirectory();
         }
     }
 
@@ -156,7 +156,7 @@ public class NetworkStressTest {
                 bootstrapLatch.await(30, TimeUnit.SECONDS));
     }
 
-    private Path createTempDirectory() throws IOException {
+    private Path createTestDataDirectory() throws IOException {
         Path stressTestDirPath;
 
         String stressTestDir = System.getenv(TEST_DIR_ENVVAR);
@@ -173,11 +173,11 @@ public class NetworkStressTest {
         return stressTestDirPath;
     }
 
-    private void deleteTempDirectory() throws IOException {
+    private void deleteTestDataDirectory() throws IOException {
         // Based on <https://stackoverflow.com/a/27917071/6239236> by Tomasz Dzięcielewski.
         if (System.getenv(TEST_DIR_ENVVAR) != null)
             return;  // do not remove if given explicitly
-        Files.walkFileTree(tempDir, new SimpleFileVisitor<Path>() {
+        Files.walkFileTree(testDataDir, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 Files.delete(file);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -114,7 +114,13 @@ public class NetworkStressTest {
 
     @NotNull
     private static NodeAddress getSeedNodeAddress() {
-        return new NodeAddress("localhost", Utils.findFreeSystemPort());
+        // The address is only considered by ``SeedNodesRepository`` if
+        // it ends in the digit matching the network identifier.
+        int port;
+        do {
+            port = Utils.findFreeSystemPort();
+        } while (port % 10 != REGTEST_NETWORK_ID);
+        return new NodeAddress("localhost", port);
     }
 
     @NotNull

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -1,7 +1,5 @@
 package io.bitsquare.p2p.network;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.bitsquare.common.UserThread;
 import io.bitsquare.p2p.NodeAddress;
 import io.bitsquare.p2p.P2PServiceListener;
 import io.bitsquare.p2p.seed.SeedNode;
@@ -19,9 +17,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 public class NetworkStressTest {
     private Path tempDir;

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -42,6 +42,8 @@ public class NetworkStressTest {
     private static final int REGTEST_NETWORK_ID = 2;
     /** Default number of peers in the test. */
     private static final int NPEERS_DEFAULT = 4;
+    /** Minimum number of peers for the test to work. */
+    private static final int NPEERS_MIN = 2;
     /** Environment variable to specify the number of peers in the test. */
     private static final String NPEERS_ENVVAR = "STRESS_TEST_NPEERS";
     /** Environment variable to specify a persistent test data directory. */
@@ -69,6 +71,9 @@ public class NetworkStressTest {
         final String nPeersEnv = System.getenv(NPEERS_ENVVAR);
         if (nPeersEnv != null && !nPeersEnv.equals(""))
             nPeers = Integer.parseInt(nPeersEnv);
+        if (nPeers < NPEERS_MIN)
+            throw new IllegalArgumentException(
+                    String.format("Test needs at least %d peer nodes to work: %d", NPEERS_MIN, nPeers));
         prelimDataLatch = new CountDownLatch(nPeers);
         bootstrapLatch = new CountDownLatch(nPeers);
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -16,7 +16,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
@@ -26,65 +29,55 @@ public class NetworkStressTest {
 
     @Before
     public void setup() throws IOException, InterruptedException {
-        // Use an executor that uses a single daemon thread.
-        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat(this.getClass().getSimpleName())
-                .setDaemon(true)
-                .build();
-        UserThread.setExecutor(Executors.newSingleThreadExecutor(threadFactory));
-
         tempDir = createTempDirectory();
         seedNode = new SeedNode(tempDir.toString());
+        final NodeAddress seedNodeAddress = new NodeAddress("localhost:8002");
+        final Set<NodeAddress> seedNodes = new HashSet<>(1);
+        seedNodes.add(seedNodeAddress);  // the only seed node in tests
 
         // Use as a barrier to wait for concurrent tasks.
         final CountDownLatch latch = new CountDownLatch(1 /*seed node*/);
         // Start the seed node.
-        final NodeAddress seedNodeAddress = new NodeAddress("localhost:8002");
-        UserThread.execute(() -> {
-            try {
-                seedNode.createAndStartP2PService(seedNodeAddress, true /*localhost*/,
-                        2 /*regtest*/, false /*detailed logging*/, null /*seed nodes*/,
-                        new P2PServiceListener() {
-                            @Override
-                            public void onRequestingDataCompleted() {
-                                // do nothing
-                            }
+        seedNode.createAndStartP2PService(seedNodeAddress, true /*localhost*/,
+                2 /*regtest*/, true /*detailed logging*/, seedNodes,
+                new P2PServiceListener() {
+                    @Override
+                    public void onRequestingDataCompleted() {
+                        // do nothing
+                    }
 
-                            @Override
-                            public void onNoSeedNodeAvailable() {
-                                // expected, do nothing
-                            }
+                    @Override
+                    public void onNoSeedNodeAvailable() {
+                        // expected, do nothing
+                    }
 
-                            @Override
-                            public void onNoPeersAvailable() {
-                                // expected, do nothing
-                            }
+                    @Override
+                    public void onNoPeersAvailable() {
+                        // expected, do nothing
+                    }
 
-                            @Override
-                            public void onBootstrapComplete() {
-                                latch.countDown();  // one less task to wait on
-                            }
+                    @Override
+                    public void onBootstrapComplete() {
+                        // do nothing
+                    }
 
-                            @Override
-                            public void onTorNodeReady() {
-                                // do nothing
-                            }
+                    @Override
+                    public void onTorNodeReady() {
+                        // do nothing
+                        System.out.println("TOR NODE READY");
+                    }
 
-                            @Override
-                            public void onHiddenServicePublished() {
-                                // do nothing
-                            }
+                    @Override
+                    public void onHiddenServicePublished() {
+                        latch.countDown();  // one less task to wait on
+                    }
 
-                            @Override
-                            public void onSetupFailed(Throwable throwable) {
-                                //XXXX
-                            }
-                        });
-            } catch (Throwable t) {
-                //log.error("Executing task failed. " + t.getMessage());
-                t.printStackTrace();
-            }
-        });
+                    @Override
+                    public void onSetupFailed(Throwable throwable) {
+                        //XXXX
+                    }
+                }
+        );
 
         // Wait for concurrent tasks to finish.
         latch.await();
@@ -96,7 +89,7 @@ public class NetworkStressTest {
         final CountDownLatch latch = new CountDownLatch(1 /*seed node*/);
         // Stop the seed node.
         if (seedNode != null) {
-            seedNode.shutDown(() -> {latch.countDown();});
+            seedNode.shutDown(latch::countDown);
         }
         // Wait for concurrent tasks to finish.
         latch.await();

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -309,6 +309,52 @@ public class NetworkStressTest {
         // (so it can get its mailbox messages),
         // and the new first online node sends messages.
         // This is repeated until all nodes have been online and offline.
+        final CountDownLatch shutDownLatch = new CountDownLatch(1);
+        P2PService peer = peerNodes.get(0);
+        peer.shutDown(shutDownLatch::countDown);
+        shutDownLatch.await();
+
+        peer = createPeerNode(0, peerPorts.get(0));
+        peerNodes.set(0, peer);
+        final CountDownLatch bootLatch = new CountDownLatch(1);
+        peer.start(new P2PServiceListener() {
+            @Override
+            public void onRequestingDataCompleted() {
+
+            }
+
+            @Override
+            public void onNoSeedNodeAvailable() {
+
+            }
+
+            @Override
+            public void onNoPeersAvailable() {
+
+            }
+
+            @Override
+            public void onBootstrapComplete() {
+                bootLatch.countDown();
+            }
+
+            @Override
+            public void onTorNodeReady() {
+
+            }
+
+            @Override
+            public void onHiddenServicePublished() {
+
+            }
+
+            @Override
+            public void onSetupFailed(Throwable throwable) {
+
+            }
+        });
+        bootLatch.await();
+
         for (int firstOnline = 0, firstOffline = (int)Math.ceil(nPeers/2.0);
                 firstOnline < nPeers;
                 firstOnline++, firstOffline = ++firstOffline%nPeers) {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -246,11 +246,10 @@ public class NetworkStressTest {
 
     @After
     public void tearDown() throws InterruptedException, IOException {
-        print("stopping all local nodes");
-
         /** A barrier to wait for concurrent shutdown of services. */
         final CountDownLatch shutdownLatch = new CountDownLatch((seedNode != null? 1 : 0) + peerNodes.size());
 
+        print("stopping all local nodes");
         // Stop peer nodes.
         for (P2PService peer : peerNodes) {
             peer.shutDown(() -> countDownAndPrint(shutdownLatch, '.'));
@@ -264,6 +263,7 @@ public class NetworkStressTest {
         print("all local nodes stopped");
 
         // Cleanup test data directory.
+        print("cleaning up test data directory");
         if (testDataDir != null) {
             deleteTestDataDirectory();
         }

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -233,13 +233,13 @@ public class NetworkStressTest {
         /** A barrier to wait for concurrent shutdown of services. */
         final CountDownLatch shutdownLatch = new CountDownLatch((seedNode != null? 1 : 0) + peerNodes.size());
 
-        // Stop the seed node.
-        if (seedNode != null) {
-            seedNode.shutDown(shutdownLatch::countDown);
-        }
         // Stop peer nodes.
         for (P2PService peer : peerNodes) {
             peer.shutDown(shutdownLatch::countDown);
+        }
+        // Stop the seed node.
+        if (seedNode != null) {
+            seedNode.shutDown(shutdownLatch::countDown);
         }
         // Wait for concurrent tasks to finish.
         shutdownLatch.await();

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.Security;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -193,7 +191,7 @@ public class NetworkStressTest {
         BooleanProperty sentDirectFailed = new SimpleBooleanProperty(false);
         final CountDownLatch sentDirectLatch = new CountDownLatch(DIRECT_COUNT * nPeers);
         final CountDownLatch receivedDirectLatch = new CountDownLatch(DIRECT_COUNT * nPeers);
-        final Instant sendStart = Instant.now();
+        final long sendStartMillis = System.currentTimeMillis();
         for (final P2PService srcPeer : peerNodes) {
             // Make the peer ready for receiving direct messages.
             srcPeer.addDecryptedDirectMessageListener((decryptedMsgWithPubKey, peerNodeAddress) -> {
@@ -240,13 +238,13 @@ public class NetworkStressTest {
         org.junit.Assert.assertTrue("timed out while receiving direct messages",
                 receivedDirectLatch.await(2 * idealMaxDirectDelay, TimeUnit.MILLISECONDS));
         print("receiving %d direct messages per peer took %ss", DIRECT_COUNT,
-                Duration.between(sendStart, Instant.now()).toMillis()/1000.0);
+                (System.currentTimeMillis() - sendStartMillis)/1000.0);
         // Wait for peers to complete sending.
         // This should be nearly instantaneous after waiting for reception is completed.
         org.junit.Assert.assertTrue("timed out while sending direct messages",
                 sentDirectLatch.await(idealMaxDirectDelay / 10, TimeUnit.MILLISECONDS));
         print("sending %d direct messages per peer took %ss", DIRECT_COUNT,
-                Duration.between(sendStart, Instant.now()).toMillis()/1000.0);
+                (System.currentTimeMillis() - sendStartMillis)/1000.0);
         org.junit.Assert.assertFalse("some peer(s) failed to send a direct message", sentDirectFailed.get());
     }
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -1,5 +1,10 @@
 package io.bitsquare.p2p.network;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.bitsquare.common.UserThread;
+import io.bitsquare.p2p.NodeAddress;
+import io.bitsquare.p2p.P2PServiceListener;
+import io.bitsquare.p2p.seed.SeedNode;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
@@ -11,17 +16,91 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 public class NetworkStressTest {
     private Path tempDir;
+    private SeedNode seedNode;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws IOException, InterruptedException {
+        // Use an executor that uses a single daemon thread.
+        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat(this.getClass().getSimpleName())
+                .setDaemon(true)
+                .build();
+        UserThread.setExecutor(Executors.newSingleThreadExecutor(threadFactory));
+
         tempDir = createTempDirectory();
+        seedNode = new SeedNode(tempDir.toString());
+
+        // Use as a barrier to wait for concurrent tasks.
+        final CountDownLatch latch = new CountDownLatch(1 /*seed node*/);
+        // Start the seed node.
+        final NodeAddress seedNodeAddress = new NodeAddress("localhost:8002");
+        UserThread.execute(() -> {
+            try {
+                seedNode.createAndStartP2PService(seedNodeAddress, true /*localhost*/,
+                        2 /*regtest*/, false /*detailed logging*/, null /*seed nodes*/,
+                        new P2PServiceListener() {
+                            @Override
+                            public void onRequestingDataCompleted() {
+                                // do nothing
+                            }
+
+                            @Override
+                            public void onNoSeedNodeAvailable() {
+                                // expected, do nothing
+                            }
+
+                            @Override
+                            public void onNoPeersAvailable() {
+                                // expected, do nothing
+                            }
+
+                            @Override
+                            public void onBootstrapComplete() {
+                                latch.countDown();  // one less task to wait on
+                            }
+
+                            @Override
+                            public void onTorNodeReady() {
+                                // do nothing
+                            }
+
+                            @Override
+                            public void onHiddenServicePublished() {
+                                // do nothing
+                            }
+
+                            @Override
+                            public void onSetupFailed(Throwable throwable) {
+                                //XXXX
+                            }
+                        });
+            } catch (Throwable t) {
+                //log.error("Executing task failed. " + t.getMessage());
+                t.printStackTrace();
+            }
+        });
+
+        // Wait for concurrent tasks to finish.
+        latch.await();
     }
 
     @After
-    public void tearDown() throws IOException {
+    public void tearDown() throws InterruptedException, IOException {
+        // Use as a barrier to wait for concurrent tasks.
+        final CountDownLatch latch = new CountDownLatch(1 /*seed node*/);
+        // Stop the seed node.
+        if (seedNode != null) {
+            seedNode.shutDown(() -> {latch.countDown();});
+        }
+        // Wait for concurrent tasks to finish.
+        latch.await();
+
         if (tempDir != null) {
             deleteRecursively(tempDir);
         }

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -189,7 +189,7 @@ public class NetworkStressTest {
         final P2PService srcPeer = peerNodes.get(srcPeerIdx);
         final P2PService dstPeer = peerNodes.get(dstPeerIdx);
         srcPeer.sendEncryptedDirectMessage(dstPeer.getAddress(), peerPKRings.get(dstPeerIdx),
-                new StressTestDirectMessage("test-" + dstPeerIdx), new SendDirectMessageListener() {
+                new StressTestDirectMessage("test/" + dstPeer.getAddress()), new SendDirectMessageListener() {
                     @Override
                     public void onArrived() {
                         sentDirectLatch.countDown();

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -129,7 +129,7 @@ public class NetworkStressTest {
                 new SeedServiceListener(localServicesLatch, localServicesFailed));
         print("created seed node");
 
-        // Create and start peer nodes.
+        // Create and start peer nodes, all connecting to the seed node above.
         SeedNodesRepository seedNodesRepository = new SeedNodesRepository();
         if (useLocalhost) {
             seedNodesRepository.setLocalhostSeedNodeAddresses(seedNodes);
@@ -137,17 +137,24 @@ public class NetworkStressTest {
             seedNodesRepository.setTorSeedNodeAddresses(seedNodes);
         }
         for (int p = 0; p < nPeers; p++) {
+            // peer network port
             final int peerPort = Utils.findFreeSystemPort();
+
+            // peer data directories
             final File peerDir = new File(testDataDir.toFile(), String.format("peer-%06d", p));
             final File peerTorDir = new File(peerDir, "tor");
             final File peerStorageDir = new File(peerDir, "db");
             final File peerKeysDir = new File(peerDir, "keys");
             //noinspection ResultOfMethodCallIgnored
             peerKeysDir.mkdirs();  // needed for creating the key ring
+
+            // peer keys
             final KeyStorage peerKeyStorage = new KeyStorage(peerKeysDir);
             final KeyRing peerKeyRing = new KeyRing(peerKeyStorage);
             peerPKRings.add(peerKeyRing.getPubKeyRing());
             final EncryptionService peerEncryptionService = new EncryptionService(peerKeyRing);
+
+            // create, save and start peer
             final P2PService peer = new P2PService(seedNodesRepository, peerPort, peerTorDir, useLocalhost,
                     REGTEST_NETWORK_ID, peerStorageDir, new Clock(), peerEncryptionService, peerKeyRing);
             peerNodes.add(peer);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -34,10 +34,17 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class NetworkStressTest {
-    /** Numeric identifier of the regtest Bitcoin network. */
-    private static final int REGTEST_NETWORK_ID = 2;
+    // Test parameters
+
     /** Number of peer nodes to create. */
     private static final int NPEERS = 1;
+
+    // Constants
+
+    /** Numeric identifier of the regtest Bitcoin network. */
+    private static final int REGTEST_NETWORK_ID = 2;
+
+    // Instance fields
 
     /** A directory to temporarily hold seed and normal nodes' configuration and state files. */
     private Path tempDir;

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -125,7 +125,7 @@ public class NetworkStressTest {
 
         // Create and start the seed node.
         seedNode = new SeedNode(testDataDir.toString());
-        final NodeAddress seedNodeAddress = getSeedNodeAddress();
+        final NodeAddress seedNodeAddress = newSeedNodeAddress();
         final boolean useLocalhost = seedNodeAddress.hostName.equals("localhost");
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
         seedNodes.add(seedNodeAddress);  // the only seed node in tests
@@ -165,7 +165,7 @@ public class NetworkStressTest {
     }
 
     @NotNull
-    private static NodeAddress getSeedNodeAddress() {
+    private static NodeAddress newSeedNodeAddress() {
         // The address is only considered by ``SeedNodesRepository`` if
         // it ends in the digit matching the network identifier.
         int port;

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -392,7 +392,8 @@ public class NetworkStressTest {
             // When done, put first online peer offline.
             final CountDownLatch stopLatch = new CountDownLatch(1);
             peerNodes.get(firstOnline).shutDown(stopLatch::countDown);
-            stopLatch.await(10, TimeUnit.SECONDS);
+            assertLatch("timed out while stopping peer " + firstOnline,
+                    stopLatch, 10, TimeUnit.SECONDS);
             print("put peer %d offline", firstOnline);
 
             // When done, put first offline peer online.
@@ -401,10 +402,11 @@ public class NetworkStressTest {
             // TODO: Setup message listeners.
             peerNodes.set(firstOffline, startedPeer);
             startedPeer.start(new MailboxStartListener(startLatch));
-            startLatch.await(10, TimeUnit.SECONDS);
+            assertLatch("timed out while starting peer " + firstOffline,
+                    startLatch, 10, TimeUnit.SECONDS);
             print("put peer %d online", firstOffline);
         }
-        // TODO: Wait for nodes to receive messages, use meaningful timeout.
+        // TODO: Use meaningful timeout.
         assertLatch("timed out while receiving mailbox messages",
                 receivedMailboxLatch, 120, TimeUnit.SECONDS);
     }

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -105,13 +105,15 @@ public class NetworkStressTest {
     /** Print a progress indicator based on the given character. */
     private void printProgress(char c, int n) {
         if (n < 1)
-            return;  // nothing to represent
+            return;  // completed tasks are not shown
 
+        // Do not print the indicator if the last one was shown less than half second ago.
         long now = System.currentTimeMillis();
         if ((now - lastProgressUpdateMillis) < 500)
-            return;  // throttle message printing below half a second
+            return;
         lastProgressUpdateMillis = now;
 
+        // Keep a fixed length so that indicators do not overwrite partially.
         System.out.print(String.format("\r%s> %c*%-6d ", this.getClass().getSimpleName(), c, n));
         System.out.flush();
     }

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -114,17 +114,19 @@ public class NetworkStressTest {
 
     /** Print a progress bar based on the given character. */
     private void printProgress(char c, int n) {
+        if (n < 1)
+            return;  // nothing to represent
+
         long now = System.currentTimeMillis();
-        if (now - lastProgressUpdateMillis < 500)
-            return;  // throttle message printing below half a second
+        if ((n != 1) && ((now - lastProgressUpdateMillis) < 500))
+            return;  // throttle message printing below half a second (but last one is always printed)
         lastProgressUpdateMillis = now;
-        if (n > 0) {
-            String hdr = String.format("\r%s> ", this.getClass().getSimpleName());
-            String msg = (hdr.length() - 1/*carriage return*/ + n + 1/*final space*/ > terminalColumns)
-                    ? String.format("%c*%d", c, n)
-                    : nChars(c, n);
-            System.out.print(hdr + msg + ' ');
-        }
+
+        String hdr = String.format("\r%s> ", this.getClass().getSimpleName());
+        String msg = (hdr.length() - 1/*carriage return*/ + n + 1/*final space*/ > terminalColumns)
+                ? String.format("%c*%d", c, n)
+                : nChars(c, n);
+        System.out.print(hdr + msg + ' ');
         if (n == 1)
             System.out.print('\n');
         System.out.flush();

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -198,9 +198,10 @@ public class NetworkStressTest {
             // Select a random peer and send a direct message to it.
             final int dstPeerIdx = (int) (Math.random() * nPeers);
             final P2PService dstPeer = peerNodes.get(dstPeerIdx);
+            final NodeAddress dstPeerAddress = dstPeer.getAddress();
             //print("sending direct message from peer %s to %s", srcPeer.getAddress(), dstPeer.getAddress());
-            srcPeer.sendEncryptedDirectMessage(dstPeer.getAddress(), peerPKRings.get(dstPeerIdx),
-                    new StressTestDirectMessage("test/" + dstPeer.getAddress()), new SendDirectMessageListener() {
+            srcPeer.sendEncryptedDirectMessage(dstPeerAddress, peerPKRings.get(dstPeerIdx),
+                    new StressTestDirectMessage("test/" + dstPeerAddress), new SendDirectMessageListener() {
                         @Override
                         public void onArrived() {
                             sentDirectLatch.countDown();

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -112,24 +112,28 @@ public class NetworkStressTest {
         return ret;
     }
 
-    /** Decrease latch count and print pending as a progress bar based on the given character. */
-    private void countDownAndPrint(CountDownLatch latch, char c) {
-        latch.countDown();
-        int remaining = (int)latch.getCount();
+    /** Print a progress bar based on the given character. */
+    private void printProgress(char c, int n) {
         long now = System.currentTimeMillis();
         if (now - lastProgressUpdateMillis < 500)
             return;  // throttle message printing below half a second
         lastProgressUpdateMillis = now;
-        if (remaining > 0) {
+        if (n > 0) {
             String hdr = String.format("\r%s> ", this.getClass().getSimpleName());
-            String msg = (hdr.length() - 1/*carriage return*/ + remaining + 1/*final space*/ > terminalColumns)
-                    ? String.format("%c*%d", c, remaining)
-                    : nChars(c, remaining);
+            String msg = (hdr.length() - 1/*carriage return*/ + n + 1/*final space*/ > terminalColumns)
+                    ? String.format("%c*%d", c, n)
+                    : nChars(c, n);
             System.out.print(hdr + msg + ' ');
         }
-        if (remaining == 1)
+        if (n == 1)
             System.out.print('\n');
         System.out.flush();
+    }
+
+    /** Decrease latch count and print pending as a progress bar based on the given character. */
+    private void countDownAndPrint(CountDownLatch latch, char c) {
+        latch.countDown();
+        printProgress(c, (int)latch.getCount());
     }
 
     @Before

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -391,7 +391,7 @@ public class NetworkStressTest {
         }
         assertLatch("timed out while stopping a half of the peers",
                 halfShutDown, 10, TimeUnit.SECONDS);
-        print("stopped a half of the peers for mailbox test");
+        //print("stopped a half of the peers for mailbox test");
 
         // Cycle through peers sending to others, stopping the peer
         // and starting one of the stopped peers.
@@ -443,7 +443,7 @@ public class NetworkStressTest {
             onlinePeer.shutDown(stopLatch::countDown);
             assertLatch("timed out while stopping peer " + firstOnline,
                     stopLatch, 10, TimeUnit.SECONDS);
-            print("put peer %d offline", firstOnline);
+            //print("put peer %d offline", firstOnline);
 
             // When done, put first offline peer online and setup message listeners.
             final CountDownLatch startLatch = new CountDownLatch(1);
@@ -453,7 +453,7 @@ public class NetworkStressTest {
             startedPeer.start(new MailboxStartListener(startLatch));
             assertLatch("timed out while starting peer " + firstOffline,
                     startLatch, 10, TimeUnit.SECONDS);
-            print("put peer %d online", firstOffline);
+            //print("put peer %d online", firstOffline);
         }
         // TODO: Use meaningful timeout.
         assertLatch("timed out while receiving mailbox messages",

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 public class NetworkStressTest {
+    private static final int REGTEST_NETWORK_ID = 2;
+
     /** A directory to temporarily hold seed and normal nodes' configuration and state files. */
     private Path tempDir;
     /** A single seed node that other nodes will contact to request initial data. */
@@ -43,9 +45,8 @@ public class NetworkStressTest {
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
         seedNodes.add(seedNodeAddress);  // the only seed node in tests
         seedNode.createAndStartP2PService(seedNodeAddress, useLocalhost,
-                2 /*regtest*/, true /*detailed logging*/, seedNodes,
-                getSetupListener(setupFailed, pendingTasks)
-        );
+                REGTEST_NETWORK_ID, true /*detailed logging*/, seedNodes,
+                getSetupListener(setupFailed, pendingTasks));
 
         // Wait for concurrent tasks to finish.
         pendingTasks.await();

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -180,12 +180,12 @@ public class NetworkStressTest {
 
         // Wait for peers to get their preliminary data.
         assertLatch("timed out while waiting for preliminary data",
-                prelimDataLatch, 30, TimeUnit.SECONDS);
+                prelimDataLatch, 2 * nPeers, TimeUnit.SECONDS);
         print("preliminary data received");
 
         // Wait for peers to complete their bootstrapping.
         assertLatch("timed out while waiting for bootstrap",
-                bootstrapLatch, 30, TimeUnit.SECONDS);
+                bootstrapLatch, 2 * nPeers, TimeUnit.SECONDS);
         print("bootstrap complete");
     }
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -251,7 +251,8 @@ public class NetworkStressTest {
                             final long sendMillis = System.currentTimeMillis();
                             srcPeer.sendEncryptedDirectMessage(
                                     dstPeerAddress, peerPKRings.get(dstPeerIdx),
-                                    new StressTestDirectMessage("test/" + dstPeerAddress), new SendDirectMessageListener() {
+                                    new StressTestDirectMessage("test/" + dstPeerAddress),
+                                    new SendDirectMessageListener() {
                                         @Override
                                         public void onArrived() {
                                             sentDelays.add(System.currentTimeMillis() - sendMillis);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -1,0 +1,55 @@
+package io.bitsquare.p2p.network;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class NetworkStressTest {
+    private Path tempDir;
+
+    @Before
+    public void setup() throws IOException {
+        tempDir = createTempDirectory();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (tempDir != null) {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void test() {
+        // do nothing
+    }
+
+    private Path createTempDirectory() throws IOException {
+        return Files.createTempDirectory("bsq" + this.getClass().getSimpleName());
+    }
+
+    private static void deleteRecursively(@NotNull final Path path) throws IOException {
+        // Based on <https://stackoverflow.com/a/27917071/6239236> by Tomasz Dzięcielewski.
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(path);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -649,8 +649,8 @@ public class NetworkStressTest {
                     TimeUnit.SECONDS);
             //print("put peer %d online", firstOffline);
         }
-        /** Time to transmit all messages with the estimated per-message delay, with 1 second computation delay. */
-        final long idealMaxMailboxDelay = 2 * (MAILBOX_DELAY_SECS + 1) * 1000 * nPeers * mailboxCount;
+        /** Time to transmit all messages with the estimated per-message delay, with no computation delays. */
+        final long idealMaxMailboxDelay = 2 * MAILBOX_DELAY_SECS * 1000 * nPeers * mailboxCount;
         assertLatch("timed out while receiving mailbox messages",
                 receivedMailboxLatch, idealMaxMailboxDelay, TimeUnit.MILLISECONDS);
         final long recvMillis = System.currentTimeMillis() - sendStartMillis;

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -71,6 +71,8 @@ public class NetworkStressTest {
     private static long MIN_DIRECT_DELAY_MILLIS = Math.round(1.25 * (1.0 / Connection.MSG_THROTTLE_PER_SEC) * 1000);
     /** Maximum delay between direct messages in milliseconds, 10 times larger than minimum. */
     private static long MAX_DIRECT_DELAY_MILLIS = 10 * MIN_DIRECT_DELAY_MILLIS;
+    /** Estimated delay in seconds to send or receive a mailbox message. */
+    private static long MAILBOX_DELAY_SECS = 2;
 
     // Instance fields
 
@@ -613,9 +615,8 @@ public class NetworkStressTest {
                             }
                         });
             }
-            // TODO: Use meaningful timeout.
             assertLatch("timed out while sending from peer " + firstOnline,
-                    sendLatch, 2 * mailboxCount, TimeUnit.SECONDS);
+                    sendLatch, MAILBOX_DELAY_SECS * mailboxCount, TimeUnit.SECONDS);
 
             // When done, put first online peer offline.
             final CountDownLatch stopLatch = new CountDownLatch(1);
@@ -631,12 +632,11 @@ public class NetworkStressTest {
             peerNodes.set(firstOffline, startedPeer);
             startedPeer.start(new MailboxStartListener(startLatch));
             assertLatch("timed out while starting peer " + firstOffline,
-                    startLatch, 10, TimeUnit.SECONDS);
+                    startLatch, 10 + MAILBOX_DELAY_SECS * nPeers, TimeUnit.SECONDS);
             //print("put peer %d online", firstOffline);
         }
-        // TODO: Use meaningful timeout.
         assertLatch("timed out while receiving mailbox messages",
-                receivedMailboxLatch, 120, TimeUnit.SECONDS);
+                receivedMailboxLatch, 2 * (MAILBOX_DELAY_SECS + 1) * nPeers * mailboxCount, TimeUnit.SECONDS);
         org.junit.Assert.assertFalse("some peer(s) failed to send a message", sentMailboxFailed.get());
     }
 

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -226,9 +226,9 @@ public class NetworkStressTest {
         }
     }
 
+    /** Test each peer sending a direct message to another random peer. */
     @Test
-    public void test() throws InterruptedException {
-        // Test each peer sending a direct message to another random peer.
+    public void test_direct() throws InterruptedException {
         final int nPeers = peerNodes.size();
         BooleanProperty sentDirectFailed = new SimpleBooleanProperty(false);
         final List<Long> sentDelays = new Vector<>(nPeers * directCount);
@@ -288,18 +288,21 @@ public class NetworkStressTest {
                 receivedDirectLatch, 10 * idealMaxDirectDelay, TimeUnit.MILLISECONDS);
         final long recvMillis = System.currentTimeMillis() - sendStartMillis;
         print("receiving %d direct messages per peer took %ss (%.2f x ideal max)",
-                directCount, recvMillis/1000.0, recvMillis/(float)idealMaxDirectDelay);
+                directCount, recvMillis / 1000.0, recvMillis / (float) idealMaxDirectDelay);
         // Wait for peers to complete sending.
         // This should be nearly instantaneous after waiting for reception is completed.
         assertLatch("timed out while sending direct messages",
                 sentDirectLatch, idealMaxDirectDelay / 10, TimeUnit.MILLISECONDS);
         Tuple3<Long, Long, Long> mma = minMaxAvg(sentDelays);
         print("sending %d direct messages per peer took %ss (min/max/avg %s/%s/%s ms)",
-                directCount, (System.currentTimeMillis() - sendStartMillis)/1000.0,
+                directCount, (System.currentTimeMillis() - sendStartMillis) / 1000.0,
                 mma.first, mma.second, mma.third);
         org.junit.Assert.assertFalse("some peer(s) failed to send a direct message", sentDirectFailed.get());
+    }
 
-        // Test sending and receiving mailbox messages.
+    /** Test sending and receiving mailbox messages. */
+    @Test
+    public void test_mailbox() throws InterruptedException {
         // We start by putting the first half of peers online and the second one offline.
         // Then the first online peer sends a number of messages to random peers (regardless of their state),
         // so that some messages are delivered directly and others into a mailbox.
@@ -353,6 +356,7 @@ public class NetworkStressTest {
         });
         bootLatch.await();
 
+        final int nPeers = peerNodes.size();
         for (int firstOnline = 0, firstOffline = (int)Math.ceil(nPeers/2.0);
                 firstOnline < nPeers;
                 firstOnline++, firstOffline = ++firstOffline%nPeers) {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -23,6 +23,9 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.Result;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,6 +85,16 @@ public class NetworkStressTest {
 
     /** Number of direct messages to be sent by each peer. */
     private int directCount = DIRECT_COUNT_DEFAULT;
+
+    // Inspired by <https://stackoverflow.com/a/9288513> by Marc Peters.
+    public static void main(String[] args) {
+        Request request = (args.length == 0)
+                ? Request.aClass(NetworkStressTest.class)
+                : Request.method(NetworkStressTest.class, args[0]);
+
+        Result result = new JUnitCore().run(request);
+        System.exit(result.wasSuccessful() ? 0 : 1);
+    }
 
     @Before
     public void setUp() throws Exception {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -113,9 +113,10 @@ public class NetworkStressTest {
         latch.countDown();
         int remaining = (int)latch.getCount();
         if (remaining > 0)
-            System.err.print(String.format("\r%s: %s ", this.getClass().getSimpleName(), nChars(c, remaining)));
+            System.out.print(String.format("\r%s> %s ", this.getClass().getSimpleName(), nChars(c, remaining)));
         if (remaining == 1)
-            System.err.println();
+            System.out.print('\n');
+        System.out.flush();
     }
 
     @Before

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -86,7 +86,7 @@ public class NetworkStressTest {
     @After
     public void tearDown() throws InterruptedException, IOException {
         /** A barrier to wait for concurrent tasks. */
-        final CountDownLatch pendingTasks = new CountDownLatch(1 /*seed node*/);
+        final CountDownLatch pendingTasks = new CountDownLatch(seedNode != null? 1 : 0);
         // Stop the seed node.
         if (seedNode != null) {
             seedNode.shutDown(pendingTasks::countDown);

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -234,14 +234,17 @@ public class NetworkStressTest {
         }
         // Since receiving is completed before sending is reported to be complete,
         // all receiving checks should end before all sending checks to avoid deadlocking.
-        // Wait for peers to complete receiving.
+        /** Time to transmit all messages in the worst random case, and with no computation delays. */
+        final long idealMaxDirectDelay = MAX_DIRECT_DELAY_MILLIS * DIRECT_COUNT;
+        // Wait for peers to complete receiving.  We are generous here.
         org.junit.Assert.assertTrue("timed out while receiving direct messages",
-                receivedDirectLatch.await(30, TimeUnit.SECONDS));
+                receivedDirectLatch.await(2 * idealMaxDirectDelay, TimeUnit.MILLISECONDS));
         print("receiving %d direct messages per peer took %ss", DIRECT_COUNT,
                 Duration.between(sendStart, Instant.now()).toMillis()/1000.0);
         // Wait for peers to complete sending.
+        // This should be nearly instantaneous after waiting for reception is completed.
         org.junit.Assert.assertTrue("timed out while sending direct messages",
-                sentDirectLatch.await(30, TimeUnit.SECONDS));
+                sentDirectLatch.await(idealMaxDirectDelay / 10, TimeUnit.MILLISECONDS));
         print("sending %d direct messages per peer took %ss", DIRECT_COUNT,
                 Duration.between(sendStart, Instant.now()).toMillis()/1000.0);
         org.junit.Assert.assertFalse("some peer(s) failed to send a direct message", sentDirectFailed.get());

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -2,6 +2,7 @@ package io.bitsquare.p2p.network;
 
 import io.bitsquare.p2p.NodeAddress;
 import io.bitsquare.p2p.P2PServiceListener;
+import io.bitsquare.p2p.Utils;
 import io.bitsquare.p2p.seed.SeedNode;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -41,7 +42,7 @@ public class NetworkStressTest {
         // Create and start the seed node.
         seedNode = new SeedNode(tempDir.toString());
         final NodeAddress seedNodeAddress = getSeedNodeAddress();
-        final boolean useLocalhost = seedNodeAddress.getFullAddress().startsWith("localhost:");
+        final boolean useLocalhost = seedNodeAddress.hostName.equals("localhost");
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
         seedNodes.add(seedNodeAddress);  // the only seed node in tests
         seedNode.createAndStartP2PService(seedNodeAddress, useLocalhost,
@@ -58,7 +59,7 @@ public class NetworkStressTest {
 
     @NotNull
     private static NodeAddress getSeedNodeAddress() {
-        return new NodeAddress("localhost:8002");
+        return new NodeAddress("localhost", Utils.findFreeSystemPort());
     }
 
     @NotNull

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -188,8 +188,7 @@ public class NetworkStressTest {
         for (final P2PService srcPeer : peerNodes) {
             final int dstPeerIdx = (int) (Math.random() * nPeers);
             final P2PService dstPeer = peerNodes.get(dstPeerIdx);
-            /*System.out.println(
-                    "Sending direct message from peer " + srcPeer.getAddress() + " to " + dstPeer.getAddress());*/
+            //print("sending direct message from peer %s to %s", srcPeer.getAddress(), dstPeer.getAddress());
             srcPeer.sendEncryptedDirectMessage(dstPeer.getAddress(), peerPKRings.get(dstPeerIdx),
                     new StressTestDirectMessage("test/" + dstPeer.getAddress()), new SendDirectMessageListener() {
                         @Override

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -159,8 +159,8 @@ public class NetworkStressTest {
     private Path createTestDataDirectory() throws IOException {
         Path stressTestDirPath;
 
-        String stressTestDir = System.getenv(TEST_DIR_ENVVAR);
-        if (stressTestDir != null) {
+        final String stressTestDir = System.getenv(TEST_DIR_ENVVAR);
+        if ((stressTestDir != null) && !stressTestDir.equals("")) {
             // Test directory specified, use and create if missing.
             stressTestDirPath = Paths.get(stressTestDir);
             if (!Files.isDirectory(stressTestDirPath)) {
@@ -181,7 +181,8 @@ public class NetworkStressTest {
      */
     private void deleteTestDataDirectory() throws IOException {
         // Based on <https://stackoverflow.com/a/27917071/6239236> by Tomasz Dzięcielewski.
-        boolean keep = System.getenv(TEST_DIR_ENVVAR) != null;  // do not remove if given explicitly
+        final String stressTestDir = System.getenv(TEST_DIR_ENVVAR);
+        final boolean keep = (stressTestDir != null) && !stressTestDir.equals("");
         Files.walkFileTree(testDataDir, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {

--- a/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
+++ b/network/src/test/java/io/bitsquare/p2p/network/NetworkStressTest.java
@@ -67,6 +67,8 @@ public class NetworkStressTest {
 
     /** A directory to (temporarily) hold seed and normal nodes' configuration and state files. */
     private Path testDataDir;
+    /** Whether to use localhost addresses instead of Tor hidden services. */
+    private boolean useLocalhost;
     /** A single seed node that other nodes will contact to request initial data. */
     private SeedNode seedNode;
     /** The repository of seed nodes used in the test. */
@@ -126,7 +128,7 @@ public class NetworkStressTest {
         // Create and start the seed node.
         seedNode = new SeedNode(testDataDir.toString());
         final NodeAddress seedNodeAddress = newSeedNodeAddress();
-        final boolean useLocalhost = seedNodeAddress.hostName.equals("localhost");
+        useLocalhost = seedNodeAddress.hostName.equals("localhost");
         final Set<NodeAddress> seedNodes = new HashSet<>(1);
         seedNodes.add(seedNodeAddress);  // the only seed node in tests
         seedNode.createAndStartP2PService(seedNodeAddress, SeedNode.MAX_CONNECTIONS_DEFAULT, useLocalhost,
@@ -145,7 +147,7 @@ public class NetworkStressTest {
             final int peerPort = Utils.findFreeSystemPort();
             peerPorts.add(peerPort);
             // create, save and start peer
-            final P2PService peer = createPeerNode(p, peerPort, useLocalhost);
+            final P2PService peer = createPeerNode(p, peerPort);
             //noinspection ConstantConditions
             peerPKRings.add(peer.getKeyRing().getPubKeyRing());
             peerNodes.add(peer);
@@ -176,7 +178,7 @@ public class NetworkStressTest {
     }
 
     @NotNull
-    private P2PService createPeerNode(int n, int port, boolean useLocalhost) {
+    private P2PService createPeerNode(int n, int port) {
         // peer data directories
         final File peerDir = new File(testDataDir.toFile(), String.format("peer-%06d", n));
         final File peerTorDir = new File(peerDir, "tor");


### PR DESCRIPTION
This PR includes a new test unit class that performs a tight stress test (of customizable size, see class documentation) on the P2P network.  Currently it only includes a test for direct messages (which I've tried with a few hundreds of nodes) and another for mailbox messages (which I've tried with a few tens of nodes).  The mailbox test doesn't yet have fine-tuned timeouts, and the direct test may require permission to open more files than usually allowed in the system: if `ulimit -n NFILES` doesn't work, please try `sudo prlimit -nNFILES -pSHELL_PID`.
