### PR TITLE
Remove Utilities.removeCryptographyRestrictions

### DIFF
--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -46,8 +46,6 @@ import javafx.scene.input.KeyEvent;
 import javax.crypto.Cipher;
 
 import java.security.NoSuchAlgorithmException;
-import java.security.Permission;
-import java.security.PermissionCollection;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -67,7 +65,6 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TimeZone;
@@ -78,9 +75,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -550,56 +544,6 @@ public class Utilities {
 
     public static String collectionToCSV(Collection<String> collection) {
         return collection.stream().map(Object::toString).collect(Collectors.joining(","));
-    }
-
-    public static void removeCryptographyRestrictions() {
-        if (!isRestrictedCryptography()) {
-            System.out.println("Cryptography restrictions removal not needed");
-            return;
-        }
-        try {
-            /*
-             * Do the following, but with reflection to bypass access checks:
-             *
-             * JceSecurity.isRestricted = false;
-             * JceSecurity.defaultPolicy.perms.clear();
-             * JceSecurity.defaultPolicy.add(CryptoAllPermission.INSTANCE);
-             */
-            final Class<?> jceSecurity = Class.forName("javax.crypto.JceSecurity");
-            final Class<?> cryptoPermissions = Class.forName("javax.crypto.CryptoPermissions");
-            final Class<?> cryptoAllPermission = Class.forName("javax.crypto.CryptoAllPermission");
-
-            final Field isRestrictedField = jceSecurity.getDeclaredField("isRestricted");
-            isRestrictedField.setAccessible(true);
-            final Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(isRestrictedField, isRestrictedField.getModifiers() & ~Modifier.FINAL);
-            isRestrictedField.set(null, false);
-
-            final Field defaultPolicyField = jceSecurity.getDeclaredField("defaultPolicy");
-            defaultPolicyField.setAccessible(true);
-            final PermissionCollection defaultPolicy = (PermissionCollection) defaultPolicyField.get(null);
-
-            final Field perms = cryptoPermissions.getDeclaredField("perms");
-            perms.setAccessible(true);
-            ((Map<?, ?>) perms.get(defaultPolicy)).clear();
-
-            final Field instance = cryptoAllPermission.getDeclaredField("INSTANCE");
-            instance.setAccessible(true);
-            defaultPolicy.add((Permission) instance.get(null));
-
-            System.out.println("Successfully removed cryptography restrictions");
-        } catch (final Exception e) {
-            System.err.println("Failed to remove cryptography restrictions" + e);
-        }
-    }
-
-    public static boolean isRestrictedCryptography() {
-        // This matches Oracle Java 7 and 8, but not Java 9 or OpenJDK.
-        final String name = System.getProperty("java.runtime.name");
-        final String ver = System.getProperty("java.version");
-        return name != null && name.equals("Java(TM) SE Runtime Environment")
-                && ver != null && (ver.startsWith("1.7") || ver.startsWith("1.8"));
     }
 
     public static byte[] integerToByteArray(int intValue, int numBytes) {

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -78,9 +78,6 @@ import static java.lang.String.join;
 
 @Slf4j
 public abstract class BisqExecutable implements GracefulShutDownHandler {
-    static {
-        Utilities.removeCryptographyRestrictions();
-    }
 
     protected Injector injector;
     protected AppModule module;

--- a/relay/src/main/java/bisq/relay/RelayMain.java
+++ b/relay/src/main/java/bisq/relay/RelayMain.java
@@ -42,8 +42,6 @@ public class RelayMain {
     static {
         // Need to set default locale initially otherwise we get problems at non-english OS
         Locale.setDefault(new Locale("en", Locale.getDefault().getCountry()));
-
-        Utilities.removeCryptographyRestrictions();
     }
 
     /**


### PR DESCRIPTION
This code is no longer necessary after the recent move to JDK10, and
removing it entirely avoids spending unnecessary cycles and eliminates
the confusing "Cryptography restrictions removal not needed" message in
console output.