### PR TITLE
Add rounded fiat value info popup

### DIFF
--- a/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -723,6 +723,10 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
         volumeListener = (observable, oldValue, newValue) -> {
           if (!newValue.equals("") && CurrencyUtil.isFiatCurrency(model.tradeCurrencyCode.get())) {
               volumeInfoInputTextField.setContentForPrivacyPopOver(createPopoverLabel(Res.get("offerbook.info.roundedFiatVolume")));
+              new Popup<>().headLine(Res.get("popup.roundedFiatValues.headline"))
+                  .information(Res.get("popup.roundedFiatValues.msg", model.tradeCurrencyCode.get()))
+                  .dontShowAgainId("FiatValuesRoundedWarning")
+                  .show();
           }
         };
 

--- a/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -145,7 +145,6 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     private BusyAnimation waitingForFundsBusyAnimation, offerAvailabilityBusyAnimation;
     private Notification walletFundedNotification;
     private OfferView.CloseHandler closeHandler;
-    private ChangeListener<Boolean> amountFocusedListener;
     private Subscription cancelButton2StyleSubscription, balanceSubscription,
             showTransactionPublishedScreenSubscription, showWarningInvalidBtcDecimalPlacesSubscription,
             isWaitingForFundsSubscription, offerWarningSubscription, errorMessageSubscription,
@@ -154,7 +153,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     private int gridRow = 0;
     private boolean offerDetailsWindowDisplayed, clearXchangeWarningDisplayed;
     private SimpleBooleanProperty errorPopupDisplayed;
-    private ChangeListener<Boolean> getShowWalletFundedNotificationListener;
+    private ChangeListener<Boolean> amountFocusedListener, getShowWalletFundedNotificationListener;
     private InfoTextField volumeInfoTextField;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -212,8 +211,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     protected void activate() {
         addBindings();
         addSubscriptions();
-
-        amountTextField.focusedProperty().addListener(amountFocusedListener);
+        addListeners();
 
         if (offerAvailabilityBusyAnimation != null && !model.showPayFundsScreenDisplayed.get()) {
             offerAvailabilityBusyAnimation.play();
@@ -253,23 +251,25 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
             showNextStepAfterAmountIsSet();
         }
 
-        // notifications
-        model.dataModel.getShowWalletFundedNotification().addListener(getShowWalletFundedNotificationListener);
+        if (CurrencyUtil.isFiatCurrency(model.getOffer().getCurrencyCode())) {
+            new Popup<>().headLine(Res.get("popup.roundedFiatValues.headline"))
+                    .information(Res.get("popup.roundedFiatValues.msg", model.getOffer().getCurrencyCode()))
+                    .dontShowAgainId("FiatValuesRoundedWarning")
+                    .show();
+        }
     }
 
     @Override
     protected void deactivate() {
         removeBindings();
         removeSubscriptions();
-        amountTextField.focusedProperty().removeListener(amountFocusedListener);
+        removeListeners();
 
         if (offerAvailabilityBusyAnimation != null)
             offerAvailabilityBusyAnimation.stop();
 
         if (waitingForFundsBusyAnimation != null)
             waitingForFundsBusyAnimation.stop();
-
-        model.dataModel.getShowWalletFundedNotification().removeListener(getShowWalletFundedNotificationListener);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -664,6 +664,15 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         cancelButton2StyleSubscription.unsubscribe();
     }
 
+    private void addListeners() {
+        amountTextField.focusedProperty().addListener(amountFocusedListener);
+        model.dataModel.getShowWalletFundedNotification().addListener(getShowWalletFundedNotificationListener);
+    }
+
+    private void removeListeners() {
+        amountTextField.focusedProperty().removeListener(amountFocusedListener);
+        model.dataModel.getShowWalletFundedNotification().removeListener(getShowWalletFundedNotificationListener);
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Build UI elements


### PR DESCRIPTION
Fixes #1511.

Besides the 👁 icon that is added already, I've added an additional popup for create and take offer screens.

Dependent on: https://github.com/bisq-network/bisq-core/pull/153

![bildschirmfoto 2018-08-16 um 11 25 37](https://user-images.githubusercontent.com/170962/44201018-6ccea780-a148-11e8-9376-6b743c9a2bd0.png)
![bildschirmfoto 2018-08-16 um 11 25 29](https://user-images.githubusercontent.com/170962/44201019-6ccea780-a148-11e8-9bcd-427a9006597c.png)
