### PR TITLE
Configure default system JDK

### DIFF
--- a/scripts/install_java.bat
+++ b/scripts/install_java.bat
@@ -1,3 +1,9 @@
+:: This script will download and install the appropriate JDK for use with Bisq development.
+:: It will also configure it as the default system JDK.
+:: If you need to change to another default JDK for another purpose later, you just need to
+:: change the JAVA_HOME environment variable. For example, use the following command:
+::     setx /M JAVA_HOME "<JDK_PATH>"
+
 @echo off
 
 :: Ensure we have administrative privileges in order to install files and set environment variables

--- a/scripts/install_java.sh
+++ b/scripts/install_java.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# This script will download and install the appropriate JDK for use with Bisq development.
+# It will also configure it as the default system JDK.
+# If you need to change to another default JDK for another purpose later, you can use the
+# following commands and select the default JDK:
+#     update-alternatives --config java
+#     update-alternatives --config javac
 
 JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
 JDK_FILENAME=openjdk-10.0.2_linux-x64_bin.tar.gz
@@ -31,3 +37,6 @@ if [ ! -d "$JAVA_HOME" ]; then
     update-alternatives --install /usr/bin/java java $JAVA_HOME/bin/java 2000
     update-alternatives --install /usr/bin/javac javac $JAVA_HOME/bin/javac 2000
 fi
+
+update-alternatives --set java $JAVA_HOME/bin/java
+update-alternatives --set javac $JAVA_HOME/bin/javac


### PR DESCRIPTION
The install_java.sh script was not setting the appropriate java and
javac as default. This is not an issue if no other JDK is installed, but
if so it could cause the wrong JDK to be used. So it now sets the
appropriate default system JDK.

Also, added a comment at the top of the install_java.sh and
install_java.bat files indicating it configures the default system
JDK and informs the user how to go about selecting a different
default JDK if necessary.