### PR TITLE
Resolve project dependencies from Maven Central vs JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ configure(subprojects) {
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
         maven { url 'https://raw.githubusercontent.com/JesusMcCloud/tor-binary/master/release/' }
     }


### PR DESCRIPTION
This change avoids the as-yet unexplained resolution errors we've been
seeing out of JCenter today, which look like the following:

    Could not resolve all files for configuration ':monitor:compileClass
    > Could not resolve net.gpedro.integrations.slack:slack-webhook:1.1.
      Required by:
          project :monitor
       > Could not resolve net.gpedro.integrations.slack:slack-webhook:1
          > Could not get resource 'http://jcenter.bintray.com/net/gpedr
             > Could not HEAD 'http://jcenter.bintray.com/net/gpedro/int
                > sun.security.validator.ValidatorException: PKIX path b

For full context, see the Travis CI build failure at
https://travis-ci.org/bisq-network/bisq/builds/451786384#L678-L679.

It is assumed this is an issue on the JCenter side, e.g. something to do
with the interaction of JCenter servers and their SSL implementation
when accessed under OpenJDK 10 and its TrustStore implementation. This
specific failure does not occur under Oracle JDK 11, but other
dependencies do fail in a similar but non-deterministic fashion. In any
case, resolving project dependencies from Maven Central solves the
problem in the meantime.

See also https://github.com/gradle/gradle/issues/6630.