### PR TITLE
Fix typos and English errors in banned node dialog

### DIFF
--- a/common/src/main/resources/i18n/displayStrings.properties
+++ b/common/src/main/resources/i18n/displayStrings.properties
@@ -1339,8 +1339,8 @@ popup.warning.offerWithoutAccountAgeWitness=Your offer with offer ID {0} was cre
   After first of February 2018 such offers are not valid anymore.\n\n\
   Please remove that offer and create a new one instead.
 popup.warning.offerWithoutAccountAgeWitness.confirm=Remove offer
-popup.warning.nodeBanned=One of the {0} nodes got banned. Please restart you application to be sure to not be connected to the banned node.
-popup.warning.priceRelay=price replay
+popup.warning.nodeBanned=One of the {0} nodes got banned. Please restart your application to be sure to not be connected to the banned node.
+popup.warning.priceRelay=price relay
 popup.warning.seed=seed
 
 popup.info.securityDepositInfo=To ensure that both traders follow the trade protocol they need to pay a security deposit.\n\nThe deposit will stay in your local trading wallet until the offer gets accepted by another trader.\nIt will be refunded to you after the trade has successfully completed.\n\nPlease note that you need to keep your application running if you have an open offer. When another trader wants to take your offer it requires that your application is online for executing the trade protocol.\nBe sure that you have standby mode deactivated as that would disconnect the network (standby of the monitor is not a problem).

--- a/common/src/main/resources/i18n/displayStrings_el.properties
+++ b/common/src/main/resources/i18n/displayStrings_el.properties
@@ -360,7 +360,7 @@ createOffer.warnCancelOffer=You have already funded that offer.\nIf you cancel n
 createOffer.fixed=Πάγιος
 createOffer.percentage=Ποσοστό
 createOffer.timeoutAtPublishing=Έληξε το χρονικό όριο για τη δημοσιοποίηση της προσφοράς.
-createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
+createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
 createOffer.tooLowSecDeposit.warning=You have set the security deposit to a lower value than the recommended default value of {0}.\nAre you sure you want to use a lower security deposit?
 createOffer.tooLowSecDeposit.makerIsSeller=Προσφέρει μικρότερη προστασία σε περίπτωση που ο έτερος συναλλασσόμενος δεν τηρήσει το πρωτόκολλο συναλλαγών.
 createOffer.tooLowSecDeposit.makerIsBuyer=Προσφέρει λιγότερη προστασία προς τον έτερο συναλλασσόμενο καθώς παρέχεις μικρότερο ποσό εγγύησης. Άλλοι χρήστες ίσως προτιμήσουν άλλες προσφορές αντί για τη δική σου.
@@ -416,10 +416,10 @@ takeOffer.failed.offererNotOnline=Το αίτημα ανάληψης προσφ�
 takeOffer.failed.offererOffline=Δεν μπορείς να αναλάβεις αυτή την προσφορά διότι ο maker είναι αποσυνδεδεμένος.
 takeOffer.warning.connectionToPeerLost=You lost connection to the maker.\nHe might have gone offline or has closed the connection to you because of too many open connections.\n\nIf you can still see his offer in the offerbook you can try to take the offer again.
 
-takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
-takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
 takeOffer.tac=With taking that offer I agree to the trade conditions as defined in that screen.
 
 takeOffer.currencyForFee=Προμήθεια Taker

--- a/common/src/main/resources/i18n/displayStrings_es.properties
+++ b/common/src/main/resources/i18n/displayStrings_es.properties
@@ -360,7 +360,7 @@ createOffer.warnCancelOffer=You have already funded that offer.\nIf you cancel n
 createOffer.fixed=Fijo
 createOffer.percentage=Porcentaje
 createOffer.timeoutAtPublishing=Error. Fuera de tiempo en la publicación de la oferta.
-createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
+createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
 createOffer.tooLowSecDeposit.warning=You have set the security deposit to a lower value than the recommended default value of {0}.\nAre you sure you want to use a lower security deposit?
 createOffer.tooLowSecDeposit.makerIsSeller=Le da menos protección en caso de que el par de intercambio no siga el protocolo de intercambio.
 createOffer.tooLowSecDeposit.makerIsBuyer=Da menos protección al par de intercambio. Tiene menos depósito en riesgo, con lo que se podría no seguir el protocolo. Otros usuarios podrían preferir tomar otras ofertas en vez de la suya.
@@ -416,10 +416,10 @@ takeOffer.failed.offererNotOnline=La solicitud de toma de oferta falló porque  
 takeOffer.failed.offererOffline=No puede tomar la oferta porque el tomador está offline.
 takeOffer.warning.connectionToPeerLost=You lost connection to the maker.\nHe might have gone offline or has closed the connection to you because of too many open connections.\n\nIf you can still see his offer in the offerbook you can try to take the offer again.
 
-takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
-takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
 takeOffer.tac=With taking that offer I agree to the trade conditions as defined in that screen.
 
 takeOffer.currencyForFee=Tasa de tomador

--- a/common/src/main/resources/i18n/displayStrings_hu.properties
+++ b/common/src/main/resources/i18n/displayStrings_hu.properties
@@ -360,7 +360,7 @@ createOffer.warnCancelOffer=You have already funded that offer.\nIf you cancel n
 createOffer.fixed=Rögzített
 createOffer.percentage=Százalék
 createOffer.timeoutAtPublishing=Az ajánlat közzétételére időtúllépés történt.
-createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
+createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
 createOffer.tooLowSecDeposit.warning=You have set the security deposit to a lower value than the recommended default value of {0}.\nAre you sure you want to use a lower security deposit?
 createOffer.tooLowSecDeposit.makerIsSeller=Kevesebb védelmet nyújt, ha a váltotárs nem követi a tranzakció protokollt.
 createOffer.tooLowSecDeposit.makerIsBuyer=Kevesebb védelmet biztosít a tranzakciós partnereknek, hogy követik a tranzakció protokollt, mivel kevésbé kockáztatott. Más felhasználók szívesebben vehetnek más ajánlatokat a tiéd helyett.
@@ -416,10 +416,10 @@ takeOffer.failed.offererNotOnline=Az ajánlatkérés sikertelen, mert az ajánl�
 takeOffer.failed.offererOffline=Nem fogadhatod el ezt az ajánlatot, mert az ajánló offline.
 takeOffer.warning.connectionToPeerLost=You lost connection to the maker.\nHe might have gone offline or has closed the connection to you because of too many open connections.\n\nIf you can still see his offer in the offerbook you can try to take the offer again.
 
-takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
-takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
 takeOffer.tac=With taking that offer I agree to the trade conditions as defined in that screen.
 
 takeOffer.currencyForFee=Vevő díj

--- a/common/src/main/resources/i18n/displayStrings_pt.properties
+++ b/common/src/main/resources/i18n/displayStrings_pt.properties
@@ -360,7 +360,7 @@ createOffer.warnCancelOffer=You have already funded that offer.\nIf you cancel n
 createOffer.fixed=Fixo
 createOffer.percentage=Porcentagem
 createOffer.timeoutAtPublishing=Um erro ocorreu ao publicar a oferta: tempo esgotado.
-createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
+createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
 createOffer.tooLowSecDeposit.warning=You have set the security deposit to a lower value than the recommended default value of {0}.\nAre you sure you want to use a lower security deposit?
 createOffer.tooLowSecDeposit.makerIsSeller=It gives you less protection in case the trading peer does not follow the trade protocol.
 createOffer.tooLowSecDeposit.makerIsBuyer=It gives less protection for the trading peer that you follow the trade protocol as you have less deposit at risk. Other users might prefer to take other offers instead of yours.
@@ -416,10 +416,10 @@ takeOffer.failed.offererNotOnline=Aceitação da oferta falhou pois o ofertador 
 takeOffer.failed.offererOffline=Não é possível aceitar a oferta pois o ofertador está offline.
 takeOffer.warning.connectionToPeerLost=You lost connection to the maker.\nHe might have gone offline or has closed the connection to you because of too many open connections.\n\nIf you can still see his offer in the offerbook you can try to take the offer again.
 
-takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
-takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
 takeOffer.tac=With taking that offer I agree to the trade conditions as defined in that screen.
 
 takeOffer.currencyForFee=Taker fee

--- a/common/src/main/resources/i18n/displayStrings_ro.properties
+++ b/common/src/main/resources/i18n/displayStrings_ro.properties
@@ -360,7 +360,7 @@ createOffer.warnCancelOffer=You have already funded that offer.\nIf you cancel n
 createOffer.fixed=Fix
 createOffer.percentage=Procentual
 createOffer.timeoutAtPublishing=Perioada de expirare a publicării ofertei a fost depășită.
-createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
+createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
 createOffer.tooLowSecDeposit.warning=You have set the security deposit to a lower value than the recommended default value of {0}.\nAre you sure you want to use a lower security deposit?
 createOffer.tooLowSecDeposit.makerIsSeller=Îți oferă mai puțină protecție în cazul în care partenerul de tranzacționare nu respectă protocolul comercial.
 createOffer.tooLowSecDeposit.makerIsBuyer=Oferă o protecție mai redusă partenerului de schimb pe care îl urmărești pe baza protocolului de tranzacționare, deoarece ai mai puține depozite periclitate. Alți utilizatori ar prefera să accepte alte oferte în locul celei tale.
@@ -416,10 +416,10 @@ takeOffer.failed.offererNotOnline=Solicitarea ofertei a eșuat, deoarece iniția
 takeOffer.failed.offererOffline=Nu poți accepta această ofertă deoarece inițiatorul nu mai este disponibil online.
 takeOffer.warning.connectionToPeerLost=You lost connection to the maker.\nHe might have gone offline or has closed the connection to you because of too many open connections.\n\nIf you can still see his offer in the offerbook you can try to take the offer again.
 
-takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
-takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
 takeOffer.tac=With taking that offer I agree to the trade conditions as defined in that screen.
 
 takeOffer.currencyForFee=Comision acceptant

--- a/common/src/main/resources/i18n/displayStrings_ru.properties
+++ b/common/src/main/resources/i18n/displayStrings_ru.properties
@@ -360,7 +360,7 @@ createOffer.warnCancelOffer=You have already funded that offer.\nIf you cancel n
 createOffer.fixed=Зафиксировано
 createOffer.percentage=Процентное соотношение
 createOffer.timeoutAtPublishing=При публикации предложения произошёл разрыв.
-createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
+createOffer.errorInfo=\n\nThe maker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
 createOffer.tooLowSecDeposit.warning=You have set the security deposit to a lower value than the recommended default value of {0}.\nAre you sure you want to use a lower security deposit?
 createOffer.tooLowSecDeposit.makerIsSeller=Это дает вам меньше защиты в случае, если торговый партнер не будет следовать торговому протоколу.
 createOffer.tooLowSecDeposit.makerIsBuyer=Это дает меньшую безопасность торгового партнера, чем у вас поскольку ваш счёт имеет меньшую сумму под угрозой. Другие пользователи могут предпочесть вместо вашего другие предложения.
@@ -416,10 +416,10 @@ takeOffer.failed.offererNotOnline=Ошибка в принятии предло�
 takeOffer.failed.offererOffline=Невозможно принять это предложение, так как участник не в сети.
 takeOffer.warning.connectionToPeerLost=You lost connection to the maker.\nHe might have gone offline or has closed the connection to you because of too many open connections.\n\nIf you can still see his offer in the offerbook you can try to take the offer again.
 
-takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.
-takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
-takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart you application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.feePaid=\n\nThe taker fee is already paid. In the worst case you have lost that fee. We are sorry about that but keep in mind it is a very small amount.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
+takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
 takeOffer.tac=With taking that offer I agree to the trade conditions as defined in that screen.
 
 takeOffer.currencyForFee=Плата за участие


### PR DESCRIPTION
This change fixes the errors seen in this dialog:

![image](https://user-images.githubusercontent.com/301810/35448390-74905752-02ba-11e8-8d18-6b109abb6542.png)