### PR TITLE
List Horizen (ZEN)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Horizen.java
+++ b/assets/src/main/java/bisq/asset/coins/Horizen.java
@@ -24,14 +24,14 @@ import bisq.asset.Coin;
 import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Base58;
 
-public class ZenCash extends Coin {
+public class Horizen extends Coin {
 
-    public ZenCash() {
-        super("ZenCash", "ZEN", new ZenCashAddressValidator());
+    public Horizen() {
+        super("Horizen", "ZEN", new HorizenAddressValidator());
     }
 
 
-    public static class ZenCashAddressValidator implements AddressValidator {
+    public static class HorizenAddressValidator implements AddressValidator {
 
         @Override
         public AddressValidationResult validate(String address) {

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -26,6 +26,7 @@ bisq.asset.coins.Dragonglass
 bisq.asset.coins.Ether
 bisq.asset.coins.EtherClassic
 bisq.asset.coins.Gridcoin
+bisq.asset.coins.Horizen
 bisq.asset.coins.Kekcoin
 bisq.asset.coins.Litecoin$Mainnet
 bisq.asset.coins.Litecoin$Regtest
@@ -50,7 +51,6 @@ bisq.asset.coins.TurtleCoin
 bisq.asset.coins.Unobtanium
 bisq.asset.coins.Zcash
 bisq.asset.coins.Zcoin
-bisq.asset.coins.ZenCash
 bisq.asset.coins.Zero
 bisq.asset.coins.ZeroOneCoin
 bisq.asset.tokens.EtherStone

--- a/assets/src/test/java/bisq/asset/coins/HorizenTest.java
+++ b/assets/src/test/java/bisq/asset/coins/HorizenTest.java
@@ -21,10 +21,10 @@ import bisq.asset.AbstractAssetTest;
 
 import org.junit.Test;
 
-public class ZenCashTest extends AbstractAssetTest {
+public class HorizenTest extends AbstractAssetTest {
 
-    public ZenCashTest() {
-        super(new ZenCash());
+    public HorizenTest() {
+        super(new Horizen());
     }
 
     @Test


### PR DESCRIPTION
- Official project URL: https://horizen.global/

- Official block explorer URL: https://explorer.horizen.global/

Continuation of https://github.com/bisq-network/bisq/pull/1784

Resubmitting bisq-network/bisq-assets#114 from the old bisq-assets` repo, which had positive comments from @cbeams and @ManfredKarrer, but did not have a comment containing "ACK".

Tested with ./gradlew :assets:build