### PR TITLE
Stream isolation for Tor

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqEnvironment.java
+++ b/core/src/main/java/bisq/core/app/BisqEnvironment.java
@@ -206,7 +206,7 @@ public class BisqEnvironment extends StandardEnvironment {
             torRcFile, torRcOptions, externalTorControlPort, externalTorPassword, externalTorCookieFile,
             socks5ProxyHttpAddress, useAllProvidedNodes, numConnectionForBtc, genesisTxId, genesisBlockHeight, referralId, daoActivated;
 
-    protected final boolean externalTorUseSafeCookieAuthentication;
+    protected final boolean externalTorUseSafeCookieAuthentication, torStreamIsolation;
 
     public BisqEnvironment(OptionSet options) {
         this(new JOptCommandLinePropertySource(BISQ_COMMANDLINE_PROPERTY_SOURCE_NAME, checkNotNull(
@@ -295,6 +295,9 @@ public class BisqEnvironment extends StandardEnvironment {
                 (String) commandLineProperties.getProperty(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE) :
                 "";
         externalTorUseSafeCookieAuthentication = commandLineProperties.containsProperty(NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE) ?
+                true :
+                false;
+        torStreamIsolation = commandLineProperties.containsProperty(NetworkOptionKeys.TOR_STREAM_ISOLATION) ?
                 true :
                 false;
 
@@ -472,6 +475,8 @@ public class BisqEnvironment extends StandardEnvironment {
                 setProperty(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE, externalTorCookieFile);
                 if (externalTorUseSafeCookieAuthentication)
                     setProperty(NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE, "true");
+                if (torStreamIsolation)
+                    setProperty(NetworkOptionKeys.TOR_STREAM_ISOLATION, "true");
 
                 setProperty(AppOptionKeys.APP_DATA_DIR_KEY, appDataDir);
                 setProperty(AppOptionKeys.DESKTOP_WITH_HTTP_API, desktopWithHttpApi);

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -415,6 +415,9 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
                 "Use the SafeCookie method when authenticating to the already running Tor service.")
                 .availableIf(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE);
 
+        parser.accepts(NetworkOptionKeys.TOR_STREAM_ISOLATION,
+                "Use stream isolation for Tor.");
+
         //AppOptionKeys
         parser.accepts(AppOptionKeys.USER_DATA_DIR_KEY,
                 "User data directory")

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -416,7 +416,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
                 .availableIf(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE);
 
         parser.accepts(NetworkOptionKeys.TOR_STREAM_ISOLATION,
-                "Use stream isolation for Tor.");
+                "Use stream isolation for Tor [experimental!].");
 
         //AppOptionKeys
         parser.accepts(AppOptionKeys.USER_DATA_DIR_KEY,

--- a/monitor/src/main/java/bisq/monitor/metrics/p2p/MonitorP2PService.java
+++ b/monitor/src/main/java/bisq/monitor/metrics/p2p/MonitorP2PService.java
@@ -106,7 +106,7 @@ public class MonitorP2PService implements SetupListener, PersistedDataHost {
 
     @Override
     public void onTorNodeReady() {
-        socks5ProxyProvider.setSocks5ProxyInternal(networkNode.getSocksProxy());
+        socks5ProxyProvider.setSocks5ProxyInternal(networkNode);
         listener.onTorNodeReady();
     }
 

--- a/p2p/src/main/java/bisq/network/NetworkOptionKeys.java
+++ b/p2p/src/main/java/bisq/network/NetworkOptionKeys.java
@@ -35,4 +35,5 @@ public class NetworkOptionKeys {
     public static final String EXTERNAL_TOR_PASSWORD = "torControlPassword";
     public static final String EXTERNAL_TOR_COOKIE_FILE = "torControlCookieFile";
     public static final String EXTERNAL_TOR_USE_SAFECOOKIE = "torControlUseSafeCookieAuth";
+    public static final String TOR_STREAM_ISOLATION = "torStreamIsolation";
 }

--- a/p2p/src/main/java/bisq/network/Socks5ProxyProvider.java
+++ b/p2p/src/main/java/bisq/network/Socks5ProxyProvider.java
@@ -19,6 +19,8 @@ package bisq.network;
 
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 
+import bisq.network.p2p.network.NetworkNode;
+
 import com.google.inject.Inject;
 
 import javax.inject.Named;
@@ -45,7 +47,7 @@ public class Socks5ProxyProvider {
     private static final Logger log = LoggerFactory.getLogger(Socks5ProxyProvider.class);
 
     @Nullable
-    private Socks5Proxy socks5ProxyInternal;
+    private NetworkNode socks5ProxyInternalFactory;
 
     // proxy used for btc network
     @Nullable
@@ -66,8 +68,8 @@ public class Socks5ProxyProvider {
     public Socks5Proxy getSocks5Proxy() {
         if (socks5ProxyBtc != null)
             return socks5ProxyBtc;
-        else if (socks5ProxyInternal != null)
-            return socks5ProxyInternal;
+        else if (socks5ProxyInternalFactory != null)
+            return getSocks5ProxyInternal();
         else
             return null;
     }
@@ -84,11 +86,11 @@ public class Socks5ProxyProvider {
 
     @Nullable
     public Socks5Proxy getSocks5ProxyInternal() {
-        return socks5ProxyInternal;
+        return socks5ProxyInternalFactory.getSocksProxy();
     }
 
-    public void setSocks5ProxyInternal(@Nullable Socks5Proxy bisqSocks5Proxy) {
-        this.socks5ProxyInternal = bisqSocks5Proxy;
+    public void setSocks5ProxyInternal(@Nullable NetworkNode bisqSocks5ProxyFactory) {
+        this.socks5ProxyInternalFactory = bisqSocks5ProxyFactory;
     }
 
     @Nullable

--- a/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
+++ b/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
@@ -50,10 +50,11 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
                                @Named(NetworkOptionKeys.EXTERNAL_TOR_CONTROL_PORT) String controlPort,
                                @Named(NetworkOptionKeys.EXTERNAL_TOR_PASSWORD) String password,
                                @Named(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE) String cookieFile,
+                               @Named(NetworkOptionKeys.TOR_STREAM_ISOLATION) boolean streamIsolation,
                                @Named(NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE) boolean useSafeCookieAuthentication ) {
         networkNode = useLocalhostForP2P ?
                 new LocalhostNetworkNode(address, port, networkProtoResolver) :
-                new TorNetworkNode(port, networkProtoResolver,
+                new TorNetworkNode(port, networkProtoResolver, streamIsolation,
                         !controlPort.isEmpty() ?
                                 new RunningTor(torDir, Integer.parseInt(controlPort), password, cookieFile, useSafeCookieAuthentication) :
                                 new NewTor(torDir, torrcFile, torrcOptions, bridgeAddressProvider.getBridgeAddresses()));

--- a/p2p/src/main/java/bisq/network/p2p/P2PModule.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PModule.java
@@ -94,5 +94,6 @@ public class P2PModule extends AppModule {
         bindConstant().annotatedWith(named(NetworkOptionKeys.EXTERNAL_TOR_PASSWORD)).to(environment.getRequiredProperty(NetworkOptionKeys.EXTERNAL_TOR_PASSWORD));
         bindConstant().annotatedWith(named(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE)).to(environment.getRequiredProperty(NetworkOptionKeys.EXTERNAL_TOR_COOKIE_FILE));
         bindConstant().annotatedWith(named(NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE)).to(environment.containsProperty(NetworkOptionKeys.EXTERNAL_TOR_USE_SAFECOOKIE) ? true : false);
+        bindConstant().annotatedWith(named(NetworkOptionKeys.TOR_STREAM_ISOLATION)).to(environment.containsProperty(NetworkOptionKeys.TOR_STREAM_ISOLATION) ? true : false);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -275,7 +275,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     public void onTorNodeReady() {
         Log.traceCall();
 
-        socks5ProxyProvider.setSocks5ProxyInternal(networkNode.getSocksProxy());
+        socks5ProxyProvider.setSocks5ProxyInternal(networkNode);
 
         boolean seedNodesAvailable = requestDataManager.requestPreliminaryData();
 

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -82,9 +82,11 @@ public class TorNetworkNode extends NetworkNode {
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public TorNetworkNode(int servicePort, NetworkProtoResolver networkProtoResolver, TorMode torMode) {
+    public TorNetworkNode(int servicePort, NetworkProtoResolver networkProtoResolver, boolean useStreamIsolation,
+            TorMode torMode) {
         super(servicePort, networkProtoResolver);
         this.torMode = torMode;
+        this.streamIsolation = useStreamIsolation;
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -45,7 +45,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 
 import java.net.Socket;
-
+import java.security.SecureRandom;
 import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +75,8 @@ public class TorNetworkNode extends NetworkNode {
     private Tor tor;
 
     private TorMode torMode;
+
+    private boolean streamIsolation = false;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -115,7 +117,17 @@ public class TorNetworkNode extends NetworkNode {
     public Socks5Proxy getSocksProxy() {
         try {
             tor = Tor.getDefault();
-            return tor != null ? tor.getProxy() : null;
+
+            String stream = "";
+            if (streamIsolation) {
+                // create a random string
+                byte[] bytes = new byte[512]; // note that getProxy does Sha256 that string anyways
+                new SecureRandom().nextBytes(bytes);
+                stream = new String(bytes);
+            }
+
+            // ask for the connection
+            return tor != null ? tor.getProxy(stream) : null;
         } catch (TorCtlException e) {
             log.error("TorCtlException at getSocksProxy: " + e.toString());
             e.printStackTrace();

--- a/p2p/src/test/java/bisq/network/p2p/network/TorNetworkNodeTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/network/TorNetworkNodeTest.java
@@ -53,7 +53,7 @@ public class TorNetworkNodeTest {
     public void testTorNodeBeforeSecondReady() throws InterruptedException, IOException {
         latch = new CountDownLatch(1);
         int port = 9001;
-        TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(),
+        TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
                 new NewTor(new File("torNode_" + port), "", "", new ArrayList<String>()));
         node1.start(new SetupListener() {
             @Override
@@ -80,7 +80,7 @@ public class TorNetworkNodeTest {
 
         latch = new CountDownLatch(1);
         int port2 = 9002;
-        TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(),
+        TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
                 new NewTor(new File("torNode_" + port), "", "", new ArrayList<String>()));
         node2.start(new SetupListener() {
             @Override
@@ -138,7 +138,7 @@ public class TorNetworkNodeTest {
     public void testTorNodeAfterBothReady() throws InterruptedException, IOException {
         latch = new CountDownLatch(2);
         int port = 9001;
-        TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(),
+        TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
                 new NewTor(new File("torNode_" + port), "", "", new ArrayList<String>()));
         node1.start(new SetupListener() {
             @Override
@@ -164,7 +164,7 @@ public class TorNetworkNodeTest {
         });
 
         int port2 = 9002;
-        TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(),
+        TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
                 new NewTor(new File("torNode_" + port), "", "", new ArrayList<String>()));
         node2.start(new SetupListener() {
             @Override


### PR DESCRIPTION
closes #731 

Adds a command line parameter `--torStreamIsolation`. If set, Bisq uses a new stream for every request to the Tor network.