### PR TITLE
List ALC altcoin

### DIFF
--- a/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
+++ b/gui/src/main/java/io/bisq/gui/util/validation/AltCoinAddressValidator.java
@@ -180,6 +180,18 @@ public final class AltCoinAddressValidator extends InputValidator {
                     } else {
                         return regexTestFailed;
                     }
+                case "ALC":
+                    if (input.matches("^[A][a-km-zA-HJ-NP-Z1-9]{25,34}$")) {
+                        //noinspection ConstantConditions
+                        try {
+                            Address.fromBase58(AlcParams.get(), input);
+                            return new ValidationResult(true);
+                        } catch (AddressFormatException e) {
+                            return new ValidationResult(false, getErrorMessage(e));
+                        }
+                    } else {
+                        return regexTestFailed;
+                    }
                 case "IOP":
                     if (input.matches("^[p][a-km-zA-HJ-NP-Z1-9]{25,34}$")) {
                         //noinspection ConstantConditions


### PR DESCRIPTION
Ticker symbol (e.g. LTC): ALC
Official token name (e.g. Litecoin): Angelcoin
Official block explorer URL: https://www.angelcoin.money/BlockExplorer/
Is it an Altcoin (dedicated blockchain) or a token (anything else) (e.g. Altcoin): Altcoin
Official token project URL: https://www.angelcoin.money