### PR TITLE
Show cancel button in wallet password prompt

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main;
 
+import bisq.desktop.app.BisqApp;
 import bisq.desktop.common.model.ViewModel;
 import bisq.desktop.components.BalanceWithConfirmationTextField;
 import bisq.desktop.components.TxIdTextField;
@@ -291,7 +292,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
         bisqSetup.setShowFirstPopupIfResyncSPVRequestedHandler(this::showFirstPopupIfResyncSPVRequested);
         bisqSetup.setRequestWalletPasswordHandler(aesKeyHandler -> walletPasswordWindow
                 .onAesKey(aesKeyHandler::accept)
-                .hideCloseButton()
+                .onClose(() -> BisqApp.getShutDownHandler().run())
                 .show());
 
         bisqSetup.setDisplayUpdateHandler((alert, key) -> new DisplayUpdateDownloadWindow(alert)

--- a/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
@@ -203,7 +203,7 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
         walletPasswordWindow.headLine(Res.get("account.seed.enterPw")).onAesKey(aesKey -> {
             initSeedWords(walletsManager.getDecryptedSeed(aesKey, btcWalletService.getKeyChainSeed(), btcWalletService.getKeyCrypter()));
             showSeedScreen();
-        }).show();
+        }).hideForgotPasswordButton().show();
     }
 
     private void initSeedWords(DeterministicSeed seed) {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.overlays.windows;
 
-import bisq.desktop.app.BisqApp;
 import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.BusyAnimation;
@@ -248,7 +247,6 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         cancelButton.setOnAction(event -> {
             hide();
             closeHandlerOptional.ifPresent(Runnable::run);
-            BisqApp.getShutDownHandler().run();
         });
 
         HBox hBox = new HBox();
@@ -257,7 +255,10 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         GridPane.setRowIndex(hBox, ++rowIndex);
         GridPane.setColumnIndex(hBox, 1);
         hBox.setAlignment(Pos.CENTER_LEFT);
-        hBox.getChildren().addAll(unlockButton, forgotPasswordButton, cancelButton, busyAnimation, deriveStatusLabel);
+        if (hideCloseButton)
+            hBox.getChildren().addAll(unlockButton, forgotPasswordButton, busyAnimation, deriveStatusLabel);
+        else
+            hBox.getChildren().addAll(unlockButton, forgotPasswordButton, cancelButton, busyAnimation, deriveStatusLabel);
         gridPane.getChildren().add(hBox);
 
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.overlays.windows;
 
+import bisq.desktop.app.BisqApp;
 import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.BusyAnimation;
@@ -247,6 +248,7 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         cancelButton.setOnAction(event -> {
             hide();
             closeHandlerOptional.ifPresent(Runnable::run);
+            BisqApp.getShutDownHandler().run();
         });
 
         HBox hBox = new HBox();
@@ -255,10 +257,7 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         GridPane.setRowIndex(hBox, ++rowIndex);
         GridPane.setColumnIndex(hBox, 1);
         hBox.setAlignment(Pos.CENTER_LEFT);
-        if (hideCloseButton)
-            hBox.getChildren().addAll(unlockButton, forgotPasswordButton, busyAnimation, deriveStatusLabel);
-        else
-            hBox.getChildren().addAll(unlockButton, cancelButton);
+        hBox.getChildren().addAll(unlockButton, forgotPasswordButton, cancelButton, busyAnimation, deriveStatusLabel);
         gridPane.getChildren().add(hBox);
 
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
@@ -104,6 +104,7 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
     private ChangeListener<String> wordsTextAreaChangeListener;
     private ChangeListener<Boolean> seedWordsValidChangeListener;
     private LocalDate walletCreationDate;
+    private boolean hideForgotPasswordButton = false;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -149,6 +150,11 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
 
     public WalletPasswordWindow onAesKey(AesKeyHandler aesKeyHandler) {
         this.aesKeyHandler = aesKeyHandler;
+        return this;
+    }
+
+    public WalletPasswordWindow hideForgotPasswordButton() {
+        this.hideForgotPasswordButton = true;
         return this;
     }
 
@@ -255,10 +261,12 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         GridPane.setRowIndex(hBox, ++rowIndex);
         GridPane.setColumnIndex(hBox, 1);
         hBox.setAlignment(Pos.CENTER_LEFT);
-        if (hideCloseButton)
-            hBox.getChildren().addAll(unlockButton, forgotPasswordButton, busyAnimation, deriveStatusLabel);
-        else
-            hBox.getChildren().addAll(unlockButton, forgotPasswordButton, cancelButton, busyAnimation, deriveStatusLabel);
+        hBox.getChildren().add(unlockButton);
+        if (!hideForgotPasswordButton)
+            hBox.getChildren().add(forgotPasswordButton);
+        if (!hideCloseButton)
+            hBox.getChildren().add(cancelButton);
+        hBox.getChildren().addAll(busyAnimation, deriveStatusLabel);
         gridPane.getChildren().add(hBox);
 
 


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/1181

When launching the application, there was no way to cancel the wallet password prompt and quit the application. Attempting to close the application window did not quit the application (at least not in Windows 10).

So a cancel button has been added:
![image](https://user-images.githubusercontent.com/603793/46637759-8372f880-cb12-11e8-99d7-abe30ebd3b66.png)