### PR TITLE
Improve readability and fix edit offer issue for multiple currency payment accounts

### DIFF
--- a/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -95,7 +95,7 @@ import javax.annotation.Nullable;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public abstract class EditableOfferDataModel extends OfferDataModel implements BsqBalanceListener {
+public abstract class MutableOfferDataModel extends OfferDataModel implements BsqBalanceListener {
     protected final OpenOfferManager openOfferManager;
     private final BsqWalletService bsqWalletService;
     private final Preferences preferences;
@@ -145,11 +145,11 @@ public abstract class EditableOfferDataModel extends OfferDataModel implements B
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    public EditableOfferDataModel(OpenOfferManager openOfferManager, BtcWalletService btcWalletService, BsqWalletService bsqWalletService,
-                                  Preferences preferences, User user, KeyRing keyRing, P2PService p2PService,
-                                  PriceFeedService priceFeedService, FilterManager filterManager,
-                                  AccountAgeWitnessService accountAgeWitnessService, TradeWalletService tradeWalletService,
-                                  FeeService feeService, ReferralIdService referralIdService, BSFormatter formatter) {
+    public MutableOfferDataModel(OpenOfferManager openOfferManager, BtcWalletService btcWalletService, BsqWalletService bsqWalletService,
+                                 Preferences preferences, User user, KeyRing keyRing, P2PService p2PService,
+                                 PriceFeedService priceFeedService, FilterManager filterManager,
+                                 AccountAgeWitnessService accountAgeWitnessService, TradeWalletService tradeWalletService,
+                                 FeeService feeService, ReferralIdService referralIdService, BSFormatter formatter) {
         super(btcWalletService);
 
         this.openOfferManager = openOfferManager;
@@ -251,11 +251,10 @@ public abstract class EditableOfferDataModel extends OfferDataModel implements B
 
         PaymentAccount account;
 
-        @Nullable
         PaymentAccount lastSelectedPaymentAccount = getPreselectedPaymentAccount();
         if (lastSelectedPaymentAccount != null &&
                 user.getPaymentAccounts() != null &&
-                user.getPaymentAccounts().contains(lastSelectedPaymentAccount)) {
+                user.getPaymentAccounts().stream().anyMatch(paymentAccount -> paymentAccount.getId() == lastSelectedPaymentAccount.getId())) {
             account = lastSelectedPaymentAccount;
         } else {
             account = user.findFirstPaymentAccountWithCurrency(tradeCurrency);
@@ -293,7 +292,6 @@ public abstract class EditableOfferDataModel extends OfferDataModel implements B
         return true;
     }
 
-    @Nullable
     protected PaymentAccount getPreselectedPaymentAccount() {
         return preferences.getSelectedPaymentAccountForCreateOffer();
     }

--- a/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -122,7 +122,7 @@ import org.jetbrains.annotations.NotNull;
 import static bisq.desktop.util.FormBuilder.*;
 import static javafx.beans.binding.Bindings.createStringBinding;
 
-public abstract class EditableOfferView<M extends EditableOfferViewModel> extends ActivatableViewAndModel<AnchorPane, M> {
+public abstract class MutableOfferView<M extends MutableOfferViewModel> extends ActivatableViewAndModel<AnchorPane, M> {
     protected final Navigation navigation;
     private final Preferences preferences;
     private final Transitions transitions;
@@ -173,8 +173,8 @@ public abstract class EditableOfferView<M extends EditableOfferViewModel> extend
     // Constructor, lifecycle
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public EditableOfferView(M model, Navigation navigation, Preferences preferences, Transitions transitions,
-                             OfferDetailsWindow offerDetailsWindow, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {
+    public MutableOfferView(M model, Navigation navigation, Preferences preferences, Transitions transitions,
+                            OfferDetailsWindow offerDetailsWindow, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {
         super(model);
 
         this.navigation = navigation;

--- a/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -80,7 +80,7 @@ import java.util.concurrent.TimeUnit;
 
 import static javafx.beans.binding.Bindings.createStringBinding;
 
-public abstract class EditableOfferViewModel<M extends EditableOfferDataModel> extends ActivatableWithDataModel<M> {
+public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> extends ActivatableWithDataModel<M> {
     private final BtcValidator btcValidator;
     private final BsqValidator bsqValidator;
     private final SecurityDepositValidator securityDepositValidator;
@@ -174,20 +174,20 @@ public abstract class EditableOfferViewModel<M extends EditableOfferDataModel> e
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    public EditableOfferViewModel(M dataModel,
-                                  FiatVolumeValidator fiatVolumeValidator,
-                                  FiatPriceValidator fiatPriceValidator,
-                                  AltcoinValidator altcoinValidator,
-                                  BtcValidator btcValidator,
-                                  BsqValidator bsqValidator,
-                                  SecurityDepositValidator securityDepositValidator,
-                                  P2PService p2PService,
-                                  WalletsSetup walletsSetup,
-                                  PriceFeedService priceFeedService,
-                                  Navigation navigation,
-                                  Preferences preferences,
-                                  BSFormatter btcFormatter,
-                                  BsqFormatter bsqFormatter) {
+    public MutableOfferViewModel(M dataModel,
+                                 FiatVolumeValidator fiatVolumeValidator,
+                                 FiatPriceValidator fiatPriceValidator,
+                                 AltcoinValidator altcoinValidator,
+                                 BtcValidator btcValidator,
+                                 BsqValidator bsqValidator,
+                                 SecurityDepositValidator securityDepositValidator,
+                                 P2PService p2PService,
+                                 WalletsSetup walletsSetup,
+                                 PriceFeedService priceFeedService,
+                                 Navigation navigation,
+                                 Preferences preferences,
+                                 BSFormatter btcFormatter,
+                                 BsqFormatter bsqFormatter) {
         super(dataModel);
 
         this.fiatVolumeValidator = fiatVolumeValidator;

--- a/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferDataModel.java
+++ b/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferDataModel.java
@@ -17,7 +17,7 @@
 
 package bisq.desktop.main.offer.createoffer;
 
-import bisq.desktop.main.offer.EditableOfferDataModel;
+import bisq.desktop.main.offer.MutableOfferDataModel;
 
 import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
@@ -43,7 +43,7 @@ import com.google.inject.Inject;
  * Note that the create offer domain has a deeper scope in the application domain (TradeManager).
  * That model is just responsible for the domain specific parts displayed needed in that UI element.
  */
-class CreateOfferDataModel extends EditableOfferDataModel {
+class CreateOfferDataModel extends MutableOfferDataModel {
 
     @Inject
     public CreateOfferDataModel(OpenOfferManager openOfferManager, BtcWalletService btcWalletService, BsqWalletService bsqWalletService, Preferences preferences, User user, KeyRing keyRing, P2PService p2PService, PriceFeedService priceFeedService, FilterManager filterManager, AccountAgeWitnessService accountAgeWitnessService, TradeWalletService tradeWalletService, FeeService feeService, ReferralIdService referralIdService, BSFormatter formatter) {

--- a/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferView.java
+++ b/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferView.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.offer.createoffer;
 
 import bisq.desktop.Navigation;
 import bisq.desktop.common.view.FxmlView;
-import bisq.desktop.main.offer.EditableOfferView;
+import bisq.desktop.main.offer.MutableOfferView;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
 import bisq.desktop.util.Transitions;
 
@@ -30,7 +30,7 @@ import bisq.core.util.BsqFormatter;
 import com.google.inject.Inject;
 
 @FxmlView
-public class CreateOfferView extends EditableOfferView<CreateOfferViewModel> {
+public class CreateOfferView extends MutableOfferView<CreateOfferViewModel> {
 
     @Inject
     public CreateOfferView(CreateOfferViewModel model, Navigation navigation, Preferences preferences, Transitions transitions, OfferDetailsWindow offerDetailsWindow, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {

--- a/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferViewModel.java
+++ b/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferViewModel.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.offer.createoffer;
 
 import bisq.desktop.Navigation;
 import bisq.desktop.common.model.ViewModel;
-import bisq.desktop.main.offer.EditableOfferViewModel;
+import bisq.desktop.main.offer.MutableOfferViewModel;
 import bisq.desktop.util.validation.AltcoinValidator;
 import bisq.desktop.util.validation.BsqValidator;
 import bisq.desktop.util.validation.BtcValidator;
@@ -37,7 +37,7 @@ import bisq.network.p2p.P2PService;
 
 import com.google.inject.Inject;
 
-class CreateOfferViewModel extends EditableOfferViewModel<CreateOfferDataModel> implements ViewModel {
+class CreateOfferViewModel extends MutableOfferViewModel<CreateOfferDataModel> implements ViewModel {
 
     @Inject
     public CreateOfferViewModel(CreateOfferDataModel dataModel, FiatVolumeValidator fiatVolumeValidator, FiatPriceValidator fiatPriceValidator, AltcoinValidator altcoinValidator, BtcValidator btcValidator, BsqValidator bsqValidator, SecurityDepositValidator securityDepositValidator, P2PService p2PService, WalletsSetup walletsSetup, PriceFeedService priceFeedService, Navigation navigation, Preferences preferences, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {

--- a/src/main/java/bisq/desktop/main/portfolio/PortfolioView.java
+++ b/src/main/java/bisq/desktop/main/portfolio/PortfolioView.java
@@ -26,7 +26,7 @@ import bisq.desktop.common.view.View;
 import bisq.desktop.common.view.ViewLoader;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.portfolio.closedtrades.ClosedTradesView;
-import bisq.desktop.main.portfolio.editoffer.EditOpenOfferView;
+import bisq.desktop.main.portfolio.editoffer.EditOfferView;
 import bisq.desktop.main.portfolio.failedtrades.FailedTradesView;
 import bisq.desktop.main.portfolio.openoffer.OpenOffersView;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesView;
@@ -64,7 +64,7 @@ public class PortfolioView extends ActivatableViewAndModel<TabPane, Activatable>
     private final ViewLoader viewLoader;
     private final Navigation navigation;
     private final FailedTradesManager failedTradesManager;
-    private EditOpenOfferView editOpenOfferView;
+    private EditOfferView editOfferView;
     private boolean editOpenOfferViewOpen;
     private OpenOffer openOffer;
     private OpenOffersView openOffersView;
@@ -102,11 +102,11 @@ public class PortfolioView extends ActivatableViewAndModel<TabPane, Activatable>
                 navigation.navigateTo(MainView.class, PortfolioView.class, FailedTradesView.class);
             else if (newValue == editOpenOfferTab) {
                 //noinspection unchecked
-                navigation.navigateTo(MainView.class, PortfolioView.class, EditOpenOfferView.class);
+                navigation.navigateTo(MainView.class, PortfolioView.class, EditOfferView.class);
             }
 
             if (oldValue != null && oldValue == editOpenOfferTab)
-                editOpenOfferView.onTabSelected(false);
+                editOfferView.onTabSelected(false);
 
         };
 
@@ -120,9 +120,9 @@ public class PortfolioView extends ActivatableViewAndModel<TabPane, Activatable>
 
     private void onEditOpenOfferRemoved() {
         editOpenOfferViewOpen = false;
-        if (editOpenOfferView != null) {
-            editOpenOfferView.onClose();
-            editOpenOfferView = null;
+        if (editOfferView != null) {
+            editOfferView.onClose();
+            editOfferView = null;
         }
 
         //noinspection unchecked
@@ -156,8 +156,8 @@ public class PortfolioView extends ActivatableViewAndModel<TabPane, Activatable>
             navigation.navigateTo(MainView.class, PortfolioView.class, FailedTradesView.class);
         else if (root.getSelectionModel().getSelectedItem() == editOpenOfferTab) {
             //noinspection unchecked
-            navigation.navigateTo(MainView.class, PortfolioView.class, EditOpenOfferView.class);
-            if (editOpenOfferView != null) editOpenOfferView.onTabSelected(true);
+            navigation.navigateTo(MainView.class, PortfolioView.class, EditOfferView.class);
+            if (editOfferView != null) editOfferView.onTabSelected(true);
         }
     }
 
@@ -185,19 +185,19 @@ public class PortfolioView extends ActivatableViewAndModel<TabPane, Activatable>
             currentTab = closedTradesTab;
         } else if (view instanceof FailedTradesView) {
             currentTab = failedTradesTab;
-        } else if (view instanceof EditOpenOfferView) {
+        } else if (view instanceof EditOfferView) {
             if (openOffer != null) {
-                if (editOpenOfferView == null) {
-                    editOpenOfferView = (EditOpenOfferView) view;
-                    editOpenOfferView.initWithData(openOffer);
+                if (editOfferView == null) {
+                    editOfferView = (EditOfferView) view;
+                    editOfferView.applyOpenOffer(openOffer);
                     editOpenOfferTab = new Tab(Res.get("portfolio.tab.editOpenOffer"));
-                    editOpenOfferView.setCloseHandler(() -> {
+                    editOfferView.setCloseHandler(() -> {
                         root.getTabs().remove(editOpenOfferTab);
                     });
                     root.getTabs().add(editOpenOfferTab);
                 }
                 if (currentTab != editOpenOfferTab)
-                    editOpenOfferView.onTabSelected(true);
+                    editOfferView.onTabSelected(true);
 
                 currentTab = editOpenOfferTab;
             } else {
@@ -218,7 +218,7 @@ public class PortfolioView extends ActivatableViewAndModel<TabPane, Activatable>
             if (!editOpenOfferViewOpen) {
                 editOpenOfferViewOpen = true;
                 PortfolioView.this.openOffer = openOffer;
-                navigation.navigateTo(MainView.class, PortfolioView.this.getClass(), EditOpenOfferView.class);
+                navigation.navigateTo(MainView.class, PortfolioView.this.getClass(), EditOfferView.class);
             } else {
                 log.error("You have already a \"Edit Offer\" tab open.");
             }

--- a/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
+++ b/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
@@ -18,18 +18,21 @@
 package bisq.desktop.main.portfolio.editoffer;
 
 
-import bisq.desktop.main.offer.EditableOfferDataModel;
+import bisq.desktop.main.offer.MutableOfferDataModel;
 
 import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.filter.FilterManager;
+import bisq.core.locale.CurrencyUtil;
+import bisq.core.locale.TradeCurrency;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.offer.OpenOffer;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.payment.AccountAgeWitnessService;
 import bisq.core.payment.PaymentAccount;
+import bisq.core.proto.persistable.CorePersistenceProtoResolver;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.statistics.ReferralIdService;
@@ -42,33 +45,41 @@ import bisq.network.p2p.P2PService;
 import bisq.common.crypto.KeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
+import bisq.common.proto.persistable.PersistenceProtoResolver;
 
 import com.google.inject.Inject;
 
-import javax.annotation.Nullable;
+class EditOfferDataModel extends MutableOfferDataModel {
 
-class EditOpenOfferDataModel extends EditableOfferDataModel {
-
+    private final CorePersistenceProtoResolver corePersistenceProtoResolver;
     private OpenOffer openOffer;
     private OpenOffer.State initialState;
 
     @Inject
-    EditOpenOfferDataModel(OpenOfferManager openOfferManager, BtcWalletService btcWalletService, BsqWalletService bsqWalletService, Preferences preferences, User user, KeyRing keyRing, P2PService p2PService, PriceFeedService priceFeedService, FilterManager filterManager, AccountAgeWitnessService accountAgeWitnessService, TradeWalletService tradeWalletService, FeeService feeService, ReferralIdService referralIdService, BSFormatter formatter) {
+    EditOfferDataModel(OpenOfferManager openOfferManager, BtcWalletService btcWalletService, BsqWalletService bsqWalletService, Preferences preferences, User user, KeyRing keyRing, P2PService p2PService, PriceFeedService priceFeedService, FilterManager filterManager, AccountAgeWitnessService accountAgeWitnessService, TradeWalletService tradeWalletService, FeeService feeService, ReferralIdService referralIdService, BSFormatter formatter, CorePersistenceProtoResolver corePersistenceProtoResolver) {
         super(openOfferManager, btcWalletService, bsqWalletService, preferences, user, keyRing, p2PService, priceFeedService, filterManager, accountAgeWitnessService, tradeWalletService, feeService, referralIdService, formatter);
+        this.corePersistenceProtoResolver = corePersistenceProtoResolver;
     }
 
-    public void initWithData(OpenOffer openOffer) {
+    public void applyOpenOffer(OpenOffer openOffer) {
         this.openOffer = openOffer;
         this.initialState = openOffer.getState();
-        this.paymentAccount = user.getPaymentAccount(openOffer.getOffer().getMakerPaymentAccountId());
+        final PaymentAccount tmpPaymentAccount = user.getPaymentAccount(openOffer.getOffer().getMakerPaymentAccountId());
+        final TradeCurrency selectedTradeCurrency = CurrencyUtil.getTradeCurrency(openOffer.getOffer().getCurrencyCode()).get();
+
+        this.paymentAccount = PaymentAccount.fromProto(tmpPaymentAccount.toProtoMessage(), corePersistenceProtoResolver);
+
+        if (paymentAccount.getSingleTradeCurrency() != null)
+            paymentAccount.setSingleTradeCurrency(selectedTradeCurrency);
+        else
+            paymentAccount.setSelectedTradeCurrency(selectedTradeCurrency);
 
         this.allowAmountUpdate = false;
     }
 
     @Override
-    @Nullable
     protected PaymentAccount getPreselectedPaymentAccount() {
-        return null;
+        return paymentAccount;
     }
 
     public void populateData() {

--- a/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.fxml
+++ b/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.fxml
@@ -18,7 +18,7 @@
   -->
 
 <?import javafx.scene.layout.AnchorPane?>
-<AnchorPane fx:id="root" fx:controller="bisq.desktop.main.portfolio.editoffer.EditOpenOfferView"
+<AnchorPane fx:id="root" fx:controller="bisq.desktop.main.portfolio.editoffer.EditOfferView"
             xmlns:fx="http://javafx.com/fxml">
 
 </AnchorPane>

--- a/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
+++ b/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
@@ -20,7 +20,7 @@ package bisq.desktop.main.portfolio.editoffer;
 import bisq.desktop.Navigation;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.BusyAnimation;
-import bisq.desktop.main.offer.EditableOfferView;
+import bisq.desktop.main.offer.MutableOfferView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
 import bisq.desktop.util.Transitions;
@@ -46,7 +46,7 @@ import static bisq.desktop.util.FormBuilder.addButton;
 import static bisq.desktop.util.FormBuilder.addButtonBusyAnimationLabelAfterGroup;
 
 @FxmlView
-public class EditOpenOfferView extends EditableOfferView<EditOpenOfferViewModel> {
+public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
 
     private BusyAnimation busyAnimation;
     private Button confirmButton;
@@ -57,7 +57,7 @@ public class EditOpenOfferView extends EditableOfferView<EditOpenOfferViewModel>
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    private EditOpenOfferView(EditOpenOfferViewModel model, Navigation navigation, Preferences preferences, Transitions transitions, OfferDetailsWindow offerDetailsWindow, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {
+    private EditOfferView(EditOfferViewModel model, Navigation navigation, Preferences preferences, Transitions transitions, OfferDetailsWindow offerDetailsWindow, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {
         super(model, navigation, preferences, transitions, offerDetailsWindow, btcFormatter, bsqFormatter);
     }
 
@@ -130,10 +130,11 @@ public class EditOpenOfferView extends EditableOfferView<EditOpenOfferViewModel>
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public void initWithData(OpenOffer openOffer) {
-        super.initWithData(openOffer.getOffer().getDirection(),
+    public void applyOpenOffer(OpenOffer openOffer) {
+        model.applyOpenOffer(openOffer);
+
+        initWithData(openOffer.getOffer().getDirection(),
                 CurrencyUtil.getTradeCurrency(openOffer.getOffer().getCurrencyCode()).get());
-        model.initWithData(openOffer);
 
         model.onStartEditOffer(errorMessage -> {
             log.error(errorMessage);

--- a/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
+++ b/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.portfolio.editoffer;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.main.offer.EditableOfferViewModel;
+import bisq.desktop.main.offer.MutableOfferViewModel;
 import bisq.desktop.util.validation.AltcoinValidator;
 import bisq.desktop.util.validation.BsqValidator;
 import bisq.desktop.util.validation.BtcValidator;
@@ -40,10 +40,10 @@ import bisq.common.handlers.ResultHandler;
 
 import com.google.inject.Inject;
 
-class EditOpenOfferViewModel extends EditableOfferViewModel<EditOpenOfferDataModel> {
+class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
 
     @Inject
-    public EditOpenOfferViewModel(EditOpenOfferDataModel dataModel, FiatVolumeValidator fiatVolumeValidator, FiatPriceValidator fiatPriceValidator, AltcoinValidator altcoinValidator, BtcValidator btcValidator, BsqValidator bsqValidator, SecurityDepositValidator securityDepositValidator, P2PService p2PService, WalletsSetup walletsSetup, PriceFeedService priceFeedService, Navigation navigation, Preferences preferences, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {
+    public EditOfferViewModel(EditOfferDataModel dataModel, FiatVolumeValidator fiatVolumeValidator, FiatPriceValidator fiatPriceValidator, AltcoinValidator altcoinValidator, BtcValidator btcValidator, BsqValidator bsqValidator, SecurityDepositValidator securityDepositValidator, P2PService p2PService, WalletsSetup walletsSetup, PriceFeedService priceFeedService, Navigation navigation, Preferences preferences, BSFormatter btcFormatter, BsqFormatter bsqFormatter) {
         super(dataModel, fiatVolumeValidator, fiatPriceValidator, altcoinValidator, btcValidator, bsqValidator, securityDepositValidator, p2PService, walletsSetup, priceFeedService, navigation, preferences, btcFormatter, bsqFormatter);
     }
 
@@ -53,8 +53,8 @@ class EditOpenOfferViewModel extends EditableOfferViewModel<EditOpenOfferDataMod
         dataModel.populateData();
     }
 
-    public void initWithData(OpenOffer openOffer) {
-        dataModel.initWithData(openOffer);
+    public void applyOpenOffer(OpenOffer openOffer) {
+        dataModel.applyOpenOffer(openOffer);
     }
 
     public void onStartEditOffer(ErrorMessageHandler errorMessageHandler) {

--- a/src/main/java/bisq/desktop/util/CurrencyList.java
+++ b/src/main/java/bisq/desktop/util/CurrencyList.java
@@ -31,8 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -61,10 +59,8 @@ public class CurrencyList extends ObservableListWrapper<CurrencyListItem> {
 
     private List<CurrencyListItem> getPartitionedSortedItems(List<TradeCurrency> currencies) {
         Map<TradeCurrency, Integer> tradesPerCurrency = countTrades(currencies);
-
-        Comparator<CurrencyListItem> comparator = getComparator();
-        Queue<CurrencyListItem> fiatCurrencies = new PriorityQueue<>(comparator);
-        Queue<CurrencyListItem> cryptoCurrencies = new PriorityQueue<>(comparator);
+        List<CurrencyListItem> fiatCurrencies = new ArrayList<>();
+        List<CurrencyListItem> cryptoCurrencies = new ArrayList<>();
 
         for (Map.Entry<TradeCurrency, Integer> entry : tradesPerCurrency.entrySet()) {
             TradeCurrency currency = entry.getKey();
@@ -80,7 +76,11 @@ public class CurrencyList extends ObservableListWrapper<CurrencyListItem> {
             }
         }
 
-        List<CurrencyListItem> result = Lists.newLinkedList();
+        Comparator<CurrencyListItem> comparator = getComparator();
+        fiatCurrencies.sort(comparator);
+        cryptoCurrencies.sort(comparator);
+
+        List<CurrencyListItem> result = new ArrayList<>();
         result.addAll(fiatCurrencies);
         result.addAll(cryptoCurrencies);
 

--- a/src/test/java/bisq/core/user/PreferenceMakers.java
+++ b/src/test/java/bisq/core/user/PreferenceMakers.java
@@ -34,12 +34,14 @@ public class PreferenceMakers {
     public static final Property<Preferences, BisqEnvironment> bisqEnvironment = new Property<>();
     public static final Property<Preferences, String> btcNodesFromOptions = new Property<>();
     public static final Property<Preferences, String> useTorFlagFromOptions = new Property<>();
+    public static final Property<Preferences, String> referralID = new Property<>();
 
     public static final Instantiator<Preferences> Preferences = lookup -> new Preferences(
             lookup.valueOf(storage, new SameValueDonor<Storage>(null)),
             lookup.valueOf(bisqEnvironment, new SameValueDonor<BisqEnvironment>(null)),
             lookup.valueOf(btcNodesFromOptions, new SameValueDonor<String>(null)),
-            lookup.valueOf(useTorFlagFromOptions, new SameValueDonor<String>(null)));
+            lookup.valueOf(useTorFlagFromOptions, new SameValueDonor<String>(null)),
+            lookup.valueOf(referralID, new SameValueDonor<String>(null)));
 
     public static final Preferences empty = make(a(Preferences));
 


### PR DESCRIPTION
Rename classes to prevent confusion and add fix for payment accounts with multiple currencies when editing offers