### PR TITLE
Not possible to select `English` anymore, if system locale is non-English

### DIFF
--- a/common/src/main/java/io/bisq/common/locale/Res.java
+++ b/common/src/main/java/io/bisq/common/locale/Res.java
@@ -43,6 +43,8 @@ public class Res {
 
     static {
         GlobalSettings.localeProperty().addListener((observable, oldValue, newValue) -> {
+            if ("en".equalsIgnoreCase(newValue.getLanguage()))
+                newValue = Locale.ROOT;
             resourceBundle = ResourceBundle.getBundle("i18n.displayStrings", newValue, new UTF8Control());
         });
     }


### PR DESCRIPTION
Fixes #1357 