### PR TITLE
Verifi dao param default vals #1769

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
@@ -59,7 +59,7 @@ public class ChangeParamValidator extends ProposalValidator {
         }
     }
 
-    // TODO
+    // TODO: Get the last checks in place.
     public void validateParamValue(Param param, long paramValue) throws ChangeParamValidationException {
         checkMinMaxForProposedValue(param, paramValue, 3, 4);
 

--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
@@ -61,6 +61,7 @@ public class ChangeParamValidator extends ProposalValidator {
 
     // TODO: Get the last checks in place.
     public void validateParamValue(Param param, long paramValue) throws ChangeParamValidationException {
+
         checkMinMaxForProposedValue(param, paramValue, 3, 4);
 
         switch (param) {

--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
@@ -61,10 +61,6 @@ public class ChangeParamValidator extends ProposalValidator {
 
     // TODO
     public void validateParamValue(Param param, long paramValue) throws ChangeParamValidationException {
-        // max 4 times the current value. min 25% of current value as general boundaries
-        //old
-//        checkMinMaxForProposedValue(param, paramValue, 300, -75);
-        //new more intuitive
         checkMinMaxForProposedValue(param, paramValue, 3, 4);
 
         switch (param) {
@@ -139,9 +135,6 @@ public class ChangeParamValidator extends ProposalValidator {
         }
     }
 
-    //TODO add git branch, test and use
-    //consider using percentages instead of factors (or doubles)... maybe discuss with Manfred after a version 1 PR.
-    //hence finish smoke test and do the switch above and PR 1 is ready!
     @VisibleForTesting
     void checkMinMaxForProposedValue(Param param, long proposedNewValue, long maxFactorChange, long minFactorChange) throws ChangeParamValidationException {
         long currentValue = getCurrentValue(param);

--- a/core/src/test/java/bisq/core/dao/governance/proposal/param/ChangeParamValidatorTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/proposal/param/ChangeParamValidatorTest.java
@@ -1,0 +1,137 @@
+package bisq.core.dao.governance.proposal.param;
+
+import bisq.core.dao.state.BsqStateService;
+import bisq.core.dao.state.governance.Param;
+import bisq.core.dao.state.period.PeriodService;
+import bisq.core.locale.Res;
+import bisq.core.util.BsqFormatter;
+
+import bisq.common.proto.persistable.PersistenceProtoResolver;
+
+import java.io.File;
+
+import mockit.Injectable;
+import mockit.Tested;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ChangeParamValidatorTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    // @Tested classes are instantiated automatically when needed in a test case,
+    // using injection where possible, see http://jmockit.github.io/tutorial/Mocking.html#tested
+    // To force instantiate earlier, use availableDuringSetup
+    @Tested(fullyInitialized = true, availableDuringSetup = true)
+    BsqStateService bsqStateService;
+    @Tested(fullyInitialized = true, availableDuringSetup = true)
+    PeriodService periodService;
+    @Tested(fullyInitialized = true, availableDuringSetup = true)
+    BsqFormatter bsqFormatter;
+    // @Injectable are mocked resources used to for injecting into @Tested classes
+    // The naming of these resources doesn't matter, any resource that fits will be used for injection
+
+    // Used by bsqStateService
+    @Injectable
+    PersistenceProtoResolver persistenceProtoResolver;
+    @Injectable
+    File storageDir;
+    @Injectable
+    String genesisTxId = "genesisTxId";
+    @Injectable
+    Integer genesisBlockHeight = 200;
+
+    // Used by periodService
+    @Injectable
+    int chainHeight = 400;
+
+    @Before
+    public void setUp() {
+        Res.setup();
+    }
+
+    @Test
+    public void testCheckMinMaxForProposedValueMin() throws ChangeParamValidationException {
+
+        Param param = Param.DEFAULT_MAKER_FEE_BSQ;
+        long proposedNewValue = 50;
+        long maxFactorChange = 2;
+        long minFactorChange = 2;
+
+        thrown.expect(ChangeParamValidationException.class);
+        thrown.expectMessage("Input has to be larger than 50.00%");
+        ChangeParamValidator changeParamValidator = new ChangeParamValidator(bsqStateService,periodService,bsqFormatter);
+        changeParamValidator.checkMinMaxForProposedValue(param,proposedNewValue,maxFactorChange,minFactorChange);
+    }
+
+    @Test
+    public void testCheckMinMaxForProposedValueMax() throws ChangeParamValidationException {
+
+        Param param = Param.DEFAULT_MAKER_FEE_BSQ;
+        long proposedNewValue = 450;
+        long maxFactorChange = 2;
+        long minFactorChange = 2;
+
+        thrown.expect(ChangeParamValidationException.class);
+        thrown.expectMessage("Input must not be larger than 200.00%");
+        ChangeParamValidator changeParamValidator = new ChangeParamValidator(bsqStateService,periodService,bsqFormatter);
+        changeParamValidator.checkMinMaxForProposedValue(param,proposedNewValue,maxFactorChange,minFactorChange);
+    }
+
+
+    @Test
+    public void testValidateMinValuePos() throws ChangeParamValidationException {
+
+        Param param = Param.DEFAULT_MAKER_FEE_BSQ;
+        long proposedNewValueMinPos = 100;
+        long minFactorChange = 2;
+        long currentValue = 200;
+
+        ChangeParamValidator changeParamValidator = new ChangeParamValidator(bsqStateService,periodService,bsqFormatter);
+        changeParamValidator.validateMinValue(param,currentValue,proposedNewValueMinPos,minFactorChange);
+    }
+
+    @Test
+    public void testValidateMinValueNeg() throws ChangeParamValidationException {
+
+        Param param = Param.DEFAULT_MAKER_FEE_BSQ;
+        long proposedNewValueMinNeg = 99;
+        long minFactorChange = 2;
+        long currentValue = 200;
+
+        thrown.expect(ChangeParamValidationException.class);
+        thrown.expectMessage("Input has to be larger than 50.00%");
+        ChangeParamValidator changeParamValidator = new ChangeParamValidator(bsqStateService,periodService,bsqFormatter);
+        changeParamValidator.validateMinValue(param,currentValue,proposedNewValueMinNeg,minFactorChange);
+    }
+
+    @Test
+    public void testValidateMaxValuePos() throws ChangeParamValidationException {
+
+        Param param = Param.DEFAULT_MAKER_FEE_BSQ;
+        long proposedNewValueMaxPos = 400;
+        long maxFactorChange = 2;
+        long currentValue = 200;
+
+        ChangeParamValidator changeParamValidator = new ChangeParamValidator(bsqStateService,periodService,bsqFormatter);
+        changeParamValidator.validateMaxValue(param,currentValue,proposedNewValueMaxPos,maxFactorChange);
+    }
+
+    @Test
+    public void testValidateMaxValueNeg() throws ChangeParamValidationException {
+
+        Param param = Param.DEFAULT_MAKER_FEE_BSQ;
+        long proposedNewValueMaxNeg = 401;
+        long maxFactorChange = 2;
+        long currentValue = 200;
+
+        thrown.expect(ChangeParamValidationException.class);
+        thrown.expectMessage("Input must not be larger than 200.00%");
+        ChangeParamValidator changeParamValidator = new ChangeParamValidator(bsqStateService,periodService,bsqFormatter);
+        changeParamValidator.validateMaxValue(param,currentValue,proposedNewValueMaxNeg,maxFactorChange);
+
+    }
+}


### PR DESCRIPTION
Surrounding code for DAO param validation

New, more intuitive methods for testing min and max values of proposed DAO parameters.
Unit tests also provided.

Next up will be a discussion of what limits each parameter should have.

First part of issue: #1769  
