### PR TITLE
Fix issues with wrong base currency

### DIFF
--- a/core/src/main/java/bisq/core/offer/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayload.java
@@ -17,8 +17,6 @@
 
 package bisq.core.offer;
 
-import bisq.core.locale.CurrencyUtil;
-
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.storage.payload.ExpirablePayload;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
@@ -372,7 +370,7 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     // The rest of the app does not support yet that concept of base currency and counter currencies
     // so we map here for convenience
     public String getCurrencyCode() {
-        return CurrencyUtil.isCryptoCurrency(getBaseCurrencyCode()) ? getBaseCurrencyCode() : getCounterCurrencyCode();
+        return getBaseCurrencyCode().equals("BTC") ? getCounterCurrencyCode() : getBaseCurrencyCode();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/statistics/AssetTradeActivityCheck.java
+++ b/core/src/main/java/bisq/core/trade/statistics/AssetTradeActivityCheck.java
@@ -62,6 +62,7 @@ public class AssetTradeActivityCheck {
 
         Map<String, Tuple2<Long, Integer>> tradeStatMap = new HashMap<>();
         tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
+                .filter(e -> !e.getBaseCurrency().equals("BTC"))
                 .filter(e -> CurrencyUtil.isCryptoCurrency(e.getBaseCurrency()))
                 .filter(e -> e.getTradeDate().getTime() > compareDate.getTime())
                 .forEach(e -> {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics.java
@@ -17,7 +17,6 @@
 
 package bisq.core.trade.statistics;
 
-import bisq.core.locale.CurrencyUtil;
 import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.AltcoinExchangeRate;
 import bisq.core.monetary.Price;
@@ -223,7 +222,7 @@ public final class TradeStatistics implements LazyProcessedPayload, ProtectedSto
     }
 
     public String getCurrencyCode() {
-        return CurrencyUtil.isCryptoCurrency(baseCurrency) ? baseCurrency : counterCurrency;
+        return baseCurrency.equals("BTC") ? counterCurrency : baseCurrency;
     }
 
     public Coin getTradeAmount() {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -17,7 +17,6 @@
 
 package bisq.core.trade.statistics;
 
-import bisq.core.locale.CurrencyUtil;
 import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.AltcoinExchangeRate;
 import bisq.core.monetary.Price;
@@ -248,7 +247,7 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
     }
 
     public String getCurrencyCode() {
-        return CurrencyUtil.isCryptoCurrency(baseCurrency) ? baseCurrency : counterCurrency;
+        return baseCurrency.equals("BTC") ? counterCurrency : baseCurrency;
     }
 
     public Coin getTradeAmount() {

--- a/desktop/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
@@ -103,9 +103,9 @@ public class OfferBookChartViewModelTest {
         model.activate();
         assertEquals(7, model.maxPlacesForBuyPrice.intValue());
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.price, 94016475L))));
-        assertEquals(7, model.maxPlacesForBuyPrice.intValue());
+        assertEquals(9, model.maxPlacesForBuyPrice.intValue()); // 9401.6475
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.price, 101016475L))));
-        assertEquals(7, model.maxPlacesForBuyPrice.intValue());
+        assertEquals(10, model.maxPlacesForBuyPrice.intValue()); //10101.6475
     }
 
     @Test
@@ -132,9 +132,9 @@ public class OfferBookChartViewModelTest {
         model.activate();
         assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //0.01
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 100000000L))));
-        assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //10.00
+        assertEquals(5, model.maxPlacesForBuyVolume.intValue()); //10.00
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 22128600000L))));
-        assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //2212.86
+        assertEquals(7, model.maxPlacesForBuyVolume.intValue()); //2212.86
     }
 
     @Test
@@ -179,11 +179,11 @@ public class OfferBookChartViewModelTest {
 
         final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null, new BSFormatter());
         model.activate();
-        assertEquals(7, model.maxPlacesForSellPrice.intValue());
+        assertEquals(7, model.maxPlacesForSellPrice.intValue()); // 10.0000 default price
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.price, 94016475L))));
-        assertEquals(7, model.maxPlacesForSellPrice.intValue());
+        assertEquals(9, model.maxPlacesForSellPrice.intValue()); // 9401.6475
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.price, 101016475L))));
-        assertEquals(7, model.maxPlacesForSellPrice.intValue());
+        assertEquals(10, model.maxPlacesForSellPrice.intValue()); // 10101.6475
     }
 
     @Test
@@ -210,8 +210,8 @@ public class OfferBookChartViewModelTest {
         model.activate();
         assertEquals(4, model.maxPlacesForSellVolume.intValue()); //0.01
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.amount, 100000000L))));
-        assertEquals(4, model.maxPlacesForSellVolume.intValue()); //10.00
+        assertEquals(5, model.maxPlacesForSellVolume.intValue()); //10.00
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.amount, 22128600000L))));
-        assertEquals(4, model.maxPlacesForSellVolume.intValue()); //2212.86
+        assertEquals(7, model.maxPlacesForSellVolume.intValue()); //2212.86
     }
 }

--- a/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
@@ -114,7 +114,7 @@ public class BSFormatterTest {
 
     @Test
     public void testFormatVolume() {
-        assertEquals("0.01", formatter.formatVolume(make(btcUsdOffer), true, 4));
+        assertEquals("1.00", formatter.formatVolume(make(btcUsdOffer), true, 4));
         assertEquals("100.00", formatter.formatVolume(make(usdVolume)));
         assertEquals("1774.62", formatter.formatVolume(make(usdVolume.but(with(volumeString, "1774.62")))));
     }


### PR DESCRIPTION
From the changes in isCryptoCurrency which return true in case of BTC
there have been some bugs. We changed the check to distinguish between
altcoin and fiat to check for BTC as base currency now.
That area would require a bigger refactoring...

Fixes https://github.com/bisq-network/bisq/issues/1909