### PR TITLE
Focus color of buttons should be more saturated/darker (Issue #2134)

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -298,12 +298,12 @@ bg color of non edit textFields: fafafa
     -fx-cursor: hand;
 }
 
-.jfx-button:hover {
-    -fx-background-color: derive(-bs-rd-grey-light, 30%);
+.jfx-button:hover, .jfx-button:focused {
+    -fx-background-color: derive(-bs-rd-grey-light, -30%);
 }
 
-.action-button:hover {
-    -fx-background-color: derive(-bs-rd-green-dark, 30%);
+.action-button:hover, .action-button:focused {
+    -fx-background-color: derive(-bs-rd-green-dark, -30%);
 }
 
 .action-button {
@@ -1718,8 +1718,9 @@ textfield */
     -fx-text-fill: -bs-rd-white;
 }
 
-#buy-button-big:hover, #buy-button:hover {
-    -fx-background-color: derive(-bs-buy, 30%);
+#buy-button-big:hover, #buy-button:hover, 
+#buy-button-big:focused, #buy-button:focused {
+    -fx-background-color: derive(-bs-buy, -30%);
 }
 
 #sell-button-big {
@@ -1733,8 +1734,9 @@ textfield */
     -fx-text-fill: -bs-rd-white;
 }
 
-#sell-button-big:hover, #sell-button:hover {
-    -fx-background-color: derive(-bs-sell, 30%);
+#sell-button-big:hover, #sell-button:hover,
+#sell-button-big:focused, #sell-button:focused {
+    -fx-background-color: derive(-bs-sell, -30%);
 }
 
 #sell-button-big.grey-style, #buy-button-big.grey-style,


### PR DESCRIPTION
Issue #2134 reports an issue with hovering or tabbing focus onto a button lightens the button rather than darkens it, making it more apt to appear disabled.

This PR corrects this behavior by changing the derived color on hover and focused to -30% rather than +30%.

One potential remaining issue is the action that occurs when the button is focused upon tabbing; there is an animated effect that dims the button.  While it is now darker than previous, it still becomes somewhat washed out and not as vivid as a mouse hover. 