### PR TITLE
Update Bisq.iss

### DIFF
--- a/package/win/Bisq.iss
+++ b/package/win/Bisq.iss
@@ -27,11 +27,11 @@ OutputBaseFilename=Bisq
 Compression=lzma
 SolidCompression=yes
 PrivilegesRequired=lowest
-SetupIconFile={localappdata}\Bisq.ico
-UninstallDisplayIcon={localappdata}\Bisq.ico
+SetupIconFile=Bisq.ico
+UninstallDisplayIcon={app}\Bisq.ico
 UninstallDisplayName=Bisq
 WizardImageStretch=No
-WizardSmallImageFile={localappdata}\Bisq-setup-icon.bmp
+WizardSmallImageFile=Bisq-setup-icon.bmp
 ArchitecturesInstallIn64BitMode=x64
 ChangesAssociations=Yes
 


### PR DESCRIPTION
the lines
```
SetupIconFile={localappdata}\Bisq.ico 
UninstallDisplayIcon={localappdata}\Bisq.ico 
```
are wrong, Bisq folder is located in {localappdata} and the icons are inside Bisq\ path so a more coherent change would be
```
SetupIconFile={localappdata}\Bisq\Bisq.ico 
UninstallDisplayIcon={localappdata}\Bisq\Bisq.ico 
```
but even this would be wrong since `SetupIconFile` directive as it is used on compile time only and should contain the absolute path to the icon
Same issue on  `WizardSmallImageFile={localappdata}\Bisq-setup-icon.bmp `

Here the proposed fix
```
SetupIconFile=Bisq.ico 
UninstallDisplayIcon={app}\Bisq.ico 
WizardSmallImageFile=Bisq-setup-icon.bmp 
```