### PR TITLE
Issue 2021 - Asset validation override issues in many coin extensions

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/BitCloud.java
+++ b/assets/src/main/java/bisq/asset/coins/BitCloud.java
@@ -37,7 +37,7 @@ public class BitCloud extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[B][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[B][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/Credits.java
+++ b/assets/src/main/java/bisq/asset/coins/Credits.java
@@ -38,7 +38,7 @@ public class Credits extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[C][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[C][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/Cryptonodes.java
+++ b/assets/src/main/java/bisq/asset/coins/Cryptonodes.java
@@ -37,7 +37,7 @@ public class Cryptonodes extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[c][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[c][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/DRIP.java
+++ b/assets/src/main/java/bisq/asset/coins/DRIP.java
@@ -37,7 +37,7 @@ public class DRIP extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[D][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[D][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/FuturoCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/FuturoCoin.java
@@ -37,7 +37,7 @@ public class FuturoCoin extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[F][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[F][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/MegaCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/MegaCoin.java
@@ -37,7 +37,7 @@ public class MegaCoin extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[M][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[M][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/MonetaryUnit.java
+++ b/assets/src/main/java/bisq/asset/coins/MonetaryUnit.java
@@ -37,7 +37,7 @@ public class MonetaryUnit extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[7][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[7][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/Neos.java
+++ b/assets/src/main/java/bisq/asset/coins/Neos.java
@@ -37,7 +37,7 @@ public class Neos extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[N][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[N][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/NewPowerCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/NewPowerCoin.java
@@ -37,7 +37,7 @@ public class NewPowerCoin extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[N][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[N][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/PIVX.java
+++ b/assets/src/main/java/bisq/asset/coins/PIVX.java
@@ -37,7 +37,7 @@ public class PIVX extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[D][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[D][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/PZDC.java
+++ b/assets/src/main/java/bisq/asset/coins/PZDC.java
@@ -37,7 +37,7 @@ public class PZDC extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[P][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[P][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/QMCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/QMCoin.java
@@ -37,7 +37,7 @@ public class QMCoin extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[Q][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[Q][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/SUB1X.java
+++ b/assets/src/main/java/bisq/asset/coins/SUB1X.java
@@ -37,7 +37,7 @@ public class SUB1X extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[Z][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[Z][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/main/java/bisq/asset/coins/Wavi.java
+++ b/assets/src/main/java/bisq/asset/coins/Wavi.java
@@ -37,7 +37,7 @@ public class Wavi extends Coin {
 
         @Override
         public AddressValidationResult validate(String address) {
-            if (!address.matches("^[W][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+            if (!address.matches("^[W][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
                 return AddressValidationResult.invalidStructure();
 
             return super.validate(address);

--- a/assets/src/test/java/bisq/asset/coins/BitCloudTest.java
+++ b/assets/src/test/java/bisq/asset/coins/BitCloudTest.java
@@ -37,8 +37,9 @@ public class BitCloudTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#");
+        assertInvalidAddress("17dtuCkeYcQQiTdr9wAK7HZtmvvrM24jEH");
+        assertInvalidAddress("BGp8DmF5wwpaDUsK9Mi3SByTDuvgy6XJGSq");
+        assertInvalidAddress("BDL6jpyNge8VB8LL8dEDX1bxfZ3jHGYz$3");
+        assertInvalidAddress("BKuvEvMrXmPFPC3YGGHHnZo0VYxeddxAjC");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/CreditsTest.java
+++ b/assets/src/test/java/bisq/asset/coins/CreditsTest.java
@@ -40,6 +40,6 @@ public class CreditsTest extends AbstractAssetTest {
         assertInvalidAddress("1fXBhPhSxx1wqxGQCryfgn6iU1M1XFUuCo32");
         assertInvalidAddress("CMde7YERCFWkCL2W5i8uyJmnpCVj8Chh");
         assertInvalidAddress("CcbqU3MLZuGAED2CuhUkquyJxKaSJqv6V6#");
-        assertInvalidAddress("bKaig5pznaUgiLqe6WkoCNGagNMhNLtqhKkggg");
+        assertInvalidAddress("cKaig5pznaUgiLqe6WkoCNGagNMhNLtqhK");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/CryptonodesTest.java
+++ b/assets/src/test/java/bisq/asset/coins/CryptonodesTest.java
@@ -37,8 +37,9 @@ public class CryptonodesTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#");
+        assertInvalidAddress("cmqiMdMJuXf3meR3Qxy9hhHS85tuTRMRbub");
+        assertInvalidAddress("CjMRzBHViq7WGgJUuNdiuks39ZCMjyG7UT");
+        assertInvalidAddress("cYXaTfAEMrvr3cZEQ30UxKJuzbvBwgTR2e");
+        assertInvalidAddress("cX38diq2mcFpBMEWbTRvyrdbINBjyv2nq9");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/DRIPTest.java
+++ b/assets/src/test/java/bisq/asset/coins/DRIPTest.java
@@ -37,8 +37,9 @@ public class DRIPTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#");
+        assertInvalidAddress("dFJku78A14HYwPSzC5PtUmda7jMr5pbD2B");
+        assertInvalidAddress("DAeiBSH4nudXgoxS4kY6uhTPobc7ALrWDAe");
+        assertInvalidAddress("DRbnCYbuMXdKI4y8dya9EnocL47gFjErWe");
+        assertInvalidAddress("DTPAqTryNRCE2FgsxzohTtJXf0BCDnG6Rc");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/FuturoCoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/FuturoCoinTest.java
@@ -46,5 +46,6 @@ public class FuturoCoinTest extends AbstractAssetTest {
         assertInvalidAddress("FheRu8mY47PpUCx4kvjgsRQcLtoG9uDbT9");
         assertInvalidAddress("Fd7gZ7dNJ1toY6TeWy3rf2dUvyRudggTL");
         assertInvalidAddress("FbRXmJUDgf5URuVGyM223P8R2JArXSSm61");
+        assertInvalidAddress("fbRXmJUDgf5URuVGyM223P8R2JArXSSm6u");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/MegaCoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/MegaCoinTest.java
@@ -37,8 +37,9 @@ public class MegaCoinTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#");
+        assertInvalidAddress("mWXQfp3wKnir6krS4SQFAxzv1AExpfFMbq");
+        assertInvalidAddress("MEfn9iWMjowxQaNOZEbtT7A34pvnJGPZ44");
+        assertInvalidAddress("MRal1xTj5eAuxMR3xDPxLUG6RP3qR1ijuo");
+        assertInvalidAddress("M9pCgxBES9EgoNxoUnXxrnaMqYUwZVMttMt");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/NeosTest.java
+++ b/assets/src/test/java/bisq/asset/coins/NeosTest.java
@@ -40,6 +40,7 @@ public class NeosTest extends AbstractAssetTest {
         assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
         assertInvalidAddress("NScgetCW5bqDTVWFH3EYNMtTo5Rc#DxD6B");
         assertInvalidAddress("NeeAy35a0irpmTARHEXpP8uTmpPCcSD9Qn");
+        assertInvalidAddress("neeAy35aQirpmTARHEXpP8uTmpPCcSD9Qn");
         assertInvalidAddress("NScgetCWRcvDxD6B");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/NewPowerCoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/NewPowerCoinTest.java
@@ -37,8 +37,9 @@ public class NewPowerCoinTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
-        assertInvalidAddress("1111111111111111111111111111111111");
-        assertInvalidAddress("2222222222222222222222222222222222");
-        assertInvalidAddress("3333333333333333333333333333333333");
+        assertInvalidAddress("nXNc8LCAe2dHumQ9vTyogRXUzGw3PJHr55");
+        assertInvalidAddress("NhWDeD4UaNK20j8oSKr9u7EAUkCFZxEsDr");
+        assertInvalidAddress("NNTuHe4p5Xr8kyN2AJjJS9dcBoG1XQKkW6r");
+        assertInvalidAddress("NQebfMl6pijp2KvFHTKQktD4y2cSKknQEg");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/PIVXTest.java
+++ b/assets/src/test/java/bisq/asset/coins/PIVXTest.java
@@ -37,8 +37,11 @@ public class PIVXTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#");
+        assertInvalidAddress("dFJku78A14HYwPSzC5PtUmda7jMr5pbD2B");
+        assertInvalidAddress("DAeiBSH4nudXgoxS4kY6uhTPobc7AlrWDA");
+        assertInvalidAddress("DRbnCYbuMXdKU4y8dya9EnocL47gFjErWeg");
+        assertInvalidAddress("DTPAqTryNRCE2FgsxzohTtJXfCBODnG6Rc");
+        assertInvalidAddress("DTPAqTryNRCE2FgsxzohTtJXfCB0DnG6Rc");
+        assertInvalidAddress("DTPAqTryNRCE2FgsxzohTtJXfCBIDnG6Rc");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/PZDCTest.java
+++ b/assets/src/test/java/bisq/asset/coins/PZDCTest.java
@@ -42,6 +42,9 @@ public class PZDCTest extends AbstractAssetTest {
     public void testInvalidAddresses() {
         assertInvalidAddress("pGXsg0jSMzh1dSqggRvHjPvE3cnwvuXC7s");
         assertInvalidAddress("PKfRRcjwzKFq3dIqE9gq8Ztxn922W4GZhm");
+        assertInvalidAddress("PKfRRcjwzKFq3d0qE9gq8Ztxn922W4GZhm");
+        assertInvalidAddress("PKfRRcjwzKFq3dOqE9gq8Ztxn922W4GZhm");
+        assertInvalidAddress("PKfRRcjwzKFq3dlqE9gq8Ztxn922W4GZhm");
         assertInvalidAddress("PXP75NnwDryYswQb9RaPFBchqLRSvBmDP");
         assertInvalidAddress("PKr3vQ7S");
     }

--- a/assets/src/test/java/bisq/asset/coins/QMCoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/QMCoinTest.java
@@ -39,8 +39,11 @@ public class QMCoinTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO");
-        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#");
+        assertInvalidAddress("qSXwS2opau1PYsvj4PrirPkP6LQHeKbQDx");
+        assertInvalidAddress("QbvD8CPJwAmpQoE8CQhzcfWp1EAmT2E2989");
+        assertInvalidAddress("QUAzsb7nq07XVsRy9vjaE4kTUpgP1pFeoL");
+        assertInvalidAddress("QQDvVM2s3WYa8EZQS1s2OsRkR4zmrjy94d");
+        assertInvalidAddress("QgdkWtsy1inr9j8RUrqDIVnrJmhE28WnLX");
+        assertInvalidAddress("Qii56aanBMiEPpjHoaE4lgEW4jPuhGjuj5");
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/SUB1XTest.java
+++ b/assets/src/test/java/bisq/asset/coins/SUB1XTest.java
@@ -37,6 +37,7 @@ public class SUB1XTest extends AbstractAssetTest {
 
     @Test
     public void testInvalidAddresses() {
+        assertInvalidAddress("zKi6EksPCZoMi6EGXS9vWVed4NeSov2ZS4");
         assertInvalidAddress("ZDxdoVuyosZ6vY3LZAP1Z4H4eXMq2ZpAC7");
         assertInvalidAddress("ZKi6EksPCZoMi6EGXS9vWVedqwfov2ZS4");
         assertInvalidAddress("ZT29B3yDJq1jzkqwrwBs4LnraM3E854MAPRm");


### PR DESCRIPTION
  - Fix length issue in regular expression of validate() override in main asset coins.
    PIVX most likely started the 1+{25,34} that was then proliferated through the copies.
    While it likely should be 1+33, I could only confirm that 35 is too long, so the
    code is changed to be 1+{24,33} in order to reduce it by the presumed forgotten first
    character.
  - Fixup testInvalidAddresses() to better test regex rules in test asset coins.  The PIVX
    base code was testing against 3 addresses, that all had a different first character,
    therefore none of the rest of the regular expression was being tested.  Changed those
    addresses (and others for other susceptable coins) to accurately test first character
    match, length, and invalid characters in the 24 to 33 series.