### PR TITLE
add plugin to automatically verify PGP signature of all project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <pgpverify.keyserver>hkps://hkps.pool.sks-keyservers.net</pgpverify.keyserver>
+                    <pgpverify.failNoSignature>true</pgpverify.failNoSignature>
+                    <pgpgverify.failWeakSignature>true</pgpgverify.failWeakSignature>
+                    <pgpverify.verifyPomFiles>true</pgpverify.verifyPomFiles>
+                </configuration>
+
             </plugin>
             <!--
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,19 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <!--This plugin allow you to automatically verify PGP signature of all project dependency.-->
+                <groupId>com.github.s4u.plugins</groupId>
+                <artifactId>pgpverify-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!--
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>


### PR DESCRIPTION
at build time all 3rd party dependency PGP signature will be validated, this may avoid poisoned local maven repository. In travis since vm is garbaged, this is unlikely. Verifying  signature is still a good move.