### PR TITLE
Update install_java.bat

### DIFF
--- a/scripts/install_java.bat
+++ b/scripts/install_java.bat
@@ -30,9 +30,11 @@ if exist "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%" (
 
 echo Downloading required files to %TEMP%
 powershell -Command "Invoke-WebRequest %jdk_url% -OutFile $env:temp\%jdk_filename%.tar.gz"
-:: Download 7zip (command line version) in order to extract the tar.gz file since there is no native support in Windows
-powershell -Command "Invoke-WebRequest https://www.7-zip.org/a/7za920.zip -OutFile $env:temp\7za920.zip"
-powershell -Command "Expand-Archive $env:temp\7za920.zip -DestinationPath $env:temp\7za920 -Force"
+if not exist "%TEMP%\7za920\7za.exe" (
+    :: Download 7zip ^(command line version^) in order to extract the tar.gz file since there is no native support in Windows
+    powershell -Command "Invoke-WebRequest https://www.7-zip.org/a/7za920.zip -OutFile $env:temp\7za920.zip"
+    powershell -Command "Expand-Archive $env:temp\7za920.zip -DestinationPath $env:temp\7za920 -Force"
+)
 
 echo Extracting and installing JDK to %PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%
 "%TEMP%\7za920\7za.exe" x "%TEMP%\%jdk_filename%.tar.gz" -o"%TEMP%" -r -y
@@ -41,8 +43,9 @@ md "%PROGRAMFILES%\Java\openjdk"
 move "%TEMP%\openjdk-%jdk_version%\jdk-%jdk_version%" "%PROGRAMFILES%\Java\openjdk"
 
 echo Removing downloaded files
-rmdir /S /Q %TEMP%\7za920
-del /Q %TEMP%\7za920.zip
+if exist "%TEMP%\7za920.zip" (
+    del /Q %TEMP%\7za920.zip
+)
 rmdir /S /Q %TEMP%\openjdk-%jdk_version%
 del /Q %TEMP%\%jdk_filename%.tar
 del /Q %TEMP%\%jdk_filename%.tar.gz


### PR DESCRIPTION
Do not download 7zip if it had previously been downloaded, for example
if this script had previously been run. And don't delete it at the end
of this script in case this script is run again. This is an attempt to
save time and bandwidth.