### PR TITLE
Add validation for trade statistics

### DIFF
--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -263,6 +263,10 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
         }
     }
 
+    public boolean isValid() {
+        return tradeAmount > 0 && tradePrice > 0;
+    }
+
     @Override
     public String toString() {
         return "TradeStatistics2{" +


### PR DESCRIPTION
We got a trade statistics object with price and amount 0. Unclear why
that can happen (maybe some dev was debugging things or it was created
with the API). We need to add validation when creating and publishing
a trade statistics object as well. This is just a fast fix for getting
a new release out.

Fixes #2222 and #2223