### PR TITLE
Optimize initial data load

### DIFF
--- a/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
@@ -136,9 +136,7 @@ public class AccountAgeWitnessService {
     }
 
     private void addToMap(AccountAgeWitness accountAgeWitness) {
-        log.debug("addToMap hash=" + Utilities.bytesAsHexString(accountAgeWitness.getHash()));
-        if (!accountAgeWitnessMap.containsKey(accountAgeWitness.getHashAsByteArray()))
-            accountAgeWitnessMap.put(accountAgeWitness.getHashAsByteArray(), accountAgeWitness);
+        accountAgeWitnessMap.putIfAbsent(accountAgeWitness.getHashAsByteArray(), accountAgeWitness);
     }
 
 


### PR DESCRIPTION
We changed the earlier behaviour with delayed execution of chunks of the list as it caused 
worse results as if it is processed in one go.
Main reason is probably that listeners trigger more code and if that is called early at 
startup we have better chances that the user has not already navigated to a screen where the
trade statistics are used for UI rendering.
We need to take care that the update period between releases stay short as with the current
situation before 0.9 release we receive 4000 objects with a newly installed client, which 
causes the application to stay stuck for quite a while at startup.