### PR TITLE
List Bitmark

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Bitmark.java
+++ b/assets/src/main/java/bisq/asset/coins/Bitmark.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Coin;
+import bisq.asset.DefaultAddressValidator;
+
+public class Bitmark extends Coin {
+
+    public Bitmark() {
+        super("Bitmark", "BTM", new DefaultAddressValidator());
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -17,6 +17,7 @@ bisq.asset.coins.Bitcoin$Regtest
 bisq.asset.coins.Bitcoin$Testnet
 bisq.asset.coins.Bitcore
 bisq.asset.coins.BitDaric
+bisq.asset.coins.Bitmark
 bisq.asset.coins.BitZeny
 bisq.asset.coins.BSQ$Mainnet
 bisq.asset.coins.BSQ$Regtest

--- a/assets/src/test/java/bisq/asset/coins/BitmarkTest.java
+++ b/assets/src/test/java/bisq/asset/coins/BitmarkTest.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetWithDefaultValidatorTest;
+
+public class BitmarkTest extends AbstractAssetWithDefaultValidatorTest {
+
+    public BitmarkTest() {
+        super(new Bitmark());
+    }
+}


### PR DESCRIPTION
If you need extra parts to the commit (like test cases), let me know. I just copied and pasted what I saw for Namecoin, which is a similar coin (both based on Bitcoin).

The version of Bitmark I want to use may different than what will soon be listed on other exchanges. The "official team" wants to add a controversial fork that is obviously a scam and departs from the honest protocol that Bitmark maintained throughout the years. You can se the discussion here: https://bitcointalk.org/index.php?topic=3169983.msg43299842#msg43299842

If you want call it "Bitmark Classic", but the ticker name BTM shouldn't conflict because the team of investors controlling the alternate repo (project-bitmark) want the ticker name to be MARKS.

The repo I want to be used is the one created by this account (bitmark-protocol/bitmark). The explorer: https://explorer.bitmark.cc