### PR TITLE
Email validator

### DIFF
--- a/gui/src/main/java/io/bitsquare/gui/util/validation/ChaseQuickPayValidator.java
+++ b/gui/src/main/java/io/bitsquare/gui/util/validation/ChaseQuickPayValidator.java
@@ -17,17 +17,22 @@
 
 package io.bitsquare.gui.util.validation;
 
-
 public final class ChaseQuickPayValidator extends InputValidator {
+
+    private final EmailValidator emailValidator;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Public methods
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    public ChaseQuickPayValidator() {
+	super();
+	emailValidator = new EmailValidator();
+    }
+
     @Override
     public ValidationResult validate(String input) {
-        // TODO
-        return super.validate(input);
+        return emailValidator.validate(input);
     }
 
 

--- a/gui/src/main/java/io/bitsquare/gui/util/validation/EmailValidator.java
+++ b/gui/src/main/java/io/bitsquare/gui/util/validation/EmailValidator.java
@@ -17,6 +17,22 @@
 
 package io.bitsquare.gui.util.validation;
 
+/*
+ * Mail addresses consist of localPart @ domainPart
+ *
+ * Local part:
+ * May contain lots of symbols A-Za-z0-9.!#$%&'*+-/=?^_`{|}~
+ * but cannot begin or end with a dot (.)
+ * between double quotes many more symbols are allowed:
+ * "(),:;<>@[\] (ASCII: 32, 34, 40, 41, 44, 58, 59, 60, 62, 64, 91–93)
+ *
+ * Domain part:
+ * Consists of name dot TLD
+ * name can but usually doesn't (compatibility reasons) contain non-ASCII
+ * symbols.
+ * TLD is at least two letters long
+ *
+ */
 
 public final class EmailValidator extends InputValidator {
 
@@ -24,10 +40,47 @@ public final class EmailValidator extends InputValidator {
     // Public methods
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    private final ValidationResult invalidAddress = new ValidationResult(false, "Invalid address");
+
     @Override
     public ValidationResult validate(String input) {
         // TODO
-        return super.validate(input);
+	if (input == null || input.length() < 6) // shortest address is l@d.cc
+		return invalidAddress;
+	String [] substrings;
+	String local, domain;
+
+	substrings = input.split("@",-1);
+
+	if (substrings.length == 1) // address does not contain '@'
+		return invalidAddress;
+	if (substrings.length > 2) // multiple @'s included -> check for valid double quotes
+		if (!checkForValidQuotes(substrings)) // around @'s -> "..@..@.." and concatenate local part
+			return invalidAddress;
+	local = substrings[0];
+	domain = substrings[substrings.length-1];
+
+	// local part cannot begin or end with '.'
+	if (local.startsWith(".") || local.endsWith("."))
+		return invalidAddress;
+
+	String [] splitDomain = domain.split("\\.", -1); // '.' is a regex in java and has to be escaped
+	String tld = splitDomain[splitDomain.length-1];
+	if (splitDomain.length < 2)
+		return invalidAddress;
+
+	if (splitDomain[0] == null || splitDomain[0].isEmpty())
+		return invalidAddress;
+
+	// TLD length is at least two
+	if (tld.length() < 2)
+		return invalidAddress;
+
+	// TLD is letters only
+	for (int k=0; k<tld.length(); k++)
+		if (!Character.isLetter(tld.charAt(k)))
+			return invalidAddress;
+	return new ValidationResult(true);
     }
 
 
@@ -35,5 +88,22 @@ public final class EmailValidator extends InputValidator {
     // Private methods
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    private boolean checkForValidQuotes(String [] substrings) {
+	int length = substrings.length - 2; // is index on last substring of local part
+
+	// check for odd number of double quotes before first and after last '@'
+	if ( (substrings[0].split("\"",-1).length %2 == 1) || (substrings[length].split("\"",-1).length %2 == 1) )
+		return false;
+	for (int k=1; k<length; k++) {
+		if (substrings[k].split("\"",-1).length % 2 == 0)
+			return false;
+	}
+
+	String patchLocal = new String("");
+	for (int k=0; k<=length; k++) // remember: length is last index not array length
+		patchLocal = patchLocal.concat(substrings[k]); // @'s are not reinstalled, since not needed for further checks
+	substrings[0] = patchLocal;
+	return true;
+    }
 
 }


### PR DESCRIPTION
ChaseQuickPayValidator calls EmailValidator

EmailValidator:
Added basic rules for email validation
- only one '@' sign allowed (unless between double quotes in local part)
- local part cannot start or end with '.'
- top level domain in domain part is letters only and at least two chars long (http://www.iana.org/domains/root/db)

Rules are taken from German Wikipedia (https://de.wikipedia.org/w/index.php?title=E-Mail-Adresse&stableid=160390365) and are mainly specified in RFC 5321 and RFC 5322