### PR TITLE
Support handling of removed assets.

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -49,6 +49,7 @@ import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.Trade;
 import bisq.core.trade.TradeManager;
+import bisq.core.trade.statistics.AssetTradeActivityCheck;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
@@ -150,6 +151,7 @@ public class BisqSetup {
     private final PriceAlert priceAlert;
     private final MarketAlerts marketAlerts;
     private final VoteResultService voteResultService;
+    private final AssetTradeActivityCheck tradeActivityCheck;
     private final BSFormatter formatter;
     @Setter
     @Nullable
@@ -223,6 +225,7 @@ public class BisqSetup {
                      PriceAlert priceAlert,
                      MarketAlerts marketAlerts,
                      VoteResultService voteResultService,
+                     AssetTradeActivityCheck tradeActivityCheck,
                      BSFormatter formatter) {
 
 
@@ -259,6 +262,7 @@ public class BisqSetup {
         this.priceAlert = priceAlert;
         this.marketAlerts = marketAlerts;
         this.voteResultService = voteResultService;
+        this.tradeActivityCheck = tradeActivityCheck;
         this.formatter = formatter;
     }
 
@@ -624,6 +628,7 @@ public class BisqSetup {
         }
 
         tradeStatisticsManager.onAllServicesInitialized();
+        tradeActivityCheck.onAllServicesInitialized();
 
         accountAgeWitnessService.onAllServicesInitialized();
 

--- a/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
+++ b/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
@@ -18,7 +18,6 @@
 package bisq.core.dao.governance.asset;
 
 import bisq.core.app.BisqEnvironment;
-import bisq.core.dao.state.DaoStateService;
 import bisq.core.locale.CurrencyUtil;
 
 import bisq.common.proto.persistable.PersistedDataHost;
@@ -34,10 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class AssetService implements PersistedDataHost {
-
-
     private final Storage<RemovedAssetsList> storage;
-    private final DaoStateService daoStateService;
     @Getter
     private final RemovedAssetsList removedAssetsList = new RemovedAssetsList();
 
@@ -47,9 +43,8 @@ public class AssetService implements PersistedDataHost {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    public AssetService(Storage<RemovedAssetsList> storage, DaoStateService daoStateService) {
+    public AssetService(Storage<RemovedAssetsList> storage) {
         this.storage = storage;
-        this.daoStateService = daoStateService;
     }
 
 

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -487,6 +487,7 @@ public class CurrencyUtil {
                 .findAny();
     }
 
+    // Excludes all assets which got removed by DAO voting
     public static List<CryptoCurrency> getWhiteListedSortedCryptoCurrencies(AssetService assetService) {
         return getAllSortedCryptoCurrencies().stream()
                 .filter(e -> !assetService.isAssetRemoved(e.getCode()))

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -418,9 +418,9 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     public String getCurrencyCode() {
-        return CurrencyUtil.isCryptoCurrency(offerPayload.getBaseCurrencyCode()) ?
-                offerPayload.getBaseCurrencyCode() :
-                offerPayload.getCounterCurrencyCode();
+        return offerPayload.getBaseCurrencyCode().equals("BTC") ?
+                offerPayload.getCounterCurrencyCode() :
+                offerPayload.getBaseCurrencyCode();
     }
 
     public long getProtocolVersion() {

--- a/core/src/main/java/bisq/core/offer/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayload.java
@@ -101,8 +101,12 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     private final boolean useMarketBasedPrice;
     private final long amount;
     private final long minAmount;
+
+    // For fiat offer the baseCurrencyCode is BTC and the counterCurrencyCode is the fiat currency
+    // For altcoin offers it is the opposite. baseCurrencyCode is the altcoin and the counterCurrencyCode is BTC.
     private final String baseCurrencyCode;
     private final String counterCurrencyCode;
+
     private final List<NodeAddress> arbitratorNodeAddresses;
     private final List<NodeAddress> mediatorNodeAddresses;
     private final String paymentMethodId;

--- a/core/src/main/java/bisq/core/trade/TradeModule.java
+++ b/core/src/main/java/bisq/core/trade/TradeModule.java
@@ -22,6 +22,7 @@ import bisq.core.payment.AccountAgeWitnessService;
 import bisq.core.payment.AccountAgeWitnessStorageService;
 import bisq.core.trade.closed.ClosedTradableManager;
 import bisq.core.trade.failed.FailedTradesManager;
+import bisq.core.trade.statistics.AssetTradeActivityCheck;
 import bisq.core.trade.statistics.ReferralIdService;
 import bisq.core.trade.statistics.TradeStatistics2StorageService;
 import bisq.core.trade.statistics.TradeStatisticsManager;
@@ -50,6 +51,7 @@ public class TradeModule extends AppModule {
         bind(AccountAgeWitnessService.class).in(Singleton.class);
         bind(ReferralIdService.class).in(Singleton.class);
         bind(AccountAgeWitnessStorageService.class).in(Singleton.class);
+        bind(AssetTradeActivityCheck.class).in(Singleton.class);
         bindConstant().annotatedWith(named(AppOptionKeys.DUMP_STATISTICS)).to(environment.getRequiredProperty(AppOptionKeys.DUMP_STATISTICS));
     }
 }

--- a/core/src/main/java/bisq/core/trade/statistics/AssetTradeActivityCheck.java
+++ b/core/src/main/java/bisq/core/trade/statistics/AssetTradeActivityCheck.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.core.dao.governance.asset.AssetService;
+import bisq.core.locale.CryptoCurrency;
+import bisq.core.locale.CurrencyUtil;
+
+import bisq.common.util.Tuple2;
+
+import org.bitcoinj.core.Coin;
+
+import javax.inject.Inject;
+
+import com.google.common.base.Joiner;
+
+import java.time.Duration;
+
+import java.text.SimpleDateFormat;
+
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AssetTradeActivityCheck {
+    private final AssetService assetService;
+    private final TradeStatisticsManager tradeStatisticsManager;
+
+    @Inject
+    public AssetTradeActivityCheck(AssetService assetService, TradeStatisticsManager tradeStatisticsManager) {
+        this.assetService = assetService;
+        this.tradeStatisticsManager = tradeStatisticsManager;
+    }
+
+    public void onAllServicesInitialized() {
+        Date compareDate = new Date(new Date().getTime() - Duration.ofDays(120).toMillis());
+        long minTradeAmount = Coin.parseCoin("0.001").value;
+        long minNumOfTrades = 3;
+
+        Map<String, Tuple2<Long, Integer>> tradeStatMap = new HashMap<>();
+        tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
+                .filter(e -> CurrencyUtil.isCryptoCurrency(e.getBaseCurrency()))
+                .filter(e -> e.getTradeDate().getTime() > compareDate.getTime())
+                .forEach(e -> {
+                    tradeStatMap.putIfAbsent(e.getBaseCurrency(), new Tuple2<>(0L, 0));
+                    Tuple2<Long, Integer> tuple2 = tradeStatMap.get(e.getBaseCurrency());
+                    long accumulatedTradeAmount = tuple2.first + e.getTradeAmount().getValue();
+                    int numTrades = tuple2.second + 1;
+                    tradeStatMap.put(e.getBaseCurrency(), new Tuple2<>(accumulatedTradeAmount, numTrades));
+                });
+        StringBuilder newAssets = new StringBuilder("\nNew assets (in warming up phase):");
+        StringBuilder sufficientlyTraded = new StringBuilder("\nSufficiently traded assets:");
+        StringBuilder insufficientlyTraded = new StringBuilder("\nInsufficiently traded assets:");
+        StringBuilder notTraded = new StringBuilder("\nNot traded assets:");
+        List<CryptoCurrency> whiteListedSortedCryptoCurrencies = CurrencyUtil.getWhiteListedSortedCryptoCurrencies(assetService);
+        Set<CryptoCurrency> assetsToRemove = new HashSet<>(whiteListedSortedCryptoCurrencies);
+        whiteListedSortedCryptoCurrencies.forEach(e -> {
+            String code = e.getCode();
+            String nameAndCode = CurrencyUtil.getNameAndCode(code);
+            long tradeAmount = 0;
+            int numTrades = 0;
+            boolean isInTradeStatMap = tradeStatMap.containsKey(code);
+            if (isInTradeStatMap) {
+                Tuple2<Long, Integer> tuple = tradeStatMap.get(code);
+                tradeAmount = tuple.first;
+                numTrades = tuple.second;
+            }
+            if (isWarmingUp(code)) {
+                assetsToRemove.remove(e);
+                newAssets.append("\n")
+                        .append(nameAndCode)
+                        .append(": Trade amount: ")
+                        .append(Coin.valueOf(tradeAmount).toFriendlyString())
+                        .append(", number of trades: ")
+                        .append(numTrades);
+            }
+            if (!isWarmingUp(code) && !hasPaidBSQFee(code)) {
+                if (isInTradeStatMap) {
+                    if (tradeAmount >= minTradeAmount || numTrades >= minNumOfTrades) {
+                        assetsToRemove.remove(e);
+                        sufficientlyTraded.append("\n")
+                                .append(nameAndCode)
+                                .append(": Trade amount: ")
+                                .append(Coin.valueOf(tradeAmount).toFriendlyString())
+                                .append(", number of trades: ")
+                                .append(numTrades);
+                    } else {
+                        insufficientlyTraded.append("\n")
+                                .append(nameAndCode)
+                                .append(": Trade amount: ")
+                                .append(Coin.valueOf(tradeAmount).toFriendlyString())
+                                .append(", number of trades: ")
+                                .append(numTrades);
+                    }
+                } else {
+                    notTraded.append("\n").append(nameAndCode);
+                }
+            }
+        });
+        List<CryptoCurrency> assetsToRemoveList = assetsToRemove.stream()
+                .sorted(Comparator.comparing(CryptoCurrency::getCode))
+                .collect(Collectors.toList());
+
+        String result = "Date for checking trade activity: " + new SimpleDateFormat("yyyy-MM-dd'T'").format(compareDate) +
+                "\n\nAssets to remove (" + assetsToRemoveList.size() + "):\n" + Joiner.on("\n").join(assetsToRemoveList) +
+                "\n\n" + insufficientlyTraded.toString() +
+                "\n\n" + notTraded.toString() +
+                "\n\n" + newAssets.toString() +
+                "\n\n" + sufficientlyTraded.toString();
+        // Utilities.copyToClipboard(result);
+        log.debug(result);
+    }
+
+    private boolean hasPaidBSQFee(String code) {
+        return assetService.hasPaidBSQFee(code);
+    }
+
+    private boolean isWarmingUp(String code) {
+        Set<String> newlyAdded = new HashSet<>();
+
+        // v0.7.1 Jul 4 2018
+        newlyAdded.add("ZOC");
+        newlyAdded.add("AQUA");
+        newlyAdded.add("BTDX");
+        newlyAdded.add("BTCC");
+        newlyAdded.add("BTI");
+        newlyAdded.add("CRDS");
+        newlyAdded.add("CNMC");
+        newlyAdded.add("TARI");
+        newlyAdded.add("DAC");
+        newlyAdded.add("DRIP");
+        newlyAdded.add("FTO");
+        newlyAdded.add("GRFT");
+        newlyAdded.add("LIKE");
+        newlyAdded.add("LOBS");
+        newlyAdded.add("MAX");
+        newlyAdded.add("MEC");
+        newlyAdded.add("MCC");
+        newlyAdded.add("XMN");
+        newlyAdded.add("XMY");
+        newlyAdded.add("NANO");
+        newlyAdded.add("NPW");
+        newlyAdded.add("NIM");
+        newlyAdded.add("PIX");
+        newlyAdded.add("PXL");
+        newlyAdded.add("PRIV");
+        newlyAdded.add("TRIT");
+        newlyAdded.add("WAVI");
+
+        // v0.8.0 Aug 22 2018
+        // none added
+
+        // v0.9.0 (Date TBD)
+        newlyAdded.add("ACM");
+        newlyAdded.add("BTC2");
+        newlyAdded.add("BLUR");
+        newlyAdded.add("CHA");
+        newlyAdded.add("CROAT");
+        newlyAdded.add("DRGL");
+        newlyAdded.add("ETHS");
+        newlyAdded.add("GBK");
+        newlyAdded.add("KEK");
+        newlyAdded.add("LOKI");
+        newlyAdded.add("MBGL");
+        newlyAdded.add("NEOS");
+        newlyAdded.add("PZDC");
+        newlyAdded.add("QMCoin");
+        newlyAdded.add("QRL");
+        newlyAdded.add("RADS");
+        newlyAdded.add("RYO");
+        newlyAdded.add("SUB1X");
+        newlyAdded.add("MAI");
+        newlyAdded.add("TRTL");
+        newlyAdded.add("ZER");
+
+        return newlyAdded.contains(code);
+    }
+}

--- a/core/src/main/java/bisq/core/trade/statistics/AssetTradeActivityCheck.java
+++ b/core/src/main/java/bisq/core/trade/statistics/AssetTradeActivityCheck.java
@@ -88,6 +88,7 @@ public class AssetTradeActivityCheck {
                 tradeAmount = tuple.first;
                 numTrades = tuple.second;
             }
+
             if (isWarmingUp(code)) {
                 assetsToRemove.remove(e);
                 newAssets.append("\n")
@@ -97,6 +98,7 @@ public class AssetTradeActivityCheck {
                         .append(", number of trades: ")
                         .append(numTrades);
             }
+
             if (!isWarmingUp(code) && !hasPaidBSQFee(code)) {
                 if (isInTradeStatMap) {
                     if (tradeAmount >= minTradeAmount || numTrades >= minNumOfTrades) {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -18,8 +18,6 @@
 package bisq.core.trade.statistics;
 
 import bisq.core.app.AppOptionKeys;
-import bisq.core.dao.governance.asset.AssetService;
-import bisq.core.locale.CryptoCurrency;
 import bisq.core.locale.CurrencyTuple;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
@@ -34,33 +32,21 @@ import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
 import bisq.common.UserThread;
 import bisq.common.storage.JsonFileManager;
 import bisq.common.storage.Storage;
-import bisq.common.util.Tuple2;
 import bisq.common.util.Utilities;
-
-import org.bitcoinj.core.Coin;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
-import com.google.common.base.Joiner;
-
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
-
-import java.time.Duration;
-
-import java.text.SimpleDateFormat;
 
 import java.io.File;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -75,7 +61,6 @@ public class TradeStatisticsManager {
     private final P2PService p2PService;
     private final PriceFeedService priceFeedService;
     private final ReferralIdService referralIdService;
-    private final AssetService assetService;
     private final boolean dumpStatistics;
     private final ObservableSet<TradeStatistics2> observableTradeStatisticsSet = FXCollections.observableSet();
 
@@ -85,13 +70,11 @@ public class TradeStatisticsManager {
                                   TradeStatistics2StorageService tradeStatistics2StorageService,
                                   AppendOnlyDataStoreService appendOnlyDataStoreService,
                                   ReferralIdService referralIdService,
-                                  AssetService assetService,
                                   @Named(Storage.STORAGE_DIR) File storageDir,
                                   @Named(AppOptionKeys.DUMP_STATISTICS) boolean dumpStatistics) {
         this.p2PService = p2PService;
         this.priceFeedService = priceFeedService;
         this.referralIdService = referralIdService;
-        this.assetService = assetService;
         this.dumpStatistics = dumpStatistics;
         jsonFileManager = new JsonFileManager(storageDir);
 
@@ -100,14 +83,14 @@ public class TradeStatisticsManager {
 
     public void onAllServicesInitialized() {
         if (dumpStatistics) {
-            ArrayList<CurrencyTuple> fiatCurrencyList = new ArrayList<>(CurrencyUtil.getAllSortedFiatCurrencies().stream()
+            ArrayList<CurrencyTuple> fiatCurrencyList = CurrencyUtil.getAllSortedFiatCurrencies().stream()
                     .map(e -> new CurrencyTuple(e.getCode(), e.getName(), 8))
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toCollection(ArrayList::new));
             jsonFileManager.writeToDisc(Utilities.objectToJson(fiatCurrencyList), "fiat_currency_list");
 
-            ArrayList<CurrencyTuple> cryptoCurrencyList = new ArrayList<>(CurrencyUtil.getAllSortedCryptoCurrencies().stream()
+            ArrayList<CurrencyTuple> cryptoCurrencyList = CurrencyUtil.getAllSortedCryptoCurrencies().stream()
                     .map(e -> new CurrencyTuple(e.getCode(), e.getName(), 8))
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toCollection(ArrayList::new));
             cryptoCurrencyList.add(0, new CurrencyTuple(Res.getBaseCurrencyCode(), Res.getBaseCurrencyName(), 8));
             jsonFileManager.writeToDisc(Utilities.objectToJson(cryptoCurrencyList), "crypto_currency_list");
         }
@@ -124,9 +107,8 @@ public class TradeStatisticsManager {
         observableTradeStatisticsSet.addAll(map.values());
 
         priceFeedService.applyLatestBisqMarketPrice(observableTradeStatisticsSet);
-        dump();
 
-        checkTradeActivity();
+        dump();
     }
 
     public void publishTradeStatistics(List<Trade> trades) {
@@ -161,7 +143,11 @@ public class TradeStatisticsManager {
         }
     }
 
-    public void addToMap(TradeStatistics2 tradeStatistics, boolean storeLocally) {
+    public ObservableSet<TradeStatistics2> getObservableTradeStatisticsSet() {
+        return observableTradeStatisticsSet;
+    }
+
+    private void addToMap(TradeStatistics2 tradeStatistics, boolean storeLocally) {
         if (!observableTradeStatisticsSet.contains(tradeStatistics)) {
             boolean itemAlreadyAdded = observableTradeStatisticsSet.stream()
                     .anyMatch(e -> (e.getOfferId().equals(tradeStatistics.getOfferId())));
@@ -177,14 +163,10 @@ public class TradeStatisticsManager {
         }
     }
 
-    public void addToMap(TradeStatistics2 tradeStatistics, Map<String, TradeStatistics2> map) {
+    private void addToMap(TradeStatistics2 tradeStatistics, Map<String, TradeStatistics2> map) {
         TradeStatistics2 prevValue = map.putIfAbsent(tradeStatistics.getOfferId(), tradeStatistics);
         if (prevValue != null)
             log.debug("We have already an item with the same offer ID. That might happen if both the maker and the taker published the tradeStatistics");
-    }
-
-    public ObservableSet<TradeStatistics2> getObservableTradeStatisticsSet() {
-        return observableTradeStatisticsSet;
     }
 
     private void dump() {
@@ -201,149 +183,5 @@ public class TradeStatisticsManager {
             list.toArray(array);
             jsonFileManager.writeToDisc(Utilities.objectToJson(array), "trade_statistics");
         }
-    }
-
-    private void checkTradeActivity() {
-        Date compareDate = new Date(new Date().getTime() - Duration.ofDays(120).toMillis());
-        long minTradeAmount = Coin.parseCoin("0.001").value;
-        long minNumOfTrades = 3;
-
-        Map<String, Tuple2<Long, Integer>> tradeStatMap = new HashMap<>();
-        observableTradeStatisticsSet.stream()
-                .filter(e -> CurrencyUtil.isCryptoCurrency(e.getBaseCurrency()))
-                .filter(e -> e.getTradeDate().getTime() > compareDate.getTime())
-                .forEach(e -> {
-                    tradeStatMap.putIfAbsent(e.getBaseCurrency(), new Tuple2<>(0L, 0));
-                    Tuple2<Long, Integer> tuple2 = tradeStatMap.get(e.getBaseCurrency());
-                    long accumulatedTradeAmount = tuple2.first + e.getTradeAmount().getValue();
-                    int numTrades = tuple2.second + 1;
-                    tradeStatMap.put(e.getBaseCurrency(), new Tuple2<>(accumulatedTradeAmount, numTrades));
-                });
-        StringBuilder newAssets = new StringBuilder("\nNew assets (in warming up phase):");
-        StringBuilder sufficientlyTraded = new StringBuilder("\nSufficiently traded assets:");
-        StringBuilder insufficientlyTraded = new StringBuilder("\nInsufficiently traded assets:");
-        StringBuilder notTraded = new StringBuilder("\nNot traded assets:");
-        List<CryptoCurrency> whiteListedSortedCryptoCurrencies = CurrencyUtil.getWhiteListedSortedCryptoCurrencies(assetService);
-        Set<CryptoCurrency> assetsToRemove = new HashSet<>(whiteListedSortedCryptoCurrencies);
-        whiteListedSortedCryptoCurrencies.forEach(e -> {
-            String code = e.getCode();
-            String nameAndCode = CurrencyUtil.getNameAndCode(code);
-            long tradeAmount = 0;
-            int numTrades = 0;
-            boolean isInTradeStatMap = tradeStatMap.containsKey(code);
-            if (isInTradeStatMap) {
-                Tuple2<Long, Integer> tuple = tradeStatMap.get(code);
-                tradeAmount = tuple.first;
-                numTrades = tuple.second;
-            }
-            if (isWarmingUp(code)) {
-                assetsToRemove.remove(e);
-                newAssets.append("\n")
-                        .append(nameAndCode)
-                        .append(": Trade amount: ")
-                        .append(Coin.valueOf(tradeAmount).toFriendlyString())
-                        .append(", number of trades: ")
-                        .append(numTrades);
-            }
-            if (!isWarmingUp(code) && !hasPaidBSQFee(code)) {
-                if (isInTradeStatMap) {
-                    if (tradeAmount >= minTradeAmount || numTrades >= minNumOfTrades) {
-                        assetsToRemove.remove(e);
-                        sufficientlyTraded.append("\n")
-                                .append(nameAndCode)
-                                .append(": Trade amount: ")
-                                .append(Coin.valueOf(tradeAmount).toFriendlyString())
-                                .append(", number of trades: ")
-                                .append(numTrades);
-                    } else {
-                        insufficientlyTraded.append("\n")
-                                .append(nameAndCode)
-                                .append(": Trade amount: ")
-                                .append(Coin.valueOf(tradeAmount).toFriendlyString())
-                                .append(", number of trades: ")
-                                .append(numTrades);
-                    }
-                } else {
-                    notTraded.append("\n").append(nameAndCode);
-                }
-            }
-        });
-        List<CryptoCurrency> assetsToRemoveList = assetsToRemove.stream()
-                .sorted(Comparator.comparing(CryptoCurrency::getCode))
-                .collect(Collectors.toList());
-
-        String result = "Date for checking trade activity: " + new SimpleDateFormat("yyyy-MM-dd'T'").format(compareDate) +
-                "\n\nAssets to remove (" + assetsToRemoveList.size() + "):\n" + Joiner.on("\n").join(assetsToRemoveList) +
-                "\n\n" + insufficientlyTraded.toString() +
-                "\n\n" + notTraded.toString() +
-                "\n\n" + newAssets.toString() +
-                "\n\n" + sufficientlyTraded.toString();
-        // Utilities.copyToClipboard(result);
-        log.debug(result);
-    }
-
-    private boolean hasPaidBSQFee(String code) {
-        return assetService.hasPaidBSQFee(code);
-    }
-
-    private boolean isWarmingUp(String code) {
-        Set<String> newlyAdded = new HashSet<>();
-
-        // v0.7.1 Jul 4 2018
-        newlyAdded.add("ZOC");
-        newlyAdded.add("AQUA");
-        newlyAdded.add("BTDX");
-        newlyAdded.add("BTCC");
-        newlyAdded.add("BTI");
-        newlyAdded.add("CRDS");
-        newlyAdded.add("CNMC");
-        newlyAdded.add("TARI");
-        newlyAdded.add("DAC");
-        newlyAdded.add("DRIP");
-        newlyAdded.add("FTO");
-        newlyAdded.add("GRFT");
-        newlyAdded.add("LIKE");
-        newlyAdded.add("LOBS");
-        newlyAdded.add("MAX");
-        newlyAdded.add("MEC");
-        newlyAdded.add("MCC");
-        newlyAdded.add("XMN");
-        newlyAdded.add("XMY");
-        newlyAdded.add("NANO");
-        newlyAdded.add("NPW");
-        newlyAdded.add("NIM");
-        newlyAdded.add("PIX");
-        newlyAdded.add("PXL");
-        newlyAdded.add("PRIV");
-        newlyAdded.add("TRIT");
-        newlyAdded.add("WAVI");
-
-        // v0.8.0 Aug 22 2018
-        // none added
-
-        // v0.9.0 (Date TBD)
-        newlyAdded.add("ACM");
-        newlyAdded.add("BTC2");
-        newlyAdded.add("BLUR");
-        newlyAdded.add("CHA");
-        newlyAdded.add("CROAT");
-        newlyAdded.add("DRGL");
-        newlyAdded.add("ETHS");
-        newlyAdded.add("GBK");
-        newlyAdded.add("KEK");
-        newlyAdded.add("LOKI");
-        newlyAdded.add("MBGL");
-        newlyAdded.add("NEOS");
-        newlyAdded.add("PZDC");
-        newlyAdded.add("QMCoin");
-        newlyAdded.add("QRL");
-        newlyAdded.add("RADS");
-        newlyAdded.add("RYO");
-        newlyAdded.add("SUB1X");
-        newlyAdded.add("MAI");
-        newlyAdded.add("TRTL");
-        newlyAdded.add("ZER");
-
-        return newlyAdded.contains(code);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -294,22 +294,19 @@ public class GUIUtil {
         };
     }
 
-    public static StringConverter<TradeCurrency> getTradeCurrencyConverter(
-            String postFixSingle,
-            String postFixMulti,
-            Map<String, Integer> offerCounts) {
-        return new StringConverter<TradeCurrency>() {
+    public static StringConverter<TradeCurrency> getTradeCurrencyConverter(String postFixSingle,
+                                                                           String postFixMulti,
+                                                                           Map<String, Integer> offerCounts) {
+        return new StringConverter<>() {
             @Override
             public String toString(TradeCurrency tradeCurrency) {
                 String code = tradeCurrency.getCode();
                 Optional<Integer> offerCountOptional = Optional.ofNullable(offerCounts.get(code));
                 final String displayString;
-                if (offerCountOptional.isPresent()) {
-                    displayString = CurrencyUtil.getNameAndCode(code)
-                            + " - " + offerCountOptional.get() + " " + (offerCountOptional.get() == 1 ? postFixSingle : postFixMulti);
-                } else {
-                    displayString = CurrencyUtil.getNameAndCode(code);
-                }
+                displayString = offerCountOptional
+                        .map(offerCount -> CurrencyUtil.getNameAndCode(code)
+                                + " - " + offerCount + " " + (offerCount == 1 ? postFixSingle : postFixMulti))
+                        .orElseGet(() -> CurrencyUtil.getNameAndCode(code));
                 // http://boschista.deviantart.com/journal/Cool-ASCII-Symbols-214218618
                 if (code.equals(GUIUtil.SHOW_ALL_FLAG))
                     return "▶ " + Res.get("list.currency.showAll");

--- a/desktop/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
@@ -91,7 +91,7 @@ public class OfferBookChartViewModelTest {
     }
 
     @Test
-    public void testMaxCharactersForBuyPrice() {
+    public void testMaxCharactersForFiatBuyPrice() {
         OfferBook offerBook = mock(OfferBook.class);
         PriceFeedService service = mock(PriceFeedService.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
@@ -103,9 +103,9 @@ public class OfferBookChartViewModelTest {
         model.activate();
         assertEquals(7, model.maxPlacesForBuyPrice.intValue());
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.price, 94016475L))));
-        assertEquals(9, model.maxPlacesForBuyPrice.intValue());
+        assertEquals(7, model.maxPlacesForBuyPrice.intValue());
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.price, 101016475L))));
-        assertEquals(10, model.maxPlacesForBuyPrice.intValue());
+        assertEquals(7, model.maxPlacesForBuyPrice.intValue());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class OfferBookChartViewModelTest {
     }
 
     @Test
-    public void testMaxCharactersForBuyVolume() {
+    public void testMaxCharactersForFiatBuyVolume() {
         OfferBook offerBook = mock(OfferBook.class);
         PriceFeedService service = mock(PriceFeedService.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
@@ -132,9 +132,9 @@ public class OfferBookChartViewModelTest {
         model.activate();
         assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //0.01
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 100000000L))));
-        assertEquals(5, model.maxPlacesForBuyVolume.intValue()); //10.00
+        assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //10.00
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 22128600000L))));
-        assertEquals(7, model.maxPlacesForBuyVolume.intValue()); //2212.86
+        assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //2212.86
     }
 
     @Test
@@ -169,7 +169,7 @@ public class OfferBookChartViewModelTest {
     }
 
     @Test
-    public void testMaxCharactersForSellPrice() {
+    public void testMaxCharactersForFiatSellPrice() {
         OfferBook offerBook = mock(OfferBook.class);
         PriceFeedService service = mock(PriceFeedService.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
@@ -181,9 +181,9 @@ public class OfferBookChartViewModelTest {
         model.activate();
         assertEquals(7, model.maxPlacesForSellPrice.intValue());
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.price, 94016475L))));
-        assertEquals(9, model.maxPlacesForSellPrice.intValue());
+        assertEquals(7, model.maxPlacesForSellPrice.intValue());
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.price, 101016475L))));
-        assertEquals(10, model.maxPlacesForSellPrice.intValue());
+        assertEquals(7, model.maxPlacesForSellPrice.intValue());
     }
 
     @Test
@@ -198,7 +198,7 @@ public class OfferBookChartViewModelTest {
     }
 
     @Test
-    public void testMaxCharactersForSellVolume() {
+    public void testMaxCharactersForFiatSellVolume() {
         OfferBook offerBook = mock(OfferBook.class);
         PriceFeedService service = mock(PriceFeedService.class);
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
@@ -210,8 +210,8 @@ public class OfferBookChartViewModelTest {
         model.activate();
         assertEquals(4, model.maxPlacesForSellVolume.intValue()); //0.01
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.amount, 100000000L))));
-        assertEquals(5, model.maxPlacesForSellVolume.intValue()); //10.00
+        assertEquals(4, model.maxPlacesForSellVolume.intValue()); //10.00
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.amount, 22128600000L))));
-        assertEquals(7, model.maxPlacesForSellVolume.intValue()); //2212.86
+        assertEquals(4, model.maxPlacesForSellVolume.intValue()); //2212.86
     }
 }

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookListItemMaker.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookListItemMaker.java
@@ -40,6 +40,8 @@ public class OfferBookListItemMaker {
     public static final Property<OfferBookListItem, OfferPayload.Direction> direction = new Property<>();
     public static final Property<OfferBookListItem, Boolean> useMarketBasedPrice = new Property<>();
     public static final Property<OfferBookListItem, Double> marketPriceMargin = new Property<>();
+    public static final Property<OfferBookListItem, String> baseCurrencyCode = new Property<>();
+    public static final Property<OfferBookListItem, String> counterCurrencyCode = new Property<>();
 
     public static final Instantiator<OfferBookListItem> OfferBookListItem = lookup ->
             new OfferBookListItem(make(btcUsdOffer.but(
@@ -49,7 +51,10 @@ public class OfferBookListItemMaker {
                     with(OfferMaker.direction, lookup.valueOf(direction, OfferPayload.Direction.BUY)),
                     with(OfferMaker.useMarketBasedPrice, lookup.valueOf(useMarketBasedPrice, false)),
                     with(OfferMaker.marketPriceMargin, lookup.valueOf(marketPriceMargin, 0.0)),
-                    with(OfferMaker.id, lookup.valueOf(id, "1234")))));
+                    with(OfferMaker.baseCurrencyCode, lookup.valueOf(baseCurrencyCode, "BTC")),
+                    with(OfferMaker.counterCurrencyCode, lookup.valueOf(counterCurrencyCode, "USD")),
+                    with(OfferMaker.id, lookup.valueOf(id, "1234"))
+            )));
 
     public static final Instantiator<OfferBookListItem> OfferBookListItemWithRange = lookup ->
             new OfferBookListItem(make(btcUsdOffer.but(

--- a/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
@@ -114,7 +114,7 @@ public class BSFormatterTest {
 
     @Test
     public void testFormatVolume() {
-        assertEquals("    1.00", formatter.formatVolume(make(btcUsdOffer), true, 8));
+        assertEquals("0.01", formatter.formatVolume(make(btcUsdOffer), true, 4));
         assertEquals("100.00", formatter.formatVolume(make(usdVolume)));
         assertEquals("1774.62", formatter.formatVolume(make(usdVolume.but(with(volumeString, "1774.62")))));
     }

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -60,7 +60,7 @@ public class GUIUtilTest {
                 offerCounts
         );
 
-        assertEquals("✦ BTC (BTC) - 11 offers", tradeCurrencyConverter.toString(bitcoin));
+        assertEquals("✦ Bitcoin (BTC) - 11 offers", tradeCurrencyConverter.toString(bitcoin));
         assertEquals("★ Euro (EUR) - 10 offers", tradeCurrencyConverter.toString(euro));
     }
 
@@ -72,7 +72,7 @@ public class GUIUtilTest {
                 Res.get("shared.multipleOffers"),
                 empty);
 
-        assertEquals("✦ BTC (BTC) - 10 offers", currencyListItemConverter.toString(make(bitcoinItem.but(with(numberOfTrades, 10)))));
+        assertEquals("✦ Bitcoin (BTC) - 10 offers", currencyListItemConverter.toString(make(bitcoinItem.but(with(numberOfTrades, 10)))));
         assertEquals("★ Euro (EUR) - 0 offers", currencyListItemConverter.toString(make(euroItem)));
         assertEquals("★ Euro (EUR) - 1 offer", currencyListItemConverter.toString(make(euroItem.but(with(numberOfTrades, 1)))));
 


### PR DESCRIPTION
- cross check the isCryptoCurrency method if the symbol matches any
fiat currency and of both not match consider it still a CC. In case of
a removed asset it was returning false before which caused an issue in
the trade currency pair showing both sides as BTC.
- Show N/A for name in case the asset is not available.

The code mostly operates with the ticker symbol which gets stored in
the offer, so even an asset is removed traders who have that asset in
their account list can trade without problems.
Tested create offer, take offer and executing a trade.