### PR TITLE
Add extra fields to /getAllMarketPrices json output (counts, origin)

### DIFF
--- a/provider/src/main/java/io/bisq/provider/price/PriceData.java
+++ b/provider/src/main/java/io/bisq/provider/price/PriceData.java
@@ -22,13 +22,13 @@ import lombok.Value;
 @SuppressWarnings("FieldCanBeLocal")
 @Value
 public class PriceData {
+    public static final String POLO_PROVIDER = "POLO";
+    public static final String COINMKTC_PROVIDER = "CMC";
+    public static final String BTCAVERAGE_LOCAL_PROVIDER = "BTCA_L";
+    public static final String BTCAVERAGE_GLOBAL_PROVIDER = "BTCA_G";
+
     private final String currencyCode;
     private final double price;
     private final long timestampSec;
-
-    public PriceData(String currencyCode, double price, long timestampSec) {
-        this.currencyCode = currencyCode;
-        this.price = price;
-        this.timestampSec = timestampSec;
-    }
+    private final String provider;
 }

--- a/provider/src/main/java/io/bisq/provider/price/PriceRequestService.java
+++ b/provider/src/main/java/io/bisq/provider/price/PriceRequestService.java
@@ -28,10 +28,7 @@ import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -63,6 +60,10 @@ public class PriceRequestService {
     private long btcAverageTs;
     private long poloniexTs;
     private long coinmarketcapTs;
+    private long btcAverageLCount;
+    private long btcAverageGCount;
+    private long poloniexCount;
+    private long coinmarketcapCount;
 
     private String json;
 
@@ -149,6 +150,7 @@ public class PriceRequestService {
                 .filter(e -> poloniexMap == null || !poloniexMap.containsKey(e.getKey()))
                 .forEach(e -> allPricesMap.put(e.getKey(), e.getValue()));
         coinmarketcapTs = Instant.now().getEpochSecond();
+        coinmarketcapCount = map.size();
 
         if (map.get("LTC") != null)
             log.info("Coinmarketcap LTC (last): " + map.get("LTC").getPrice());
@@ -164,6 +166,7 @@ public class PriceRequestService {
         removeOutdatedPrices(allPricesMap);
         allPricesMap.putAll(poloniexMap);
         poloniexTs = Instant.now().getEpochSecond();
+        poloniexCount = poloniexMap.size();
 
         if (poloniexMap.get("LTC") != null)
             log.info("Poloniex LTC (last): " + poloniexMap.get("LTC").getPrice());
@@ -182,6 +185,7 @@ public class PriceRequestService {
         removeOutdatedPrices(allPricesMap);
         allPricesMap.putAll(btcAverageLocalMap);
         btcAverageTs = Instant.now().getEpochSecond();
+        btcAverageLCount = btcAverageLocalMap.size();
         writeToJson();
     }
 
@@ -201,14 +205,19 @@ public class PriceRequestService {
                 .filter(e -> btcAverageLocalMap == null || !btcAverageLocalMap.containsKey(e.getKey()))
                 .forEach(e -> allPricesMap.put(e.getKey(), e.getValue()));
         btcAverageTs = Instant.now().getEpochSecond();
+        btcAverageGCount = map.size();
         writeToJson();
     }
 
     private void writeToJson() {
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("btcAverageTs", btcAverageTs);
         map.put("poloniexTs", poloniexTs);
         map.put("coinmarketcapTs", coinmarketcapTs);
+        map.put("btcAverageLCount", btcAverageLCount);
+        map.put("btcAverageGCount", btcAverageGCount);
+        map.put("poloniexCount", poloniexCount);
+        map.put("coinmarketcapCount", coinmarketcapCount);
         map.put("data", allPricesMap.values().toArray());
         json = Utilities.objectToJson(map);
     }

--- a/provider/src/main/java/io/bisq/provider/price/providers/BtcAverageProvider.java
+++ b/provider/src/main/java/io/bisq/provider/price/providers/BtcAverageProvider.java
@@ -56,14 +56,14 @@ public class BtcAverageProvider {
     }
 
     public Map<String, PriceData> getLocal() throws NoSuchAlgorithmException, InvalidKeyException, IOException {
-        return getMap(httpClient.requestWithGETNoProxy("indices/local/ticker/all?crypto=BTC", "X-signature", getHeader()));
+        return getMap(httpClient.requestWithGETNoProxy("indices/local/ticker/all?crypto=BTC", "X-signature", getHeader()), PriceData.BTCAVERAGE_LOCAL_PROVIDER);
     }
 
     public Map<String, PriceData> getGlobal() throws NoSuchAlgorithmException, InvalidKeyException, IOException {
-        return getMap(httpClient.requestWithGETNoProxy("indices/global/ticker/all?crypto=BTC", "X-signature", getHeader()));
+        return getMap(httpClient.requestWithGETNoProxy("indices/global/ticker/all?crypto=BTC", "X-signature", getHeader()), PriceData.BTCAVERAGE_GLOBAL_PROVIDER);
     }
 
-    private Map<String, PriceData> getMap(String json) {
+    private Map<String, PriceData> getMap(String json, String provider) {
         Map<String, PriceData> marketPriceMap = new HashMap<>();
         LinkedTreeMap<String, Object> treeMap = new Gson().<LinkedTreeMap<String, Object>>fromJson(json, LinkedTreeMap.class);
         long ts = Instant.now().getEpochSecond();
@@ -88,9 +88,7 @@ public class BtcAverageProvider {
                             log.warn("Unexpected data type: lastAsObject=" + lastAsObject);
 
                         marketPriceMap.put(currencyCode,
-                                new PriceData(currencyCode,
-                                        last,
-                                        ts));
+                                new PriceData(currencyCode, last, ts, provider));
                     } catch (Throwable exception) {
                         log.error("Error converting btcaverage data: " + currencyCode, exception);
                     }

--- a/provider/src/main/java/io/bisq/provider/price/providers/CoinmarketcapProvider.java
+++ b/provider/src/main/java/io/bisq/provider/price/providers/CoinmarketcapProvider.java
@@ -39,9 +39,7 @@ public class CoinmarketcapProvider {
             String code = (String) treeMap.get("symbol");
             if (supportedAltcoins.contains(code)) {
                 double price_btc = parseDouble((String) treeMap.get("price_btc"));
-                marketPriceMap.put(code, new PriceData(code,
-                        price_btc,
-                        ts));
+                marketPriceMap.put(code, new PriceData(code, price_btc, ts, PriceData.COINMKTC_PROVIDER));
             }
         });
         return marketPriceMap;

--- a/provider/src/main/java/io/bisq/provider/price/providers/PoloniexProvider.java
+++ b/provider/src/main/java/io/bisq/provider/price/providers/PoloniexProvider.java
@@ -53,7 +53,7 @@ public class PoloniexProvider {
                             marketPriceMap.put(altcoinCurrency,
                                     new PriceData(altcoinCurrency,
                                             parseDouble((String) data.get("last")),
-                                            ts)
+                                            ts, PriceData.POLO_PROVIDER)
                             );
                         }
                     }


### PR DESCRIPTION
Next time our price feeds fail, we will be able to easily track which one failed specifically. 
Having the counts will also enable us to monitor the counts and note any changes in the data feed.

This PR is linked do #1088 