### PR TITLE
Use Seedpeers for default DNS Discovery when Socks proxy active. ( Tor )

### DIFF
--- a/common/src/main/java/io/bitsquare/app/Log.java
+++ b/common/src/main/java/io/bitsquare/app/Log.java
@@ -114,6 +114,6 @@ public class Log {
         if (DevFlags.STRESS_TEST_MODE)
             System.err.println(new SimpleDateFormat("HH:mm:ss.SSS").format(new Date()) +
                     " - " + msg +
-                    " / Memory(MB): " + Profiler.getUsedMemory());
+                    " / Memory(MB): " + Profiler.getUsedMemoryInMB());
     }
 }

--- a/core/src/main/java/io/bitsquare/btc/WalletAppKitBitSquare.java
+++ b/core/src/main/java/io/bitsquare/btc/WalletAppKitBitSquare.java
@@ -64,11 +64,6 @@ public class WalletAppKitBitSquare extends WalletAppKit {
         mgr.setConnectTimeoutMillis(CONNECT_TIMEOUT_MSEC);
         peerGroup.setConnectTimeoutMillis(CONNECT_TIMEOUT_MSEC);
 
-        // This enables remote DNS lookup of peers over socks5 proxy.
-        // It is slower, but more private.
-        // This could be turned into a user option.
-        this.setDiscovery( new SeedPeersSocks5Dns(socks5Proxy, params) );
-        
         return peerGroup;
     }    
 }

--- a/core/src/main/java/io/bitsquare/btc/WalletService.java
+++ b/core/src/main/java/io/bitsquare/btc/WalletService.java
@@ -39,6 +39,8 @@ import javafx.beans.property.*;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
+import org.bitcoinj.kits.WalletAppKit;
+import org.bitcoinj.net.discovery.SeedPeers;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.TestNet3Params;
@@ -268,6 +270,7 @@ public class WalletService {
         walletAppKit.setBloomFilterFalsePositiveRate(0.00005);
 
         log.debug( "seedNodes: " + seedNodes.toString() );
+        boolean setPeerNodes = false;
         
         // Pass custom seed nodes if set in options
         if (seedNodes != null && !seedNodes.isEmpty()) {
@@ -280,6 +283,10 @@ public class WalletService {
             List<PeerAddress> peerAddressList = new ArrayList<PeerAddress>();
             for(String node : nodes) {
                 String[] parts = node.split(":");
+                if( parts.length == 1) {
+                    // port not specified.  Use default port for network.
+                    parts = new String[] { parts[0], Integer.toString(params.getPort()) };
+                }
                 if( parts.length == 2 ) {
                     // note: this will cause a DNS request if hostname used.
                     // note: DNS requests are routed over socks5 proxy, if used.
@@ -305,6 +312,7 @@ public class WalletService {
                 log.debug("seedNodes parsed: " + Arrays.toString(peerAddressListFixed));
                 
                 walletAppKit.setPeerNodes(peerAddressList.toArray(peerAddressListFixed));
+                setPeerNodes = true;
             }
         }
 
@@ -320,6 +328,7 @@ public class WalletService {
             if (regTestHost == RegTestHost.REG_TEST_SERVER) {
                 try {
                     walletAppKit.setPeerNodes(new PeerAddress(InetAddress.getByName(RegTestHost.SERVER_IP), params.getPort()));
+                    setPeerNodes = true;
                 } catch (UnknownHostException e) {
                     throw new RuntimeException(e);
                 }
@@ -339,6 +348,22 @@ public class WalletService {
             }
         } else if (params == TestNet3Params.get()) {
             walletAppKit.setCheckpoints(getClass().getResourceAsStream("/wallet/checkpoints.testnet"));
+        }
+
+        // If operating over a proxy and we haven't set any peer nodes, then
+        // we want to use SeedPeers for discovery instead of the default DnsDiscovery.
+        // This is only because we do not yet have a Dns discovery class that works
+        // reliably over proxy/tor.
+        //
+        // todo: There should be a user pref called "Use Local DNS for Proxy/Tor"
+        // that disables this.  In that case, the default DnsDiscovery class will
+        // be used which should work, but is less private.  The aim here is to
+        // be private by default when using proxy/tor.  However, the seedpeers
+        // could become outdated, so it is important that the user be able to
+        // disable it, but should be made aware of the reduced privacy.
+        if( proxy != null && !setPeerNodes ) {
+            // SeedPeersSocks5Dns should replace SeedPeers once working reliably.
+            walletAppKit.setDiscovery( new SeedPeers( params) );
         }
 
         walletAppKit.setDownloadListener(downloadListener)

--- a/core/src/main/java/io/bitsquare/btc/WalletService.java
+++ b/core/src/main/java/io/bitsquare/btc/WalletService.java
@@ -39,7 +39,6 @@ import javafx.beans.property.*;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.net.discovery.SeedPeers;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;


### PR DESCRIPTION
This is a temporary measure until  SeedPeersSocks5Dns can be made to work more reliably.

This pull request relies upon bitcoinj PR for up-to-date seeds:
    https://github.com/bitsquare/bitcoinj/pull/2

Code comments are pretty explanatory.

```
        // If operating over a proxy and we haven't set any peer nodes, then
        // we want to use SeedPeers for discovery instead of the default DnsDiscovery.
        // This is only because we do not yet have a Dns discovery class that works
        // reliably over proxy/tor.
        //
        // todo: There should be a user pref called "Use Local DNS for Proxy/Tor"
        // that disables this.  In that case, the default DnsDiscovery class will
        // be used which should work, but is less private.  The aim here is to
        // be private by default when using proxy/tor.  However, the seedpeers
        // could become outdated, so it is important that the user be able to
        // disable it, but should be made aware of the reduced privacy.
        // SeedPeersSocks5Dns should replace SeedPeers once working reliably.
```
