### PR TITLE
Update fee estimate URL from 21.co => earn.com

### DIFF
--- a/common/src/main/resources/i18n/displayStrings_de.properties
+++ b/common/src/main/resources/i18n/displayStrings_de.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq: Das dezentrale Handelsnetzwerk
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Bitte stellen Sie sicher, dass die Transaktionsgebühr Ihrer externen Wallet ausreichend hoch ist, damit die Finanzierungstransaktion von den Minern akzeptiert wird.\nAndernfalls kann die Handelstransaktion nicht bestätigt werden und der Handel würde in einem Konflikt enden.\n\nSie können die momentan empfohlenen Gebühren hier überprüfen: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Bitte stellen Sie sicher, dass die Transaktionsgebühr Ihrer externen Wallet ausreichend hoch ist, damit die Finanzierungstransaktion von den Minern akzeptiert wird.\nAndernfalls kann die Handelstransaktion nicht bestätigt werden und der Handel würde in einem Konflikt enden.\n\nSie können die momentan empfohlenen Gebühren hier überprüfen: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Handelskonten in Verzeichnis gespeichert:\n{0}
 guiUtil.accountExport.noAccountSetup=Sie haben kein Handelskonto zum Exportieren eingerichtet.
 guiUtil.accountExport.selectPath=Verzeichnis auswählen zum {0}

--- a/common/src/main/resources/i18n/displayStrings_el.properties
+++ b/common/src/main/resources/i18n/displayStrings_el.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq: Αποκεντρωμένο χρηματιστηριακ
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
 guiUtil.accountExport.noAccountSetup=Δεν έχεις λογαριασμούς έτοιμους για εξαγωγή.
 guiUtil.accountExport.selectPath=Επίλεξε φάκελο προς {0}

--- a/common/src/main/resources/i18n/displayStrings_es.properties
+++ b/common/src/main/resources/i18n/displayStrings_es.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq: La red de intercambio descentralizada
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
 guiUtil.accountExport.noAccountSetup=No tiene cuentas de intercambio configuradas para exportar.
 guiUtil.accountExport.selectPath=Seleccionar directorio a {0}

--- a/common/src/main/resources/i18n/displayStrings_hu.properties
+++ b/common/src/main/resources/i18n/displayStrings_hu.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq: A decentralizált cserehálózat
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
 guiUtil.accountExport.noAccountSetup=Nincsenek tranzakció fiókjai exportálásra beállítva.
 guiUtil.accountExport.selectPath=Útvonal kiválasztása {0}

--- a/common/src/main/resources/i18n/displayStrings_pt.properties
+++ b/common/src/main/resources/i18n/displayStrings_pt.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq: The decentralized exchange network
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
 guiUtil.accountExport.noAccountSetup=Você não tem contas de negociação prontas para exportar.
 guiUtil.accountExport.selectPath=Selecione diretório de {0}

--- a/common/src/main/resources/i18n/displayStrings_ro.properties
+++ b/common/src/main/resources/i18n/displayStrings_ro.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq: Rețeaua de schimb descentralizată
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
 guiUtil.accountExport.noAccountSetup=Nu ai conturi de tranzacționare configurate spre export.
 guiUtil.accountExport.selectPath=Selectează calea spre {0}

--- a/common/src/main/resources/i18n/displayStrings_ru.properties
+++ b/common/src/main/resources/i18n/displayStrings_ru.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq : децентрализованная обменная 
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
 guiUtil.accountExport.noAccountSetup=У вас нет торговых счетов для экспортирования.
 guiUtil.accountExport.selectPath=Выбрать путь к {0}

--- a/common/src/main/resources/i18n/displayStrings_sr.properties
+++ b/common/src/main/resources/i18n/displayStrings_sr.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq: Decentralizovana mreža razmene
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=Please be sure that the mining fee used at your external wallet is sufficiently high so that the funding transaction will be accepted by the miners.\nOtherwise the trade transactions cannot be confirmed and a trade would end up in a dispute.\n\nYou can check out the currently recommended fees at: https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
 guiUtil.accountExport.noAccountSetup=Nemate trgovinske naloge podešene za izvoz.
 guiUtil.accountExport.selectPath=Izaberi lokaciju {0}

--- a/common/src/main/resources/i18n/displayStrings_zh.properties
+++ b/common/src/main/resources/i18n/displayStrings_zh.properties
@@ -1169,7 +1169,7 @@ systemTray.tooltip=Bisq:去中心化交易网络
 # GUI Util
 ####################################################################
 
-guiUtil.miningFeeInfo=请确保您的外部钱包使用的矿工手续费费用足够高，以便矿工接受资金交易。\n否则交易所交易无法确认，交易最终将会出现纠纷\n\n您可以在以下网址查看目前推荐的费用： https://bitcoinfees.21.co
+guiUtil.miningFeeInfo=请确保您的外部钱包使用的矿工手续费费用足够高，以便矿工接受资金交易。\n否则交易所交易无法确认，交易最终将会出现纠纷\n\n您可以在以下网址查看目前推荐的费用： https://bitcoinfees.earn.com
 guiUtil.accountExport.savedToPath=交易账户保存在路径:\n{0}
 guiUtil.accountExport.noAccountSetup=您没有交易账户设置导出。
 guiUtil.accountExport.selectPath=选择路径{0}

--- a/gui/src/main/java/io/bisq/gui/main/settings/about/AboutView.java
+++ b/gui/src/main/java/io/bisq/gui/main/settings/about/AboutView.java
@@ -81,7 +81,7 @@ public class AboutView extends ActivatableViewAndModel<GridPane, Activatable> {
                 "Poloniex (https://poloniex.com)",
                 "Coinmarketcap (https://coinmarketcap.com)"));
         if (isBtc)
-            addLabelTextField(root, ++gridRow, Res.get("setting.about.feeEstimation.label"), "21 (https://bitcoinfees.21.co)");
+            addLabelTextField(root, ++gridRow, Res.get("setting.about.feeEstimation.label"), "21 (https://bitcoinfees.earn.com)");
 
         titledGroupBg = addTitledGroupBg(root, ++gridRow, 2, Res.get("setting.about.versionDetails"), Layout.GROUP_DISTANCE);
         GridPane.setColumnSpan(titledGroupBg, 2);

--- a/provider/src/main/java/io/bisq/provider/fee/providers/BtcFeesProvider.java
+++ b/provider/src/main/java/io/bisq/provider/fee/providers/BtcFeesProvider.java
@@ -22,14 +22,14 @@ public class BtcFeesProvider {
 
     // other: https://estimatefee.com/n/2
     public BtcFeesProvider() {
-        this.httpClient = new HttpClient("https://bitcoinfees.21.co/api/v1/fees/");
+        this.httpClient = new HttpClient("https://bitcoinfees.earn.com/api/v1/fees/");
     }
 
     public Long getFee() throws IOException {
-        // prev. used:  https://bitcoinfees.21.co/api/v1/fees/recommended
+        // prev. used:  https://bitcoinfees.earn.com/api/v1/fees/recommended
         // but was way too high
 
-        // https://bitcoinfees.21.co/api/v1/fees/list
+        // https://bitcoinfees.earn.com/api/v1/fees/list
         String response = httpClient.requestWithGET("list", "User-Agent", "");
         log.info("Get recommended fee response:  " + response);
 


### PR DESCRIPTION
Per the announcement quoted below at
https://news.earn.com/21-co-is-now-earn-com-3e37e50c444f, this change
updates all instances of the bitcoinfees.21.co to bitcoinfees.earn.com.

> Our Bitcoin Fees and Bitnodes services will now be canonically hosted
at bitcoinfees.earn.com and bitnodes.earn.com respectively. You can
still access them via bitcoinfees.21.co and bitnodes.21.co — though
there will be the slight overhead of a 301 redirect, so you should
update to the earn.com versions of the URLs for maximum performance.