### PR TITLE
Remove *nix scripts on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,8 @@ configure([project(':desktop'),
 
             if (osdetector.os != 'windows')
                 delete fileTree(dir: rootProject.projectDir, include: 'bisq-*.bat')
+            else
+                delete fileTree(dir: rootProject.projectDir, include: 'bisq-*', exclude: '*.bat')
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/bisq-network/bisq/pull/1959 which removed .bat files on a non-Windows OS to prevent a cluttered root directory, this change will delete *nix scripts on a Windows OS.