### PR TITLE
Propose JAVA_HOME=/usr/lib/jvm/default-java

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -55,8 +55,11 @@ If `$JAVA_HOME` is not present, open your `.bashrc` file:
     $ touch ~/.bashrc
     $ gedit ~/.bashrc
 
-For OpenJDK add: `export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64`
-For Oracle JDK add: `export JAVA_HOME=/usr/lib/jvm/java-8-oracle`
+* For OpenJDK add: `export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64`
+* For Oracle JDK add: `export JAVA_HOME=/usr/lib/jvm/java-8-oracle`
+* For your current *alternative* JDK add: `export JAVA_HOME=/usr/lib/jvm/default-java`  
+  (or `/usr/lib/jvm/default` for Arch or `/usr/lib/jvm/java` for Fedora)
+
 Save and close the file.
 
 Reload the file in your shell:


### PR DESCRIPTION
The command line `update-alternatives --config java`
changes the symbolic link `/usr/lib/jvm/default-java`
in order to switch to another installed JDK.

From my knowledge, I know three different paths/distros:

* `/usr/lib/jvm/default-java` since Ubuntu 16.10
* `/usr/lib/jvm/default` for Arch
* `/usr/lib/jvm/java` for Fedora