### PR TITLE
Make role details popup readable

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RoleDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RoleDetailsWindow.java
@@ -69,7 +69,7 @@ class RoleDetailsWindow extends Overlay<RoleDetailsWindow> {
     @Override
     protected void createGridPane() {
         super.createGridPane();
-        gridPane.setPadding(new Insets(35, 40, 30, 40));
+        gridPane.setPadding(new Insets(70, 80, 60, 80));
         gridPane.getStyleClass().add("grid-pane");
     }
 
@@ -83,8 +83,8 @@ class RoleDetailsWindow extends Overlay<RoleDetailsWindow> {
         FormBuilder.addTopLabelTextField(gridPane, ++rowIndex, Res.get("dao.bond.details.unlockTime"),
                 Res.get("dao.bond.details.blocks", bondedRoleType.getUnlockTimeInBlocks()));
 
-        FormBuilder.addLabelHyperlinkWithIcon(gridPane, ++rowIndex, Res.get("dao.bond.details.link"),
-                bondedRoleType.getLink(), bondedRoleType.getLink());
+        FormBuilder.addTopLabelHyperlinkWithIcon(gridPane, ++rowIndex, Res.get("dao.bond.details.link"),
+                bondedRoleType.getLink(), bondedRoleType.getLink(), 0);
 
         FormBuilder.addTopLabelTextField(gridPane, ++rowIndex, Res.get("dao.bond.details.isSingleton"),
                 bsqFormatter.booleanToYesNo(bondedRoleType.isAllowMultipleHolders()));


### PR DESCRIPTION
The info popup had alignment issues. This way it's readable but perhaps not conforming to the remaining UI components, not sure since I haven't followed that development closely.