### PR TITLE
Update to latest shadow plugin version 4.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
         classpath files('gradle/witness/gradle-witness.jar')
         classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.10.RELEASE'
     }


### PR DESCRIPTION
Updating to the latest shadow plugin version will resolve the following deprecation warning:

```
> Task :desktop:shadowJar UP-TO-DATE
Registering invalid inputs and outputs via TaskInputs and TaskOutputs
methods has been deprecated. This is scheduled to be removed in Gradle
5.0. A problem was found with the configuration of task
':desktop:shadowJar'.
```

See: https://github.com/johnrengelman/shadow/issues/336