### PR TITLE
Resolve BisqHelpFormatterTest failure on Windows

### DIFF
--- a/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
+++ b/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
@@ -114,7 +114,7 @@ public class BisqHelpFormatterTest {
                 "Application data directory")
                 .withRequiredArg()
                 .ofType(File.class)
-                .defaultsTo(new File("/Users/cbeams/Library/Applicaton Support/Bisq"));
+                .defaultsTo(new File("/Users/cbeams/Library/Application Support/Bisq"));
 
         parser.accepts("enum-opt",
                 "Some option that accepts an enum value as an argument")
@@ -124,6 +124,9 @@ public class BisqHelpFormatterTest {
 
         ByteArrayOutputStream actual = new ByteArrayOutputStream();
         String expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output.txt").toURI())));
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output_windows.txt").toURI())));
+        }
 
         parser.printHelpOn(new PrintStream(actual));
         assertThat(actual.toString(), equalTo(expected));

--- a/core/src/test/resources/bisq/core/app/cli-output_windows.txt
+++ b/core/src/test/resources/bisq/core/app/cli-output_windows.txt
@@ -49,7 +49,7 @@ Options:
   --with-default-value=<String> (default: Wat)
         Some option with a default value
 
-  --data-dir=<File> (default: /Users/cbeams/Library/Application Support/Bisq)
+  --data-dir=<File> (default: \Users\cbeams\Library\Application Support\Bisq)
         Application data directory
 
   --enum-opt=<foo|bar|baz> (default: foo)


### PR DESCRIPTION
BisqHelpFormatterTest introduced in https://github.com/bisq-network/bisq/pull/1961 was failing on Windows.