### PR TITLE
Update offer button state on account change

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
@@ -178,7 +178,7 @@ class TakeOfferDataModel extends OfferDataModel {
 
         ObservableList<PaymentAccount> possiblePaymentAccounts = getPossiblePaymentAccounts();
         checkArgument(!possiblePaymentAccounts.isEmpty(), "possiblePaymentAccounts.isEmpty()");
-        paymentAccount = possiblePaymentAccounts.get(0);
+        paymentAccount = getLastSelectedPaymentAccount();
 
         long myLimit = accountAgeWitnessService.getMyTradeLimit(paymentAccount, getCurrencyCode());
         this.amount.set(Coin.valueOf(Math.min(offer.getAmount().value, myLimit)));
@@ -411,7 +411,7 @@ class TakeOfferDataModel extends OfferDataModel {
             this.paymentAccount = paymentAccount;
 
             long myLimit = accountAgeWitnessService.getMyTradeLimit(paymentAccount, getCurrencyCode());
-            this.amount.set(Coin.valueOf(Math.min(amount.get().value, myLimit)));
+            this.amount.set(Coin.valueOf(Math.max(offer.getMinAmount().value, Math.min(amount.get().value, myLimit))));
 
             preferences.setTakeOfferSelectedPaymentAccountId(paymentAccount.getId());
         }

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -282,9 +282,10 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         volumeDescriptionLabel.setText(model.volumeDescriptionLabel.get());
 
         if (model.getPossiblePaymentAccounts().size() > 1) {
+            PaymentAccount lastPaymentAccount = model.getLastSelectedPaymentAccount();
             paymentAccountsComboBox.setItems(model.getPossiblePaymentAccounts());
-            paymentAccountsComboBox.getSelectionModel().select(model.getLastSelectedPaymentAccount());
-
+            paymentAccountsComboBox.getSelectionModel().select(lastPaymentAccount);
+            model.onPaymentAccountSelected(lastPaymentAccount);
             paymentAccountTitledGroupBg.setText(Res.get("shared.selectTradingAccount"));
 
             // TODO if we have multiple payment accounts we should show some info/warning to

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -246,6 +246,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     public void onPaymentAccountSelected(PaymentAccount paymentAccount) {
         dataModel.onPaymentAccountSelected(paymentAccount);
         btcValidator.setMaxTradeLimit(Coin.valueOf(Math.min(dataModel.getMaxTradeLimit(), offer.getAmount().value)));
+        updateButtonDisableState();
     }
 
     public void onShowPayFundsScreen() {


### PR DESCRIPTION
fixes #2204 

Add updateButtonDisabledState() to onPaymentAccountSelected() in
TakeOfferViewModel since changing the account dropdown in the take
offer screen does not trigger an update of the "Next Step" button.

The default amount of an offer should not change to less than what is
actually offered, change onPaymentAccountSelected() in
TakeOfferDataModel to take into account the min. amount offered.

In TakeOfferView, the payment account defaults to the last one
selected.  Make sure TakeOfferViewModel and TakeOfferDataModel take
this into account in a couple locations.