### PR TITLE
Limit initial window size on application launch

### DIFF
--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -71,6 +71,9 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -83,8 +86,10 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import static bisq.desktop.util.Layout.INITIAL_SCENE_HEIGHT;
-import static bisq.desktop.util.Layout.INITIAL_SCENE_WIDTH;
+import static bisq.desktop.util.Layout.INITIAL_WINDOW_HEIGHT;
+import static bisq.desktop.util.Layout.INITIAL_WINDOW_WIDTH;
+import static bisq.desktop.util.Layout.MIN_WINDOW_HEIGHT;
+import static bisq.desktop.util.Layout.MIN_WINDOW_WIDTH;
 
 @Slf4j
 public class BisqApp extends Application implements UncaughtExceptionHandler {
@@ -205,7 +210,14 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private Scene createAndConfigScene(MainView mainView, Injector injector) {
-        Scene scene = new Scene(mainView.getRoot(), INITIAL_SCENE_WIDTH, INITIAL_SCENE_HEIGHT);
+        Rectangle maxWindowBounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+        Scene scene = new Scene(mainView.getRoot(),
+                maxWindowBounds.width < INITIAL_WINDOW_WIDTH ?
+                        (maxWindowBounds.width < MIN_WINDOW_WIDTH ? MIN_WINDOW_WIDTH : maxWindowBounds.width) :
+                        INITIAL_WINDOW_WIDTH,
+                maxWindowBounds.height < INITIAL_WINDOW_HEIGHT ?
+                        (maxWindowBounds.height < MIN_WINDOW_HEIGHT ? MIN_WINDOW_HEIGHT : maxWindowBounds.height) :
+                        INITIAL_WINDOW_HEIGHT);
         scene.getStylesheets().setAll(
                 "/bisq/desktop/bisq.css",
                 "/bisq/desktop/images.css",
@@ -231,8 +243,8 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
             appName += " [REGTEST]";
         stage.setTitle(appName);
         stage.setScene(scene);
-        stage.setMinWidth(1020);
-        stage.setMinHeight(620);
+        stage.setMinWidth(MIN_WINDOW_WIDTH);
+        stage.setMinHeight(MIN_WINDOW_HEIGHT);
 
         // on Windows the title icon is also used as task bar icon in a larger size
         // on Linux no title icon is supported but also a large task bar icon is derived from that title icon

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -86,7 +86,7 @@ import javafx.util.StringConverter;
 import java.util.Collections;
 import java.util.function.Function;
 
-import static bisq.desktop.util.Layout.INITIAL_SCENE_HEIGHT;
+import static bisq.desktop.util.Layout.INITIAL_WINDOW_HEIGHT;
 
 @FxmlView
 public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookChartViewModel> {
@@ -116,7 +116,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     private final double initialOfferTableViewHeight = 109;
     private final double pixelsPerOfferTableRow = (initialOfferTableViewHeight / 4.0) + 10.0; // initial visible row count=4
     private final Function<Double, Double> offerTableViewHeight = (screenSize) -> {
-        int extraRows = screenSize <= INITIAL_SCENE_HEIGHT ? 0 : (int) ((screenSize - INITIAL_SCENE_HEIGHT) / pixelsPerOfferTableRow);
+        int extraRows = screenSize <= INITIAL_WINDOW_HEIGHT ? 0 : (int) ((screenSize - INITIAL_WINDOW_HEIGHT) / pixelsPerOfferTableRow);
         return extraRows == 0 ? initialOfferTableViewHeight : Math.ceil(initialOfferTableViewHeight + (extraRows * pixelsPerOfferTableRow));
     };
 

--- a/desktop/src/main/java/bisq/desktop/util/Layout.java
+++ b/desktop/src/main/java/bisq/desktop/util/Layout.java
@@ -18,8 +18,10 @@
 package bisq.desktop.util;
 
 public class Layout {
-    public static final double INITIAL_SCENE_WIDTH = 1200;
-    public static final double INITIAL_SCENE_HEIGHT = 710; //740
+    public static final double INITIAL_WINDOW_WIDTH = 1200;
+    public static final double INITIAL_WINDOW_HEIGHT = 710; //740
+    public static final double MIN_WINDOW_WIDTH = 1020;
+    public static final double MIN_WINDOW_HEIGHT = 620;
     public static final double FIRST_ROW_DISTANCE = 20d;
     public static final double GROUP_DISTANCE = 40d;
     public static final double FIRST_ROW_AND_GROUP_DISTANCE = GROUP_DISTANCE + FIRST_ROW_DISTANCE;


### PR DESCRIPTION
**Problem:** When launching Bisq on my Windows 10 laptop, the application window is larger than the usable screen bounds causing the title bar of the application to be mostly off the screen. This is an annoyance and requires me to move and resize the window so that it is within the screen bounds.

**Cause:** My laptop has a 13-inch 1920x1080 display and uses 150% display scaling. As a result, it has a usable resolution (maximum screen bounds) of 1280x660 (accounting for the height of the Windows task bar). When launching the application, it sets the initial window height to 710px, which exceeds my usable screen height.

**Fix:** When launching the application, prevent the initial window size from exceeding the maximum available bounds. These bounds account for objects in the native windowing system such as task bars and menu bars.

<s>**Note: This is a work in progress as I have yet to test it on anything other than Windows (I plan to verify against Ubuntu). Nor have I verified a multi-display setup. But I still wanted to put this PR together in case anyone is able to verify it especially on Mac which I do not have available to test.**</s>