### PR TITLE
Only show range when necessary

### DIFF
--- a/core/src/main/java/io/bisq/core/offer/Offer.java
+++ b/core/src/main/java/io/bisq/core/offer/Offer.java
@@ -270,6 +270,10 @@ public class Offer implements NetworkPayload, PersistablePayload {
         return Coin.valueOf(offerPayload.getMinAmount());
     }
 
+    public boolean isRange() {
+        return offerPayload.getAmount() != offerPayload.getMinAmount();
+    }
+
     public Date getDate() {
         return new Date(offerPayload.getDate());
     }

--- a/core/src/test/java/io/bisq/core/offer/OfferTest.java
+++ b/core/src/test/java/io/bisq/core/offer/OfferTest.java
@@ -1,0 +1,36 @@
+package io.bisq.core.offer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(OfferPayload.class)
+public class OfferTest {
+
+    @Test
+    public void testHasNoRange() {
+        OfferPayload payload = mock(OfferPayload.class);
+        when(payload.getMinAmount()).thenReturn(1000L);
+        when(payload.getAmount()).thenReturn(1000L);
+
+        Offer offer = new Offer(payload);
+        assertFalse(offer.isRange());
+    }
+
+    @Test
+    public void testHasRange() {
+        OfferPayload payload = mock(OfferPayload.class);
+        when(payload.getMinAmount()).thenReturn(1000L);
+        when(payload.getAmount()).thenReturn(2000L);
+
+        Offer offer = new Offer(payload);
+        assertTrue(offer.isRange());
+    }
+}

--- a/gui/src/main/java/io/bisq/gui/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/gui/src/main/java/io/bisq/gui/main/offer/takeoffer/TakeOfferViewModel.java
@@ -555,6 +555,8 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
         return dataModel.getOffer();
     }
 
+    public boolean isRange() {return dataModel.getOffer().isRange(); }
+
     public String getAmountRange() {
         return amountRange;
     }

--- a/gui/src/main/java/io/bisq/gui/util/BSFormatter.java
+++ b/gui/src/main/java/io/bisq/gui/util/BSFormatter.java
@@ -303,7 +303,16 @@ public class BSFormatter {
     }
 
     public String formatMinVolumeAndVolume(Offer offer) {
-        return formatVolume(offer.getMinVolume()) + " - " + formatVolume(offer.getVolume());
+        String volume = "";
+
+        if (offer.getMinVolume() != null) {
+            if (offer.getMinVolume().equals(offer.getVolume())) {
+                volume = formatVolume(offer.getVolume());
+            } else {
+                volume = formatVolume(offer.getMinVolume()) + " - " + formatVolume(offer.getVolume());
+            }
+        }
+        return volume;
     }
 
 
@@ -316,7 +325,16 @@ public class BSFormatter {
     }
 
     public String formatAmountWithMinAmount(Offer offer) {
-        return formatCoin(offer.getMinAmount()) + " - " + formatCoin(offer.getAmount());
+        String amount = "";
+
+        if (offer.getMinAmount() != null) {
+            if (offer.getMinAmount().equals(offer.getAmount())) {
+                amount = formatCoin(offer.getAmount());
+            } else {
+                amount = formatCoin(offer.getMinAmount()) + " - " + formatCoin(offer.getAmount());
+            }
+        }
+        return amount;
     }
 
 

--- a/gui/src/main/java/io/bisq/gui/util/BSFormatter.java
+++ b/gui/src/main/java/io/bisq/gui/util/BSFormatter.java
@@ -303,16 +303,7 @@ public class BSFormatter {
     }
 
     public String formatMinVolumeAndVolume(Offer offer) {
-        String volume = "";
-
-        if (offer.getMinVolume() != null) {
-            if (offer.getMinVolume().equals(offer.getVolume())) {
-                volume = formatVolume(offer.getVolume());
-            } else {
-                volume = formatVolume(offer.getMinVolume()) + " - " + formatVolume(offer.getVolume());
-            }
-        }
-        return volume;
+        return offer.isRange() ? formatVolume(offer.getMinVolume()) + " - " + formatVolume(offer.getVolume()) : formatVolume(offer.getVolume());
     }
 
 
@@ -325,16 +316,7 @@ public class BSFormatter {
     }
 
     public String formatAmountWithMinAmount(Offer offer) {
-        String amount = "";
-
-        if (offer.getMinAmount() != null) {
-            if (offer.getMinAmount().equals(offer.getAmount())) {
-                amount = formatCoin(offer.getAmount());
-            } else {
-                amount = formatCoin(offer.getMinAmount()) + " - " + formatCoin(offer.getAmount());
-            }
-        }
-        return amount;
+        return offer.isRange() ? formatCoin(offer.getMinAmount()) + " - " + formatCoin(offer.getAmount()) : formatCoin(offer.getAmount());
     }
 
 

--- a/gui/src/test/java/io/bisq/gui/util/BSFormatterTest.java
+++ b/gui/src/test/java/io/bisq/gui/util/BSFormatterTest.java
@@ -20,6 +20,7 @@ package io.bisq.gui.util;
 import io.bisq.common.locale.Res;
 import io.bisq.common.monetary.Volume;
 import io.bisq.core.offer.Offer;
+import io.bisq.core.offer.OfferPayload;
 import org.bitcoinj.core.Coin;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Offer.class)
+@PrepareForTest({Offer.class,OfferPayload.class})
 public class BSFormatterTest {
 
     private BSFormatter formatter;
@@ -93,6 +94,7 @@ public class BSFormatterTest {
         Offer offer = mock(Offer.class);
         Volume btcMin = Volume.parse("0.10", "BTC");
         Volume btcMax = Volume.parse("0.25", "BTC");
+        when(offer.isRange()).thenReturn(true);
         when(offer.getMinVolume()).thenReturn(btcMin);
         when(offer.getVolume()).thenReturn(btcMax);
 
@@ -119,9 +121,10 @@ public class BSFormatterTest {
 
     @Test
     public void testFormatDifferentAmount() {
-        Offer offer = mock(Offer.class);
-        when(offer.getMinAmount()).thenReturn(Coin.valueOf(10000000));
-        when(offer.getAmount()).thenReturn(Coin.valueOf(20000000));
+        OfferPayload offerPayload = mock(OfferPayload.class);
+        Offer offer = new Offer(offerPayload);
+        when(offerPayload.getMinAmount()).thenReturn(10000000L);
+        when(offerPayload.getAmount()).thenReturn(20000000L);
 
         assertEquals("0.10 - 0.20", formatter.formatAmountWithMinAmount(offer));
     }

--- a/gui/src/test/java/io/bisq/gui/util/BSFormatterTest.java
+++ b/gui/src/test/java/io/bisq/gui/util/BSFormatterTest.java
@@ -18,21 +18,31 @@
 package io.bisq.gui.util;
 
 import io.bisq.common.locale.Res;
+import io.bisq.common.monetary.Volume;
+import io.bisq.core.offer.Offer;
+import org.bitcoinj.core.Coin;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Offer.class)
 public class BSFormatterTest {
 
     private BSFormatter formatter;
 
     @Before
-    public void setup() {
+    public void setUp() {
         Locale.setDefault(new Locale("en", "US"));
         formatter = new BSFormatter();
         Res.setBaseCurrencyCode("BTC");
@@ -66,5 +76,62 @@ public class BSFormatterTest {
         assertEquals("1 hour, 0 minutes, 2 seconds", formatter.formatDurationAsWords(oneHour + oneSecond * 2, true));
         assertEquals("", formatter.formatDurationAsWords(0));
         assertTrue(formatter.formatDurationAsWords(0).isEmpty());
+    }
+
+    @Test
+    public void testFormatSameVolume() {
+        Offer offer = mock(Offer.class);
+        Volume btc = Volume.parse("0.10", "BTC");
+        when(offer.getMinVolume()).thenReturn(btc);
+        when(offer.getVolume()).thenReturn(btc);
+
+        assertEquals("0.10000000", formatter.formatMinVolumeAndVolume(offer));
+    }
+
+    @Test
+    public void testFormatDifferentVolume() {
+        Offer offer = mock(Offer.class);
+        Volume btcMin = Volume.parse("0.10", "BTC");
+        Volume btcMax = Volume.parse("0.25", "BTC");
+        when(offer.getMinVolume()).thenReturn(btcMin);
+        when(offer.getVolume()).thenReturn(btcMax);
+
+        assertEquals("0.10000000 - 0.25000000", formatter.formatMinVolumeAndVolume(offer));
+    }
+
+    @Test
+    public void testFormatNullVolume() {
+        Offer offer = mock(Offer.class);
+        when(offer.getMinVolume()).thenReturn(null);
+        when(offer.getVolume()).thenReturn(null);
+
+        assertEquals("", formatter.formatMinVolumeAndVolume(offer));
+    }
+
+    @Test
+    public void testFormatSameAmount() {
+        Offer offer = mock(Offer.class);
+        when(offer.getMinAmount()).thenReturn(Coin.valueOf(10000000));
+        when(offer.getAmount()).thenReturn(Coin.valueOf(10000000));
+
+        assertEquals("0.10", formatter.formatAmountWithMinAmount(offer));
+    }
+
+    @Test
+    public void testFormatDifferentAmount() {
+        Offer offer = mock(Offer.class);
+        when(offer.getMinAmount()).thenReturn(Coin.valueOf(10000000));
+        when(offer.getAmount()).thenReturn(Coin.valueOf(20000000));
+
+        assertEquals("0.10 - 0.20", formatter.formatAmountWithMinAmount(offer));
+    }
+
+    @Test
+    public void testFormatNullAmount() {
+        Offer offer = mock(Offer.class);
+        when(offer.getMinAmount()).thenReturn(null);
+        when(offer.getAmount()).thenReturn(null);
+
+        assertEquals("", formatter.formatAmountWithMinAmount(offer));
     }
 }


### PR DESCRIPTION
This will fix https://github.com/bisq-network/exchange/issues/1215.
It only shows an range (amount, volume), if there is one and only will allow the user select an amount (take offer) if there is one to select from. In the case of take offer, it will directly jump to the fund offer step if no amount needs to be selected