### PR TITLE
Add cleanup tor files button to tor network settings

### DIFF
--- a/common/src/main/resources/i18n/displayStrings.properties
+++ b/common/src/main/resources/i18n/displayStrings.properties
@@ -1250,8 +1250,8 @@ torNetworkSettingWindow.restartInfo=You need to restart to apply the changes
 torNetworkSettingWindow.openTorWebPage=Open Tor project web page
 torNetworkSettingWindow.deleteFiles.header=Connection problems?
 torNetworkSettingWindow.deleteFiles.info=If you have repeated connection problems at start up, deleting outdated Tor files might help. To do that click the button below and restart afterwards.
-torNetworkSettingWindow.deleteFiles.button=Deleting outdated Tor files and shut down
-torNetworkSettingWindow.deleteFiles.success=Deleting outdated Tor files wa successful. Please restart.
+torNetworkSettingWindow.deleteFiles.button=Delete outdated Tor files and shut down
+torNetworkSettingWindow.deleteFiles.success=Outdated Tor files deleted successfully. Please restart.
 torNetworkSettingWindow.bridges.header=Is Tor blocked?
 torNetworkSettingWindow.bridges.info=If Tor is blocked by your internet provider or in your country you can try to use Tor bridges.\n\
   Visit the Tor web page at: https://bridges.torproject.org/bridges to learn more about \

--- a/common/src/main/resources/i18n/displayStrings.properties
+++ b/common/src/main/resources/i18n/displayStrings.properties
@@ -811,7 +811,7 @@ settings.net.roundTripTimeColumn=Roundtrip
 settings.net.sentBytesColumn=Sent
 settings.net.receivedBytesColumn=Received
 settings.net.peerTypeColumn=Peer type
-settings.net.openTorSettingsButton=Open Tor network settings
+settings.net.openTorSettingsButton=Open Tor settings
 
 settings.net.needRestart=You need to restart the application to apply that change.\nDo you want to do that now?
 settings.net.notKnownYet=Not known yet...
@@ -1248,7 +1248,12 @@ torNetworkSettingWindow.enterBridge=Enter one or more bridge relays (one per lin
 torNetworkSettingWindow.enterBridgePrompt=type address:port
 torNetworkSettingWindow.restartInfo=You need to restart to apply the changes
 torNetworkSettingWindow.openTorWebPage=Open Tor project web page
-torNetworkSettingWindow.info=If Tor is blocked by your internet provider or in your country you can try to use Tor bridges.\n\
+torNetworkSettingWindow.deleteFiles.header=Connection problems?
+torNetworkSettingWindow.deleteFiles.info=If you have repeated connection problems at start up, deleting outdated Tor files might help. To do that click the button below and restart afterwards.
+torNetworkSettingWindow.deleteFiles.button=Deleting outdated Tor files and shut down
+torNetworkSettingWindow.deleteFiles.success=Deleting outdated Tor files wa successful. Please restart.
+torNetworkSettingWindow.bridges.header=Is Tor blocked?
+torNetworkSettingWindow.bridges.info=If Tor is blocked by your internet provider or in your country you can try to use Tor bridges.\n\
   Visit the Tor web page at: https://bridges.torproject.org/bridges to learn more about \
   bridges and pluggable transports.
 

--- a/common/src/main/resources/i18n/displayStrings_de.properties
+++ b/common/src/main/resources/i18n/displayStrings_de.properties
@@ -1101,7 +1101,7 @@ torNetworkSettingWindow.enterBridge="Bridge relays" angeben (zeilenweise):
 torNetworkSettingWindow.enterBridgePrompt=address:port eingeben
 torNetworkSettingWindow.restartInfo=Du musst neu starten, um Änderungen anzuwenden
 torNetworkSettingWindow.openTorWebPage=Tor Webseite öffnen
-torNetworkSettingWindow.info=Falls Tor von deinem Internetanbieter oder Land blockiert wird, kannst du es mit \
+torNetworkSettingWindow.bridges.info=Falls Tor von deinem Internetanbieter oder Land blockiert wird, kannst du es mit \
   "Tor Bridges" versuchen.\n\
   Besuche die Tor Webseite unter: https://bridges.torproject.org/bridges, um mehr über "Bridges" und \
   "Pluggable Transports" zu erfahren.

--- a/gui/src/main/java/io/bisq/gui/bisq.css
+++ b/gui/src/main/java/io/bisq/gui/bisq.css
@@ -1068,6 +1068,15 @@ textfield */
     -fx-effect: dropshadow(gaussian, #999, 10, 0, 0, 0);
 }
 
+#popup-grid-pane-bg {
+    -fx-font-size: 14;
+    -fx-text-fill: #333;
+    -fx-background-color: -bs-content-bg-grey;
+    -fx-background-radius: 10 10 10 10;
+    -fx-background-insets: 10;
+    -fx-effect: dropshadow(gaussian, #999, 10, 0, 0, 0);
+}
+
 #notification-popup-headline {
     -fx-font-size: 13;
     -fx-font-weight: bold;

--- a/gui/src/main/java/io/bisq/gui/main/MainView.java
+++ b/gui/src/main/java/io/bisq/gui/main/MainView.java
@@ -37,7 +37,6 @@ import io.bisq.gui.main.market.MarketView;
 import io.bisq.gui.main.offer.BuyOfferView;
 import io.bisq.gui.main.offer.SellOfferView;
 import io.bisq.gui.main.overlays.popups.Popup;
-import io.bisq.gui.main.overlays.windows.TorNetworkSettingsWindow;
 import io.bisq.gui.main.portfolio.PortfolioView;
 import io.bisq.gui.main.settings.SettingsView;
 import io.bisq.gui.util.BSFormatter;
@@ -100,12 +99,15 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
         transitions.removeEffect(MainView.rootContainer);
     }
 
-    private final ToggleGroup navButtons = new ToggleGroup();
+    private static Transitions transitions;
+    private static StackPane rootContainer;
+
 
     private final ViewLoader viewLoader;
     private final Navigation navigation;
-    private static Transitions transitions;
     private final BSFormatter formatter;
+
+    private final ToggleGroup navButtons = new ToggleGroup();
     private ChangeListener<String> walletServiceErrorMsgListener;
     private ChangeListener<String> btcSyncIconIdListener;
     private ChangeListener<String> splashP2PNetworkErrorMsgListener;
@@ -117,11 +119,13 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
     private Label btcSplashInfo;
     private List<String> persistedFilesCorrupted;
     private Popup<?> p2PNetworkWarnMsgPopup, btcNetworkWarnMsgPopup;
-    private static StackPane rootContainer;
 
     @SuppressWarnings("WeakerAccess")
     @Inject
-    public MainView(MainViewModel model, CachingViewLoader viewLoader, Navigation navigation, Transitions transitions,
+    public MainView(MainViewModel model,
+                    CachingViewLoader viewLoader,
+                    Navigation navigation,
+                    Transitions transitions,
                     BSFormatter formatter) {
         super(model);
         this.viewLoader = viewLoader;
@@ -478,7 +482,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
         showTorNetworkSettingsButton.setVisible(false);
         showTorNetworkSettingsButton.setManaged(false);
         showTorNetworkSettingsButton.setOnAction(e -> {
-            new TorNetworkSettingsWindow(model.preferences).show();
+            model.torNetworkSettingsWindow.show();
         });
 
         ImageView splashP2PNetworkIcon = new ImageView();

--- a/gui/src/main/java/io/bisq/gui/main/MainViewModel.java
+++ b/gui/src/main/java/io/bisq/gui/main/MainViewModel.java
@@ -144,6 +144,7 @@ public class MainViewModel implements ViewModel {
     private final FailedTradesManager failedTradesManager;
     private final ClosedTradableManager closedTradableManager;
     private final AccountAgeWitnessService accountAgeWitnessService;
+    final TorNetworkSettingsWindow torNetworkSettingsWindow;
     private final BSFormatter formatter;
 
     // BTC network
@@ -197,7 +198,6 @@ public class MainViewModel implements ViewModel {
     private MonadicBinding<String> marketPriceBinding;
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private Subscription priceFeedAllLoadedSubscription;
-    private TorNetworkSettingsWindow torNetworkSettingsWindow;
     private BooleanProperty p2pNetWorkReady;
     private final BooleanProperty walletInitialized = new SimpleBooleanProperty();
     private boolean allBasicServicesInitialized;
@@ -219,7 +219,7 @@ public class MainViewModel implements ViewModel {
                          DaoManager daoManager, EncryptionService encryptionService,
                          KeyRing keyRing, BisqEnvironment bisqEnvironment, FailedTradesManager failedTradesManager,
                          ClosedTradableManager closedTradableManager, AccountAgeWitnessService accountAgeWitnessService,
-                         BSFormatter formatter) {
+                         TorNetworkSettingsWindow torNetworkSettingsWindow, BSFormatter formatter) {
         this.walletsManager = walletsManager;
         this.walletsSetup = walletsSetup;
         this.btcWalletService = btcWalletService;
@@ -247,6 +247,7 @@ public class MainViewModel implements ViewModel {
         this.failedTradesManager = failedTradesManager;
         this.closedTradableManager = closedTradableManager;
         this.accountAgeWitnessService = accountAgeWitnessService;
+        this.torNetworkSettingsWindow = torNetworkSettingsWindow;
         this.formatter = formatter;
 
         TxIdTextField.setPreferences(preferences);
@@ -332,7 +333,6 @@ public class MainViewModel implements ViewModel {
 
     private void showTorNetworkSettingsWindow() {
         MainView.blur();
-        torNetworkSettingsWindow = new TorNetworkSettingsWindow(preferences).useShutDownButton();
         torNetworkSettingsWindow.show();
     }
 

--- a/gui/src/main/java/io/bisq/gui/main/overlays/Overlay.java
+++ b/gui/src/main/java/io/bisq/gui/main/overlays/Overlay.java
@@ -174,17 +174,19 @@ public abstract class Overlay<T extends Overlay> {
     }
 
     public void hide() {
-        animateHide(() -> {
-            removeEffectFromBackground();
+        if (gridPane != null) {
+            animateHide(() -> {
+                removeEffectFromBackground();
 
-            if (stage != null)
-                stage.hide();
-            else
-                log.warn("Stage is null");
+                if (stage != null)
+                    stage.hide();
+                else
+                    log.warn("Stage is null");
 
-            cleanup();
-            onHidden();
-        });
+                cleanup();
+                onHidden();
+            });
+        }
     }
 
     protected void onHidden() {

--- a/gui/src/main/java/io/bisq/gui/main/settings/network/NetworkSettingsView.java
+++ b/gui/src/main/java/io/bisq/gui/main/settings/network/NetworkSettingsView.java
@@ -90,6 +90,7 @@ public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activ
     private final BitcoinNodes bitcoinNodes;
     private final FilterManager filterManager;
     private final BisqEnvironment bisqEnvironment;
+    private final TorNetworkSettingsWindow torNetworkSettingsWindow;
     private final Clock clock;
     private final BSFormatter formatter;
     private final WalletsSetup walletsSetup;
@@ -109,8 +110,15 @@ public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activ
     private ChangeListener<Filter> filterPropertyListener;
 
     @Inject
-    public NetworkSettingsView(WalletsSetup walletsSetup, P2PService p2PService, Preferences preferences, BitcoinNodes bitcoinNodes,
-                               FilterManager filterManager, BisqEnvironment bisqEnvironment, Clock clock, BSFormatter formatter) {
+    public NetworkSettingsView(WalletsSetup walletsSetup,
+                               P2PService p2PService,
+                               Preferences preferences,
+                               BitcoinNodes bitcoinNodes,
+                               FilterManager filterManager,
+                               BisqEnvironment bisqEnvironment,
+                               TorNetworkSettingsWindow torNetworkSettingsWindow,
+                               Clock clock,
+                               BSFormatter formatter) {
         super();
         this.walletsSetup = walletsSetup;
         this.p2PService = p2PService;
@@ -118,6 +126,7 @@ public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activ
         this.bitcoinNodes = bitcoinNodes;
         this.filterManager = filterManager;
         this.bisqEnvironment = bisqEnvironment;
+        this.torNetworkSettingsWindow = torNetworkSettingsWindow;
         this.clock = clock;
         this.formatter = formatter;
     }
@@ -260,7 +269,7 @@ public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activ
         btcNodesInputTextField.textProperty().addListener(btcNodesInputTextFieldListener);
         btcNodesInputTextField.focusedProperty().addListener(btcNodesInputTextFieldFocusListener);
 
-        openTorSettingsButton.setOnAction(e -> new TorNetworkSettingsWindow(preferences).show());
+        openTorSettingsButton.setOnAction(e -> torNetworkSettingsWindow.show());
     }
 
     @Override


### PR DESCRIPTION
Update (by @cbeams):

This PR fixes #1300. The following is from @ManfredKarrer's original comment there:

> I observed an issue with one seed node and after deleting the whole tor directory in the app dir folder (except the hidden service folder!) it seems to have resolved the issue. I assume some files there get invalidated and cause issues.
> I will add a button in settings/network to do that deletion in a safe way (not deleting the hidden service folder) to give users an easy option to fix similar issues.
>

----

@ManfredKarrer's original text in this PR:

Could you also review the deleteDirectory method in FileUtils. We have to be sure to not delete the hidden service folder. As far I tested it it worked... 

```
   public static void deleteDirectory(File file, File exclude) throws IOException {
        boolean excludeFileFound = false;
        if (file.isDirectory()) {
            File[] files = file.listFiles();
            if (files != null)
                for (File f : files) {
                    if (!excludeFileFound)
                        excludeFileFound = f.equals(exclude);
                    if (!f.equals(exclude))
                        deleteDirectory(f);
                }
        }
        // Finally delete main file/dir if exclude file was not found in directory
        if (!excludeFileFound && !file.equals(exclude))
            deleteFileIfExists(file);
    }
```