### PR TITLE
List Kekcoin (KEK)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Kekcoin.java
+++ b/assets/src/main/java/bisq/asset/coins/Kekcoin.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class Kekcoin extends Coin {
+
+    public Kekcoin() {
+        super("Kekcoin", "KEK", new Base58BitcoinAddressValidator(new KekcoinParams()));
+    }
+
+
+    public static class KekcoinParams extends NetworkParametersAdapter {
+
+        public KekcoinParams() {
+            super();
+            addressHeader = 45;
+            p2shHeader = 88;
+            acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+        }
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -56,6 +56,7 @@ bisq.asset.coins.Gridcoin
 bisq.asset.coins.InfinityEconomics
 bisq.asset.coins.Instacash
 bisq.asset.coins.InternetOfPeople
+bisq.asset.coins.Kekcoin
 bisq.asset.coins.Koto
 bisq.asset.coins.Kumacoin
 bisq.asset.coins.LBRY

--- a/assets/src/test/java/bisq/asset/coins/KekcoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/KekcoinTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class KekcoinTest extends AbstractAssetTest {
+
+    public KekcoinTest() {
+        super(new Kekcoin());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("KHWHFVU5ZMUfkiYEMMuXRDv1LjD2j1HJ2H");
+        assertValidAddress("KSXQWsaKC9qL2e2RoeXNXY4FgQC6qUBpjD");
+        assertValidAddress("KNVy3X1iuiF7Gz9a4fSYLF3RehN2yGkFvP");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("1LgfapHEPhZbRF9pMd5WPT35hFXcZS1USrW");
+        assertInvalidAddress("1K5B7SDcuZvd2oUTaW9d62gwqsZkteXqA4");
+        assertInvalidAddress("1GckU1XSCknLBcTGnayBVRjNsDjxqopNav");
+    }
+}


### PR DESCRIPTION
- Official project URL: https://kekcoin.co
- Official block explorer URL: http://explorer.kekcoin.co

This is a resubmission. The original submission can be found here: https://github.com/bisq-network/bisq-assets/pull/113. The PR did not have an ACK at time of migration.