### PR TITLE
Scrollpanes in market section

### DIFF
--- a/gui/src/main/java/io/bitsquare/gui/main/market/MarketView.fxml
+++ b/gui/src/main/java/io/bitsquare/gui/main/market/MarketView.fxml
@@ -17,15 +17,26 @@
   ~ along with Bitsquare. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<?import javafx.scene.control.Tab?>
-<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.*?>
 <?import javafx.scene.layout.AnchorPane?>
 <TabPane fx:id="root" fx:controller="io.bitsquare.gui.main.market.MarketView"
          AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
          AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0"
          xmlns:fx="http://javafx.com/fxml">
 
-    <Tab fx:id="chartsTab" text="Offer book" closable="false"/>
+    <Tab fx:id="chartsTab" text="Offer book" closable="false">
+        <content>
+            <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        </content>
+    </Tab>
     <Tab fx:id="statisticsTab" text="Spreads" closable="false"/>
-    <Tab fx:id="tradesTab" text="Trades" closable="false"/>
+    <Tab fx:id="tradesTab" text="Trades" closable="false">
+        <content>
+            <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        </content>
+    </Tab>
 </TabPane>

--- a/gui/src/main/java/io/bitsquare/gui/main/market/MarketView.java
+++ b/gui/src/main/java/io/bitsquare/gui/main/market/MarketView.java
@@ -26,6 +26,7 @@ import io.bitsquare.gui.main.market.spread.SpreadView;
 import io.bitsquare.gui.main.market.trades.TradesChartsView;
 import javafx.beans.value.ChangeListener;
 import javafx.fxml.FXML;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 
@@ -91,7 +92,11 @@ public class MarketView extends ActivatableViewAndModel<TabPane, Activatable> {
         else if (view instanceof SpreadView) tab = statisticsTab;
         else throw new IllegalArgumentException("Navigation to " + viewClass + " is not supported");
 
-        tab.setContent(view.getRoot());
+        if (tab.getContent() != null && tab.getContent() instanceof ScrollPane) {
+            ((ScrollPane) tab.getContent()).setContent(view.getRoot());
+        } else {
+            tab.setContent(view.getRoot());
+        }
         root.getSelectionModel().select(tab);
     }
 

--- a/gui/src/main/java/io/bitsquare/gui/main/market/offerbook/OfferBookChartView.java
+++ b/gui/src/main/java/io/bitsquare/gui/main/market/offerbook/OfferBookChartView.java
@@ -144,7 +144,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     @Override
     protected void activate() {
         // root.getParent() is null at initialize
-        tabPaneSelectionModel = ((TabPane) root.getParent().getParent()).getSelectionModel();
+        tabPaneSelectionModel = GUIUtil.getParentOfType(root, TabPane.class).getSelectionModel();
         selectedTabIndexListener = (observable, oldValue, newValue) -> model.setSelectedTabIndex((int) newValue);
 
         model.setSelectedTabIndex(tabPaneSelectionModel.getSelectedIndex());
@@ -271,6 +271,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         areaChart.setAnimated(false);
         areaChart.setId("charts");
         areaChart.setMinHeight(300);
+        areaChart.setPrefHeight(300);
         areaChart.setPadding(new Insets(0, 30, 0, 0));
         areaChart.getData().addAll(seriesBuy, seriesSell);
     }
@@ -286,6 +287,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     private Tuple4<TableView<OfferListItem>, VBox, Button, Label> getOfferTable(Offer.Direction direction) {
         TableView<OfferListItem> tableView = new TableView<>();
         tableView.setMinHeight(109);
+        tableView.setPrefHeight(121);
         tableView.setMinWidth(480); //530
 
         // price
@@ -466,6 +468,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         vBox.setSpacing(10);
         vBox.setFillWidth(true);
         vBox.setMinHeight(190);
+//        vBox.setPrefHeight(190);
         vBox.getChildren().addAll(titleLabel, tableView, button);
 
         button.prefWidthProperty().bind(vBox.widthProperty());

--- a/gui/src/main/java/io/bitsquare/gui/main/market/offerbook/OfferBookChartView.java
+++ b/gui/src/main/java/io/bitsquare/gui/main/market/offerbook/OfferBookChartView.java
@@ -468,7 +468,6 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         vBox.setSpacing(10);
         vBox.setFillWidth(true);
         vBox.setMinHeight(190);
-//        vBox.setPrefHeight(190);
         vBox.getChildren().addAll(titleLabel, tableView, button);
 
         button.prefWidthProperty().bind(vBox.widthProperty());

--- a/gui/src/main/java/io/bitsquare/gui/main/market/trades/TradesChartsView.java
+++ b/gui/src/main/java/io/bitsquare/gui/main/market/trades/TradesChartsView.java
@@ -135,7 +135,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     @Override
     protected void activate() {
         // root.getParent() is null at initialize
-        tabPaneSelectionModel = ((TabPane) root.getParent().getParent()).getSelectionModel();
+        tabPaneSelectionModel = GUIUtil.getParentOfType(root, TabPane.class).getSelectionModel();
         selectedTabIndexListener = (observable, oldValue, newValue) -> model.setSelectedTabIndex((int) newValue);
         model.setSelectedTabIndex(tabPaneSelectionModel.getSelectedIndex());
         tabPaneSelectionModel.selectedIndexProperty().addListener(selectedTabIndexListener);
@@ -279,7 +279,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 return null;
             }
         });
-        priceChart.setMinHeight(200);
+        priceChart.setMinHeight(198);
+        priceChart.setPrefHeight(198);
         priceChart.setMaxHeight(300);
         priceChart.setLegendVisible(false);
         priceChart.setData(FXCollections.observableArrayList(priceSeries));
@@ -321,7 +322,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             }
         });
         volumeChart.setData(FXCollections.observableArrayList(volumeSeries));
-        volumeChart.setMinHeight(150);
+        volumeChart.setMinHeight(148);
+        volumeChart.setPrefHeight(148);
         volumeChart.setMaxHeight(200);
         volumeChart.setLegendVisible(false);
     }
@@ -422,6 +424,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private void createTable() {
         tableView = new TableView<>();
         tableView.setMinHeight(140);
+        tableView.setPrefHeight(140);
         VBox.setVgrow(tableView, Priority.ALWAYS);
 
         // date

--- a/gui/src/main/java/io/bitsquare/gui/util/GUIUtil.java
+++ b/gui/src/main/java/io/bitsquare/gui/util/GUIUtil.java
@@ -24,6 +24,7 @@ import com.googlecode.jcsv.writer.CSVWriter;
 import com.googlecode.jcsv.writer.internal.CSVWriterBuilder;
 import io.bitsquare.app.DevFlags;
 import io.bitsquare.common.util.Utilities;
+import io.bitsquare.gui.common.view.View;
 import io.bitsquare.gui.main.overlays.popups.Popup;
 import io.bitsquare.locale.CurrencyUtil;
 import io.bitsquare.locale.TradeCurrency;
@@ -300,4 +301,19 @@ public class GUIUtil {
             e.printStackTrace();
         }
     }
+    
+    public static <T> T getParentOfType(Node node, Class<T> t) {
+        Node parent = node.getParent();
+
+        while (parent != null) {
+            if (parent.getClass().isAssignableFrom(t)) {
+                break;
+            } else {
+                parent = parent.getParent();
+            }
+        }
+
+        return parent != null ? (T) parent : null;
+    }
+    
 }

--- a/gui/src/main/java/io/bitsquare/gui/util/GUIUtil.java
+++ b/gui/src/main/java/io/bitsquare/gui/util/GUIUtil.java
@@ -24,7 +24,6 @@ import com.googlecode.jcsv.writer.CSVWriter;
 import com.googlecode.jcsv.writer.internal.CSVWriterBuilder;
 import io.bitsquare.app.DevFlags;
 import io.bitsquare.common.util.Utilities;
-import io.bitsquare.gui.common.view.View;
 import io.bitsquare.gui.main.overlays.popups.Popup;
 import io.bitsquare.locale.CurrencyUtil;
 import io.bitsquare.locale.TradeCurrency;


### PR DESCRIPTION
Added scrollpanes to
- Market/Offer book
- Market/Trades

Also added a new method in GUIUtil to prevent a _.getParent()_-row in offerbook and trades classes.

_Portfolio/Open trades_ is empty for me. 
@ManfredKarrer please send me a screenshot for this. 