### PR TITLE
Check bisq.asset.Asset sort order during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 jdk: oraclejdk8
+before_install:
+  grep -v '^#' src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
 notifications:
   slack:
     on_success: change


### PR DESCRIPTION
This check had been set up for some time in the original
bisq-network/bisq-assets repository.