### PR TITLE
List Dragonglass (DRGL)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Dragonglass.java
+++ b/assets/src/main/java/bisq/asset/coins/Dragonglass.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Coin;
+import bisq.asset.RegexAddressValidator;
+
+public class Dragonglass extends Coin {
+
+    public Dragonglass() {
+        super("Dragonglass", "DRGL", new RegexAddressValidator("^(dRGL)[1-9A-HJ-NP-Za-km-z]{94}$"));
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -47,6 +47,7 @@ bisq.asset.coins.Diamond
 bisq.asset.coins.DigiMoney
 bisq.asset.coins.Dinero
 bisq.asset.coins.Dogecoin
+bisq.asset.coins.Dragonglass
 bisq.asset.coins.DRIP
 bisq.asset.coins.DSTRA
 bisq.asset.coins.DynamicCoin

--- a/assets/src/test/java/bisq/asset/coins/DragonglassTest.java
+++ b/assets/src/test/java/bisq/asset/coins/DragonglassTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class DragonglassTest extends AbstractAssetTest {
+
+    public DragonglassTest() {
+        super(new Dragonglass());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("dRGLhxvCtLk1vfSD3WmFzyTN5ph2gZYvkZfxvLSrcdry95x4PPJrCKBTKDEFZYTw4bCGqoiaUWxNd8B41vqXaTY72Vi2XcvikX");
+        assertValidAddress("dRGLjS5v91tDd4GDZeahUj95nkXSNQs5DMY1YStLN2hSNWD67iZh7ED7oDw841Kx6oUYouZaXmBNFcqSptNZ4dL94CbZbF53jt");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("dRGLjS5v91tDd4GDZeahUj95nkXSNQs5DMY1YStLN2hSNWD67iZh7ED7oDw841Kx6oUYouZaXmBNFcqSptNZ4dL94CbZbF53j");
+        assertInvalidAddress("dRGLjS5v91tDd4GDZeahUj95nkXSNQs5DMY1YStLN2hSNWD67iZh7ED7oDw841Ko6oUYouZaXmBNFcqSptNZ4dL94oUCifk4048");
+        assertInvalidAddress("DRGLhxvCtLk1vfSD3WmFzyTN5ph2gZYvkZfxvLSrcdry95x4PPJrCKBTKDEFZYTw4bCGqoiaUWxNd8B41vqXaTY72Vi2XcvikX");
+        assertInvalidAddress("drglhxvCtLk1vfSD3WmFzyTN5ph2gZYvkZfxvLSrcdry95x4PPJrCKBTKDEFZYTw4bCGqoiaUWxNd8B41vqXaTY72Vi2XcvikX");
+        assertInvalidAddress("dRgLjS5v91tDd4GDZeahUj95nkXSNQs5DMY1YStLN2hSNWD67iZh7ED7oDw841Kx6oUYouZaXmBNFcqSptNZ4dL94CbZbF53jt");
+        assertInvalidAddress("dRGlhxvCtLk1vfSD3WmFzyTN5ph2gZYvkZfxvLSrcdry95x4PPJrCKBTKDEFZYTw4bCGqoiaUWxNd8B41vqXaTY72Vi2XcvikX");
+    }
+}


### PR DESCRIPTION
This is a resubmission of [(DRGL) bisq-assets#86](https://github.com/bisq-network/bisq-assets/pull/86)
awaiting ACK/approval.

Official project URL: https://zirtysperzys.org
Official block explorer URL: http://zirtysperzys.info
Additional: DRGL wallets support transaction keys that enable 3rd party audits in case of a dispute similar to Monero


