### PR TITLE
Update artifact metadata to allow seamless resolution from JitPack or local ~/.m2 repo

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <version>0.6.7</version>
         <groupId>io.bisq.exchange</groupId>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <groupId>io.bisq</groupId>
         <version>0.6.7</version>
+        <groupId>io.bisq.exchange</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -128,7 +128,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>consensus</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <version>0.6.7</version>
         <groupId>io.bisq.exchange</groupId>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/consensus/pom.xml
+++ b/consensus/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <groupId>io.bisq</groupId>
         <version>0.6.7</version>
+        <groupId>io.bisq.exchange</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,25 +5,25 @@
 
     <parent>
         <artifactId>parent</artifactId>
-        <groupId>io.bisq</groupId>
         <version>0.6.7</version>
+        <groupId>io.bisq.exchange</groupId>
     </parent>
 
     <artifactId>core</artifactId>
 
     <dependencies>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>consensus</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>network</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,8 +5,8 @@
 
     <parent>
         <artifactId>parent</artifactId>
-        <version>0.6.7</version>
         <groupId>io.bisq.exchange</groupId>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -21,8 +21,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <groupId>io.bisq</groupId>
         <version>0.6.7</version>
+        <groupId>io.bisq.exchange</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -339,7 +339,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -21,8 +21,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <version>0.6.7</version>
         <groupId>io.bisq.exchange</groupId>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/monitor/pom.xml
+++ b/monitor/pom.xml
@@ -21,8 +21,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <groupId>io.bisq</groupId>
         <version>0.6.7</version>
+        <groupId>io.bisq.exchange</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -138,7 +138,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/monitor/pom.xml
+++ b/monitor/pom.xml
@@ -21,8 +21,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <version>0.6.7</version>
         <groupId>io.bisq.exchange</groupId>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <version>0.6.7</version>
         <groupId>io.bisq.exchange</groupId>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <groupId>io.bisq</groupId>
         <version>0.6.7</version>
+        <groupId>io.bisq.exchange</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.bisq.exchange</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.6.7</version>
+    <version>0.7.0-SNAPSHOT</version>
     <description>Bisq - The decentralized exchange network</description>
     <url>https://bisq.io</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.bisq</groupId>
+    <groupId>io.bisq.exchange</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
     <version>0.6.7</version>

--- a/statistics/pom.xml
+++ b/statistics/pom.xml
@@ -21,8 +21,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <groupId>io.bisq</groupId>
         <version>0.6.7</version>
+        <groupId>io.bisq.exchange</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -137,7 +137,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.bisq</groupId>
+            <groupId>io.bisq.exchange</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/statistics/pom.xml
+++ b/statistics/pom.xml
@@ -21,8 +21,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
-        <version>0.6.7</version>
         <groupId>io.bisq.exchange</groupId>
+        <version>0.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
_I'm including the full commit comments below, as they might otherwise get missed and are definitely worth understanding._

d21809426 (Chris Beams, 16 minutes ago)

   Bump Maven artifact versions to 0.7.0-SNAPSHOT

   Problem: When resolving Bisq libraries, e.g. `core` or `network` from
   JitPack for use in other components like bisq-seednode or bisq-pricenode,
   we have historically, resolved them by tag or by branchname, e.g. with GAV
   coordinates like `io.bisq:core:v0.6.7` or
   `io.bisq:core:master`. This works well enough, but now that we are
   beginning to modularize more aggressively, we want to make sure that it's
   possible at any time to publish the latest snapshots of these libraries to
   one's own local ~/.m2 repository such that they can be easily resolved from
   downstream components without the need to push commits to the
   bisq-network/exchange remote, and to wait for JitPack to do a just-in-time
   build.

   Solution: By updating the version value of all modules here in the exchange
   repository from 0.6.7 => 0.7.0-SNAPSHOT, one can run
   `mvn install` to publish the latest "snapshot" of exchange libraries to the
   local ~/.m2 repository and be sure to resolve them from whatever downstream
   component that they are working on. The -SNAPSHOT qualifier ensures that no
   caching occurs, and that the very latest such binary will always be used.

   This new arrangement creates a situation where one can transparently
   resolve these dependencies remotely from JitPack and then subsequently
   resolve them locally from one's ~/.m2 repository without having to change a
   line of code.

   It also opens up the ability to manage all Bisq components together in a
   single IDE window as if they were all in one repository, avoiding the need
   even to issue a `mvn install` command to publish locally--but that's not
   the main focus of this change.

   Note that the change to 0.7.0 here is based on the fact that we already
   planned to have the next version shipped from `master` be 0.7.0, as there
   are quite a few new UI changes that probably merit the bump in minor
   version. The version change also aligns well with the fact that we're
   modularizing a number of components right now, and all newly-extracted
   components have been jumping to v0.7.0 to indicate their new independent
   status. This has been the case with bisq-seednode and pricenode so far.

   Finally, it is important to note here that the ONLY versions updated by
   this change are those specific to Maven metadata and therefore artifact
   management / dependency resolution. The version that the Bisq desktop
   client reports in its UI and to the network in its user agent has NOT been
   changed, on account of the fact that users may run Bisq from source, and we
   need to think through more fully the implications of reporting a verison
   like 0.7.0-SNAPSHOT in those situations. Here is a list of files containing
   the old version (0.6.7) that have NOT been updated:

    - common/src/main/java/io/bisq/common/app/Version.java
    - package/linux/32bitBuild.sh
    - package/linux/Dockerfile
    - package/osx/create_app.sh
    - package/osx/finalize.sh
    - package/windows/32bitBuild.bat
    - package/windows/64bitBuild.bat
    - package/windows/Bisq.iss
    - package/linux/64bitBuild.sh

   One thing we know for sure that wouldn't work here is that Bisq's Version
   class currently does not support -SNAPSHOT qualifiers. It just breaks the
   version string validation entirely. So we'd need to patch that in any case
   if we do decide it's a good idea to let pre-release builds report their
   version accurately.

19d8c252b (Chris Beams, 53 minutes ago)

   Change groupid from io.bisq => io.bisq.exchange

   Problem: The current `io.bisq` groupid does not align with the way JitPack
   supports custom groupids. In order to be able to both resolve artifacts
   from JitPack *and* be able to resolve the same artifacts from one's local
   ~/.m2 repository, Bisq artifacts need to have the same GAV coordinates
   everywhere (groupid, artifactid, version).

   Solution: This commit changes all groupids from io.bisq => io.bisq.exchange
   to match the GAV coordinates produced / expected by JitPack.

   So where Bisq's core module would previously have been resolvable with GAV
   coordinates `io.bisq:core:v0.6.7` it will now be resolvable as
   `io.bisq.exchange:core:v0.6.7`.

   Note that this change is not just to satisfy JitPack idiosyncracies, but is
   actually good naming practice anyway where a multi-module build is
   involved, and is arguably the way it should have been all along.

   [1]: https://jitpack.io/docs/#publishing-on-jitpack