### PR TITLE
Update install_java.bat

### DIFF
--- a/scripts/install_java.bat
+++ b/scripts/install_java.bat
@@ -23,26 +23,22 @@ set jdk_version=10.0.2
 set jdk_filename=openjdk-%jdk_version%_windows-x64_bin
 set jdk_url=https://download.java.net/java/GA/jdk10/%jdk_version%/19aef61b38124481863b1413dce1855f/13/%jdk_filename%.tar.gz
 
-echo Downloading required files
+if exist "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%" (
+    echo %PROGRAMFILES%\Java\openjdk\jdk-%jdk_version% already exists, skipping install
+    goto SetEnvVars
+)
+
+echo Downloading required files to %TEMP%
 powershell -Command "Invoke-WebRequest %jdk_url% -OutFile $env:temp\%jdk_filename%.tar.gz"
 ::Download 7zip (command line version) in order to extract the tar.gz file since there is no native support in Windows
 powershell -Command "Invoke-WebRequest https://www.7-zip.org/a/7za920.zip -OutFile $env:temp\7za920.zip"
 powershell -Command "Expand-Archive $env:temp\7za920.zip -DestinationPath $env:temp\7za920 -Force"
 
-echo Extracting and installing JDK
+echo Extracting and installing JDK to %PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%
 "%TEMP%\7za920\7za.exe" x "%TEMP%\%jdk_filename%.tar.gz" -o"%TEMP%" -r -y
 "%TEMP%\7za920\7za.exe" x "%TEMP%\%jdk_filename%.tar" -o"%TEMP%\openjdk-%jdk_version%" -r -y
-if exist "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%" (
-    rmdir /S /Q "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%"
-) else (
-    md "%PROGRAMFILES%\Java\openjdk"
-)
+md "%PROGRAMFILES%\Java\openjdk"
 move "%TEMP%\openjdk-%jdk_version%\jdk-%jdk_version%" "%PROGRAMFILES%\Java\openjdk"
-
-echo Setting environment variables
-setx /M JAVA_HOME "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%"
-set java_bin=%%JAVA_HOME%%\bin
-echo %PATH%|find /i "%java_bin%">nul  || setx /M PATH "%PATH%;%java_bin%"
 
 echo Removing downloaded files
 rmdir /S /Q %TEMP%\7za920
@@ -50,5 +46,11 @@ del /Q %TEMP%\7za920.zip
 rmdir /S /Q %TEMP%\openjdk-%jdk_version%
 del /Q %TEMP%\%jdk_filename%.tar
 del /Q %TEMP%\%jdk_filename%.tar.gz
+
+:SetEnvVars
+echo Setting environment variables
+setx /M JAVA_HOME "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%"
+set java_bin=%%JAVA_HOME%%\bin
+echo %PATH%|find /i "%java_bin%">nul  || setx /M PATH "%PATH%;%java_bin%"
 
 pause


### PR DESCRIPTION
If the JDK is already installed, there is no need to download,
extract, and install it again. Just need to ensure the environment
variables are set.