### PR TITLE
Misc fixes and cleanups

### DIFF
--- a/src/main/java/bisq/desktop/main/MainView.java
+++ b/src/main/java/bisq/desktop/main/MainView.java
@@ -230,7 +230,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
 
         };
         model.getSelectedPriceFeedComboBoxItemProperty().addListener(selectedPriceFeedItemListener);
-        priceComboBox.setItems(model.priceFeedComboBoxItems);
+        priceComboBox.setItems(model.getPriceFeedComboBoxItems());
 
         HBox.setMargin(marketPriceBox.second, new Insets(0, 0, 0, 0));
 

--- a/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -72,7 +72,6 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.StringProperty;
 
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import java.util.Date;
@@ -108,9 +107,6 @@ public class MainViewModel implements ViewModel {
 
     @Getter
     private BooleanProperty showAppScreen = new SimpleBooleanProperty();
-
-
-    final ObservableList<PriceFeedComboBoxItem> priceFeedComboBoxItems = FXCollections.observableArrayList();
     private final BooleanProperty isSplashScreenRemoved = new SimpleBooleanProperty();
     private Timer checkNumberOfBtcPeersTimer;
     private Timer checkNumberOfP2pNetworkPeersTimer;
@@ -557,5 +553,9 @@ public class MainViewModel implements ViewModel {
 
     IntegerProperty getMarketPriceUpdated() {
         return marketPricePresentation.getMarketPriceUpdated();
+    }
+
+    public ObservableList<PriceFeedComboBoxItem> getPriceFeedComboBoxItems() {
+        return marketPricePresentation.getPriceFeedComboBoxItems();
     }
 }

--- a/src/main/java/bisq/desktop/main/MarketPricePresentation.java
+++ b/src/main/java/bisq/desktop/main/MarketPricePresentation.java
@@ -57,10 +57,13 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import lombok.Getter;
+
 public class MarketPricePresentation {
     private final Preferences preferences;
     private final BSFormatter formatter;
     private final PriceFeedService priceFeedService;
+    @Getter
     private final ObservableList<PriceFeedComboBoxItem> priceFeedComboBoxItems = FXCollections.observableArrayList();
     @SuppressWarnings("FieldCanBeLocal")
     private MonadicBinding<String> marketPriceBinding;

--- a/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -231,8 +231,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         assertEquals(0, model.maxPlacesForAmount.intValue());
     }
 
@@ -246,8 +245,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         model.activate();
 
         assertEquals(6, model.maxPlacesForAmount.intValue());
@@ -265,8 +263,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         model.activate();
 
         assertEquals(15, model.maxPlacesForAmount.intValue());
@@ -285,8 +282,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         assertEquals(0, model.maxPlacesForVolume.intValue());
     }
 
@@ -300,8 +296,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         model.activate();
 
         assertEquals(8, model.maxPlacesForVolume.intValue());
@@ -319,8 +314,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         model.activate();
 
         assertEquals(15, model.maxPlacesForVolume.intValue());
@@ -339,8 +333,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         assertEquals(0, model.maxPlacesForPrice.intValue());
     }
 
@@ -354,8 +347,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         model.activate();
 
         assertEquals(7, model.maxPlacesForPrice.intValue());
@@ -373,8 +365,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         assertEquals(0, model.maxPlacesForMarketPriceMargin.intValue());
     }
 
@@ -402,8 +393,7 @@ public class OfferBookViewModelTest {
         offerBookListItems.addAll(item1, item2);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, priceFeedService,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
         model.activate();
 
         assertEquals(8, model.maxPlacesForMarketPriceMargin.intValue()); //" (1.97%)"
@@ -424,8 +414,7 @@ public class OfferBookViewModelTest {
         when(priceFeedService.getMarketPrice(anyString())).thenReturn(new MarketPrice("USD", 12684.0450, Instant.now().getEpochSecond(), true));
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null,
-                null, null, null, null, null,
-                new BSFormatter());
+                null, null, null, null, new BSFormatter());
 
         final OfferBookListItem item = make(btcBuyItem.but(
                 with(useMarketBasedPrice, true),


### PR DESCRIPTION
- Fix bug with ignored taker check (use peer instead of
offer.getMakerNodeAddress()).
- Remove redundant tradeStatisticsSet in TradeStatisticsManager
- Remove handling for old TradeStatistics objects (since v 0.6.0 not
supported anymore)
- Use marketPricePresentation.priceFeedComboBoxItems instead of  MainVievModel.priceFeedComboBoxItems.
- Replace Authorisation # with Authorisation number.
- Remove https://bisq.network/survey and https://bisq.community links
in tradeFeedbackWindow text.
- Add null checks.
- Improve logging.
- Cleanup

Depends on https://github.com/bisq-network/bisq-core/pull/130