### PR TITLE
Route HttpClient over Socks5 Proxy, with remote DNS resolution.

### DIFF
--- a/network/pom.xml
+++ b/network/pom.xml
@@ -23,5 +23,12 @@
             <artifactId>jtorproxy</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>4.5</version>
+        </dependency>
+        
     </dependencies>
 </project>

--- a/network/src/main/java/io/bitsquare/http/FakeDnsResolver.java
+++ b/network/src/main/java/io/bitsquare/http/FakeDnsResolver.java
@@ -1,0 +1,15 @@
+package io.bitsquare.http;
+
+import org.apache.http.conn.DnsResolver;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+// This class is adapted from
+//   http://stackoverflow.com/a/25203021/5616248
+class FakeDnsResolver implements DnsResolver {
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+        // Return some fake DNS record for every request, we won't be using it
+        return new InetAddress[] { InetAddress.getByAddress(new byte[] { 1, 1, 1, 1 }) };
+    }
+}

--- a/network/src/main/java/io/bitsquare/http/HttpClient.java
+++ b/network/src/main/java/io/bitsquare/http/HttpClient.java
@@ -42,8 +42,7 @@ public class HttpClient {
     }
 
     public String requestWithGET(String param) throws IOException, HttpException {
-        return requestWithGETProxy(param);
-//        return proxy != null ? requestWithGETProxy(param) : requestWithGETNoProxy(param);
+        return proxy != null ? requestWithGETProxy(param) : requestWithGETNoProxy(param);
     }
 
     /**
@@ -76,7 +75,6 @@ public class HttpClient {
      * Make an HTTP Get request routed over socks5 proxy.
      */
     private String requestWithGETProxy(String param) throws IOException, HttpException {
-        
         // This code is adapted from:
         //  http://stackoverflow.com/a/25203021/5616248
         
@@ -88,22 +86,22 @@ public class HttpClient {
                 
         // Use FakeDNSResolver if not resolving DNS locally.
         // This prevents a local DNS lookup (which would be ignored anyway)
-        PoolingHttpClientConnectionManager cm = proxy.resolveAddrLocally() ?
+        PoolingHttpClientConnectionManager cm = proxy != null && proxy.resolveAddrLocally() ?
                                                     new PoolingHttpClientConnectionManager(reg) :
                                                     new PoolingHttpClientConnectionManager(reg, new FakeDnsResolver());
         CloseableHttpClient httpclient = HttpClients.custom().setConnectionManager(cm).build();
         try {
-            // InetSocketAddress socksaddr = new InetSocketAddress(proxy.getInetAddress(), proxy.getPort());
+            InetSocketAddress socksaddr = new InetSocketAddress(proxy.getInetAddress(), proxy.getPort());
             
-            // remove me: Use this to test with system-wide Tor proxy.
-            InetSocketAddress socksaddr = new InetSocketAddress("127.0.0.1", 9050);
+            // remove me: Use this to test with system-wide Tor proxy, or change port for another proxy.
+            // InetSocketAddress socksaddr = new InetSocketAddress("127.0.0.1", 9050);
             
             HttpClientContext context = HttpClientContext.create();
             context.setAttribute("socks.address", socksaddr);
     
             HttpGet request = new HttpGet(baseUrl + param);
     
-            log.error( "Executing request " + request + " proxy: " + socksaddr);
+            log.info( "Executing request " + request + " proxy: " + socksaddr);
             CloseableHttpResponse response = httpclient.execute(request, context);
             try {
                 InputStream stream = response.getEntity().getContent();

--- a/network/src/main/java/io/bitsquare/http/HttpClient.java
+++ b/network/src/main/java/io/bitsquare/http/HttpClient.java
@@ -1,24 +1,58 @@
 package io.bitsquare.http;
 
+import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 import java.io.BufferedReader;
-import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.URL;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContexts;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-// TODO route over tor
+
 public class HttpClient {
 
+    private static final Logger log = LoggerFactory.getLogger(HttpClient.class);
+    
     private final String baseUrl;
+    private final Socks5Proxy proxy;
 
     public HttpClient(String baseUrl) {
         this.baseUrl = baseUrl;
+        this.proxy = null;
+    }
+    
+    public HttpClient(Socks5Proxy proxy, String baseUrl) {
+        this.baseUrl = baseUrl;
+        this.proxy = proxy;
     }
 
     public String requestWithGET(String param) throws IOException, HttpException {
+        return requestWithGETProxy(param);
+//        return proxy != null ? requestWithGETProxy(param) : requestWithGETNoProxy(param);
+    }
+
+    /**
+     * Make an HTTP Get request directly (not routed over socks5 proxy).
+     */
+    private String requestWithGETNoProxy(String param) throws IOException, HttpException {
         HttpURLConnection connection = null;
         try {
+            log.info( "Executing HTTP request " + baseUrl + param + " proxy: none.");
             URL url = new URL(baseUrl + param);
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
@@ -35,6 +69,51 @@ public class HttpClient {
         } finally {
             if (connection != null)
                 connection.getInputStream().close();
+        }
+    }
+    
+    /**
+     * Make an HTTP Get request routed over socks5 proxy.
+     */
+    private String requestWithGETProxy(String param) throws IOException, HttpException {
+        
+        // This code is adapted from:
+        //  http://stackoverflow.com/a/25203021/5616248
+        
+        // Register our own SocketFactories to override createSocket() and connectSocket().
+        // connectSocket does NOT resolve hostname before passing it to proxy.
+        Registry<ConnectionSocketFactory> reg = RegistryBuilder.<ConnectionSocketFactory> create()
+                .register("http", new SocksConnectionSocketFactory())
+                .register("https", new SocksSSLConnectionSocketFactory(SSLContexts.createSystemDefault())).build();
+                
+        // Use FakeDNSResolver if not resolving DNS locally.
+        // This prevents a local DNS lookup (which would be ignored anyway)
+        PoolingHttpClientConnectionManager cm = proxy.resolveAddrLocally() ?
+                                                    new PoolingHttpClientConnectionManager(reg) :
+                                                    new PoolingHttpClientConnectionManager(reg, new FakeDnsResolver());
+        CloseableHttpClient httpclient = HttpClients.custom().setConnectionManager(cm).build();
+        try {
+            // InetSocketAddress socksaddr = new InetSocketAddress(proxy.getInetAddress(), proxy.getPort());
+            
+            // remove me: Use this to test with system-wide Tor proxy.
+            InetSocketAddress socksaddr = new InetSocketAddress("127.0.0.1", 9050);
+            
+            HttpClientContext context = HttpClientContext.create();
+            context.setAttribute("socks.address", socksaddr);
+    
+            HttpGet request = new HttpGet(baseUrl + param);
+    
+            log.error( "Executing request " + request + " proxy: " + socksaddr);
+            CloseableHttpResponse response = httpclient.execute(request, context);
+            try {
+                InputStream stream = response.getEntity().getContent();
+                String buf = convertInputStreamToString(stream);
+                return buf;
+            } finally {
+                response.close();
+            }
+        } finally {
+            httpclient.close();
         }
     }
 

--- a/network/src/main/java/io/bitsquare/http/SocksConnectionSocketFactory.java
+++ b/network/src/main/java/io/bitsquare/http/SocksConnectionSocketFactory.java
@@ -1,0 +1,38 @@
+package io.bitsquare.http;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.HttpHost;
+import org.apache.http.protocol.HttpContext;
+
+// This class is adapted from
+//   http://stackoverflow.com/a/25203021/5616248
+//
+// This class routes connections over Socks, and avoids resolving hostnames locally.
+class SocksConnectionSocketFactory extends PlainConnectionSocketFactory {
+    
+    /**
+     * creates an unconnected Socks Proxy socket
+     */
+    @Override
+    public Socket createSocket(final HttpContext context) throws IOException {
+        InetSocketAddress socksaddr = (InetSocketAddress) context.getAttribute("socks.address");
+        Proxy proxy = new Proxy(Proxy.Type.SOCKS, socksaddr);
+        return new Socket(proxy);
+    }
+
+    /**
+     * connects a Socks Proxy socket and passes hostname to proxy without resolving it locally.
+     */
+    @Override
+    public Socket connectSocket(int connectTimeout, Socket socket, HttpHost host, InetSocketAddress remoteAddress,
+            InetSocketAddress localAddress, HttpContext context) throws IOException {
+        // Convert address to unresolved
+        InetSocketAddress unresolvedRemote = InetSocketAddress
+                .createUnresolved(host.getHostName(), remoteAddress.getPort());
+        return super.connectSocket(connectTimeout, socket, host, unresolvedRemote, localAddress, context);
+    }
+}

--- a/network/src/main/java/io/bitsquare/http/SocksSSLConnectionSocketFactory.java
+++ b/network/src/main/java/io/bitsquare/http/SocksSSLConnectionSocketFactory.java
@@ -1,0 +1,48 @@
+package io.bitsquare.http;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import javax.net.ssl.SSLContext;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.HttpHost;
+import org.apache.http.protocol.HttpContext;
+
+// This class is adapted from
+//   http://stackoverflow.com/a/25203021/5616248
+//
+// This class routes connections over Socks, and avoids resolving hostnames locally.
+class SocksSSLConnectionSocketFactory extends SSLConnectionSocketFactory {
+
+    public SocksSSLConnectionSocketFactory(final SSLContext sslContext) {
+        
+        // Only allow connection's to site's with valid certs.
+        super(sslContext, STRICT_HOSTNAME_VERIFIER);
+        
+        // Or to allow insecure (eg self-signed certs)
+        // super(sslContext, ALLOW_ALL_HOSTNAME_VERIFIER);
+    }
+
+    /**
+     * creates an unconnected Socks Proxy socket
+     */
+    @Override
+    public Socket createSocket(final HttpContext context) throws IOException {
+        InetSocketAddress socksaddr = (InetSocketAddress) context.getAttribute("socks.address");
+        Proxy proxy = new Proxy(Proxy.Type.SOCKS, socksaddr);
+        return new Socket(proxy);
+    }
+
+    /**
+     * connects a Socks Proxy socket and passes hostname to proxy without resolving it locally.
+     */
+    @Override
+    public Socket connectSocket(int connectTimeout, Socket socket, HttpHost host, InetSocketAddress remoteAddress,
+            InetSocketAddress localAddress, HttpContext context) throws IOException {
+        // Convert address to unresolved
+        InetSocketAddress unresolvedRemote = InetSocketAddress
+                .createUnresolved(host.getHostName(), remoteAddress.getPort());
+        return super.connectSocket(connectTimeout, socket, host, unresolvedRemote, localAddress, context);
+    }
+}

--- a/network/src/main/java/io/bitsquare/http/SocksSSLConnectionSocketFactory.java
+++ b/network/src/main/java/io/bitsquare/http/SocksSSLConnectionSocketFactory.java
@@ -20,7 +20,7 @@ class SocksSSLConnectionSocketFactory extends SSLConnectionSocketFactory {
         // Only allow connection's to site's with valid certs.
         super(sslContext, STRICT_HOSTNAME_VERIFIER);
         
-        // Or to allow insecure (eg self-signed certs)
+        // Or to allow "insecure" (eg self-signed certs)
         // super(sslContext, ALLOW_ALL_HOSTNAME_VERIFIER);
     }
 


### PR DESCRIPTION
This pull request partially addresses #522.

I say partially because there is some wiring up left to do so that HttpClient gets access to a Socks5Proxy object when called by a PriceProvider subclass.  But the core functionality of making a request over socks5 with remote DNS is working.

I found it necessary to pull in apache components, as commented in the issue.  They are only used when a proxy is available to HttpClient.  Otherwise, the pre-existing code is used.  The caller API (requestWithGet) remains the same.

The HttpClient code (proxy case) looks at the value of proxy.resolveAddrLocally().  So if a user setting is made to control that, then HttpClient will abide by it.
## Testing

I tested this code twice by hard-coding addresses of  (1) system tor port 9050 and (2) an ssh socks proxy, so that all callers used the proxy even without passing in a Socks5Proxy.  I went so far as to firewall block all outgoing tcp/udp ports on the system except those used by tor (9001,9030).  With this configuration, I was able to run bitsquare with full functionality when using the ssh tor port, and with everything but poloniex working when run over Tor ( because Poloniex uses cloudflare that blocks tor exit nodes. )

If anyone would like to duplicate the tor-only firewall config, I used the following ufw script on ubuntu:

```
$ cat ~/ufw_onlytor.sh 
sudo ufw reset
sudo ufw allow out 9001/tcp
sudo ufw allow out 9030/tcp
sudo ufw deny out 1:65535/tcp
sudo ufw deny out 1:65535/udp
sudo ufw enable
```

It can then be turned off with sudo ufw disable.  You will likely want to save your old firewall config first, if any.

Note that bitsquare may take a little longer to connect to tor network with these firewall rules because tor normally use ports 80 and 443 as well as 9001 and 9030.  I disabled 80 and 443 to be certain the http requests are not leaking.

I would have liked to finalize the integration, but I find myself baffled as to how to get the Socks5Proxy object to HttpClient.  I do not yet grok this injection voodoo.  So I think it best that @ManfredKarrer wire that up, and I will thereby learn.
## Bounty

A bounty offer was [made](https://github.com/bitsquare/bitsquare/issues/488#issuecomment-232954150).  At such time as the code is deemed acceptable to be merged, payment can be made to 1Byv5zUGHYtodMScTZcdBBc47Ber2GWNf.  A reduced payment is acceptable given the unfinished status.   I consider this code to be at least 90% complete.   Of course I will fix any issues/nits found during review, etc.
