### PR TITLE
Redesign CLI help output

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -31,7 +31,6 @@ import bisq.core.offer.OpenOfferManager;
 import bisq.core.setup.CorePersistedDataHost;
 import bisq.core.setup.CoreSetup;
 import bisq.core.trade.TradeManager;
-import bisq.core.util.joptsimple.EnumValueConverter;
 
 import bisq.network.NetworkOptionKeys;
 import bisq.network.p2p.P2PService;
@@ -47,7 +46,6 @@ import bisq.common.storage.CorruptedDatabaseFilesHandler;
 import bisq.common.storage.Storage;
 
 import org.springframework.core.env.JOptCommandLinePropertySource;
-import org.springframework.util.StringUtils;
 
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
@@ -72,8 +70,6 @@ import lombok.extern.slf4j.Slf4j;
 import static bisq.core.app.BisqEnvironment.DEFAULT_APP_NAME;
 import static bisq.core.app.BisqEnvironment.DEFAULT_USER_DATA_DIR;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.lang.String.format;
-import static java.lang.String.join;
 
 @Slf4j
 public abstract class BisqExecutable implements GracefulShutDownHandler {
@@ -87,10 +83,16 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
         // So we only handle the absolute minimum which is APP_NAME, APP_DATA_DIR_KEY and USER_DATA_DIR
         OptionParser parser = new OptionParser();
         parser.allowsUnrecognizedOptions();
-        parser.accepts(AppOptionKeys.USER_DATA_DIR_KEY, description("User data directory", DEFAULT_USER_DATA_DIR))
-                .withRequiredArg();
-        parser.accepts(AppOptionKeys.APP_NAME_KEY, description("Application name", DEFAULT_APP_NAME))
-                .withRequiredArg();
+
+        parser.accepts(AppOptionKeys.USER_DATA_DIR_KEY,
+                "User data directory")
+                .withRequiredArg()
+                .defaultsTo(DEFAULT_USER_DATA_DIR);
+
+        parser.accepts(AppOptionKeys.APP_NAME_KEY,
+                "Application name")
+                .withRequiredArg()
+                .defaultsTo(DEFAULT_APP_NAME);
 
         OptionSet options;
         try {
@@ -156,10 +158,10 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
         /*
          * JOptSimple does support input parsing. However, doing only options = parser.parse(args) isn't enough to trigger the parsing.
          * The parsing is done when the actual value is going to be retrieved, i.e. options.valueOf(attributename).
-         * 
+         *
          * In order to keep usability high, we work around the aforementioned characteristics by catching the exception below
          * (valueOf is called somewhere in getBisqEnvironment), thus, neatly inform the user of a ill-formed parameter and stop execution.
-         * 
+         *
          * Might be changed when the project features more user parameters meant for the user.
          */
         try {
@@ -167,7 +169,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
         } catch (OptionException e) {
             // unfortunately, the OptionArgumentConversionException is not visible so we cannot catch only those.
             // hence, workaround
-            if(e.getCause() != null)
+            if (e.getCause() != null)
                 // get something like "Error while parsing application parameter '--torrcFile': File [/path/to/file] does not exist"
                 System.err.println("Error while parsing application parameter '--" + e.options().get(0) + "': " + e.getCause().getMessage());
             else
@@ -316,189 +318,251 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
     protected void customizeOptionParsing(OptionParser parser) {
         //CommonOptionKeys
         parser.accepts(CommonOptionKeys.LOG_LEVEL_KEY,
-                description("Log level [OFF, ALL, ERROR, WARN, INFO, DEBUG, TRACE]", BisqEnvironment.LOG_LEVEL_DEFAULT))
-                .withRequiredArg();
+                "Log level")
+                .withRequiredArg()
+                .describedAs("OFF|ALL|ERROR|WARN|INFO|DEBUG|TRACE")
+                .defaultsTo(BisqEnvironment.LOG_LEVEL_DEFAULT);
 
         //NetworkOptionKeys
         parser.accepts(NetworkOptionKeys.SEED_NODES_KEY,
-                description("Override hard coded seed nodes as comma separated list: E.g. rxdkppp3vicnbgqt.onion:8002, mfla72c4igh5ta2t.onion:8002", ""))
-                .withRequiredArg();
+                "Override hard coded seed nodes as comma separated list e.g. " +
+                        "'rxdkppp3vicnbgqt.onion:8002,mfla72c4igh5ta2t.onion:8002'")
+                .withRequiredArg()
+                .describedAs("host:port[,...]");
+
         parser.accepts(NetworkOptionKeys.MY_ADDRESS,
-                description("My own onion address (used for bootstrap nodes to exclude itself)", ""))
-                .withRequiredArg();
+                "My own onion address (used for bootstrap nodes to exclude itself)")
+                .withRequiredArg()
+                .describedAs("host:port");
+
         parser.accepts(NetworkOptionKeys.BAN_LIST,
-                description("Nodes to exclude from network connections.", ""))
-                .withRequiredArg();
+                "Nodes to exclude from network connections.")
+                .withRequiredArg()
+                .describedAs("host:port[,...]");
+
         // use a fixed port as arbitrator use that for his ID
         parser.accepts(NetworkOptionKeys.PORT_KEY,
-                description("Port to listen on", 9999))
+                "Port to listen on")
                 .withRequiredArg()
-                .ofType(int.class);
+                .ofType(int.class)
+                .defaultsTo(9999);
+
         parser.accepts(NetworkOptionKeys.USE_LOCALHOST_FOR_P2P,
-                description("Use localhost P2P network for development", false))
+                "Use localhost P2P network for development")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(NetworkOptionKeys.MAX_CONNECTIONS,
-                description("Max. connections a peer will try to keep", P2PService.MAX_CONNECTIONS_DEFAULT))
+                "Max. connections a peer will try to keep")
                 .withRequiredArg()
-                .ofType(int.class);
+                .ofType(int.class)
+                .defaultsTo(P2PService.MAX_CONNECTIONS_DEFAULT);
+
         parser.accepts(NetworkOptionKeys.SOCKS_5_PROXY_BTC_ADDRESS,
-                description("A proxy address to be used for Bitcoin network. [host:port]", ""))
-                .withRequiredArg();
+                "A proxy address to be used for Bitcoin network.")
+                .withRequiredArg()
+                .describedAs("host:port");
+
         parser.accepts(NetworkOptionKeys.SOCKS_5_PROXY_HTTP_ADDRESS,
-                description("A proxy address to be used for Http requests (should be non-Tor). [host:port]", ""))
-                .withRequiredArg();
+                "A proxy address to be used for Http requests (should be non-Tor)")
+                .withRequiredArg()
+                .describedAs("host:port");
+
         parser.accepts(NetworkOptionKeys.TORRC_FILE,
-                description("An existing torrc-file to be sourced for Tor. Note that torrc-entries, which are critical to Bisqs flawless operation, cannot be overwritten.", ""))
+                "An existing torrc-file to be sourced for Tor. Note that torrc-entries, " +
+                        "which are critical to Bisq's flawless operation, cannot be overwritten.")
                 .withRequiredArg()
                 .withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE));
+
         parser.accepts(NetworkOptionKeys.TORRC_OPTIONS,
-                description("A list of torrc-entries to amend to Bisqs torrc. Note that torrc-entries, which are critical to Bisqs flawless operation, cannot be overwritten. [torrc options line, torrc option, ...]", ""))
+                "A list of torrc-entries to amend to Bisq's torrc. Note that torrc-entries," +
+                        "which are critical to Bisq's flawless operation, cannot be overwritten. " +
+                        "[torrc options line, torrc option, ...]")
                 .withRequiredArg()
                 .withValuesConvertedBy(RegexMatcher.regex("^([^\\s,]+\\s[^,]+,?\\s*)+$"));
+
         parser.accepts(NetworkOptionKeys.EXTERNAL_TOR_CONTROL_PORT,
-                description("The control port of an already running Tor service to be used by Bisq [port].", ""))
+                "The control port of an already running Tor service to be used by Bisq.")
                 .availableUnless(NetworkOptionKeys.TORRC_FILE, NetworkOptionKeys.TORRC_OPTIONS)
                 .withRequiredArg()
-                .ofType(int.class);
+                .ofType(int.class)
+                .describedAs("port");
+
         parser.accepts(NetworkOptionKeys.EXTERNAL_TOR_PASSWORD,
-                description("The password for controlling the already running Tor service.", ""))
+                "The password for controlling the already running Tor service.")
                 .availableIf(NetworkOptionKeys.EXTERNAL_TOR_CONTROL_PORT)
                 .withRequiredArg();
+
         parser.accepts(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE,
-                description("The cookie file for authenticating against the already running Tor service. Use in conjunction with --" + NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE, ""))
+                "The cookie file for authenticating against the already running Tor service. " +
+                        "Use in conjunction with --" + NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE)
                 .availableIf(NetworkOptionKeys.EXTERNAL_TOR_CONTROL_PORT)
                 .availableUnless(NetworkOptionKeys.EXTERNAL_TOR_PASSWORD)
                 .withRequiredArg()
                 .withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE));
+
         parser.accepts(NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE,
-                description("Use the SafeCookie method when authenticating to the already running Tor service.", ""))
+                "Use the SafeCookie method when authenticating to the already running Tor service.")
                 .availableIf(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE);
 
         //AppOptionKeys
         parser.accepts(AppOptionKeys.USER_DATA_DIR_KEY,
-                description("User data directory", BisqEnvironment.DEFAULT_USER_DATA_DIR))
-                .withRequiredArg();
+                "User data directory")
+                .withRequiredArg()
+                .defaultsTo(BisqEnvironment.DEFAULT_USER_DATA_DIR);
+
         parser.accepts(AppOptionKeys.APP_NAME_KEY,
-                description("Application name", BisqEnvironment.DEFAULT_APP_NAME))
-                .withRequiredArg();
+                "Application name")
+                .withRequiredArg()
+                .defaultsTo(BisqEnvironment.DEFAULT_APP_NAME);
+
         parser.accepts(AppOptionKeys.MAX_MEMORY,
-                description("Max. permitted memory (used only at headless versions)", 600))
-                .withRequiredArg();
+                "Max. permitted memory (used only at headless versions)")
+                .withRequiredArg()
+                .defaultsTo("600");
+
         parser.accepts(AppOptionKeys.APP_DATA_DIR_KEY,
-                description("Application data directory", BisqEnvironment.DEFAULT_APP_DATA_DIR))
-                .withRequiredArg();
+                "Application data directory")
+                .withRequiredArg()
+                .defaultsTo(BisqEnvironment.DEFAULT_APP_DATA_DIR);
+
         parser.accepts(AppOptionKeys.IGNORE_DEV_MSG_KEY,
-                description("If set to true all signed network_messages from bisq developers are ignored " +
-                        "(Global alert, Version update alert, Filters for offers, nodes or trading account data)", false))
+                "If set to true all signed network_messages from bisq developers are ignored " +
+                        "(Global alert, Version update alert, Filters for offers, nodes or trading account data)")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(AppOptionKeys.DESKTOP_WITH_HTTP_API,
-                description("If set to true Bisq Desktop starts with Http API", false))
+                "If set to true Bisq Desktop starts with Http API")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(AppOptionKeys.DESKTOP_WITH_GRPC_API,
-                description("If set to true Bisq Desktop starts with gRPC API", false))
+                "If set to true Bisq Desktop starts with gRPC API")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS,
-                description("If that is true all the privileged features which requires a private key to enable it are overridden by a dev key pair " +
-                        "(This is for developers only!)", false))
+                "If that is true all the privileged features which requires a private key " +
+                        "to enable it are overridden by a dev key pair (This is for developers only!)")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(AppOptionKeys.REFERRAL_ID,
-                description("Optional Referral ID (e.g. for API users or pro market makers)", ""))
+                "Optional Referral ID (e.g. for API users or pro market makers)")
                 .withRequiredArg();
+
         parser.accepts(CommonOptionKeys.USE_DEV_MODE,
-                description("Enables dev mode which is used for convenience for developer testing", false))
+                "Enables dev mode which is used for convenience for developer testing")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(AppOptionKeys.DUMP_STATISTICS,
-                description("If set to true the trade statistics are stored as json file in the data dir.", false))
+                "If set to true the trade statistics are stored as json file in the data dir.")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(AppOptionKeys.PROVIDERS,
-                description("Custom providers (comma separated)", false))
-                .withRequiredArg();
+                "Custom providers (comma separated)")
+                .withRequiredArg()
+                .describedAs("host:port[,...]");
 
         //BtcOptionKeys
         parser.accepts(BtcOptionKeys.BASE_CURRENCY_NETWORK,
-                description("Base currency network", BisqEnvironment.getDefaultBaseCurrencyNetwork().name()))
+                "Base currency network")
                 .withRequiredArg()
-                .ofType(String.class);
-        //.withValuesConvertedBy(new EnumValueConverter(String.class));
-        parser.accepts(BtcOptionKeys.REG_TEST_HOST,
-                description("", RegTestHost.DEFAULT))
+                .ofType(String.class)
+                .defaultsTo(BisqEnvironment.getDefaultBaseCurrencyNetwork().name());
+
+        parser.accepts(BtcOptionKeys.REG_TEST_HOST)
                 .withRequiredArg()
                 .ofType(RegTestHost.class)
-                .withValuesConvertedBy(new EnumValueConverter(RegTestHost.class));
+                .defaultsTo(RegTestHost.DEFAULT);
+
         parser.accepts(BtcOptionKeys.BTC_NODES,
-                description("Custom nodes used for BitcoinJ as comma separated IP addresses.", ""))
-                .withRequiredArg();
+                "Custom nodes used for BitcoinJ as comma separated IP addresses.")
+                .withRequiredArg()
+                .describedAs("ip[,...]");
+
         parser.accepts(BtcOptionKeys.USE_TOR_FOR_BTC,
-                description("If set to true BitcoinJ is routed over tor (socks 5 proxy).", ""))
-                .withRequiredArg();
-        parser.accepts(BtcOptionKeys.SOCKS5_DISCOVER_MODE,
-                description("Specify discovery mode for Bitcoin nodes. One or more of: [ADDR, DNS, ONION, ALL]" +
-                        " (comma separated, they get OR'd together). Default value is ALL", "ALL"))
-                .withRequiredArg();
-        parser.accepts(BtcOptionKeys.USE_ALL_PROVIDED_NODES,
-                description("Set to true if connection of bitcoin nodes should include clear net nodes", ""))
-                .withRequiredArg();
-        parser.accepts(BtcOptionKeys.USER_AGENT,
-                description("User agent at btc node connections", ""))
-                .withRequiredArg();
-        parser.accepts(BtcOptionKeys.NUM_CONNECTIONS_FOR_BTC,
-                description("Number of connections to the Bitcoin network", "9"))
+                "If set to true BitcoinJ is routed over tor (socks 5 proxy).")
                 .withRequiredArg();
 
+        parser.accepts(BtcOptionKeys.SOCKS5_DISCOVER_MODE,
+                "Specify discovery mode for Bitcoin nodes. One or more of: [ADDR, DNS, ONION, ALL]" +
+                        " (comma separated, they get OR'd together).")
+                .withRequiredArg()
+                .describedAs("mode[,...]")
+                .defaultsTo("ALL");
+
+        parser.accepts(BtcOptionKeys.USE_ALL_PROVIDED_NODES,
+                "Set to true if connection of bitcoin nodes should include clear net nodes")
+                .withRequiredArg();
+
+        parser.accepts(BtcOptionKeys.USER_AGENT,
+                "User agent at btc node connections")
+                .withRequiredArg();
+
+        parser.accepts(BtcOptionKeys.NUM_CONNECTIONS_FOR_BTC,
+                "Number of connections to the Bitcoin network")
+                .withRequiredArg()
+                .defaultsTo("9");
 
         //RpcOptionKeys
         parser.accepts(DaoOptionKeys.RPC_USER,
-                description("Bitcoind rpc username", ""))
+                "Bitcoind rpc username")
                 .withRequiredArg();
+
         parser.accepts(DaoOptionKeys.RPC_PASSWORD,
-                description("Bitcoind rpc password", ""))
+                "Bitcoind rpc password")
                 .withRequiredArg();
+
         parser.accepts(DaoOptionKeys.RPC_PORT,
-                description("Bitcoind rpc port", ""))
+                "Bitcoind rpc port")
                 .withRequiredArg();
+
         parser.accepts(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT,
-                description("Bitcoind rpc port for block notifications", ""))
+                "Bitcoind rpc port for block notifications")
                 .withRequiredArg();
+
         parser.accepts(DaoOptionKeys.DUMP_BLOCKCHAIN_DATA,
-                description("If set to true the blockchain data from RPC requests to Bitcoin Core are stored " +
-                        "as json file in the data dir.", false))
+                "If set to true the blockchain data from RPC requests to Bitcoin Core are " +
+                        "stored as json file in the data dir.")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .ofType(boolean.class)
+                .defaultsTo(false);
+
         parser.accepts(DaoOptionKeys.FULL_DAO_NODE,
-                description("If set to true the node requests the blockchain data via RPC requests from Bitcoin Core and " +
-                        "provide the validated BSQ txs to the network. It requires that the other RPC properties are " +
-                        "set as well.", ""))
+                "If set to true the node requests the blockchain data via RPC requests " +
+                        "from Bitcoin Core and provide the validated BSQ txs to the network. " +
+                        "It requires that the other RPC properties are set as well.")
                 .withRequiredArg();
+
         parser.accepts(DaoOptionKeys.GENESIS_TX_ID,
-                description("Genesis transaction ID when not using the hard coded one", ""))
+                "Genesis transaction ID when not using the hard coded one")
                 .withRequiredArg();
+
         parser.accepts(DaoOptionKeys.GENESIS_BLOCK_HEIGHT,
-                description("Genesis transaction block height when not using the hard coded one", -1))
-                .withRequiredArg();
-        parser.accepts(DaoOptionKeys.DAO_ACTIVATED,
-                description("Developer flag. If true it enables dao phase 2 features.", false))
+                "Genesis transaction block height when not using the hard coded one")
                 .withRequiredArg()
-                .ofType(boolean.class);
+                .defaultsTo("-1");
+
+        parser.accepts(DaoOptionKeys.DAO_ACTIVATED,
+                "Developer flag. If true it enables dao phase 2 features.")
+                .withRequiredArg()
+                .ofType(boolean.class)
+                .defaultsTo(false);
     }
 
     public static BisqEnvironment getBisqEnvironment(OptionSet options) {
         return new BisqEnvironment(new JOptCommandLinePropertySource(BisqEnvironment.BISQ_COMMANDLINE_PROPERTY_SOURCE_NAME, checkNotNull(options)));
-    }
-
-    protected static String description(String descText, Object defaultValue) {
-        String description = "";
-        if (StringUtils.hasText(descText))
-            description = description.concat(descText);
-        if (defaultValue != null)
-            description = join(" ", description, format("(default: %s)", defaultValue));
-        return description;
     }
 
     public static void initAppDir(String appDir) {

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -114,6 +114,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
 
     public void execute(String[] args) throws Exception {
         OptionParser parser = new OptionParser();
+        parser.formatHelpWith(new BisqHelpFormatter());
         parser.accepts(HELP_KEY, "This help text").forHelp();
 
         this.customizeOptionParsing(parser);

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -74,9 +74,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 public abstract class BisqExecutable implements GracefulShutDownHandler {
 
+    private final String fullName;
+    private final String scriptName;
+    private final String version;
+
     protected Injector injector;
     protected AppModule module;
     protected BisqEnvironment bisqEnvironment;
+
+    public BisqExecutable(String fullName, String scriptName, String version) {
+        this.fullName = fullName;
+        this.scriptName = scriptName;
+        this.version = version;
+    }
 
     public static boolean setupInitialOptionParser(String[] args) throws IOException {
         // We don't want to do the full argument parsing here as that might easily change in update versions
@@ -116,7 +126,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
 
     public void execute(String[] args) throws Exception {
         OptionParser parser = new OptionParser();
-        parser.formatHelpWith(new BisqHelpFormatter());
+        parser.formatHelpWith(new BisqHelpFormatter(fullName, scriptName, version));
         parser.accepts(HELP_KEY, "This help text").forHelp();
 
         this.customizeOptionParsing(parser);

--- a/core/src/main/java/bisq/core/app/BisqHeadlessAppMain.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessAppMain.java
@@ -21,6 +21,7 @@ import bisq.core.CoreModule;
 
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
+import bisq.common.app.Version;
 import bisq.common.setup.CommonSetup;
 
 import joptsimple.OptionSet;
@@ -35,6 +36,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BisqHeadlessAppMain extends BisqExecutable {
     protected HeadlessApp headlessApp;
+
+    public BisqHeadlessAppMain() {
+        super("Bisq Daemon", "bisqd", Version.VERSION);
+    }
 
     public static void main(String[] args) throws Exception {
         if (BisqExecutable.setupInitialOptionParser(args)) {

--- a/core/src/main/java/bisq/core/app/BisqHelpFormatter.java
+++ b/core/src/main/java/bisq/core/app/BisqHelpFormatter.java
@@ -27,11 +27,22 @@ import java.util.stream.Collectors;
 
 public class BisqHelpFormatter implements HelpFormatter {
 
+    private final String fullName;
+    private final String scriptName;
+    private final String version;
+
+    public BisqHelpFormatter(String fullName, String scriptName, String version) {
+        this.fullName = fullName;
+        this.scriptName = scriptName;
+        this.version = version;
+    }
+
     public String format(Map<String, ? extends OptionDescriptor> descriptors) {
 
         StringBuilder output = new StringBuilder();
-        output.append("Options:\n");
-        output.append("\n");
+        output.append(String.format("%s version %s\n\n", fullName, version));
+        output.append(String.format("Usage: %s [options]\n\n", scriptName));
+        output.append("Options:\n\n");
 
         for (Map.Entry<String, ? extends OptionDescriptor> entry : descriptors.entrySet()) {
             String optionName = entry.getKey();

--- a/core/src/main/java/bisq/core/app/BisqHelpFormatter.java
+++ b/core/src/main/java/bisq/core/app/BisqHelpFormatter.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.app;
+
+import joptsimple.HelpFormatter;
+import joptsimple.OptionDescriptor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BisqHelpFormatter implements HelpFormatter {
+
+    public String format(Map<String, ? extends OptionDescriptor> descriptors) {
+
+        StringBuilder output = new StringBuilder();
+        output.append("Options:\n");
+        output.append("\n");
+
+        for (Map.Entry<String, ? extends OptionDescriptor> entry : descriptors.entrySet()) {
+            String optionName = entry.getKey();
+            OptionDescriptor optionDesc = entry.getValue();
+
+            if (optionDesc.representsNonOptions())
+                continue;
+
+            output.append(String.format("%s\n", formatOptionSyntax(optionName, optionDesc)));
+            output.append(String.format("%s\n", formatOptionDescription(optionDesc)));
+        }
+
+        return output.toString();
+    }
+
+    private String formatOptionSyntax(String optionName, OptionDescriptor optionDesc) {
+        StringBuilder result = new StringBuilder(String.format("  --%s", optionName));
+
+        if (optionDesc.acceptsArguments())
+            result.append(String.format("=<%s>", formatArgDescription(optionDesc)));
+
+        List<?> defaultValues = optionDesc.defaultValues();
+        if (defaultValues.size() > 0)
+            result.append(String.format(" (default: %s)", formatDefaultValues(defaultValues)));
+
+        return result.toString();
+    }
+
+    private String formatArgDescription(OptionDescriptor optionDesc) {
+        String argDescription = optionDesc.argumentDescription();
+
+        if (argDescription.length() > 0)
+            return argDescription;
+
+        String typeIndicator = optionDesc.argumentTypeIndicator();
+
+        if (typeIndicator == null)
+            return "value";
+
+        try {
+            Class<?> type = Class.forName(typeIndicator);
+            return type.isEnum() ?
+                    Arrays.stream(type.getEnumConstants()).map(Object::toString).collect(Collectors.joining("|")) :
+                    typeIndicator.substring(typeIndicator.lastIndexOf('.') + 1);
+        } catch (ClassNotFoundException ex) {
+            // typeIndicator is something other than a class name, which can occur
+            // in certain cases e.g. where OptionParser.withValuesConvertedBy is used.
+            return typeIndicator;
+        }
+    }
+
+    private Object formatDefaultValues(List<?> defaultValues) {
+        return defaultValues.size() == 1 ?
+                defaultValues.get(0) :
+                defaultValues.toString();
+    }
+
+    private String formatOptionDescription(OptionDescriptor optionDesc) {
+        StringBuilder output = new StringBuilder();
+
+        String remainder = optionDesc.description().trim();
+
+        // Wrap description text at 80 characters with 8 spaces of indentation and a
+        // maximum of 72 chars of text, wrapping on spaces. Strings longer than 72 chars
+        // without any spaces (e.g. a URL) are allowed to overflow the 80-char margin.
+        while (remainder.length() > 72) {
+            int idxFirstSpace = remainder.indexOf(' ');
+            int chunkLen = idxFirstSpace == -1 ? remainder.length() : idxFirstSpace > 73 ? idxFirstSpace : 73;
+            String chunk = remainder.substring(0, chunkLen);
+            int idxLastSpace = chunk.lastIndexOf(' ');
+            int idxBreak = idxLastSpace > 0 ? idxLastSpace : chunk.length();
+            String line = remainder.substring(0, idxBreak);
+            output.append(formatLine(line));
+            remainder = remainder.substring(chunk.length() - (chunk.length() - idxBreak)).trim();
+        }
+
+        if (remainder.length() > 0)
+            output.append(formatLine(remainder));
+
+        return output.toString();
+    }
+
+    private String formatLine(String line) {
+        return String.format("        %s\n", line.trim());
+    }
+}

--- a/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
@@ -51,6 +51,10 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable implements 
     private volatile boolean stopped;
     private static long maxMemory = MAX_MEMORY_MB_DEFAULT;
 
+    public ExecutableForAppWithP2p(String fullName, String scriptName, String version) {
+        super(fullName, scriptName, version);
+    }
+
     @Override
     protected void configUserThread() {
         final ThreadFactory threadFactory = new ThreadFactoryBuilder()

--- a/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
+++ b/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
@@ -41,7 +41,7 @@ public class BisqHelpFormatterTest {
 
         OptionParser parser = new OptionParser();
 
-        parser.formatHelpWith(new BisqHelpFormatter());
+        parser.formatHelpWith(new BisqHelpFormatter("Bisq Test", "bisq-test", "0.1.0"));
 
         parser.accepts("name",
                 "The name of the Bisq node")

--- a/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
+++ b/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.app;
+
+import joptsimple.OptionParser;
+
+import java.net.URISyntaxException;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class BisqHelpFormatterTest {
+
+    @Test
+    public void testHelpFormatter() throws IOException, URISyntaxException {
+
+        OptionParser parser = new OptionParser();
+
+        parser.formatHelpWith(new BisqHelpFormatter());
+
+        parser.accepts("name",
+                "The name of the Bisq node")
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("Bisq");
+
+        parser.accepts("another-option",
+                "This is a long description which will need to break over multiple linessssssssssss such " +
+                        "that no line is longer than 80 characters in the help output.")
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("WAT");
+
+        parser.accepts("exactly-72-char-description",
+                "012345678911234567892123456789312345678941234567895123456789612345678971")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("exactly-72-char-description-with-spaces",
+                " 123456789 123456789 123456789 123456789 123456789 123456789 123456789 1")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("90-char-description-without-spaces",
+                "-123456789-223456789-323456789-423456789-523456789-623456789-723456789-823456789-923456789")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("90-char-description-with-space-at-char-80",
+                "-123456789-223456789-323456789-423456789-523456789-623456789-723456789-823456789 923456789")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("90-char-description-with-spaces-at-chars-5-and-80",
+                "-123 56789-223456789-323456789-423456789-523456789-623456789-723456789-823456789 923456789")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("90-char-description-with-space-at-char-73",
+                "-123456789-223456789-323456789-423456789-523456789-623456789-723456789-8 3456789-923456789")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("1-char-description-with-only-a-space", " ")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("empty-description", "")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("no-description")
+                .withRequiredArg()
+                .ofType(String.class);
+
+        parser.accepts("no-arg", "Some description");
+
+        parser.accepts("optional-arg",
+                "Option description")
+                .withOptionalArg();
+
+        parser.accepts("with-default-value",
+                "Some option with a default value")
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("Wat");
+
+        parser.accepts("data-dir",
+                "Application data directory")
+                .withRequiredArg()
+                .ofType(File.class)
+                .defaultsTo(new File("/Users/cbeams/Library/Applicaton Support/Bisq"));
+
+        parser.accepts("enum-opt",
+                "Some option that accepts an enum value as an argument")
+                .withRequiredArg()
+                .ofType(AnEnum.class)
+                .defaultsTo(AnEnum.foo);
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        String expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output.txt").toURI())));
+
+        parser.printHelpOn(new PrintStream(actual));
+        assertThat(actual.toString(), equalTo(expected));
+    }
+
+
+    enum AnEnum {foo, bar, baz}
+}

--- a/core/src/test/resources/bisq/core/app/cli-output.txt
+++ b/core/src/test/resources/bisq/core/app/cli-output.txt
@@ -1,0 +1,53 @@
+Options:
+
+  --name=<String> (default: Bisq)
+        The name of the Bisq node
+
+  --another-option=<String> (default: WAT)
+        This is a long description which will need to break over multiple
+        linessssssssssss such that no line is longer than 80 characters in the
+        help output.
+
+  --exactly-72-char-description=<String>
+        012345678911234567892123456789312345678941234567895123456789612345678971
+
+  --exactly-72-char-description-with-spaces=<String>
+        123456789 123456789 123456789 123456789 123456789 123456789 123456789 1
+
+  --90-char-description-without-spaces=<String>
+        -123456789-223456789-323456789-423456789-523456789-623456789-723456789-823456789-923456789
+
+  --90-char-description-with-space-at-char-80=<String>
+        -123456789-223456789-323456789-423456789-523456789-623456789-723456789-823456789
+        923456789
+
+  --90-char-description-with-spaces-at-chars-5-and-80=<String>
+        -123
+        56789-223456789-323456789-423456789-523456789-623456789-723456789-823456789
+        923456789
+
+  --90-char-description-with-space-at-char-73=<String>
+        -123456789-223456789-323456789-423456789-523456789-623456789-723456789-8
+        3456789-923456789
+
+  --1-char-description-with-only-a-space=<String>
+
+  --empty-description=<String>
+
+  --no-description=<String>
+
+  --no-arg
+        Some description
+
+  --optional-arg=<value>
+        Option description
+
+  --with-default-value=<String> (default: Wat)
+        Some option with a default value
+
+  --data-dir=<File> (default: /Users/cbeams/Library/Applicaton Support/Bisq)
+        Application data directory
+
+  --enum-opt=<foo|bar|baz> (default: foo)
+        Some option that accepts an enum value as an argument
+

--- a/core/src/test/resources/bisq/core/app/cli-output.txt
+++ b/core/src/test/resources/bisq/core/app/cli-output.txt
@@ -1,3 +1,7 @@
+Bisq Test version 0.1.0
+
+Usage: bisq-test [options]
+
 Options:
 
   --name=<String> (default: Bisq)

--- a/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
@@ -25,6 +25,7 @@ import bisq.core.app.BisqExecutable;
 
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
+import bisq.common.app.Version;
 import bisq.common.proto.persistable.PersistedDataHost;
 import bisq.common.setup.CommonSetup;
 
@@ -38,6 +39,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BisqAppMain extends BisqExecutable {
     private BisqApp application;
+
+    public BisqAppMain() {
+        super("Bisq Desktop", "bisq-desktop", Version.VERSION);
+    }
 
     /* @Nullable
      private BisqHttpApiServer bisqHttpApiServer;*/

--- a/monitor/src/main/java/bisq/monitor/MonitorMain.java
+++ b/monitor/src/main/java/bisq/monitor/MonitorMain.java
@@ -119,16 +119,20 @@ public class MonitorMain extends ExecutableForAppWithP2p {
         super.customizeOptionParsing(parser);
 
         parser.accepts(MonitorOptionKeys.SLACK_URL_SEED_CHANNEL,
-                description("Set slack secret for seed node monitor", ""))
+                "Set slack secret for seed node monitor")
                 .withRequiredArg();
+
         parser.accepts(MonitorOptionKeys.SLACK_BTC_SEED_CHANNEL,
-                description("Set slack secret for Btc node monitor", ""))
+                "Set slack secret for Btc node monitor")
                 .withRequiredArg();
+
         parser.accepts(MonitorOptionKeys.SLACK_PROVIDER_SEED_CHANNEL,
-                description("Set slack secret for provider node monitor", ""))
+                "Set slack secret for provider node monitor")
                 .withRequiredArg();
+
         parser.accepts(MonitorOptionKeys.PORT,
-                description("Set port to listen on", "80"))
-                .withRequiredArg();
+                "Set port to listen on")
+                .withRequiredArg()
+                .defaultsTo("80");
     }
 }

--- a/monitor/src/main/java/bisq/monitor/MonitorMain.java
+++ b/monitor/src/main/java/bisq/monitor/MonitorMain.java
@@ -42,6 +42,10 @@ public class MonitorMain extends ExecutableForAppWithP2p {
     private static final String VERSION = "1.0.1";
     private Monitor monitor;
 
+    public MonitorMain() {
+        super("Bisq Monitor", "bisq-monitor", VERSION);
+    }
+
     public static void main(String[] args) throws Exception {
         log.info("Monitor.VERSION: " + VERSION);
         BisqEnvironment.setDefaultAppName("bisq_monitor");

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -36,6 +36,10 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
     private static final String VERSION = "0.8.0";
     private SeedNode seedNode;
 
+    public SeedNodeMain() {
+        super("Bisq Seednode", "bisq-seednode", VERSION);
+    }
+
     public static void main(String[] args) throws Exception {
         log.info("SeedNode.VERSION: " + VERSION);
         BisqEnvironment.setDefaultAppName("bisq_seednode");

--- a/statsnode/src/main/java/bisq/statistics/StatisticsMain.java
+++ b/statsnode/src/main/java/bisq/statistics/StatisticsMain.java
@@ -35,6 +35,10 @@ public class StatisticsMain extends ExecutableForAppWithP2p {
     private static final String VERSION = "0.6.1";
     private Statistics statistics;
 
+    public StatisticsMain() {
+        super("Bisq Statsnode", "bisq-statistics", VERSION);
+    }
+
     public static void main(String[] args) throws Exception {
         log.info("Statistics.VERSION: " + VERSION);
         BisqEnvironment.setDefaultAppName("bisq_statistics");


### PR DESCRIPTION
Prior to this pull request, Bisq's `--help` output looked like this:

    $ bisq-desktop --help
    Option                                  Description
    ------                                  -----------
    --appDataDir <String>                   Application data directory (default:
                                              /Users/cbeams/Library/Application
                                              Support/Bisq)
    --appName <String>                      Application name (default: Bisq)
    --banList <String>                      Nodes to exclude from network
                                              connections. (default: )
    --baseCurrencyNetwork <String>          Base currency network (default:
                                              BTC_MAINNET)
    --bitcoinRegtestHost <RegTestHost>      (default: LOCALHOST)
    --btcNodes <String>                     Custom nodes used for BitcoinJ as
                                              comma separated IP addresses.
                                              (default: )
    [...]


Now it reads as follows:

    $ bisq-desktop --help
    Bisq Desktop version 0.8.0

    Usage: bisq-desktop [options]

    Options:

      --help
            This help text

      --logLevel=<OFF|ALL|ERROR|WARN|INFO|DEBUG|TRACE> (default: INFO)
            Log level

      --seedNodes=<host:port[,...]>
            Override hard coded seed nodes as comma separated list e.g.
            'rxdkppp3vicnbgqt.onion:8002,mfla72c4igh5ta2t.onion:8002'

      --myAddress=<host:port>
            My own onion address (used for bootstrap nodes to exclude itself)

      --banList=<host:port[,...]>
            Nodes to exclude from network connections.

      --nodePort=<Integer> (default: 9999)
            Port to listen on

      --useLocalhostForP2P=<Boolean> (default: false)
            Use localhost P2P network for development

      [...]


This new help format is modeled after bitcoind's own help output, which reads as follows:

    $ bitcoind --help | head -20
    Bitcoin Core Daemon version v0.17.0.0-ge1ed37edaedc85b8c3468bd9a726046344036243

    Usage:  bitcoind [options]                     Start Bitcoin Core Daemon

    Options:

      -?
           Print this help message and exit

      -alertnotify=<cmd>
           Execute command when a relevant alert is received or we see a really
           long fork (%s in cmd is replaced by message)

      -assumevalid=<hex>
           If this block is in the chain assume that it and its ancestors are valid
           and potentially skip their script verification (0 to verify all,
           default:
           0000000000000000002e63058c023a9a1de233554f28c7b21380b6c9003f36a8,
           testnet:
           0000000000000037a8cd3e06cd5edbfe9dd1dbcc5dacab279376ef7cfc2b4c75)

    [...]

The goal is to maximize readibility, make best use of the available 80-character width and to present Bisq's command line interface in a way that is friendly and familiar to those well-versed in *nix idioms.

Reviewers, please look through the commits one-by-one and read the detailed commit comments, thanks.