### PR TITLE
Add BETR (Better Betting) token

### DIFF
--- a/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
+++ b/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
@@ -94,6 +94,7 @@ public class CurrencyUtil {
             result.add(new CryptoCurrency("BTC", "Bitcoin"));
         result.add(new CryptoCurrency("BCH", "Bitcoin Cash"));
         result.add(new CryptoCurrency("BCHC", "Bitcoin Clashic"));
+        result.add(new CryptoCurrency("BETR", "Better Betting", true));
         result.add(new CryptoCurrency("BTG", "Bitcoin Gold"));
         result.add(new CryptoCurrency("BURST", "Burstcoin"));
         result.add(new CryptoCurrency("GBYTE", "Byte"));

--- a/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
@@ -416,6 +416,12 @@ public final class AltCoinAddressValidator extends InputValidator {
                         return regexTestFailed;
                     else
                         return new ValidationResult(true);
+                case "BETR":
+                    // https://github.com/ethereum/web3.js/blob/master/lib/utils/utils.js#L403
+                    if (!input.matches("^(0x)?[0-9a-fA-F]{40}$"))
+                        return regexTestFailed;
+                    else
+                        return new ValidationResult(true);
 
                     // Add new coins at the end...
                 default:

--- a/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
+++ b/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
@@ -525,4 +525,18 @@ public class AltCoinAddressValidatorTest {
         assertFalse(validator.validate("XIN-FXFA-LR6Y-QZA-9V4SX").isValid);
         assertFalse(validator.validate("XIN-FXFA-LR6Y-QZAW-9V4S").isValid);
     }
+
+    @Test
+    public void testBETR() {
+        AltCoinAddressValidator validator = new AltCoinAddressValidator();
+        validator.setCurrencyCode("BETR");
+
+        assertTrue(validator.validate("0x2a65Aca4D5fC5B5C859090a6c34d164135398226").isValid);
+        assertTrue(validator.validate("2a65Aca4D5fC5B5C859090a6c34d164135398226").isValid);
+
+        assertFalse(validator.validate("0x2a65Aca4D5fC5B5C859090a6c34d1641353982266").isValid);
+        assertFalse(validator.validate("0x2a65Aca4D5fC5B5C859090a6c34d16413539822g").isValid);
+        assertFalse(validator.validate("2a65Aca4D5fC5B5C859090a6c34d16413539822g").isValid);
+        assertFalse(validator.validate("").isValid);
+    }
 }


### PR DESCRIPTION
- Ticker symbol (e.g. LTC): BETR
- Official token name (e.g. Litecoin): Better Betting
- Official block explorer URL: https://etherscan.io/token/0x763186eb8d4856d536ed4478302971214febc6a9
- Is it an Altcoin (dedicated blockchain) or a token (anything else) (e.g. Altcoin): token
- Official token project URL: https://betterbetting.org/
- The email I have with the organisation (I forgot to sign the commit with it, apologies): anton@betterbetting.org

Seemed to build without failure. Token also shows up in the built application as an available token to use.