### PR TITLE
Move javafx dependencies to common

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -46,6 +46,12 @@ protobuf {
 }
 
 dependencies {
+    compile "org.openjfx:javafx-base:11:$platform"
+    compile "org.openjfx:javafx-graphics:11:$platform"
+    compile "org.openjfx:javafx-controls:11:$platform"
+    compile "org.openjfx:javafx-fxml:11:$platform"
+    compile "org.openjfx:javafx-swing:11:$platform"
+
     compile "com.google.protobuf:protobuf-java:$protobufVersion"
     compile 'com.google.code.gson:gson:2.7'
     compile('com.googlecode.json-simple:json-simple:1.1.1') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,12 +46,6 @@ dependencies {
         exclude(module: 'jackson-annotations')
     }
 
-    compile "org.openjfx:javafx-base:11:$platform"
-    compile "org.openjfx:javafx-graphics:11:$platform"
-    compile "org.openjfx:javafx-controls:11:$platform"
-    compile "org.openjfx:javafx-fxml:11:$platform"
-    compile "org.openjfx:javafx-swing:11:$platform"
-
     compileOnly 'org.projectlombok:lombok:1.18.2'
     annotationProcessor 'org.projectlombok:lombok:1.18.2'
 


### PR DESCRIPTION
For the upcoming API work we use java fx classes also in common (PR
is pending), so that is one reason to move that. But there was also an
issue on Linux (travis) as the platform property was not set in the
core gradle build file, but it is already defined in common.