### PR TITLE
Fix pricenode gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ configure(project(':monitor')) {
 configure(project(':pricenode')) {
     apply plugin: "org.springframework.boot"
 
-    version = file("src/main/resources/version.txt").text
+    version = file("src/main/resources/version.txt").text.trim()
 
     jar.manifest.attributes(
         "Implementation-Title": project.name,


### PR DESCRIPTION
As a result of changes done to the gradle build in https://github.com/bisq-network/bisq/pull/1862, I started encountering the following:

```
> Task :pricenode:jar FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':pricenode:jar'.
> Could not create ZIP 'C:\Users\Devin\Documents\GitHub\bisq-network\bisq\pricenode\build\libs\pricenode-0.7.2-SNAPSHOT
  .jar'
```

**Issue**
It was attempting to generate jar file with LF in filename.

**Fix**
Make sure to trim whitespace for version variable retrieved from file.