### PR TITLE
Removing undefined 'jdkfixFile' var from 'srcfiles' param

### DIFF
--- a/package/linux/32bitBuild.sh
+++ b/package/linux/32bitBuild.sh
@@ -25,7 +25,7 @@ $JAVA_HOME/bin/javapackager \
     -title Bisq \
     -vendor Bisq \
     -outdir gui/deploy \
-    -srcfiles $jarFile:$jdkfixFile \
+    -srcfiles $jarFile \
     -srcfiles package/linux/LICENSE \
     -appclass io.bisq.gui.app.BisqAppMain \
     -BjvmOptions=-Xss1280k \

--- a/package/linux/64bitBuild.sh
+++ b/package/linux/64bitBuild.sh
@@ -25,7 +25,7 @@ $JAVA_HOME/bin/javapackager \
     -title Bisq \
     -vendor Bisq \
     -outdir gui/deploy \
-    -srcfiles $jarFile:$jdkfixFile \
+    -srcfiles $jarFile \
     -srcfiles package/linux/LICENSE \
     -appclass io.bisq.gui.app.BisqAppMain \
     -BjvmOptions=-Xss1280k \


### PR DESCRIPTION
Looks like this was overlooked in https://github.com/bitsquare/bitsquare/commit/f076a840f59b1db9d28a4a767eff4695da4598c0