### PR TITLE
Fix wrong positioning of requirements field in CashDeposit

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/CashDepositForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/CashDepositForm.java
@@ -123,7 +123,7 @@ public class CashDepositForm extends GeneralBankForm {
             addCompactTopLabelTextFieldWithCopyIcon(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow, getIndexOfColumn(colIndex++), bankNameLabel, data.getBankName());
 
         if (!bankNameBankIdCombined && !bankNameBranchIdCombined && !branchIdAccountNrCombined && bankIdBranchIdCombined) {
-            addCompactTopLabelTextFieldWithCopyIcon(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow,
+            addCompactTopLabelTextFieldWithCopyIcon(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow, getIndexOfColumn(colIndex++),
                     bankIdLabel + " / " +
                             branchIdLabel,
                     data.getBankId() + " / " + data.getBranchId());
@@ -144,7 +144,7 @@ public class CashDepositForm extends GeneralBankForm {
             addCompactTopLabelTextFieldWithCopyIcon(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow, getIndexOfColumn(colIndex++), branchIdLabel, data.getBranchId());
 
         if (!branchIdAccountNrCombined && accountNrAccountTypeCombined) {
-            addCompactTopLabelTextFieldWithCopyIcon(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow,
+            addCompactTopLabelTextFieldWithCopyIcon(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow, getIndexOfColumn(colIndex++),
                     accountNrLabel + " / " + accountTypeLabel,
                     data.getAccountNr() + " / " + data.getAccountType());
         }
@@ -162,7 +162,7 @@ public class CashDepositForm extends GeneralBankForm {
                             " / " + data.getAccountNr());
 
         if (showRequirements) {
-            TextArea textArea = addTopLabelTextArea(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow, getIndexOfColumn(colIndex++),
+            TextArea textArea = addCompactTopLabelTextArea(gridPane, getIndexOfColumn(colIndex) == 0 ? ++gridRow : gridRow, getIndexOfColumn(colIndex++),
                     Res.get("payment.extras"), "").second;
             textArea.setMinHeight(45);
             textArea.setMaxHeight(45);

--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -410,6 +410,10 @@ public class FormBuilder {
         return addTopLabelTextArea(gridPane, rowIndex, title, prompt, -Layout.FLOATING_LABEL_DISTANCE);
     }
 
+    public static Tuple2<Label, TextArea> addCompactTopLabelTextArea(GridPane gridPane, int rowIndex, int colIndex, String title, String prompt) {
+        return addTopLabelTextArea(gridPane, rowIndex, colIndex, title, prompt, -Layout.FLOATING_LABEL_DISTANCE);
+    }
+
     public static Tuple2<Label, TextArea> addTopLabelTextArea(GridPane gridPane, int rowIndex, String title, String prompt) {
         return addTopLabelTextArea(gridPane, rowIndex, title, prompt, 0);
     }
@@ -1173,6 +1177,7 @@ public class FormBuilder {
         textFieldWithCopyIcon.setText(value);
 
         final Tuple2<Label, VBox> topLabelWithVBox = addTopLabelWithVBox(gridPane, rowIndex, title, textFieldWithCopyIcon, top);
+        topLabelWithVBox.second.setAlignment(Pos.TOP_LEFT);
         GridPane.setColumnIndex(topLabelWithVBox.second, colIndex);
 
         return new Tuple2<>(topLabelWithVBox.first, textFieldWithCopyIcon);


### PR DESCRIPTION
Although there was no missing display of the requirements field, I found a positioning bug. Fixes #2038.