### PR TITLE
Use Amount term for Volume

### DIFF
--- a/gui/src/main/java/io/bisq/gui/main/portfolio/closedtrades/ClosedTradesView.java
+++ b/gui/src/main/java/io/bisq/gui/main/portfolio/closedtrades/ClosedTradesView.java
@@ -96,7 +96,7 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
     public void initialize() {
         priceColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.price")));
         amountColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amountWithCur", Res.getBaseCurrencyCode())));
-        volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.volume")));
+        volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amount")));
         marketColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.market")));
         directionColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.offerType")));
         dateColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.dateTime")));

--- a/gui/src/main/java/io/bisq/gui/main/portfolio/closedtrades/ClosedTradesViewModel.java
+++ b/gui/src/main/java/io/bisq/gui/main/portfolio/closedtrades/ClosedTradesViewModel.java
@@ -53,7 +53,7 @@ class ClosedTradesViewModel extends ActivatableWithDataModel<ClosedTradesDataMod
 
     String getAmount(ClosedTradableListItem item) {
         if (item != null && item.getTradable() instanceof Trade)
-            return formatter.formatCoinWithCode(((Trade) item.getTradable()).getTradeAmount());
+            return formatter.formatCoin(((Trade) item.getTradable()).getTradeAmount());
         else if (item != null && item.getTradable() instanceof OpenOffer)
             return "-";
         else

--- a/gui/src/main/java/io/bisq/gui/main/portfolio/failedtrades/FailedTradesView.java
+++ b/gui/src/main/java/io/bisq/gui/main/portfolio/failedtrades/FailedTradesView.java
@@ -56,7 +56,7 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     public void initialize() {
         priceColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.price")));
         amountColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amountWithCur", Res.getBaseCurrencyCode())));
-        volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.volume")));
+        volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amount")));
         marketColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.market")));
         directionColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.offerType")));
         dateColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.dateTime")));

--- a/gui/src/main/java/io/bisq/gui/main/portfolio/failedtrades/FailedTradesViewModel.java
+++ b/gui/src/main/java/io/bisq/gui/main/portfolio/failedtrades/FailedTradesViewModel.java
@@ -45,7 +45,7 @@ class FailedTradesViewModel extends ActivatableWithDataModel<FailedTradesDataMod
 
     String getAmount(FailedTradesListItem item) {
         if (item != null && item.getTrade() != null)
-            return formatter.formatCoinWithCode(item.getTrade().getTradeAmount());
+            return formatter.formatCoin(item.getTrade().getTradeAmount());
         else
             return "";
     }

--- a/gui/src/main/java/io/bisq/gui/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/gui/src/main/java/io/bisq/gui/main/portfolio/pendingtrades/PendingTradesView.java
@@ -101,7 +101,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
     public void initialize() {
         priceColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.price")));
         amountColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amountWithCur", Res.getBaseCurrencyCode())));
-        volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.volume")));
+        volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amount")));
         marketColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.market")));
         roleColumn.setGraphic(new AutoTooltipLabel(Res.get("portfolio.pending.role")));
         dateColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.dateTime")));
@@ -343,7 +343,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                             public void updateItem(final PendingTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty)
-                                    setGraphic(new AutoTooltipLabel(formatter.formatCoinWithCode(item.getTrade().getTradeAmount())));
+                                    setGraphic(new AutoTooltipLabel(formatter.formatCoin(item.getTrade().getTradeAmount())));
                                 else
                                     setGraphic(null);
                             }


### PR DESCRIPTION
This PR will add the last changes discussed with @ManfredKarrer recently. It will remove the redundant coin code in colume "Amount in {COIN_CODE}" and rename Volume to Amount in Failed trades, Open trades and History.