### PR TITLE
Simplifying DepositView popup message

### DIFF
--- a/gui/src/main/java/io/bitsquare/gui/main/funds/deposit/DepositView.java
+++ b/gui/src/main/java/io/bitsquare/gui/main/funds/deposit/DepositView.java
@@ -187,8 +187,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
         generateNewAddressButton.setOnAction(event -> {
             boolean hasUnUsedAddress = observableList.stream().filter(e -> e.getNumTxOutputs() == 0).findAny().isPresent();
             if (hasUnUsedAddress) {
-                new Popup().warning("You have already at least one address which is not used yet in any transaction.\n" +
-                        "Please select in the address table an unused address.").show();
+                new Popup().warning("Please select an unused address from the table above rather than generating a new one.").show();
             } else {
                 AddressEntry newSavingsAddressEntry = walletService.getOrCreateUnusedAddressEntry(AddressEntry.Context.AVAILABLE);
                 updateList();
@@ -196,7 +195,6 @@ public class DepositView extends ActivatableView<VBox, Void> {
                         .filter(depositListItem -> depositListItem.getAddressString().equals(newSavingsAddressEntry.getAddressString()))
                         .findAny()
                         .ifPresent(depositListItem -> tableView.getSelectionModel().select(depositListItem));
-
             }
         });
 


### PR DESCRIPTION
No code changes in this PR, however I wonder if we might do better.
Why do we show an active button to "Generate new address" and then complain if the user clicks on it?  Might be better to disable the button, then show a message on hover, eg:
"Please select an unused address from the above table."

Thoughts?
