### PR TITLE
fix the wrong ticker name from SPACE to XSC in Coin second param

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/SpaceCash.java
+++ b/assets/src/main/java/bisq/asset/coins/SpaceCash.java
@@ -23,6 +23,6 @@ import bisq.asset.RegexAddressValidator;
 public class SpaceCash extends Coin {
 
     public SpaceCash() {
-        super("SpaceCash", "SPACE", new RegexAddressValidator("^([0-9a-z]{76})$"));
+        super("SpaceCash", "XSC", new RegexAddressValidator("^([0-9a-z]{76})$"));
     }
 }


### PR DESCRIPTION
we use a wrong param in the pr before, fix that in this pr

the pr before:
https://github.com/bisq-network/bisq/pull/1970
