### PR TITLE
Change "until" to "by" in three places

### DIFF
--- a/common/src/main/resources/i18n/displayStrings.properties
+++ b/common/src/main/resources/i18n/displayStrings.properties
@@ -470,7 +470,7 @@ portfolio.pending.step2_buyer.startPaymentUsing=Start payment using {0}
 portfolio.pending.step2_buyer.amountToTransfer=Amount to transfer:
 portfolio.pending.step2_buyer.sellersAddress=Seller''s {0} address:
 portfolio.pending.step2_buyer.paymentStarted=Payment started
-portfolio.pending.step2_buyer.warn=You still have not done your {0} payment!\nPlease note that the trade has to be completed until {1} otherwise the trade will be investigated by the arbitrator.
+portfolio.pending.step2_buyer.warn=You still have not done your {0} payment!\nPlease note that the trade has to be completed by {1} otherwise the trade will be investigated by the arbitrator.
 portfolio.pending.step2_buyer.openForDispute=You have not completed your payment!\nThe max. period for the trade has elapsed.\n\nPlease contact the arbitrator for opening a dispute.
 portfolio.pending.step2_buyer.paperReceipt.headline=Did you sent the paper receipt to the BTC seller?
 portfolio.pending.step2_buyer.paperReceipt.msg=Remember:\n\
@@ -489,7 +489,7 @@ portfolio.pending.step3_buyer.wait.headline=Wait for BTC seller's payment confir
 portfolio.pending.step3_buyer.wait.info=Waiting for the BTC seller''s confirmation for the receipt of the {0} payment.
 portfolio.pending.step3_buyer.warn.part1a=on the {0} blockchain
 portfolio.pending.step3_buyer.warn.part1b=at your payment provider (e.g. bank)
-portfolio.pending.step3_buyer.warn.part2=The BTC seller still has not confirmed your payment!\nPlease check {0} if the payment sending was successful.\nIf the BTC seller does not confirm the receipt of your payment until {1} the trade will be investigated by the arbitrator.
+portfolio.pending.step3_buyer.warn.part2=The BTC seller still has not confirmed your payment!\nPlease check {0} if the payment sending was successful.\nIf the BTC seller does not confirm the receipt of your payment by {1} the trade will be investigated by the arbitrator.
 portfolio.pending.step3_buyer.openForDispute=The BTC seller has not confirmed your payment!\nThe max. period for the trade has elapsed.\nPlease contact the arbitrator for opening a dispute.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.part=Your trading partner has confirmed that he initiated the {0} payment.\n\n
@@ -520,7 +520,7 @@ portfolio.pending.step3_seller.buyerStartedPayment.altcoin=Check for blockchain 
 portfolio.pending.step3_seller.buyerStartedPayment.fiat=Check at your trading account (e.g. bank account) and confirm when you have received the payment.
 portfolio.pending.step3_seller.warn.part1a=on the {0} blockchain
 portfolio.pending.step3_seller.warn.part1b=at your payment provider (e.g. bank)
-portfolio.pending.step3_seller.warn.part2=You still have not confirmed the receipt of the payment!\nPlease check {0} if you have received the payment.\nIf you don''t confirm receipt until {1} the trade will be investigated by the arbitrator.
+portfolio.pending.step3_seller.warn.part2=You still have not confirmed the receipt of the payment!\nPlease check {0} if you have received the payment.\nIf you don''t confirm receipt by {1} the trade will be investigated by the arbitrator.
 portfolio.pending.step3_seller.openForDispute=You have not confirmed the receipt of the payment!\nThe max. period for the trade has elapsed.\nPlease contact the arbitrator for opening a dispute.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.part1=Have you received the {0} payment from your trading partner?\n\n


### PR DESCRIPTION
This common grammatical error for German-speakers can sound
particularly strange to native English speakers. The rule
is subtle, but these two sentences mean the same thing:
  1. You have until 12am to place your drink order.
  2. You must place your drink order by 12am.