### PR TITLE
Handle cli-output_windows.txt with CRLF line endings

### DIFF
--- a/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
+++ b/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
@@ -125,7 +125,10 @@ public class BisqHelpFormatterTest {
         ByteArrayOutputStream actual = new ByteArrayOutputStream();
         String expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output.txt").toURI())));
         if (System.getProperty("os.name").startsWith("Windows")) {
-            expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output_windows.txt").toURI())));
+            // Load the expected content from a different file for Windows due to different path separator
+            // And normalize line endings to LF in case the file has CRLF line endings
+            expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output_windows.txt").toURI())))
+                    .replaceAll("\\r\\n?", "\n");
         }
 
         parser.printHelpOn(new PrintStream(actual));


### PR DESCRIPTION
On Windows, it is likely that cli-output_windows.txt will have CRLF line
endings since core.autocrlf is normally true which converts LF endings
to CRLF on checkout. This causes BisqHelpFormatterTest to fail since
the actual content it is compared against uses LF endings.

As a result, when loading the cli-output_windows.txt file normalize
line endings to LF.