### PR TITLE
Add WACoins coin

### DIFF
--- a/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
@@ -26,6 +26,7 @@ import io.bisq.gui.util.validation.altcoins.OctocoinAddressValidator;
 import io.bisq.gui.util.validation.params.IOPParams;
 import io.bisq.gui.util.validation.params.OctocoinParams;
 import io.bisq.gui.util.validation.params.PivxParams;
+import io.bisq.gui.util.validation.params.WACoinsParams;
 import io.bisq.gui.util.validation.params.btc.BtcMainNetParams;
 import lombok.extern.slf4j.Slf4j;
 import org.bitcoinj.core.Address;
@@ -245,6 +246,15 @@ public final class AltCoinAddressValidator extends InputValidator {
                     } catch (NxtReedSolomonValidator.DecodeException e) {
                         return wrongChecksum;
                     }
+                case "WAC":
+                    try {
+                        Address.fromBase58(WACoinsParams.get(), input);
+                    }
+                    catch (AddressFormatException e) {
+                        return new ValidationResult(false, getErrorMessage(e));
+                    }
+                    return new ValidationResult(true);
+
                 default:
                     log.debug("Validation for AltCoinAddress not implemented yet. currencyCode: " + currencyCode);
                     return validationResult;

--- a/gui/src/main/java/io/bisq/gui/util/validation/params/WACoinsParams.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/params/WACoinsParams.java
@@ -1,0 +1,71 @@
+package io.bisq.gui.util.validation.params;
+
+import org.bitcoinj.core.*;
+import org.bitcoinj.store.BlockStore;
+import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.utils.MonetaryFormat;
+
+public class WACoinsParams extends NetworkParameters {
+
+    private static WACoinsParams instance;
+
+    public static synchronized WACoinsParams get() {
+        if (instance == null) {
+            instance = new WACoinsParams();
+        }
+        return instance;
+    }
+
+    // We only use the properties needed for address validation
+    public WACoinsParams() {
+        super();
+        addressHeader = 73;
+        p2shHeader = 3;
+        acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+    }
+
+    // default dummy implementations, not used...
+    @Override
+    public String getPaymentProtocolId() {
+        return PAYMENT_PROTOCOL_ID_MAINNET;
+    }
+
+    @Override
+    public void checkDifficultyTransitions(StoredBlock storedPrev, Block next, BlockStore blockStore) throws VerificationException, BlockStoreException {
+    }
+
+    @Override
+    public Coin getMaxMoney() {
+        return null;
+    }
+
+    @Override
+    public Coin getMinNonDustOutput() {
+        return null;
+    }
+
+    @Override
+    public MonetaryFormat getMonetaryFormat() {
+        return null;
+    }
+
+    @Override
+    public String getUriScheme() {
+        return null;
+    }
+
+    @Override
+    public boolean hasMaxMoney() {
+        return false;
+    }
+
+    @Override
+    public BitcoinSerializer getSerializer(boolean parseRetain) {
+        return null;
+    }
+
+    @Override
+    public int getProtocolVersionNum(ProtocolVersion version) {
+        return 0;
+    }
+    }

--- a/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
+++ b/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
@@ -135,4 +135,20 @@ public class AltCoinAddressValidatorTest {
         assertFalse(validator.validate("NXT-JM2U-U4AE-G7WF-3Np9F").isValid);
         assertFalse(validator.validate("NXT-2222-2222-2222-22222").isValid);
     }
+
+    @Test
+    public void testWAC() {
+        AltCoinAddressValidator validator = new AltCoinAddressValidator();
+        validator.setCurrencyCode("WAC");
+
+        assertTrue(validator.validate("WfEnB3VGrBqW7uamJMymymEwxMBYQKELKY").isValid);
+        assertTrue(validator.validate("WTLWtNN5iJJQyTeMfZMMrfrDvdGZrYGP5U").isValid);
+        assertTrue(validator.validate("WemK3MgwREsEaF4vdtYLxmMqAXp49C2LYQ").isValid);
+        assertTrue(validator.validate("WZggcFY5cJdAxx9unBW5CVPAH8VLTxZ6Ym").isValid);
+
+        assertFalse(validator.validate("").isValid);
+        assertFalse(validator.validate("abcde").isValid);
+        assertFalse(validator.validate("mWvZ7nZAUzpRMFp2Bfjxz27Va47nUfB79E").isValid);
+        assertFalse(validator.validate("WemK3MgwREsE23fgsadtYLxmMqAX9C2LYQ").isValid);
+    }
 }


### PR DESCRIPTION
* Ticker symbol (e.g. BTC): WAC
* Official coin name (e.g. Bitcoin): WACoins
* Official altcoin webpage where Bitsquare will be added as official exchange: https://wacoins.net/quick-start
* URL of the block explorer: https://explorer.wacoins.net/
* Example address (e.g. 3MPe1LfMeJvumN7ykswSwkPSoXLbheXnCH): WZggcFY5cJdAxx9unBW5CVPAH8VLTxZ6Ym
* Confirmation that you have checked that the ticker does not conflict with https://en.wikipedia.org/wiki/ISO_4217128 and https://coinmarketcap.com/currencies2: we have checked and it does not conflict
* Social media accounts like Twitter account, subreddit, etc.: Twitter: https://twitter.com/@wacoins Facebook: https://www.facebook.com/WACoins-1940195516252023/?ref=bookmarks Slack: wacoins.slack.com