### PR TITLE
parent directory might not exist: causes exception

### DIFF
--- a/core/src/main/java/io/bitsquare/app/BitsquareExecutable.java
+++ b/core/src/main/java/io/bitsquare/app/BitsquareExecutable.java
@@ -147,7 +147,7 @@ public abstract class BitsquareExecutable {
                 return;
         }
         try {
-            Files.createDirectory(dir);
+            Files.createDirectories(dir);
         } catch (IOException ex) {
             throw new BitsquareException(ex, "Application data directory '%s' could not be created", dir);
         }


### PR DESCRIPTION
Files.createDirectories fixes this.

exception:
Application data directory '.../.local/share/Bitsquare' could not be created
Caused by: java.nio.file.NoSuchFileException
