### PR TITLE
List ALC altcoin 

### DIFF
--- a/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
+++ b/common/src/main/java/io/bisq/common/locale/CurrencyUtil.java
@@ -135,6 +135,7 @@ public class CurrencyUtil {
         result.add(new CryptoCurrency("PASC", "Pascal Coin", true));
         result.add(new CryptoCurrency("PEPECASH", "Pepe Cash"));
         result.add(new CryptoCurrency("PIVX", "PIVX"));
+		result.add(new CryptoCurrency("ALC", "Angelcoin"));
         result.add(new CryptoCurrency("POST", "PostCoin"));
         result.add(new CryptoCurrency("PNC", "Pranacoin"));
         result.add(new CryptoCurrency("RDD", "ReddCoin"));


### PR DESCRIPTION
Ticker symbol (e.g. LTC): ALC
Official token name (e.g. Litecoin): Angelcoin
Official block explorer URL: https://www.angelcoin.money/BlockExplorer/
Is it an Altcoin (dedicated blockchain) or a token (anything else) (e.g. Altcoin): Altcoin
Official token project URL: https://www.angelcoin.money