### PR TITLE
bugfix/1315/connection-lock-problem

### DIFF
--- a/network/src/main/java/io/bisq/network/p2p/network/BisqRuntimeException.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/BisqRuntimeException.java
@@ -1,0 +1,7 @@
+package io.bisq.network.p2p.network;
+
+class BisqRuntimeException extends RuntimeException {
+    BisqRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/network/src/main/java/io/bisq/network/p2p/network/Connection.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/Connection.java
@@ -225,9 +225,6 @@ public class Connection implements MessageListener {
                     }
                 } catch (Throwable t) {
                     handleException(t);
-                } finally {
-                    if (protoOutputStreamLock.isLocked())
-                        protoOutputStreamLock.unlock();
                 }
             } else {
                 log.debug("We did not send the message because the peer does not support our required capabilities. message={}, peers supportedCapabilities={}", networkEnvelope, sharedModel.getSupportedCapabilities());

--- a/network/src/main/java/io/bisq/network/p2p/network/Connection.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/Connection.java
@@ -1,6 +1,5 @@
 package io.bisq.network.p2p.network;
 
-import com.google.common.util.concurrent.CycleDetectingLockFactory;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.bisq.common.UserThread;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.*;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -83,9 +81,6 @@ public class Connection implements MessageListener {
         return PERMITTED_MESSAGE_SIZE;
     }
 
-    private static final CycleDetectingLockFactory cycleDetectingLockFactory = CycleDetectingLockFactory.newInstance(CycleDetectingLockFactory.Policies.THROW);
-
-
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Class fields
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -96,14 +91,13 @@ public class Connection implements MessageListener {
     private final String portInfo;
     private final String uid;
     private final ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
-    private final ReentrantLock protoOutputStreamLock = cycleDetectingLockFactory.newReentrantLock("protoOutputStreamLock");
     // holder of state shared between InputHandler and Connection
     private final SharedModel sharedModel;
     private final Statistic statistic;
 
     // set in init
     private InputHandler inputHandler;
-    private OutputStream protoOutputStream;
+    private SynchronizedProtoOutputStream protoOutputStream;
 
     // mutable data, set from other threads but not changed internally.
     private Optional<NodeAddress> peersNodeAddressOptional = Optional.<NodeAddress>empty();
@@ -146,7 +140,7 @@ public class Connection implements MessageListener {
             // When you construct an ObjectInputStream, in the constructor the class attempts to read a header that
             // the associated ObjectOutputStream on the other end of the connection has written.
             // It will not return until that header has been read.
-            protoOutputStream = socket.getOutputStream();
+            protoOutputStream = new SynchronizedProtoOutputStream(socket.getOutputStream(), statistic);
             InputStream protoInputStream = socket.getInputStream();
             // We create a thread for handling inputStream data
             inputHandler = new InputHandler(sharedModel, protoInputStream, portInfo, this, networkProtoResolver);
@@ -227,16 +221,7 @@ public class Connection implements MessageListener {
                     }
 
                     if (!stopped) {
-                        protoOutputStreamLock.lock();
-                        proto.writeDelimitedTo(protoOutputStream);
-                        protoOutputStream.flush();
-
-                        statistic.addSentBytes(proto.getSerializedSize());
-                        statistic.addSentMessage(networkEnvelope);
-
-                        // We don't want to get the activity ts updated by ping/pong msg
-                        if (!(networkEnvelope instanceof KeepAliveMessage))
-                            statistic.updateLastActivityTimestamp();
+                        protoOutputStream.writeEnvelope(networkEnvelope);
                     }
                 } catch (Throwable t) {
                     handleException(t);
@@ -490,24 +475,7 @@ public class Connection implements MessageListener {
             log.error("Exception at shutdown. " + e.getMessage());
             e.printStackTrace();
         } finally {
-            try {
-                //TODO check why the exc. is thrown
-                /* We got those exceptions at seed nodes:
-                java.lang.IllegalMonitorStateException
-                at java.util.concurrent.locks.ReentrantLock$Sync.tryRelease(ReentrantLock.java:151)
-                at java.util.concurrent.locks.AbstractQueuedSynchronizer.release(AbstractQueuedSynchronizer.java:1261)
-                at java.util.concurrent.locks.ReentrantLock.unlock(ReentrantLock.java:457)
-                at com.google.common.util.concurrent.CycleDetectingLockFactory$CycleDetectingReentrantLock.unlock(CycleDetectingLockFactory.java:858)
-                at io.bisq.network.p2p.network.Connection.doShutDown(Connection.java:502)
-                 */
-                if (protoOutputStreamLock.isLocked())
-                    protoOutputStreamLock.unlock();
-            } catch (Throwable ignore) {
-            }
-            try {
-                protoOutputStream.close();
-            } catch (Throwable ignore) {
-            }
+            protoOutputStream.onConnectionShutdown();
             MoreExecutors.shutdownAndAwaitTermination(singleThreadExecutor, 500, TimeUnit.MILLISECONDS);
 
             log.debug("Connection shutdown complete " + this.toString());

--- a/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
@@ -1,0 +1,29 @@
+package io.bisq.network.p2p.network;
+
+import io.bisq.common.proto.network.NetworkEnvelope;
+import io.bisq.network.p2p.peers.keepalive.messages.KeepAliveMessage;
+
+import java.io.OutputStream;
+
+class ProtoOutputStream {
+    private final OutputStream deleage;
+    private final Statistic statistic;
+
+    ProtoOutputStream(OutputStream deleage, Statistic statistic) {
+        this.deleage = deleage;
+        this.statistic = statistic;
+    }
+
+    void writeEnvelope(NetworkEnvelope envelope) {
+        PB.NetworkEnvelope proto = envelope.toProtoNetworkEnvelope();
+        proto.writeDelimitedTo(deleage);
+        deleage.flush();
+
+        statistic.addSentBytes(proto.getSerializedSize());
+        statistic.addSentMessage(envelope);
+
+        if (!(envelope instanceof KeepAliveMessage)) {
+            statistic.updateLastActivityTimestamp();
+        }
+    }
+}

--- a/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
@@ -1,23 +1,40 @@
 package io.bisq.network.p2p.network;
 
 import io.bisq.common.proto.network.NetworkEnvelope;
+import io.bisq.generated.protobuffer.PB;
 import io.bisq.network.p2p.peers.keepalive.messages.KeepAliveMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
 import java.io.OutputStream;
 
+@NotThreadSafe
 class ProtoOutputStream {
-    private final OutputStream deleage;
+    private static final Logger log = LoggerFactory.getLogger(ProtoOutputStream.class);
+
+    private final OutputStream delegate;
     private final Statistic statistic;
 
-    ProtoOutputStream(OutputStream deleage, Statistic statistic) {
-        this.deleage = deleage;
+    ProtoOutputStream(OutputStream delegate, Statistic statistic) {
+        this.delegate = delegate;
         this.statistic = statistic;
     }
 
     void writeEnvelope(NetworkEnvelope envelope) {
+        try {
+            writeEnvelopeOrThrow(envelope);
+        } catch (IOException e) {
+            log.error("Failed to write envelope", e);
+            throw new BisqRuntimeException("Failed to write envelope", e);
+        }
+    }
+
+    private void writeEnvelopeOrThrow(NetworkEnvelope envelope) throws IOException {
         PB.NetworkEnvelope proto = envelope.toProtoNetworkEnvelope();
-        proto.writeDelimitedTo(deleage);
-        deleage.flush();
+        proto.writeDelimitedTo(delegate);
+        delegate.flush();
 
         statistic.addSentBytes(proto.getSerializedSize());
         statistic.addSentMessage(envelope);

--- a/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
@@ -31,6 +31,14 @@ class ProtoOutputStream {
         }
     }
 
+    void onConnectionShutdown() {
+        try {
+            delegate.close();
+        } catch (IOException e) {
+            log.error("Failed to close connection", e);
+        }
+    }
+
     private void writeEnvelopeOrThrow(NetworkEnvelope envelope) throws IOException {
         PB.NetworkEnvelope proto = envelope.toProtoNetworkEnvelope();
         proto.writeDelimitedTo(delegate);

--- a/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/ProtoOutputStream.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package io.bisq.network.p2p.network;
 
 import io.bisq.common.proto.network.NetworkEnvelope;
@@ -34,8 +51,8 @@ class ProtoOutputStream {
     void onConnectionShutdown() {
         try {
             delegate.close();
-        } catch (IOException e) {
-            log.error("Failed to close connection", e);
+        } catch (Throwable t) {
+            log.error("Failed to close connection", t);
         }
     }
 

--- a/network/src/main/java/io/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
@@ -1,14 +1,37 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package io.bisq.network.p2p.network;
 
 import io.bisq.common.proto.network.NetworkEnvelope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.OutputStream;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 @ThreadSafe
 class SynchronizedProtoOutputStream extends ProtoOutputStream {
+    private static final Logger log = LoggerFactory.getLogger(SynchronizedProtoOutputStream.class);
+
     private final ExecutorService executorService;
 
     SynchronizedProtoOutputStream(OutputStream delegate, Statistic statistic) {
@@ -18,11 +41,26 @@ class SynchronizedProtoOutputStream extends ProtoOutputStream {
 
     @Override
     void writeEnvelope(NetworkEnvelope envelope) {
-        executorService.submit(() -> super.writeEnvelope(envelope));
+        Future<?> future = executorService.submit(() -> super.writeEnvelope(envelope));
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            Thread currentThread = Thread.currentThread();
+            currentThread.interrupt();
+            log.error("Thread " + currentThread + " was interrupted", e);
+            throw new BisqRuntimeException("Failed to write envelope", e);
+        } catch (ExecutionException e) {
+            log.error("Failed to write envelope", e);
+            throw new BisqRuntimeException("Failed to write envelope", e);
+        }
     }
 
     void onConnectionShutdown() {
-        executorService.shutdownNow();
-        super.onConnectionShutdown();
+        try {
+            executorService.shutdownNow();
+            super.onConnectionShutdown();
+        } catch (Throwable t) {
+            log.error("Failed to handle connection shutdown", t);
+        }
     }
 }

--- a/network/src/main/java/io/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
@@ -1,0 +1,27 @@
+package io.bisq.network.p2p.network;
+
+import io.bisq.common.proto.network.NetworkEnvelope;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.OutputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@ThreadSafe
+class SynchronizedProtoOutputStream extends ProtoOutputStream {
+    private final ExecutorService executorService;
+
+    SynchronizedProtoOutputStream(OutputStream delegate, Statistic statistic) {
+        super(delegate, statistic);
+        this.executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    void writeEnvelope(NetworkEnvelope envelope) {
+        executorService.submit(() -> super.writeEnvelope(envelope));
+    }
+
+    void onConnectionShutdown() {
+        executorService.shutdownNow();
+    }
+}

--- a/network/src/main/java/io/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
+++ b/network/src/main/java/io/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
@@ -23,5 +23,6 @@ class SynchronizedProtoOutputStream extends ProtoOutputStream {
 
     void onConnectionShutdown() {
         executorService.shutdownNow();
+        super.onConnectionShutdown();
     }
 }


### PR DESCRIPTION
Hello!

Here is my implementation for #1315. I've moved all locking logic from `Connection` to `SynchronizedProtoOutputStream` class.

What is attempted to be achieved:
1. Only one thread can write into socket's `OutputStream` each time;
2. Only currently writing thread would finish message sending on connection's shutdown; other locked threads would be immediately unlocked, but wouldn't attempt to write anything.

I've used a single thread executor, so only one thread performs actions upon socket's `OutputStream`, all other writing threads would wait on `Future#get()` (to simulate synchronous execution)

I understand that i've modified a very sensitive code, so please, double check after me 😃 