### PR TITLE
List ALC altcoin

### DIFF
--- a/core/src/main/java/io/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/io/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -214,6 +214,7 @@ public class TradeStatisticsManager {
         coinsWithValidator.add("DASH");
         coinsWithValidator.add("ETH");
         coinsWithValidator.add("PIVX");
+        coinsWithValidator.add("ALC");
         coinsWithValidator.add("IOP");
         coinsWithValidator.add("888");
         coinsWithValidator.add("ZEC");


### PR DESCRIPTION
Ticker symbol (e.g. LTC): ALC
Official token name (e.g. Litecoin): Angelcoin
Official block explorer URL: https://www.angelcoin.money/BlockExplorer/
Is it an Altcoin (dedicated blockchain) or a token (anything else) (e.g. Altcoin): Altcoin
Official token project URL: https://www.angelcoin.money