### PR TITLE
Hide text that is not applicable in take offer view

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -418,6 +418,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         cancelButton1.setVisible(false);
         cancelButton1.setManaged(false);
         cancelButton1.setOnAction(null);
+        offerAvailabilityBusyAnimation.stop();
         offerAvailabilityLabel.setVisible(false);
         offerAvailabilityLabel.setManaged(false);
 
@@ -457,7 +458,6 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
                     .show();
         }
 
-        offerAvailabilityBusyAnimation.stop();
         cancelButton2.setVisible(true);
 
         waitingForFundsBusyAnimation.play();

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -418,6 +418,8 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         cancelButton1.setVisible(false);
         cancelButton1.setManaged(false);
         cancelButton1.setOnAction(null);
+        offerAvailabilityLabel.setVisible(false);
+        offerAvailabilityLabel.setManaged(false);
 
 
         model.onShowPayFundsScreen();

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -254,7 +254,10 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         maybeShowClearXchangeWarning();
 
         if (!model.isRange()) {
-            showNextStepAfterAmountIsSet();
+            nextButton.setVisible(false);
+            cancelButton1.setVisible(false);
+            if (model.isOfferAvailable.get())
+                showNextStepAfterAmountIsSet();
         }
 
         if (CurrencyUtil.isFiatCurrency(model.getOffer().getCurrencyCode())) {
@@ -587,8 +590,11 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         });
 
         isOfferAvailableSubscription = EasyBind.subscribe(model.isOfferAvailable, isOfferAvailable -> {
-            if (isOfferAvailable)
+            if (isOfferAvailable) {
                 offerAvailabilityBusyAnimation.stop();
+                if (!model.isRange() && !model.showPayFundsScreenDisplayed.get())
+                    showNextStepAfterAmountIsSet();
+            }
 
             offerAvailabilityLabel.setVisible(!isOfferAvailable);
             offerAvailabilityLabel.setManaged(!isOfferAvailable);


### PR DESCRIPTION
When taking an offer that does not specify an amount range, "Check if offer is available" text was being displayed when it shouldn't be.

It was explicitly hiding the offerAvailabilityBusyAnimation, but not the offerAvailabilityLabel.

Fixes https://github.com/bisq-network/bisq/issues/1742