### PR TITLE
Left align columns, except last one

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -193,6 +193,9 @@ shared.all=All
 shared.edit=Edit
 shared.advancedOptions=Advanced options
 shared.interval=Interval
+shared.actions=Actions
+shared.buyerUpperCase=Buyer
+shared.sellerUpperCase=Seller
 
 ####################################################################
 # UI views

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -402,7 +402,7 @@ bg color of non edit textFields: fafafa
     -fx-text-fill: -bs-dim-grey;
 }
 
-.jfx-text-field:readonly {
+.jfx-text-field:readonly, .hyperlink-with-icon {
     -fx-background-color: -bs-rd-grey-medium-light;
     -fx-padding: 0.333333em 0.333333em 0.333333em 0.333333em;
 }
@@ -424,14 +424,6 @@ bg color of non edit textFields: fafafa
     -fx-background-color: transparent;
     -fx-border-width: 0;
 }
-
-/* hyperlink-with-icon has same style as jfx-text-field:readonly */
-
-.hyperlink-with-icon {
-    -fx-background-color: -bs-rd-grey-medium-light;
-    -fx-padding: 0.333333em 0.333333em 0.333333em 0.333333em;
-}
-
 
 #info-field {
     -fx-prompt-text-fill: -bs-rd-black;
@@ -968,12 +960,48 @@ textfield */
  ******************************************************************************/
 
 .table-view .table-cell {
-    -fx-alignment: center;
-    -fx-padding: 3 0 2 0;
+    -fx-alignment: center-left;
+    -fx-padding: 2 0 2 0;
+    /*-fx-padding: 3 0 2 0;*/
 }
 
-#addressColumn {
-    -fx-alignment: center-left;
+.table-view .table-cell.last-column {
+    -fx-alignment: center-right;
+    -fx-padding: 2 10 2 0;
+}
+
+.table-view .table-cell.last-column.avatar-column {
+    -fx-alignment: center;
+    -fx-padding: 2 0 2 0;
+}
+
+.table-view .column-header.last-column {
+    -fx-padding: 0 10 0 0;
+}
+
+.table-view .column-header.last-column .label {
+    -fx-alignment: center-right;
+}
+
+.table-view .column-header.last-column.avatar-column {
+    -fx-padding: 0;
+}
+
+.table-view .column-header.last-column.avatar-column .label {
+    -fx-alignment: center;
+}
+
+.table-view .table-cell.first-column {
+    -fx-padding: 2 0 2 10;
+}
+
+.table-view .column-header.first-column {
+    -fx-padding: 0 0 0 10;
+}
+
+.number-column.table-cell {
+    -fx-font-size: 1em;
+    -fx-padding: 0 0 0 0;
 }
 
 .table-view .filler {
@@ -985,17 +1013,19 @@ textfield */
 }
 
 .table-view .column-header .label {
-    -fx-alignment: center;
+    -fx-alignment: center-left;
     -fx-font-weight: normal;
     -fx-font-size: 0.923em;
+    -fx-padding: 0;
 }
 
 .table-view .column-header {
     -fx-background-color: -bs-rd-grey-very-light;
+    -fx-padding: 0;
 }
 
 .table-view .focus {
-    -fx-alignment: center;
+    -fx-alignment: center-left;
 }
 
 .table-view .text {
@@ -1095,17 +1125,6 @@ textfield */
 
 .table-view.large-rows .table-row-cell {
     -fx-cell-size: 47px;
-}
-
-.number-column.table-cell {
-
-    -fx-font-family: "IBM Plex Mono";
-    -fx-font-size: 1em;
-    -fx-padding: 0 0 0 0;
-}
-
-.address-column {
-    -fx-alignment: center !important;
 }
 
 /*******************************************************************************
@@ -1680,7 +1699,7 @@ textfield */
 
 #charts .axis-label {
     -fx-font-size: 0.769em;
-    -fx-alignment: left;
+    -fx-alignment: center-left;
 }
 /********************************************************************************************************************
  *                                                                                                                  *

--- a/desktop/src/main/java/bisq/desktop/components/AddressWithIconAndDirection.java
+++ b/desktop/src/main/java/bisq/desktop/components/AddressWithIconAndDirection.java
@@ -23,11 +23,11 @@ import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 
 import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -35,7 +35,7 @@ import javafx.event.EventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AddressWithIconAndDirection extends AnchorPane {
+public class AddressWithIconAndDirection extends HBox {
     private static final Logger log = LoggerFactory.getLogger(AddressWithIconAndDirection.class);
     private final Hyperlink hyperlink;
 
@@ -48,28 +48,21 @@ public class AddressWithIconAndDirection extends AnchorPane {
             directionIcon.setRotate(180);
         directionIcon.setMouseTransparent(true);
 
-        HBox hBox = new HBox();
-        hBox.setSpacing(-1);
+        setAlignment(Pos.CENTER_LEFT);
         Label label = new AutoTooltipLabel(text);
         label.setMouseTransparent(true);
-        HBox.setMargin(label, new Insets(3, 0, 0, 0));
+        HBox.setMargin(directionIcon, new Insets(0, 3, 0, 0));
         HBox.setHgrow(label, Priority.ALWAYS);
 
         hyperlink = new HyperlinkWithIcon(address, awesomeIcon);
-        HBox.setMargin(hyperlink, new Insets(0, 0, 0, 0));
+        HBox.setMargin(hyperlink, new Insets(0));
         HBox.setHgrow(hyperlink, Priority.SOMETIMES);
         // You need to set max width to Double.MAX_VALUE to make HBox.setHgrow working like expected!
         // also pref width needs to be not default (-1)
         hyperlink.setMaxWidth(Double.MAX_VALUE);
         hyperlink.setPrefWidth(0);
 
-        hBox.getChildren().addAll(label, hyperlink);
-
-        AnchorPane.setLeftAnchor(directionIcon, 3.0);
-        AnchorPane.setTopAnchor(directionIcon, 4.0);
-        AnchorPane.setLeftAnchor(hBox, 22.0);
-        AnchorPane.setRightAnchor(hBox, 15.0);
-        getChildren().addAll(directionIcon, hBox);
+        getChildren().addAll(directionIcon, label, hyperlink);
     }
 
     public void setOnAction(EventHandler<ActionEvent> handler) {

--- a/desktop/src/main/java/bisq/desktop/components/AutoTooltipTableColumn.java
+++ b/desktop/src/main/java/bisq/desktop/components/AutoTooltipTableColumn.java
@@ -83,7 +83,7 @@ public class AutoTooltipTableColumn<S, T> extends TableColumn<S, T> {
         });
 
         final HBox hBox = new HBox(label, helpIcon);
-        hBox.setStyle("-fx-alignment: center");
+        hBox.setStyle("-fx-alignment: center-left");
         hBox.setSpacing(4);
         setGraphic(hBox);
     }

--- a/desktop/src/main/java/bisq/desktop/components/ColoredDecimalPlacesWithZerosText.java
+++ b/desktop/src/main/java/bisq/desktop/components/ColoredDecimalPlacesWithZerosText.java
@@ -47,7 +47,7 @@ public class ColoredDecimalPlacesWithZerosText extends HBox {
             Tuple2<Label, Label> numbers = getSplittedNumberNodes(number, numberOfZerosToColorize);
             getChildren().addAll(numbers.first, numbers.second);
         }
-        setAlignment(Pos.CENTER);
+        setAlignment(Pos.CENTER_LEFT);
     }
 
     private Tuple2<Label, Label> getSplittedNumberNodes(String number, int numberOfZeros) {

--- a/desktop/src/main/java/bisq/desktop/components/HyperlinkWithIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/HyperlinkWithIcon.java
@@ -45,6 +45,7 @@ public class HyperlinkWithIcon extends Hyperlink {
         icon.setMinWidth(20);
         icon.setOpacity(0.7);
         icon.getStyleClass().addAll("hyperlink", "no-underline");
+        setPadding(new Insets(0));
         icon.setPadding(new Insets(0));
 
         setGraphic(icon);

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
@@ -142,6 +142,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
 
         column = new AutoTooltipTableColumn<>(Res.get("shared.amountWithCur", "BSQ"));
         column.setMinWidth(80);
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override
@@ -268,6 +269,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
         column = new AutoTooltipTableColumn<>(Res.get("dao.bond.table.column.lockupTxId"));
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(60);
+        column.getStyleClass().add("last-column");
         column.setCellFactory(
                 new Callback<>() {
                     @Override

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
@@ -289,6 +289,7 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
         column = new AutoTooltipTableColumn<>(Res.get("shared.amountWithCur", "BSQ"));
         column.setMinWidth(120);
         column.setMaxWidth(column.getMinWidth());
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override
@@ -452,6 +453,7 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
         column = new TableColumn<>();
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(60);
+        column.getStyleClass().add("last-column");
         column.setCellFactory(
                 new Callback<>() {
                     @Override

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
@@ -135,6 +135,7 @@ public class RolesView extends ActivatableView<GridPane, Void> {
         column = new AutoTooltipTableColumn<>(Res.get("dao.bond.table.column.name"));
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(80);
+        column.getStyleClass().add("first-column");
         column.setCellFactory(
                 new Callback<>() {
                     @Override
@@ -285,6 +286,7 @@ public class RolesView extends ActivatableView<GridPane, Void> {
         column = new TableColumn<>();
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(80);
+        column.getStyleClass().add("last-column");
         column.setCellFactory(
                 new Callback<>() {
                     @Override

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
@@ -296,6 +296,7 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
 
         column = new AutoTooltipTableColumn<>(Res.get("dao.burnBsq.assets.nameAndCode"));
         column.setMinWidth(120);
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override
@@ -406,6 +407,7 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
 
         column = new AutoTooltipTableColumn<>(Res.get("dao.burnBsq.assets.totalFee"));
         column.setMinWidth(120);
+        column.getStyleClass().add("last-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
@@ -297,6 +297,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
         column = new AutoTooltipTableColumn<>(Res.get("dao.proofOfBurn.amount"));
         column.setMinWidth(80);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
+        column.getStyleClass().add("first-column");
         column.setCellFactory(new Callback<>() {
             @Override
             public TableCell<MyProofOfBurnListItem, MyProofOfBurnListItem> call(TableColumn<MyProofOfBurnListItem,
@@ -440,6 +441,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
         column = new AutoTooltipTableColumn<>("");
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(60);
+        column.getStyleClass().add("last-column");
         column.setCellFactory(
                 new Callback<>() {
 
@@ -478,6 +480,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
 
         column = new AutoTooltipTableColumn<>(Res.get("dao.proofOfBurn.amount"));
         column.setMinWidth(80);
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override
@@ -603,6 +606,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
         column = new AutoTooltipTableColumn<>("");
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(80);
+        column.getStyleClass().add("last-column");
         column.setCellFactory(
                 new Callback<>() {
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -712,14 +712,14 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         column = new AutoTooltipTableColumn<>(Res.get("shared.dateTime"));
         column.setMinWidth(190);
         column.setMaxWidth(column.getMinWidth());
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<ProposalsListItem, ProposalsListItem>, TableCell<ProposalsListItem,
-                        ProposalsListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<ProposalsListItem, ProposalsListItem> call(
                             TableColumn<ProposalsListItem, ProposalsListItem> column) {
-                        return new TableCell<ProposalsListItem, ProposalsListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final ProposalsListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -741,12 +741,11 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         column.setMinWidth(60);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<ProposalsListItem, ProposalsListItem>, TableCell<ProposalsListItem,
-                        ProposalsListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<ProposalsListItem, ProposalsListItem> call(
                             TableColumn<ProposalsListItem, ProposalsListItem> column) {
-                        return new TableCell<ProposalsListItem, ProposalsListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final ProposalsListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -766,13 +765,12 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         column.setMinWidth(80);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<ProposalsListItem, ProposalsListItem>, TableCell<ProposalsListItem,
-                        ProposalsListItem>>() {
+                new Callback<>() {
 
                     @Override
                     public TableCell<ProposalsListItem, ProposalsListItem> call(TableColumn<ProposalsListItem,
                             ProposalsListItem> column) {
-                        return new TableCell<ProposalsListItem, ProposalsListItem>() {
+                        return new TableCell<>() {
                             private HyperlinkWithIcon field;
 
                             @Override
@@ -801,12 +799,11 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         column.setMinWidth(60);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<ProposalsListItem, ProposalsListItem>, TableCell<ProposalsListItem,
-                        ProposalsListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<ProposalsListItem, ProposalsListItem> call(
                             TableColumn<ProposalsListItem, ProposalsListItem> column) {
-                        return new TableCell<ProposalsListItem, ProposalsListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final ProposalsListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -825,6 +822,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         column = new TableColumn<>();
         column.setMinWidth(50);
         column.setMaxWidth(column.getMinWidth());
+        column.getStyleClass().add("last-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -427,6 +427,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         TableColumn<CycleListItem, CycleListItem> column;
         column = new AutoTooltipTableColumn<>(Res.get("dao.results.cycles.table.header.cycle"));
         column.setMinWidth(160);
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -521,6 +522,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
 
         column = new AutoTooltipTableColumn<>(Res.get("dao.results.cycles.table.header.issuance"));
         column.setMinWidth(70);
+        column.getStyleClass().add("last-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -554,6 +556,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         column = new AutoTooltipTableColumn<>(Res.get("shared.dateTime"));
         column.setMinWidth(190);
         column.setMaxWidth(column.getMinWidth());
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -724,6 +727,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         column = new AutoTooltipTableColumn<>(Res.get("dao.results.proposals.table.header.result"));
         column.setMinWidth(90);
         column.setMaxWidth(column.getMinWidth());
+        column.getStyleClass().add("last-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override
@@ -765,6 +769,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         column.setSortable(false);
         column.setMinWidth(50);
         column.setMaxWidth(column.getMinWidth());
+        column.getStyleClass().add("first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -841,6 +846,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         column = new AutoTooltipTableColumn<>(Res.get("dao.results.votes.table.header.stake"));
         column.setSortable(false);
         column.setMinWidth(100);
+        column.getStyleClass().add("last-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -282,6 +282,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(180);
         column.setMaxWidth(column.getMinWidth() + 20);
+        column.getStyleClass().add("first-column");
 
         column.setCellFactory(
                 new Callback<TableColumn<BsqTxListItem, BsqTxListItem>, TableCell<BsqTxListItem,
@@ -492,6 +493,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
         column.setCellValueFactory(item -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setMinWidth(70);
         column.setMaxWidth(column.getMinWidth());
+        column.getStyleClass().add("last-column");
         column.setCellFactory(
                 new Callback<TableColumn<BsqTxListItem, BsqTxListItem>, TableCell<BsqTxListItem,
                         BsqTxListItem>>() {

--- a/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
@@ -1013,6 +1013,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
         column.setMinWidth(80);
         column.setMaxWidth(80);
         column.setSortable(false);
+        column.getStyleClass().add("first-column");
 
         column.setCellValueFactory((addressListItem) ->
                 new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
@@ -1298,6 +1299,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                 setMinWidth(50);
             }
         };
+        column.getStyleClass().add("last-column");
         column.setCellValueFactory((dispute) -> new ReadOnlyObjectWrapper<>(dispute.getValue()));
         column.setCellFactory(
                 new Callback<>() {

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
@@ -319,6 +319,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void setUsageColumnCellFactory() {
+        usageColumn.getStyleClass().add("last-column");
         usageColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         usageColumn.setCellFactory(new Callback<>() {
 
@@ -342,6 +343,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
     }
 
     private void setSelectColumnCellFactory() {
+        selectColumn.getStyleClass().add("first-column");
         selectColumn.setCellValueFactory((addressListItem) ->
                 new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         selectColumn.setCellFactory(
@@ -377,7 +379,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
 
     private void setAddressColumnCellFactory() {
         addressColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        addressColumn.getStyleClass().add("address-column");
+
         addressColumn.setCellFactory(
                 new Callback<>() {
 

--- a/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
@@ -61,6 +61,8 @@ import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
 
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -116,9 +118,9 @@ public class LockedView extends ActivatableView<VBox, Void> {
         setAddressColumnCellFactory();
         setBalanceColumnCellFactory();
 
-        addressColumn.setComparator((o1, o2) -> o1.getAddressString().compareTo(o2.getAddressString()));
-        detailsColumn.setComparator((o1, o2) -> o1.getTrade().getId().compareTo(o2.getTrade().getId()));
-        balanceColumn.setComparator((o1, o2) -> o1.getBalance().compareTo(o2.getBalance()));
+        addressColumn.setComparator(Comparator.comparing(LockedListItem::getAddressString));
+        detailsColumn.setComparator(Comparator.comparing(o -> o.getTrade().getId()));
+        balanceColumn.setComparator(Comparator.comparing(LockedListItem::getBalance));
         dateColumn.setComparator((o1, o2) -> {
             if (getTradable(o1).isPresent() && getTradable(o2).isPresent())
                 return getTradable(o2).get().getDate().compareTo(getTradable(o1).get().getDate());
@@ -168,16 +170,12 @@ public class LockedView extends ActivatableView<VBox, Void> {
         observableList.setAll(tradeManager.getLockedTradesStream()
                 .map(trade -> {
                     final Optional<AddressEntry> addressEntryOptional = btcWalletService.getAddressEntry(trade.getId(), AddressEntry.Context.MULTI_SIG);
-                    if (addressEntryOptional.isPresent()) {
-                        return new LockedListItem(trade,
-                                addressEntryOptional.get(),
-                                btcWalletService,
-                                formatter);
-                    } else {
-                        return null;
-                    }
+                    return addressEntryOptional.map(addressEntry -> new LockedListItem(trade,
+                            addressEntry,
+                            btcWalletService,
+                            formatter)).orElse(null);
                 })
-                .filter(e -> e != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
     }
 
@@ -193,7 +191,7 @@ public class LockedView extends ActivatableView<VBox, Void> {
         } else if (openOfferManager.getOpenOfferById(offerId).isPresent()) {
             return Optional.of(openOfferManager.getOpenOfferById(offerId).get());
         } else {
-            return Optional.<Tradable>empty();
+            return Optional.empty();
         }
     }
 
@@ -215,14 +213,14 @@ public class LockedView extends ActivatableView<VBox, Void> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void setDateColumnCellFactory() {
+        dateColumn.getStyleClass().add("first-column");
         dateColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        dateColumn.setCellFactory(new Callback<TableColumn<LockedListItem, LockedListItem>,
-                TableCell<LockedListItem, LockedListItem>>() {
+        dateColumn.setCellFactory(new Callback<>() {
 
             @Override
             public TableCell<LockedListItem, LockedListItem> call(TableColumn<LockedListItem,
                     LockedListItem> column) {
-                return new TableCell<LockedListItem, LockedListItem>() {
+                return new TableCell<>() {
 
                     @Override
                     public void updateItem(final LockedListItem item, boolean empty) {
@@ -243,13 +241,12 @@ public class LockedView extends ActivatableView<VBox, Void> {
 
     private void setDetailsColumnCellFactory() {
         detailsColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        detailsColumn.setCellFactory(new Callback<TableColumn<LockedListItem, LockedListItem>,
-                TableCell<LockedListItem, LockedListItem>>() {
+        detailsColumn.setCellFactory(new Callback<>() {
 
             @Override
             public TableCell<LockedListItem, LockedListItem> call(TableColumn<LockedListItem,
                     LockedListItem> column) {
-                return new TableCell<LockedListItem, LockedListItem>() {
+                return new TableCell<>() {
 
                     private HyperlinkWithIcon field;
 
@@ -285,15 +282,14 @@ public class LockedView extends ActivatableView<VBox, Void> {
 
     private void setAddressColumnCellFactory() {
         addressColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        addressColumn.getStyleClass().add("address-column");
+
         addressColumn.setCellFactory(
-                new Callback<TableColumn<LockedListItem, LockedListItem>, TableCell<LockedListItem,
-                        LockedListItem>>() {
+                new Callback<>() {
 
                     @Override
                     public TableCell<LockedListItem, LockedListItem> call(TableColumn<LockedListItem,
                             LockedListItem> column) {
-                        return new TableCell<LockedListItem, LockedListItem>() {
+                        return new TableCell<>() {
                             private HyperlinkWithIcon hyperlinkWithIcon;
 
                             @Override
@@ -318,15 +314,15 @@ public class LockedView extends ActivatableView<VBox, Void> {
     }
 
     private void setBalanceColumnCellFactory() {
+        balanceColumn.getStyleClass().add("last-column");
         balanceColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         balanceColumn.setCellFactory(
-                new Callback<TableColumn<LockedListItem, LockedListItem>, TableCell<LockedListItem,
-                        LockedListItem>>() {
+                new Callback<>() {
 
                     @Override
                     public TableCell<LockedListItem, LockedListItem> call(TableColumn<LockedListItem,
                             LockedListItem> column) {
-                        return new TableCell<LockedListItem, LockedListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final LockedListItem item, boolean empty) {
                                 super.updateItem(item, empty);

--- a/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
@@ -61,6 +61,8 @@ import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
 
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -116,9 +118,9 @@ public class ReservedView extends ActivatableView<VBox, Void> {
         setAddressColumnCellFactory();
         setBalanceColumnCellFactory();
 
-        addressColumn.setComparator((o1, o2) -> o1.getAddressString().compareTo(o2.getAddressString()));
-        detailsColumn.setComparator((o1, o2) -> o1.getOpenOffer().getId().compareTo(o2.getOpenOffer().getId()));
-        balanceColumn.setComparator((o1, o2) -> o1.getBalance().compareTo(o2.getBalance()));
+        addressColumn.setComparator(Comparator.comparing(ReservedListItem::getAddressString));
+        detailsColumn.setComparator(Comparator.comparing(o -> o.getOpenOffer().getId()));
+        balanceColumn.setComparator(Comparator.comparing(ReservedListItem::getBalance));
         dateColumn.setComparator((o1, o2) -> {
             if (getTradable(o1).isPresent() && getTradable(o2).isPresent())
                 return getTradable(o2).get().getDate().compareTo(getTradable(o1).get().getDate());
@@ -168,16 +170,12 @@ public class ReservedView extends ActivatableView<VBox, Void> {
         observableList.setAll(openOfferManager.getObservableList().stream()
                 .map(openOffer -> {
                     Optional<AddressEntry> addressEntryOptional = btcWalletService.getAddressEntry(openOffer.getId(), AddressEntry.Context.RESERVED_FOR_TRADE);
-                    if (addressEntryOptional.isPresent()) {
-                        return new ReservedListItem(openOffer,
-                                addressEntryOptional.get(),
-                                btcWalletService,
-                                formatter);
-                    } else {
-                        return null;
-                    }
+                    return addressEntryOptional.map(addressEntry -> new ReservedListItem(openOffer,
+                            addressEntry,
+                            btcWalletService,
+                            formatter)).orElse(null);
                 })
-                .filter(e -> e != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
     }
 
@@ -215,14 +213,14 @@ public class ReservedView extends ActivatableView<VBox, Void> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void setDateColumnCellFactory() {
+        dateColumn.getStyleClass().add("first-column");
         dateColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        dateColumn.setCellFactory(new Callback<TableColumn<ReservedListItem, ReservedListItem>,
-                TableCell<ReservedListItem, ReservedListItem>>() {
+        dateColumn.setCellFactory(new Callback<>() {
 
             @Override
             public TableCell<ReservedListItem, ReservedListItem> call(TableColumn<ReservedListItem,
                     ReservedListItem> column) {
-                return new TableCell<ReservedListItem, ReservedListItem>() {
+                return new TableCell<>() {
 
                     @Override
                     public void updateItem(final ReservedListItem item, boolean empty) {
@@ -243,13 +241,12 @@ public class ReservedView extends ActivatableView<VBox, Void> {
 
     private void setDetailsColumnCellFactory() {
         detailsColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        detailsColumn.setCellFactory(new Callback<TableColumn<ReservedListItem, ReservedListItem>,
-                TableCell<ReservedListItem, ReservedListItem>>() {
+        detailsColumn.setCellFactory(new Callback<>() {
 
             @Override
             public TableCell<ReservedListItem, ReservedListItem> call(TableColumn<ReservedListItem,
                     ReservedListItem> column) {
-                return new TableCell<ReservedListItem, ReservedListItem>() {
+                return new TableCell<>() {
 
                     private HyperlinkWithIcon field;
 
@@ -283,16 +280,16 @@ public class ReservedView extends ActivatableView<VBox, Void> {
     }
 
     private void setAddressColumnCellFactory() {
+        addressColumn.getStyleClass().add("last-column");
         addressColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        addressColumn.getStyleClass().add("address-column");
+
         addressColumn.setCellFactory(
-                new Callback<TableColumn<ReservedListItem, ReservedListItem>, TableCell<ReservedListItem,
-                        ReservedListItem>>() {
+                new Callback<>() {
 
                     @Override
                     public TableCell<ReservedListItem, ReservedListItem> call(TableColumn<ReservedListItem,
                             ReservedListItem> column) {
-                        return new TableCell<ReservedListItem, ReservedListItem>() {
+                        return new TableCell<>() {
                             private HyperlinkWithIcon hyperlinkWithIcon;
 
                             @Override
@@ -317,15 +314,15 @@ public class ReservedView extends ActivatableView<VBox, Void> {
     }
 
     private void setBalanceColumnCellFactory() {
+        balanceColumn.getStyleClass().add("last-column");
         balanceColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         balanceColumn.setCellFactory(
-                new Callback<TableColumn<ReservedListItem, ReservedListItem>, TableCell<ReservedListItem,
-                        ReservedListItem>>() {
+                new Callback<>() {
 
                     @Override
                     public TableCell<ReservedListItem, ReservedListItem> call(TableColumn<ReservedListItem,
                             ReservedListItem> column) {
-                        return new TableCell<ReservedListItem, ReservedListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final ReservedListItem item, boolean empty) {
                                 super.updateItem(item, empty);

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -216,9 +216,14 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         };
 
         keyEventEventHandler = event -> {
-            if (Utilities.isAltOrCtrlPressed(KeyCode.R, event))
+            if (Utilities.isAltOrCtrlPressed(KeyCode.R, event)) {
+                if (revertTxColumn.isVisible()) {
+                    confidenceColumn.getStyleClass().remove("last-column");
+                } else {
+                    confidenceColumn.getStyleClass().add("last-column");
+                }
                 revertTxColumn.setVisible(!revertTxColumn.isVisible());
-            else if (Utilities.isAltOrCtrlPressed(KeyCode.A, event))
+            } else if (Utilities.isAltOrCtrlPressed(KeyCode.A, event))
                 showStatisticsPopup();
         };
 
@@ -298,6 +303,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void setDateColumnCellFactory() {
+        dateColumn.getStyleClass().add("first-column");
         dateColumn.setCellValueFactory((addressListItem) ->
                 new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         dateColumn.setMaxWidth(200);
@@ -363,7 +369,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
 
     private void setAddressColumnCellFactory() {
         addressColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        addressColumn.getStyleClass().add("address-column");
+
         addressColumn.setCellFactory(
                 new Callback<>() {
 
@@ -456,6 +462,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     }
 
     private void setConfidenceColumnCellFactory() {
+        confidenceColumn.getStyleClass().add("last-column");
         confidenceColumn.setCellValueFactory((addressListItem) ->
                 new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         confidenceColumn.setCellFactory(
@@ -482,6 +489,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     }
 
     private void setRevertTxColumnCellFactory() {
+        revertTxColumn.getStyleClass().add("last-column");
         revertTxColumn.setCellValueFactory((addressListItem) ->
                 new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         revertTxColumn.setCellFactory(

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -536,7 +536,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
 
     private void setAddressColumnCellFactory() {
         addressColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
-        addressColumn.getStyleClass().add("address-column");
+
         addressColumn.setCellFactory(
                 new Callback<>() {
 
@@ -569,6 +569,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
     }
 
     private void setBalanceColumnCellFactory() {
+        balanceColumn.getStyleClass().add("last-column");
         balanceColumn.setCellValueFactory((addressListItem) -> new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         balanceColumn.setCellFactory(
                 new Callback<>() {
@@ -588,6 +589,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
     }
 
     private void setSelectColumnCellFactory() {
+        selectColumn.getStyleClass().add("first-column");
         selectColumn.setCellValueFactory((addressListItem) ->
                 new ReadOnlyObjectWrapper<>(addressListItem.getValue()));
         selectColumn.setCellFactory(

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -434,7 +434,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         volumeColumn.setMinWidth(115);
         volumeColumn.setSortable(false);
         volumeColumn.textProperty().bind(volumeColumnLabel);
-        volumeColumn.getStyleClass().add("number-column");
+        volumeColumn.getStyleClass().addAll("number-column", "first-column");
         volumeColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         volumeColumn.setCellFactory(
                 new Callback<>() {
@@ -504,14 +504,19 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                     }
                 });
 
+        boolean isSellOffer = direction == OfferPayload.Direction.SELL;
+
         // trader avatar
-        TableColumn<OfferListItem, OfferListItem> avatarColumn = new AutoTooltipTableColumn<>(Res.get("offerbook.trader")) {
+        TableColumn<OfferListItem, OfferListItem> avatarColumn = new AutoTooltipTableColumn<>(isSellOffer ?
+                Res.get("shared.sellerUpperCase") : Res.get("shared.buyerUpperCase")) {
             {
                 setMinWidth(80);
                 setMaxWidth(80);
                 setSortable(true);
             }
         };
+
+        avatarColumn.getStyleClass().addAll("last-column", "avatar-column");
         avatarColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         avatarColumn.setCellFactory(
                 new Callback<>() {
@@ -533,6 +538,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                                             model.accountAgeWitnessService,
                                             formatter,
                                             useDevPrivilegeKeys);
+//                                    setAlignment(Pos.CENTER);
                                     setGraphic(peerInfoIcon);
                                 } else {
                                     setGraphic(null);
@@ -558,7 +564,6 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         Label titleLabel = new AutoTooltipLabel();
         titleLabel.getStyleClass().add("table-title");
 
-        boolean isSellOffer = direction == OfferPayload.Direction.SELL;
         AutoTooltipButton button = new AutoTooltipButton();
         ImageView iconView = new ImageView();
         iconView.setId(isSellOffer ? "image-buy-white" : "image-sell-white");

--- a/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadView.java
@@ -70,6 +70,7 @@ public class SpreadView extends ActivatableViewAndModel<GridPane, SpreadViewMode
     public void initialize() {
         tableView = new TableView<>();
         tableView.getStyleClass().add("large-rows");
+
         int gridRow = 0;
         GridPane.setRowIndex(tableView, gridRow);
         GridPane.setVgrow(tableView, Priority.ALWAYS);
@@ -142,7 +143,7 @@ public class SpreadView extends ActivatableViewAndModel<GridPane, SpreadViewMode
                 setMinWidth(160);
             }
         };
-        column.getStyleClass().add("number-column");
+        column.getStyleClass().addAll("number-column", "first-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -284,7 +285,7 @@ public class SpreadView extends ActivatableViewAndModel<GridPane, SpreadViewMode
                 setMinWidth(110);
             }
         };
-        column.getStyleClass().add("number-column");
+        column.getStyleClass().addAll("number-column", "last-column");
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -507,7 +507,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 setMaxWidth(240);
             }
         };
-        dateColumn.getStyleClass().add("number-column");
+        dateColumn.getStyleClass().addAll("number-column", "first-column");
         dateColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
         dateColumn.setCellFactory(
                 new Callback<>() {
@@ -663,7 +663,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
         // direction
         TableColumn<TradeStatistics2, TradeStatistics2> directionColumn = new AutoTooltipTableColumn<>(Res.get("shared.offerType"));
-        directionColumn.getStyleClass().add("number-column");
+        directionColumn.getStyleClass().addAll("number-column", "last-column");
         directionColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
         directionColumn.setCellFactory(
                 new Callback<>() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -119,7 +119,8 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
     private ComboBox<TradeCurrency> currencyComboBox;
     private ComboBox<PaymentMethod> paymentMethodComboBox;
     private AutoTooltipButton createOfferButton;
-    private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> amountColumn, volumeColumn, marketColumn, priceColumn;
+    private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> amountColumn, volumeColumn, marketColumn,
+            priceColumn, avatarColumn;
     private TableView<OfferBookListItem> tableView;
 
     private OfferView.OfferActionHandler offerActionHandler;
@@ -212,9 +213,9 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         tableView.getColumns().add(volumeColumn);
         TableColumn<OfferBookListItem, OfferBookListItem> paymentMethodColumn = getPaymentMethodColumn();
         tableView.getColumns().add(paymentMethodColumn);
-        TableColumn<OfferBookListItem, OfferBookListItem> avatarColumn = getAvatarColumn();
-        tableView.getColumns().add(avatarColumn);
+        avatarColumn = getAvatarColumn();
         tableView.getColumns().add(getActionColumn());
+        tableView.getColumns().add(avatarColumn);
 
         tableView.getSortOrder().add(priceColumn);
         tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
@@ -299,12 +300,14 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                     if (showAll) {
                         volumeColumn.setTitleWithHelpText(Res.get("shared.amountMinMax"), Res.get("shared.amountHelp"));
                         priceColumn.setTitle(Res.get("shared.price"));
+                        priceColumn.getStyleClass().remove("first-column");
 
                         if (!tableView.getColumns().contains(marketColumn))
                             tableView.getColumns().add(0, marketColumn);
                     } else {
                         volumeColumn.setTitleWithHelpText(Res.get("offerbook.volume", code), Res.get("shared.amountHelp"));
                         priceColumn.setTitle(formatter.getPriceWithCurrencyCode(code));
+                        priceColumn.getStyleClass().add("first-column");
 
                         tableView.getColumns().remove(marketColumn);
                     }
@@ -355,6 +358,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         createOfferButton.setGraphic(iconView);
         iconView.setId(direction == OfferPayload.Direction.SELL ? "image-sell-white" : "image-buy-white");
         createOfferButton.setId(direction == OfferPayload.Direction.SELL ? "sell-button-big" : "buy-button-big");
+        avatarColumn.setTitle(direction == OfferPayload.Direction.SELL ? Res.get("shared.buyerUpperCase") : Res.get("shared.sellerUpperCase"));
         setDirectionTitles();
     }
 
@@ -555,7 +559,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 setMinWidth(40);
             }
         };
-        column.getStyleClass().add("number-column");
+        column.getStyleClass().addAll("number-column", "first-column");
         column.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -778,7 +782,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
     }
 
     private TableColumn<OfferBookListItem, OfferBookListItem> getActionColumn() {
-        TableColumn<OfferBookListItem, OfferBookListItem> column = new AutoTooltipTableColumn<>("") {
+        TableColumn<OfferBookListItem, OfferBookListItem> column = new AutoTooltipTableColumn<>(Res.get("shared.actions")) {
             {
                 setMinWidth(80);
                 setSortable(false);
@@ -883,6 +887,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                                 isInsufficientTradeLimit));
 
                                     button.updateText(title);
+                                    setPadding(new Insets(0, 15, 0, 0));
                                     setGraphic(button);
                                 } else {
                                     setGraphic(null);
@@ -899,14 +904,15 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         return column;
     }
 
-    private TableColumn<OfferBookListItem, OfferBookListItem> getAvatarColumn() {
-        TableColumn<OfferBookListItem, OfferBookListItem> column = new AutoTooltipTableColumn<>(Res.get("offerbook.trader")) {
+    private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> getAvatarColumn() {
+        AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> column = new AutoTooltipTableColumn<>(Res.get("offerbook.trader")) {
             {
                 setMinWidth(80);
                 setMaxWidth(80);
                 setSortable(true);
             }
         };
+        column.getStyleClass().addAll("last-column", "avatar-column");
         column.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         column.setCellFactory(
                 new Callback<>() {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
@@ -221,6 +221,7 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
 
 
     private void setTradeIdColumnCellFactory() {
+        tradeIdColumn.getStyleClass().add("first-column");
         tradeIdColumn.setCellValueFactory((offerListItem) -> new ReadOnlyObjectWrapper<>(offerListItem.getValue()));
         tradeIdColumn.setCellFactory(
                 new Callback<>() {
@@ -318,6 +319,7 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
 
     @SuppressWarnings("UnusedReturnValue")
     private TableColumn<ClosedTradableListItem, ClosedTradableListItem> setAvatarColumnCellFactory() {
+        avatarColumn.getStyleClass().addAll("last-column", "avatar-column");
         avatarColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         avatarColumn.setCellFactory(
                 new Callback<>() {
@@ -345,7 +347,7 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
                                             model.accountAgeWitnessService,
                                             formatter,
                                             useDevPrivilegeKeys);
-                                    setPadding(new Insets(1, 0, 0, 0));
+                                    setPadding(new Insets(1, 15, 0, 0));
                                     setGraphic(peerInfoIcon);
                                 } else {
                                     setGraphic(null);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -41,6 +41,8 @@ import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
 
+import java.util.Comparator;
+
 @FxmlView
 public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTradesViewModel> {
 
@@ -81,9 +83,9 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
         setMarketColumnCellFactory();
         setStateColumnCellFactory();
 
-        tradeIdColumn.setComparator((o1, o2) -> o1.getTrade().getId().compareTo(o2.getTrade().getId()));
-        dateColumn.setComparator((o1, o2) -> o1.getTrade().getDate().compareTo(o2.getTrade().getDate()));
-        priceColumn.setComparator((o1, o2) -> o1.getTrade().getTradePrice().compareTo(o2.getTrade().getTradePrice()));
+        tradeIdColumn.setComparator(Comparator.comparing(o -> o.getTrade().getId()));
+        dateColumn.setComparator(Comparator.comparing(o -> o.getTrade().getDate()));
+        priceColumn.setComparator(Comparator.comparing(o -> o.getTrade().getTradePrice()));
 
         volumeColumn.setComparator((o1, o2) -> {
             if (o1.getTrade().getTradeVolume() != null && o2.getTrade().getTradeVolume() != null)
@@ -98,8 +100,8 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
                 return 0;
         });
 
-        stateColumn.setComparator((o1, o2) -> model.getState(o1).compareTo(model.getState(o2)));
-        marketColumn.setComparator((o1, o2) -> model.getMarketLabel(o1).compareTo(model.getMarketLabel(o2)));
+        stateColumn.setComparator(Comparator.comparing(model::getState));
+        marketColumn.setComparator(Comparator.comparing(model::getMarketLabel));
 
         dateColumn.setSortType(TableColumn.SortType.DESCENDING);
         tableView.getSortOrder().add(dateColumn);
@@ -120,15 +122,15 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
 
 
     private void setTradeIdColumnCellFactory() {
+        tradeIdColumn.getStyleClass().add("first-column");
         tradeIdColumn.setCellValueFactory((offerListItem) -> new ReadOnlyObjectWrapper<>(offerListItem.getValue()));
         tradeIdColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
 
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(TableColumn<FailedTradesListItem,
                             FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             private HyperlinkWithIcon field;
 
                             @Override
@@ -153,12 +155,11 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private void setDateColumnCellFactory() {
         dateColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         dateColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(
                             TableColumn<FailedTradesListItem, FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final FailedTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -175,12 +176,11 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private void setMarketColumnCellFactory() {
         marketColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         marketColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(
                             TableColumn<FailedTradesListItem, FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final FailedTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -192,14 +192,14 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     }
 
     private void setStateColumnCellFactory() {
+        stateColumn.getStyleClass().add("last-column");
         stateColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         stateColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(
                             TableColumn<FailedTradesListItem, FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final FailedTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -217,12 +217,11 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private void setAmountColumnCellFactory() {
         amountColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         amountColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(
                             TableColumn<FailedTradesListItem, FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final FailedTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -236,12 +235,11 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private void setPriceColumnCellFactory() {
         priceColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         priceColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(
                             TableColumn<FailedTradesListItem, FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final FailedTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -255,12 +253,11 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private void setVolumeColumnCellFactory() {
         volumeColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         volumeColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(
                             TableColumn<FailedTradesListItem, FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final FailedTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -277,12 +274,11 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private void setDirectionColumnCellFactory() {
         directionColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         directionColumn.setCellFactory(
-                new Callback<TableColumn<FailedTradesListItem, FailedTradesListItem>, TableCell<FailedTradesListItem,
-                        FailedTradesListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<FailedTradesListItem, FailedTradesListItem> call(
                             TableColumn<FailedTradesListItem, FailedTradesListItem> column) {
-                        return new TableCell<FailedTradesListItem, FailedTradesListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final FailedTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersView.java
@@ -57,6 +57,8 @@ import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
 
+import java.util.Comparator;
+
 import org.jetbrains.annotations.NotNull;
 
 import static bisq.desktop.util.FormBuilder.getIconButton;
@@ -109,10 +111,10 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
         tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.openOffers"))));
 
-        offerIdColumn.setComparator((o1, o2) -> o1.getOffer().getId().compareTo(o2.getOffer().getId()));
-        directionColumn.setComparator((o1, o2) -> o1.getOffer().getDirection().compareTo(o2.getOffer().getDirection()));
-        marketColumn.setComparator((o1, o2) -> model.getMarketLabel(o1).compareTo(model.getMarketLabel(o2)));
-        amountColumn.setComparator((o1, o2) -> o1.getOffer().getAmount().compareTo(o2.getOffer().getAmount()));
+        offerIdColumn.setComparator(Comparator.comparing(o -> o.getOffer().getId()));
+        directionColumn.setComparator(Comparator.comparing(o -> o.getOffer().getDirection()));
+        marketColumn.setComparator(Comparator.comparing(model::getMarketLabel));
+        amountColumn.setComparator(Comparator.comparing(o -> o.getOffer().getAmount()));
         priceColumn.setComparator((o1, o2) -> {
             Price price1 = o1.getOffer().getPrice();
             Price price2 = o2.getOffer().getPrice();
@@ -123,7 +125,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
             Volume offerVolume2 = o2.getOffer().getVolume();
             return offerVolume1 != null && offerVolume2 != null ? offerVolume1.compareTo(offerVolume2) : 0;
         });
-        dateColumn.setComparator((o1, o2) -> o1.getOffer().getDate().compareTo(o2.getOffer().getDate()));
+        dateColumn.setComparator(Comparator.comparing(o -> o.getOffer().getDate()));
 
         dateColumn.setSortType(TableColumn.SortType.DESCENDING);
         tableView.getSortOrder().add(dateColumn);
@@ -144,9 +146,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void onDeactivateOpenOffer(OpenOffer openOffer) {
         if (model.isBootstrapped()) {
             model.onDeactivateOpenOffer(openOffer,
-                    () -> {
-                        log.debug("Deactivate offer was successful");
-                    },
+                    () -> log.debug("Deactivate offer was successful"),
                     (message) -> {
                         log.error(message);
                         new Popup<>().warning(Res.get("offerbook.deactivateOffer.failed", message)).show();
@@ -159,9 +159,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void onActivateOpenOffer(OpenOffer openOffer) {
         if (model.isBootstrapped()) {
             model.onActivateOpenOffer(openOffer,
-                    () -> {
-                        log.debug("Activate offer was successful");
-                    },
+                    () -> log.debug("Activate offer was successful"),
                     (message) -> {
                         log.error(message);
                         new Popup<>().warning(Res.get("offerbook.activateOffer.failed", message)).show();
@@ -219,13 +217,14 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
 
     private void setOfferIdColumnCellFactory() {
         offerIdColumn.setCellValueFactory((openOfferListItem) -> new ReadOnlyObjectWrapper<>(openOfferListItem.getValue()));
+        offerIdColumn.getStyleClass().addAll("number-column", "first-column");
         offerIdColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem, OpenOfferListItem>>() {
+                new Callback<>() {
 
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(TableColumn<OpenOfferListItem,
                             OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             private HyperlinkWithIcon field;
 
                             @Override
@@ -251,12 +250,11 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void setDateColumnCellFactory() {
         dateColumn.setCellValueFactory((openOfferListItem) -> new ReadOnlyObjectWrapper<>(openOfferListItem.getValue()));
         dateColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem,
-                        OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(
                             TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final OpenOfferListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -276,12 +274,11 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void setAmountColumnCellFactory() {
         amountColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         amountColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem,
-                        OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(
                             TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final OpenOfferListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -302,12 +299,11 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void setPriceColumnCellFactory() {
         priceColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         priceColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem,
-                        OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(
                             TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final OpenOfferListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -328,12 +324,11 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void setVolumeColumnCellFactory() {
         volumeColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         volumeColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem,
-                        OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(
                             TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final OpenOfferListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -354,12 +349,11 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void setDirectionColumnCellFactory() {
         directionColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         directionColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem,
-                        OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(
                             TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final OpenOfferListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -380,12 +374,11 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void setMarketColumnCellFactory() {
         marketColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
         marketColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem,
-                        OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(
                             TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final OpenOfferListItem item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -406,10 +399,10 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     private void setDeactivateColumnCellFactory() {
         deactivateItemColumn.setCellValueFactory((offerListItem) -> new ReadOnlyObjectWrapper<>(offerListItem.getValue()));
         deactivateItemColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem, OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             final ImageView iconView = new ImageView();
                             CheckBox checkBox;
 
@@ -455,12 +448,13 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
     }
 
     private void setRemoveColumnCellFactory() {
+        removeItemColumn.getStyleClass().addAll("last-column", "avatar-column");
         removeItemColumn.setCellValueFactory((offerListItem) -> new ReadOnlyObjectWrapper<>(offerListItem.getValue()));
         removeItemColumn.setCellFactory(
-                new Callback<TableColumn<OpenOfferListItem, OpenOfferListItem>, TableCell<OpenOfferListItem, OpenOfferListItem>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<OpenOfferListItem, OpenOfferListItem> call(TableColumn<OpenOfferListItem, OpenOfferListItem> column) {
-                        return new TableCell<OpenOfferListItem, OpenOfferListItem>() {
+                        return new TableCell<>() {
                             Button button;
 
                             @Override

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -294,6 +294,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void setTradeIdColumnCellFactory() {
+        tradeIdColumn.getStyleClass().add("first-column");
         tradeIdColumn.setCellValueFactory((pendingTradesListItem) -> new ReadOnlyObjectWrapper<>(pendingTradesListItem.getValue()));
         tradeIdColumn.setCellFactory(
                 new Callback<>() {
@@ -472,6 +473,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
     @SuppressWarnings("UnusedReturnValue")
     private TableColumn<PendingTradesListItem, PendingTradesListItem> setAvatarColumnCellFactory() {
         avatarColumn.setCellValueFactory((offer) -> new ReadOnlyObjectWrapper<>(offer.getValue()));
+        avatarColumn.getStyleClass().addAll("last-column", "avatar-column");
         avatarColumn.setCellFactory(
                 new Callback<>() {
 

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -166,6 +166,7 @@ public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activ
         reSyncSPVChainButton.updateText(Res.get("settings.net.reSyncSPVChainButton"));
         p2PPeersLabel.setText(Res.get("settings.net.p2PPeersLabel"));
         onionAddressColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.onionAddressColumn")));
+        onionAddressColumn.getStyleClass().add("first-column");
         creationDateColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.creationDateColumn")));
         connectionTypeColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.connectionTypeColumn")));
         totalTrafficTextField.setPromptText(Res.get("settings.net.totalTrafficLabel"));
@@ -173,6 +174,7 @@ public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activ
         sentBytesColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.sentBytesColumn")));
         receivedBytesColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.receivedBytesColumn")));
         peerTypeColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.peerTypeColumn")));
+        peerTypeColumn.getStyleClass().add("last-column");
         openTorSettingsButton.updateText(Res.get("settings.net.openTorSettingsButton"));
 
         GridPane.setMargin(p2PPeersLabel, new Insets(4, 0, 0, 0));


### PR DESCRIPTION
Adapted the left align style for all columns except the last one based on the design of @pedromvpg. I saw that for avatars and icons that are in the last column they were centered, so I implemented it like that. @pedromvpg Could you please have a look if it is as you wanted it to have?

Maybe we could discuss in this PR also the line height of rows in certain screens. It came up during the release that some are not very happy with the line height as it will show less information now than it did before. 

The question is f the user has the requirement to get everything in one screen or if the extended height of the rows is more pleasant to watch.

As this is an design issue @pedromvpg has the last call, but it seems there should be some public discussion on this.

<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 45 02" src="https://user-images.githubusercontent.com/170962/49517636-fdb6c380-f89c-11e8-8edc-c5c49742246d.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 44 58" src="https://user-images.githubusercontent.com/170962/49517637-fdb6c380-f89c-11e8-9d60-3977e109c422.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 44 50" src="https://user-images.githubusercontent.com/170962/49517638-fdb6c380-f89c-11e8-85cd-eaadc86e90a1.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 43 36" src="https://user-images.githubusercontent.com/170962/49517639-fdb6c380-f89c-11e8-8651-2b764a8ca095.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 43 32" src="https://user-images.githubusercontent.com/170962/49517640-fdb6c380-f89c-11e8-8d62-67f87725333c.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 43 27" src="https://user-images.githubusercontent.com/170962/49517641-fe4f5a00-f89c-11e8-9a28-748f36800d23.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 42 49" src="https://user-images.githubusercontent.com/170962/49517642-fe4f5a00-f89c-11e8-9225-f353f9217f81.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 41 36" src="https://user-images.githubusercontent.com/170962/49517643-fe4f5a00-f89c-11e8-9e97-3c3dc7008040.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 36 09" src="https://user-images.githubusercontent.com/170962/49517644-fee7f080-f89c-11e8-82a4-0e438cbb4c71.png">
<img width="1312" alt="bildschirmfoto 2018-12-05 um 14 36 01" src="https://user-images.githubusercontent.com/170962/49517645-fee7f080-f89c-11e8-9c1e-45e6c4a18b17.png">
