### PR TITLE
[WIP] Split bsq changeoutputs

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -465,6 +465,10 @@ public abstract class WalletService {
         return outputs;
     }
 
+    public int getNumUtxos() {
+        return wallet.getUnspents().size();
+    }
+
     public boolean isAddressUnused(Address address) {
         return getNumTxOutputsForAddress(address) == 0;
     }

--- a/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
+++ b/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
@@ -326,7 +326,7 @@ public class AssetService implements DaoSetupService, DaoStateListener {
         checkArgument(listingFee % 100 == 0, "Fee must be a multiple of 1 BSQ (100 satoshi).");
         try {
             // We create a prepared Bsq Tx for the listing fee.
-            final Transaction preparedBurnFeeTx = bsqWalletService.getPreparedBurnFeeTx(Coin.valueOf(listingFee));
+            final Transaction preparedBurnFeeTx = bsqWalletService.getPreparedAssetListingFeeTx(Coin.valueOf(listingFee));
             byte[] hash = AssetConsensus.getHash(statefulAsset);
             byte[] opReturnData = AssetConsensus.getOpReturnData(hash);
             // We add the BTC inputs for the miner fee.

--- a/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
@@ -141,7 +141,7 @@ public class ProofOfBurnService implements DaoSetupService, DaoStateListener {
     public Transaction burn(String preImageAsString, long amount) throws InsufficientMoneyException, TxException {
         try {
             // We create a prepared Bsq Tx for the burn amount
-            final Transaction preparedBurnFeeTx = bsqWalletService.getPreparedBurnFeeTx(Coin.valueOf(amount));
+            final Transaction preparedBurnFeeTx = bsqWalletService.getPreparedProofOfBurnTx(Coin.valueOf(amount));
             byte[] hash = getHashFromPreImage(preImageAsString);
             byte[] opReturnData = ProofOfBurnConsensus.getOpReturnData(hash);
             // We add the BTC inputs for the miner fee.

--- a/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
@@ -17,6 +17,7 @@
 
 package bisq.core.dao.governance.proposal.compensation;
 
+import bisq.core.btc.exceptions.InsufficientBsqException;
 import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.exceptions.WalletException;
 import bisq.core.btc.wallet.BsqWalletService;
@@ -78,6 +79,11 @@ public class CompensationProposalFactory extends BaseProposalFactory<Compensatio
                 link,
                 requestedBsq,
                 bsqAddress);
+    }
+
+    @Override
+    protected Transaction getPreparedProposalTx(Coin fee) throws InsufficientBsqException {
+        return bsqWalletService.getPreparedIssuanceCandidateTx(fee);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
@@ -17,6 +17,7 @@
 
 package bisq.core.dao.governance.proposal.reimbursement;
 
+import bisq.core.btc.exceptions.InsufficientBsqException;
 import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.exceptions.WalletException;
 import bisq.core.btc.wallet.BsqWalletService;
@@ -78,6 +79,11 @@ public class ReimbursementProposalFactory extends BaseProposalFactory<Reimbursem
                 link,
                 requestedBsq,
                 bsqAddress);
+    }
+
+    @Override
+    protected Transaction getPreparedProposalTx(Coin fee) throws InsufficientBsqException {
+        return bsqWalletService.getPreparedIssuanceCandidateTx(fee);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/offer/placeoffer/tasks/CreateMakerFeeTx.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/tasks/CreateMakerFeeTx.java
@@ -110,7 +110,7 @@ public class CreateMakerFeeTx extends Task<PlaceOfferModel> {
                         });
             } else {
                 final BsqWalletService bsqWalletService = model.getBsqWalletService();
-                Transaction preparedBurnFeeTx = model.getBsqWalletService().getPreparedBurnFeeTx(offer.getMakerFee());
+                Transaction preparedBurnFeeTx = model.getBsqWalletService().getPreparedTradeFeeTx(offer.getMakerFee());
                 Transaction txWithBsqFee = tradeWalletService.completeBsqTradingFeeTx(preparedBurnFeeTx,
                         fundingAddress,
                         reservedForTradeAddress,

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
@@ -104,7 +104,7 @@ public class CreateTakerFeeTx extends TradeTask {
                         });
             } else {
                 final BsqWalletService bsqWalletService = processModel.getBsqWalletService();
-                Transaction preparedBurnFeeTx = processModel.getBsqWalletService().getPreparedBurnFeeTx(trade.getTakerFee());
+                Transaction preparedBurnFeeTx = processModel.getBsqWalletService().getPreparedTradeFeeTx(trade.getTakerFee());
                 Transaction txWithBsqFee = tradeWalletService.completeBsqTradingFeeTx(preparedBurnFeeTx,
                         fundingAddress,
                         reservedForTradeAddress,

--- a/core/src/test/java/bisq/core/dao/state/DaoStateSnapshotServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/state/DaoStateSnapshotServiceTest.java
@@ -17,6 +17,8 @@
 
 package bisq.core.dao.state;
 
+import bisq.core.dao.governance.period.CycleService;
+
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -31,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({DaoStateService.class, GenesisTxInfo.class, DaoStateStorageService.class})
+@PrepareForTest({DaoStateService.class, GenesisTxInfo.class, CycleService.class, DaoStateStorageService.class})
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class DaoStateSnapshotServiceTest {
 
@@ -41,6 +43,7 @@ public class DaoStateSnapshotServiceTest {
     public void setup() {
         daoStateSnapshotService = new DaoStateSnapshotService(mock(DaoStateService.class),
                 mock(GenesisTxInfo.class),
+                mock(CycleService.class),
                 mock(DaoStateStorageService.class));
     }
 


### PR DESCRIPTION
 Add multiple change outputs in case there are not sufficient utxos

To avoid that a user cannot make another BSQ tx before a pending tx is
confirmed in case he used up all utxo for that tx we add multiple change
outputs to following tx types:
- ~~Trade fee tx~~ (Trade protocol assumes 1 change output so we cannut use it here)
- Send BSQ tx
- Proposal Tx (but not comp. request and reimbursement)
- Blind vote tx
- Lockup tx

All others have more strict consensus rule regarding the output
structure.