### PR TITLE
Use correct version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'witness'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'network.bisq'
-version = '-SNAPSHOT'
+version = '0.8.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
Didn't have an effect on the release, but should be now 0.8.0-SNAPSHOT