### PR TITLE
Make BisqAppModule public so bisq-api can use it

### DIFF
--- a/gui/src/main/java/io/bisq/gui/app/BisqAppModule.java
+++ b/gui/src/main/java/io/bisq/gui/app/BisqAppModule.java
@@ -52,7 +52,7 @@ import java.io.File;
 
 import static com.google.inject.name.Names.named;
 
-class BisqAppModule extends AppModule {
+public class BisqAppModule extends AppModule {
 
     private final Stage primaryStage;
 


### PR DESCRIPTION
The GUI startup executable of bisq-api reuses BisqAppModule, for this the class needs to be public.