### PR TITLE
Handle unknown PB data from encrypted messages

### DIFF
--- a/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -88,6 +88,7 @@ import bisq.common.app.Version;
 import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.SealedAndSigned;
+import bisq.common.proto.ProtobufferException;
 import bisq.common.storage.CorruptedDatabaseFilesHandler;
 
 import org.bitcoinj.core.Address;
@@ -807,7 +808,7 @@ public class MainViewModel implements ViewModel {
                     } else {
                         throw new CryptoException("Payload not correct after decryption");
                     }
-                } catch (CryptoException e) {
+                } catch (CryptoException | ProtobufferException e) {
                     e.printStackTrace();
                     String msg = Res.get("popup.warning.cryptoTestFailed", e.getMessage());
                     log.error(msg);


### PR DESCRIPTION
https://github.com/bisq-network/bisq-common/pull/25 , https://github.com/bisq-network/bisq-p2p/pull/11 and https://github.com/bisq-network/bisq-core/pull/122

- Use ProtobufferException for
CoreNetworkProtoResolver.fromProto(PB.NetworkEnvelope proto)
- Add raw PB data in case if an exception
- log error if the encrypted data contains unknown PB data

Note: We should refactor the resolvers with checked exceptions instead
of the ProtobufferRuntimeException, but for the moment we leave that to
not add too much complexity/risk for that release.