### PR TITLE
Fix syntax error in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,6 @@
 
 * @ManfredKarrer
 /assets/ @blabno
-/desktop/ @ripcurlx, @ManfredKarrer
+/desktop/ @ripcurlx @ManfredKarrer
 *gradle* @cbeams
 /pricenode/ @cbeams


### PR DESCRIPTION
Owners are space-separated, not comma-separated. It is presumed that
this syntax error is why reviews have not been being suggested for
assignment as expected.