### PR TITLE
Update build.md (Clarify Windows gradlew command)

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -24,7 +24,7 @@ Bisq executables are now available in the root project directory. Run Bisq Deskt
 
     ./bisq-desktop
 
-If on Windows use the `bisq-desktop.bat` script instead.
+If on Windows run `gradlew.bat build` instead.
 
 
 ## See also


### PR DESCRIPTION
To an inexperienced user such as myself, it wasn't clear to me I needed to run "gradlew.bat build" and I was running simply "gradlew.bat".