### PR TITLE
Remove offer duplicates in spread view

### DIFF
--- a/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
+++ b/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
@@ -51,6 +51,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 class SpreadViewModel extends ActivatableViewModel {
@@ -90,6 +94,12 @@ class SpreadViewModel extends ActivatableViewModel {
         offerBookListItems.removeListener(listChangeListener);
     }
 
+    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor)
+    {
+        Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return t -> seen.add(keyExtractor.apply(t));
+    }
+
     private void update(ObservableList<OfferBookListItem> offerBookListItems) {
         Map<String, List<Offer>> offersByCurrencyMap = new HashMap<>();
         for (OfferBookListItem offerBookListItem : offerBookListItems) {
@@ -106,7 +116,10 @@ class SpreadViewModel extends ActivatableViewModel {
         for (String currencyCode : offersByCurrencyMap.keySet()) {
             List<Offer> offers = offersByCurrencyMap.get(currencyCode);
             final boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(currencyCode);
-            List<Offer> buyOffers = offers
+
+            List<Offer> uniqueOffers = offers.stream().filter(distinctByKey(Offer::getId)).collect(Collectors.toList());
+
+            List<Offer> buyOffers = uniqueOffers
                     .stream()
                     .filter(e -> e.getDirection().equals(OfferPayload.Direction.BUY))
                     .sorted((o1, o2) -> {
@@ -123,7 +136,7 @@ class SpreadViewModel extends ActivatableViewModel {
                     })
                     .collect(Collectors.toList());
 
-            List<Offer> sellOffers = offers
+            List<Offer> sellOffers = uniqueOffers
                     .stream()
                     .filter(e -> e.getDirection().equals(OfferPayload.Direction.SELL))
                     .sorted((o1, o2) -> {
@@ -198,7 +211,7 @@ class SpreadViewModel extends ActivatableViewModel {
 
             totalAmount = Coin.valueOf(offers.stream().mapToLong(offer -> offer.getAmount().getValue()).sum());
             spreadItems.add(new SpreadItem(currencyCode, buyOffers.size(), sellOffers.size(),
-                    offers.size(), spread, percentage, totalAmount));
+                    uniqueOffers.size(), spread, percentage, totalAmount));
         }
 
         maxPlacesForAmount.set(formatAmount(totalAmount, false).length());

--- a/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
+++ b/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
@@ -94,8 +94,7 @@ class SpreadViewModel extends ActivatableViewModel {
         offerBookListItems.removeListener(listChangeListener);
     }
 
-    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor)
-    {
+    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
         Set<Object> seen = ConcurrentHashMap.newKeySet();
         return t -> seen.add(keyExtractor.apply(t));
     }

--- a/src/test/java/bisq/core/offer/OfferMaker.java
+++ b/src/test/java/bisq/core/offer/OfferMaker.java
@@ -33,9 +33,10 @@ public class OfferMaker {
     public static final Property<Offer, OfferPayload.Direction> direction = new Property<>();
     public static final Property<Offer, Boolean> useMarketBasedPrice = new Property<>();
     public static final Property<Offer, Double> marketPriceMargin = new Property<>();
+    public static final Property<Offer, String> id = new Property<>();
 
     public static final Instantiator<Offer> Offer = lookup -> new Offer(
-            new OfferPayload("",
+            new OfferPayload(lookup.valueOf(id, "1234"),
                     0L,
                     null,
                     null,

--- a/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
+++ b/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 
 import static bisq.core.locale.TradeCurrencyMakers.usd;
 import static bisq.core.user.PreferenceMakers.empty;
-import static bisq.desktop.main.offer.offerbook.OfferBookListItemMaker.btcItem;
+import static bisq.desktop.main.offer.offerbook.OfferBookListItemMaker.btcBuyItem;
 import static bisq.desktop.main.offer.offerbook.OfferBookListItemMaker.btcSellItem;
 import static com.natpryce.makeiteasy.MakeItEasy.make;
 import static com.natpryce.makeiteasy.MakeItEasy.with;
@@ -75,7 +75,7 @@ public class OfferBookChartViewModelTest {
 
 
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        final OfferBookListItem item = make(OfferBookListItemMaker.btcItem.but(with(OfferBookListItemMaker.useMarketBasedPrice, true)));
+        final OfferBookListItem item = make(OfferBookListItemMaker.btcBuyItem.but(with(OfferBookListItemMaker.useMarketBasedPrice, true)));
         item.getOffer().setPriceFeedService(priceFeedService);
         offerBookListItems.addAll(item);
 
@@ -93,16 +93,16 @@ public class OfferBookChartViewModelTest {
         OfferBook offerBook = mock(OfferBook.class);
         PriceFeedService service = mock(PriceFeedService.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        offerBookListItems.addAll(make(OfferBookListItemMaker.btcItem));
+        offerBookListItems.addAll(make(OfferBookListItemMaker.btcBuyItem));
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null, new BSFormatter());
         model.activate();
         assertEquals(7, model.maxPlacesForBuyPrice.intValue());
-        offerBookListItems.addAll(make(btcItem.but(with(OfferBookListItemMaker.price, 94016475L))));
+        offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.price, 94016475L))));
         assertEquals(9, model.maxPlacesForBuyPrice.intValue());
-        offerBookListItems.addAll(make(btcItem.but(with(OfferBookListItemMaker.price, 101016475L))));
+        offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.price, 101016475L))));
         assertEquals(10, model.maxPlacesForBuyPrice.intValue());
     }
 
@@ -122,16 +122,16 @@ public class OfferBookChartViewModelTest {
         OfferBook offerBook = mock(OfferBook.class);
         PriceFeedService service = mock(PriceFeedService.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        offerBookListItems.addAll(make(OfferBookListItemMaker.btcItem));
+        offerBookListItems.addAll(make(OfferBookListItemMaker.btcBuyItem));
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null, new BSFormatter());
         model.activate();
         assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //0.01
-        offerBookListItems.addAll(make(btcItem.but(with(OfferBookListItemMaker.amount, 100000000L))));
+        offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 100000000L))));
         assertEquals(5, model.maxPlacesForBuyVolume.intValue()); //10.00
-        offerBookListItems.addAll(make(btcItem.but(with(OfferBookListItemMaker.amount, 22128600000L))));
+        offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 22128600000L))));
         assertEquals(7, model.maxPlacesForBuyVolume.intValue()); //2212.86
     }
 

--- a/src/test/java/bisq/desktop/main/market/spread/SpreadViewModelTest.java
+++ b/src/test/java/bisq/desktop/main/market/spread/SpreadViewModelTest.java
@@ -74,7 +74,7 @@ public class SpreadViewModelTest {
     }
 
     @Test
-    public void testfilterSpreadItemsForUniqueOffers() {
+    public void testFilterSpreadItemsForUniqueOffers() {
         OfferBook offerBook = mock(OfferBook.class);
         PriceFeedService priceFeedService = mock(PriceFeedService.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();

--- a/src/test/java/bisq/desktop/main/market/spread/SpreadViewModelTest.java
+++ b/src/test/java/bisq/desktop/main/market/spread/SpreadViewModelTest.java
@@ -54,7 +54,7 @@ public class SpreadViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final SpreadViewModel model = new SpreadViewModel(offerBook, null, new BSFormatter());
+        SpreadViewModel model = new SpreadViewModel(offerBook, null, new BSFormatter());
         assertEquals(0, model.maxPlacesForAmount.intValue());
     }
 
@@ -66,7 +66,7 @@ public class SpreadViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final SpreadViewModel model = new SpreadViewModel(offerBook, null, new BSFormatter());
+        SpreadViewModel model = new SpreadViewModel(offerBook, null, new BSFormatter());
         model.activate();
         assertEquals(6, model.maxPlacesForAmount.intValue()); // 0.001
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 1403000000L))));
@@ -82,7 +82,7 @@ public class SpreadViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final SpreadViewModel model = new SpreadViewModel(offerBook, priceFeedService, new BSFormatter());
+        SpreadViewModel model = new SpreadViewModel(offerBook, priceFeedService, new BSFormatter());
         model.activate();
 
         assertEquals(1, model.spreadItems.get(0).numberOfOffers);

--- a/src/test/java/bisq/desktop/main/market/spread/SpreadViewModelTest.java
+++ b/src/test/java/bisq/desktop/main/market/spread/SpreadViewModelTest.java
@@ -23,6 +23,8 @@ import bisq.desktop.main.offer.offerbook.OfferBookListItem;
 import bisq.desktop.main.offer.offerbook.OfferBookListItemMaker;
 import bisq.desktop.util.BSFormatter;
 
+import bisq.core.provider.price.PriceFeedService;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -32,7 +34,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static bisq.desktop.main.offer.offerbook.OfferBookListItemMaker.btcItem;
+import static bisq.desktop.main.offer.offerbook.OfferBookListItemMaker.btcBuyItem;
+import static bisq.desktop.main.offer.offerbook.OfferBookListItemMaker.btcSellItem;
+import static bisq.desktop.main.offer.offerbook.OfferBookListItemMaker.id;
 import static com.natpryce.makeiteasy.MakeItEasy.make;
 import static com.natpryce.makeiteasy.MakeItEasy.with;
 import static org.junit.Assert.assertEquals;
@@ -40,7 +44,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(OfferBook.class)
+@PrepareForTest({OfferBook.class, PriceFeedService.class})
 public class SpreadViewModelTest {
 
     @Test
@@ -58,14 +62,38 @@ public class SpreadViewModelTest {
     public void testMaxCharactersForAmount() {
         OfferBook offerBook = mock(OfferBook.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        offerBookListItems.addAll(make(OfferBookListItemMaker.btcItem));
+        offerBookListItems.addAll(make(btcBuyItem));
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final SpreadViewModel model = new SpreadViewModel(offerBook, null, new BSFormatter());
         model.activate();
         assertEquals(6, model.maxPlacesForAmount.intValue()); // 0.001
-        offerBookListItems.addAll(make(btcItem.but(with(OfferBookListItemMaker.amount, 1403000000L))));
+        offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 1403000000L))));
         assertEquals(7, model.maxPlacesForAmount.intValue()); //14.0300
+    }
+
+    @Test
+    public void testfilterSpreadItemsForUniqueOffers() {
+        OfferBook offerBook = mock(OfferBook.class);
+        PriceFeedService priceFeedService = mock(PriceFeedService.class);
+        final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
+        offerBookListItems.addAll(make(btcBuyItem));
+
+        when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
+
+        final SpreadViewModel model = new SpreadViewModel(offerBook, priceFeedService, new BSFormatter());
+        model.activate();
+
+        assertEquals(1, model.spreadItems.get(0).numberOfOffers);
+
+        offerBookListItems.addAll(make(btcBuyItem.but(with(id, "2345"))),
+                make(btcBuyItem.but(with(id, "2345"))),
+                make(btcSellItem.but(with(id, "3456"))),
+                make(btcSellItem.but(with(id, "3456"))));
+
+        assertEquals(2, model.spreadItems.get(0).numberOfBuyOffers);
+        assertEquals(1, model.spreadItems.get(0).numberOfSellOffers);
+        assertEquals(3, model.spreadItems.get(0).numberOfOffers);
     }
 }

--- a/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookListItemMaker.java
+++ b/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookListItemMaker.java
@@ -32,6 +32,7 @@ import static com.natpryce.makeiteasy.MakeItEasy.with;
 
 public class OfferBookListItemMaker {
 
+    public static final Property<OfferBookListItem, String> id = new Property<>();
     public static final Property<OfferBookListItem, Long> price = new Property<>();
     public static final Property<OfferBookListItem, Long> amount = new Property<>();
     public static final Property<OfferBookListItem, Long> minAmount = new Property<>();
@@ -46,7 +47,8 @@ public class OfferBookListItemMaker {
                     with(OfferMaker.minAmount, lookup.valueOf(amount, 100000L)),
                     with(OfferMaker.direction, lookup.valueOf(direction, OfferPayload.Direction.BUY)),
                     with(OfferMaker.useMarketBasedPrice, lookup.valueOf(useMarketBasedPrice, false)),
-                    with(OfferMaker.marketPriceMargin, lookup.valueOf(marketPriceMargin, 0.0)))));
+                    with(OfferMaker.marketPriceMargin, lookup.valueOf(marketPriceMargin, 0.0)),
+                    with(OfferMaker.id, lookup.valueOf(id, "1234")))));
 
     public static final Instantiator<OfferBookListItem> OfferBookListItemWithRange = lookup ->
             new OfferBookListItem(make(btcUsdOffer.but(
@@ -54,7 +56,7 @@ public class OfferBookListItemMaker {
                     with(OfferMaker.minAmount, lookup.valueOf(minAmount, 100000L)),
                     with(OfferMaker.amount, lookup.valueOf(amount, 200000L)))));
 
-    public static final Maker<OfferBookListItem> btcItem = a(OfferBookListItem);
+    public static final Maker<OfferBookListItem> btcBuyItem = a(OfferBookListItem);
     public static final Maker<OfferBookListItem> btcSellItem = a(OfferBookListItem, with(direction, OfferPayload.Direction.SELL));
 
     public static final Maker<OfferBookListItem> btcItemWithRange = a(OfferBookListItemWithRange);

--- a/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -242,7 +242,7 @@ public class OfferBookViewModelTest {
         OfferBook offerBook = mock(OfferBook.class);
         OpenOfferManager openOfferManager = mock(OpenOfferManager.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        offerBookListItems.addAll(make(OfferBookListItemMaker.btcItem));
+        offerBookListItems.addAll(make(OfferBookListItemMaker.btcBuyItem));
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
@@ -252,7 +252,7 @@ public class OfferBookViewModelTest {
         model.activate();
 
         assertEquals(6, model.maxPlacesForAmount.intValue());
-        offerBookListItems.addAll(make(btcItem.but(with(amount, 2000000000L))));
+        offerBookListItems.addAll(make(btcBuyItem.but(with(amount, 2000000000L))));
         assertEquals(7, model.maxPlacesForAmount.intValue());
     }
 
@@ -296,7 +296,7 @@ public class OfferBookViewModelTest {
         OfferBook offerBook = mock(OfferBook.class);
         OpenOfferManager openOfferManager = mock(OpenOfferManager.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        offerBookListItems.addAll(make(OfferBookListItemMaker.btcItem));
+        offerBookListItems.addAll(make(OfferBookListItemMaker.btcBuyItem));
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
@@ -306,7 +306,7 @@ public class OfferBookViewModelTest {
         model.activate();
 
         assertEquals(8, model.maxPlacesForVolume.intValue());
-        offerBookListItems.addAll(make(btcItem.but(with(amount, 2000000000L))));
+        offerBookListItems.addAll(make(btcBuyItem.but(with(amount, 2000000000L))));
         assertEquals(10, model.maxPlacesForVolume.intValue());
     }
 
@@ -350,7 +350,7 @@ public class OfferBookViewModelTest {
         OfferBook offerBook = mock(OfferBook.class);
         OpenOfferManager openOfferManager = mock(OpenOfferManager.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        offerBookListItems.addAll(make(OfferBookListItemMaker.btcItem));
+        offerBookListItems.addAll(make(OfferBookListItemMaker.btcBuyItem));
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
@@ -360,9 +360,9 @@ public class OfferBookViewModelTest {
         model.activate();
 
         assertEquals(7, model.maxPlacesForPrice.intValue());
-        offerBookListItems.addAll(make(btcItem.but(with(price, 149558240L)))); //14955.8240
+        offerBookListItems.addAll(make(btcBuyItem.but(with(price, 149558240L)))); //14955.8240
         assertEquals(10, model.maxPlacesForPrice.intValue());
-        offerBookListItems.addAll(make(btcItem.but(with(price, 14955824L)))); //1495.58240
+        offerBookListItems.addAll(make(btcBuyItem.but(with(price, 14955824L)))); //1495.58240
         assertEquals(10, model.maxPlacesForPrice.intValue());
     }
 
@@ -386,7 +386,7 @@ public class OfferBookViewModelTest {
         PriceFeedService priceFeedService = mock(PriceFeedService.class);
 
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
-        final Maker<OfferBookListItem> item = btcItem.but(with(useMarketBasedPrice, true));
+        final Maker<OfferBookListItem> item = btcBuyItem.but(with(useMarketBasedPrice, true));
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
         when(priceFeedService.getMarketPrice(anyString())).thenReturn(null);
@@ -428,15 +428,15 @@ public class OfferBookViewModelTest {
                 null, null, null, null, null,
                 new BSFormatter());
 
-        final OfferBookListItem item = make(btcItem.but(
+        final OfferBookListItem item = make(btcBuyItem.but(
                 with(useMarketBasedPrice, true),
                 with(marketPriceMargin, -0.12)));
 
-        final OfferBookListItem lowItem = make(btcItem.but(
+        final OfferBookListItem lowItem = make(btcBuyItem.but(
                 with(useMarketBasedPrice, true),
                 with(marketPriceMargin, 0.01)));
 
-        final OfferBookListItem fixedItem = make(btcItem);
+        final OfferBookListItem fixedItem = make(btcBuyItem);
 
         item.getOffer().setPriceFeedService(priceFeedService);
         lowItem.getOffer().setPriceFeedService(priceFeedService);


### PR DESCRIPTION
Fixes #1202.

I was only able to reproduce it in a test in the SpreadModel so I added an additional safeguard there.