### PR TITLE
Remove "pricenode" direct dependency on "assets"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,7 +354,6 @@ configure(project(':pricenode')) {
 
     dependencies {
         compile project(":core")
-        compile project(":assets")
         compile("org.knowm.xchange:xchange-bitcoinaverage:4.3.3")
         compile("org.knowm.xchange:xchange-coinmarketcap:4.3.3")
         compile("org.knowm.xchange:xchange-poloniex:4.3.3")


### PR DESCRIPTION
It depends on "assets" already because it is a depencendy of "core"