### PR TITLE
Rename Bicoin Clashic ticker symbol from BCHC to BCL

### DIFF
--- a/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
+++ b/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
@@ -94,7 +94,7 @@ public class CurrencyUtil {
         if (!baseCurrencyCode.equals("BTC"))
             result.add(new CryptoCurrency("BTC", "Bitcoin"));
         result.add(new CryptoCurrency("BCH", "Bitcoin Cash"));
-        result.add(new CryptoCurrency("BCHC", "Bitcoin Clashic"));
+        result.add(new CryptoCurrency("BCL", "Bitcoin Clashic"));
         result.add(new CryptoCurrency("BTG", "Bitcoin Gold"));
         result.add(new CryptoCurrency("DARX", "BitDaric"));
         result.add(new CryptoCurrency("BURST", "Burstcoin"));

--- a/core/src/main/java/io/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/io/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -235,7 +235,7 @@ public class TradeStatisticsManager {
         // v0.6.1
         newlyAdded.add("MAD");
         newlyAdded.add("BCH");
-        newlyAdded.add("BCHC");
+        newlyAdded.add("BCL");
         newlyAdded.add("BTG");
         // v0.6.2
         newlyAdded.add("CAGE");

--- a/gui/src/main/java/io/bisq/gui/main/account/content/altcoinaccounts/AltCoinAccountsView.java
+++ b/gui/src/main/java/io/bisq/gui/main/account/content/altcoinaccounts/AltCoinAccountsView.java
@@ -149,7 +149,7 @@ public class AltCoinAccountsView extends ActivatableViewAndModel<GridPane, AltCo
                             .show();
                     break;
                 case "BCH":
-                case "BCHC":
+                case "BCL":
                     new Popup<>().information(Res.get("account.altcoin.popup.bch"))
                             .useIUnderstandButton()
                             .show();

--- a/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
@@ -353,7 +353,7 @@ public final class AltCoinAddressValidator extends InputValidator {
                     } catch (AddressFormatException e) {
                         return new ValidationResult(false, getErrorMessage(e));
                     }
-                case "BCHC":
+                case "BCL":
                     try {
                         Address.fromBase58(BtcMainNetParamsForValidation.get(), input);
                         return new ValidationResult(true);

--- a/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
+++ b/gui/src/test/java/io/bisq/gui/util/validation/AltCoinAddressValidatorTest.java
@@ -383,9 +383,9 @@ public class AltCoinAddressValidatorTest {
     }
 
     @Test
-    public void testBCHC() {
+    public void testBCL() {
         AltCoinAddressValidator validator = new AltCoinAddressValidator();
-        validator.setCurrencyCode("BCHC");
+        validator.setCurrencyCode("BCL");
 
         assertTrue(validator.validate("1HQQgsvLTgN9xD9hNmAgAreakzVzQUSLSH").isValid);
         assertTrue(validator.validate("1MEbUJ5v5MdDEqFJGz4SZp58KkaLdmXZ85").isValid);


### PR DESCRIPTION
From https://twitter.com/bisq_network/status/963508497328549889:

![image](https://user-images.githubusercontent.com/301810/36430239-f775b9d4-1654-11e8-9dcc-3ee59b27f575.png)

@ManfredKarrer, please note that this PR does *not* update `network/src/main/resources/PersistableNetworkPayloadMap_BTC_MAINNET`, which I believe you usually do when making these kinds of changes. I'm not sure what process you follow there, please update it as you see fit, and perhaps provide details about how and when that resource should be updated in the future. I only considered changing it because it matched a `git grep BCHC` search of the codebase.

Another caveat is that I don't know what effect this change will have on calculating the market price of BCL. We don't get Bitcoin Clashic exchange rate data from any of our providers, so we're displaying market price based on the last Bisq trade. I imagine that we'll revert to a state where there is no last price information, since there will (after this change) be no last BCL trade to base it on. Again, any details you can provide here would be appreciated.