### PR TITLE
Dockerize seednode for development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ desktop.ini
 */target/*
 *.class
 /gui/deploy/*
+/seednode/hostname
+/seednode/private_key

--- a/seednode/.dockerignore
+++ b/seednode/.dockerignore
@@ -1,0 +1,9 @@
+.dockerignore
+docker-compose.yml
+docker-compose.prod.yml
+Dockerfile
+
+.idea
+*.iml
+
+target

--- a/seednode/Dockerfile
+++ b/seednode/Dockerfile
@@ -1,12 +1,11 @@
 ###
+# WARNING!!! THIS IMAGE IS FOR  D E V E L O P M E N T  USE ONLY!
+#
 # The directory of the Dockerfile should contain your 'hostname' and 'private_key' files.
-# In the docker-compose.yml file you can pass the ONION_ADDRESS referenced below.
 ###
 
 # pull base image
 FROM openjdk:8-jdk
-
-ARG ONION_ADDRESS
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     maven \
@@ -14,13 +13,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fakeroot \
     openjfx && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/bisq-network/exchange.git
 WORKDIR /exchange/
-RUN mvn clean install
-RUN mkdir -p /root/.local/share/seed_BTC_MAINNET_${ONION_ADDRESS}/btc_mainnet/tor/hiddenservice
+CMD ./docker/startSeedNode.sh
 
-COPY hostname private_key /root/.local/share/seed_BTC_MAINNET_${ONION_ADDRESS}/btc_mainnet/tor/hiddenservice/
+ENV ONION_ADDRESS=
+ENV MAX_CONNECTIONS=30
+ENV BASE_CURRENCY_NETWORK=BTC_REGTEST
+ENV NODE_PORT=8000
+ENV APP_NAME=seednode
+ENV USE_LOCALHOST_FOR_P2P=
 
-CMD java -Xms1800m -Xmx1800m -jar ./seednode/target/SeedNode.jar --maxConnections=30 --baseCurrencyNetwork=BTC_MAINNET --nodePort=8000 \
-    --myAddress=${ONION_ADDRESS}.onion:8000 --appName=seed_BTC_MAINNET_${ONION_ADDRESS} \
-    2>error_seed_BTC_MAINNET_${ONION_ADDRESS}.log
+COPY ./ ./

--- a/seednode/docker-compose.prod.yml
+++ b/seednode/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+# Fill in your own ONION addres, without the .onion suffix
+
+services:
+    seednode:
+        build:
+            context: .
+            dockerfile: docker/prod/Dockerfile
+            args:
+            - ONION_ADDRESS=123xxxxxxxxxx
+        image: bisq:seednode
+        ports:
+            - 8000:8000
+        environment:
+            - ONION_ADDRESS=123xxxxxxxxxx

--- a/seednode/docker-compose.yml
+++ b/seednode/docker-compose.yml
@@ -1,15 +1,20 @@
-version: '3'
-
-# Fill in your own ONION addres, without the .onion suffix
+version: '2.1'
 
 services:
     seednode:
         build:
             context: .
-            args:
-            - ONION_ADDRESS=123xxxxxxxxxx
-        image: bisq:seednode
+            dockerfile: Dockerfile
+        image: bisq-seednode
         ports:
             - 8000:8000
         environment:
-            - ONION_ADDRESS=123xxxxxxxxxx
+            - SEED_NODES=seednode:8000
+            - MY_ADDRESS=seednode:8000
+            - USE_LOCALHOST_FOR_P2P=true
+        volumes:
+          - m2:/root/.m2
+
+volumes:
+  m2:
+    name: m2

--- a/seednode/docker/prod/Dockerfile
+++ b/seednode/docker/prod/Dockerfile
@@ -1,0 +1,26 @@
+###
+# The directory of the Dockerfile should contain your 'hostname' and 'private_key' files.
+# In the docker-compose.yml file you can pass the ONION_ADDRESS referenced below.
+###
+
+# pull base image
+FROM openjdk:8-jdk
+
+ARG ONION_ADDRESS
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    maven \
+    vim \
+    fakeroot \
+    openjfx && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/bisq-network/exchange.git
+WORKDIR /exchange/
+RUN mvn clean install
+RUN mkdir -p /root/.local/share/seed_BTC_MAINNET_${ONION_ADDRESS}/btc_mainnet/tor/hiddenservice
+
+COPY hostname private_key /root/.local/share/seed_BTC_MAINNET_${ONION_ADDRESS}/btc_mainnet/tor/hiddenservice/
+
+CMD java -Xms1800m -Xmx1800m -jar ./seednode/target/SeedNode.jar --maxConnections=30 --baseCurrencyNetwork=BTC_MAINNET --nodePort=8000 \
+    --myAddress=${ONION_ADDRESS}.onion:8000 --appName=seed_BTC_MAINNET_${ONION_ADDRESS} \
+    2>error_seed_BTC_MAINNET_${ONION_ADDRESS}.log

--- a/seednode/docker/setup.sh
+++ b/seednode/docker/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+mvn install -DskipTests

--- a/seednode/docker/startSeedNode.sh
+++ b/seednode/docker/startSeedNode.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SETUP_SCRIPT=$SCRIPT_DIR/setup.sh
+source $SETUP_SCRIPT
+
+ARGS="--maxConnections=$MAX_CONNECTIONS --baseCurrencyNetwork=$BASE_CURRENCY_NETWORK --nodePort=$NODE_PORT --appName=$APP_NAME"
+
+if [ ! -z "$SEED_NODES" ]; then
+    ARGS="$ARGS --seedNodes=$SEED_NODES"
+fi
+if [ ! -z "$BTC_NODES" ]; then
+    ARGS="$ARGS --btcNodes=$BTC_NODES"
+fi
+if [ ! -z "$USE_LOCALHOST_FOR_P2P" ]; then
+    ARGS="$ARGS --useLocalhostForP2P=$USE_LOCALHOST_FOR_P2P"
+fi
+if [ ! -z "$MY_ADDRESS" ]; then
+    ARGS="$ARGS --myAddress=${MY_ADDRESS}"
+elif [ ! -z "$ONION_ADDRESS" ]; then
+    ARGS="$ARGS --myAddress=${ONION_ADDRESS}.onion:$NODE_PORT"
+fi
+
+echo java -Xms1800m -Xmx1800m -jar ./target/SeedNode.jar $ARGS
+java -Xms1800m -Xmx1800m -jar ./target/SeedNode.jar $ARGS
+
+#TODO validate mandatory params


### PR DESCRIPTION
This introduces docker container for developers. It is required to run integration tests for bisq-api using Arquillian Cube. 