### PR TITLE
Remove java 9 module configuration

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -85,12 +85,3 @@ dependencies {
     compile "org.openjfx:javafx-graphics:11:$platform"
     compile "org.openjfx:javafx-controls:11:$platform"
 }
-
-compileJava {
-    doFirst {
-        options.compilerArgs = [
-            '--module-path', classpath.asPath,
-            '--add-modules', 'javafx.controls'
-        ]
-    }
-}

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -75,23 +75,6 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.2'
 }
 
-compileJava {
-    doFirst {
-        options.compilerArgs = [
-            '--module-path', classpath.asPath,
-            '--add-modules', 'javafx.controls'
-        ]
-    }
-}
-run {
-    doFirst {
-        jvmArgs = [
-            '--module-path', classpath.asPath,
-            '--add-modules', 'javafx.controls'
-        ]
-    }
-}
-
 test {
     systemProperty 'jdk.attach.allowAttachSelf', true
 


### PR DESCRIPTION
Remove java 9 module configuration for openjfx libraries as they are used regularily during compile time.