### PR TITLE
Use btcNodes argument in regtest mode.

### DIFF
--- a/core/src/main/java/io/bisq/core/btc/wallet/WalletsSetup.java
+++ b/core/src/main/java/io/bisq/core/btc/wallet/WalletsSetup.java
@@ -196,7 +196,7 @@ public class WalletsSetup {
         };
 
         if (params == RegTestParams.get()) {
-            configPeerNodesForRegTest();
+            configPeerNodesForRegTest(socks5Proxy);
         } else if (bisqEnvironment.isBitcoinLocalhostNodeRunning()) {
             configPeerNodesForLocalHostBitcoinNode();
         } else {
@@ -268,7 +268,7 @@ public class WalletsSetup {
         return mode;
     }
 
-    private void configPeerNodesForRegTest() {
+    private void configPeerNodesForRegTest(@Nullable Socks5Proxy proxy) {
         walletConfig.setMinBroadcastConnections(1);
         if (regTestHost == RegTestHost.REG_TEST_SERVER) {
             try {
@@ -280,6 +280,8 @@ public class WalletsSetup {
             }
         } else if (regTestHost == RegTestHost.LOCALHOST) {
             walletConfig.setPeerNodesForLocalHost();
+        } else {
+            configPeerNodes(proxy);
         }
     }
 


### PR DESCRIPTION
This is needed for bisq-api and bitcoin docker containers to see each other during dockerized regtest. 