### PR TITLE
Enable distZip flag in "build.gradle".

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
 build.dependsOn installDist
 installDist.destinationDir = file('build/app')
-distZip.enabled = false
+distZip.enabled = true
 
 // generated with `./gradlew -q calculateChecksums | grep -v network.bisq:bisq-`
 dependencyVerification {


### PR DESCRIPTION
This flag is required to run `./gradlew install` which in turn is required by jitpack.