### PR TITLE
Installing protobuf automagically

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -11,18 +11,90 @@
 
     <artifactId>common</artifactId>
 
+    <properties>
+        <protobuf.version>3.3.0</protobuf.version>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <protobuf.classifier>windows-x86_64</protobuf.classifier>
+                <protobuf.exe>protoc.exe</protobuf.exe>
+            </properties>
+        </profile>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <properties>
+                <protobuf.classifier>linux-x86_64</protobuf.classifier>
+                <protobuf.exe>protoc</protobuf.exe>
+            </properties>
+        </profile>
+        <profile>
+            <id>macos</id>
+            <activation>
+                <os>
+                    <family>macos</family>
+                </os>
+            </activation>
+            <properties>
+                <protobuf.classifier>osx-x86_64</protobuf.classifier>
+                <protobuf.exe>protoc</protobuf.exe>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-protoc</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.google.protobuf</groupId>
+                                    <artifactId>protoc</artifactId>
+                                    <version>${protobuf.version}</version>
+                                    <classifier>${protobuf.classifier}</classifier>
+                                    <type>exe</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <destFileName>${protobuf.exe}</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- https://www.xolstice.org/protobuf-maven-plugin/usage.html -->
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.0</version>
                 <configuration>
-                    <protocExecutable>/usr/local/bin/protoc</protocExecutable>
+                    <protocExecutable>${project.build.directory}/${protobuf.exe}</protocExecutable>
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>generate-sources</phase>
                         <goals>
                             <goal>compile</goal>
                             <goal>test-compile</goal>
@@ -37,7 +109,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.3.0</version>
+            <version>${protobuf.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/doc/build.md
+++ b/doc/build.md
@@ -74,8 +74,8 @@ For Mac OSX, you will need to set JAVA_HOME as:
     $ . ~/.bashrc
 
 
-### 2. Install the latest protobuffer release on your machine (3.3.0 at the time of writing):
-https://github.com/google/protobuf/releases
+### Protobuf
+Note that Bisq use protobuf during maven build https://github.com/google/protobuf/releases
 
 ### 2.1 Increase the Intellij Idea Code insight limit, because it breaks on the generated protobuffer files:
 Go to Help > Edit custom properties => paste the following line:
@@ -111,15 +111,8 @@ It is not needed for a normal user to run such a "full node" but for the build i
 
 Prepare bisq build
 -----------------
-### 4. Install Protobuffer
 
-Install Protobuffer.
-       
-    $ wget https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip
-    $ unzip protoc-3.3.0-linux-x86_64.zip -d protoc3
-    $ sudo mv protoc3/bin/protoc /usr/local/bin/protoc
-
-### 5. Get bisq source code and build a preliminary bisq version (don't run the jar, it wont work)
+### 4. Get bisq source code and build a preliminary bisq version (don't run the jar, it wont work)
 
 We need to get the bisq dependencies resolved first as we need to copy the BouncyCastle jar to the JRE directory.
 
@@ -127,14 +120,14 @@ We need to get the bisq dependencies resolved first as we need to copy the Bounc
     $ cd bisq
     $ mvn clean package -DskipTests -Dmaven.javadoc.skip=true
 
-### 6. Copy the BouncyCastle provider jar file
+### 5. Copy the BouncyCastle provider jar file
 
 Copy the BountyCastle provider jar file from the local maven repository to the jre/lib/ext directory.
 This prevents a "JCE cannot authenticate the provider BC" exception when starting the bisq client.
 
     $ sudo cp ~/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.53/bcprov-jdk15on-1.53.jar $JAVA_HOME/jre/lib/ext/
 
-### 7. Edit the java.security file and add BouncyCastleProvider
+### 6. Edit the java.security file and add BouncyCastleProvider
 
 Add org.bouncycastle.jce.provider.BouncyCastleProvider as last entry at: ﻿List of providers and their preference orders
 E.g.:
@@ -143,7 +136,7 @@ security.provider.10=org.bouncycastle.jce.provider.BouncyCastleProvider
     $ sudo gedit $JAVA_HOME/jre/lib/security/java.security
     ... edit and save
 
-### 8. Enable unlimited Strength for cryptographic keys (only required for Oracle JDK)
+### 7. Enable unlimited Strength for cryptographic keys (only required for Oracle JDK)
 
 If you are using Oracle JDK 8 you must **[enable strong cryptographic cyphers](https://github.com/jonathancross/jc-docs/blob/master/java-strong-crypto-test/README.md)**. If you use OpenJDK + OpenJFX you can skip this step.
 
@@ -153,7 +146,7 @@ In Windows the new crypto files need to be copied to `Java/jdk1.8.0_xxx/jre/lib/
 Build bisq
 -----------------
 
-### 9. Build final bisq jar
+### 8. Build final bisq jar
 
 Now we have all prepared to build the correct bisq jar.
 

--- a/pom.xml
+++ b/pom.xml
@@ -250,4 +250,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- Oracle JDK 9 will support strong cyphers, but they must be explicitly enabled-->
+            <id>enable-strong-cipher-jdk9</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <properties>
+                    <crypto.policy>unlimited</crypto.policy>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Protobuf compiler get extracted as dependency under linux, windows, macos removing the need to install it using sudo and documenting it. This is more the maven way of doing: all in pom, mvn package and it is done without more explanation except what is in pom. Build is now more portable

Middle term objective in this branch is to be able to build with mvn package without any documentation,  in intellij windows/linux/macos

this is lowering the barrier entry to do proper TDD, and avoid complicated howto run
