### PR TITLE
Add advanced cash payment method

### DIFF
--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -723,6 +723,7 @@ message PaymentAccountPayload {
         MoneyGramAccountPayload money_gram_account_payload = 23;
         HalCashAccountPayload hal_cash_account_payload = 24;
         PromptPayAccountPayload prompt_pay_account_payload = 25;
+        AdvancedCashAccountPayload advanced_cash_account_payload = 26;
     }
     map<string, string> exclude_from_json_data = 15;
 }
@@ -900,6 +901,11 @@ message F2FAccountPayload {
 message PromptPayAccountPayload {
     string prompt_pay_id = 1;
 }
+
+message AdvancedCashAccountPayload {
+    string account_nr = 1;
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // PersistableEnvelope

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -147,6 +147,20 @@ public class CurrencyUtil {
     }
 
     // At OKPay you can exchange internally those currencies
+    public static List<TradeCurrency> getAllAdvancedCashCurrencies() {
+        ArrayList<TradeCurrency> currencies = new ArrayList<>(Arrays.asList(
+                new FiatCurrency("USD"),
+                new FiatCurrency("EUR"),
+                new FiatCurrency("GBP"),
+                new FiatCurrency("RUB"),
+                new FiatCurrency("UAH"),
+                new FiatCurrency("KZT"),
+                new FiatCurrency("BRL")
+        ));
+        currencies.sort(Comparator.comparing(TradeCurrency::getCode));
+        return currencies;
+    }
+
     public static List<TradeCurrency> getAllOKPayCurrencies() {
         ArrayList<TradeCurrency> currencies = new ArrayList<>(Arrays.asList(
                 new FiatCurrency("EUR"),

--- a/core/src/main/java/bisq/core/payment/AdvancedCashAccount.java
+++ b/core/src/main/java/bisq/core/payment/AdvancedCashAccount.java
@@ -17,7 +17,7 @@
 
 package bisq.core.payment;
 
-import bisq.core.locale.FiatCurrency;
+import bisq.core.locale.CurrencyUtil;
 import bisq.core.payment.payload.AdvancedCashAccountPayload;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PaymentMethod;
@@ -28,7 +28,7 @@ import lombok.EqualsAndHashCode;
 public final class AdvancedCashAccount extends PaymentAccount {
     public AdvancedCashAccount() {
         super(PaymentMethod.ADVANCED_CASH);
-        setSingleTradeCurrency(new FiatCurrency("USD"));
+        tradeCurrencies.addAll(CurrencyUtil.getAllAdvancedCashCurrencies());
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/AdvancedCashAccount.java
+++ b/core/src/main/java/bisq/core/payment/AdvancedCashAccount.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment;
+
+import bisq.core.locale.FiatCurrency;
+import bisq.core.payment.payload.AdvancedCashAccountPayload;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.payment.payload.PaymentMethod;
+
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public final class AdvancedCashAccount extends PaymentAccount {
+    public AdvancedCashAccount() {
+        super(PaymentMethod.ADVANCED_CASH);
+        setSingleTradeCurrency(new FiatCurrency("USD"));
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new AdvancedCashAccountPayload(paymentMethod.getId(), id);
+    }
+
+    public void setAccountNr(String accountNr) {
+        ((AdvancedCashAccountPayload) paymentAccountPayload).setAccountNr(accountNr);
+    }
+
+    public String getAccountNr() {
+        return ((AdvancedCashAccountPayload) paymentAccountPayload).getAccountNr();
+    }
+}

--- a/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
@@ -78,6 +78,8 @@ public class PaymentAccountFactory {
                 return new F2FAccount();
             case PaymentMethod.PROMPT_PAY_ID:
                 return new PromptPayAccount();
+            case PaymentMethod.ADVANCED_CASH_ID:
+                return new AdvancedCashAccount();
             default:
                 throw new RuntimeException("Not supported PaymentMethod: " + paymentMethod);
         }

--- a/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import io.bisq.generated.protobuffer.PB;
+
+import com.google.protobuf.Message;
+
+import org.springframework.util.CollectionUtils;
+
+import java.nio.charset.Charset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Setter
+@Getter
+@Slf4j
+public final class AdvancedCashAccountPayload extends PaymentAccountPayload {
+    private String accountNr = "";
+
+    public AdvancedCashAccountPayload(String paymentMethod, String id) {
+        super(paymentMethod, id);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private AdvancedCashAccountPayload(String paymentMethod,
+                                       String id,
+                                       String accountNr,
+                                       long maxTradePeriod,
+                                       @Nullable Map<String, String> excludeFromJsonDataMap) {
+        super(paymentMethod,
+                id,
+                maxTradePeriod,
+                excludeFromJsonDataMap);
+
+        this.accountNr = accountNr;
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        return getPaymentAccountPayloadBuilder()
+                .setAdvancedCashAccountPayload(PB.AdvancedCashAccountPayload.newBuilder()
+                        .setAccountNr(accountNr))
+                .build();
+    }
+
+    public static AdvancedCashAccountPayload fromProto(PB.PaymentAccountPayload proto) {
+        return new AdvancedCashAccountPayload(proto.getPaymentMethodId(),
+                proto.getId(),
+                proto.getAdvancedCashAccountPayload().getAccountNr(),
+                proto.getMaxTradePeriod(),
+                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public String getPaymentDetails() {
+        return "Advanced Cash - Account no.: " + accountNr;
+    }
+
+    @Override
+    public String getPaymentDetailsForTradePopup() {
+        return getPaymentDetails();
+    }
+
+    @Override
+    public byte[] getAgeWitnessInputData() {
+        return super.getAgeWitnessInputData(accountNr.getBytes(Charset.forName("UTF-8")));
+    }
+}

--- a/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
@@ -89,7 +89,7 @@ public final class AdvancedCashAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return "Advanced Cash - Account no.: " + accountNr;
+        return "Advanced Cash - Wallet ID: " + accountNr;
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -82,6 +82,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
     public static final String F2F_ID = "F2F";
     public static final String BLOCK_CHAINS_ID = "BLOCK_CHAINS";
     public static final String PROMPT_PAY_ID = "PROMPT_PAY";
+    public static final String ADVANCED_CASH_ID = "ADVANCED_CASH";
 
     @Deprecated
     public static PaymentMethod OK_PAY;
@@ -114,6 +115,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
     public static PaymentMethod HAL_CASH;
     public static PaymentMethod BLOCK_CHAINS;
     public static PaymentMethod PROMPT_PAY;
+    public static PaymentMethod ADVANCED_CASH;
 
     private static List<PaymentMethod> ALL_VALUES;
 
@@ -224,6 +226,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
                     UPHOLD = new PaymentMethod(UPHOLD_ID, DAY, maxTradeLimitHighRisk),
                     REVOLUT = new PaymentMethod(REVOLUT_ID, DAY, maxTradeLimitHighRisk),
                     PERFECT_MONEY = new PaymentMethod(PERFECT_MONEY_ID, DAY, maxTradeLimitLowRisk),
+                    ADVANCED_CASH = new PaymentMethod(ADVANCED_CASH_ID, DAY, maxTradeLimitVeryLowRisk),
 
                     // China
                     ALI_PAY = new PaymentMethod(ALI_PAY_ID, DAY, maxTradeLimitLowRisk),

--- a/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -20,6 +20,7 @@ package bisq.core.proto;
 import bisq.core.dao.governance.blindvote.storage.BlindVotePayload;
 import bisq.core.dao.governance.proposal.storage.appendonly.ProposalPayload;
 import bisq.core.payment.AccountAgeWitness;
+import bisq.core.payment.payload.AdvancedCashAccountPayload;
 import bisq.core.payment.payload.AliPayAccountPayload;
 import bisq.core.payment.payload.CashAppAccountPayload;
 import bisq.core.payment.payload.CashDepositAccountPayload;
@@ -138,6 +139,8 @@ public class CoreProtoResolver implements ProtoResolver {
                     return USPostalMoneyOrderAccountPayload.fromProto(proto);
                 case PROMPT_PAY_ACCOUNT_PAYLOAD:
                     return PromptPayAccountPayload.fromProto(proto);
+                case ADVANCED_CASH_ACCOUNT_PAYLOAD:
+                    return AdvancedCashAccountPayload.fromProto(proto);
                 default:
                     throw new ProtobufferRuntimeException("Unknown proto message case(PB.PaymentAccountPayload). messageCase=" + messageCase);
             }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2450,6 +2450,8 @@ HAL_CASH=HalCash
 BLOCK_CHAINS=Altcoins
 # suppress inspection "UnusedProperty"
 PROMPT_PAY=PromptPay
+# suppress inspection "UnusedProperty"
+ADVANCED_CASH=Advanced Cash
 
 # suppress inspection "UnusedProperty"
 OK_PAY_SHORT=OKPay
@@ -2491,7 +2493,8 @@ HAL_CASH_SHORT=HalCash
 BLOCK_CHAINS_SHORT=Altcoins
 # suppress inspection "UnusedProperty"
 PROMPT_PAY_SHORT=PromptPay
-
+# suppress inspection "UnusedProperty"
+ADVANCED_CASH_SHORT=Advanced Cash
 
 ####################################################################
 # Validation
@@ -2552,3 +2555,4 @@ validation.amountBelowDust=The amount below the dust limit of {0} is not allowed
 validation.length=Length must be between {0} and {1}
 validation.pattern=Input must be of format: {0}
 validation.noHexString=The input is not in HEX format.
+validation.advancedCash.invalidFormat=Must be a valid email or account number of format: X000000000000

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2555,4 +2555,4 @@ validation.amountBelowDust=The amount below the dust limit of {0} is not allowed
 validation.length=Length must be between {0} and {1}
 validation.pattern=Input must be of format: {0}
 validation.noHexString=The input is not in HEX format.
-validation.advancedCash.invalidFormat=Must be a valid email or account number of format: X000000000000
+validation.advancedCash.invalidFormat=Must be a valid email or wallet id of format: X000000000000

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AdvancedCashForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AdvancedCashForm.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.paymentmethods;
+
+import bisq.desktop.util.validation.AdvancedCashValidator;
+
+import bisq.core.locale.FiatCurrency;
+import bisq.core.locale.Res;
+import bisq.core.payment.AccountAgeWitnessService;
+import bisq.core.payment.AdvancedCashAccount;
+import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.payload.AdvancedCashAccountPayload;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.util.BSFormatter;
+import bisq.core.util.validation.InputValidator;
+
+import javafx.scene.layout.GridPane;
+
+import javafx.collections.FXCollections;
+
+
+import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
+
+public class AdvancedCashForm extends GeneralAccountNumberForm {
+
+    private final AdvancedCashAccount advancedCashAccount;
+
+    public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
+        addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.account.no"), ((AdvancedCashAccountPayload) paymentAccountPayload).getAccountNr());
+        return gridRow;
+    }
+
+    public AdvancedCashForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService, AdvancedCashValidator advancedCashValidator, InputValidator inputValidator, GridPane gridPane, int
+            gridRow, BSFormatter formatter) {
+        super(paymentAccount, accountAgeWitnessService, inputValidator, advancedCashValidator, gridPane, gridRow, formatter);
+        this.advancedCashAccount = (AdvancedCashAccount) paymentAccount;
+    }
+
+    @Override
+    public void addTradeCurrency() {
+        addTradeCurrencyComboBox();
+        currencyComboBox.setItems(FXCollections.observableArrayList(
+                new FiatCurrency("USD"),
+                new FiatCurrency("EUR"),
+                new FiatCurrency("GBP"),
+                new FiatCurrency("RUB"),
+                new FiatCurrency("UAH"),
+                new FiatCurrency("KZT"),
+                new FiatCurrency("BRL")));
+        currencyComboBox.getSelectionModel().select(0);
+    }
+
+    @Override
+    void setAccountNumber(String newValue) {
+        advancedCashAccount.setAccountNr(newValue);
+    }
+
+    @Override
+    String getAccountNr() {
+        return advancedCashAccount.getAccountNr();
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/GeneralAccountNumberForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/GeneralAccountNumberForm.java
@@ -21,16 +21,9 @@ import static bisq.desktop.util.FormBuilder.addTopLabelTextField;
 abstract public class GeneralAccountNumberForm extends PaymentMethodForm {
 
     private InputTextField accountNrInputTextField;
-    private InputValidator accountNumberValidator;
 
     GeneralAccountNumberForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService, InputValidator inputValidator, GridPane gridPane, int gridRow, BSFormatter formatter) {
-        this(paymentAccount, accountAgeWitnessService, inputValidator, null, gridPane, gridRow, formatter);
-    }
-
-    GeneralAccountNumberForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService, InputValidator inputValidator, InputValidator accountNumberValidator, GridPane gridPane, int gridRow, BSFormatter formatter) {
         super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
-
-        this.accountNumberValidator = (accountNumberValidator != null) ? accountNumberValidator : inputValidator;
     }
 
     @Override
@@ -38,7 +31,7 @@ abstract public class GeneralAccountNumberForm extends PaymentMethodForm {
         gridRowFrom = gridRow + 1;
 
         accountNrInputTextField = addInputTextField(gridPane, ++gridRow, Res.get("payment.account.no"));
-        accountNrInputTextField.setValidator(accountNumberValidator);
+        accountNrInputTextField.setValidator(inputValidator);
         accountNrInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
             setAccountNumber(newValue);
             updateFromInputs();
@@ -71,7 +64,7 @@ abstract public class GeneralAccountNumberForm extends PaymentMethodForm {
     @Override
     public void updateAllInputsValid() {
         allInputsValid.set(isAccountNameValid()
-                && accountNumberValidator.validate(getAccountNr()).isValid
+                && inputValidator.validate(getAccountNr()).isValid
                 && paymentAccount.getTradeCurrencies().size() > 0);
     }
 

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/GeneralAccountNumberForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/GeneralAccountNumberForm.java
@@ -21,9 +21,16 @@ import static bisq.desktop.util.FormBuilder.addTopLabelTextField;
 abstract public class GeneralAccountNumberForm extends PaymentMethodForm {
 
     private InputTextField accountNrInputTextField;
+    private InputValidator accountNumberValidator;
 
     GeneralAccountNumberForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService, InputValidator inputValidator, GridPane gridPane, int gridRow, BSFormatter formatter) {
+        this(paymentAccount, accountAgeWitnessService, inputValidator, null, gridPane, gridRow, formatter);
+    }
+
+    GeneralAccountNumberForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService, InputValidator inputValidator, InputValidator accountNumberValidator, GridPane gridPane, int gridRow, BSFormatter formatter) {
         super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
+
+        this.accountNumberValidator = (accountNumberValidator != null) ? accountNumberValidator : inputValidator;
     }
 
     @Override
@@ -31,7 +38,7 @@ abstract public class GeneralAccountNumberForm extends PaymentMethodForm {
         gridRowFrom = gridRow + 1;
 
         accountNrInputTextField = addInputTextField(gridPane, ++gridRow, Res.get("payment.account.no"));
-        accountNrInputTextField.setValidator(inputValidator);
+        accountNrInputTextField.setValidator(accountNumberValidator);
         accountNrInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
             setAccountNumber(newValue);
             updateFromInputs();
@@ -64,7 +71,7 @@ abstract public class GeneralAccountNumberForm extends PaymentMethodForm {
     @Override
     public void updateAllInputsValid() {
         allInputsValid.set(isAccountNameValid()
-                && inputValidator.validate(getAccountNr()).isValid
+                && accountNumberValidator.validate(getAccountNr()).isValid
                 && paymentAccount.getTradeCurrencies().size() > 0);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.account.content.fiataccounts;
 
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.TitledGroupBg;
+import bisq.desktop.components.paymentmethods.AdvancedCashForm;
 import bisq.desktop.components.paymentmethods.AliPayForm;
 import bisq.desktop.components.paymentmethods.CashAppForm;
 import bisq.desktop.components.paymentmethods.CashDepositForm;
@@ -52,6 +53,7 @@ import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
+import bisq.desktop.util.validation.AdvancedCashValidator;
 import bisq.desktop.util.validation.AliPayValidator;
 import bisq.desktop.util.validation.BICValidator;
 import bisq.desktop.util.validation.CashAppValidator;
@@ -141,6 +143,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
     private final HalCashValidator halCashValidator;
     private final F2FValidator f2FValidator;
     private final PromptPayValidator promptPayValidator;
+    private final AdvancedCashValidator advancedCashValidator;
     private final AccountAgeWitnessService accountAgeWitnessService;
     private final BSFormatter formatter;
     private ComboBox<PaymentMethod> paymentMethodComboBox;
@@ -172,6 +175,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                             HalCashValidator halCashValidator,
                             F2FValidator f2FValidator,
                             PromptPayValidator promptPayValidator,
+                            AdvancedCashValidator advancedCashValidator,
                             AccountAgeWitnessService accountAgeWitnessService,
                             BSFormatter formatter) {
         super(model);
@@ -197,6 +201,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
         this.halCashValidator = halCashValidator;
         this.f2FValidator = f2FValidator;
         this.promptPayValidator = promptPayValidator;
+        this.advancedCashValidator = advancedCashValidator;
         this.accountAgeWitnessService = accountAgeWitnessService;
         this.formatter = formatter;
     }
@@ -465,6 +470,8 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                 return new F2FForm(paymentAccount, accountAgeWitnessService, f2FValidator, inputValidator, root, gridRow, formatter);
             case PaymentMethod.PROMPT_PAY_ID:
                 return new PromptPayForm(paymentAccount, accountAgeWitnessService, promptPayValidator, inputValidator, root, gridRow, formatter);
+            case PaymentMethod.ADVANCED_CASH_ID:
+                return new AdvancedCashForm(paymentAccount, accountAgeWitnessService, advancedCashValidator, inputValidator, root, gridRow, formatter);
             default:
                 log.error("Not supported PaymentMethod: " + paymentMethod);
                 return null;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.portfolio.pendingtrades.steps.buyer;
 import bisq.desktop.components.BusyAnimation;
 import bisq.desktop.components.TextFieldWithCopyIcon;
 import bisq.desktop.components.TitledGroupBg;
+import bisq.desktop.components.paymentmethods.AdvancedCashForm;
 import bisq.desktop.components.paymentmethods.AliPayForm;
 import bisq.desktop.components.paymentmethods.CashAppForm;
 import bisq.desktop.components.paymentmethods.CashDepositForm;
@@ -298,6 +299,9 @@ public class BuyerStep2View extends TradeStepView {
                 break;
             case PaymentMethod.PROMPT_PAY_ID:
                 gridRow = PromptPayForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
+                break;
+            case PaymentMethod.ADVANCED_CASH_ID:
+                gridRow = AdvancedCashForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
                 break;
             default:
                 log.error("Not supported PaymentMethod: " + paymentMethodId);

--- a/desktop/src/main/java/bisq/desktop/util/validation/AdvancedCashValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/AdvancedCashValidator.java
@@ -1,0 +1,36 @@
+package bisq.desktop.util.validation;
+
+import bisq.core.locale.Res;
+import bisq.core.util.validation.InputValidator;
+
+import javax.inject.Inject;
+
+public class AdvancedCashValidator extends InputValidator {
+    private EmailValidator emailValidator;
+    private RegexValidator regexValidator;
+
+    @Inject
+    public AdvancedCashValidator(EmailValidator emailValidator, RegexValidator regexValidator) {
+
+        this.emailValidator = emailValidator;
+
+        regexValidator.setPattern("[A-Za-z]{1}\\d{12}");
+        regexValidator.setErrorMessage(Res.get("validation.advancedCash.invalidFormat"));
+        this.regexValidator = regexValidator;
+    }
+
+    @Override
+    public ValidationResult validate(String input) {
+        ValidationResult result = super.validate(input);
+
+        if (!result.isValid)
+            return result;
+
+        result = emailValidator.validate(input);
+
+        if (!result.isValid)
+            result = regexValidator.validate(input);
+
+        return result;
+    }
+}

--- a/desktop/src/test/java/bisq/desktop/util/validation/AdvancedCashValidatorTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/validation/AdvancedCashValidatorTest.java
@@ -1,0 +1,38 @@
+package bisq.desktop.util.validation;
+
+import bisq.core.app.BisqEnvironment;
+import bisq.core.btc.BaseCurrencyNetwork;
+import bisq.core.locale.CurrencyUtil;
+import bisq.core.locale.Res;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AdvancedCashValidatorTest {
+    @Before
+    public void setup() {
+        final BaseCurrencyNetwork baseCurrencyNetwork = BisqEnvironment.getBaseCurrencyNetwork();
+        final String currencyCode = baseCurrencyNetwork.getCurrencyCode();
+        Res.setBaseCurrencyCode(currencyCode);
+        Res.setBaseCurrencyName(baseCurrencyNetwork.getCurrencyName());
+        CurrencyUtil.setBaseCurrencyCode(currencyCode);
+    }
+
+    @Test
+    public void validate(){
+        AdvancedCashValidator validator = new AdvancedCashValidator(
+                new EmailValidator(),
+                new RegexValidator()
+        );
+
+        assertTrue(validator.validate("U123456789012").isValid);
+        assertTrue(validator.validate("test@user.com").isValid);
+
+        assertFalse(validator.validate("").isValid);
+        assertFalse(validator.validate(null).isValid);
+        assertFalse(validator.validate("123456789012").isValid);
+    }
+}


### PR DESCRIPTION
closes #1876 and closes #1785

A couple notes about this:

1. In addition to RUB, USD, EUR, GBP as described, Advanced pay also supports UAH, KZT and BRL.  These were included in the currency dropdown as well.
2. All wallet id's follow the form X000000000000 (a letter followed by 12 numbers, confirmed with advanced pay devs) so validation was added for this.