### PR TITLE
Fix log path

### DIFF
--- a/core/src/main/java/bisq/core/setup/CoreSetup.java
+++ b/core/src/main/java/bisq/core/setup/CoreSetup.java
@@ -17,7 +17,6 @@
 
 package bisq.core.setup;
 
-import bisq.core.app.AppOptionKeys;
 import bisq.core.app.BisqEnvironment;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
@@ -59,7 +58,7 @@ public class CoreSetup {
     }
 
     private static void setupLog(BisqEnvironment bisqEnvironment) {
-        String logPath = Paths.get(bisqEnvironment.getProperty(AppOptionKeys.APP_DATA_DIR_KEY), "bisq").toString();
+        String logPath = Paths.get(bisqEnvironment.getAppDataDir(), "bisq").toString();
         Log.setup(logPath);
         log.info("\n\n\nLog files under: " + logPath);
         Utilities.printSysInfo();


### PR DESCRIPTION
Resolving the property from the bisqEnvironment via getProperty returns
the default value instead of the program argument value. Not sure why,
seems to be related to recent changes in the property handling.

@freimair Could you have a look. Maybe you find out what is the reason why the getProperty call returns the incorrect value. You can reproduce it when starting a seed node. The log path is the the default Bisq directory. Feel free to revert my change if you found the cause... 