### PR TITLE
Fix broken startScripts in $destinationDir/bin dirs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ configure([project(':desktop'),
 
             // edit generated shell scripts such that they expect to be executed in the
             // project root dir as opposed to a 'bin' subdirectory
-            def windowsScriptFile = file("${rootProject.projectDir}/bisq-$applicationName.bat")
+            def windowsScriptFile = file("${rootProject.projectDir}/bisq-${applicationName}.bat")
             windowsScriptFile.text = windowsScriptFile.text.replace(
                 'set APP_HOME=%DIRNAME%..', 'set APP_HOME=%DIRNAME%')
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,16 @@ configure([project(':desktop'),
                 into "${rootProject.projectDir}/lib"
             }
 
+            // edit generated shell scripts such that they expect to be executed in the
+            // project root dir as opposed to a 'bin' subdirectory
+            def windowsScriptFile = file("${rootProject.projectDir}/bisq-$applicationName.bat")
+            windowsScriptFile.text = windowsScriptFile.text.replace(
+                'set APP_HOME=%DIRNAME%..', 'set APP_HOME=%DIRNAME%')
+
+            def unixScriptFile = file("${rootProject.projectDir}/bisq-$applicationName")
+            unixScriptFile.text = unixScriptFile.text.replace(
+                'cd "`dirname \\"$PRG\\"`/.." >/dev/null', 'cd "`dirname \\"$PRG\\"`" >/dev/null')
+
             if (osdetector.os != 'windows')
                 delete fileTree(dir: rootProject.projectDir, include: 'bisq-*.bat')
             else
@@ -114,18 +124,6 @@ configure([project(':desktop'),
     startScripts {
         // rename scripts from, e.g. `desktop` to `bisq-desktop`
         applicationName = "bisq-$applicationName"
-
-        // edit generated shell scripts such that they expect to be executed in the
-        // project root dir as opposed to a 'bin' subdirectory
-        doLast {
-            def windowsScriptFile = file getWindowsScript()
-            windowsScriptFile.text = windowsScriptFile.text.replace(
-                'set APP_HOME=%DIRNAME%..', 'set APP_HOME=%DIRNAME%')
-
-            def unixScriptFile = file getUnixScript()
-            unixScriptFile.text = unixScriptFile.text.replace(
-                'cd "`dirname \\"$PRG\\"`/.." >/dev/null', 'cd "`dirname \\"$PRG\\"`" >/dev/null')
-        }
     }
 }
 


### PR DESCRIPTION
A recent change in the build procedure produces broken startScripts in the respective `$destinationDir/bin`-directories.

### Issue
startScripts located in `$destinationDir/bin`-directories yield
```
Error: Could not find or load main class bisq.desktop.app.BisqAppMain
Caused by: java.lang.ClassNotFoundException: bisq.desktop.app.BisqAppMain
```
when executed.

### Cause
The startScripts get changed in order to be executed in the project root directory. However, they get changed before they are copied and thus, the original startScripts (still located in the `$destinationDir/bin`-directories) have a wrong path prefix for the classpath declaration (i.e. `.../bin/lib/...` instead of `.../bin/../lib/...`)

### Fix
First copy the startScripts to `rootProject.projectDir` and only then change them.

### Notes
- I believe that every startScript should work, regardless where it resides (even when its use is somewhat deprecated)
- I stumbled over the issue while fixing the [AUR bisq-git package](https://aur.archlinux.org/packages/bisq-git/) (doing my duty https://github.com/bisq-network/roles/issues/78)