### PR TITLE
Fix base currency option handling

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -68,7 +68,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.app.BisqEnvironment.DEFAULT_APP_NAME;
 import static bisq.core.app.BisqEnvironment.DEFAULT_USER_DATA_DIR;
+import static bisq.core.btc.BaseCurrencyNetwork.BTC_MAINNET;
+import static bisq.core.btc.BaseCurrencyNetwork.BTC_REGTEST;
+import static bisq.core.btc.BaseCurrencyNetwork.BTC_TESTNET;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 @Slf4j
 public abstract class BisqExecutable implements GracefulShutDownHandler {
@@ -481,10 +485,10 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
 
         //BtcOptionKeys
         parser.accepts(BtcOptionKeys.BASE_CURRENCY_NETWORK,
-                "Base currency network")
+                format("Base currency network (default: %s)", BisqEnvironment.getDefaultBaseCurrencyNetwork().name()))
                 .withRequiredArg()
                 .ofType(String.class)
-                .defaultsTo(BisqEnvironment.getDefaultBaseCurrencyNetwork().name());
+                .describedAs(format("%s|%s|%s", BTC_MAINNET, BTC_TESTNET, BTC_REGTEST));
 
         parser.accepts(BtcOptionKeys.REG_TEST_HOST)
                 .withRequiredArg()


### PR DESCRIPTION
This change fixes #2048 by removing the assignment of a default value
for the `baseCurrencyNetwork` option at the level of the command line
option parser. The assignment of this default was an oversight in #1961
(specifically commit 83e1dd3) that did not account for the fact that
users can change the `baseCurrencyNetwork` value via the Settings screen
in the application. When users change the setting in the application, the new
value is persisted to <appDataDir>/bisq.properties, which is handled at
runtime as a PropertySource with lower precedence than the command line
property source, which means that the changed value is never picked up
because the higher-precedence command line PropertySource always has a
default value.

This fix is surgical in that it addresses only this specific option. A
subsequent change should address the more general issue that setting
defaults in the command line option parser always precludes the
possibility of overriding them in bisq.properties. Basically, we should
revert to the previous strategy of reporting what the default value will
be in the help text without actually assigning a default value in the
option parser using the `defaultsTo` method.