### PR TITLE
Fix ever increasing height of arbitrator selection headline

### DIFF
--- a/gui/src/main/java/io/bisq/gui/components/TableGroupHeadline.java
+++ b/gui/src/main/java/io/bisq/gui/components/TableGroupHeadline.java
@@ -47,7 +47,6 @@ public class TableGroupHeadline extends Pane {
         Pane bg = new StackPane();
         bg.setId("table-group-headline");
         bg.prefWidthProperty().bind(widthProperty());
-        bg.prefHeightProperty().bind(heightProperty());
 
         label = new Label();
         label.textProperty().bind(text);


### PR DESCRIPTION
It seems a bit weird to bind to height and width. For the height it
causes an ever increasing pane height of the headline, at least for the
arbitrator selection.

Under account arbitrator selection, try clicking one of your languages and then click outside that list, the "Which arbitrators do you accept" label pane will grow a little every time. Not relying on the current height will avoid resizing the pane.