### PR TITLE
replace instanceof with getClass on equals methods

### DIFF
--- a/common/src/main/java/io/bitsquare/common/FrameRateTimer.java
+++ b/common/src/main/java/io/bitsquare/common/FrameRateTimer.java
@@ -73,7 +73,7 @@ public class FrameRateTimer implements Timer, Runnable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof FrameRateTimer)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         FrameRateTimer that = (FrameRateTimer) o;
 

--- a/common/src/main/java/io/bitsquare/common/crypto/DecryptedDataTuple.java
+++ b/common/src/main/java/io/bitsquare/common/crypto/DecryptedDataTuple.java
@@ -32,7 +32,7 @@ public final class DecryptedDataTuple {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DecryptedDataTuple)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         DecryptedDataTuple that = (DecryptedDataTuple) o;
 

--- a/common/src/main/java/io/bitsquare/common/crypto/KeyRing.java
+++ b/common/src/main/java/io/bitsquare/common/crypto/KeyRing.java
@@ -55,7 +55,7 @@ public class KeyRing {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof KeyRing)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         KeyRing keyRing = (KeyRing) o;
 

--- a/common/src/main/java/io/bitsquare/common/crypto/PubKeyRing.java
+++ b/common/src/main/java/io/bitsquare/common/crypto/PubKeyRing.java
@@ -77,7 +77,7 @@ public final class PubKeyRing implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PubKeyRing)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PubKeyRing that = (PubKeyRing) o;
 

--- a/common/src/main/java/io/bitsquare/common/crypto/SealedAndSigned.java
+++ b/common/src/main/java/io/bitsquare/common/crypto/SealedAndSigned.java
@@ -59,7 +59,7 @@ public final class SealedAndSigned implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof SealedAndSigned)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         SealedAndSigned that = (SealedAndSigned) o;
 

--- a/common/src/main/java/io/bitsquare/common/util/Tuple2.java
+++ b/common/src/main/java/io/bitsquare/common/util/Tuple2.java
@@ -31,7 +31,7 @@ public class Tuple2<A, B> implements Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Tuple2)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Tuple2<?, ?> tuple2 = (Tuple2<?, ?>) o;
 

--- a/common/src/main/java/io/bitsquare/common/util/Tuple3.java
+++ b/common/src/main/java/io/bitsquare/common/util/Tuple3.java
@@ -33,7 +33,7 @@ public class Tuple3<A, B, C> implements Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Tuple3)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Tuple3<?, ?, ?> tuple3 = (Tuple3<?, ?, ?>) o;
 

--- a/common/src/main/java/io/bitsquare/common/util/Tuple4.java
+++ b/common/src/main/java/io/bitsquare/common/util/Tuple4.java
@@ -35,7 +35,7 @@ public class Tuple4<A, B, C, D> implements Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Tuple4)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Tuple4<?, ?, ?, ?> tuple4 = (Tuple4<?, ?, ?, ?>) o;
 

--- a/core/src/main/java/io/bitsquare/alert/Alert.java
+++ b/core/src/main/java/io/bitsquare/alert/Alert.java
@@ -96,7 +96,7 @@ public final class Alert implements StoragePayload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Alert)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Alert alert = (Alert) o;
 

--- a/core/src/main/java/io/bitsquare/alert/PrivateNotification.java
+++ b/core/src/main/java/io/bitsquare/alert/PrivateNotification.java
@@ -66,7 +66,7 @@ public final class PrivateNotification implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PrivateNotification)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PrivateNotification that = (PrivateNotification) o;
 

--- a/core/src/main/java/io/bitsquare/alert/PrivateNotificationMessage.java
+++ b/core/src/main/java/io/bitsquare/alert/PrivateNotificationMessage.java
@@ -40,7 +40,7 @@ public class PrivateNotificationMessage implements MailboxMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PrivateNotificationMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PrivateNotificationMessage that = (PrivateNotificationMessage) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/Arbitrator.java
+++ b/core/src/main/java/io/bitsquare/arbitration/Arbitrator.java
@@ -113,7 +113,7 @@ public final class Arbitrator implements StoragePayload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Arbitrator)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Arbitrator that = (Arbitrator) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/Dispute.java
+++ b/core/src/main/java/io/bitsquare/arbitration/Dispute.java
@@ -294,7 +294,7 @@ public final class Dispute implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Dispute)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Dispute dispute = (Dispute) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/DisputeResult.java
+++ b/core/src/main/java/io/bitsquare/arbitration/DisputeResult.java
@@ -257,7 +257,7 @@ public final class DisputeResult implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DisputeResult)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         DisputeResult that = (DisputeResult) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/messages/DisputeCommunicationMessage.java
+++ b/core/src/main/java/io/bitsquare/arbitration/messages/DisputeCommunicationMessage.java
@@ -136,7 +136,7 @@ public final class DisputeCommunicationMessage extends DisputeMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DisputeCommunicationMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         DisputeCommunicationMessage that = (DisputeCommunicationMessage) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/messages/DisputeResultMessage.java
+++ b/core/src/main/java/io/bitsquare/arbitration/messages/DisputeResultMessage.java
@@ -36,7 +36,7 @@ public final class DisputeResultMessage extends DisputeMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DisputeResultMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         DisputeResultMessage that = (DisputeResultMessage) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/messages/OpenNewDisputeMessage.java
+++ b/core/src/main/java/io/bitsquare/arbitration/messages/OpenNewDisputeMessage.java
@@ -36,7 +36,7 @@ public final class OpenNewDisputeMessage extends DisputeMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof OpenNewDisputeMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         OpenNewDisputeMessage that = (OpenNewDisputeMessage) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/messages/PeerOpenedDisputeMessage.java
+++ b/core/src/main/java/io/bitsquare/arbitration/messages/PeerOpenedDisputeMessage.java
@@ -36,7 +36,7 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PeerOpenedDisputeMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PeerOpenedDisputeMessage that = (PeerOpenedDisputeMessage) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/messages/PeerPublishedPayoutTxMessage.java
+++ b/core/src/main/java/io/bitsquare/arbitration/messages/PeerPublishedPayoutTxMessage.java
@@ -39,7 +39,7 @@ public final class PeerPublishedPayoutTxMessage extends DisputeMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PeerPublishedPayoutTxMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PeerPublishedPayoutTxMessage that = (PeerPublishedPayoutTxMessage) o;
 

--- a/core/src/main/java/io/bitsquare/arbitration/payload/Attachment.java
+++ b/core/src/main/java/io/bitsquare/arbitration/payload/Attachment.java
@@ -31,7 +31,7 @@ public final class Attachment implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Attachment)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Attachment that = (Attachment) o;
 

--- a/core/src/main/java/io/bitsquare/btc/data/RawTransactionInput.java
+++ b/core/src/main/java/io/bitsquare/btc/data/RawTransactionInput.java
@@ -39,7 +39,7 @@ public final class RawTransactionInput implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof RawTransactionInput)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         RawTransactionInput rawTransactionInput = (RawTransactionInput) o;
 

--- a/core/src/main/java/io/bitsquare/btc/pricefeed/MarketPrice.java
+++ b/core/src/main/java/io/bitsquare/btc/pricefeed/MarketPrice.java
@@ -34,7 +34,7 @@ public class MarketPrice {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MarketPrice)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         MarketPrice that = (MarketPrice) o;
 

--- a/core/src/main/java/io/bitsquare/filter/Filter.java
+++ b/core/src/main/java/io/bitsquare/filter/Filter.java
@@ -84,7 +84,7 @@ public final class Filter implements StoragePayload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Filter)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Filter filter = (Filter) o;
 

--- a/core/src/main/java/io/bitsquare/locale/TradeCurrency.java
+++ b/core/src/main/java/io/bitsquare/locale/TradeCurrency.java
@@ -74,7 +74,7 @@ public abstract class TradeCurrency implements Persistable, Comparable<TradeCurr
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof TradeCurrency)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         TradeCurrency that = (TradeCurrency) o;
 

--- a/core/src/main/java/io/bitsquare/payment/CountryBasedPaymentAccount.java
+++ b/core/src/main/java/io/bitsquare/payment/CountryBasedPaymentAccount.java
@@ -63,7 +63,7 @@ public abstract class CountryBasedPaymentAccount extends PaymentAccount {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CountryBasedPaymentAccount)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
         CountryBasedPaymentAccount that = (CountryBasedPaymentAccount) o;

--- a/core/src/main/java/io/bitsquare/payment/CountryBasedPaymentAccountContractData.java
+++ b/core/src/main/java/io/bitsquare/payment/CountryBasedPaymentAccountContractData.java
@@ -58,7 +58,7 @@ public abstract class CountryBasedPaymentAccountContractData extends PaymentAcco
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CountryBasedPaymentAccountContractData)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
         CountryBasedPaymentAccountContractData that = (CountryBasedPaymentAccountContractData) o;

--- a/core/src/main/java/io/bitsquare/payment/PaymentAccount.java
+++ b/core/src/main/java/io/bitsquare/payment/PaymentAccount.java
@@ -143,7 +143,7 @@ public abstract class PaymentAccount implements Persistable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PaymentAccount)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PaymentAccount that = (PaymentAccount) o;
 

--- a/core/src/main/java/io/bitsquare/payment/PaymentAccountContractData.java
+++ b/core/src/main/java/io/bitsquare/payment/PaymentAccountContractData.java
@@ -62,7 +62,7 @@ public abstract class PaymentAccountContractData implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PaymentAccountContractData)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PaymentAccountContractData that = (PaymentAccountContractData) o;
 

--- a/core/src/main/java/io/bitsquare/payment/PaymentMethod.java
+++ b/core/src/main/java/io/bitsquare/payment/PaymentMethod.java
@@ -178,7 +178,7 @@ public final class PaymentMethod implements Persistable, Comparable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PaymentMethod)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         PaymentMethod that = (PaymentMethod) o;
 

--- a/core/src/main/java/io/bitsquare/trade/Contract.java
+++ b/core/src/main/java/io/bitsquare/trade/Contract.java
@@ -174,7 +174,7 @@ public final class Contract implements Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Contract)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Contract contract = (Contract) o;
 

--- a/core/src/main/java/io/bitsquare/trade/offer/Offer.java
+++ b/core/src/main/java/io/bitsquare/trade/offer/Offer.java
@@ -517,7 +517,7 @@ public final class Offer implements StoragePayload, RequiresOwnerIsOnlinePayload
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Offer)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         Offer that = (Offer) o;
         if (date != that.date) return false;
         if (fiatPrice != that.fiatPrice) return false;

--- a/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/DepositTxPublishedMessage.java
+++ b/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/DepositTxPublishedMessage.java
@@ -54,7 +54,7 @@ public final class DepositTxPublishedMessage extends TradeMessage implements Mai
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DepositTxPublishedMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
         DepositTxPublishedMessage that = (DepositTxPublishedMessage) o;

--- a/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/FiatTransferStartedMessage.java
+++ b/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/FiatTransferStartedMessage.java
@@ -53,7 +53,7 @@ public final class FiatTransferStartedMessage extends TradeMessage implements Ma
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof FiatTransferStartedMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
         FiatTransferStartedMessage that = (FiatTransferStartedMessage) o;

--- a/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/FinalizePayoutTxRequest.java
+++ b/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/FinalizePayoutTxRequest.java
@@ -62,7 +62,7 @@ public final class FinalizePayoutTxRequest extends TradeMessage implements Mailb
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof FinalizePayoutTxRequest)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
         FinalizePayoutTxRequest that = (FinalizePayoutTxRequest) o;

--- a/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/PayDepositRequest.java
+++ b/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/PayDepositRequest.java
@@ -96,7 +96,7 @@ public final class PayDepositRequest extends TradeMessage implements MailboxMess
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PayDepositRequest)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
         PayDepositRequest that = (PayDepositRequest) o;

--- a/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/PayoutTxFinalizedMessage.java
+++ b/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/PayoutTxFinalizedMessage.java
@@ -54,7 +54,7 @@ public final class PayoutTxFinalizedMessage extends TradeMessage implements Mail
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PayoutTxFinalizedMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
         PayoutTxFinalizedMessage that = (PayoutTxFinalizedMessage) o;

--- a/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/TradeMessage.java
+++ b/core/src/main/java/io/bitsquare/trade/protocol/trade/messages/TradeMessage.java
@@ -34,7 +34,7 @@ public abstract class TradeMessage implements DirectMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof TradeMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         TradeMessage that = (TradeMessage) o;
 

--- a/core/src/main/java/io/bitsquare/trade/statistics/TradeStatistics.java
+++ b/core/src/main/java/io/bitsquare/trade/statistics/TradeStatistics.java
@@ -115,7 +115,7 @@ public final class TradeStatistics implements LazyProcessedStoragePayload, Capab
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof TradeStatistics)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         TradeStatistics that = (TradeStatistics) o;
 

--- a/core/src/main/java/io/bitsquare/trade/statistics/TradeStatisticsForJson.java
+++ b/core/src/main/java/io/bitsquare/trade/statistics/TradeStatisticsForJson.java
@@ -114,7 +114,7 @@ public final class TradeStatisticsForJson {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof TradeStatisticsForJson)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         TradeStatisticsForJson that = (TradeStatisticsForJson) o;
 

--- a/gui/src/main/java/io/bitsquare/gui/main/funds/withdrawal/WithdrawalListItem.java
+++ b/gui/src/main/java/io/bitsquare/gui/main/funds/withdrawal/WithdrawalListItem.java
@@ -79,7 +79,7 @@ public class WithdrawalListItem {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof WithdrawalListItem)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         WithdrawalListItem that = (WithdrawalListItem) o;
 

--- a/gui/src/main/java/io/bitsquare/gui/main/offer/offerbook/OfferBookListItem.java
+++ b/gui/src/main/java/io/bitsquare/gui/main/offer/offerbook/OfferBookListItem.java
@@ -29,7 +29,7 @@ public class OfferBookListItem {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof OfferBookListItem)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         OfferBookListItem that = (OfferBookListItem) o;
 

--- a/network/src/main/java/io/bitsquare/crypto/DecryptedMsgWithPubKey.java
+++ b/network/src/main/java/io/bitsquare/crypto/DecryptedMsgWithPubKey.java
@@ -38,7 +38,7 @@ public final class DecryptedMsgWithPubKey implements Persistable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DecryptedMsgWithPubKey)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         DecryptedMsgWithPubKey that = (DecryptedMsgWithPubKey) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/NodeAddress.java
+++ b/network/src/main/java/io/bitsquare/p2p/NodeAddress.java
@@ -45,7 +45,7 @@ public final class NodeAddress implements Persistable, Payload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof NodeAddress)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         NodeAddress nodeAddress = (NodeAddress) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/network/Connection.java
+++ b/network/src/main/java/io/bitsquare/p2p/network/Connection.java
@@ -507,7 +507,7 @@ public class Connection implements MessageListener {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Connection)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Connection that = (Connection) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/peers/BroadcastHandler.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/BroadcastHandler.java
@@ -256,7 +256,7 @@ public class BroadcastHandler implements PeerManager.Listener {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof BroadcastHandler)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         BroadcastHandler that = (BroadcastHandler) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/peers/peerexchange/Peer.java
+++ b/network/src/main/java/io/bitsquare/p2p/peers/peerexchange/Peer.java
@@ -32,7 +32,7 @@ public final class Peer implements Payload, Persistable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Peer)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         Peer that = (Peer) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/storage/P2PDataStorage.java
+++ b/network/src/main/java/io/bitsquare/p2p/storage/P2PDataStorage.java
@@ -699,7 +699,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof ByteArray)) return false;
+            if (o == null || this.getClass() != o.getClass()) return false;
 
             ByteArray byteArray = (ByteArray) o;
 
@@ -738,7 +738,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof MapValue)) return false;
+            if (o == null || this.getClass() != o.getClass()) return false;
 
             MapValue mapValue = (MapValue) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/storage/messages/AddDataMessage.java
+++ b/network/src/main/java/io/bitsquare/p2p/storage/messages/AddDataMessage.java
@@ -16,7 +16,7 @@ public final class AddDataMessage extends BroadcastMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof AddDataMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         AddDataMessage that = (AddDataMessage) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/storage/messages/RemoveDataMessage.java
+++ b/network/src/main/java/io/bitsquare/p2p/storage/messages/RemoveDataMessage.java
@@ -16,7 +16,7 @@ public final class RemoveDataMessage extends BroadcastMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof RemoveDataMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         RemoveDataMessage that = (RemoveDataMessage) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/storage/messages/RemoveMailboxDataMessage.java
+++ b/network/src/main/java/io/bitsquare/p2p/storage/messages/RemoveMailboxDataMessage.java
@@ -16,7 +16,7 @@ public final class RemoveMailboxDataMessage extends BroadcastMessage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof RemoveMailboxDataMessage)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         RemoveMailboxDataMessage that = (RemoveMailboxDataMessage) o;
 

--- a/network/src/main/java/io/bitsquare/p2p/storage/payload/MailboxStoragePayload.java
+++ b/network/src/main/java/io/bitsquare/p2p/storage/payload/MailboxStoragePayload.java
@@ -87,7 +87,7 @@ public final class MailboxStoragePayload implements StoragePayload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MailboxStoragePayload)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         MailboxStoragePayload that = (MailboxStoragePayload) o;
 

--- a/network/src/test/java/io/bitsquare/p2p/mocks/MockMailboxPayload.java
+++ b/network/src/test/java/io/bitsquare/p2p/mocks/MockMailboxPayload.java
@@ -33,7 +33,7 @@ public final class MockMailboxPayload implements MailboxMessage, ExpirablePayloa
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MockMailboxPayload)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         MockMailboxPayload that = (MockMailboxPayload) o;
 

--- a/network/src/test/java/io/bitsquare/p2p/mocks/MockPayload.java
+++ b/network/src/test/java/io/bitsquare/p2p/mocks/MockPayload.java
@@ -21,7 +21,7 @@ public final class MockPayload implements Message, ExpirablePayload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MockPayload)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         MockPayload that = (MockPayload) o;
 

--- a/network/src/test/java/io/bitsquare/p2p/storage/mocks/MockData.java
+++ b/network/src/test/java/io/bitsquare/p2p/storage/mocks/MockData.java
@@ -17,7 +17,7 @@ public class MockData implements StoragePayload {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MockData)) return false;
+        if (o == null || this.getClass() != o.getClass()) return false;
 
         MockData that = (MockData) o;
 


### PR DESCRIPTION
This patch simply replaces the instanceof usage on equals() by getClass().
This was done with a replace all: !(o instanceof *)  -->  o == null || this.getClass() != o.getClass()

The code is equivalent, except for the instanceof version breaking the symmetry contract. Even though I have not checked if there are places where bitsquare relies on breaking object symmetry, I highly doubt that behaviour exists. It has actually only been a demonstrable issue on the Hibernate Java library.

One of the very old discussions over this issue on the eclipse forums: http://www.eclipsezone.com/eclipse/forums/t92613.html