### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 # See https://help.github.com/articles/about-codeowners/.
 
 * @ManfredKarrer
+/assets/ @blabno

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,4 @@
 
 * @ManfredKarrer
 /assets/ @blabno
+/desktop/ @ripcurlx, @ManfredKarrer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 # This doc specifies who gets requested to review GitHub pull requests.
 # See https://help.github.com/articles/about-codeowners/.
+
+* @ManfredKarrer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# This doc specifies who gets requested to review GitHub pull requests.
+# See https://help.github.com/articles/about-codeowners/.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,4 @@
 /assets/ @blabno
 /desktop/ @ripcurlx, @ManfredKarrer
 *gradle* @cbeams
+/pricenode/ @cbeams

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,4 @@
 * @ManfredKarrer
 /assets/ @blabno
 /desktop/ @ripcurlx, @ManfredKarrer
+*gradle* @cbeams


### PR DESCRIPTION
Per documentation at https://help.github.com/articles/about-codeowners/, this file specifies who should get requested to review what in the repository. I was prompted to add this by the desire to auto-request @blabno for all `/assets` PRs, and added other obvious or established code owners as well.

@ManfredKarrer, take note that while you're the default code owner, and will therefore be requested to review all PRs by default, you will *not* be requested to review any PRs for subsequent entries in the file that you are not the code owner for. So for example, you would be requested to review anything under `/core` because no more specific code owner is specified for that, but you will not be requested to review `*.gradle` files, because I'm the code owner for those.