### PR TITLE
Added XSPEC altcoin

### DIFF
--- a/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
+++ b/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
@@ -141,6 +141,7 @@ public class CurrencyUtil {
 
         result.add(new CryptoCurrency("UNO", "Unobtanium"));
         result.add(new CryptoCurrency("WAC", "WACoins"));
+        result.add(new CryptoCurrency("XSPEC", "Spectrecoin"));
         result.add(new CryptoCurrency("XZC", "Zcoin"));
         result.add(new CryptoCurrency("ZEC", "Zcash"));
         result.add(new CryptoCurrency("ZEN", "ZenCash"));

--- a/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
@@ -367,6 +367,13 @@ public final class AltCoinAddressValidator extends InputValidator {
                     } catch (AddressFormatException e) {
                         return new ValidationResult(false, getErrorMessage(e));
                     }
+                case "XSPEC":
+                    try {
+                        Address.fromBase58(XspecParams.get(), input);
+                        return new ValidationResult(true);
+                    } catch (AddressFormatException e) {
+                        return new ValidationResult(false, getErrorMessage(e));
+                    }
                     // Add new coins at the end...
                 default:
                     log.debug("Validation for AltCoinAddress not implemented yet. currencyCode: " + currencyCode);

--- a/gui/src/main/java/io/bisq/gui/util/validation/params/XspecParams.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/params/XspecParams.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.bisq.gui.util.validation.params;
+
+import org.bitcoinj.core.*;
+import org.bitcoinj.store.BlockStore;
+import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.utils.MonetaryFormat;
+
+public class XspecParams extends NetworkParameters {
+
+    private static XspecParams instance;
+
+    public static synchronized XspecParams get() {
+        if (instance == null) {
+            instance = new XspecParams();
+        }
+        return instance;
+    }
+
+    // We only use the properties needed for address validation
+    public XspecParams() {
+        super();
+        addressHeader = 63;
+        p2shHeader = 136;
+        acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+    }
+
+    // default dummy implementations, not used...
+    @Override
+    public String getPaymentProtocolId() {
+        return PAYMENT_PROTOCOL_ID_MAINNET;
+    }
+
+    @Override
+    public void checkDifficultyTransitions(StoredBlock storedPrev, Block next, BlockStore blockStore) throws VerificationException, BlockStoreException {
+    }
+
+    @Override
+    public Coin getMaxMoney() {
+        return null;
+    }
+
+    @Override
+    public Coin getMinNonDustOutput() {
+        return null;
+    }
+
+    @Override
+    public MonetaryFormat getMonetaryFormat() {
+        return null;
+    }
+
+    @Override
+    public String getUriScheme() {
+        return null;
+    }
+
+    @Override
+    public boolean hasMaxMoney() {
+        return false;
+    }
+
+    @Override
+    public BitcoinSerializer getSerializer(boolean parseRetain) {
+        return null;
+    }
+
+    @Override
+    public int getProtocolVersionNum(ProtocolVersion version) {
+        return 0;
+    }
+}

--- a/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
+++ b/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
@@ -412,4 +412,20 @@ public class AltCoinAddressValidatorTest {
         assertFalse(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH#").isValid);
         assertFalse(validator.validate("").isValid);
     }
+
+    @Test
+    public void testXSPEC() {
+        AltCoinAddressValidator validator = new AltCoinAddressValidator();
+        validator.setCurrencyCode("XSPEC");
+
+        assertTrue(validator.validate("SUZRHjTLSCr581qLsGqMqBD5f3oW2JHckn").isValid);
+        assertTrue(validator.validate("SZ4S1oFfUa4a9s9Kg8bNRywucHiDZmcUuz").isValid);
+        assertTrue(validator.validate("SdyjGEmgroK2vxBhkHE1MBUVRbUWpRAdVG").isValid);
+
+        assertFalse(validator.validate("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq").isValid);
+        assertFalse(validator.validate("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO").isValid);
+        assertFalse(validator.validate("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#").isValid);
+        assertFalse(validator.validate("").isValid);
+    }
+
 }


### PR DESCRIPTION
Answers to questions from ["How to list a token"](https://github.com/bisq-network/docs/blob/master/exchange/howto/list-token.adoc):

- Ticker symbol (e.g. LTC): XSPEC
- Official token name (e.g. Litecoin): Spectrecoin
- Official block explorer URL: https://chainz.cryptoid.info/xspec/
- Is it an Altcoin (dedicated blockchain) or a token (anything else) (e.g. Altcoin): Altcoin
- Official token project URL: https://spectreproject.io/

Please let me know if you need anything else.