### PR TITLE
Only hide prompt text after user starts typing

### DIFF
--- a/gui/src/main/java/io/bisq/gui/bisq.css
+++ b/gui/src/main/java/io/bisq/gui/bisq.css
@@ -150,6 +150,10 @@ bg color of non edit textFields: fafafa
     -fx-text-fill: white;
 }
 
+.text-field {
+    -fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);
+}
+
 .text-field:readonly {
     -fx-text-fill: #000000;
     -fx-background-color: #FAFAFA;


### PR DESCRIPTION
This will display the prompt text also if the component receives focus to keep the prompt text visible to the user.