### PR TITLE
Add Bitcoin Cash, Bitcoin Gold and Bitcoin Clashic

### DIFF
--- a/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
+++ b/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
@@ -87,8 +87,12 @@ public class CurrencyUtil {
         final List<CryptoCurrency> result = new ArrayList<>();
 
         // result.add(new CryptoCurrency("BSQ", "Bisq Token"));
+
         if (!baseCurrencyCode.equals("BTC"))
             result.add(new CryptoCurrency("BTC", "Bitcoin"));
+        result.add(new CryptoCurrency("BCH", "Bitcoin Cash"));
+        result.add(new CryptoCurrency("BCHC", "Bitcoin Clashic"));
+        result.add(new CryptoCurrency("BTG", "Bitcoin Gold"));
         result.add(new CryptoCurrency("BURST", "Burstcoin"));
         result.add(new CryptoCurrency("GBYTE", "Byte"));
         result.add(new CryptoCurrency("XCP", "Counterparty"));

--- a/core/src/main/java/io/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/io/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -258,6 +258,9 @@ public class TradeStatisticsManager {
         newlyAdded.add("PART");
         // v0.6.1
         newlyAdded.add("MAD");
+        newlyAdded.add("BCH");
+        newlyAdded.add("BCHC");
+        newlyAdded.add("BTG");
 
         CurrencyUtil.getAllSortedCryptoCurrencies().stream()
                 .forEach(e -> allCryptoCurrencies.add(e.getNameAndCode()));

--- a/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
@@ -22,6 +22,7 @@ import io.bisq.common.locale.Res;
 import io.bisq.core.app.BisqEnvironment;
 import io.bisq.gui.util.validation.altcoins.*;
 import io.bisq.gui.util.validation.params.*;
+import io.bisq.gui.util.validation.params.btc.BTGParams;
 import io.bisq.gui.util.validation.params.btc.BtcMainNetParamsForValidation;
 import lombok.extern.slf4j.Slf4j;
 import org.bitcoinj.core.Address;
@@ -345,6 +346,27 @@ public final class AltCoinAddressValidator extends InputValidator {
                         return new ValidationResult(true);
                     else
                         return regexTestFailed;
+                case "BCH":
+                    try {
+                        Address.fromBase58(BtcMainNetParamsForValidation.get(), input);
+                        return new ValidationResult(true);
+                    } catch (AddressFormatException e) {
+                        return new ValidationResult(false, getErrorMessage(e));
+                    }
+                case "BCHC":
+                    try {
+                        Address.fromBase58(BtcMainNetParamsForValidation.get(), input);
+                        return new ValidationResult(true);
+                    } catch (AddressFormatException e) {
+                        return new ValidationResult(false, getErrorMessage(e));
+                    }
+                case "BTG":
+                    try {
+                        Address.fromBase58(BTGParams.get(), input);
+                        return new ValidationResult(true);
+                    } catch (AddressFormatException e) {
+                        return new ValidationResult(false, getErrorMessage(e));
+                    }
                     // Add new coins at the end...
                 default:
                     log.debug("Validation for AltCoinAddress not implemented yet. currencyCode: " + currencyCode);

--- a/gui/src/main/java/io/bisq/gui/util/validation/params/btc/BTGParams.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/params/btc/BTGParams.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013 Google Inc.
+ * Copyright 2015 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bisq.gui.util.validation.params.btc;
+
+import org.bitcoinj.core.Utils;
+
+public class BTGParams extends AbstractBitcoinNetParams {
+
+    public BTGParams() {
+        super();
+        interval = INTERVAL;
+        targetTimespan = TARGET_TIMESPAN;
+        maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
+        dumpedPrivateKeyHeader = 128;
+
+        // Address format is different to BTC, rest is the same
+        addressHeader = 38;
+        p2shHeader = 23;
+
+        acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+        port = 8333;
+        packetMagic = 0xf9beb4d9L;
+        bip32HeaderPub = 0x0488B21E; //The 4 byte header that serializes in base58 to "xpub".
+        bip32HeaderPriv = 0x0488ADE4; //The 4 byte header that serializes in base58 to "xprv"
+
+        id = ID_MAINNET;
+    }
+
+    private static BTGParams instance;
+
+    public static synchronized BTGParams get() {
+        if (instance == null) {
+            instance = new BTGParams();
+        }
+        return instance;
+    }
+
+    @Override
+    public String getPaymentProtocolId() {
+        return PAYMENT_PROTOCOL_ID_MAINNET;
+    }
+}

--- a/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
+++ b/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
@@ -367,4 +367,49 @@ public class AltCoinAddressValidatorTest {
         assertFalse(validator.validate("12KYrjTdVGjFMtaxERSk3gphreJ5US8aUP").isValid);
         assertFalse(validator.validate("").isValid);
     }
+
+    @Test
+    public void testBCH() {
+        AltCoinAddressValidator validator = new AltCoinAddressValidator();
+        validator.setCurrencyCode("BCH");
+
+        assertTrue(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH").isValid);
+        assertTrue(validator.validate("1MEbUJ5v5MdDEqFJGz4SZp58KkaLdmXZ85").isValid);
+        assertTrue(validator.validate("34dvotXMg5Gxc37TBVV2e5GUAfCFu7Ms4g").isValid);
+
+        assertFalse(validator.validate("21HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSHa").isValid);
+        assertFalse(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSHs").isValid);
+        assertFalse(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH#").isValid);
+        assertFalse(validator.validate("").isValid);
+    }
+
+    @Test
+    public void testBCHC() {
+        AltCoinAddressValidator validator = new AltCoinAddressValidator();
+        validator.setCurrencyCode("BCHC");
+
+        assertTrue(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH").isValid);
+        assertTrue(validator.validate("1MEbUJ5v5MdDEqFJGz4SZp58KkaLdmXZ85").isValid);
+        assertTrue(validator.validate("34dvotXMg5Gxc37TBVV2e5GUAfCFu7Ms4g").isValid);
+
+        assertFalse(validator.validate("21HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSHa").isValid);
+        assertFalse(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSHs").isValid);
+        assertFalse(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH#").isValid);
+        assertFalse(validator.validate("").isValid);
+    }
+
+    @Test
+    public void testBTG() {
+        AltCoinAddressValidator validator = new AltCoinAddressValidator();
+        validator.setCurrencyCode("BTG");
+
+        assertTrue(validator.validate("AehvQ57Fp168uY592LCUYBbyNEpiRAPufb").isValid);
+        assertTrue(validator.validate("GWaSW6PHfQKBv8EXV3xiqGG2zxKZh4XYNu").isValid);
+        assertTrue(validator.validate("GLpT8yG2kwPMdMfgwekG6tEAa91PSmN4ZC").isValid);
+
+        assertFalse(validator.validate("GVTPWDVJgLxo5ZYSPXPDxE4s7LE5cLRwCc1").isValid);
+        assertFalse(validator.validate("1GVTPWDVJgLxo5ZYSPXPDxE4s7LE5cLRwCc").isValid);
+        assertFalse(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH#").isValid);
+        assertFalse(validator.validate("").isValid);
+    }
 }


### PR DESCRIPTION
Adding missing 'airdrop' coins, so they can be transacted in a more privacy-preserving way on the Bisq exchange.