### PR TITLE
Quell help output on option parsing error

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -100,9 +100,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
         try {
             options = parser.parse(args);
         } catch (OptionException ex) {
-            System.out.println("error: " + ex.getMessage());
-            System.out.println();
-            parser.printHelpOn(System.out);
+            System.err.println("error: " + ex.getMessage());
             System.exit(EXIT_FAILURE);
             return false;
         }
@@ -133,9 +131,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
                 return;
             }
         } catch (OptionException ex) {
-            System.out.println("error: " + ex.getMessage());
-            System.out.println();
-            parser.printHelpOn(System.out);
+            System.err.println("error: " + ex.getMessage());
             System.exit(EXIT_FAILURE);
             return;
         }


### PR DESCRIPTION
This change suppresses help output when option parsing fails, e.g. due
to an unrecognized option being specified. This is in keeping with *nix
utility idioms; for example, notice what happens when running `git
--bogus` or `ls --bogus`: they output an error message, and in some
cases a usage message, but they do not print complete help text.
This approach is especially important in the case of an application like
Bisq, where there are many options and the help text is longer than a
typical screen, making it easy to miss the error message altogether, as
it is printed at the top of the screen.

This change also prints the error message to stderr vs stdout, which is
again in keeping with *nix utility idoms.