### PR TITLE
Fix preferences view combobox selection

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -426,6 +426,17 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
         fiatCurrenciesComboBox = FormBuilder.<FiatCurrency>addLabelComboBox(root, ++gridRow).second;
         fiatCurrenciesComboBox.setPromptText(Res.get("setting.preferences.addFiat"));
+        fiatCurrenciesComboBox.setButtonCell(new ListCell<FiatCurrency>() {
+            @Override
+            protected void updateItem(final FiatCurrency item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(Res.get("setting.preferences.addFiat"));
+                } else {
+                    setText(item.getNameAndCode());
+                }
+            }
+        });
         fiatCurrenciesComboBox.setConverter(new StringConverter<FiatCurrency>() {
             @Override
             public String toString(FiatCurrency tradeCurrency) {
@@ -442,6 +453,17 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         cryptoCurrenciesComboBox = labelComboBoxTuple2.second;
         GridPane.setColumnIndex(cryptoCurrenciesComboBox, 3);
         cryptoCurrenciesComboBox.setPromptText(Res.get("setting.preferences.addAltcoin"));
+        cryptoCurrenciesComboBox.setButtonCell(new ListCell<CryptoCurrency>() {
+            @Override
+            protected void updateItem(final CryptoCurrency item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(Res.get("setting.preferences.addAltcoin"));
+                } else {
+                    setText(item.getNameAndCode());
+                }
+            }
+        });
         cryptoCurrenciesComboBox.setConverter(new StringConverter<CryptoCurrency>() {
             @Override
             public String toString(CryptoCurrency tradeCurrency) {

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -604,7 +604,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
         fiatCurrenciesComboBox.setItems(allFiatCurrencies);
         fiatCurrenciesListView.setItems(fiatCurrencies);
-        fiatCurrenciesComboBox.setOnAction(e -> {
+        fiatCurrenciesComboBox.setOnHiding(e -> {
             FiatCurrency selectedItem = fiatCurrenciesComboBox.getSelectionModel().getSelectedItem();
             if (selectedItem != null) {
                 preferences.addFiatCurrency(selectedItem);
@@ -619,7 +619,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         });
         cryptoCurrenciesComboBox.setItems(allCryptoCurrencies);
         cryptoCurrenciesListView.setItems(cryptoCurrencies);
-        cryptoCurrenciesComboBox.setOnAction(e -> {
+        cryptoCurrenciesComboBox.setOnHiding(e -> {
             CryptoCurrency selectedItem = cryptoCurrenciesComboBox.getSelectionModel().getSelectedItem();
             if (selectedItem != null) {
                 preferences.addCryptoCurrency(selectedItem);

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -360,8 +360,10 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                                     new Popup<>().warning(Res.get("setting.preferences.cannotRemovePrefCurrency")).show();
                                 } else {
                                     preferences.removeFiatCurrency(item);
-                                    if (!allFiatCurrencies.contains(item))
+                                    if (!allFiatCurrencies.contains(item)) {
                                         allFiatCurrencies.add(item);
+                                        allFiatCurrencies.sort(TradeCurrency::compareTo);
+                                    }
                                 }
                             });
                             setGraphic(pane);
@@ -410,8 +412,10 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                                     new Popup<>().warning(Res.get("setting.preferences.cannotRemovePrefCurrency")).show();
                                 } else {
                                     preferences.removeCryptoCurrency(item);
-                                    if (!allCryptoCurrencies.contains(item))
+                                    if (!allCryptoCurrencies.contains(item)) {
                                         allCryptoCurrencies.add(item);
+                                        allCryptoCurrencies.sort(TradeCurrency::compareTo);
+                                    }
                                 }
                             });
                             setGraphic(pane);


### PR DESCRIPTION
Relates to https://github.com/bisq-network/bisq/pull/1771.

Regarding the ComboBoxes for adding currencies and altcoins in the preferences view:
- Fix for using arrow keys to navigate the ComboBox adding the first option.
- Fix prompt text no longer appearing after selecting an option.
- Fix option not sorted when added back to the ComboBox.