### PR TITLE
Add install_java.sh

### DIFF
--- a/scripts/install_java.sh
+++ b/scripts/install_java.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
+
+if [ ! -d "$JAVA_HOME" ]; then
+    apt-get -y install curl
+
+    curl -L -O https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz
+    mkdir -p $JAVA_HOME
+    tar -zxf openjdk-10.0.2_linux-x64_bin.tar.gz -C $JAVA_HOME --strip 1
+    rm openjdk-10.0.2_linux-x64_bin.tar.gz
+
+    update-alternatives --install /usr/bin/java java $JAVA_HOME/bin/java 2000
+    update-alternatives --install /usr/bin/javac javac $JAVA_HOME/bin/javac 2000
+fi


### PR DESCRIPTION
Add a bash script for installing and configuring Java, based on [this file](https://github.com/bisq-network/bisq/blob/a762a6cc7c7eab6423b43a60f11e7ef698d7c236/doc/scripts/install_on_unix.sh), which was removed as part of restructuring done in https://github.com/bisq-network/bisq/pull/1924.

I have put it under a new scripts folder for lack of a better location.