### PR TITLE
ClassCastException in BtcAverageProvider

### DIFF
--- a/provider/src/main/java/io/bisq/provider/price/providers/BtcAverageProvider.java
+++ b/provider/src/main/java/io/bisq/provider/price/providers/BtcAverageProvider.java
@@ -69,7 +69,7 @@ public class BtcAverageProvider {
         long ts = Instant.now().getEpochSecond();
         treeMap.entrySet().stream().forEach(e -> {
             Object value = e.getValue();
-            // We need to check the type as we get an unexpected "timestamp" object at the end: 
+            // We need to check the type as we get an unexpected "timestamp" object at the end:
             if (value instanceof LinkedTreeMap) {
                 //noinspection unchecked
                 LinkedTreeMap<String, Object> data = (LinkedTreeMap) value;
@@ -77,10 +77,14 @@ public class BtcAverageProvider {
                 // We ignore venezuelan currency as the official exchange rate is wishful thinking only....
                 // We should use that api with a custom provider: http://api.bitcoinvenezuela.com/1
                 if (!("VEF".equals(currencyCode))) {
-                    marketPriceMap.put(currencyCode,
-                            new PriceData(currencyCode,
-                                    (double) data.get("last"),
-                                    ts));
+                    try {
+                        marketPriceMap.put(currencyCode,
+                                new PriceData(currencyCode,
+                                        (double) data.get("last"),
+                                        ts));
+                    } catch (Throwable exception) {
+                        log.error("Error converting btcaverage data: " + currencyCode, exception);
+                    }
                 }
             }
         });

--- a/provider/src/main/java/io/bisq/provider/price/providers/BtcAverageProvider.java
+++ b/provider/src/main/java/io/bisq/provider/price/providers/BtcAverageProvider.java
@@ -80,7 +80,7 @@ public class BtcAverageProvider {
                     try {
                         marketPriceMap.put(currencyCode,
                                 new PriceData(currencyCode,
-                                        (double) data.get("last"),
+                                        Double.valueOf((String) data.get("last")),
                                         ts));
                     } catch (Throwable exception) {
                         log.error("Error converting btcaverage data: " + currencyCode, exception);


### PR DESCRIPTION
Fix for the exception below, seen on a priceprovider node.
This should affect all priceprovider nodes (see errors.log on your node). 
Please check if my interpretation is correct before merging !

```
Exception in thread “main” java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Double
        at io.bisq.provider.price.providers.BtcAverageProvider.lambda$getMap$0(BtcAverageProvider.java:82)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580)
        at io.bisq.provider.price.providers.BtcAverageProvider.getMap(BtcAverageProvider.java:70)
        at io.bisq.provider.price.providers.BtcAverageProvider.getLocal(BtcAverageProvider.java:59)
        at io.bisq.provider.price.PriceRequestService.requestBtcAverageLocalPrices(PriceRequestService.java:176)
        at io.bisq.provider.price.PriceRequestService.startRequests(PriceRequestService.java:133)
        at io.bisq.provider.price.PriceRequestService.<init>(PriceRequestService.java:71)
        at io.bisq.provider.ProviderMain.handleGetAllMarketPrices(ProviderMain.java:65)
        at io.bisq.provider.ProviderMain.main(ProviderMain.java:56)
```