### PR TITLE
Fix unexpected mouse behavior in AddressTextField

### DIFF
--- a/gui/src/main/java/io/bitsquare/gui/components/AddressTextField.java
+++ b/gui/src/main/java/io/bitsquare/gui/components/AddressTextField.java
@@ -56,7 +56,6 @@ public class AddressTextField extends AnchorPane {
         textField.textProperty().bind(address);
         String tooltipText = "Open your default bitcoin wallet";
         Tooltip.install(textField, new Tooltip(tooltipText));
-        textField.setOnMouseClicked(mouseEvent -> GUIUtil.showFeeInfoBeforeExecute(this::openWallet));
         textField.focusTraversableProperty().set(focusTraversableProperty().get());
         //TODO app wide focus
         //focusedProperty().addListener((ov, oldValue, newValue) -> textField.requestFocus());


### PR DESCRIPTION
This fixes all major items in #630
- Address text is still clickable with primary (left) button.
- Address text is now selectable.
- In empty white space, secondary mouse button (right) opens context menu.
- In empty white space, `mouseReleased` event (after click) does not trigger external bitcoin wallet URI.

Testing:
I tested `DepositView` and confirmed that both Mac and Linux worked identically before the change, then confirmed the fix on Mac (no access to Linux at the moment, but fairly confident it will also be fixed there).

I looked for other views using AddressTextField, but was not able to visually confirm because I didn't want to create bogus trades, deposits, etc.  I am happy to get some testnet coins and test all instances if needed, but I think this mouse behavioral removal is pretty safe.
