### PR TITLE
Fix last request timestamp in price feed service

### DIFF
--- a/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
@@ -280,13 +280,13 @@ public class PriceFeedService {
     }
 
     public Date getLastRequestTimeStampBtcAverage() {
-        return new Date(epochInSecondAtLastRequest * 1000);
+        return new Date(epochInSecondAtLastRequest);
     }
 
     public Date getLastRequestTimeStampPoloniex() {
         Long ts = timeStampMap.get("btcAverageTs");
         if (ts != null) {
-            return new Date(ts * 1000);
+            return new Date(ts);
         } else
             return new Date();
     }
@@ -294,7 +294,7 @@ public class PriceFeedService {
     public Date getLastRequestTimeStampCoinmarketcap() {
         Long ts = timeStampMap.get("coinmarketcapTs");
         if (ts != null) {
-            return new Date(ts * 1000);
+            return new Date(ts);
         } else
             return new Date();
     }


### PR DESCRIPTION
I noticed the last update time shown in the market price popup was incorrect. It was updating/refreshing, but not accurate.
![image](https://user-images.githubusercontent.com/603793/46172266-ea152e00-c257-11e8-9ea1-e140df0bd666.png)

Upon debugging, I identified the timestamps were incorrectly being multiplied by 1000 in the price feed service. Removing this caused it to return the correct date, as shown below.
![image](https://user-images.githubusercontent.com/603793/46172785-3876fc80-c259-11e8-81dc-a7169d0d5504.png)