### PR TITLE
Fix wrong row span so group is closed after offer table

### DIFF
--- a/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -148,7 +148,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
     public void initialize() {
         root.setPadding(new Insets(20, 25, 5, 25));
 
-        addTitledGroupBg(root, gridRow, 3, Res.get("offerbook.availableOffers"));
+        addTitledGroupBg(root, gridRow, 2, Res.get("offerbook.availableOffers"));
 
         final Tuple3<HBox, AutoTooltipLabel, ComboBox> filterBoxTuple = addHBoxLabelComboBox(root, gridRow, Res.get("offerbook.filterByCurrency"), Layout.FIRST_ROW_DISTANCE);
         final HBox filterBox = filterBoxTuple.first;


### PR DESCRIPTION
Was before:
![before](https://user-images.githubusercontent.com/170962/38015636-a258f446-326c-11e8-906c-68a65aa1c698.png)
Should be:
![after](https://user-images.githubusercontent.com/170962/38015637-a27a1a5e-326c-11e8-97f7-d6b74de34795.png)
