### PR TITLE
Dockerfile for a hidden service seednode

### DIFF
--- a/seednode/Dockerfile
+++ b/seednode/Dockerfile
@@ -1,0 +1,26 @@
+###
+# The directory of the Dockerfile should contain your 'hostname' and 'private_key' files.
+# In the docker-compose.yml file you can pass the ONION_ADDRESS referenced below.
+###
+
+# pull base image
+FROM openjdk:8-jdk
+
+ARG ONION_ADDRESS
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    maven \
+    vim \
+    fakeroot \
+    openjfx && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/bisq-network/exchange.git
+WORKDIR /exchange/
+RUN mvn clean install
+RUN mkdir -p /root/.local/share/seed_BTC_MAINNET_${ONION_ADDRESS}/btc_mainnet/tor/hiddenservice
+
+COPY hostname private_key /root/.local/share/seed_BTC_MAINNET_${ONION_ADDRESS}/btc_mainnet/tor/hiddenservice/
+
+CMD java -Xms1800m -Xmx1800m  -jar ./seednode/target/SeedNode.jar --maxConnections=30 --baseCurrencyNetwork=BTC_MAINNET --nodePort=8000 \
+    --myAddress=${ONION_ADDRESS}.onion:8000 --appName=seed_BTC_MAINNET_${ONION_ADDRESS} \
+    2>error_seed_BTC_MAINNET_${ONION_ADDRESS}.log

--- a/seednode/docker-compose.yml
+++ b/seednode/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+# Fill in your own ONION addres, without the .onion suffix
+
+services:
+    seednode:
+        build:
+            context: .
+            args:
+            - ONION_ADDRESS=123xxxxxxxxxx
+        image: bisq:seednode
+        ports:
+            - 8000:8000
+        environment:
+            - ONION_ADDRESS=123xxxxxxxxxx

--- a/seednode/src/main/java/io/bisq/seednode/SeedNode.java
+++ b/seednode/src/main/java/io/bisq/seednode/SeedNode.java
@@ -46,7 +46,7 @@ public class SeedNode {
     public SeedNode() {
         String logPath = Paths.get(bisqEnvironment.getProperty(AppOptionKeys.APP_DATA_DIR_KEY), "bisq").toString();
         Log.setup(logPath);
-        log.info("Log files under: " + logPath);
+        log.info("Log files under: {}.log", logPath);
         Utilities.printSysInfo();
         Log.setLevel(Level.toLevel(bisqEnvironment.getRequiredProperty(CommonOptionKeys.LOG_LEVEL_KEY)));
 

--- a/seednode/src/main/java/io/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/io/bisq/seednode/SeedNodeMain.java
@@ -28,6 +28,7 @@ import io.bisq.core.app.BisqExecutable;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.bitcoinj.store.BlockStoreException;
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ import java.util.concurrent.ThreadFactory;
 import static io.bisq.core.app.BisqEnvironment.DEFAULT_APP_NAME;
 import static io.bisq.core.app.BisqEnvironment.DEFAULT_USER_DATA_DIR;
 
+@Slf4j
 public class SeedNodeMain extends BisqExecutable {
     private static final Logger log = LoggerFactory.getLogger(SeedNodeMain.class);
     private static final long MAX_MEMORY_MB_DEFAULT = 500;


### PR DESCRIPTION
Adds Dockerfile and docker-compose.yml files to easily build a new
seednode from the latest master branch. The Dockerfile assumes you
have 'hostname' and 'private_keys' files.
Also small fixes to SeedNode/SeedNodeMain.

Note: these files are currently in the root folder of the seednode module, a subdir or another location might be better, suggestions welcome.