### PR TITLE
New branching mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 
 script:
   # run plugin to rename pom version to branch name in reactor
-  - mvn post-clean -Prename-pom-version-like-branch
+  - mvn clean -Prename-pom-version-like-branch
   # run now a normal build
   - mvn install -DskipTests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ install:
   - mvn clean install -DskipTests
   - cd ..
 
-script: mvn clean install -DskipTests
+script:
+  # run plugin to rename pom version to branch name in reactor
+  - mvn post-clean -Prename-pom-version-like-branch
+  # run now a normal build
+  - mvn install -DskipTests
 
 #notifications:
 #  irc:

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jsocks/pom.xml
+++ b/jsocks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jtorctl/pom.xml
+++ b/jtorctl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jtorproxy/pom.xml
+++ b/jtorproxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,24 +62,6 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            <!--
-            <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-                <version>MASTER-SNAPSHOT</version>
-                <configuration>
-                    <protocExecutable>/usr/local/bin/protoc</protocExecutable>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>test-compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
                                 <goals>
                                     <goal>pom</goal>
                                 </goals>
-                                <phase>post-clean</phase>
+                                <phase>clean</phase>
                                 <configuration>
                                     <release>false</release>
                                     <forceNumericalVersion>false</forceNumericalVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.bisq</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.5.3</version>
+    <version>MASTER-SNAPSHOT</version>
     <description>Bisq - The decentralized exchange network</description>
     <url>https://bisq.io</url>
 
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.3</version>
+                <version>MASTER-SNAPSHOT</version>
                 <configuration>
                     <protocExecutable>/usr/local/bin/protoc</protocExecutable>
                 </configuration>
@@ -254,6 +254,39 @@
                     <crypto.policy>unlimited</crypto.policy>
             </properties>
         </profile>
+
+        <profile>
+            <id>rename-pom-version-like-branch</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.cedricwalter</groupId>
+                        <artifactId>git-branch-renamer-maven-plugin</artifactId>
+                        <version>1.5.0</version>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>pom</goal>
+                                </goals>
+                                <phase>post-clean</phase>
+                                <configuration>
+                                    <release>false</release>
+                                    <forceNumericalVersion>false</forceNumericalVersion>
+                                    <toUpperCase>false</toUpperCase>
+                                    <toLowerCase>false</toLowerCase>
+                                    <filterOutBranchQualifier>true</filterOutBranchQualifier>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
 

--- a/provider/pom.xml
+++ b/provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/seednode/pom.xml
+++ b/seednode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statistics/pom.xml
+++ b/statistics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.bisq</groupId>
-        <version>0.5.3</version>
+        <version>MASTER-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Work in progress!

In this branch i propose you a successful mechanism to 

- speed up development 
- avoid merge conflict when changing pom versions
- never commit anymore a pom bump version manually
- truly unleash power of pull request

When working with many feature/release/bugfix/hotfix branches, it is a bad idea to start changing the pom version as this will create merge conflicts when using pull request.

The trick is that the pom versions will be changed auto-magically based on branch name in reactor using a custom maven plugin. This plugin allow you to keep in ALL branches the same pom version for all your projects: for example MASTER-SNAPSHOT and never change it again.

Some easy rules as consequences
1. you never change the pom version, leave it to MASTER-SNAPSHOT (but can be anything else)
2. when you want to make a new snapshot version of bisq, open a new branch named release/0.5.4 and push: code will be checkout out, pom version changed to 0.5.4-SNAPSHOT and the build will run in travis
3. when you want to make a new release version of bisq, run the same build as point 2 but add -DreleaseNow=true, so pom version changed to 0.5.4

# pull request
- all pull request should be opened from MASTER (the best) or from release branch
- pull request that need to are not ready can be merged later on any release branch
- pull request branch can be build and deploy with an unique name to any maven repository

This allow also to create more branches category:  bugfix branches (not a new feature, but a fix) and hotfix branches (ugly fix in an hurry that will need to be solved in a proper bugfix branch with high prio)

If you want to rename pom version locally, for example to install to your local repository, just run a maven clean with the profile "rename-pom-version-like-branch" but DONT commit these pom version changes

`mvn clean -Prename-pom-version-like-branch`