### PR TITLE
Use OpenJDK10 in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ jdk: openjdk10
 script:
   - export JAVA_HOME=$HOME/openjdk10
   - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk10 --target $JAVA_HOME
+addons:
+  apt:
+    packages:
+      - openjfx
 before_install:
   grep -v '^#' src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
-jdk: oraclejdk10
+jdk: openjdk10
+script:
+  - export JAVA_HOME=$HOME/openjdk10
+  - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk10 --target $JAVA_HOME
 before_install:
   grep -v '^#' src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
 notifications:


### PR DESCRIPTION
Following OracleJDK10's EOL this month, and subsequent removal of
downloads. See
https://docs.travis-ci.com/user/languages/java/#using-java-10-and-later
for details.