### PR TITLE
Workaround for JDK-8199592; text being truncated at certain display scaling levels

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
@@ -488,6 +488,7 @@ public abstract class Overlay<T extends Overlay> {
                     event.consume();
                     doClose();
                 });
+                stage.sizeToScene();
                 stage.show();
 
                 layout();


### PR DESCRIPTION
Using display scaling (e.g. 150% in Windows 10), text content within popups were being truncated.
A couple examples:
![image](https://user-images.githubusercontent.com/603793/46785717-8541e500-cce7-11e8-942d-b2e50d86de61.png)

![image](https://user-images.githubusercontent.com/603793/46785774-aa365800-cce7-11e8-92c2-31feed89e4f5.png)

This is a result of a known Java bug (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8199592) which mentions a workaround:
> explicitly calling sizeToScene appears to suppress the bug at DPI levels other than 175%

I confirmed that this workaround fixes the truncation at 125% and 150% scaling, but noticed it still truncates the checkbox label at 175% (as stated in the workaround):
![image](https://user-images.githubusercontent.com/603793/46785899-0b5e2b80-cce8-11e8-832b-0ee18dec25c5.png)