### PR TITLE
Fix arbitrator language selection

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/account/content/arbitratorselection/ArbitratorSelectionView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/arbitratorselection/ArbitratorSelectionView.java
@@ -193,6 +193,17 @@ public class ArbitratorSelectionView extends ActivatableViewAndModel<GridPane, A
 
         languageComboBox = FormBuilder.<String>addLabelComboBox(root, ++gridRow, "", 15).second;
         languageComboBox.setPromptText(Res.get("shared.addLanguage"));
+        languageComboBox.setButtonCell(new ListCell<String>() {
+            @Override
+            protected void updateItem(final String item, boolean empty) {
+                super.updateItem(item, empty) ;
+                if (empty || item == null) {
+                    setText(Res.get("shared.addLanguage"));
+                } else {
+                    setText(LanguageUtil.getDisplayName(item));
+                }
+            }
+        });
         languageComboBox.setConverter(new StringConverter<String>() {
             @Override
             public String toString(String code) {

--- a/desktop/src/main/java/bisq/desktop/main/account/content/arbitratorselection/ArbitratorSelectionView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/arbitratorselection/ArbitratorSelectionView.java
@@ -204,7 +204,7 @@ public class ArbitratorSelectionView extends ActivatableViewAndModel<GridPane, A
                 return null;
             }
         });
-        languageComboBox.setOnAction(e -> onAddLanguage());
+        languageComboBox.setOnHiding(e -> onAddLanguage());
     }
 
     private void addArbitratorsGroup() {


### PR DESCRIPTION
- Fix arbitrator language selection where using arrow keys to navigate the combobox would add the first language. (https://github.com/bisq-network/bisq/issues/354)
- Fix arbitrator language selection prompt text no longer appearing after selecting a language.