### PR TITLE
Remove .bat scripts unless user OS is Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ configure([project(':desktop'),
                 from "$destinationDir/lib"
                 into "${rootProject.projectDir}/lib"
             }
+
+            if (osdetector.os != 'windows')
+                delete fileTree(dir: rootProject.projectDir, include: 'bisq-*.bat')
         }
     }
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -15,12 +15,16 @@ You do _not_ need to install Gradle to complete the following command. The `grad
 
     ./gradlew build
 
+If on Windows use the `gradlew.bat` script instead.
+
 
 ## Run
 
 Bisq executables are now available in the root project directory. Run Bisq Desktop as follows:
 
     ./bisq-desktop
+
+If on Windows use the `bisq-desktop.bat` script instead.
 
 
 ## See also


### PR DESCRIPTION
Previously, start scripts were generated for both *nix and Windows
platforms, resulting in an unnecessarily cluttered root directory.

With this change, both types of script are still generated, but Windows
.bat scripts are deleted immediately afterward if the user is running a
non-Windows OS (unfortunately, there was no clean way to suppress the
generation of these scripts in the Gradle StartScripts API).

See #1956