### PR TITLE
Sync minAmount with amount until minAmount is set

### DIFF
--- a/gui/src/main/java/io/bisq/gui/main/offer/createoffer/CreateOfferViewModel.java
+++ b/gui/src/main/java/io/bisq/gui/main/offer/createoffer/CreateOfferViewModel.java
@@ -146,6 +146,7 @@ class CreateOfferViewModel extends ActivatableWithDataModel<CreateOfferDataModel
     private MarketPrice marketPrice;
     final IntegerProperty marketPriceAvailableProperty = new SimpleIntegerProperty(-1);
     private ChangeListener<Number> currenciesUpdateListener;
+    private boolean syncMinAmountWithAmount = true;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -669,6 +670,7 @@ class CreateOfferViewModel extends ActivatableWithDataModel<CreateOfferDataModel
             InputValidator.ValidationResult result = isBtcInputValid(minAmount.get());
             minAmountValidationResult.set(result);
             if (result.isValid) {
+                syncMinAmountWithAmount = dataModel.getMinAmount().getValue().equals(dataModel.getAmount().getValue());
                 setMinAmountToModel();
                 minAmount.set(btcFormatter.formatCoin(dataModel.getMinAmount().get()));
 
@@ -679,6 +681,8 @@ class CreateOfferViewModel extends ActivatableWithDataModel<CreateOfferDataModel
                     if (amount.get() != null)
                         amountValidationResult.set(isBtcInputValid(amount.get()));
                 }
+            } else {
+                syncMinAmountWithAmount = true;
             }
         }
     }
@@ -918,7 +922,7 @@ class CreateOfferViewModel extends ActivatableWithDataModel<CreateOfferDataModel
     private void setAmountToModel() {
         if (amount.get() != null && !amount.get().isEmpty()) {
             dataModel.setAmount(btcFormatter.parseToCoinWith4Decimals(amount.get()));
-            if (dataModel.getMinAmount().get() == null || dataModel.getMinAmount().get().equals(Coin.ZERO)) {
+            if (syncMinAmountWithAmount || dataModel.getMinAmount().get() == null || dataModel.getMinAmount().get().equals(Coin.ZERO)) {
                 minAmount.set(amount.get());
                 setMinAmountToModel();
             }

--- a/gui/src/test/java/io/bisq/gui/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/gui/src/test/java/io/bisq/gui/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -39,16 +39,15 @@ import static org.mockito.Mockito.when;
 @PrepareForTest({BtcWalletService .class, AddressEntry.class, PriceFeedService.class, User.class, FeeService.class, CreateOfferDataModel.class, PaymentAccount.class, BsqWalletService.class})
 public class CreateOfferViewModelTest {
 
+    private CreateOfferViewModel model;
+
     @Before
     public void setUp() {
         final CryptoCurrency btc = new CryptoCurrency("BTC", "bitcoin");
         GlobalSettings.setDefaultTradeCurrency(btc);
         Res.setBaseCurrencyCode(btc.getCode());
         Res.setBaseCurrencyName(btc.getName());
-    }
 
-    @Test
-    public void testSyncMinAmountWithAmountUntilChanged() {
         final BSFormatter bsFormatter = new BSFormatter();
         final BtcValidator btcValidator = new BtcValidator(bsFormatter);
         final AltcoinValidator altcoinValidator = new AltcoinValidator();
@@ -73,8 +72,12 @@ public class CreateOfferViewModelTest {
         dataModel.initWithData(OfferPayload.Direction.BUY, new CryptoCurrency("BTC", "bitcoin"));
         dataModel.activate();
 
-        final CreateOfferViewModel model = new CreateOfferViewModel(dataModel, null, fiatPriceValidator, altcoinValidator, btcValidator, null, null, null, null, priceFeedService, null, bsFormatter, null);
+        model = new CreateOfferViewModel(dataModel, null, fiatPriceValidator, altcoinValidator, btcValidator, null, null, null, null, priceFeedService, null, bsFormatter, null);
         model.activate();
+    }
+
+    @Test
+    public void testSyncMinAmountWithAmountUntilChanged() {
         assertNull(model.amount.get());
         assertNull(model.minAmount.get());
 
@@ -92,12 +95,6 @@ public class CreateOfferViewModelTest {
         assertEquals("0.0312", model.amount.get());
         assertEquals("0.0312", model.minAmount.get());
 
-        model.minAmount.set("0.0312");
-        model.onFocusOutMinAmountTextField(true, false);
-
-        model.amount.set("0.0315");
-        assertEquals("0.0315", model.minAmount.get());
-
         model.minAmount.set("0.01");
         model.onFocusOutMinAmountTextField(true, false);
 
@@ -107,13 +104,53 @@ public class CreateOfferViewModelTest {
 
         assertEquals("0.0301", model.amount.get());
         assertEquals("0.01", model.minAmount.get());
+    }
+
+    @Test
+    public void testSyncMinAmountWithAmountWhenZeroCoinIsSet() {
+        model.amount.set("0.03");
+
+        assertEquals("0.03", model.amount.get());
+        assertEquals("0.03", model.minAmount.get());
 
         model.minAmount.set("0.00");
         model.onFocusOutMinAmountTextField(true, false);
 
-        model.amount.set("0.0302");
+        model.amount.set("0.04");
 
-        assertEquals("0.0302", model.amount.get());
-        assertEquals("0.0302", model.minAmount.get());
+        assertEquals("0.04", model.amount.get());
+        assertEquals("0.04", model.minAmount.get());
+
     }
+
+    @Test
+    public void testSyncMinAmountWithAmountWhenSameValueIsSet() {
+        model.amount.set("0.03");
+
+        assertEquals("0.03", model.amount.get());
+        assertEquals("0.03", model.minAmount.get());
+
+        model.minAmount.set("0.03");
+        model.onFocusOutMinAmountTextField(true, false);
+
+        model.amount.set("0.04");
+
+        assertEquals("0.04", model.amount.get());
+        assertEquals("0.04", model.minAmount.get());
+    }
+
+    @Test
+    public void testSyncMinAmountWithAmountWhenHigherMinAmountValueIsSet() {
+        model.amount.set("0.03");
+
+        assertEquals("0.03", model.amount.get());
+        assertEquals("0.03", model.minAmount.get());
+
+        model.minAmount.set("0.05");
+        model.onFocusOutMinAmountTextField(true, false);
+
+        assertEquals("0.05", model.amount.get());
+        assertEquals("0.05", model.minAmount.get());
+    }
+
 }

--- a/gui/src/test/java/io/bisq/gui/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/gui/src/test/java/io/bisq/gui/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -1,0 +1,119 @@
+package io.bisq.gui.main.offer.createoffer;
+
+import io.bisq.common.GlobalSettings;
+import io.bisq.common.locale.CryptoCurrency;
+import io.bisq.common.locale.Res;
+import io.bisq.common.locale.TradeCurrency;
+import io.bisq.core.btc.AddressEntry;
+import io.bisq.core.btc.wallet.BsqWalletService;
+import io.bisq.core.btc.wallet.BtcWalletService;
+import io.bisq.core.offer.OfferPayload;
+import io.bisq.core.payment.PaymentAccount;
+import io.bisq.core.provider.fee.FeeService;
+import io.bisq.core.provider.price.PriceFeedService;
+import io.bisq.core.trade.Trade;
+import io.bisq.core.user.User;
+import io.bisq.gui.util.BSFormatter;
+import io.bisq.gui.util.validation.AltcoinValidator;
+import io.bisq.gui.util.validation.BtcValidator;
+import io.bisq.gui.util.validation.FiatPriceValidator;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import org.bitcoinj.core.Coin;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static io.bisq.core.user.PreferenceMakers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BtcWalletService .class, AddressEntry.class, PriceFeedService.class, User.class, FeeService.class, CreateOfferDataModel.class, PaymentAccount.class, BsqWalletService.class})
+public class CreateOfferViewModelTest {
+
+    @Before
+    public void setUp() {
+        final CryptoCurrency btc = new CryptoCurrency("BTC", "bitcoin");
+        GlobalSettings.setDefaultTradeCurrency(btc);
+        Res.setBaseCurrencyCode(btc.getCode());
+        Res.setBaseCurrencyName(btc.getName());
+    }
+
+    @Test
+    public void testSyncMinAmountWithAmountUntilChanged() {
+        final BSFormatter bsFormatter = new BSFormatter();
+        final BtcValidator btcValidator = new BtcValidator(bsFormatter);
+        final AltcoinValidator altcoinValidator = new AltcoinValidator();
+        final FiatPriceValidator fiatPriceValidator = new FiatPriceValidator();
+
+        FeeService feeService = mock(FeeService.class);
+        AddressEntry addressEntry = mock(AddressEntry.class);
+        BtcWalletService btcWalletService = mock(BtcWalletService.class);
+        PriceFeedService priceFeedService = mock(PriceFeedService.class);
+        User user = mock(User.class);
+        PaymentAccount paymentAccount = mock(PaymentAccount.class);
+        BsqWalletService bsqWalletService = mock(BsqWalletService.class);
+
+        when(btcWalletService.getOrCreateAddressEntry(anyString(), any())).thenReturn(addressEntry);
+        when(btcWalletService.getBalanceForAddress(any())).thenReturn(Coin.valueOf(1000L));
+        when(priceFeedService.updateCounterProperty()).thenReturn(new SimpleIntegerProperty());
+        when(feeService.getTxFee(anyInt())).thenReturn(Coin.valueOf(1000L));
+        when(user.findFirstPaymentAccountWithCurrency(any())).thenReturn(paymentAccount);
+        when(user.getPaymentAccountsAsObservable()).thenReturn(FXCollections.observableSet());
+
+        CreateOfferDataModel dataModel = new CreateOfferDataModel(null, btcWalletService, bsqWalletService, empty, user, null,null, priceFeedService,null, null, null, feeService, bsFormatter);
+        dataModel.initWithData(OfferPayload.Direction.BUY, new CryptoCurrency("BTC", "bitcoin"));
+        dataModel.activate();
+
+        final CreateOfferViewModel model = new CreateOfferViewModel(dataModel, null, fiatPriceValidator, altcoinValidator, btcValidator, null, null, null, null, priceFeedService, null, bsFormatter, null);
+        model.activate();
+        assertNull(model.amount.get());
+        assertNull(model.minAmount.get());
+
+        model.amount.set("0.0");
+        assertEquals("0.0", model.amount.get());
+        assertNull(model.minAmount.get());
+
+        model.amount.set("0.03");
+
+        assertEquals("0.03", model.amount.get());
+        assertEquals("0.03", model.minAmount.get());
+
+        model.amount.set("0.0312");
+
+        assertEquals("0.0312", model.amount.get());
+        assertEquals("0.0312", model.minAmount.get());
+
+        model.minAmount.set("0.0312");
+        model.onFocusOutMinAmountTextField(true, false);
+
+        model.amount.set("0.0315");
+        assertEquals("0.0315", model.minAmount.get());
+
+        model.minAmount.set("0.01");
+        model.onFocusOutMinAmountTextField(true, false);
+
+        assertEquals("0.01", model.minAmount.get());
+
+        model.amount.set("0.0301");
+
+        assertEquals("0.0301", model.amount.get());
+        assertEquals("0.01", model.minAmount.get());
+
+        model.minAmount.set("0.00");
+        model.onFocusOutMinAmountTextField(true, false);
+
+        model.amount.set("0.0302");
+
+        assertEquals("0.0302", model.amount.get());
+        assertEquals("0.0302", model.minAmount.get());
+    }
+}


### PR DESCRIPTION
This fixes behavior that minAmount is not synchronized anymore as soon as the first value is added to the amount input.

**Current Behavior:**
```
amount: 0.01
minAmount:0.01
```
When entering an additional decimal
```
amount:0.012
minAmount:0.01
```
**Behavior after PR:**
```
amount: 0.01
minAmount:0.01
```
When entering an additional decimal
```
amount:0.012
minAmount:0.012
```

As soon as minAmount is manually changed for the first time, the synchronization is stopped. If the user enters 0, minAmount is synchronized again.