### PR TITLE
Add scrollpane to account screen #708

### DIFF
--- a/gui/src/main/java/io/bitsquare/gui/main/account/content/altcoinaccounts/AltCoinAccountsView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/account/content/altcoinaccounts/AltCoinAccountsView.fxml
@@ -21,8 +21,8 @@
 <?import javafx.scene.layout.*?>
 <GridPane fx:id="root" fx:controller="io.bitsquare.gui.main.account.content.altcoinaccounts.AltCoinAccountsView"
           hgap="5.0" vgap="5.0"
-          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-          AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="-10.0"
+          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="20.0"
+          AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="20.0"
           xmlns:fx="http://javafx.com/fxml">
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" halignment="RIGHT" minWidth="160.0"/>

--- a/gui/src/main/java/io/bitsquare/gui/main/account/content/arbitratorselection/ArbitratorSelectionView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/account/content/arbitratorselection/ArbitratorSelectionView.fxml
@@ -20,8 +20,8 @@
 <?import javafx.scene.layout.*?>
 <GridPane fx:id="root" fx:controller="io.bitsquare.gui.main.account.content.arbitratorselection.ArbitratorSelectionView"
           hgap="5.0" vgap="5.0"
-          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-          AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="-10.0"
+          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="20.0"
+          AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="20.0"
           xmlns:fx="http://javafx.com/fxml">
 
     <columnConstraints>

--- a/gui/src/main/java/io/bitsquare/gui/main/account/content/backup/BackupView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/account/content/backup/BackupView.fxml
@@ -20,8 +20,8 @@
 <?import javafx.scene.layout.*?>
 <GridPane fx:id="root" fx:controller="io.bitsquare.gui.main.account.content.backup.BackupView"
           hgap="5.0" vgap="5.0"
-          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-          AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="-10.0"
+          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="20.0"
+          AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="20.0"
           xmlns:fx="http://javafx.com/fxml">
 
     <columnConstraints>

--- a/gui/src/main/java/io/bitsquare/gui/main/account/content/fiataccounts/FiatAccountsView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/account/content/fiataccounts/FiatAccountsView.fxml
@@ -21,8 +21,8 @@
 <?import javafx.scene.layout.*?>
 <GridPane fx:id="root" fx:controller="io.bitsquare.gui.main.account.content.fiataccounts.FiatAccountsView"
           hgap="5.0" vgap="5.0"
-          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-          AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="-10.0"
+          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="20.0"
+          AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="20.0"
           xmlns:fx="http://javafx.com/fxml">
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" halignment="RIGHT" minWidth="160.0"/>

--- a/gui/src/main/java/io/bitsquare/gui/main/account/content/password/PasswordView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/account/content/password/PasswordView.fxml
@@ -20,8 +20,8 @@
 <?import javafx.scene.layout.*?>
 <GridPane fx:id="root" fx:controller="io.bitsquare.gui.main.account.content.password.PasswordView"
           hgap="5.0" vgap="5.0"
-          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-          AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="-10.0"
+          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="20.0"
+          AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="20.0"
           xmlns:fx="http://javafx.com/fxml">
 
     <columnConstraints>

--- a/gui/src/main/java/io/bitsquare/gui/main/account/content/seedwords/SeedWordsView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/account/content/seedwords/SeedWordsView.fxml
@@ -20,8 +20,8 @@
 <?import javafx.scene.layout.*?>
 <GridPane fx:id="root" fx:controller="io.bitsquare.gui.main.account.content.seedwords.SeedWordsView"
           hgap="5.0" vgap="5.0"
-          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-          AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="-10.0"
+          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="20.0"
+          AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="20.0"
           xmlns:fx="http://javafx.com/fxml">
 
     <columnConstraints>

--- a/gui/src/main/java/io/bitsquare/gui/main/account/settings/AccountSettingsView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/account/settings/AccountSettingsView.fxml
@@ -1,31 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ This file is part of Bitsquare.
-  ~
-  ~ Bitsquare is free software: you can redistribute it and/or modify it
-  ~ under the terms of the GNU Affero General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or (at
-  ~ your option) any later version.
-  ~
-  ~ Bitsquare is distributed in the hope that it will be useful, but WITHOUT
-  ~ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  ~ FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
-  ~ License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with Bitsquare. If not, see <http://www.gnu.org/licenses/>.
-  -->
+~ This file is part of Bitsquare.
+~
+~ Bitsquare is free software: you can redistribute it and/or modify it
+~ under the terms of the GNU Affero General Public License as published by
+~ the Free Software Foundation, either version 3 of the License, or (at
+~ your option) any later version.
+~
+~ Bitsquare is distributed in the hope that it will be useful, but WITHOUT
+~ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+~ FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+~ License for more details.
+~
+~ You should have received a copy of the GNU Affero General Public License
+~ along with Bitsquare. If not, see <http://www.gnu.org/licenses/>.
+-->
 
-
+<?import javafx.scene.control.*?>
+<?import java.lang.*?>
 <?import javafx.scene.layout.*?>
-<AnchorPane fx:id="root" fx:controller="io.bitsquare.gui.main.account.settings.AccountSettingsView"
-            prefHeight="660.0" prefWidth="1000.0"
-            xmlns:fx="http://javafx.com/fxml">
 
-    <VBox fx:id="leftVBox" spacing="5" prefWidth="240" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15"
-          AnchorPane.topAnchor="20"/>
-    <AnchorPane fx:id="content" AnchorPane.bottomAnchor="10" AnchorPane.rightAnchor="25" AnchorPane.leftAnchor="290"
-                AnchorPane.topAnchor="30"/>
+<AnchorPane fx:id="root" prefHeight="660.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.bitsquare.gui.main.account.settings.AccountSettingsView">
+    <children>
+   
+        <VBox fx:id="leftVBox" prefWidth="240" spacing="5" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15" AnchorPane.topAnchor="20" />
+       
+        <ScrollPane fx:id="scrollPane" 
+                    fitToWidth="true" hbarPolicy="NEVER" 
+                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0" 
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <content>
+                <AnchorPane fx:id="content" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+            </content>
+        </ScrollPane>
+         
+    </children>
 </AnchorPane>
-


### PR DESCRIPTION
I've added a scrollpane not only for the fiat account screen.
A scrollpane is now available for all six account screens (AltCoin, ArbitratorSelection, Backup, Fiat, Password, SeedWords). 
Only FXML files are changed.

Please try it out. 