### PR TITLE
Fix maven transitive dependency

### DIFF
--- a/common/src/main/resources/i18n/displayStrings_de.properties
+++ b/common/src/main/resources/i18n/displayStrings_de.properties
@@ -98,7 +98,7 @@ shared.openDefaultWalletFailed=Öffnen einer Standard-Bitcoin-Wallet-Anwendung s
 shared.distanceInPercent=Abstand in % vom Marktpreis
 shared.enterPercentageValue=% Wert eingeben
 shared.OR=ODER
-shared.notEnoughFunds=Sie haben nicht genug Gelder in Ihrer Bisq-Wallet.\nSie benötigen {0}, haben aber nur {1} in ihrer Bisq-Wallet.\n\nFinanzieren sie diesen Handel bitte von einer externen Bitcoin-Wallet oder finanzieren sie Ihre Bisq-Wallet unter \\"Gelder/Gelder erhalten\\".
+shared.notEnoughFunds=Sie haben nicht genug Gelder in Ihrer Bisq-Wallet.\nSie benötigen {0}, haben aber nur {1} in ihrer Bisq-Wallet.\n\nFinanzieren sie diesen Handel bitte von einer externen Bitcoin-Wallet oder finanzieren sie Ihre Bisq-Wallet unter Replace \"Gelder/Gelder erhalten\".
 shared.waitingForFunds=Warte auf Gelder...
 shared.depositTransactionId=Kautionstransaktionskennung
 shared.TheBTCBuyer=Der BTC-Käufer
@@ -338,12 +338,12 @@ createOffer.fundsBox.networkFee=Mining Gebühr:
 createOffer.fundsBox.placeOfferSpinnerInfo=Veröffentlichung des Angebots in Bearbeitung ...
 createOffer.fundsBox.paymentLabel=Bisq Handel mit Kennung {0}
 createOffer.success.headline=Ihr Angebot wurde veröffentlicht
-createOffer.success.info=Sie können Ihre offenen Angebote unter \\"Mappe/Meine offenen Angebote\\" verwalten.
+createOffer.success.info=Sie können Ihre offenen Angebote unter \"Mappe/Meine offenen Angebote\" verwalten.
 
 
 # new entries
 createOffer.placeOfferButton=Überprüfung: Anbieten Bitcoin zu {0}
-createOffer.alreadyFunded=Sie hatten das Angebot bereits finanziert.\nIhre Gelder wurden in Ihre lokale Bisq-Wallet verschoben und sind unter \\"Gelder/Gelder senden\\" abhebbar.
+createOffer.alreadyFunded=Sie hatten das Angebot bereits finanziert.\nIhre Gelder wurden in Ihre lokale Bisq-Wallet verschoben und sind unter \"Gelder/Gelder senden\" abhebbar.
 createOffer.createOfferFundWalletInfo.headline=Ihr Angebot finanzieren
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Handelsbetrag: {0}\n
@@ -352,7 +352,7 @@ createOffer.createOfferFundWalletInfo.msg=Sie müssen zum Annehmen dieses Angebo
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
 createOffer.amountPriceBox.error.message=Es gab einen Fehler beim Erstellen des Angebots:\n\n{0}\n\nEs haben noch keine Gelder Ihre Wallet verlassen.\nBitte starten Sie Ihre Anwendung neu und überprüfen Sie Ihre Netzwerkverbindung.
 createOffer.setAmountPrice=Betrag und Preis festlegen
-createOffer.warnCancelOffer=Sie haben das Angebot bereits finanziert.\nWenn Sie jetzt abbrechen, werden Ihre Gelder in Ihre lokale Bisq-Wallet verschoben und unter \\"Gelder/Gelder senden\\" abhebbar sein.\nSind Sie sicher, dass Sie abbrechen wollen?
+createOffer.warnCancelOffer=Sie haben das Angebot bereits finanziert.\nWenn Sie jetzt abbrechen, werden Ihre Gelder in Ihre lokale Bisq-Wallet verschoben und unter \"Gelder/Gelder senden\" abhebbar sein.\nSind Sie sicher, dass Sie abbrechen wollen?
 createOffer.fixed=Fest
 createOffer.percentage=Prozent
 createOffer.timeoutAtPublishing=Ein timeout ist beim veröffentlichen des Angebots aufgetreten.
@@ -390,21 +390,21 @@ takeOffer.fundsBox.networkFee=Mining Gebühren (3x):
 takeOffer.fundsBox.takeOfferSpinnerInfo=Angebotsannahme im Gange ...
 takeOffer.fundsBox.paymentLabel=Bisq Handel mit Kennung {0}
 takeOffer.success.headline=Sie haben ein Angebot erfolgreich angenommen.
-takeOffer.success.info=Sie können den Status Ihres Angebots unter \\"Mappe/Offene Angebote\\" einsehen.
+takeOffer.success.info=Sie können den Status Ihres Angebots unter \"Mappe/Offene Angebote\" einsehen.
 takeOffer.error.message=Während der Annahme des Angebots ist ein Fehler aufgetreten.\n\n{0}
 
 # new entries
 takeOffer.takeOfferButton=Überprüfung: Angebot annehmen Bitcoin zu {0}
 takeOffer.noPriceFeedAvailable=Sie können dieses Angebot nicht annehmen, da es auf einem Prozentsatz vom Marktpreis basiert, jedoch kein Marktpreis verfügbar ist.
-takeOffer.alreadyFunded.movedFunds=Sie haben das Angebot bereits finanziert.\nIhre Gelder wurden in Ihre lokale Bisq-Wallet verschoben und sind unter \\"Gelder/Gelder senden\\" abhebbar.
+takeOffer.alreadyFunded.movedFunds=Sie haben das Angebot bereits finanziert.\nIhre Gelder wurden in Ihre lokale Bisq-Wallet verschoben und sind unter \"Gelder/Gelder senden\" abhebbar.
 takeOffer.takeOfferFundWalletInfo.headline=Ihren Handel finanzieren
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Handelsbetrag: {0}\n
 takeOffer.takeOfferFundWalletInfo.msg=Sie müssen zum Annehmen dieses Angebots {0} einzahlen.\n\nDer Betrag ist die Summe von:\n{1}- Kaution: {2}\n- Handelsgebühr: {3}\n- Mining Gebühr (3x): {4}\n\nSie haben zwei Möglichkeiten ihren Handel zu finanzieren:\n- Nutzen Sie Ihre Bisq Wallet (bequem, aber Transaktionen können verknüpfbar sein) ODER\n- Von einer externen Wallet übertragen (möglicherweise privater)\n\nSie werden nach dem Schließen dieses Dialogs alle Finanzierungsmöglichkeiten und Details sehen.
-takeOffer.alreadyPaidInFunds=Wenn Sie schon Gelder gezahlt haben, können sie diese unter \\"Gelder/Gelder senden\\" abheben.
+takeOffer.alreadyPaidInFunds=Wenn Sie schon Gelder gezahlt haben, können sie diese unter \"Gelder/Gelder senden\" abheben.
 takeOffer.paymentInfo=Zahlungsinformationen
 takeOffer.setAmountPrice=Betrag festlegen
-takeOffer.alreadyFunded.askCancel=Sie haben das Angebot bereits finanziert.\nWenn Sie jetzt abbrechen, werden Ihre Gelder in Ihre lokale Bisq-Wallet verschoben und unter \\"Gelder/Gelder senden\\" abhebbar sein.\nSind Sie sicher, dass Sie abbrechen wollen?
+takeOffer.alreadyFunded.askCancel=Sie haben das Angebot bereits finanziert.\nWenn Sie jetzt abbrechen, werden Ihre Gelder in Ihre lokale Bisq-Wallet verschoben und unter \"Gelder/Gelder senden\" abhebbar sein.\nSind Sie sicher, dass Sie abbrechen wollen?
 takeOffer.failed.offerNotAvailable=Annahme des Angebots ist fehlgeschlagen, weil dieses nicht mehr verfügbar ist. Vielleicht hat ein anderer Händler das Angebot zwischenzeitlich angenommen.
 takeOffer.failed.offerTaken=Sie können dieses Angebot nicht annehmen, weil es schon von einem anderen Händler angenommen wurde.
 takeOffer.failed.offerRemoved=Sie können dieses Angebot nicht annehmen, weil es inzwischen entfernt wurde.
@@ -446,12 +446,12 @@ portfolio.pending.step1.openForDispute=Die Kautionstransaktion wurde immer noch 
 portfolio.pending.step2.confReached=Ihr Handel hat wenigstens eine Blockkettenbestätigung erreicht.\n(Sie können auf weitere Bestätigungen warten, wenn Sie möchten. 6 Bestätigungen werden als sehr sicher angesehen.)\n\n
 
 portfolio.pending.step2_buyer.copyPaste=(Sie können die Werte vom Hauptbildschirm kopieren und anderswo einfügen, nachdem dieser Dialog geschlossen wurde.)
-portfolio.pending.step2_buyer.refTextWarn=Nutzen Sie KEINE zusätzlichen Informationen im \\"Verwendungszweck\\" wie Bitcoin, BTC oder Bisq.
+portfolio.pending.step2_buyer.refTextWarn=Nutzen Sie KEINE zusätzlichen Informationen im \"Verwendungszweck\" wie Bitcoin, BTC oder Bisq.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.accountDetails=Hier sind die Handelskontodetails des BTC-Verkäufers:\n
 portfolio.pending.step2_buyer.tradeId=Vergessen Sie bitte nicht, die Handelskennung anzufügen
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.assign= als \\"Verwendungszweck\\", damit der Empfänger Ihre Zahlung diesem Handel zuordnen kann.\n\n
+portfolio.pending.step2_buyer.assign= als \"Verwendungszweck\", damit der Empfänger Ihre Zahlung diesem Handel zuordnen kann.\n\n
 portfolio.pending.step2_buyer.fees=Sollte Ihre Bank Gebühren berechnen, müssen Sie diese decken.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.altcoin=Bitte überweisen Sie von ihrer externen {0} Wallet\n{1} an den BTC-Verkäufer.\n\n
@@ -459,7 +459,7 @@ portfolio.pending.step2_buyer.altcoin=Bitte überweisen Sie von ihrer externen {
 portfolio.pending.step2_buyer.cash=Bitte gehen Sie zu eine Bank und zahlen Sie {0} an den BTC-Verkäufer.\n\n
 portfolio.pending.step2_buyer.cash.extra=WICHTIGE VORAUSSETZUNG:\nNachdem Sie die Zahlung getätigt haben, schreiben Sie auf die Quittung: NO REFUNDS.\nReißen Sie es in 2 Teile und machen Sie ein Foto, das Sie an die E-Mailadresse des BTC-Verkäufers senden.
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.postal=Bitte senden Sie {0} per \\"US Postal Money Order\\" an den BTC-Verkäufer.\n\n.\n\n
+portfolio.pending.step2_buyer.postal=Bitte senden Sie {0} per \"US Postal Money Order\" an den BTC-Verkäufer.\n\n.\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.bank=Bitte gehen Sie auf Ihre Onlinebanking-Webseite und zahlen {0} an den BTC-Verkäufer.\n\n
 portfolio.pending.step2_buyer.startPaymentUsing=Zahlung per {0} beginnen
@@ -488,11 +488,11 @@ portfolio.pending.step3_buyer.openForDispute=Der BTC-Verkäufer hat Ihre Zahlung
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.part=Ihr Handelspartner hat bestätigt, die {0} Zahlung begonnen zu haben.\n\n
 portfolio.pending.step3_seller.altcoin={0}Bitte überprüfen Sie mit ihrem bevorzugten {1} Blockkettenforscher, ob die Transaktion zu Ihrer Empfangsadresse\n{2}\nschon genug Blockkettenbestätigungen hat.\nDer Zahlungsbetrag muss {3} sein\n\nSie können Ihre {4} Adresse vom Hauptbildschirm kopieren und woanders einfügen, nachdem dieser Dialog geschlossen wurde.
-portfolio.pending.step3_seller.postal={0}Bitte überprüfen Sie, ob Sie {1} per \\"US Postal Money Order\\" vom BTC-Käufer erhalten haben.\n\nDie Handelskennung (\\"Verwendungszweck") der Transaktion ist: \\"{2}\\"
-portfolio.pending.step3_seller.bank=Ihr Handelspartner hat bestätigt die Zahlung mit {0} begonnen zu haben.\n\nBitte gehen Sie auf Ihre Onlinebanking Webseite und überprüfen Sie, ob Sie {1} vom BTC Käufer erhalten haben.\n\nDie Handelskennung (\\"Verwendungszweck\\") der Transaktion ist: \\"{2}\\"
-portfolio.pending.step3_seller.cash=\n\nWeil die Zahlung per Cash Deposit ausgeführt wurde, muss der BTC Käufer \\"NO REFUND\\" auf die Quittung schreiben, Sie in 2 Teile reißen und ihnen ein Foto per E-Mail schicken.\n\nUm die Gefahr einer Rückbuchung zu vermeiden, bestätigen Sie nur, wenn Sie die E-Mail erhalten haben und Sie sicher sind, dass die Quittung gültig ist.\nWenn Sie nicht sicher sind, {0}
+portfolio.pending.step3_seller.postal={0}Bitte überprüfen Sie, ob Sie {1} per \"US Postal Money Order\" vom BTC-Käufer erhalten haben.\n\nDie Handelskennung (\"Verwendungszweck") der Transaktion ist: \"{2}\"
+portfolio.pending.step3_seller.bank=Ihr Handelspartner hat bestätigt die Zahlung mit {0} begonnen zu haben.\n\nBitte gehen Sie auf Ihre Onlinebanking Webseite und überprüfen Sie, ob Sie {1} vom BTC Käufer erhalten haben.\n\nDie Handelskennung (\"Verwendungszweck\") der Transaktion ist: \"{2}\"
+portfolio.pending.step3_seller.cash=\n\nWeil die Zahlung per Cash Deposit ausgeführt wurde, muss der BTC Käufer \"NO REFUND\" auf die Quittung schreiben, Sie in 2 Teile reißen und ihnen ein Foto per E-Mail schicken.\n\nUm die Gefahr einer Rückbuchung zu vermeiden, bestätigen Sie nur, wenn Sie die E-Mail erhalten haben und Sie sicher sind, dass die Quittung gültig ist.\nWenn Sie nicht sicher sind, {0}
 portfolio.pending.step3_seller.bankCheck=\n\nÜberprüfen Sie auch, ob der Name des Senders in Ihrer Bankmitteilung mit dem des Handelskontaktes übereinstimmt:\nSendername: {0}\n\nFalls der Name nicht derselbe wie der hier angezeigte ist, {1}
-portfolio.pending.step3_seller.openDispute=bestätigen Sie bitte nicht, sondern öffnen Sie einen Konflikt, indem Sie \\"alt + o\\" oder \\"option + o\\" drücken.
+portfolio.pending.step3_seller.openDispute=bestätigen Sie bitte nicht, sondern öffnen Sie einen Konflikt, indem Sie \"alt + o\" oder \"option + o\" drücken.
 portfolio.pending.step3_seller.confirmPaymentReceipt=Zahlungserhalt bestätigen
 portfolio.pending.step3_seller.amountToReceive=Zu erhaltender Betrag:
 portfolio.pending.step3_seller.yourAddress=Ihre {0} Adresse:
@@ -510,9 +510,9 @@ portfolio.pending.step3_seller.openForDispute=Sie haben den Erhalt der Zahlung n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.part1=Haben Sie die {0} Zahlung von ihrem Handelspartner erhalten?\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.fiat=Die Handelskennung (\\"Verwendungszweck\\") der Transaktion ist: \\"{0}\\"\n\n
+portfolio.pending.step3_seller.onPaymentReceived.fiat=Die Handelskennung (\"Verwendungszweck\") der Transaktion ist: \"{0}\"\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.name=Überprüfen Sie bitte auch, ob der Name des Sender in ihrer Bankmitteilung mit dem vom Handelsvertrag übereinstimmt:\nSendername: {0}\n\nFalls der Name nicht der hier angezeigt ist, bestätigen Sie bitte nicht, sondern öffnen Sie einen Konflikt indem Sie \\"alt + o\\" oder \\"option + o\\" drücken,\n\n
+portfolio.pending.step3_seller.onPaymentReceived.name=Überprüfen Sie bitte auch, ob der Name des Sender in ihrer Bankmitteilung mit dem vom Handelsvertrag übereinstimmt:\nSendername: {0}\n\nFalls der Name nicht der hier angezeigt ist, bestätigen Sie bitte nicht, sondern öffnen Sie einen Konflikt indem Sie \"alt + o\" oder \"option + o\" drücken,\n\n
 portfolio.pending.step3_seller.onPaymentReceived.note=Bitte beachten Sie, dass sobald Sie den Erhalt bestätigt haben, der eingesperrte Handelsbetrag an den BTC Käufer freigegeben wird und die Kaution erstattet wird.
 portfolio.pending.step3_seller.onPaymentReceived.confirm.headline=Bestätigen Sie die Zahlung erhalten zu haben
 portfolio.pending.step3_seller.onPaymentReceived.confirm.yes=Ja, ich habe die Zahlung erhalten
@@ -529,7 +529,7 @@ portfolio.pending.step5_buyer.alreadyWithdrawn=Ihre Gelder wurden bereits abgeho
 portfolio.pending.step5_buyer.confirmWithdrawal=Abhebeanfrage bestätigen
 portfolio.pending.step5_buyer.amountTooLow=Der zu transferierende Betrag ist kleiner als die Transaktionsgebühr und der minimale Tx-Wert (Staub). 
 portfolio.pending.step5_buyer.withdrawalCompleted.headline=Abheben abgeschlossen
-portfolio.pending.step5_buyer.withdrawalCompleted.msg=Ihre abgeschlossenen Händel sind unter \\"Mappe/Verlauf\\" gespeichert.\nSie können all Ihre Bitcointransaktionen unter \\"Gelder/Transaktionen\\" einsehen
+portfolio.pending.step5_buyer.withdrawalCompleted.msg=Ihre abgeschlossenen Händel sind unter \"Mappe/Verlauf\" gespeichert.\nSie können all Ihre Bitcointransaktionen unter \"Gelder/Transaktionen\" einsehen
 portfolio.pending.step5_buyer.bought=Sie haben gekauft:
 portfolio.pending.step5_buyer.paid=Sie haben gezahlt:
 
@@ -543,7 +543,7 @@ portfolio.pending.tradeProcess=Handelsprozess
 portfolio.pending.openAgainDispute.msg=Falls Sie nicht sicher sind, ob Ihre Nachricht den Vermittler erreicht hat (z.B. wenn Sie nach 1 Tag noch keine Rückmeldung erhalten haben) können Sie gerne erneut einen Konflikt öffnen.
 portfolio.pending.openAgainDispute.button=Konflikt erneut öffnen
 portfolio.pending.openSupportTicket.headline=Unterstützungsticket öffnen
-portfolio.pending.openSupportTicket.msg=Nutzen Sie dies bitte nur in Notfällen, wenn ihnen die \\"Unterstützung öffnen\\" oder \\"Konflikt öffnen\\" Schaltflächen nicht angezeigt wird.\n\nSollten Sie ein Unterstützungsticket öffnen, wird der Handel unterbrochen und von dem Vermittler gehandhabt.
+portfolio.pending.openSupportTicket.msg=Nutzen Sie dies bitte nur in Notfällen, wenn ihnen die \"Unterstützung öffnen\" oder \"Konflikt öffnen\" Schaltflächen nicht angezeigt wird.\n\nSollten Sie ein Unterstützungsticket öffnen, wird der Handel unterbrochen und von dem Vermittler gehandhabt.
 portfolio.pending.notification=Benachrichtigung
 portfolio.pending.openDispute=Einen Konflikt öffnen
 portfolio.pending.disputeOpened=Konflikt geöffnet
@@ -551,7 +551,7 @@ portfolio.pending.openSupport=Unterstützungsticket öffnen
 portfolio.pending.supportTicketOpened=Unterstützungsticket geöffnet
 portfolio.pending.requestSupport=Unterstützung anfordern
 portfolio.pending.error.requestSupport=Bitte melden Sie das Problem ihrem Vermittler.\n\nEr wird die Informationen an die Entwickler weitergeben um das Problem zu untersuchen.\nNachdem das Problem analysiert wurde, werden Sie all Ihre eingesperrten Gelder zurück erhalten.
-portfolio.pending.communicateWithArbitrator=Bitte kommunizieren Sie mit dem Vermittler im \\"Unterstützung\\" Bildschirm,
+portfolio.pending.communicateWithArbitrator=Bitte kommunizieren Sie mit dem Vermittler im \"Unterstützung\" Bildschirm,
 portfolio.pending.supportTicketOpenedMyUser=Sie haben bereits ein Unterstützungsticket geöffnet.\n{0}
 portfolio.pending.disputeOpenedMyUser=Sie haben bereits einen Konflikt geöffnet.\n{0}
 portfolio.pending.disputeOpenedByPeer=Ihr Handelspartner hat einen Konflikt geöffnet\n{0}
@@ -660,7 +660,7 @@ support.buyerOfferer=BTC Käufer/Ersteller
 support.sellerOfferer=BTC Verkäufer/Ersteller
 support.buyerTaker=BTC Käufer/Abnehmer
 support.sellerTaker=BTC Verkäufer/Abnehmer
-support.backgroundInfo=Bisq ist keine Firma und betreibt keine Form von Kundendienst.\n\nGibt es Konflikte während des Handelsprozess (z.B. ein Händler befolgt nicht das Handelsprotokoll), wird die Anwendung nach der Handelsdauer eine \\"Konflikt öffnen\\" Schaltfläche anzeigen, um den Vermittler zu kontaktieren.\nIm Falle von Softwarefehlern oder anderen Problemen, die von der Anwendung entdeckt werden, wird eine \\"Unterstützungsticket öffnen\\" Schaltfläche angezeigt, um den Vermittler zu kontaktieren, der die Probleme an die Entwickler weiterleitet.\n\nIm Falle, dass ein Nutzer durch einen Fehler fest hängt, ohne dass die \\"Unterstützungsticket öffnen\\" Schaltfläche angezeigt wird, können Sie ein Unterstützungsticket mit einer speziellen Tastenkombination manuell öffnen.\n\nBitte nutzen Sie diese nur, wenn Sie sicher sind, dass die Software sich nicht wie erwartet verhält. Falls Sie Probleme wie man Bisq verwendet oder andere Fragen haben, überprüfen Sie bitte das FAQ auf der bisq.io Website oder posten Sie in das Bisq Forum in die Unterstützungsabteilung.\n\nFalls Sie sicher sind, dass Sie ein Unterstützungsticket öffnen wollen, wählen Sie bitte den Handel, der Probleme bereitet, unter \\"Mappe/Offene Händel\\" und drücken Sie die Tastenkombination \\"alt + o\\" oder \\"option + o\\" um das Unterstützungsticket zu öffnen.
+support.backgroundInfo=Bisq ist keine Firma und betreibt keine Form von Kundendienst.\n\nGibt es Konflikte während des Handelsprozess (z.B. ein Händler befolgt nicht das Handelsprotokoll), wird die Anwendung nach der Handelsdauer eine \"Konflikt öffnen\" Schaltfläche anzeigen, um den Vermittler zu kontaktieren.\nIm Falle von Softwarefehlern oder anderen Problemen, die von der Anwendung entdeckt werden, wird eine \"Unterstützungsticket öffnen\" Schaltfläche angezeigt, um den Vermittler zu kontaktieren, der die Probleme an die Entwickler weiterleitet.\n\nIm Falle, dass ein Nutzer durch einen Fehler fest hängt, ohne dass die \"Unterstützungsticket öffnen\" Schaltfläche angezeigt wird, können Sie ein Unterstützungsticket mit einer speziellen Tastenkombination manuell öffnen.\n\nBitte nutzen Sie diese nur, wenn Sie sicher sind, dass die Software sich nicht wie erwartet verhält. Falls Sie Probleme wie man Bisq verwendet oder andere Fragen haben, überprüfen Sie bitte das FAQ auf der bisq.io Website oder posten Sie in das Bisq Forum in die Unterstützungsabteilung.\n\nFalls Sie sicher sind, dass Sie ein Unterstützungsticket öffnen wollen, wählen Sie bitte den Handel, der Probleme bereitet, unter \"Mappe/Offene Händel\" und drücken Sie die Tastenkombination \"alt + o\" oder \"option + o\" um das Unterstützungsticket zu öffnen.
 support.initialInfo="Bitte beachten Sie die grundlegenen Regeln für den Konfliktprozess:\n1. Sie müssen innerhalb von 2 Tagen auf die Anfrage des Vermittlers reagieren.\n2. Die maximale Dauer des Konflikts ist 14 Tage.\n3. Sie müssen erfüllen, was der Vermittler von ihnen verlangt, um Beweise für ihren Fall zu liefern.\n4. Sie akzeptieren die Regeln, die im Wiki im Nutzungsvereinbarung umrissen wurden, als Sie das erste Mal die Anwendung gestartet haben.\n\nErfahren Sie mehr über den Konfliktprozess in unserem Wiki:\nhttps://github.com/bitsquare/bitsquare/wiki/Dispute-process
 support.systemMsg=Systemnachricht: {0}
 support.youOpenedTicket=Sie haben eine Anfrage auf Unterstützung geöffnet.
@@ -700,7 +700,7 @@ setting.preferences.displayOptions=Darstellungsoptionen
 setting.preferences.showOwnOffers=Meine eigenen Angebote im Angebotsbuch zeigen:
 setting.preferences.useAnimations=Animationen nutzen:
 setting.preferences.sortWithNumOffers=Marktlisten nach Anzahl Angebote/Händler sortieren:
-setting.preferences.resetAllFlags=Alle \\"Nicht erneut anzeigen\\" Markierungen zurücksetzen.
+setting.preferences.resetAllFlags=Alle \"Nicht erneut anzeigen\" Markierungen zurücksetzen.
 setting.preferences.reset=Zurücksetzen
 settings.preferences.languageChange=Den Sprachwechsel auf alle Bildschirme anzuwenden benötigt einen Neustart.
 settings.preferences.selectCurrencyNetwork=Ausgangswährung wählen
@@ -764,7 +764,7 @@ setting.about.subsystems.val=Netzwerkversion: {0}; P2P Nachrichtenversion: {1}; 
 account.tab.arbitratorRegistration=Vermittler Registrierung
 account.tab.account=Konto
 account.info.headline=Willkommen zu Ihrem Bisq-Konto
-account.info.msg=Hier können Sie Handelskonten für nationale Währungen & Altcoins konfigurieren, Vermittler auswählen und Backups für Ihre Wallets & Kontodaten erstellen.\n\nEine leere Bitcoinwallet wurde erstellt, als Sie das erste Mal Bisq gestartet haben.\nWir empfehlen, dass Sie Ihre Bitcoin-Wallet-Keimwörter aufschreiben (siehe Schaltfläche links) und sich überlegen ein Passwort hinzu zu fügen, bevor Sie finanzieren. Bitcoin-Kautionen und Abhebungen werden unter \\"Gelder\\" verwaltet.\n\nPrivatsphäre & Sicherheit:\nBisq ist ein dezentralisierte Börse, was bedeutet, dass all Ihre Daten auf ihrem Computer bleiben. Es gibt keine Server und wir haben keinen Zugriff auf Ihre persönlichen Informationen, Ihre Gelder oder selbst Ihre IP Adresse. Daten wie Bankkontonummern, Altcoin- & Bitcoinadressen, etc werden nur mit Ihrem Handelspartner geteilt, um Händel abzuschließen, die Sie gestartet haben (im Falle eines Konflikts wird der Vermittler die selben Daten sehen wie Ihr Handelspartner).
+account.info.msg=Hier können Sie Handelskonten für nationale Währungen & Altcoins konfigurieren, Vermittler auswählen und Backups für Ihre Wallets & Kontodaten erstellen.\n\nEine leere Bitcoinwallet wurde erstellt, als Sie das erste Mal Bisq gestartet haben.\nWir empfehlen, dass Sie Ihre Bitcoin-Wallet-Keimwörter aufschreiben (siehe Schaltfläche links) und sich überlegen ein Passwort hinzu zu fügen, bevor Sie finanzieren. Bitcoin-Kautionen und Abhebungen werden unter \"Gelder\" verwaltet.\n\nPrivatsphäre & Sicherheit:\nBisq ist ein dezentralisierte Börse, was bedeutet, dass all Ihre Daten auf ihrem Computer bleiben. Es gibt keine Server und wir haben keinen Zugriff auf Ihre persönlichen Informationen, Ihre Gelder oder selbst Ihre IP Adresse. Daten wie Bankkontonummern, Altcoin- & Bitcoinadressen, etc werden nur mit Ihrem Handelspartner geteilt, um Händel abzuschließen, die Sie gestartet haben (im Falle eines Konflikts wird der Vermittler die selben Daten sehen wie Ihr Handelspartner).
 
 account.menu.paymentAccount=Nationale Währungskonten
 account.menu.altCoinsAccountView=Altcoinkonten
@@ -821,7 +821,7 @@ account.password.setPw.headline=Passwortschutz Ihrer Wallet einrichten
 account.password.info=Mit Passwortschutz müssen Sie Ihr Passwort eingeben, wenn Sie Bitcoins aus Ihrer Wallet abheben, wenn Sie Ihre Wallet einsehen oder aus den Keimwörtern wiederherstellen wollen, als auch beim Start der Anwendung.
 
 account.seed.backup.title=Backup Ihrer Wallets-Keimwörter erstellen
-account.seed.info=Bitte schreiben Sie die Keimwörter und das Datum auf! Mit diesen Keimwörtern und dem Datum können Sie Ihre Wallet jederzeit wiederherstellen.\nDie Keimwörter werden für die BTC- und BSQ-Wallet genutzt.\n\nSie sollten die Keimwörter auf ein Blatt Papier schreiben und nicht auf Ihrem Computer speichern.\n\nBitte beachten Sie, dass die Keimwörter kein Ersatz für ein Backup sind.\nSie müssen ein Backup des gesamten Anwendungsverzeichnisses unter \\"Konto/Backup\\" erstellen, um den gültigen Anwendungsstatus und Daten wiederherstellen zu können.
+account.seed.info=Bitte schreiben Sie die Keimwörter und das Datum auf! Mit diesen Keimwörtern und dem Datum können Sie Ihre Wallet jederzeit wiederherstellen.\nDie Keimwörter werden für die BTC- und BSQ-Wallet genutzt.\n\nSie sollten die Keimwörter auf ein Blatt Papier schreiben und nicht auf Ihrem Computer speichern.\n\nBitte beachten Sie, dass die Keimwörter kein Ersatz für ein Backup sind.\nSie müssen ein Backup des gesamten Anwendungsverzeichnisses unter \"Konto/Backup\" erstellen, um den gültigen Anwendungsstatus und Daten wiederherstellen zu können.
 account.seed.warn.noPw.msg=Sie haben kein Walletpasswort festgelegt, was das Anzeigen der Keimwörter schützen würde.\n\nMöchten Sie die Keimwörter jetzt anzeigen?
 account.seed.warn.noPw.yes=Ja, und nicht erneut fragen
 account.seed.enterPw=Passwort eingeben um Keimwörter zu sehen
@@ -957,7 +957,7 @@ disputeSummaryWindow.close.msg=Ticket geschlossen am {0}\n\nZusammenfassung:\n{1
 disputeSummaryWindow.close.closePeer=Sie müssen auch das Ticket das Handelspartner schließen!
 
 emptyWalletWindow.headline=Notfall-Walletwerkzeug
-emptyWalletWindow.info=Bitte nur in Notfällen nutzen, wenn Sie Ihre Gelder nicht vom UI aus zugreifen können.\n\nBeachten Sie bitte, dass alle offenen Angebote geschlossen werden, wenn Sie dieses Werkzeug verwenden.\n\nErstellen Sie ein Backup Ihre Datenverzeichnisses, bevor Sie dieses Werkzeug verwenden. Dies können Sie unter \\"Konto/Backup\\" tun.\n\nBitte melden Sie uns das Problem und füllen Sie eine Bugmeldung auf Github oder dem Bisq Forum aus, damit wir feststellen können, was das Problem verursacht hat.
+emptyWalletWindow.info=Bitte nur in Notfällen nutzen, wenn Sie Ihre Gelder nicht vom UI aus zugreifen können.\n\nBeachten Sie bitte, dass alle offenen Angebote geschlossen werden, wenn Sie dieses Werkzeug verwenden.\n\nErstellen Sie ein Backup Ihre Datenverzeichnisses, bevor Sie dieses Werkzeug verwenden. Dies können Sie unter \"Konto/Backup\" tun.\n\nBitte melden Sie uns das Problem und füllen Sie eine Bugmeldung auf Github oder dem Bisq Forum aus, damit wir feststellen können, was das Problem verursacht hat.
 emptyWalletWindow.balance=Ihr verfügbares Walletguthaben:
 emptyWalletWindow.address=Ihre Zieladresse:
 emptyWalletWindow.button=Alle Gelder senden
@@ -1001,7 +1001,7 @@ selectDepositTxWindow.msg=Die Kautionstransaktion wurde nicht im Handel gespeich
 selectDepositTxWindow.select=Kautionstransaktion auswählen
 
 selectBaseCurrencyWindow.headline=Marktauswahl
-selectBaseCurrencyWindow.msg=Der ausgewählte Standardmarkt ist {0}.\n\nWenn sie zu einer anderen Ausgangswährung wechseln möchten, wählen sie bitte eine aus dem Dropdown-Feld.\nSie können die Ausgangswährung auch später unter \\"Einstellungen/Netzwerk\\" ändern.
+selectBaseCurrencyWindow.msg=Der ausgewählte Standardmarkt ist {0}.\n\nWenn sie zu einer anderen Ausgangswährung wechseln möchten, wählen sie bitte eine aus dem Dropdown-Feld.\nSie können die Ausgangswährung auch später unter \"Einstellungen/Netzwerk\" ändern.
 selectBaseCurrencyWindow.select=Ausgangswährung wählen
 selectBaseCurrencyWindow.default={0} als Standardmarkt nutzen
 
@@ -1055,7 +1055,7 @@ popup.headline.error=Fehler
 popup.doNotShowAgain=Nicht erneut anzeigen
 popup.reportError.gitHub=Github Issue Tracker melden
 popup.reportError.forum=Im Bisq Forum melden
-popup.reportError={0}\n\nUm uns zu helfen die Software zu verbessern, melden Sie bitte den Bug  auf unserem Issue Tracker auf Github oder posten Sie ihn in unserem Bisq Forum.\nDie Fehlernachricht wird in die Zwischenablage kopiert, wenn Sie die Schaltflächen unterhalb klicken.\nEs wird Debuggen einfacher machen, wenn Sie die bisq.log Datei anfügen, die Sie im Anwendungsordner finden.\nSie können den Anwendungsordner unter \\"Konto/Backup\\" öffnen. 
+popup.reportError={0}\n\nUm uns zu helfen die Software zu verbessern, melden Sie bitte den Bug  auf unserem Issue Tracker auf Github oder posten Sie ihn in unserem Bisq Forum.\nDie Fehlernachricht wird in die Zwischenablage kopiert, wenn Sie die Schaltflächen unterhalb klicken.\nEs wird Debuggen einfacher machen, wenn Sie die bisq.log Datei anfügen, die Sie im Anwendungsordner finden.\nSie können den Anwendungsordner unter \"Konto/Backup\" öffnen. 
 
 popup.error.tryRestart=Versuchen Sie bitte Ihre Anwendung neu zu starten und überprüfen Sie Ihre Netzwerkverbindung um zu sehen, ob Sie das Problem beheben können.
 popup.error.createTx=Fehler beim erstellen der Transaktion: {0}
@@ -1072,8 +1072,8 @@ popup.warning.startupFailed.twoInstances=Bisq läuft bereits. Sie können nicht 
 popup.warning.cryptoTestFailed=Scheint so als nützen Sie selbst kompilierte Binärdateien und haben nicht den Anweisung aus https://github.com/bitsquare/bitsquare/blob/master/doc/build.md#7-enable-unlimited-strength-for-cryptographic-keys gefolgt.\n\nWenn dies nicht der Fall ist und Sie die offiziellen Bisq Binärdateien genutzt haben, füllen Sie bitte eine Bugmeldung auf der Githubseite aus.\nFehler={0}
 popup.warning.oldOffers.msg=Sie haben offene Angebote, die mit einer älteren Version von Bisq erstellt wurden.\nBitte entfernen Sie diese Angebote, da Sie nicht mehr gültig sind.\n\nAngebote (Kennung): {0}
 popup.warning.oldOffers.buttonText=Veraltete Angebot(e) entfernen
-popup.warning.tradePeriod.halfReached=Ihr Handel mit Kennung {0} hat die Hälfte der maximal erlaubten Handelsdauer erreicht und ist immer noch nicht abgeschlossen.\n\nDie Handelsdauer endet am {1}\n\nBitte überprüfen Sie den Status ihres Handels unter \\"Mappe/Offene Händel\\" für weitere Informationen.
-popup.warning.tradePeriod.ended=Ihr Handel mit Kennung {0} hat die maximal erlaubte Handelsdauer erreicht und ist nicht abgeschlossen.\n\nDie Handelsdauer endete am {1}\n\nBitte überprüfen Sie den Status ihres Handels unter \\"Mappe/Offene Händel\\" um den Vermittler zu kontaktieren.
+popup.warning.tradePeriod.halfReached=Ihr Handel mit Kennung {0} hat die Hälfte der maximal erlaubten Handelsdauer erreicht und ist immer noch nicht abgeschlossen.\n\nDie Handelsdauer endet am {1}\n\nBitte überprüfen Sie den Status ihres Handels unter \"Mappe/Offene Händel\" für weitere Informationen.
+popup.warning.tradePeriod.ended=Ihr Handel mit Kennung {0} hat die maximal erlaubte Handelsdauer erreicht und ist nicht abgeschlossen.\n\nDie Handelsdauer endete am {1}\n\nBitte überprüfen Sie den Status ihres Handels unter \"Mappe/Offene Händel\" um den Vermittler zu kontaktieren.
 popup.warning.noTradingAccountSetup.headline=Sie haben kein Handelskonto konfiguriert
 popup.warning.noTradingAccountSetup.msg=Sie müssen ein nationales Währungs- oder Altcoinkonto konfigurieren, bevor Sie ein Angebot konfigurieren können.\nMöchten Sie ein Konto konfigurieren?
 popup.warning.noArbitratorSelected.headline=Sie haben keinen Vermittler gewählt.
@@ -1081,21 +1081,21 @@ popup.warning.noArbitratorSelected.msg=Sie müssen wenigstens einen Vermittler k
 popup.warning.notFullyConnected=Sie müssen warten, bis Sie vollständig mit dem Netzwerk verbunden sind.\nDas kann bis ungefähr 2 Minuten beim Start dauern.
 popup.warning.removeOffer=Sind Sie sicher, dass Sie das Angebot entfernen wollen?\nDie Erstellergebühr von {0} geht verloren, wenn Sie des Angebot entfernen.
 popup.warning.tooLargePercentageValue=Es können keinen Prozentsatz von oder mehr 100% verwenden.
-popup.warning.examplePercentageValue=Bitte geben sei einen Prozentsatz wie folgt ein \\"5.4\\" für 5.4%
+popup.warning.examplePercentageValue=Bitte geben sei einen Prozentsatz wie folgt ein \"5.4\" für 5.4%
 popup.warning.noPriceFeedAvailable=Es ist kein Preis für diese Währung verfügbar. Sie können keinen Prozent basierten Preis verwenden.\nBitte wählen Sie den Festpreis.
 popup.warning.sendMsgFailed=Senden der Nachricht an ihren Handelspartner fehlgeschlagen.\nVersuchen Sie es bitte erneut und falls es weiter fehlschlägt, melden Sie einen Bug.
 popup.warning.insufficientBtcFundsForBsqTx=Sie haben nicht genügend BTC-Gelder, um die Tx-Gebühr für diese BSQ-Transaktion zu bezahlen.\nBitte finanzieren sie ihre BTC-Wallet, um BSQ übertragen zu können.\nFehlende Gelder: {0}
 popup.warning.insufficientBsqFundsForBtcFeePayment=Sie haben nicht genügend BTC-Gelder, um die Tx-Gebühr in BSQ zu bezahlen.\nSie können die Gebühr in BTC bezahlen, oder müssen ihre BSQ-Wallet finanzieren.\nFehlende BSQ Gelder: {0}
 popup.warning.noBsqFundsForBtcFeePayment=Ihre BSQ-Wallet hat nicht ausreichende Gelder, um die Tx-Gebühr in BSQ zu bezahlen.
 popup.warning.messageTooLong=Ihre Nachricht überschreitet die maximal erlaubte Größe. Sende Sie diese in mehreren Teilen oder laden Sie sie in einen Dienst wie https://pastebin.com hoch.
-popup.warning.lockedUpFunds=Sie haben eingesperrte Gelder von einem fehlgeschlagenen Handel.\nEingesperrtes Guthaben: {0} \nKaution Tx Adresse: {1}\nHandel Kennung: {2}.\n\nBitte öffnen sie ein Unterstützungsticket indem sie den Handel im ausstehende Händel Schirm auswählen und \\"alt + o\\" oder \\"option + o\\" drücken.
+popup.warning.lockedUpFunds=Sie haben eingesperrte Gelder von einem fehlgeschlagenen Handel.\nEingesperrtes Guthaben: {0} \nKaution Tx Adresse: {1}\nHandel Kennung: {2}.\n\nBitte öffnen sie ein Unterstützungsticket indem sie den Handel im ausstehende Händel Schirm auswählen und \"alt + o\" oder \"option + o\" drücken.
 
 popup.info.securityDepositInfo=Um sicher zu stellen, dass beide Händler dem Handelsprotokoll folgen, müssen diese eine Kaution zahlen.\n\nDie Kaution wird in ihrer lokalen Wallet bleiben, bis das Angebot von einem anderen Händler angenommen wurde.\nSie wird Ihnen zurückgezahlt, wenn der Handel erfolgreich abgeschlossen wurde.\n\nBitte beachten Sie, dass Sie die Anwendung laufen lassen müssen, wenn Sie ein offenes Angebot haben.\nWenn ein anderer Händler Ihr Angebot annehmen will, ist es notwendig, dass Ihre Anwendung online ist und reagieren kann.\nStellen Sie sicher, dass Sie den Standbymodus deaktiviert haben, da dieser Ihren Client vom Netzwerk trennen würde (Standby des Monitors ist kein Problem).
 
 popup.privateNotification.headline=Wichtige private Benachrichtigung!
 
 popup.securityRecommendation.headline=Wichtige Sicherheitsempfehlung
-popup.securityRecommendation.msg=Wir würden Sie gerne erinnern sich zu überlegen, Passwortschutz Ihrer Wallet zu verwenden, falls Sie diesen noch nicht aktiviert haben.\n\nEs wird außerdem dringend empfohlen, dass Sie die Wallets-Keimwörter aufschreiben. Diese Keimwörter sind wie ein Master-Passwort zum Wiederherstellen ihrer Bitcoin-Wallet.\nIm \\"Walletkeim\\" Abschnitt finden Sie weitere Informationen.\n\nZusätzlich sollten Sie ein Backup des ganzen Anwendungsdatenordners im \\"Backup\\" Abschnitt erstellen.
+popup.securityRecommendation.msg=Wir würden Sie gerne erinnern sich zu überlegen, Passwortschutz Ihrer Wallet zu verwenden, falls Sie diesen noch nicht aktiviert haben.\n\nEs wird außerdem dringend empfohlen, dass Sie die Wallets-Keimwörter aufschreiben. Diese Keimwörter sind wie ein Master-Passwort zum Wiederherstellen ihrer Bitcoin-Wallet.\nIm \"Walletkeim\" Abschnitt finden Sie weitere Informationen.\n\nZusätzlich sollten Sie ein Backup des ganzen Anwendungsdatenordners im \"Backup\" Abschnitt erstellen.
 
 popup.shutDownInProgress.headline=Herunterfahren im Gange
 popup.shutDownInProgress.msg=Das Herunterfahren der Anwendung kann einige Sekunden dauern.\nBitte unterbrechen Sie diesen Vorgang nicht.
@@ -1150,7 +1150,7 @@ guiUtil.accountExport.exportFailed=Export in CVS fehlgeschlagen, aufgrund eines 
 guiUtil.accountExport.selectExportPath=Exportverzeichnis auswählen
 guiUtil.accountImport.imported=Handelskonto aus Verzeichnis importiert:\n{0}\n\nImportierte Konten:\n{1}
 guiUtil.accountImport.noAccountsFound=Keine exportierten Handelskonten im Verzeichnis gefunden: {0}.\nDateiname ist {1}."
-guiUtil.openWebBrowser.warning=Sie werden eine Webseite in dem Webbrowser ihes Systems öffnen.\nMöchten Sie die Webseite jetzt öffnen?\n\nWenn Sie nicht den \\"Torbrowser\\" als Standardwebbrowser verwenden, werden Sie sich über das Klarweb mit der Webseite verbinden.\n\nURL:\\"{0}\\"
+guiUtil.openWebBrowser.warning=Sie werden eine Webseite in dem Webbrowser ihes Systems öffnen.\nMöchten Sie die Webseite jetzt öffnen?\n\nWenn Sie nicht den \"Torbrowser\" als Standardwebbrowser verwenden, werden Sie sich über das Klarweb mit der Webseite verbinden.\n\nURL:\"{0}\"
 guiUtil.openWebBrowser.doOpen=Webseite öffnen und nicht erneut fragen
 guiUtil.openWebBrowser.copyUrl=URL kopieren und abbrechen
 guiUtil.ofTradeAmount=von Handelsbetrag
@@ -1201,16 +1201,16 @@ txIdTextField.blockExplorerIcon.tooltip=Blockkettenforscher mit dieser Transakti
 # Navigation
 ####################################################################
 
-navigation.account=\\"Konto\\"
-navigation.arbitratorSelection=\\"Vermittlerauswahl\\"
-navigation.funds.availableForWithdrawal=\\"Gelder/Gelder senden\\"
-navigation.portfolio.myOpenOffers=\\"Mappe/Meine offenen Angebote\\"
-navigation.portfolio.pending=\\"Mappe/Offene Händel\\"
-navigation.funds.depositFunds=\\"Gelder/Gelder erhalten\\"
-navigation.settings.preferences=\\"Einstellungen/Präferenzen\\"
-navigation.funds.transactions=\\"Gelder/Transaktionen\\"
-navigation.support=\\"Unterstützung\\"
-navigation.dao.wallet.receive=\\"DAO/BSQ-Wallet/Erhalten\\"
+navigation.account=\"Konto\"
+navigation.arbitratorSelection=\"Vermittlerauswahl\"
+navigation.funds.availableForWithdrawal=\"Gelder/Gelder senden\"
+navigation.portfolio.myOpenOffers=\"Mappe/Meine offenen Angebote\"
+navigation.portfolio.pending=\"Mappe/Offene Händel\"
+navigation.funds.depositFunds=\"Gelder/Gelder erhalten\"
+navigation.settings.preferences=\"Einstellungen/Präferenzen\"
+navigation.funds.transactions=\"Gelder/Transaktionen\"
+navigation.support=\"Unterstützung\"
+navigation.dao.wallet.receive=\"DAO/BSQ-Wallet/Erhalten\"
 
 
 ####################################################################
@@ -1288,7 +1288,7 @@ seed.date=Wallets-Datum:
 seed.restore.title=Wallet aus Keimwörtern wiederherstellen
 seed.restore=Wallets wiederherstellen
 seed.creationDate=Erstellungsdatum:
-seed.warn.walletNotEmpty.msg=Ihre Bitcoin-Wallet ist nicht leer.\n\nSie müssen diese Wallet leeren, bevor Sie versuchen, eine ältere wiederherzustellen, da das Mischen von Wallets zu ungültigen Backups führen kann.\n\nBitte schließen Sie Ihre Händel ab, schließen Sie all Ihre offenen Angebote und gehen Sie zu dem Gelder-Abschnitt, um Ihre Bitcoin abzuheben.\nSollten Sie nicht auf Ihre Bitcoin zugreifen können, können Sie das Notfallwerkzeug nutzen, um Ihre Wallet zu leeren.\nUm das Notfallwerkzeug zu öffnen, drücken Sie \\"alt + e\\" oder \\"option + e\\".
+seed.warn.walletNotEmpty.msg=Ihre Bitcoin-Wallet ist nicht leer.\n\nSie müssen diese Wallet leeren, bevor Sie versuchen, eine ältere wiederherzustellen, da das Mischen von Wallets zu ungültigen Backups führen kann.\n\nBitte schließen Sie Ihre Händel ab, schließen Sie all Ihre offenen Angebote und gehen Sie zu dem Gelder-Abschnitt, um Ihre Bitcoin abzuheben.\nSollten Sie nicht auf Ihre Bitcoin zugreifen können, können Sie das Notfallwerkzeug nutzen, um Ihre Wallet zu leeren.\nUm das Notfallwerkzeug zu öffnen, drücken Sie \"alt + e\" oder \"option + e\".
 seed.warn.walletNotEmpty.restore=Ich möchte trotzdem wiederherstellen
 seed.warn.walletNotEmpty.emptyWallet=Ich werde meine Wallets erst leeren
 seed.warn.notEncryptedAnymore=Ihre Wallets sind verschlüsselt.\n\nNach einer Wiederherstellung werden die Wallets nicht mehr verschlüsselt sein, und Sie werden ein neues Passwort festlegen müssen.\n\nMöchten Sie fortfahren?
@@ -1318,7 +1318,7 @@ payment.email=E-Mail:
 payment.country=Land:
 payment.owner.email=Kontoinhaber E-Mail:
 payment.extras=Besondere Anforderungen:
-payment.us.info=Überweisung mit WIRE oder ACH wird nicht unterstützt in den USA, weil WIRE zu teuer ist und ACH ein hohes Rückbuchungsrisikio hat.\n\nBitte nutzen Sie stattdessen die Zahlungsmethoden \\"ClearXchange\\", \\"US Postal Money Order\\" oder \\"Cash Deposit\\".
+payment.us.info=Überweisung mit WIRE oder ACH wird nicht unterstützt in den USA, weil WIRE zu teuer ist und ACH ein hohes Rückbuchungsrisikio hat.\n\nBitte nutzen Sie stattdessen die Zahlungsmethoden \"ClearXchange\", \"US Postal Money Order\" oder \"Cash Deposit\".
 payment.email.mobile=E-Mail oder Telefonnummer:
 payment.altcoin.address=Altcoin-Adresse:
 payment.altcoin=Altcoin:

--- a/common/src/main/resources/i18n/displayStrings_el.properties
+++ b/common/src/main/resources/i18n/displayStrings_el.properties
@@ -98,7 +98,7 @@ shared.openDefaultWalletFailed=Άνοιγμα προκαθορισμένου π�
 shared.distanceInPercent=Απόκλιση % από τιμή αγοράς
 shared.enterPercentageValue=Εισήγαγε % αξίας
 shared.OR=Ή
-shared.notEnoughFunds=Δεν έχεις επαρκή κεφάλαια στο Bisq πορτοφόλι σου.\nΧρειάζεσαι {0}, αλλά έχεις μόνο {1}.\n\nΧρηματοδότησε τη συναλλαγή από ένα εξωτερικό πορτοφόλι ή χρηματοδότησε το Bisq πορτοφόλι σου στην καρτέλα \\"Κεφάλαια/Λήψη Κεφαλαίων\\".
+shared.notEnoughFunds=Δεν έχεις επαρκή κεφάλαια στο Bisq πορτοφόλι σου.\nΧρειάζεσαι {0}, αλλά έχεις μόνο {1}.\n\nΧρηματοδότησε τη συναλλαγή από ένα εξωτερικό πορτοφόλι ή χρηματοδότησε το Bisq πορτοφόλι σου στην καρτέλα \"Κεφάλαια/Λήψη Κεφαλαίων\".
 shared.waitingForFunds=Αναμονή για κεφάλαια...
 shared.depositTransactionId=Ταυτότητα κατάθεσης
 shared.TheBTCBuyer=Ο αγοραστής BTC
@@ -338,12 +338,12 @@ createOffer.fundsBox.networkFee=Προμήθεια εξόρυξης:
 createOffer.fundsBox.placeOfferSpinnerInfo=Κοινοποίηση προσφοράς σε εξέλιξη...
 createOffer.fundsBox.paymentLabel=Συναλλαγή Bisq με ταυτότητα {0} 
 createOffer.success.headline=Η προσφορά σου έχει κοινοποιηθεί
-createOffer.success.info=Μπορείς να διαχειριστείς τις ανοιχτές προσφορές σου στο \\"Χαρτοφυλάκιο/Οι τρέχουσες προσφορές μου\\".
+createOffer.success.info=Μπορείς να διαχειριστείς τις ανοιχτές προσφορές σου στο \"Χαρτοφυλάκιο/Οι τρέχουσες προσφορές μου\".
 
 
 # new entries
 createOffer.placeOfferButton=Ανασκόπηση: Τοποθέτησε προσφορά σε {0} bitcoin
-createOffer.alreadyFunded=Είχες ήδη χρηματοδοτήσει αυτή την προσφορά.\nΤα κεφάλαιά σου έχουν μετακινηθεί στο τοπικό Bisq πορτοφόλι σου και είναι διαθέσιμα προς ανάληψη στο \\"Κεφάλαια/Αποστολή κεφαλαίων\\".
+createOffer.alreadyFunded=Είχες ήδη χρηματοδοτήσει αυτή την προσφορά.\nΤα κεφάλαιά σου έχουν μετακινηθεί στο τοπικό Bisq πορτοφόλι σου και είναι διαθέσιμα προς ανάληψη στο \"Κεφάλαια/Αποστολή κεφαλαίων\".
 createOffer.createOfferFundWalletInfo.headline=Χρηματοδότησε την προσφορά σου.
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Ποσό συναλλαγής: {0}\n
@@ -352,7 +352,7 @@ createOffer.createOfferFundWalletInfo.msg=Πρέπει να καταθέσεις
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
 createOffer.amountPriceBox.error.message=Προέκυψε σφάλμα κατά την τοποθέτηση της προσφοράς:\n\n{0}\n\nΔεν αποσύρθηκαν κεφάλαια από το πορτοφόλι σου.\nΕπανεκκίνησε την εφαρμογή και έλεγξε τη σύνδεσή σου στο διαδίκτυο.
 createOffer.setAmountPrice=Καθόρισε ποσό και τιμή
-createOffer.warnCancelOffer=Έχεις ήδη χρηματοδοτήσει αυτή την προσφορά.\nΑν την ακυρώσεις τώρα, τα κεφάλαιά σου θα μεταφερθούν στο τοπικό Bisq πορτοφόλι σου και θα είναι διαθέσιμα προς ανάληψη στο \\"Κεφάλαια/Αποστολή κεφαλαίων\\" παράθυρο.\nΕίσαι σίγουρος/η πως θέλεις να ακυρώσεις την προσφορά;
+createOffer.warnCancelOffer=Έχεις ήδη χρηματοδοτήσει αυτή την προσφορά.\nΑν την ακυρώσεις τώρα, τα κεφάλαιά σου θα μεταφερθούν στο τοπικό Bisq πορτοφόλι σου και θα είναι διαθέσιμα προς ανάληψη στο \"Κεφάλαια/Αποστολή κεφαλαίων\" παράθυρο.\nΕίσαι σίγουρος/η πως θέλεις να ακυρώσεις την προσφορά;
 createOffer.fixed=Πάγιος
 createOffer.percentage=Ποσοστό
 createOffer.timeoutAtPublishing=Έληξε το χρονικό όριο για τη δημοσιοποίηση της προσφοράς.
@@ -390,21 +390,21 @@ takeOffer.fundsBox.networkFee=Προμήθεια εξόρυξης (3x):
 takeOffer.fundsBox.takeOfferSpinnerInfo=Αποδοχή προσφοράς σε εξέλιξη...
 takeOffer.fundsBox.paymentLabel=Συναλλαγή Bisq με ταυτότητα {0} 
 takeOffer.success.headline=Αποδέχτηκες επιτυχώς μία προσφορά.
-takeOffer.success.info=Μπορείς να δεις την κατάσταση της συναλλαγής στο \\"Χαρτοφυλάκιο/Τρέχουσες συναλλαγές\\".
+takeOffer.success.info=Μπορείς να δεις την κατάσταση της συναλλαγής στο \"Χαρτοφυλάκιο/Τρέχουσες συναλλαγές\".
 takeOffer.error.message=Προέκυψε σφάλμα κατά την αποδοχή της προσφοράς.\n\n{0}
 
 # new entries
 takeOffer.takeOfferButton=Ανασκόπηση: Αποδοχή προσφοράς έναντι {0} bitcoin
 takeOffer.noPriceFeedAvailable=Δεν μπορείς να αποδεχθείς αυτή την προσφορά καθώς χρησιμοποιεί ποσοστό επί της τιμής αγοράς, αλλά δεν υπάρχει διαθέσιμη ανατροφοδότηση τιμής.
-takeOffer.alreadyFunded.movedFunds=Είχες ήδη χρηματοδοτήσει αυτή την προσφορά.\nΤα κεφάλαιά σου έχουν μετακινηθεί στο τοπικό Bisq πορτοφόλι σου και είναι διαθέσιμα προς ανάληψη στο \\"Κεφάλαια/Αποστολή κεφαλαίων\\".
+takeOffer.alreadyFunded.movedFunds=Είχες ήδη χρηματοδοτήσει αυτή την προσφορά.\nΤα κεφάλαιά σου έχουν μετακινηθεί στο τοπικό Bisq πορτοφόλι σου και είναι διαθέσιμα προς ανάληψη στο \"Κεφάλαια/Αποστολή κεφαλαίων\".
 takeOffer.takeOfferFundWalletInfo.headline=Χρηματοδότησε τη συναλλαγή σου
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Ποσό συναλλαγής: {0}\n
 takeOffer.takeOfferFundWalletInfo.msg=You need to deposit {0} for taking this offer.\n\nThe amount is the sum of:\n{1}- Security deposit: {2}\n- Trading fee: {3}\n- Mining fee (3x): {4}\n\nYou can choose between two options when funding your trade:\n- Use your Bisq wallet (convenient, but transactions may be linkable) OR\n- Transfer from an external wallet (potentially more private)\n\nYou will see all funding options and details after closing this popup.
-takeOffer.alreadyPaidInFunds=Αν έχεις ήδη κατατεθιμένα κεφάλαια, μπορείς να τα αποσύρεις στο \\"Κεφάλαια/Αποστολή κεφαλαίων\\".
+takeOffer.alreadyPaidInFunds=Αν έχεις ήδη κατατεθιμένα κεφάλαια, μπορείς να τα αποσύρεις στο \"Κεφάλαια/Αποστολή κεφαλαίων\".
 takeOffer.paymentInfo=Πληροφορίες πληρωμής
 takeOffer.setAmountPrice=Θέσε ποσό
-takeOffer.alreadyFunded.askCancel=Έχεις ήδη χρηματοδοτήσει αυτή την προσφορά.\nΑν την ακυρώσεις τώρα, τα κεφάλαιά σου θα μεταφερθούν στο τοπικό Bisq πορτοφόλι σου και θα είναι διαθέσιμα προς ανάληψη στο \\"Κεφάλαια/Αποστολή κεφαλαίων\\" παράθυρο.\nΕίσαι σίγουρος/η πως θέλεις να ακυρώσεις την προσφορά;
+takeOffer.alreadyFunded.askCancel=Έχεις ήδη χρηματοδοτήσει αυτή την προσφορά.\nΑν την ακυρώσεις τώρα, τα κεφάλαιά σου θα μεταφερθούν στο τοπικό Bisq πορτοφόλι σου και θα είναι διαθέσιμα προς ανάληψη στο \"Κεφάλαια/Αποστολή κεφαλαίων\" παράθυρο.\nΕίσαι σίγουρος/η πως θέλεις να ακυρώσεις την προσφορά;
 takeOffer.failed.offerNotAvailable=Το αίτημα ανάληψης προσφοράς απέτυχε διότι η προσφορά δεν είναι πια διαθέσιμη. Ίσως κάποιος άλλος συναλλασσόμενος ανέλαβε την προσφορά στο μεσοδιάστημα.
 takeOffer.failed.offerTaken=Δεν μπορείς να αποδεχθείς αυτή την προσφορά καθώς έχει ήδη ληφθεί από άλλον συναλλασσόμενο.
 takeOffer.failed.offerRemoved=Δεν μπορείς να αποδεχθείς αυτή την προσφορά γιατί στο μεσοδιάστημα αφαιρέθηκε.
@@ -446,12 +446,12 @@ portfolio.pending.step1.openForDispute=Η κατάθεση δεν έχει ακ�
 portfolio.pending.step2.confReached=Η συναλλαγή έχει λάβει τουλάχιστον μία επιβεβαίωση στο blockchain.\n(Αν θέλεις, μπορείς να περιμένεις για περισσότερες επιβεβαιώσεις - 6 επιβεβαιώσεις θεωρούνται εξαιρετικά ασφαλείς).\n\n
 
 portfolio.pending.step2_buyer.copyPaste=(Μπορείς να κάνεις αντιγραφή & επικόλληση των τιμών από την κεντρική οθόνη αφού κλείσεις αυτό το παράθυρο).
-portfolio.pending.step2_buyer.refTextWarn=ΜΗΝ αναφέρεις οτιδήποτε επιπλέον στην \\"αιτία πληρωμής\\", όπως Bitcoin, BTC, ή Bisq.
+portfolio.pending.step2_buyer.refTextWarn=ΜΗΝ αναφέρεις οτιδήποτε επιπλέον στην \"αιτία πληρωμής\", όπως Bitcoin, BTC, ή Bisq.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.accountDetails=Ακολούθως παραθέτονται τα στοιχεία λογαριασμού του πωλητή BTC:\n
 portfolio.pending.step2_buyer.tradeId=Μην ξεχάσεις να συμπεριλάβεις την ταυτότητα συναλλαγής
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.assign= ως \\"reason for payment\\" ώστε ο παραλήπτης να αντιστοιχίσει την πληρωμή σου με αυτή τη συναλλαγή.\n
+portfolio.pending.step2_buyer.assign= ως \"reason for payment\" ώστε ο παραλήπτης να αντιστοιχίσει την πληρωμή σου με αυτή τη συναλλαγή.\n
 portfolio.pending.step2_buyer.fees=Αν η τράπεζά σου χρεώνει προμήθειες θα πρέπει να καλύψεις αυτά τα ποσά.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.altcoin=Μετάφερε από το εξωτερικό {0} πορτοφόλι σου\n{1} στον αγοραστή BTC.\n\n
@@ -459,7 +459,7 @@ portfolio.pending.step2_buyer.altcoin=Μετάφερε από το εξωτερ�
 portfolio.pending.step2_buyer.cash=Κατευθύνσου σε τραπεζικό κατάστημα και πλήρωσε {0} στον πωλητή BTC.\n\n
 portfolio.pending.step2_buyer.cash.extra=ΣΗΜΑΝΤΙΚΗ ΑΠΑΙΤΗΣΗ:\nΑφού ολοκληρώσεις την πληρωμή γράψε στην έντυπη απόδειξη: NO REFUNDS.\nΣτη συνέχεια κόψε την απόδειξη σε 2 κομμάτια, φωτογράφισέ τη και στείλε τη φωτογραφία στη διεύθυνση email του πωλητή BTC.
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.postal=Στείλε {0} μέσω \\"US Postal Money Order\\" στον πωλητή BTC.\n\n
+portfolio.pending.step2_buyer.postal=Στείλε {0} μέσω \"US Postal Money Order\" στον πωλητή BTC.\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.bank=Συνδέσου στον e-banking λογαριασμό σου και πλήρωσε {0} στον BTC πωλητή.\n
 portfolio.pending.step2_buyer.startPaymentUsing=Ξεκίνα την πληρωμή με χρήση {0}
@@ -488,11 +488,11 @@ portfolio.pending.step3_buyer.openForDispute=Ο πωλητής BTC δεν επι
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.part=Ο συναλλασσόμενος επιβεβαίωσε πως ξεκίνησε την {0} πληρωμή.\n
 portfolio.pending.step3_seller.altcoin={0}Έλεγξε στον {1} blockchain explorer που προτιμάς, αν η συναλλαγή προς τη διεύθυνση παραλαβής\n{2}\nέχει επαρκείς επιβεβαιώσεις στο blockchain.\nΤο ποσό πληρωμής θα πρέπει να είναι {3}\n\nΘα πρέπει να αντιγράψεις και να επικολλήσεις τη διεύθυνση {4} από την κύρια οθόνη αφού κλείσεις αυτό το παράθυρο.
-portfolio.pending.step3_seller.postal={0}Έλεγξε αν παρέλαβες {1} μέσω \\"US Postal Money Order\\" από τον αγοραστή BTC.\n\nΗ ταυτότητα συναλλαγής (πεδίο \\"reason for payent\\") στη συναλλαγή είναι: \\"{2}\\"
-portfolio.pending.step3_seller.bank=Ο έτερος συναλλασσόμενος επιβεβαίωσε την έναρξη της πληρωμής {0}.\n\nΣυνδέσου στον e-banking λογαριασμό σου και έλεγξε αν έχεις παραλάβει {1} από τον αγοραστή BTC.\n\nΗ ταυτότητα συναλλαγής (πεδίο \\"reason for payent\\") στη συναλλαγή είναι: \\"{2}\\"
-portfolio.pending.step3_seller.cash=\n\nΚαθώς η πληρωμή έγινε μέσω κατάθεσης μετρητών, ο αγοραστής BTC πρέπει να γράψει \\"NO REFUND\\" στην έντυπη απόδειξη, να την κόψει σε 2 κομμάτια, και να σου στείλει μια φωτογραφία μέσω email.\n\nΓια να αποφύγεις την πιθανότητα αντιλογισμού χρέωσης, επιβεβαίωσε την παραλαβή του email, καθώς επίσης και αν είσαι σίγουρος πως το παραστατικό κατάθεσης είναι έγκυρο.\nΑν δεν είσαι σίγουρος, {0}
+portfolio.pending.step3_seller.postal={0}Έλεγξε αν παρέλαβες {1} μέσω \"US Postal Money Order\" από τον αγοραστή BTC.\n\nΗ ταυτότητα συναλλαγής (πεδίο \"reason for payent\") στη συναλλαγή είναι: \"{2}\"
+portfolio.pending.step3_seller.bank=Ο έτερος συναλλασσόμενος επιβεβαίωσε την έναρξη της πληρωμής {0}.\n\nΣυνδέσου στον e-banking λογαριασμό σου και έλεγξε αν έχεις παραλάβει {1} από τον αγοραστή BTC.\n\nΗ ταυτότητα συναλλαγής (πεδίο \"reason for payent\") στη συναλλαγή είναι: \"{2}\"
+portfolio.pending.step3_seller.cash=\n\nΚαθώς η πληρωμή έγινε μέσω κατάθεσης μετρητών, ο αγοραστής BTC πρέπει να γράψει \"NO REFUND\" στην έντυπη απόδειξη, να την κόψει σε 2 κομμάτια, και να σου στείλει μια φωτογραφία μέσω email.\n\nΓια να αποφύγεις την πιθανότητα αντιλογισμού χρέωσης, επιβεβαίωσε την παραλαβή του email, καθώς επίσης και αν είσαι σίγουρος πως το παραστατικό κατάθεσης είναι έγκυρο.\nΑν δεν είσαι σίγουρος, {0}
 portfolio.pending.step3_seller.bankCheck=\n\nΕπιβεβαίωσε επίσης ότι το όνομα αποστολέα στην ειδοποίηση από την τράπεζά σου ταιριάζει με αυτό από τα στοιχεία της συναλλαγής:\nΌνομα αποστολέα: {0}\n\nΑν το όνομα δεν είναι το ίδιο όπως αυτό που παρουσιάζεται εδώ, {1}
-portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".
+portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".
 portfolio.pending.step3_seller.confirmPaymentReceipt=Επιβεβαίωσε την απόδειξη πληρωμής
 portfolio.pending.step3_seller.amountToReceive=Ποσό προς λήψη:
 portfolio.pending.step3_seller.yourAddress=Η {0} διεύθυνσή σου:
@@ -510,9 +510,9 @@ portfolio.pending.step3_seller.openForDispute=Δεν επιβεβαίωσες τ
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.part1=Έλαβες την πληρωμή {0} από τον έτερο συναλλασσόμενο;\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.fiat=Η ταυτότητα συναλλαγής (\\"λόγος πληρωμής\\" κείμενο) είναι: \\"{0}\\"\n
+portfolio.pending.step3_seller.onPaymentReceived.fiat=Η ταυτότητα συναλλαγής (\"λόγος πληρωμής\" κείμενο) είναι: \"{0}\"\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".\n\n
+portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".\n\n
 portfolio.pending.step3_seller.onPaymentReceived.note=Λάβε υπόψιν πως αμέσως μόλις επιβεβαιώσεις την απόδειξη, το κλειδωμένο ποσό της συναλλαγής θα αποδεσμευτεί στον αγοραστή BTC και η εγγύηση θα επιστραφεί.
 portfolio.pending.step3_seller.onPaymentReceived.confirm.headline=Επιβεβαίωσε πως έλαβες την πληρωμή
 portfolio.pending.step3_seller.onPaymentReceived.confirm.yes=Ναι, έλαβα την πληρωμή
@@ -529,7 +529,7 @@ portfolio.pending.step5_buyer.alreadyWithdrawn=Τα κεφάλαιά σου έχ
 portfolio.pending.step5_buyer.confirmWithdrawal=Επιβεβαίωση αίτησης ανάληψης
 portfolio.pending.step5_buyer.amountTooLow=Το ποσό προς μεταφορά είναι χαμηλότερο από την προμήθεια συναλλαγής και την ελάχιστη δυνατή αξία συναλλαγής (dust).
 portfolio.pending.step5_buyer.withdrawalCompleted.headline=Ανάληψη ολοκληρώθηκε
-portfolio.pending.step5_buyer.withdrawalCompleted.msg=Οι ολοκληρωμένες συναλλαγές σου βρίσκονται αποθηκευμένες στο \\"Χαρτοφυλάκιο/Ιστορικό\\".\nΜπορείς να δεις όλες τις bitcoin συναλλαγές σου στο \\"Κεφάλαια/Συναλλαγές\\"
+portfolio.pending.step5_buyer.withdrawalCompleted.msg=Οι ολοκληρωμένες συναλλαγές σου βρίσκονται αποθηκευμένες στο \"Χαρτοφυλάκιο/Ιστορικό\".\nΜπορείς να δεις όλες τις bitcoin συναλλαγές σου στο \"Κεφάλαια/Συναλλαγές\"
 portfolio.pending.step5_buyer.bought=Αγόρασες:
 portfolio.pending.step5_buyer.paid=Πλήρωσες:
 
@@ -543,7 +543,7 @@ portfolio.pending.tradeProcess=Διαδικασία συναλλαγής
 portfolio.pending.openAgainDispute.msg=Αν δεν είσαι σίγουρος/η πως το μήνυμα ελήφθη από τον διαμεσολαβητή (π.χ. αν δεν έλαβες απάντηση εντός 1 ημέρας) μπορείς να ξεκινήσεις ξανά την επίλυση διένεξης.
 portfolio.pending.openAgainDispute.button=Άνοιξε τη διένεξη ξανά
 portfolio.pending.openSupportTicket.headline=Άνοιξε αίτημα υποστήριξης
-portfolio.pending.openSupportTicket.msg=Χρησιμοποίησέ το μονάχα σε επείγουσες περιπτώσεις, αν δεν υπάρχει  το \\"Αίτημα υποστήριξης\\" ή το \\"Επίλυση διένεξης\\" κουμπί.\n\nΚαταθέτοντας ένα αίτημα υποστήριξης η συναλλαγή αναστέλλεται και τη διαχείριση αναλαμβάνει ο διαμεσολαβητής
+portfolio.pending.openSupportTicket.msg=Χρησιμοποίησέ το μονάχα σε επείγουσες περιπτώσεις, αν δεν υπάρχει  το \"Αίτημα υποστήριξης\" ή το \"Επίλυση διένεξης\" κουμπί.\n\nΚαταθέτοντας ένα αίτημα υποστήριξης η συναλλαγή αναστέλλεται και τη διαχείριση αναλαμβάνει ο διαμεσολαβητής
 portfolio.pending.notification=Ειδοποίηση
 portfolio.pending.openDispute=Άνοιξε την επίλυση διένεξης
 portfolio.pending.disputeOpened=Η επίλυση διένεξης άνοιξε
@@ -551,7 +551,7 @@ portfolio.pending.openSupport=Άνοιξε αίτημα υποστήριξης
 portfolio.pending.supportTicketOpened=Το αίτημα υποστήριξης άνοιξε
 portfolio.pending.requestSupport=Αίτηση υποστήριξης
 portfolio.pending.error.requestSupport=Ανάφερε το πρόβλημα στον διαμεσολαβητή.\n\nΘα προωθήσει τις πληροφορίες στους προγραμματιστές για να το διερευνήσουν.\nΜετά την ανάλυση του προβλήματος θα σου επιστραφούν όλα τα κλειδωμένα κεφάλαια.\n
-portfolio.pending.communicateWithArbitrator=Επικοινώνησε με τον διαμεσολαβητή στο παράθυρο \\"Υποστήριξη\\".
+portfolio.pending.communicateWithArbitrator=Επικοινώνησε με τον διαμεσολαβητή στο παράθυρο \"Υποστήριξη\".
 portfolio.pending.supportTicketOpenedMyUser=Έχεις ήδη ανοίξει ένα αίτημα υποστήριξης.\n{0}
 portfolio.pending.disputeOpenedMyUser=Έχεις ήδη ανοίξει μια επίλυση διένεξης.\n{0}
 portfolio.pending.disputeOpenedByPeer=Ο έτερος συναλλασσόμενος άνοιξε μια επίλυση διένεξης\n{0}
@@ -660,7 +660,7 @@ support.buyerOfferer=Αγοραστής/Maker BTC
 support.sellerOfferer=Πωλητής/Maker BTC
 support.buyerTaker=Αγοραστής/Taker BTC
 support.sellerTaker=Πωλητής/Taker BTC
-support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \\"Open dispute\\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \\"Open support ticket\\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \\"Open support ticket\\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \\"Portfolio/Open trades\\" and type the key combination \\"alt + o\\" or \\"option + o\\" to open the support ticket.
+support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \"Open dispute\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \"Open support ticket\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \"Open support ticket\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \"Portfolio/Open trades\" and type the key combination \"alt + o\" or \"option + o\" to open the support ticket.
 support.initialInfo="Please note the basic rules for the dispute process:\n1. You need to respond to the arbitrators requests in between 2 days.\n2. The maximum period for the dispute is 14 days.\n3. You need to fulfill what the arbitrator is requesting from you to deliver evidence for your case.\n4. You accepted the rules outlined in the wiki in the user agreement when you first started the application.\n\nPlease read more in detail about the dispute process in our wiki:\nhttps://github.com/bitsquare/bitsquare/wiki/Dispute-process
 support.systemMsg=Μήνυμα συστήματος: {0}
 support.youOpenedTicket=Άνοιξες ένα αίτημα υποστήριξης.
@@ -700,7 +700,7 @@ setting.preferences.displayOptions=Προβολή επιλογών
 setting.preferences.showOwnOffers=Εμφάνισε τις προσφορές μου στο καθολικό προσφορών:
 setting.preferences.useAnimations=Χρήση animations:
 setting.preferences.sortWithNumOffers=Ταξινόμησε τους καταλόγους αγορών σύμφωνα με το πλήθος προσφορών/συναλλαγών:
-setting.preferences.resetAllFlags=Επανάφερε όλες τις επισημάνσεις \\"Να μην επανεμφανιστεί\\":
+setting.preferences.resetAllFlags=Επανάφερε όλες τις επισημάνσεις \"Να μην επανεμφανιστεί\":
 setting.preferences.reset=Επαναφορά
 settings.preferences.languageChange=Για αλλαγή γλώσσας σε όλα τα παράθυρα απαιτείται επανεκκίνηση.
 settings.preferences.selectCurrencyNetwork=Select base currency
@@ -764,7 +764,7 @@ setting.about.subsystems.val=Έλδοση δικτύου: {0}. Έκδοση P2P 
 account.tab.arbitratorRegistration=Εγγραφή διαμεσολαβητή
 account.tab.account=Λογαριασμός
 account.info.headline=Καλωσόρισες στον Bisq λογαριασμό σου
-account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \\"Funds\\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
+account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \"Funds\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
 
 account.menu.paymentAccount=Λογαριασμοί εθνικών νομισμάτων
 account.menu.altCoinsAccountView=Λογαριασμοί altcoins
@@ -821,7 +821,7 @@ account.password.setPw.headline=Όρισε κωδικό προστασίας π�
 account.password.info=Με κωδικό προστασίας απαιτείται η εισαγωγή του κωδικού για αναλήψεις bitcoin από το πορτοφόλι σου ή αν θέλεις να δεις ή να επαναφέρεις ένα πορτοφόλι μέσω των λέξεων seed, καθώς και κατά την εκκίνηση της εφαρμογής.
 
 account.seed.backup.title=Αποθήκευση αντιγράφου ασφαλείας για seed words πορτοφολιού
-account.seed.info=Σημείωσε τόσο τις λέξεις seed του πορτοφολιού, όσο και την ημερομηνία! Μπορείς να επαναφέρεις το πορτοφόλι σου οποιαδήποτε στιγμή με αυτές τις λέξεις και την ημερομηνία.\nΟι λέξεις seed  χρησιμοποιούνται τόσο για το πορτοφόλι BTC όσο και για το πορτοφόλι BSQ.\n\nΠρέπει να καταγράψεις τις λέξεις seed σε ένα φύλλο χαρτί, αλλά δεν πρέπει να τις αποθηκεύσεις στον υπολογιστή σου.\n\nΛάβε υπόψιν σου πως οι λέξεις seed δεν αντικαθιστούν το αντίγραφο ασφαλείας.\nΠρέπει να δημιουργείς αντίγραφα ασφαλείας ολόκληρης της εφαρμογής μέσω της καρτέλας \\"Λογαριασμός/Αντίγραφο ασφαλείας\\" για να επαναφέρεις μια έγκυρη κατάσταση της εφαρμογής και των δεδομένων.
+account.seed.info=Σημείωσε τόσο τις λέξεις seed του πορτοφολιού, όσο και την ημερομηνία! Μπορείς να επαναφέρεις το πορτοφόλι σου οποιαδήποτε στιγμή με αυτές τις λέξεις και την ημερομηνία.\nΟι λέξεις seed  χρησιμοποιούνται τόσο για το πορτοφόλι BTC όσο και για το πορτοφόλι BSQ.\n\nΠρέπει να καταγράψεις τις λέξεις seed σε ένα φύλλο χαρτί, αλλά δεν πρέπει να τις αποθηκεύσεις στον υπολογιστή σου.\n\nΛάβε υπόψιν σου πως οι λέξεις seed δεν αντικαθιστούν το αντίγραφο ασφαλείας.\nΠρέπει να δημιουργείς αντίγραφα ασφαλείας ολόκληρης της εφαρμογής μέσω της καρτέλας \"Λογαριασμός/Αντίγραφο ασφαλείας\" για να επαναφέρεις μια έγκυρη κατάσταση της εφαρμογής και των δεδομένων.
 account.seed.warn.noPw.msg=Δεν έχεις δημιουργήσει κωδικό πορτοφολιού, ο οποίος θα προστατεύσει την εμφάνιση των λέξεων seed.\n\nΘέλεις να εμφανίσεις τις λέξεις seed;
 account.seed.warn.noPw.yes=Ναι, και να μην ερωτηθώ ξανά
 account.seed.enterPw=Εισήγαγε κωδικό για την εμφάνιση των λέξεων seed
@@ -957,7 +957,7 @@ disputeSummaryWindow.close.msg=Το αίτημα έκλεισε στις {0}\n\n
 disputeSummaryWindow.close.closePeer=Κλείσε και το αίτημα του έτερου συναλλασσόμενου (trading peer)!
 
 emptyWalletWindow.headline=Εργαλείο πορτοφολιού έκτακτης ανάγκης
-emptyWalletWindow.info=Please use that only in emergency case if you cannot access your fund from the UI.\n\nPlease note that all open offers will be closed automatically when using this tool.\n\nBefore you use this tool, please backup your data directory. You can do this at \\"Account/Backup\\".\n\nPlease report us your problem and file a bug report on Github or at the Bisq forum so that we can investigate what was causing the problem.
+emptyWalletWindow.info=Please use that only in emergency case if you cannot access your fund from the UI.\n\nPlease note that all open offers will be closed automatically when using this tool.\n\nBefore you use this tool, please backup your data directory. You can do this at \"Account/Backup\".\n\nPlease report us your problem and file a bug report on Github or at the Bisq forum so that we can investigate what was causing the problem.
 emptyWalletWindow.balance=Διαθέσιμα κεφάλαια πορτοφολιού:
 emptyWalletWindow.address=Διεύθυνση αποστολής:
 emptyWalletWindow.button=Αποστολή συνόλου κεφαλαίων
@@ -1001,7 +1001,9 @@ selectDepositTxWindow.msg=Η κατάθεση δεν αποθηκεύτηκε σ
 selectDepositTxWindow.select=Διάλεξε κατάθεση
 
 selectBaseCurrencyWindow.headline=Market selection
-selectBaseCurrencyWindow.msg=The selected default market is {0}.\n\nIf you want to change to another base currency please select one from the drop down box.\nYou can also change later the base currency at the \\"Settings/Network\\" screen.
+selectBaseCurrencyWindow.msg=The selected default market is {0}.\n\n\
+  If you want to change to another base currency please select one from the drop down box.\n\
+  You can also change later the base currency at the \"Settings/Network\" screen.
 selectBaseCurrencyWindow.select=Select base currency
 selectBaseCurrencyWindow.default=Use {0} as default market
 
@@ -1055,7 +1057,7 @@ popup.headline.error=Σφάλμα
 popup.doNotShowAgain=Ακύρωση επανεμφάνισης
 popup.reportError.gitHub=Ανάφερε στο Github issue tracker
 popup.reportError.forum=Στείλε αναφορά στο φόρουμ του Bisq
-popup.reportError={0}\n\nTo help us to improve the software please report the bug at our issue tracker at Github or post it at the Bisq forum.\nThe error message will be copied to clipboard when you click the below buttons.\nIt will make debugging easier if you can attach the Bisq.log file which you can find in the application directory.\nYou can open the application directory at \\"Account/Backup\\".
+popup.reportError={0}\n\nTo help us to improve the software please report the bug at our issue tracker at Github or post it at the Bisq forum.\nThe error message will be copied to clipboard when you click the below buttons.\nIt will make debugging easier if you can attach the Bisq.log file which you can find in the application directory.\nYou can open the application directory at \"Account/Backup\".
 
 popup.error.tryRestart=Επανεκκίνησε την εφαρμογή και έλεγξε τη σύνδεση δικτύου για να επιλυθεί το πρόβλημα.
 popup.error.createTx=Σφάλμα στη δημιουργία συναλλαγής: {0}
@@ -1072,8 +1074,8 @@ popup.warning.startupFailed.twoInstances=Το Bisq λειτουργεί ήδη. 
 popup.warning.cryptoTestFailed=Seems that you use a self compiled binary and have not following the build instructions in https://github.com/bitsquare/bitsquare/blob/master/doc/build.md#7-enable-unlimited-strength-for-cryptographic-keys.\n\nIf that is not the case and you use the official Bisq binary, please file a bug report to the Github page.\nError={0}
 popup.warning.oldOffers.msg=You have open offers which have been created with an older version of Bisq.\nPlease remove those offers as they are not valid anymore.\n\nOffers (ID): {0}
 popup.warning.oldOffers.buttonText=Ακύρωσε παρωχημένες προσφορές
-popup.warning.tradePeriod.halfReached=Η συναλλαγή σου με ταυτότητα {0} έφτασε το μισό της επιτρεπόμενης  χρονικής περιόδου και δεν έχει ολοκληρωθεί ακόμα.\n\nΗ περίοδος συναλλαγής κλείνει στις {1}\n\nΈλεγξε την κατάσταση της συναλλαγής στο \\"Χαρτοφυλάκιο/Ανοιχτές συναλλαγές\\" για περαιτέρω πληροφορίες.
-popup.warning.tradePeriod.ended=Η συναλλαγή σου με ταυτότητα {0} έφτασε τη μέγιστη επιτρεπόμενη χρονική περίοδο χωρίς να ολοκληρωθεί.\n\nΗ περίοδος συναλλαγής έκλεισε στις {1}\n\nΈλεγξε τη συναλλαγή σου στο \\"Χαρτοφυλάκιο/Ανοιχτές συναλλαγές\\" για να επικοινωνήσεις με τον διαμεσολαβητή.
+popup.warning.tradePeriod.halfReached=Η συναλλαγή σου με ταυτότητα {0} έφτασε το μισό της επιτρεπόμενης  χρονικής περιόδου και δεν έχει ολοκληρωθεί ακόμα.\n\nΗ περίοδος συναλλαγής κλείνει στις {1}\n\nΈλεγξε την κατάσταση της συναλλαγής στο \"Χαρτοφυλάκιο/Ανοιχτές συναλλαγές\" για περαιτέρω πληροφορίες.
+popup.warning.tradePeriod.ended=Η συναλλαγή σου με ταυτότητα {0} έφτασε τη μέγιστη επιτρεπόμενη χρονική περίοδο χωρίς να ολοκληρωθεί.\n\nΗ περίοδος συναλλαγής έκλεισε στις {1}\n\nΈλεγξε τη συναλλαγή σου στο \"Χαρτοφυλάκιο/Ανοιχτές συναλλαγές\" για να επικοινωνήσεις με τον διαμεσολαβητή.
 popup.warning.noTradingAccountSetup.headline=Δεν έχεις δημιουργήσει λογαριασμό συναλλαγών
 popup.warning.noTradingAccountSetup.msg=Πρέπει να δημιουργήσεις ένα λογαριασμό εθνικού νομίσματος ή κρυπτονομίσματος πριν σου επιτραπεί να δημιουργήσεις μια προσφορά.\nΘέλεις να δημιουργήσεις ένα λογαριασμό τώρα;
 popup.warning.noArbitratorSelected.headline=Δεν έχεις επιλέξει διαμεσολαβητή.
@@ -1081,21 +1083,21 @@ popup.warning.noArbitratorSelected.msg=Πρέπει να επιλέξεις το
 popup.warning.notFullyConnected=Πρέπει να περιμένεις έως ότου είσαι πλήρως συνδεδεμένος με το δίκτυο.\nΑυτό ίσως διαρκέσει μέχρι 2 λεπτά κατά την εκκίνηση.
 popup.warning.removeOffer=Είσαι σίγουρος πως θέλεις να αναιρέσεις αυτή την προσφορά;\nΗ προμήθεια maker των {0} θα χαθεί αν αναιρέσεις την προσφορά.
 popup.warning.tooLargePercentageValue=Δεν μπορείς να θέσεις ποσοστό 100% ή μεγαλύτερο.
-popup.warning.examplePercentageValue=Παρακαλώ εισήγαγε ποσοστιαίο αριθμό όπως \\"5.4\\" για 5.4%
+popup.warning.examplePercentageValue=Παρακαλώ εισήγαγε ποσοστιαίο αριθμό όπως \"5.4\" για 5.4%
 popup.warning.noPriceFeedAvailable=Δεν υπάρχει διαθέσιμη τροφοδοσία τιμής για αυτό το νόμισμα. Δεν μπορείς να θέσεις τιμή βάση ποσοστού.\nΕπίλεξε την καθορισμένη τιμή.
 popup.warning.sendMsgFailed=Η αποστολή μηνύματος στο έτερο συναλλασσόμενο απέτυχε.\nΠροσπάθησε ξανά και αν επαναληφθεί ανάφερε το σφάλμα.
 popup.warning.insufficientBtcFundsForBsqTx=Δεν έχεις επαρκή κεφάλαιο BTC για να πληρώσεις την προμήθεια αυτής της BSQ συναλλαγής.\nΧρηματοδότησε το BTC πορτοφόλι σου για να μπορείς να μεταφέρεις BSQ.\nΑπαιτούμενο κεφάλαιο: {0}
 popup.warning.insufficientBsqFundsForBtcFeePayment=Δεν έχεις επαρκή κεφάλαιο BSQ για να πληρώσεις την προμήθεια συναλλαγής σε BSQ.\nΜπορείς να πληρώσεις την προμήθεια σε BTC ή να χρηματοδοτήσεις το BSQ πορτοφόλι σου.\nΑπαιτούμενο κεφάλαιο BSQ: {0}
 popup.warning.noBsqFundsForBtcFeePayment=Το BSQ πορτοφόλι σου δεν έχει επαρκή κεφάλαια για την πληρωμή της προμήθειας συναλλαγής σε BSQ.
 popup.warning.messageTooLong=Το μήνυμά σου υπερβαίνει το μέγιστο επιτρεπόμενο μέγεθος. Στείλ' το τμηματικά ή ανέβασέ το σε υπηρεσία όπως η https://pastebin.com.
-popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \\"alt + o\\" or \\"option + o\\"."
+popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \"alt + o\" or \"option + o\"."
 
 popup.info.securityDepositInfo=To ensure that both traders follow the trade protocol they need to pay a security deposit.\n\nThe deposit will stay in your local trading wallet until the offer gets accepted by another trader.\nIt will be refunded to you after the trade has successfully completed.\n\nPlease note that you need to keep your application running if you have an open offer. When another trader wants to take your offer it requires that your application is online for executing the trade protocol.\nBe sure that you have standby mode deactivated as that would disconnect the network (standby of the monitor is not a problem).
 
 popup.privateNotification.headline=Σημαντική προσωπική ειδοποίηση!
 
 popup.securityRecommendation.headline=Σημαντική σύσταση ασφάλειας
-popup.securityRecommendation.msg=Θα θέλαμε να σου υπενθυμίσουμε να σκεφτείς τη χρήση κωδικού για το πορτοφόλι σου, αν δεν το έχεις ήδη κάνει.\n\nΕπίσης συνιστάται ιδιαιτέρως η καταγραφή των λέξεων seed του πορτοφολιού. Οι λέξεις seed αποτελούν τον βασικό κωδικό ανάκτησης του Bitcoin πορτοφολιού σου.\nΣτην καρτέλα \\"Seed πορτοφολιού\\" θα βρεις περισσότερες πληροφορίες.\n\nΕπιπλέον θα πρέπει να κρατήσεις αντίγραφο ασφαλείας του συνόλου του φακέλου της εφαρμογής στην καρτέλα \\"Αντίγραφο ασφαλείας\\".
+popup.securityRecommendation.msg=Θα θέλαμε να σου υπενθυμίσουμε να σκεφτείς τη χρήση κωδικού για το πορτοφόλι σου, αν δεν το έχεις ήδη κάνει.\n\nΕπίσης συνιστάται ιδιαιτέρως η καταγραφή των λέξεων seed του πορτοφολιού. Οι λέξεις seed αποτελούν τον βασικό κωδικό ανάκτησης του Bitcoin πορτοφολιού σου.\nΣτην καρτέλα \"Seed πορτοφολιού\" θα βρεις περισσότερες πληροφορίες.\n\nΕπιπλέον θα πρέπει να κρατήσεις αντίγραφο ασφαλείας του συνόλου του φακέλου της εφαρμογής στην καρτέλα \"Αντίγραφο ασφαλείας\".
 
 popup.shutDownInProgress.headline=Διακοπή λειτουργίας σε εξέλιξη
 popup.shutDownInProgress.msg=Η διακοπή λειτουργίας ίσως διαρκέσει λίγα δευτερόλεπτα.\nΠαρακαλώ μη διακόψεις τη διαδικασία.
@@ -1150,7 +1152,7 @@ guiUtil.accountExport.exportFailed=Εξαγωγή προς CSV απέτυχε ε
 guiUtil.accountExport.selectExportPath=Επίλεξε φάκελο εξαγωγής
 guiUtil.accountImport.imported=Εισαγωγή λογαριασμού συναλλαγών από το φάκελο:\n{0}\nΕισηγμένοι λογαριασμοί:\n{1}
 guiUtil.accountImport.noAccountsFound=Δεν βρέθηκαν λογαριασμοί συναλλαγών στο φάκελο: {0}\nΤο όνομα αρχείου είναι {1}.
-guiUtil.openWebBrowser.warning=Πρόκειται να ανοίξεις μια ιστοσελίδα στον προεπιλεγμένο περιηγητή του συστήματός σου.\nΘέλεις να ανοίξεις την ιστοσελίδα  τώρα;\n\nΑν ο \\"Tor Browser\\" δεν είναι ο προεπιλεγμένος περιηγητής του συστήματός σου θα συνδεθείς στην ιστοσελίδα μέσω του κοινού δικτύου.\n\nURL: \\"{0}\\"
+guiUtil.openWebBrowser.warning=Πρόκειται να ανοίξεις μια ιστοσελίδα στον προεπιλεγμένο περιηγητή του συστήματός σου.\nΘέλεις να ανοίξεις την ιστοσελίδα  τώρα;\n\nΑν ο \"Tor Browser\" δεν είναι ο προεπιλεγμένος περιηγητής του συστήματός σου θα συνδεθείς στην ιστοσελίδα μέσω του κοινού δικτύου.\n\nURL: \"{0}\"
 guiUtil.openWebBrowser.doOpen=Άνοιξε την ιστοσελίδα και να μην ερωτηθώ ξανά
 guiUtil.openWebBrowser.copyUrl=Αντιγραφή διεύθυνσης URL και ακύρωση
 guiUtil.ofTradeAmount=ποσού συναλλαγής
@@ -1201,16 +1203,16 @@ txIdTextField.blockExplorerIcon.tooltip=Άνοιξε blockchain explorer με α
 # Navigation
 ####################################################################
 
-navigation.account=\\"Λογαριασμός\\"
-navigation.arbitratorSelection=\\"Επιλογή Διαμεσολαβητή\\"
-navigation.funds.availableForWithdrawal=\\"Κεφάλαια/Αποστολή κεφαλαίων\\"
-navigation.portfolio.myOpenOffers=\\"Χαρτοφυλάκιο/Οι τρέχουσες προσφορές μου\\"
-navigation.portfolio.pending=\\"Χαρτοφυλάκιο/Ανοιχτές προσφορές\\"
-navigation.funds.depositFunds=\\"Κεφάλαια/Λήψη κεφαλαίων\\"
-navigation.settings.preferences=\\"Ρυθμίσεις/Προτιμήσεις\\"
-navigation.funds.transactions=\\"Κεφάλαια/Συναλλαγές\\"
-navigation.support=\\"Υποστήριξη\\"
-navigation.dao.wallet.receive=\\"DAO/πορτοφόλι BSQ/Λήψη\\"
+navigation.account=\"Λογαριασμός\"
+navigation.arbitratorSelection=\"Επιλογή Διαμεσολαβητή\"
+navigation.funds.availableForWithdrawal=\"Κεφάλαια/Αποστολή κεφαλαίων\"
+navigation.portfolio.myOpenOffers=\"Χαρτοφυλάκιο/Οι τρέχουσες προσφορές μου\"
+navigation.portfolio.pending=\"Χαρτοφυλάκιο/Ανοιχτές προσφορές\"
+navigation.funds.depositFunds=\"Κεφάλαια/Λήψη κεφαλαίων\"
+navigation.settings.preferences=\"Ρυθμίσεις/Προτιμήσεις\"
+navigation.funds.transactions=\"Κεφάλαια/Συναλλαγές\"
+navigation.support=\"Υποστήριξη\"
+navigation.dao.wallet.receive=\"DAO/πορτοφόλι BSQ/Λήψη\"
 
 
 ####################################################################
@@ -1288,7 +1290,7 @@ seed.date=Ημερομηνία πορτοφολιού:
 seed.restore.title=Επαναφορά πορτοφολιών μέσω λέξεων seed
 seed.restore=Επαναφορά πορτοφολιών
 seed.creationDate=Ημερομηνία δημιουργίας:
-seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \\"alt + e\\" or \\"option + e\\" .
+seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \"alt + e\" or \"option + e\" .
 seed.warn.walletNotEmpty.restore=Θέλω να επαναφέρω το πορτοφόλι
 seed.warn.walletNotEmpty.emptyWallet=Αρχικά θα αδειάσω τα πορτοφόλια μου
 seed.warn.notEncryptedAnymore=Τα πορτοφόλια σου είναι κρυπτογραφημένα.\n\nΜετά την επαναφορά τα πορτοφόλια δεν θα είναι πλέον κρυπτογραφημένα και θα πρέπει να θέσεις νέο κωδικό.\n\nΘέλεις να προχωρήσεις;
@@ -1318,7 +1320,7 @@ payment.email=Email:
 payment.country=Χώρα:
 payment.owner.email=Email κατόχου λογαριασμού:
 payment.extras=Επιπλέον προαπαιτήσεις:
-payment.us.info=Δεν υποστηρίζεται τραπεζική μεταφορά μέσω εμβάσματος (WIRE) ή μέσω Αυτοματοποιημένου Κέντρου Συμψηφισμού (ACH) προς τις ΗΠΑ. Το έμβασμα έχει υψηλό κόστος, ενώ το ACH έχει υψηλό ρίσκο αντιλογισμού χρέωσης.\nΠαρακαλώ χρησιμοποίησε είτε \\"ClearXchange\\", είτε \\"Ταχυδρομική επιταγή US Postal\\", είτε \\"Κατάθεση μετρητών\\".
+payment.us.info=Δεν υποστηρίζεται τραπεζική μεταφορά μέσω εμβάσματος (WIRE) ή μέσω Αυτοματοποιημένου Κέντρου Συμψηφισμού (ACH) προς τις ΗΠΑ. Το έμβασμα έχει υψηλό κόστος, ενώ το ACH έχει υψηλό ρίσκο αντιλογισμού χρέωσης.\nΠαρακαλώ χρησιμοποίησε είτε \"ClearXchange\", είτε \"Ταχυδρομική επιταγή US Postal\", είτε \"Κατάθεση μετρητών\".
 payment.email.mobile=Email ή αριθμός κινητού:
 payment.altcoin.address=Διεύθυνση altcoin:
 payment.altcoin=Altcoin:

--- a/common/src/main/resources/i18n/displayStrings_es.properties
+++ b/common/src/main/resources/i18n/displayStrings_es.properties
@@ -98,7 +98,7 @@ shared.openDefaultWalletFailed=Fallo al abrir la aplicación del monedero bitcoi
 shared.distanceInPercent=Distancia en % del precio de mercado
 shared.enterPercentageValue=Introduzca valor %
 shared.OR=ó
-shared.notEnoughFunds=No posee suficientes fondos en su billetera Bisq.\nNecesita {0} sin embargo, solo tiene {1} en su billetera Bisq.\n\nPor favor, financie su intercambio desde una billetera externa de Bitcoin o financie su billetera Bisq en  \\"Fondos/Recibir fondos\\".
+shared.notEnoughFunds=No posee suficientes fondos en su billetera Bisq.\nNecesita {0} sin embargo, solo tiene {1} en su billetera Bisq.\n\nPor favor, financie su intercambio desde una billetera externa de Bitcoin o financie su billetera Bisq en  \"Fondos/Recibir fondos\".
 shared.waitingForFunds=Esperando fondos...
 shared.depositTransactionId=ID deposito de la transacción 
 shared.TheBTCBuyer=El comprador de BTC
@@ -338,12 +338,12 @@ createOffer.fundsBox.networkFee=Tasa de minado:
 createOffer.fundsBox.placeOfferSpinnerInfo=Publicación de oferta en curso...
 createOffer.fundsBox.paymentLabel=Intercambio en Bitsquare con ID {0}
 createOffer.success.headline=Su oferta ha sido publicada.
-createOffer.success.info=Puede gestionar sus ofertas abiertas en  \\"Portafolio/Mis ofertas abiertas\\".
+createOffer.success.info=Puede gestionar sus ofertas abiertas en  \"Portafolio/Mis ofertas abiertas\".
 
 
 # new entries
 createOffer.placeOfferButton=Revisar: Poner oferta a {0} bitcoin
-createOffer.alreadyFunded=Ya ha depositado fondos en esta oferta.\nSus fondos se han movido al monedero local Bisq y están disponibles para la retirada en la pantalla \\"Fondos/Enviar fondos\\".
+createOffer.alreadyFunded=Ya ha depositado fondos en esta oferta.\nSus fondos se han movido al monedero local Bisq y están disponibles para la retirada en la pantalla \"Fondos/Enviar fondos\".
 createOffer.createOfferFundWalletInfo.headline=Dote de fondos su trato.
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Cantidad a intercambiar: {0}\n
@@ -352,7 +352,7 @@ createOffer.createOfferFundWalletInfo.msg=Necesita depositar {0} a esta oferta.\
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
 createOffer.amountPriceBox.error.message=Ocurrió un error al poner la oferta:\n\n{0}\n\nAún no hay fondos disponibles en su cartera.\nPor favor reinicie la aplicación y compruebe su conexión a la red.
 createOffer.setAmountPrice=Establezca cantidad y precio
-createOffer.warnCancelOffer=Ya ha dotado de fondos esta oferta.\nSi cancela ahora, sus fondos se moverán a su monedero local Bisq y estarán disponibles para retirar en la pantalla \\"Fondos/Enviar fondos\\".\nEstá seguro de que quiere cancelar?
+createOffer.warnCancelOffer=Ya ha dotado de fondos esta oferta.\nSi cancela ahora, sus fondos se moverán a su monedero local Bisq y estarán disponibles para retirar en la pantalla \"Fondos/Enviar fondos\".\nEstá seguro de que quiere cancelar?
 createOffer.fixed=Fijo
 createOffer.percentage=Porcentaje
 createOffer.timeoutAtPublishing=Error. Fuera de tiempo en la publicación de la oferta.
@@ -390,21 +390,21 @@ takeOffer.fundsBox.networkFee=Tasas de minería (3x):
 takeOffer.fundsBox.takeOfferSpinnerInfo=Aceptación de oferta en espera...
 takeOffer.fundsBox.paymentLabel=Trato de Bitsquare con ID {0}
 takeOffer.success.headline=Ha aceptado la oferta con éxito.
-takeOffer.success.info=Puede ver el estado de su intercambio en \\"Portafolio/Intercambios abiertos\\".
+takeOffer.success.info=Puede ver el estado de su intercambio en \"Portafolio/Intercambios abiertos\".
 takeOffer.error.message=Un error ocurrió aceptando la oferta.\n\n{0}
 
 # new entries
 takeOffer.takeOfferButton=Revisión: Tomar oferta a {0} bitcoin
 takeOffer.noPriceFeedAvailable=No puede tomar esta oferta porque utiliza un precio porcentual basado en el precio de mercado y no hay fuentes de precio disponibles.
-takeOffer.alreadyFunded.movedFunds=Ya ha depositado fondos en esta oferta.\nSus fondos se han movido al monedero local Bisq y están disponibles para la retirada en la pantalla \\"Fondos/Enviar fondos\\".
+takeOffer.alreadyFunded.movedFunds=Ya ha depositado fondos en esta oferta.\nSus fondos se han movido al monedero local Bisq y están disponibles para la retirada en la pantalla \"Fondos/Enviar fondos\".
 takeOffer.takeOfferFundWalletInfo.headline=Dotar de fondos su intercambio
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Cantidad de intercambio: {0}\n
 takeOffer.takeOfferFundWalletInfo.msg=Necesita depositar {0} para aceptar esta oferta.\n\nLa cantidad es la suma de:\n{1} - Depósito de seguridad: {2}\n- Tasa de intercambio: {3}\n- Tasa de minado (3x): {4}\n\nPuede elegir entre dos opciones al dotar de fondos su intercambio:\n- Usar el monedero Bisq (conveniente, pero las transacciones pueden ser trazadas)\n- Transferir desde un monedero externo (potencialmente más privado)\n\nVerá todas las opciones de depósito y detalles al cerrar el popup.
-takeOffer.alreadyPaidInFunds=Si ya ha depositado fondos, puede retirarlos en la pantalla \\"Fondos/Disponible para retirar\\".
+takeOffer.alreadyPaidInFunds=Si ya ha depositado fondos, puede retirarlos en la pantalla \"Fondos/Disponible para retirar\".
 takeOffer.paymentInfo=Información de pago
 takeOffer.setAmountPrice=Establecer cantidad
-takeOffer.alreadyFunded.askCancel=Ya ha dotado de fondos esta oferta.\nSi cancela ahora, sus fondos se moverán a su monedero local Bisq y estarán disponibles para retirar en la pantalla \\"Fondos/Enviar fondos\\".\nEstá seguro de que quiere cancelar?
+takeOffer.alreadyFunded.askCancel=Ya ha dotado de fondos esta oferta.\nSi cancela ahora, sus fondos se moverán a su monedero local Bisq y estarán disponibles para retirar en la pantalla \"Fondos/Enviar fondos\".\nEstá seguro de que quiere cancelar?
 takeOffer.failed.offerNotAvailable=Falló la solicitud de toma de oferta porque la oferta ya no está disponible. Tal vez otro comerciante la haya tomado en su lugar.
 takeOffer.failed.offerTaken=No puede tomar la oferta porque la oferta fue tomada por otro comerciante.
 takeOffer.failed.offerRemoved=No puede tomar esta oferta porque la oferta ha sido eliminada.
@@ -446,12 +446,12 @@ portfolio.pending.step1.openForDispute=La transacción de depósito sigue sin ha
 portfolio.pending.step2.confReached=Su intercambio ha alcanzado al menos una confirmación en la cadena de bloques.\n(Puede esperar más confirmaciones si quiere - 6 confirmaciones son consideradas muy seguras.)
 
 portfolio.pending.step2_buyer.copyPaste=(Puede copiar y pegar los valores desde la pantalla principal después de cerrar el popup).
-portfolio.pending.step2_buyer.refTextWarn=NO publique ninguna razón adicional en el texto \\"reason for payment\\" como Bitcoin, BTC  o Bisq.
+portfolio.pending.step2_buyer.refTextWarn=NO publique ninguna razón adicional en el texto \"reason for payment\" como Bitcoin, BTC  o Bisq.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.accountDetails=Estos son los detalles de la cuenta de intercambio del vendedor de BTC:\n
 portfolio.pending.step2_buyer.tradeId=Por favor no olvide añadir la ID de intercambio
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.assign= como \\"concepto de pago\\" con lo que el receptor pueda asignar su pago a este intercambio.\n\n
+portfolio.pending.step2_buyer.assign= como \"concepto de pago\" con lo que el receptor pueda asignar su pago a este intercambio.\n\n
 portfolio.pending.step2_buyer.fees=Si su banco cobra tasas, corren a su cuenta.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.altcoin=Por favor transfiera de su monedero externo {0}\n{1} a el vendedor de BTC.\n\n
@@ -459,7 +459,7 @@ portfolio.pending.step2_buyer.altcoin=Por favor transfiera de su monedero extern
 portfolio.pending.step2_buyer.cash=Por favor vaya al banco y pague {0} a el vendedor de BTC.\n\n
 portfolio.pending.step2_buyer.cash.extra=REQUERIMIENTO IMPORTANTE:\nDespués de haber hecho el pago escribe en el recibo de papel: SIN REEMBOLSOS\nLuego divídalo en 2 partes, haga una foto y envíela a la dirección de e-mail del vendedor de BTC.
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.postal=Por favor, envíe {0} mediante \\"Giro postal US Postal\\" a el vendedor de BTC.\n\n
+portfolio.pending.step2_buyer.postal=Por favor, envíe {0} mediante \"Giro postal US Postal\" a el vendedor de BTC.\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.bank=Por favor, vaya a la página web de su banco y pague {0} a el vendedor de BTC.\n\n
 portfolio.pending.step2_buyer.startPaymentUsing=Comenzar pago utilizando {0}
@@ -488,11 +488,11 @@ portfolio.pending.step3_buyer.openForDispute=El vendedor de BTC no ha confirmado
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.part=La otra parte del intercambio confirma haber iniciado el pago de {0}.\n\n
 portfolio.pending.step3_seller.altcoin={0} Por favor compruebe en un {1} explorador de cadena de bloques si la transacción en la dirección de recepción {2} tiene suficientes confirmaciones.\nLa cantidad de pago tiene que ser {3}\n\nPuede copiar y pegar su dirección {4} desde la pantalla principal después de cerrar este popup.
-portfolio.pending.step3_seller.postal={0}Por favor, compruebe si ha recibido {1} con \\"Giro postal US Postal\\"desde el comprador de BTC.\n\nLa ID de intercambio (el texto \\"concepto de pago\\") de la transacción es: \\"{2}\\"
-portfolio.pending.step3_seller.bank=Su par de intercambio ha confirmado haber iniciado el pago de {0}.\n\nPor favor, vaya a la web de su banco y compruebe si ha recibido {1} desde la cuenta del comprador de BTC.\n\nLa ID de intercambio (texto \\"concepto de pago\\") de la transacción es: \\"{2}\\"
-portfolio.pending.step3_seller.cash=\n\nDebido a que el pago se hacho vía depósito en efectivo el comprador de BTC tiene que escribir \\"SIN REEMBOLSO\\" en el recibo de papel, dividirlo en 2 partes y enviarte una foto por e-mail.\n\nPara impedir el riesgo de devolución, confirme que todo está bien sólo si has recibido el e-mail y si está seguro de que el recibo es válido.\nSi no está seguro, {0}
+portfolio.pending.step3_seller.postal={0}Por favor, compruebe si ha recibido {1} con \"Giro postal US Postal\"desde el comprador de BTC.\n\nLa ID de intercambio (el texto \"concepto de pago\") de la transacción es: \"{2}\"
+portfolio.pending.step3_seller.bank=Su par de intercambio ha confirmado haber iniciado el pago de {0}.\n\nPor favor, vaya a la web de su banco y compruebe si ha recibido {1} desde la cuenta del comprador de BTC.\n\nLa ID de intercambio (texto \"concepto de pago\") de la transacción es: \"{2}\"
+portfolio.pending.step3_seller.cash=\n\nDebido a que el pago se hacho vía depósito en efectivo el comprador de BTC tiene que escribir \"SIN REEMBOLSO\" en el recibo de papel, dividirlo en 2 partes y enviarte una foto por e-mail.\n\nPara impedir el riesgo de devolución, confirme que todo está bien sólo si has recibido el e-mail y si está seguro de que el recibo es válido.\nSi no está seguro, {0}
 portfolio.pending.step3_seller.bankCheck=\n\nPor favor verifique también que el nombre del remitente en la nota bancaria concuerda con el de el contrato de intercambio:\nNombre del remitente: {0}\n\nSi el nombre no es el mismo que el mostrado aquí, {1}
-portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".
+portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".
 portfolio.pending.step3_seller.confirmPaymentReceipt=Confirmar recibo de pago
 portfolio.pending.step3_seller.amountToReceive=Cantidad a recibir:
 portfolio.pending.step3_seller.yourAddress=Su dirección {0}:
@@ -510,9 +510,9 @@ portfolio.pending.step3_seller.openForDispute=No se ha confirmado el recibo del 
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.part1=Ha recibido el pago de {0} de su par de intercambio?\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.fiat=La ID de intercambio (texto \\"concepto de pago\\") de la transacción es: \\"{0}\\"\n\n
+portfolio.pending.step3_seller.onPaymentReceived.fiat=La ID de intercambio (texto \"concepto de pago\") de la transacción es: \"{0}\"\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".\n\n
+portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".\n\n
 portfolio.pending.step3_seller.onPaymentReceived.note=Por favor, tenga en cuenta que tan pronto como confirme el recibo, la cantidad de intercambio bloqueada se liberará a el comprador de BTC y se le devolverá el depósito de seguridad.
 portfolio.pending.step3_seller.onPaymentReceived.confirm.headline=Confirme que ha recibido el pago
 portfolio.pending.step3_seller.onPaymentReceived.confirm.yes=Sí, he recibido el pago
@@ -529,7 +529,7 @@ portfolio.pending.step5_buyer.alreadyWithdrawn=Sus fondos ya han sido retirados.
 portfolio.pending.step5_buyer.confirmWithdrawal=Confirme la petición de retiro
 portfolio.pending.step5_buyer.amountTooLow=La cantidad a transferir es inferior a la tasa de transacción y el mínimo valor de transacción posible (polvo - dust).
 portfolio.pending.step5_buyer.withdrawalCompleted.headline=Retiro completado
-portfolio.pending.step5_buyer.withdrawalCompleted.msg=Sus intercambios completados están almacenados en  \\"Portfolio/Historial\\".\nPuede revisar todas las transacciones de bitcoin en \\"Fondos/Transacciones\\"
+portfolio.pending.step5_buyer.withdrawalCompleted.msg=Sus intercambios completados están almacenados en  \"Portfolio/Historial\".\nPuede revisar todas las transacciones de bitcoin en \"Fondos/Transacciones\"
 portfolio.pending.step5_buyer.bought=Ha comprado:
 portfolio.pending.step5_buyer.paid=Ha pagado:
 
@@ -543,7 +543,7 @@ portfolio.pending.tradeProcess=Proceso de intercambio
 portfolio.pending.openAgainDispute.msg=Si no está seguro de que el mensaje al árbitro llegó (v.g. si no ha tenido respuesta después de 1 día) siéntase libre de abrir una disputa de nuevo.
 portfolio.pending.openAgainDispute.button=Abrir disputa de nuevo
 portfolio.pending.openSupportTicket.headline=Abrir ticket de soporte
-portfolio.pending.openSupportTicket.msg=Por favor usar sólo en caso de emergencia si no se muestra el bótón \\"Abrir soporte\\" o \\"Abrir disputa\\".\n\nCuando abra un ticket de soporte el intercambio se interrumpirá y será manejado por el árbitro.
+portfolio.pending.openSupportTicket.msg=Por favor usar sólo en caso de emergencia si no se muestra el bótón \"Abrir soporte\" o \"Abrir disputa\".\n\nCuando abra un ticket de soporte el intercambio se interrumpirá y será manejado por el árbitro.
 portfolio.pending.notification=Notificación
 portfolio.pending.openDispute=Abrir una disputa
 portfolio.pending.disputeOpened=Disputa abierta
@@ -551,7 +551,7 @@ portfolio.pending.openSupport=Abrir ticket de soporte
 portfolio.pending.supportTicketOpened=Ticket de soporte abierto
 portfolio.pending.requestSupport=Solicitar soporte
 portfolio.pending.error.requestSupport=Por favor, reporte el problema al árbitro.\n\nEnviará la información a los desarrolladores para investigar el problema.\nUna vez se analice el problema se le devolverán los fondos, si había fondos bloqueados.
-portfolio.pending.communicateWithArbitrator=Por favor, comuníquese en la pantalla de \\"Soporte\\" con el árbitro.
+portfolio.pending.communicateWithArbitrator=Por favor, comuníquese en la pantalla de \"Soporte\" con el árbitro.
 portfolio.pending.supportTicketOpenedMyUser=Ya ha abierto un ticket de soporte.\n{0}
 portfolio.pending.disputeOpenedMyUser=Ya ha abierto una disputa.\n{0}
 portfolio.pending.disputeOpenedByPeer=Su pareja de intercambio ha abierto una disputa\n{0}
@@ -660,7 +660,7 @@ support.buyerOfferer= comprador/creador BTC
 support.sellerOfferer=vendedor/creador BTC
 support.buyerTaker=comprador/Tomador BTC
 support.sellerTaker=vendedor/Tomador BTC
-support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \\"Open dispute\\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \\"Open support ticket\\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \\"Open support ticket\\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \\"Portfolio/Open trades\\" and type the key combination \\"alt + o\\" or \\"option + o\\" to open the support ticket.
+support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \"Open dispute\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \"Open support ticket\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \"Open support ticket\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \"Portfolio/Open trades\" and type the key combination \"alt + o\" or \"option + o\" to open the support ticket.
 support.initialInfo="Por favor, tenga en cuenta las reglas básicas para el proceso de disputa:\n1. Necesita responder a las peticiones de los árbitros en menos de 2 días.\n2. El periodo máximo total de la disputa es de 14 días.\n3. Necesitará completar todas las peticiones del árbitro para entregar evidencia de su caso.\n4. Acepta las reglas destacadas en la wiki de acuerdo de usuario al comenzar la aplicación.\n\nPor favor lea en más detalle acerca del proceso de disputa en nuestra wiki:\nhttps://github.com/bitsquare/bitsquare/wiki/Dispute-process
 support.systemMsg=Mensaje de sistema: {0}
 support.youOpenedTicket=Ha abierto una solicitud de soporte.
@@ -700,7 +700,7 @@ setting.preferences.displayOptions=Mostrar opciones
 setting.preferences.showOwnOffers=Mostrar mis propias ofertas en el libro de ofertas:
 setting.preferences.useAnimations=Usar animaciones:
 setting.preferences.sortWithNumOffers=Ordenar listas de mercado con número de ofertas/intercambios:
-setting.preferences.resetAllFlags=Reiniciar todas las marcas  \\"No mostrar de nuevo\\":
+setting.preferences.resetAllFlags=Reiniciar todas las marcas  \"No mostrar de nuevo\":
 setting.preferences.reset=Restablecer
 settings.preferences.languageChange=Para aplicar un cambio de idioma en todas las pantallas, se precisa reiniciar.
 settings.preferences.selectCurrencyNetwork=Elija moneda base
@@ -764,7 +764,7 @@ setting.about.subsystems.val=Versión de red: {0}; Versión de mensajes P2P: {1}
 account.tab.arbitratorRegistration=Registro de árbitro
 account.tab.account=Cuenta
 account.info.headline=Bienvenido a su cuenta Bisq
-account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \\"Funds\\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
+account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \"Funds\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
 
 account.menu.paymentAccount=Cuentas de moneda nacional
 account.menu.altCoinsAccountView=Cuentas de altcoi
@@ -821,7 +821,7 @@ account.password.setPw.headline=Establecer protección por password del monedero
 account.password.info=Con protección por password tiene que introducir su password al retirar bitcoin de su monedero o si quiere ver o restaurar un monedero desde las palabras semilla, así como al inicio de la aplicación
 
 account.seed.backup.title=Copia de seguridad de palabras semilla del monedero
-account.seed.info=Por favor apunte en un papel tanto las palabras semilla del monedero como la fecha! Puede recuperar su monedero en cualquier momento con las palabras semilla y la fecha.\nLas palabras semilla se usan tanto para el monedero BTC como para el monedero BSQ.\n\nDebe apuntar las palabras semillas en una hoja de papel y no guardarla en su computadora.\n\nPor favor, tenga en cuenta que las palabras semilla no son un sustituto de la copia de seguridad.\nNecesita hacer la copia de seguridad de todo el directorio de aplicación en la pantalla \\"Cuenta/Copia de seguridad\\" para recuperar un estado de aplicación válido y los datos.
+account.seed.info=Por favor apunte en un papel tanto las palabras semilla del monedero como la fecha! Puede recuperar su monedero en cualquier momento con las palabras semilla y la fecha.\nLas palabras semilla se usan tanto para el monedero BTC como para el monedero BSQ.\n\nDebe apuntar las palabras semillas en una hoja de papel y no guardarla en su computadora.\n\nPor favor, tenga en cuenta que las palabras semilla no son un sustituto de la copia de seguridad.\nNecesita hacer la copia de seguridad de todo el directorio de aplicación en la pantalla \"Cuenta/Copia de seguridad\" para recuperar un estado de aplicación válido y los datos.
 account.seed.warn.noPw.msg=No ha establecido un password de monedero que proteja la visualización de las palabras semilla.\n\nQuiere que se muestren las palabras semilla?
 account.seed.warn.noPw.yes=Sí, y no preguntar de nuevo
 account.seed.enterPw=Introducir password para ver las palabras semilla
@@ -957,7 +957,7 @@ disputeSummaryWindow.close.msg=Ticket cerrado el {0}\n\nResumen:\n{1} evidencia 
 disputeSummaryWindow.close.closePeer=Necesitar cerrar también el ticket del par de intercambio!
 
 emptyWalletWindow.headline=Herramienta monedero de emergencia
-emptyWalletWindow.info=Por favor usar sólo en caso de emergencia si no puede acceder a sus fondos desde la Interfaz de Usuario (UI).\n\nPor favor, tenga en cuenta que todas las ofertas abiertas se cerrarán automáticamente al usar esta herramienta.\n\nAntes de usar esta herramienta, por favor realice una copia de seguridad del directorio de datos. Puede hacerlo en \\"Cuenta/Copia de Seguridad\\".\n\nPor favor repórtenos su problema y envíe un reporte de fallos en Github en el foro de Bisq para que podamos investigar qué causa el problema.
+emptyWalletWindow.info=Por favor usar sólo en caso de emergencia si no puede acceder a sus fondos desde la Interfaz de Usuario (UI).\n\nPor favor, tenga en cuenta que todas las ofertas abiertas se cerrarán automáticamente al usar esta herramienta.\n\nAntes de usar esta herramienta, por favor realice una copia de seguridad del directorio de datos. Puede hacerlo en \"Cuenta/Copia de Seguridad\".\n\nPor favor repórtenos su problema y envíe un reporte de fallos en Github en el foro de Bisq para que podamos investigar qué causa el problema.
 emptyWalletWindow.balance=Su balance disponible en el monedero:
 emptyWalletWindow.address=Su dirección de destino:
 emptyWalletWindow.button=Enviar todos los fondos
@@ -1001,7 +1001,7 @@ selectDepositTxWindow.msg=La transacción de depósito no se almacenó en el int
 selectDepositTxWindow.select=Selección depósito de transacción
 
 selectBaseCurrencyWindow.headline=Selección de mercado
-selectBaseCurrencyWindow.msg=El mercado por defecto es {0}.\n\nSi quiere cambiar a otra moneda base por favor seleccione una de las del menú desplegable.\nPuede cambiar más tarde la moneda base en la pantalla \\"Ajustes/Red\\".
+selectBaseCurrencyWindow.msg=El mercado por defecto es {0}.\n\nSi quiere cambiar a otra moneda base por favor seleccione una de las del menú desplegable.\nPuede cambiar más tarde la moneda base en la pantalla \"Ajustes/Red\".
 selectBaseCurrencyWindow.select=Seleccione moneda base
 selectBaseCurrencyWindow.default=Usar {0} como mercado por defecto
 
@@ -1055,7 +1055,7 @@ popup.headline.error=Error
 popup.doNotShowAgain=No mostrar de nuevo
 popup.reportError.gitHub=Reportar al rastreador de problemas de Github
 popup.reportError.forum=Informe en el foro de Bisq
-popup.reportError={0}\n\nPara ayudarnos a mejorar el software por favor reporte el fallo en nuestro rastreador de fallos en Github o postee en el forum Bisq.\nEl mensaje de error será copiado a nuestro portapapeles cuando clique los botones inferiores.\nHará el depurado de fallos más fácil si puede adjuntar el archivo bisq.log que puede encontrar en el directorio de la aplicación.\nPuede abrir el directorio de aplicación en \\"Cuenta/Copia de Seguridad\\".
+popup.reportError={0}\n\nPara ayudarnos a mejorar el software por favor reporte el fallo en nuestro rastreador de fallos en Github o postee en el forum Bisq.\nEl mensaje de error será copiado a nuestro portapapeles cuando clique los botones inferiores.\nHará el depurado de fallos más fácil si puede adjuntar el archivo bisq.log que puede encontrar en el directorio de la aplicación.\nPuede abrir el directorio de aplicación en \"Cuenta/Copia de Seguridad\".
 
 popup.error.tryRestart=Por favor pruebe a reiniciar la aplicación y comprobar su conexión a la red para ver si puede resolver el problema.
 popup.error.createTx=Error creando la transacción: {0}
@@ -1072,8 +1072,8 @@ popup.warning.startupFailed.twoInstances=Ya está ejecutando Bisq. No puede ejec
 popup.warning.cryptoTestFailed=Al parecer está utilizando un binario que ha compilado usted mismo siguiendo las instrucciones en https://github.com/bitsquare/bitsquare/blob/master/doc/build.md#7-enable-unlimited-strength-for-cryptographic-keys.\n\nSi no es el caso y está utilizando el binario oficial de Bisq, por favor informe del error en la página de Github.\nError={0}
 popup.warning.oldOffers.msg=Tiene ofertas abiertas que han sido creadas con una versión antigua de Bisq.\nPor favor, elimine esas ofertas puesto que ya no son válidas.\n\nOfertas (ID): {0}
 popup.warning.oldOffers.buttonText=Eliminar oferta/s anticuada/s
-popup.warning.tradePeriod.halfReached=Su intercambio con ID {0} ha alcanzado la mitad de el periodo máximo permitido de intercambio y aún no está completada.\n\nEl periodo de intercambio termina el {1}\n\nPor favor, compruebe su estado de intercambio en \\"Portafolio/Intercambios abiertos\\" para más información.
-popup.warning.tradePeriod.ended=Su intercambio con ID {0} ha alcanzado el periodo máximo permitido de intercambio y aún no está completada.\n\nEl periodo de intercambio terminó el {1}\n\nPor favor, compruebe su estado de intercambio en \\"Portafolio/Intercambios abiertos\\" para contactar con el árbitro.
+popup.warning.tradePeriod.halfReached=Su intercambio con ID {0} ha alcanzado la mitad de el periodo máximo permitido de intercambio y aún no está completada.\n\nEl periodo de intercambio termina el {1}\n\nPor favor, compruebe su estado de intercambio en \"Portafolio/Intercambios abiertos\" para más información.
+popup.warning.tradePeriod.ended=Su intercambio con ID {0} ha alcanzado el periodo máximo permitido de intercambio y aún no está completada.\n\nEl periodo de intercambio terminó el {1}\n\nPor favor, compruebe su estado de intercambio en \"Portafolio/Intercambios abiertos\" para contactar con el árbitro.
 popup.warning.noTradingAccountSetup.headline=No ha configurado una cuenta de intercambio
 popup.warning.noTradingAccountSetup.msg=Necesita configurar una moneda nacional o cuenta de altcoin antes de crear una oferta.\nQuiere configurar una cuenta?
 popup.warning.noArbitratorSelected.headline=No tiene un árbitro seleccionado.
@@ -1081,21 +1081,21 @@ popup.warning.noArbitratorSelected.msg=Necesita configurar al menos un árbitro 
 popup.warning.notFullyConnected=Necesita esperar hasta que esté completamente conectado a la red.\nPuede llevar hasta 2 minutos al inicio.
 popup.warning.removeOffer=Está seguro que quiere eliminar la oferta?\nLa tasa de creador de {0} se perderá si elimina la oferta.
 popup.warning.tooLargePercentageValue=No puede establecer un porcentaje del 100% o superior.
-popup.warning.examplePercentageValue=Por favor, introduzca un número de porcentaje como \\"5.4\\" para 5.4%
+popup.warning.examplePercentageValue=Por favor, introduzca un número de porcentaje como \"5.4\" para 5.4%
 popup.warning.noPriceFeedAvailable=No hay una fuente de precios disponible para esta moneda. No puede utilizar un precio pasado en porcentaje.\nPor favor, seleccione un precio fijo.
 popup.warning.sendMsgFailed=Ocurrió un error al enviar un mensaje a su pareja de intercambio.\nPor favor, pruebe de nuevo y si el fallo continúa, reporte el error.
 popup.warning.insufficientBtcFundsForBsqTx=No tiene suficientes BTC para pagar la tasa de transacción para esta transacción BSQ.\nPor favor, dote de fondos su monedero BTC para poder transferir BSQ.\nFondos necesarios: {0}
 popup.warning.insufficientBsqFundsForBtcFeePayment=No tiene suficientes fondos BSQ para pagar la tasa de transacción en BSQ.\nPuede pagar la tasa en BTC o dotar de fondos su monedero BSQ.\nFondos BSQ necesarios: {0}
 popup.warning.noBsqFundsForBtcFeePayment=Su monedero BSQ no tiene suficientes fondos para pagar la tasa de transacción en BSQ.
 popup.warning.messageTooLong=Su mensaje excede el tamaño máximo permitido. Por favor, envíelo por partes o súbalo a un servicio como https://pastebin.com
-popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \\"alt + o\\" or \\"option + o\\"."
+popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \"alt + o\" or \"option + o\"."
 
 popup.info.securityDepositInfo=To ensure that both traders follow the trade protocol they need to pay a security deposit.\n\nThe deposit will stay in your local trading wallet until the offer gets accepted by another trader.\nIt will be refunded to you after the trade has successfully completed.\n\nPlease note that you need to keep your application running if you have an open offer. When another trader wants to take your offer it requires that your application is online for executing the trade protocol.\nBe sure that you have standby mode deactivated as that would disconnect the network (standby of the monitor is not a problem).
 
 popup.privateNotification.headline=Notificación privada importante!
 
 popup.securityRecommendation.headline=Recomendación de seguridad importante
-popup.securityRecommendation.msg=Nos gustaría recordarle que considere usar protección por password para su monedero si no la ha activado ya.\n\nTambién es muy recomendable que escriba en un papel las palabras semilla del monedero. Esas palabras semilla son como una contraseña maestra para recuperar su monedero Bitcoin.\nEn la sección \\"Semilla del monedero\\" encontrará más información.\n\nAdicionalmente, puede hacer una copia de seguridad completa del directorio de aplicación en la sección \\"Copia de seguridad\\"
+popup.securityRecommendation.msg=Nos gustaría recordarle que considere usar protección por password para su monedero si no la ha activado ya.\n\nTambién es muy recomendable que escriba en un papel las palabras semilla del monedero. Esas palabras semilla son como una contraseña maestra para recuperar su monedero Bitcoin.\nEn la sección \"Semilla del monedero\" encontrará más información.\n\nAdicionalmente, puede hacer una copia de seguridad completa del directorio de aplicación en la sección \"Copia de seguridad\"
 
 popup.shutDownInProgress.headline=Cerrando aplicación...
 popup.shutDownInProgress.msg=Cerrrar la aplicación puede llevar unos segundos.\nPor favor no interrumpa el proceso.
@@ -1150,7 +1150,7 @@ guiUtil.accountExport.exportFailed=Exportando a CSV falló por un error.\nError 
 guiUtil.accountExport.selectExportPath=Seleccionar directorio de exportación.
 guiUtil.accountImport.imported=Cuenta de intercambio importada desde:\n{0}\n\nCuentas importadas:\n{1}
 guiUtil.accountImport.noAccountsFound=No se han encontrado cuentas de intercambio exportadas en el directorio: {0}.\nEl nombre del archivo es {1}."
-guiUtil.openWebBrowser.warning=Va a abrir una página web en el navegador de su sistema.\nQuiere abrir la página web ahora?\n\nSi no está usando \\"Tor Browser\\" como su navegador de sistema por defecto, se conectará a la página web en la red abierta.\n\nURL: \\"{0}\\"
+guiUtil.openWebBrowser.warning=Va a abrir una página web en el navegador de su sistema.\nQuiere abrir la página web ahora?\n\nSi no está usando \"Tor Browser\" como su navegador de sistema por defecto, se conectará a la página web en la red abierta.\n\nURL: \"{0}\"
 guiUtil.openWebBrowser.doOpen=Abrir la página web y no preguntar de nuevo
 guiUtil.openWebBrowser.copyUrl=Copiar URL y cancelar
 guiUtil.ofTradeAmount=de cantidad de intercambio
@@ -1201,16 +1201,16 @@ txIdTextField.blockExplorerIcon.tooltip=Abrir un explorador de bloques con esta 
 # Navigation
 ####################################################################
 
-navigation.account=\\"Cuenta\\"
-navigation.arbitratorSelection=\\"Selección de árbitro\\"
-navigation.funds.availableForWithdrawal=\\"Ingresar/Enviar fondos\\"
-navigation.portfolio.myOpenOffers=\\"Portafolio/Mis ofertas abiertas\\"
-navigation.portfolio.pending=\\"Portafolio/Intercambios abiertos\\"
-navigation.funds.depositFunds=\\"Ingresar/Recibir fondos\\"
-navigation.settings.preferences=\\"Ajustes/Preferencias\\"
-navigation.funds.transactions=\\"Fondos/Transacciones\\"
-navigation.support=\\"Soporte\\"
-navigation.dao.wallet.receive=\\"DAO/Monedero BSQ/Recibir\\"
+navigation.account=\"Cuenta\"
+navigation.arbitratorSelection=\"Selección de árbitro\"
+navigation.funds.availableForWithdrawal=\"Ingresar/Enviar fondos\"
+navigation.portfolio.myOpenOffers=\"Portafolio/Mis ofertas abiertas\"
+navigation.portfolio.pending=\"Portafolio/Intercambios abiertos\"
+navigation.funds.depositFunds=\"Ingresar/Recibir fondos\"
+navigation.settings.preferences=\"Ajustes/Preferencias\"
+navigation.funds.transactions=\"Fondos/Transacciones\"
+navigation.support=\"Soporte\"
+navigation.dao.wallet.receive=\"DAO/Monedero BSQ/Recibir\"
 
 
 ####################################################################
@@ -1288,7 +1288,7 @@ seed.date=Fecha del monedero:
 seed.restore.title=Restaurar monederos desde las palabras semilla
 seed.restore=Restaurar monederos
 seed.creationDate=Fecha creación:
-seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \\"alt + e\\" or \\"option + e\\" .
+seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \"alt + e\" or \"option + e\" .
 seed.warn.walletNotEmpty.restore=Quiero restaurar de todos modos
 seed.warn.walletNotEmpty.emptyWallet=Vaciaré mi monedero antes
 seed.warn.notEncryptedAnymore=Sus monederos están encriptados.\n\nDespués de restaurar, los monederos no estarán encriptados y deberá configurar un nuevo password.\n\nQuiere continuar?
@@ -1318,7 +1318,7 @@ payment.email=Email:
 payment.country=País:
 payment.owner.email=Email del titular de la cuenta:
 payment.extras=Requisitos extra:
-payment.us.info=Las transferencias bancarias con WIRE o ACH no están soportadas en USA porque WIRE es demasiado caro y ACH tiene un alto riesgo de devolución de cargo.\nPor favor use los métodos de pago \\"ClearXchange\\", \\"Giro Postal US Postal\\" o \\"Depósito en efectivo\\"
+payment.us.info=Las transferencias bancarias con WIRE o ACH no están soportadas en USA porque WIRE es demasiado caro y ACH tiene un alto riesgo de devolución de cargo.\nPor favor use los métodos de pago \"ClearXchange\", \"Giro Postal US Postal\" o \"Depósito en efectivo\"
 payment.email.mobile=Email o número de móvil:
 payment.altcoin.address=Dirección de altcoin:
 payment.altcoin=Altcoin:

--- a/common/src/main/resources/i18n/displayStrings_pt.properties
+++ b/common/src/main/resources/i18n/displayStrings_pt.properties
@@ -98,7 +98,7 @@ shared.openDefaultWalletFailed=Falha na abertura de uma carteira padrão de bitc
 shared.distanceInPercent=Distância em % do preço de mercado
 shared.enterPercentageValue=Insira % do valor
 shared.OR=OR
-shared.notEnoughFunds=Você não possui fundos suficientes em sua carteira bisq.\nVocê necessita de {0} porém possui apenas {1} em sua carteira bisq.\n\nFavor financiar essa negociação usando uma carteira Bitcoin externa ou financie sua carteira bisq em \\"Fundos/Receber fundos\\".
+shared.notEnoughFunds=Você não possui fundos suficientes em sua carteira bisq.\nVocê necessita de {0} porém possui apenas {1} em sua carteira bisq.\n\nFavor financiar essa negociação usando uma carteira Bitcoin externa ou financie sua carteira bisq em \"Fundos/Receber fundos\".
 shared.waitingForFunds=Esperando por saldo...
 shared.depositTransactionId=ID da Transação de depósito
 shared.TheBTCBuyer=O comprador de BTC
@@ -338,12 +338,12 @@ createOffer.fundsBox.networkFee=Taxa de mineração:
 createOffer.fundsBox.placeOfferSpinnerInfo=Oferta sendo publicada...
 createOffer.fundsBox.paymentLabel=negociação bisq com ID {0}
 createOffer.success.headline=Sua oferta foi publicada.
-createOffer.success.info=Você pode administrar suas ofertas abertas em \\"Portfolio/Minhas ofertas\\".
+createOffer.success.info=Você pode administrar suas ofertas abertas em \"Portfolio/Minhas ofertas\".
 
 
 # new entries
 createOffer.placeOfferButton=Revisar: Colocar oferta para {0} bitcoin
-createOffer.alreadyFunded=Você já havia financiado aquela oferta.\nSeus fundos foram movidos para sua carteira bisq local e estão disponiveis para retirada na janela \\"Fundos/Enviar fundos\\".
+createOffer.alreadyFunded=Você já havia financiado aquela oferta.\nSeus fundos foram movidos para sua carteira bisq local e estão disponiveis para retirada na janela \"Fundos/Enviar fundos\".
 createOffer.createOfferFundWalletInfo.headline=Financiar sua oferta.
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Valor a ser trocado: {0}\n
@@ -352,7 +352,7 @@ createOffer.createOfferFundWalletInfo.msg=Você precisa depositar {0} para esta 
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
 createOffer.amountPriceBox.error.message=Um erro ocorreu ao emitir uma oferta:\n\n{0}\n\nNenhum fundo foi retirado de sua carteira até agora.\nFavor reinicie o programa e verifique sua conexão de internet.
 createOffer.setAmountPrice=Definir preço e quantidade
-createOffer.warnCancelOffer=Você já financiou aquela oferta.\nSe você cancelar agora, seus fundos serão movidos para a sua carteira bisq local e estão disponiveis para retirada na janela \\"Fundos/Enviar fundos\\"\nTem certeza que deseja cancelar?
+createOffer.warnCancelOffer=Você já financiou aquela oferta.\nSe você cancelar agora, seus fundos serão movidos para a sua carteira bisq local e estão disponiveis para retirada na janela \"Fundos/Enviar fundos\"\nTem certeza que deseja cancelar?
 createOffer.fixed=Fixo
 createOffer.percentage=Porcentagem
 createOffer.timeoutAtPublishing=Um erro ocorreu ao publicar a oferta: tempo esgotado.
@@ -390,21 +390,21 @@ takeOffer.fundsBox.networkFee=Taxas de mineração (3x):
 takeOffer.fundsBox.takeOfferSpinnerInfo=Aceitação da oferta em progresso ...
 takeOffer.fundsBox.paymentLabel=negociação Bisq com ID {0}
 takeOffer.success.headline=Você aceitou uma oferta com sucesso.
-takeOffer.success.info=Você pode ver o status de sua negociação em \\"Portfolio/Negociações em aberto\\".
+takeOffer.success.info=Você pode ver o status de sua negociação em \"Portfolio/Negociações em aberto\".
 takeOffer.error.message=Ocorreu um erro ao aceitar a oferta.\n\n{0}
 
 # new entries
 takeOffer.takeOfferButton=Revisar: Aceitar oferta para {0} bitcoin
 takeOffer.noPriceFeedAvailable=Você não pode aceitar aquela oferta pois ela utiliza uma porcentagem do preço baseada no preço de mercado, porém o canal de preços está indisponível no momento.
-takeOffer.alreadyFunded.movedFunds=Você já havia financiado aquela oferta.\nSeus fundos foram movidos para sua carteira Bisq local e estão disponíveis para retirada na janela \\"Fundos/Enviar fundos\\".Save
+takeOffer.alreadyFunded.movedFunds=Você já havia financiado aquela oferta.\nSeus fundos foram movidos para sua carteira Bisq local e estão disponíveis para retirada na janela \"Fundos/Enviar fundos\".Save
 takeOffer.takeOfferFundWalletInfo.headline=Financiar sua negociação
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Quantia a ser negociada: {0}\n
 takeOffer.takeOfferFundWalletInfo.msg=Você precisa depositar {0} para aceitar esta oferta.\n\nA quantia é uma soma de:\n{1}- Depósito de segurança: {2}\n- Taxa de negociação: {3}\n- Taxa de mineração (3x): {4}\n\nVocê pode escolher entre duas opções para financiar sua negociação:\n- Usar sua carteira Bisq (conveniente, mas transações podem ser associadas entre si) OU\n- Transferir de uma carteira externa (potencialmente mais privativo)\n\nVocê verá todas as opções de financiamento e detalhes após fechar esta janela.
-takeOffer.alreadyPaidInFunds=Se você já pagou com seus fundos você pode retirar na janela \\"Fundos/Enviar fundos\\".
+takeOffer.alreadyPaidInFunds=Se você já pagou com seus fundos você pode retirar na janela \"Fundos/Enviar fundos\".
 takeOffer.paymentInfo=Informações de pagamento
 takeOffer.setAmountPrice=Definir quantidade
-takeOffer.alreadyFunded.askCancel=Você já havia financiado aquela oferta.\nSeus fundos foram movidos para sua carteira Bisq local e estão disponíveis para retirada na janela \\"Fundos/Enviar fundos\\".\nTem certeza que deseja cancelar?
+takeOffer.alreadyFunded.askCancel=Você já havia financiado aquela oferta.\nSeus fundos foram movidos para sua carteira Bisq local e estão disponíveis para retirada na janela \"Fundos/Enviar fundos\".\nTem certeza que deseja cancelar?
 takeOffer.failed.offerNotAvailable=Pedido de aceitar oferta de negociação falhou pois a oferta não está mais disponível. Talvez outro negociador tenha aceitado a oferta neste período.
 takeOffer.failed.offerTaken=Não é possível aceitar a oferta pois ela já foi aceita por outro negociador.
 takeOffer.failed.offerRemoved=Não é possível aceitar a oferta pois ela foi removida.
@@ -446,12 +446,12 @@ portfolio.pending.step1.openForDispute=A transação do depósito ainda não foi
 portfolio.pending.step2.confReached=Sua negociação já tem ao menos uma confirmação do protocolo.\n(Você pode aguardar mais confirmações se quiser - 6 confirmações são consideradas muito seguras.)\n\n
 
 portfolio.pending.step2_buyer.copyPaste=(Você pode copia e colar os valores da janela principal após fechar aquele popup)
-portfolio.pending.step2_buyer.refTextWarn=NÃO utilize avisos adicionais no texto \\"razão do pagamento\\" como Bitcoin, BTC ou Bisq.
+portfolio.pending.step2_buyer.refTextWarn=NÃO utilize avisos adicionais no texto \"razão do pagamento\" como Bitcoin, BTC ou Bisq.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.accountDetails=Aqui estão os detalhes da conta do vendedor de BTC:
 portfolio.pending.step2_buyer.tradeId=Favor não esquecer de adicionar o ID da negociação
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.assign= como \\"razão do pagamento\\" para que o recebedor possa associar seu pagamento a esta negociação.\n\n
+portfolio.pending.step2_buyer.assign= como \"razão do pagamento\" para que o recebedor possa associar seu pagamento a esta negociação.\n\n
 portfolio.pending.step2_buyer.fees=Caso seu banco cobre taxas você terá que cobrir estas taxas.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.altcoin=Favor transferir a partir de sua carteira {0} externa\n{1} para o vendedor de BTC.\n\n
@@ -459,7 +459,7 @@ portfolio.pending.step2_buyer.altcoin=Favor transferir a partir de sua carteira 
 portfolio.pending.step2_buyer.cash=Favor ir ao banco e pagar {0} ao vendedor de BTC
 portfolio.pending.step2_buyer.cash.extra=REQUESITO IMPORTANTE:\nApós executar o pagamento escrever no recibo: NÃO ACEITO RESTITUIÇÃO\nEntão rasgue-o em 2 partes, tire uma foto e envia-a para o email do vendedor de BTC.
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.postal=Favor enviar {0} através de \\"US Postal Money Order\\" para o vendedor de BTC.\n\n
+portfolio.pending.step2_buyer.postal=Favor enviar {0} através de \"US Postal Money Order\" para o vendedor de BTC.\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.bank=Favor acessar sua conta bancária online e pagar {0} ao vendedor de BTC.\n\n
 portfolio.pending.step2_buyer.startPaymentUsing=Iniciar pagamento usando {0}
@@ -488,11 +488,11 @@ portfolio.pending.step3_buyer.openForDispute=O vendedor de BTC ainda não confir
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.part=Seu parceiro de negociação confirmou que iniciou o pagamento de {0}.\n\n
 portfolio.pending.step3_seller.altcoin={0}Favor verifique com seu explorador de blockchain {1} se a transação para o seu endereço de recebimento\n{2}\nTem confirmações suficientes.\nO pagamento deve ser {3}\n\nVocê pode copiar e colar seu endereço {4} da janela principal após fechar aquele popup.
-portfolio.pending.step3_seller.postal={0}Por gentileza verifique se recebeu {1} como \\"US Postal Money Order\\" do comprador de BTC.\n\nO ID de negociação (texto \\"razão do pagamento\\") da transação é: \\"{2}\\"
-portfolio.pending.step3_seller.bank=Seu parceiro de negociação confirmou que ele já iniciou o pagamento de {0}.\n\nFavor ir à sua conta bancária online e verificar que você recebeu {1} do comprador de BTC.\n\nO ID de negociação (texto \\"razão do pagamento\\") da transação é: \\"{2}\\"
-portfolio.pending.step3_seller.cash=\n\nDevido ao pagamento ser realizado via depósito de dinheiro, o comprador de BTC deve escrever \\"SEM RESTITUIÇÃO\\" no recibo de papel, rasgá-lo em 2 partes e enviar uma foto para você por email.\n\nPara evitar risco de restituição, apenas confirme se você recebeu o email e tem certeza de que o recibo é válido.\nSe não tiver certeza, {0}
+portfolio.pending.step3_seller.postal={0}Por gentileza verifique se recebeu {1} como \"US Postal Money Order\" do comprador de BTC.\n\nO ID de negociação (texto \"razão do pagamento\") da transação é: \"{2}\"
+portfolio.pending.step3_seller.bank=Seu parceiro de negociação confirmou que ele já iniciou o pagamento de {0}.\n\nFavor ir à sua conta bancária online e verificar que você recebeu {1} do comprador de BTC.\n\nO ID de negociação (texto \"razão do pagamento\") da transação é: \"{2}\"
+portfolio.pending.step3_seller.cash=\n\nDevido ao pagamento ser realizado via depósito de dinheiro, o comprador de BTC deve escrever \"SEM RESTITUIÇÃO\" no recibo de papel, rasgá-lo em 2 partes e enviar uma foto para você por email.\n\nPara evitar risco de restituição, apenas confirme se você recebeu o email e tem certeza de que o recibo é válido.\nSe não tiver certeza, {0}
 portfolio.pending.step3_seller.bankCheck=\n\nFavor também verifique que o nome do remetente no seu extrato bancário confere com o nome no contrato de negociação:\nNome do remetente: {0}\n\nSe o nome não for o mesmo que mostrado aqui, {1}
-portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".
+portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".
 portfolio.pending.step3_seller.confirmPaymentReceipt=Confirmar recibo de pagamento
 portfolio.pending.step3_seller.amountToReceive=Valor a receber:
 portfolio.pending.step3_seller.yourAddress=Seu endereço de {0}:
@@ -510,9 +510,9 @@ portfolio.pending.step3_seller.openForDispute=Você ainda não confirmou o receb
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.part1=Você recebeu o pagamento {0} de seu parceiro de negociação?\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.fiat=O ID de negociação (texto \\"razão do pagamento\\") da transação é: \\"{0}\\"\n
+portfolio.pending.step3_seller.onPaymentReceived.fiat=O ID de negociação (texto \"razão do pagamento\") da transação é: \"{0}\"\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".\n\n
+portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".\n\n
 portfolio.pending.step3_seller.onPaymentReceived.note=Favor tenha em mente que assim que confirmar o recibo o valor reservado será liberado para o comprador de BTC e o depósito de segurança será devolvido.
 portfolio.pending.step3_seller.onPaymentReceived.confirm.headline=Confirme que recebeu o pagamento
 portfolio.pending.step3_seller.onPaymentReceived.confirm.yes=Sim, eu recebi o pagamento
@@ -529,7 +529,7 @@ portfolio.pending.step5_buyer.alreadyWithdrawn=Seus fundos já forem retirados.\
 portfolio.pending.step5_buyer.confirmWithdrawal=Confirmar solicitação de retirada
 portfolio.pending.step5_buyer.amountTooLow=A quantidade a ser transferida é inferior à taxa de transação e o valor mínimo de transação (poeira).
 portfolio.pending.step5_buyer.withdrawalCompleted.headline=Retirada completada
-portfolio.pending.step5_buyer.withdrawalCompleted.msg=Suas negociações concluídas estão salvas em \\"Portfolio/Histórico\\".\nVocê pode rever todas as suas transações bitcoin em \\"Fundos/Transações\\"
+portfolio.pending.step5_buyer.withdrawalCompleted.msg=Suas negociações concluídas estão salvas em \"Portfolio/Histórico\".\nVocê pode rever todas as suas transações bitcoin em \"Fundos/Transações\"
 portfolio.pending.step5_buyer.bought=Você comprou:
 portfolio.pending.step5_buyer.paid=Você pagou:
 
@@ -543,7 +543,7 @@ portfolio.pending.tradeProcess=Processo de negociação
 portfolio.pending.openAgainDispute.msg=Se você não tem certeza de que o árbitro recebeu a mensagem (por exemplo se não tiver resposta após 1 dia), pode abrir a disputa novamente à vontade.
 portfolio.pending.openAgainDispute.button=Abrir disputa novamente
 portfolio.pending.openSupportTicket.headline=Abrir ticket de suporte
-portfolio.pending.openSupportTicket.msg=Favor abrir apenas em caso de emergência se você não for mostrado o botão \\"Abrir suporte\\" ou \\"Abrir disuputa\\".\n\nQuando você abre um ticket de suporte, a negociação é interrompida e passada para o árbitro.
+portfolio.pending.openSupportTicket.msg=Favor abrir apenas em caso de emergência se você não for mostrado o botão \"Abrir suporte\" ou \"Abrir disuputa\".\n\nQuando você abre um ticket de suporte, a negociação é interrompida e passada para o árbitro.
 portfolio.pending.notification=Notificação
 portfolio.pending.openDispute=Abrir uma disputa
 portfolio.pending.disputeOpened=Disputa aberta
@@ -551,7 +551,7 @@ portfolio.pending.openSupport=Abrir ticket de suporte
 portfolio.pending.supportTicketOpened=Ticket de suporte aberto
 portfolio.pending.requestSupport=Solicitar suporte
 portfolio.pending.error.requestSupport=Favor reportar o problema para seu árbitro.\n\nEle encaminhará a informação para os desenvolvedores para investigar o problema.\nApós o problema ser analisado você receberá todos os fundos travados de volta.
-portfolio.pending.communicateWithArbitrator=Por favor vá até a janela \\"Suporte\\" e entre em contato com o árbitro.
+portfolio.pending.communicateWithArbitrator=Por favor vá até a janela \"Suporte\" e entre em contato com o árbitro.
 portfolio.pending.supportTicketOpenedMyUser=Você já abriu um ticket de suporte\n{0}
 portfolio.pending.disputeOpenedMyUser=Você já abriu uma disputa.\n{0}
 portfolio.pending.disputeOpenedByPeer=Seu parceiro de negociação abriu uma disputa\n{0}
@@ -660,7 +660,7 @@ support.buyerOfferer=Comprador de BTC / Ofetante
 support.sellerOfferer=Vendedor de BTC / Ofertante
 support.buyerTaker=Comprador de BTC / Aceitador da oferta
 support.sellerTaker=Vendedor de BTC / Aceitador da oferta
-support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \\"Open dispute\\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \\"Open support ticket\\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \\"Open support ticket\\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \\"Portfolio/Open trades\\" and type the key combination \\"alt + o\\" or \\"option + o\\" to open the support ticket.
+support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \"Open dispute\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \"Open support ticket\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \"Open support ticket\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \"Portfolio/Open trades\" and type the key combination \"alt + o\" or \"option + o\" to open the support ticket.
 support.initialInfo="Favor note as regras básicas para o processo de disputa:\n1. Você precisa responder aos pedidos de árbitros em até 2 dias.\n2.  O período máximo de uma disputa é 14 dias.\n3. Você precisa atender ao que o árbitro está pedindo e fornecer evidências necessárias para seu caso.\n4. Você aceitou as regras delineadas na wiki no acordo de usuário quando você iniciou o programa.\n\nMais detalhes sobre o processo de disputa se encontram na wiki:\nhttps://github.com/bitsquare/bitsquare/wiki/Dispute-process
 support.systemMsg=Mensagem do sistema: {0}
 support.youOpenedTicket=Você abriu uma solicitação para suporte.
@@ -700,7 +700,7 @@ setting.preferences.displayOptions=Opções de exibição
 setting.preferences.showOwnOffers=Mostrar minha próprias ofertas no livro de ofertas:
 setting.preferences.useAnimations=Usar animações:
 setting.preferences.sortWithNumOffers=Ordenar listas de mercado por número de ofertas/negociações:
-setting.preferences.resetAllFlags=Limpar todas as marcações de \\"Não mostrar novamente\\":
+setting.preferences.resetAllFlags=Limpar todas as marcações de \"Não mostrar novamente\":
 setting.preferences.reset=Limpar
 settings.preferences.languageChange=Para aplicar a mudança de língua em todas as telas requer uma reinicialização.
 settings.preferences.selectCurrencyNetwork=Select base currency
@@ -764,7 +764,7 @@ setting.about.subsystems.val=Versão da rede: {0}; Versão de mensagens P2P: {1}
 account.tab.arbitratorRegistration=Registro de árbitro
 account.tab.account=Conta
 account.info.headline=Bem vindo à sua conta Bisq
-account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \\"Funds\\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
+account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \"Funds\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
 
 account.menu.paymentAccount=Contas de moedas nacionais
 account.menu.altCoinsAccountView=Contas de altcoins
@@ -821,7 +821,7 @@ account.password.setPw.headline=Definir proteção de senha da carteira
 account.password.info=Com proteção por senha você precisa digitar sua senha quando for retirar bitcoin de sua carteira ou quando quiser ver ou restaurar uma carteira de palavras semente, e também quando for abrir o programa.
 
 account.seed.backup.title=Fazer backup das palavras semente de sua carteira wallet seed words)
-account.seed.info=Favor escrever as palavas semente da carteira (wallet seed words) e a data! Você pode recuperar sua carteira a qualquer momento com estas palavras semente e a data.\nEstas palavras sementes são utilizadas tanto para a carteira BTC como para a carteira BSQ.\n\nVocê deve escrever as palavras semente num papel e não é aconselhável salvá-las num computador.\n\nFavor note que as palavras semente não substituem um backup.\nVocê precisa fazer packup do diretório do programa na janela \\"Conta/Backup\\" para conseguir recuperar o estado total do programa e dados.
+account.seed.info=Favor escrever as palavas semente da carteira (wallet seed words) e a data! Você pode recuperar sua carteira a qualquer momento com estas palavras semente e a data.\nEstas palavras sementes são utilizadas tanto para a carteira BTC como para a carteira BSQ.\n\nVocê deve escrever as palavras semente num papel e não é aconselhável salvá-las num computador.\n\nFavor note que as palavras semente não substituem um backup.\nVocê precisa fazer packup do diretório do programa na janela \"Conta/Backup\" para conseguir recuperar o estado total do programa e dados.
 account.seed.warn.noPw.msg=Você não definiu uma senha para carteira, que protegeria a exibição das palavras semente.\n\nGostaria de exibir as palavras semente?
 account.seed.warn.noPw.yes=Sim, e não me pergunte novamente
 account.seed.enterPw=Digite a senha para ver palavras semente
@@ -957,7 +957,7 @@ disputeSummaryWindow.close.msg=Ticket fechado em {0}\n\nResumo:\n{1} evidência 
 disputeSummaryWindow.close.closePeer=Você também precisa fechar o ticket dos parceiros de negociação!
 
 emptyWalletWindow.headline=Ferramenta de emergência da carteira
-emptyWalletWindow.info=Please use that only in emergency case if you cannot access your fund from the UI.\n\nPlease note that all open offers will be closed automatically when using this tool.\n\nBefore you use this tool, please backup your data directory. You can do this at \\"Account/Backup\\".\n\nPlease report us your problem and file a bug report on Github or at the Bisq forum so that we can investigate what was causing the problem.
+emptyWalletWindow.info=Please use that only in emergency case if you cannot access your fund from the UI.\n\nPlease note that all open offers will be closed automatically when using this tool.\n\nBefore you use this tool, please backup your data directory. You can do this at \"Account/Backup\".\n\nPlease report us your problem and file a bug report on Github or at the Bisq forum so that we can investigate what was causing the problem.
 emptyWalletWindow.balance=Fundos disponívels da sua carteira:
 emptyWalletWindow.address=Seu endereço de destino:
 emptyWalletWindow.button=Enviar todos os fundos
@@ -1001,7 +1001,9 @@ selectDepositTxWindow.msg=A transação do depósito não foi guardada na negoci
 selectDepositTxWindow.select=Selecionar transação de depósito
 
 selectBaseCurrencyWindow.headline=Market selection
-selectBaseCurrencyWindow.msg=The selected default market is {0}.\n\nIf you want to change to another base currency please select one from the drop down box.\nYou can also change later the base currency at the \\"Settings/Network\\" screen.
+selectBaseCurrencyWindow.msg=The selected default market is {0}.\n\n\
+  If you want to change to another base currency please select one from the drop down box.\n\
+  You can also change later the base currency at the \"Settings/Network\" screen.
 selectBaseCurrencyWindow.select=Select base currency
 selectBaseCurrencyWindow.default=Use {0} as default market
 
@@ -1055,7 +1057,7 @@ popup.headline.error=Erro
 popup.doNotShowAgain=Não mostrar novamente
 popup.reportError.gitHub=Relatar à lista de problemas do Github
 popup.reportError.forum=Report at Bisq forum
-popup.reportError={0}\n\nTo help us to improve the software please report the bug at our issue tracker at Github or post it at the Bisq forum.\nThe error message will be copied to clipboard when you click the below buttons.\nIt will make debugging easier if you can attach the Bisq.log file which you can find in the application directory.\nYou can open the application directory at \\"Account/Backup\\".
+popup.reportError={0}\n\nTo help us to improve the software please report the bug at our issue tracker at Github or post it at the Bisq forum.\nThe error message will be copied to clipboard when you click the below buttons.\nIt will make debugging easier if you can attach the Bisq.log file which you can find in the application directory.\nYou can open the application directory at \"Account/Backup\".
 
 popup.error.tryRestart=Favor tente reiniciar o programa e verifique sua conexão de Internet para ver se o problema é resolvido.
 popup.error.createTx=Erro ao criar transação: {0}
@@ -1072,8 +1074,8 @@ popup.warning.startupFailed.twoInstances=Bisq is already running. You cannot run
 popup.warning.cryptoTestFailed=Seems that you use a self compiled binary and have not following the build instructions in https://github.com/bitsquare/bitsquare/blob/master/doc/build.md#7-enable-unlimited-strength-for-cryptographic-keys.\n\nIf that is not the case and you use the official Bisq binary, please file a bug report to the Github page.\nError={0}
 popup.warning.oldOffers.msg=You have open offers which have been created with an older version of Bisq.\nPlease remove those offers as they are not valid anymore.\n\nOffers (ID): {0}
 popup.warning.oldOffers.buttonText=Remover oferta(s) ultrapassada(s)
-popup.warning.tradePeriod.halfReached=Sua negociação com ID {0} atingiu metade do período máximo permitido e ainda não foi concluída.\n\nO período de negociação acaba em {1}\n\nFavor verifique o estado de sua negociação em \\"Portfolio/Negociações em aberto\\" para mais informações.
-popup.warning.tradePeriod.ended=Sua negociação com ID {0} atingiu o período máximo permitido e ainda não foi concluída.\n\nO período de negociação acabou em {1}\n\nFavor verifique sua negociação em \\"Portfolio/Negociações em aberto\\" para entrar em contato com o árbitro.
+popup.warning.tradePeriod.halfReached=Sua negociação com ID {0} atingiu metade do período máximo permitido e ainda não foi concluída.\n\nO período de negociação acaba em {1}\n\nFavor verifique o estado de sua negociação em \"Portfolio/Negociações em aberto\" para mais informações.
+popup.warning.tradePeriod.ended=Sua negociação com ID {0} atingiu o período máximo permitido e ainda não foi concluída.\n\nO período de negociação acabou em {1}\n\nFavor verifique sua negociação em \"Portfolio/Negociações em aberto\" para entrar em contato com o árbitro.
 popup.warning.noTradingAccountSetup.headline=Você ainda não configurou uma conta de negociação
 popup.warning.noTradingAccountSetup.msg=Você precisa criar uma conta de moeda nacional ou altcoin antes de criar uma oferta.\nQuer criar uma conta?
 popup.warning.noArbitratorSelected.headline=Você não selecionou um árbitro
@@ -1081,21 +1083,21 @@ popup.warning.noArbitratorSelected.msg=Você precisa configurar ao menos um árb
 popup.warning.notFullyConnected=Você precisa aguardar até estar totalmente conectado à rede.\nIsto pode levar até 2 minutos na inicialização do programa.
 popup.warning.removeOffer=Tem certeza que deseja remover essa oferta?\nA taxa de oferta de {0} será perdida se você removê-la.
 popup.warning.tooLargePercentageValue=Você não pode definir uma porcentage suprior a 100%.
-popup.warning.examplePercentageValue=Favor digitar um número porcentual como \\"5.4\\" para 5.4%
+popup.warning.examplePercentageValue=Favor digitar um número porcentual como \"5.4\" para 5.4%
 popup.warning.noPriceFeedAvailable=Não há canal de preços disponível para essa moeda. Você não pode usar um preço porcentual.\nFavor selecionar um preço fixo.
 popup.warning.sendMsgFailed=O envio da mensagem para seu parceiro de negociação falhou.\nFavor tentar novamente e se o erro persistir reportar o erro (bug report).
 popup.warning.insufficientBtcFundsForBsqTx=Você não possui fundos BTC suficientes para pagar a taxa de transferência para essa transação BSQ.\nFavor financiar sua carteira BTC para pode transferir BSQ.\nFundos que faltam: {0}
 popup.warning.insufficientBsqFundsForBtcFeePayment=Você não tem fundos BSQ suficientes para pagar a taxa de transferência em BSQ.\nVocê pode pagar a taxa em BTC ou você precisa financiar sua carteira BSQ.\nFundos BSQ que faltam: {0}
 popup.warning.noBsqFundsForBtcFeePayment=Sua carteira BSQ não tem fundos suficientes para pagar a taxa de transferência em BSQ.
 popup.warning.messageTooLong=Sua mensagem excede o tamanho máximo permitido. Favor enviá-la em várias partes ou subir utilizando um serviço como https://pastebin.com.
-popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \\"alt + o\\" or \\"option + o\\"."
+popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \"alt + o\" or \"option + o\"."
 
 popup.info.securityDepositInfo=To ensure that both traders follow the trade protocol they need to pay a security deposit.\n\nThe deposit will stay in your local trading wallet until the offer gets accepted by another trader.\nIt will be refunded to you after the trade has successfully completed.\n\nPlease note that you need to keep your application running if you have an open offer. When another trader wants to take your offer it requires that your application is online for executing the trade protocol.\nBe sure that you have standby mode deactivated as that would disconnect the network (standby of the monitor is not a problem).
 
 popup.privateNotification.headline=Notificação privada importante!
 
 popup.securityRecommendation.headline=Recomendação de segurança importante
-popup.securityRecommendation.msg=Nós gostariamos de lembrá-lo para utilizar proteção com senha para sua carteira caso você já não tenha habilitado.\n\nTambém é recomendado que você escreva num papel as suas palavras sementes da certeira. Essas palavras sementes são como uma senha mestra para recuperar sua carteira Bitcoin.\nNa seção \\"Semente da carteira\\" você encontra mais informações.\n\nTambém aconselhamos que faça backup completo do aquivo de dados do programa na seção \\"Backup\\".
+popup.securityRecommendation.msg=Nós gostariamos de lembrá-lo para utilizar proteção com senha para sua carteira caso você já não tenha habilitado.\n\nTambém é recomendado que você escreva num papel as suas palavras sementes da certeira. Essas palavras sementes são como uma senha mestra para recuperar sua carteira Bitcoin.\nNa seção \"Semente da carteira\" você encontra mais informações.\n\nTambém aconselhamos que faça backup completo do aquivo de dados do programa na seção \"Backup\".
 
 popup.shutDownInProgress.headline=Desligando
 popup.shutDownInProgress.msg=Desligar o programa pode levar alguns segundos.\nFavor não interromper o processo.
@@ -1150,7 +1152,7 @@ guiUtil.accountExport.exportFailed=Exportar para CSV falhou pois houve um erro.\
 guiUtil.accountExport.selectExportPath=Selecionar diretório para exportar
 guiUtil.accountImport.imported=Conta de negociação importada do diretório:\n{0}\n\nContas importadas:\n{1}
 guiUtil.accountImport.noAccountsFound=Nenhuma conta de negociação exportada foi encontrada no caminho: {0}.\nNome do arquivo é {1}."
-guiUtil.openWebBrowser.warning=Você abrirá uma página da web em seu navegador padrão.\nDeseja abrir a página agora?\n\nSe você não estiver usando o \\"Tor Browser\\" como seu navegador padrão você conectará à página na rede aberta (clear net).\n\nURL: \\"{0}\\"
+guiUtil.openWebBrowser.warning=Você abrirá uma página da web em seu navegador padrão.\nDeseja abrir a página agora?\n\nSe você não estiver usando o \"Tor Browser\" como seu navegador padrão você conectará à página na rede aberta (clear net).\n\nURL: \"{0}\"
 guiUtil.openWebBrowser.doOpen=Abrir a página da web e não perguntar novamente
 guiUtil.openWebBrowser.copyUrl=Copiar URL e cancelar
 guiUtil.ofTradeAmount=da quantia de negociação
@@ -1201,16 +1203,16 @@ txIdTextField.blockExplorerIcon.tooltip=Abrir um explorador de blockchain com o 
 # Navigation
 ####################################################################
 
-navigation.account=\\"Conta\\"
-navigation.arbitratorSelection=\\"Seleção de árbitro\\"
-navigation.funds.availableForWithdrawal=\\"Fundos/Enviar fundos\\"
-navigation.portfolio.myOpenOffers=\\"Portfolio/Minhas ofertas\\"
-navigation.portfolio.pending=\\"Portfolio/Negociações em aberto\\"
-navigation.funds.depositFunds=\\"Fundos/Receber fundos\\"
-navigation.settings.preferences=\\"Configurações/Preferências\\"
-navigation.funds.transactions=\\"Fundos/Transações\\"
-navigation.support=\\"Suporte\\"
-navigation.dao.wallet.receive=\\"DAO/Carteira BSQ/Receber\\"
+navigation.account=\"Conta\"
+navigation.arbitratorSelection=\"Seleção de árbitro\"
+navigation.funds.availableForWithdrawal=\"Fundos/Enviar fundos\"
+navigation.portfolio.myOpenOffers=\"Portfolio/Minhas ofertas\"
+navigation.portfolio.pending=\"Portfolio/Negociações em aberto\"
+navigation.funds.depositFunds=\"Fundos/Receber fundos\"
+navigation.settings.preferences=\"Configurações/Preferências\"
+navigation.funds.transactions=\"Fundos/Transações\"
+navigation.support=\"Suporte\"
+navigation.dao.wallet.receive=\"DAO/Carteira BSQ/Receber\"
 
 
 ####################################################################
@@ -1288,7 +1290,7 @@ seed.date=Data da carteira:
 seed.restore.title=Restaurar carteira a partir de palavras semente
 seed.restore=Restaurar carteiras
 seed.creationDate=Data da criação:
-seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \\"alt + e\\" or \\"option + e\\" .
+seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \"alt + e\" or \"option + e\" .
 seed.warn.walletNotEmpty.restore=Eu desejo restaurar de qualquer forma
 seed.warn.walletNotEmpty.emptyWallet=Eu esvaziarei as carteiras primeiro
 seed.warn.notEncryptedAnymore=Suas carteiras estão criptografadas.\n\nApós a restauração, as carteiras não estarão mais criptografadas e você deve definir uma nova senha.\n\nQuer continuar?
@@ -1318,7 +1320,7 @@ payment.email=Email:
 payment.country=País:
 payment.owner.email=Email do titular da conta:
 payment.extras=Requerimentos adicionais:
-payment.us.info=Transferência bancária com WIRE ou ACH não tem suporte nos EUA pois WIRE é muito caro e ACH possui um grande risco com devoluções.\n\nFavor usar métodos de pagamento \\"ClearXchange\\", \\"US Postal Money Order\\" ou \\"Cash Deposit\\" no lugar.
+payment.us.info=Transferência bancária com WIRE ou ACH não tem suporte nos EUA pois WIRE é muito caro e ACH possui um grande risco com devoluções.\n\nFavor usar métodos de pagamento \"ClearXchange\", \"US Postal Money Order\" ou \"Cash Deposit\" no lugar.
 payment.email.mobile=Email ou celular:
 payment.altcoin.address=Endereço altcoin:
 payment.altcoin=Altcoin:

--- a/common/src/main/resources/i18n/displayStrings_sr.properties
+++ b/common/src/main/resources/i18n/displayStrings_sr.properties
@@ -98,7 +98,7 @@ shared.openDefaultWalletFailed=Otvaranje podrazumevane bitkoin novčanik aplikac
 shared.distanceInPercent=Odstupanje u % od tržišne cene
 shared.enterPercentageValue=Unesi % vrednost
 shared.OR=ILI
-shared.notEnoughFunds=Nemate dovoljno sredstava u vašem Bisq novčaniku,\nTreba vam {0} ali vi imate samo {1} u vašem Bisq novčaniku.\n\nMolimo vas finansirajte trgovinu iz eksternog Bitkoin novčanika ili finansirajte vaš Bisq novčanik pod \\"Sredstva/Primi sredstava".
+shared.notEnoughFunds=Nemate dovoljno sredstava u vašem Bisq novčaniku,\nTreba vam {0} ali vi imate samo {1} u vašem Bisq novčaniku.\n\nMolimo vas finansirajte trgovinu iz eksternog Bitkoin novčanika ili finansirajte vaš Bisq novčanik pod \"Sredstva/Primi sredstava".
 shared.waitingForFunds=Čekanje sredstava...
 shared.depositTransactionId=ID transakcije depozita
 shared.TheBTCBuyer=BTC kupac
@@ -338,12 +338,12 @@ createOffer.fundsBox.networkFee=Provizija rudara:
 createOffer.fundsBox.placeOfferSpinnerInfo=Postavljanje ponude je u toku ...
 createOffer.fundsBox.paymentLabel=Bisq trgovina sa ID {0}
 createOffer.success.headline=Vaša ponuda je objavljena
-createOffer.success.info=Možete upravljati sa vašim otvorenim ponudama u \\"Portfolio/Moje otvorene ponude".
+createOffer.success.info=Možete upravljati sa vašim otvorenim ponudama u \"Portfolio/Moje otvorene ponude".
 
 
 # new entries
 createOffer.placeOfferButton=Pregled: Postavi ponudu na {0} bitkoina
-createOffer.alreadyFunded=Već ste finansirali tu ponudu.\nVaša novčana sredstva su premeštena u vaš lokalni Bisq novčanik i dostupni su za podizanje u \\"Sredstva/Pošalji sredstva" ekranu.
+createOffer.alreadyFunded=Već ste finansirali tu ponudu.\nVaša novčana sredstva su premeštena u vaš lokalni Bisq novčanik i dostupni su za podizanje u \"Sredstva/Pošalji sredstva" ekranu.
 createOffer.createOfferFundWalletInfo.headline=Finansirajte vašu ponudu
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Iznos trgovine: {0}\n
@@ -352,7 +352,7 @@ createOffer.createOfferFundWalletInfo.msg=Morate deponovati {0} ovoj ponudi.\n\n
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
 createOffer.amountPriceBox.error.message=Došlo je do greške pri postavljanju ponude:\n\n{0}\n\nNovčana sredstva još uvek nisu napustila vaš novčanik.\nMolimo vas pokrenite ponovo vašu aplikaciju i proverite vašu mrežnu povezanost.
 createOffer.setAmountPrice=Podesi iznos i cenu.
-createOffer.warnCancelOffer=Već ste finansirali tu ponudu.\nAko otkažete sada, vaša sredstva će biti pomerena u vaš lokalni Bisq novčanik i dostupna su za podizanje u \\"Sredstva/Pošalji sredstva\\" ekranu.\nDa li ste sigurni da želite da otkažete?
+createOffer.warnCancelOffer=Već ste finansirali tu ponudu.\nAko otkažete sada, vaša sredstva će biti pomerena u vaš lokalni Bisq novčanik i dostupna su za podizanje u \"Sredstva/Pošalji sredstva\" ekranu.\nDa li ste sigurni da želite da otkažete?
 createOffer.fixed=Fiksirano
 createOffer.percentage=Procenat
 createOffer.timeoutAtPublishing=Došlo je do isteka vremena pri objavljivanju ponude.
@@ -390,21 +390,21 @@ takeOffer.fundsBox.networkFee=Provizija rudara (3x):
 takeOffer.fundsBox.takeOfferSpinnerInfo=Prihvatanje ponude je u toku ...
 takeOffer.fundsBox.paymentLabel=Bisq trgovina sa ID {0}
 takeOffer.success.headline=Uspešno se prihvatili ponudu.
-takeOffer.success.info=Možete pogledati status vaše trgovine u "Portfolio/Otvorene trgovine\\".
+takeOffer.success.info=Možete pogledati status vaše trgovine u "Portfolio/Otvorene trgovine\".
 takeOffer.error.message=Došlo je do greške prilikom prihvatanja ponude.\n\n{0}
 
 # new entries
 takeOffer.takeOfferButton=Pregled: Prihvati ponudu da se {0} bitkoin
 takeOffer.noPriceFeedAvailable=Ne možete prihvatiti tu ponudu jer koristi cenu zasnovanu na procentu od tržišne cene ali ne postoji dostupan unos za cenu.
-takeOffer.alreadyFunded.movedFunds=Već ste finansirali tu ponudu.\nVaša novčana sredstva su premeštena u vaš lokalni Bisq novčanik i dostupni su za podizanje u \\"Sredstva/Pošalji sredstva" ekranu.
+takeOffer.alreadyFunded.movedFunds=Već ste finansirali tu ponudu.\nVaša novčana sredstva su premeštena u vaš lokalni Bisq novčanik i dostupni su za podizanje u \"Sredstva/Pošalji sredstva" ekranu.
 takeOffer.takeOfferFundWalletInfo.headline=Finansirajte vašu trgovinu
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Iznos trgovine: {0}\n
 takeOffer.takeOfferFundWalletInfo.msg=Morate deponovati {0} za prihvatanje ove ponude.\n\nIznos je suma:\n{1}- Bezbednosnog depozita: {2}\n- Provizije trgovanja: {3}\n- Provizije rudara(3x): {4}\n\nMožete birati izmedju dve opcije pri finansiranju vaše trgovine:\n- Koristite vaš Bisq novčanik (pogodno, ali transakcije možda mogu biti povezive) ILI\n- Prenesite iz vašeg eksternog novčanika (potencijalno veća privatnost)\n\nVidećete sve opcije finansiranja i detalje kad zatvorite ovaj popup.
-takeOffer.alreadyPaidInFunds=Ako ste već platili u novčanim sredstvima možete ih podići u \\"Sredstva/Pošalji sredstva\\" ekranu.
+takeOffer.alreadyPaidInFunds=Ako ste već platili u novčanim sredstvima možete ih podići u \"Sredstva/Pošalji sredstva\" ekranu.
 takeOffer.paymentInfo=Informacije o plaćanju
 takeOffer.setAmountPrice=Podesi iznos
-takeOffer.alreadyFunded.askCancel=Već ste finansirali tu ponudu.\nAko otkažete sada, vaša sredstva će biti pomerena u vaš lokalni Bisq novčanik i dostupna su za podizanje u \\"Sredstva/Pošalji sredstva\\" ekranu.\nDa li ste sigurni da želite da otkažete?
+takeOffer.alreadyFunded.askCancel=Već ste finansirali tu ponudu.\nAko otkažete sada, vaša sredstva će biti pomerena u vaš lokalni Bisq novčanik i dostupna su za podizanje u \"Sredstva/Pošalji sredstva\" ekranu.\nDa li ste sigurni da želite da otkažete?
 takeOffer.failed.offerNotAvailable=Zahtev za prihvatanje ponude nije uspeo jer ponuda više nije dostupna. Možda je drugi trgovac prihvatio ponudu u međuvremenu.
 takeOffer.failed.offerTaken=Ne možete prihvatiti tu ponudu jer je ponuda već prihvaćena od strane drugog trgovca.
 takeOffer.failed.offerRemoved=Ne možete prihvatiti tu ponudu jer je ponuda uklonjena u međuvremenu.
@@ -446,12 +446,12 @@ portfolio.pending.step1.openForDispute=Transakcija depozita još uvek nije potvr
 portfolio.pending.step2.confReached=Vaša trgovina je dostigla bar jednu potvrdu blokčejna.\n(Možete sačekati još potvrda ako želite - 6 potvrda su smatrane veoma bezbednim.)\n\n
 
 portfolio.pending.step2_buyer.copyPaste=(Možete kopirati i lepiti vrednosti sa glavnog ekrana nakon što zatvorite taj popup.)
-portfolio.pending.step2_buyer.refTextWarn=NEMOJTE koristiti nikakve dodatne beleške u tekstu \\"razlog za uplatu\\" kao sto su Bitkoin, BTC ili Bisq.
+portfolio.pending.step2_buyer.refTextWarn=NEMOJTE koristiti nikakve dodatne beleške u tekstu \"razlog za uplatu\" kao sto su Bitkoin, BTC ili Bisq.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.accountDetails=Ovde su detalji trgovinskog naloga od BTC prodavca:\n
 portfolio.pending.step2_buyer.tradeId=Molimo vas ne zaboravite da dodate ID trgovine 
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.assign= kao \\"razlog za uplatu\\" da bi primalac mogao da dodeli vašu uplatu ovoj trgovini.\n\n
+portfolio.pending.step2_buyer.assign= kao \"razlog za uplatu\" da bi primalac mogao da dodeli vašu uplatu ovoj trgovini.\n\n
 portfolio.pending.step2_buyer.fees=Ako vaša banka naplaćuje provizije moraćete da pokrijete tu proviziju.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.altcoin=Molimo vas prenesite iz vašeg eksternog {0} novčanika\n{1} BTC prodavcu.\n\n
@@ -459,7 +459,7 @@ portfolio.pending.step2_buyer.altcoin=Molimo vas prenesite iz vašeg eksternog {
 portfolio.pending.step2_buyer.cash=Molimo vas idite u banku i platite {0} BTC prodavcu.\n\n
 portfolio.pending.step2_buyer.cash.extra=VAŽAN USLOV:\nNakon što ste izvršili uplatu napišite na papirnom računu: NO REFUNDS.\nZatim ga pocepajte na 2 dela, slikajte i pošaljite sliku na email adresu BTC prodavca.
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.postal=Molimo vas pošaljite {0} BTC prodavcu preko \\"US Postal Money Order\\".\n\n
+portfolio.pending.step2_buyer.postal=Molimo vas pošaljite {0} BTC prodavcu preko \"US Postal Money Order\".\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.bank=Molimo vas idite na vašu online banking veb stranicu i platite {0} BTC prodavcu.\n\n
 portfolio.pending.step2_buyer.startPaymentUsing=Započni uplatu korišćenjem {0}
@@ -488,11 +488,11 @@ portfolio.pending.step3_buyer.openForDispute=BTC prodavac nije potvrdio vašu up
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.part=Vaš trgovinski partner je potvrdio da je započeo {0} uplatu.\n\n
 portfolio.pending.step3_seller.altcoin={0}Moilmo proverite na vašem preferiranom {1} blokčejn pretraživaču da li transakcija na vašu adresu primanja\n{2}\nveć ima dovoljano blokčejn potvrda.\nIznos uplate mora da bude {3}\n\nMožete da kopirate & nalepite vašu {4} adresu sa glavnog ekrana nakon zatvaranja tog popup-a.
-portfolio.pending.step3_seller.postal={0}Molimo proverite da li ste primili {1} sa \\"US Postal Money Order\\" od BTC kupca.\n\nID trgovine (\\"razlog za uplatu\\" tekst) od transakcije je: \\"{2}\\"
-portfolio.pending.step3_seller.bank=Vaš trgovinski partner je potvrdio da je započeo {0} uplatu.\n\nMolimo idite na vašu online banking veb stranicu i proverite da li ste primili {1} od BTC kupca.\n\nID trgovine (\\"razlog za uplatu\\" tekst) od transakcije je: \\"{2}\\"
-portfolio.pending.step3_seller.cash=\n\nPošto je uplata izvršena putem Cash Deposit-a BTC kupac mora da napiše \\"NO REFUND\\" na papirnom računu, pocepa ga na 2 dela i pošalje vam sliku email-om.\n\nDa bi se izbegao rizik povraćaja, potvrdite samo ako ste primili email i ako ste sigurni da je papirni račun važeći.\nAko niste sigurni, {0}
+portfolio.pending.step3_seller.postal={0}Molimo proverite da li ste primili {1} sa \"US Postal Money Order\" od BTC kupca.\n\nID trgovine (\"razlog za uplatu\" tekst) od transakcije je: \"{2}\"
+portfolio.pending.step3_seller.bank=Vaš trgovinski partner je potvrdio da je započeo {0} uplatu.\n\nMolimo idite na vašu online banking veb stranicu i proverite da li ste primili {1} od BTC kupca.\n\nID trgovine (\"razlog za uplatu\" tekst) od transakcije je: \"{2}\"
+portfolio.pending.step3_seller.cash=\n\nPošto je uplata izvršena putem Cash Deposit-a BTC kupac mora da napiše \"NO REFUND\" na papirnom računu, pocepa ga na 2 dela i pošalje vam sliku email-om.\n\nDa bi se izbegao rizik povraćaja, potvrdite samo ako ste primili email i ako ste sigurni da je papirni račun važeći.\nAko niste sigurni, {0}
 portfolio.pending.step3_seller.bankCheck=\n\nMolimo da takođe proverite da ime pošiljalaca u vašem izveštaju banke odgovara onom iz ugovora trgovine:\nIme pošiljalaca: {0}\n\nAko ime nije isto kao ono prikazano ovde, {1}
-portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".
+portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".
 portfolio.pending.step3_seller.confirmPaymentReceipt=Potvrdi primanje uplate
 portfolio.pending.step3_seller.amountToReceive=Iznos koji se dobija:
 portfolio.pending.step3_seller.yourAddress=Vaša {0} adresa:
@@ -510,9 +510,9 @@ portfolio.pending.step3_seller.openForDispute=Niste potvrdili primanje uplate!\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.part1=Da li ste primili {0} uplatu od vašeg trgovinskog partnera?\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.fiat=ID trgovine (\\"razlog za uplatu\\" tekst) transakcije je: \\"{0}\\"\n\n
+portfolio.pending.step3_seller.onPaymentReceived.fiat=ID trgovine (\"razlog za uplatu\" tekst) transakcije je: \"{0}\"\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \\"alt + o\\" or \\"option + o\\".\n\n
+portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the senders name in your bank statement matches that one from the trade contract:\nSenders name: {0}\n\nIf the name is not the same as the one displayed here, please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".\n\n
 portfolio.pending.step3_seller.onPaymentReceived.note=Imajte na umu, da čim potvrdite primanje uplate, zaključani iznos trgovine će biti oslobođen BTC kupcu i bezbednosni depozit će biti vraćen.
 portfolio.pending.step3_seller.onPaymentReceived.confirm.headline=Potvrdite da ste primili uplatu
 portfolio.pending.step3_seller.onPaymentReceived.confirm.yes=Da, primio sam uplatu
@@ -529,7 +529,7 @@ portfolio.pending.step5_buyer.alreadyWithdrawn=Vaša sredstva su već bila podig
 portfolio.pending.step5_buyer.confirmWithdrawal=Potvrdi zahtev za podizanje
 portfolio.pending.step5_buyer.amountTooLow=Iznos za prenos je manji od provizije transakcije i minimalne moguće vrednosti tks. (prašina).
 portfolio.pending.step5_buyer.withdrawalCompleted.headline=Završeno podizanje
-portfolio.pending.step5_buyer.withdrawalCompleted.msg=Vaše završene trgovine su čuvane pod \\"Portfolio/Istorija\\".\nMožete pregledati sve vaše bitkoin transakcije pod \\"Sredstva/Transakcije\\"
+portfolio.pending.step5_buyer.withdrawalCompleted.msg=Vaše završene trgovine su čuvane pod \"Portfolio/Istorija\".\nMožete pregledati sve vaše bitkoin transakcije pod \"Sredstva/Transakcije\"
 portfolio.pending.step5_buyer.bought=Kupili ste:
 portfolio.pending.step5_buyer.paid=Platili ste:
 
@@ -543,7 +543,7 @@ portfolio.pending.tradeProcess=Proces trgovine
 portfolio.pending.openAgainDispute.msg=Ako niste sigurni da je stigla poruka arbitru (npr. ako niste dobili odgovor nakon 1 dan) slobodno ponovo otvorite raspravu.
 portfolio.pending.openAgainDispute.button=Ponovo otvori raspravu
 portfolio.pending.openSupportTicket.headline=Otvori tiket podrške
-portfolio.pending.openSupportTicket.msg=Molimo koristite to samo u vanrednim slučajevima ako nije prikazano \\"Otvori podršku\\" ili \\"Otvori raspravu\\" dugme.\n\nKada otvorite tiket podrške trgovina će biti prekinuta i biće u nadležnosti arbitra
+portfolio.pending.openSupportTicket.msg=Molimo koristite to samo u vanrednim slučajevima ako nije prikazano \"Otvori podršku\" ili \"Otvori raspravu\" dugme.\n\nKada otvorite tiket podrške trgovina će biti prekinuta i biće u nadležnosti arbitra
 portfolio.pending.notification=Notifikacija
 portfolio.pending.openDispute=Otvori raspravu
 portfolio.pending.disputeOpened=Rasprava otvorena
@@ -551,7 +551,7 @@ portfolio.pending.openSupport=Otvori tiket podrške
 portfolio.pending.supportTicketOpened=Tiket podrške otvoren
 portfolio.pending.requestSupport=Zatraži podršku
 portfolio.pending.error.requestSupport=Molimo prijavite problem vašem arbitru.\n\nOn će proslediti informacije programerima da istraže problem.\nNakon što problem bude analiziran dobićete nazad sva zaključana sredstva.
-portfolio.pending.communicateWithArbitrator=Molimo komunicirajte u \\"Podrška\\" ekranu sa arbitrom.
+portfolio.pending.communicateWithArbitrator=Molimo komunicirajte u \"Podrška\" ekranu sa arbitrom.
 portfolio.pending.supportTicketOpenedMyUser=Otvorili ste već tiket podrške.\n{0}
 portfolio.pending.disputeOpenedMyUser=Otvorili ste već raspravu.\n{0}
 portfolio.pending.disputeOpenedByPeer=Vaš trgovinski partner je otvorio raspravu\n{0}
@@ -660,7 +660,7 @@ support.buyerOfferer=BTC kupac/Tvorac
 support.sellerOfferer=BTC prodavac/Tvorac
 support.buyerTaker=BTC kupac/Uzimalac
 support.sellerTaker=BTC prodavac/Tvorac
-support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \\"Open dispute\\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \\"Open support ticket\\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \\"Open support ticket\\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \\"Portfolio/Open trades\\" and type the key combination \\"alt + o\\" or \\"option + o\\" to open the support ticket.
+support.backgroundInfo=Bisq is not a company and not operating any kind of customer support.\n\nIf there are disputes in the trade process (e.g. one trader does not follow the trade protocol) the application will display a \"Open dispute\" button after the trade period is over for contacting the arbitrator.\nIn cases of software bugs or other problems, which are detected by the application there will be displayed a \"Open support ticket\" button to contact the arbitrator who will forward the issue to the developers.\n\nIn cases where a user got stuck by a bug without getting displayed that \"Open support ticket\" button, you can open a support ticket manually with a special short cut.\n\nPlease use that only if you are sure that the software is not working like expected. If you have problems how to use Bisq or any questions please review the FAQ at the bisq.io web page or post in the Bisq forum at the support section.\n\nIf you are sure that you want to open a support ticket please select the trade which causes the problem under \"Portfolio/Open trades\" and type the key combination \"alt + o\" or \"option + o\" to open the support ticket.
 support.initialInfo="Imajte na umu osnovna pravila za proces rasprave:\n1. Potrebno je da odgovorite zahtevima arbitra u razmaku od 2 dana.\n2. Maksimalni period rasprave je 14 dana.\n3. Morate da ispunite što arbitar zahteva od vas radi dostavljanja dokaza za vaš slučaj.\n4. Prihvatili ste pravila navedena u wiki u korisničkom ugovoru kada ste prvi put pokrenuli aplikaciju.\n\nMolimo pročitajte detaljnije o procesu rasprave u našoj wiki:\nhttps://github.com/bitsquare/bitsquare/wiki/Dispute-process
 support.systemMsg=Poruka sistema: {0}
 support.youOpenedTicket=Otvorili ste zahtev za podršku.
@@ -700,7 +700,7 @@ setting.preferences.displayOptions=Opcije prikaza
 setting.preferences.showOwnOffers=Prikaži moje ponude u knjigi ponuda:
 setting.preferences.useAnimations=Koristi animacije:
 setting.preferences.sortWithNumOffers=Sortiraj liste tržišta sa br. ponuda/trgovina
-setting.preferences.resetAllFlags=Resetuj sve \\"Ne prikazuj opet\\" obeležja:
+setting.preferences.resetAllFlags=Resetuj sve \"Ne prikazuj opet\" obeležja:
 setting.preferences.reset=Resetuj
 settings.preferences.languageChange=Primenjivanje promene jezika na sve ekrane zahteva ponovo pokretanje.
 settings.preferences.selectCurrencyNetwork=Izaberi osnovnu valutu
@@ -764,7 +764,7 @@ setting.about.subsystems.val=Verzija mreže: {0}; Verzija P2P poruka: {1}; Verzi
 account.tab.arbitratorRegistration=Registracija arbitra
 account.tab.account=Nalog
 account.info.headline=Dobrodošli na vaš Bisq Nalog
-account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \\"Funds\\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
+account.info.msg=Here you can setup trading accounts for national currencies & altcoins, select arbitrators and backup your wallet & account data.\n\nAn empty Bitcoin wallet was created the first time you started Bisq.\nWe recommend that you write down your Bitcoin wallet seed words (see button on the left) and consider adding a password before funding. Bitcoin deposits and withdrawals are managed in the \"Funds\" section.\n\nPrivacy & Security:\nBisq is a decentralized exchange – meaning all of your data is kept on your computer, there are no servers and we have no access to your personal info, your funds or even your IP address. Data such as bank account numbers, altcoin & Bitcoin addresses, etc are only shared with your trading partner to fulfill trades you initiate (in case of a dispute the arbitrator will see the same data like your trading peer).
 
 account.menu.paymentAccount=Nalozi nacionalne valute
 account.menu.altCoinsAccountView=Altkoin nalozi
@@ -821,7 +821,7 @@ account.password.setPw.headline=Podesi zaštitu lozinkom za novčanik
 account.password.info=Sa zaštitom lozinkom potrebno je da unesete lozinku kada podižete bitkoin iz vašeg novčanika ili ako želite da vidite ili da povratite novčanik iz sid reči kao i pri pokretanju aplikacije.
 
 account.seed.backup.title=Napravi rezervu sid reči vašeg novčanika
-account.seed.info=Molimo zapišite i sid reči novčanika i datum! Možete povratiti vaš novčanik bilo kad sa tim sid rečima i datumom.\nSid reči se koriste i za BTC i za BSQ novčanik.\n\nTreba da zapišete sid reči na list papira i ne čuvati ih na vašem računaru.\n\nImajte na umu da sid reči nisu zamena za rezervnu kopiju.\nPotrebno je da napravite rezervu celog direktorijuma aplikacije u \\"Nalog/Rezerva\\" ekranu da bi povratili ispravno stanje aplikacije i podatke.
+account.seed.info=Molimo zapišite i sid reči novčanika i datum! Možete povratiti vaš novčanik bilo kad sa tim sid rečima i datumom.\nSid reči se koriste i za BTC i za BSQ novčanik.\n\nTreba da zapišete sid reči na list papira i ne čuvati ih na vašem računaru.\n\nImajte na umu da sid reči nisu zamena za rezervnu kopiju.\nPotrebno je da napravite rezervu celog direktorijuma aplikacije u \"Nalog/Rezerva\" ekranu da bi povratili ispravno stanje aplikacije i podatke.
 account.seed.warn.noPw.msg=Niste podesili lozinku novčanika koji bi štitio prikazivanje sid reči.\n\nDa li želite da prikažete sid reči?
 account.seed.warn.noPw.yes=Da, ne pitaj me ponovo
 account.seed.enterPw=Unesite lozinku da bi videli sid reči
@@ -957,7 +957,7 @@ disputeSummaryWindow.close.msg=Tiket zatvoren {0}\n\nRezime:\n{1} predat dokaz k
 disputeSummaryWindow.close.closePeer=Potrebno je takodje da zatvorite tiket trgovinskih partnera!
 
 emptyWalletWindow.headline=Novčanik alatka vanrednog slučaja
-emptyWalletWindow.info=Molimo koristite to samo u hitnim slučajevima ako ne možete da pristupite vašim sredstvima iz UI.\n\nImajte na umu da će sve otvorene ponude biti zatvorene automatski prilikom korišćenja ovog alata.\n\nPre koršćenja ovog alata, molimo napravite rezervu vašeg direktorijuma podataka. Možete ovo uraditi u \\"Nalog/Rezerva\\".\n\nMolimo prijavite nam vaš problem i podnesite izveštaj greške na Github-u ili na Bisq forumu da bi mogli da istražimo šta je prouzrokovalo problem.
+emptyWalletWindow.info=Molimo koristite to samo u hitnim slučajevima ako ne možete da pristupite vašim sredstvima iz UI.\n\nImajte na umu da će sve otvorene ponude biti zatvorene automatski prilikom korišćenja ovog alata.\n\nPre koršćenja ovog alata, molimo napravite rezervu vašeg direktorijuma podataka. Možete ovo uraditi u \"Nalog/Rezerva\".\n\nMolimo prijavite nam vaš problem i podnesite izveštaj greške na Github-u ili na Bisq forumu da bi mogli da istražimo šta je prouzrokovalo problem.
 emptyWalletWindow.balance=Vaše dostupno stanje novčanika:
 emptyWalletWindow.address=Vaša adresa destinacije:
 emptyWalletWindow.button=Pošalji sva sredstva
@@ -1001,7 +1001,7 @@ selectDepositTxWindow.msg=Transakcija depozita nije sačuvana u trgovini.\nMolim
 selectDepositTxWindow.select=Izaberi transakciju depozita
 
 selectBaseCurrencyWindow.headline=Izbor tržišta
-selectBaseCurrencyWindow.msg=Izabrano podrazumevano tržište je {0}.\n\nAko želite da promenite na drugu osnovnu valutu molimo izaberite jednu iz spuštajućeg menija.\nTakođe možete posle promeniti osnovnu valutu u \\"Podešavanja/Mreža\\" ekranu.
+selectBaseCurrencyWindow.msg=Izabrano podrazumevano tržište je {0}.\n\nAko želite da promenite na drugu osnovnu valutu molimo izaberite jednu iz spuštajućeg menija.\nTakođe možete posle promeniti osnovnu valutu u \"Podešavanja/Mreža\" ekranu.
 selectBaseCurrencyWindow.select=Izaberi osnovnu valutu
 selectBaseCurrencyWindow.default=Koristi {0} kao podrazumevano tržište
 
@@ -1055,7 +1055,7 @@ popup.headline.error=Greška
 popup.doNotShowAgain=Ne prikazuj opet
 popup.reportError.gitHub=Prijavi Github pratiocu problema
 popup.reportError.forum=Prijavi na Bisq forumu
-popup.reportError={0}\n\nDa bi nam pomogli da poboljšamo softver molimo prijavite grešku kod našeg pratioca problema na Github-u ili postavite na Bisq forum.\nPoruka o grešci biće kopirana u klipbord kada kliknete dugmad ispod.\nUčiniće otklanjanje grešaka lakšim ako prilepite Bisq.log fajl koji možete naći u direktorijumu aplikacije.\nMožete otvoriti direktorijum aplikacije u \\"Nalog/Rezerva\\".
+popup.reportError={0}\n\nDa bi nam pomogli da poboljšamo softver molimo prijavite grešku kod našeg pratioca problema na Github-u ili postavite na Bisq forum.\nPoruka o grešci biće kopirana u klipbord kada kliknete dugmad ispod.\nUčiniće otklanjanje grešaka lakšim ako prilepite Bisq.log fajl koji možete naći u direktorijumu aplikacije.\nMožete otvoriti direktorijum aplikacije u \"Nalog/Rezerva\".
 
 popup.error.tryRestart=Molimo pokušajte da ponovo pokrenete vašu aplikaciju i proverite vašu mrežnu konekciju da vidite da li možete da rešite problem.
 popup.error.createTx=Greška prilikom pravljenja transakcije: {0}
@@ -1072,8 +1072,8 @@ popup.warning.startupFailed.twoInstances=Bisq je već pokrenut. Ne možete pokre
 popup.warning.cryptoTestFailed=Izgleda da koristite samo kompajlirani izvršni fajl i niste pratili build instrukcije u https://github.com/bitsquare/bitsquare/blob/master/doc/build.md#7-enable-unlimited-strength-for-cryptographic-keys.\n\nAko to nije slučaj i koristite zvaničnu bisq izvršnu datoteku, molimo podnesite prijavu o grešci na Github stranici.\nGreška={0}
 popup.warning.oldOffers.msg=Imate otvorene ponude koje su napravljene sa starijom verzijom Bisq.\nMolimo uklonite te ponude pošto nisu više važeće.\n\nPonude (ID): {0}
 popup.warning.oldOffers.buttonText=Ukloni zastarele ponde
-popup.warning.tradePeriod.halfReached=Vaša trgovina sa ID {0} je dostigla polovinu od maks. dozvoljenog perioda trgovine i još uvek nije završena.\n\nPeriod trgovine se završava {1}\n\nMolimo proverite stanje vaše trgovine u \\"Portfolio/Otvorene trgovine\\" za više informacija.
-popup.warning.tradePeriod.ended=Vaša trgovina sa ID {0} je dostigla maks. dozvoljen period trgovine i nije završena.\n\nPeriod trgovine se završio {1}\n\nMolimo proverite vašu trgovine u \\"Portfolio/Otvorene trgovine\\" radi kontaktiranja arbitra.
+popup.warning.tradePeriod.halfReached=Vaša trgovina sa ID {0} je dostigla polovinu od maks. dozvoljenog perioda trgovine i još uvek nije završena.\n\nPeriod trgovine se završava {1}\n\nMolimo proverite stanje vaše trgovine u \"Portfolio/Otvorene trgovine\" za više informacija.
+popup.warning.tradePeriod.ended=Vaša trgovina sa ID {0} je dostigla maks. dozvoljen period trgovine i nije završena.\n\nPeriod trgovine se završio {1}\n\nMolimo proverite vašu trgovine u \"Portfolio/Otvorene trgovine\" radi kontaktiranja arbitra.
 popup.warning.noTradingAccountSetup.headline=Niste podesili trgovinski nalog
 popup.warning.noTradingAccountSetup.msg=Potrebno je da podesite nacionalnu valutu ili altkoin nalog pre nego što možete da napravite ponudu.\nDa li želite da podesite nalog?
 popup.warning.noArbitratorSelected.headline=Nemate arbitra izabranog.
@@ -1081,21 +1081,21 @@ popup.warning.noArbitratorSelected.msg=Potrebno je da podesite bar jednog arbitr
 popup.warning.notFullyConnected=Potrebno je da sačekate da se potpune povežete sa mrežom.\nTo može da potraje do oko 2 minuta pri pokretanju.
 popup.warning.removeOffer=Da li ste sigurni da želite da uklonite tu ponudu?\nProvizija pravljenja od {0} biće izgubljena ako uklonite tu ponudu.
 popup.warning.tooLargePercentageValue=Ne možete postaviti procenat od 100% ili više.
-popup.warning.examplePercentageValue=Molimo unesite procenat kao \\"5.4\\" za 5.4%
+popup.warning.examplePercentageValue=Molimo unesite procenat kao \"5.4\" za 5.4%
 popup.warning.noPriceFeedAvailable=Ne postoji unos cene dostupan za tu valutu. Ne možete koristiti cenu zasnovanu na procentu.\nMolimo izaberite fiksnu cenu.
 popup.warning.sendMsgFailed=Slanje poruke vašem trgovinskom partneru nije uspelo.\nMolimo pokušajte ponovo i ako se problem nastavi podnesite prijavu o grešci.
 popup.warning.insufficientBtcFundsForBsqTx=Nemate dovoljno BTC sredstava za plaćanje tks provizije za tu BSQ transakciju.\nMolimo finansirajte vaš BTC novčanik da bi ste mogli da prenesete BSQ.\nNedostajuća sredstva: {0}
 popup.warning.insufficientBsqFundsForBtcFeePayment=Nemate dovoljno BSQ sredstava za plaćanje tks provizije u BSQ.\nMožete da platite proviziju u BTC ili je potrebno da finansirate vaš BSQ novčanik.\nNedostajuća BSQ sredstva: {0}
 popup.warning.noBsqFundsForBtcFeePayment=Vaš BSQ novčanik nema dovoljno sredstava za plaćanje tks provizije u BSQ.
 popup.warning.messageTooLong=Vaša poruka prevazilazi maks. dozvoljenu veličinu. Molimo pošaljite je u više delova ili je otpremite na servis kao što je https://pastebin.com.
-popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \\"alt + o\\" or \\"option + o\\"."
+popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\nLocked up balance: {0} \nDeposit tx address: {1}\nTrade ID: {2}.\n\nPlease open a support ticket by selecting the trade in the pending trades screen and clicking \"alt + o\" or \"option + o\"."
 
 popup.info.securityDepositInfo=To ensure that both traders follow the trade protocol they need to pay a security deposit.\n\nThe deposit will stay in your local trading wallet until the offer gets accepted by another trader.\nIt will be refunded to you after the trade has successfully completed.\n\nPlease note that you need to keep your application running if you have an open offer. When another trader wants to take your offer it requires that your application is online for executing the trade protocol.\nBe sure that you have standby mode deactivated as that would disconnect the network (standby of the monitor is not a problem).
 
 popup.privateNotification.headline=Važno privatno obaveštenje!
 
 popup.securityRecommendation.headline=Važna preporuka za bezbednost
-popup.securityRecommendation.msg=Želeli bismo da vas podsetimo da razmotrite da koristite zaštitu lozinkom za vaš novčanik ako niste već to omogućili.\n\nTakođe je jako preporučljivo da zapišete sid reči novčanika. Te sid reči su kao glavna lozinka za povratak vašeg Bitkoin novčanika.\nU \\"Sid Novčanika\\" sekciji možete naći više informacija.\n\nDodatno traba da napravite rezervu kompletnog foldera podataka aplikacije u \\"Rezerva\\" sekciji.
+popup.securityRecommendation.msg=Želeli bismo da vas podsetimo da razmotrite da koristite zaštitu lozinkom za vaš novčanik ako niste već to omogućili.\n\nTakođe je jako preporučljivo da zapišete sid reči novčanika. Te sid reči su kao glavna lozinka za povratak vašeg Bitkoin novčanika.\nU \"Sid Novčanika\" sekciji možete naći više informacija.\n\nDodatno traba da napravite rezervu kompletnog foldera podataka aplikacije u \"Rezerva\" sekciji.
 
 popup.shutDownInProgress.headline=Gašenje u toku
 popup.shutDownInProgress.msg=Gašenje aplikacije može da potraje par sekundi.\nMolimo vas ne prekidajte ovaj proces.
@@ -1150,7 +1150,7 @@ guiUtil.accountExport.exportFailed=Izvoz u CSV nije uspelo zbog greške.\nGrešk
 guiUtil.accountExport.selectExportPath=Izaberi lokaciju izvoza
 guiUtil.accountImport.imported=Trgovinski nalog uvezen sa lokacije:\n{0}\n\nUvezeni nalozi:\n{1}
 guiUtil.accountImport.noAccountsFound=Izvezeni trgovinski nalozi nisu pronađeni na lokaciji: {0}\nIme fajla je {1}."
-guiUtil.openWebBrowser.warning=Otvorićete veb stranicu u veb pretraživaču vašeg sistema.\nDa li želite sada da otvorite veb stranicu?\n\nAko ne koristite \\"Tor Browser\\" kao podrazumevani veb pretraživač vašeg sistema povezaćete se na veb staranicu u klearnetu.\n\nURL: \\"{0}\\"
+guiUtil.openWebBrowser.warning=Otvorićete veb stranicu u veb pretraživaču vašeg sistema.\nDa li želite sada da otvorite veb stranicu?\n\nAko ne koristite \"Tor Browser\" kao podrazumevani veb pretraživač vašeg sistema povezaćete se na veb staranicu u klearnetu.\n\nURL: \"{0}\"
 guiUtil.openWebBrowser.doOpen=Otvori veb stranicu i ne pitaj ponovo
 guiUtil.openWebBrowser.copyUrl=Kopiraj URL i otkaži
 guiUtil.ofTradeAmount=od iznosa trgovine
@@ -1201,16 +1201,16 @@ txIdTextField.blockExplorerIcon.tooltip=Otvori blokčejn pretraživač sa ID te 
 # Navigation
 ####################################################################
 
-navigation.account=\\"Nalog\\"
-navigation.arbitratorSelection=\\"Izbor arbitra\\"
-navigation.funds.availableForWithdrawal=\\"Sredstva/Pošalji sredstva\\"
-navigation.portfolio.myOpenOffers="Portfolio/Moje otvorene ponude\\"
-navigation.portfolio.pending=\\"Portfolio/Otvorene trgovine\\"
-navigation.funds.depositFunds=\\"Sredstva/Primi sredstva"
-navigation.settings.preferences=\\"Podešavanje/Preference\\"
-navigation.funds.transactions=\\"Sredstva/Transakcije\\"
-navigation.support=\\"Podrška\\"
-navigation.dao.wallet.receive=\\"DAO/BSQ Novčanik/Primi\\"
+navigation.account=\"Nalog\"
+navigation.arbitratorSelection=\"Izbor arbitra\"
+navigation.funds.availableForWithdrawal=\"Sredstva/Pošalji sredstva\"
+navigation.portfolio.myOpenOffers="Portfolio/Moje otvorene ponude\"
+navigation.portfolio.pending=\"Portfolio/Otvorene trgovine\"
+navigation.funds.depositFunds=\"Sredstva/Primi sredstva"
+navigation.settings.preferences=\"Podešavanje/Preference\"
+navigation.funds.transactions=\"Sredstva/Transakcije\"
+navigation.support=\"Podrška\"
+navigation.dao.wallet.receive=\"DAO/BSQ Novčanik/Primi\"
 
 
 ####################################################################
@@ -1288,7 +1288,7 @@ seed.date=Datum novčanika:
 seed.restore.title=Povrati novčanike iz sid reči
 seed.restore=Povrati novčanike
 seed.creationDate=Datum Pravljenja:
-seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \\"alt + e\\" or \\"option + e\\" .
+seed.warn.walletNotEmpty.msg=Your bitcoin wallet is not empty.\n\nYou must empty this wallet before attempting to restore an older one, as mixing wallets together can lead to invalidated backups.\n\nPlease finalize your trades, close all your open offers and go to the Funds section to withdraw your bitcoin.\nIn case you cannot access your bitcoin you can use the emergency tool to empty the wallet.\nTo open that emergency tool press \"alt + e\" or \"option + e\" .
 seed.warn.walletNotEmpty.restore=Želim da svejedno povratim
 seed.warn.walletNotEmpty.emptyWallet=Isprazniću moje novčanike prvo
 seed.warn.notEncryptedAnymore=Vaši novčanici su šifrovani.\n\nNakon povratka, novčanici neće više biti sifrovani i morćete da postavite novu lozinku.\n\nDa li želite da nastavite?
@@ -1318,7 +1318,7 @@ payment.email=Email:
 payment.country=Država:
 payment.owner.email=Ime vlasnika email-a:
 payment.extras=Dodatni zahtevi:
-payment.us.info=Bankarski transfer korišćenjem WIRE ili ACH nije podržan za SAD jer je WIRE previše skup i ACH ima veliki rizik povraćaja.\n\nUmesto vas molimo da koristite metod plaćanja \\"ClearXchange\\", \\"US Postal Money Order\\" ili \\"Cash Deposit\\".
+payment.us.info=Bankarski transfer korišćenjem WIRE ili ACH nije podržan za SAD jer je WIRE previše skup i ACH ima veliki rizik povraćaja.\n\nUmesto vas molimo da koristite metod plaćanja \"ClearXchange\", \"US Postal Money Order\" ili \"Cash Deposit\".
 payment.email.mobile=Email ili br. mobilnog:
 payment.altcoin.address=Altkoin adresa:
 payment.altcoin=Altkoin:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>common</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>network</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>core</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/jtorproxy/pom.xml
+++ b/jtorproxy/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>jsocks</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>jtorctl</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>common</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>jtorproxy</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>core</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/seednode/pom.xml
+++ b/seednode/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>core</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/statistics/pom.xml
+++ b/statistics/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>io.bisq</groupId>
             <artifactId>core</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixed maven transitive dependencies, do not use ${project.parent.version} (while it was valid is has side-effect) but ${project.version} 

With this change you can now run test without installing first all artifacts to local repository! test now run before install as expected and with current code version of ide/reactor.

How to test:
`git clone .... `of this branch
`mvn test `-> work -> transitive module are found when running `mvn test`

before a` mvn install -DskipTest` was required first then a `mvn test`, you were running test with previous installed code version repository when in Intellij