### PR TITLE
Add basic stubs for buyer-as-maker trade protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk: openjdk10
 before_install:
-  grep -v '^#' src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
+  grep -v '^#' assets/src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
 notifications:
   slack:
     on_success: change

--- a/assets/src/main/java/bisq/asset/coins/Australiacash.java
+++ b/assets/src/main/java/bisq/asset/coins/Australiacash.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class Australiacash extends Coin {
+    public Australiacash() {
+        super("Australiacash", "AUS", new Base58BitcoinAddressValidator(new AustraliacashParams()));
+    }
+	   public static class AustraliacashParams extends NetworkParametersAdapter {
+
+        public AustraliacashParams() {
+            addressHeader = 23;
+            p2shHeader = 5;
+            acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+        }
+    }
+}

--- a/assets/src/main/java/bisq/asset/coins/DeepOnion.java
+++ b/assets/src/main/java/bisq/asset/coins/DeepOnion.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AddressValidationResult;
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+import org.libdohj.params.DashMainNetParams;
+
+public class DeepOnion extends Coin {
+    public DeepOnion() {
+        super("DeepOnion", "ONION", new DeepOnionAddressValidator());
+    }
+
+    public static class DeepOnionAddressValidator extends Base58BitcoinAddressValidator {
+
+        public DeepOnionAddressValidator() {
+            super(new DeepOnionParams());
+        }
+
+        @Override
+        public AddressValidationResult validate(String address) {
+            if (!address.matches("^[D][a-km-zA-HJ-NP-Z1-9]{24,33}$"))
+                return AddressValidationResult.invalidStructure();
+
+            return super.validate(address);
+        }
+    }
+
+    public static class DeepOnionParams extends NetworkParametersAdapter {
+
+        public DeepOnionParams() {
+            super();
+            addressHeader = 31;
+            p2shHeader = 78;
+            acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+        }
+    }
+}

--- a/assets/src/main/java/bisq/asset/coins/Persona.java
+++ b/assets/src/main/java/bisq/asset/coins/Persona.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Coin;
+import bisq.asset.RegexAddressValidator;
+
+public class Persona extends Coin {
+
+    public Persona() {
+        super("Persona", "PRSN", new RegexAddressValidator("^[P][a-km-zA-HJ-NP-Z1-9]{33}$"));
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -5,9 +5,9 @@
 bisq.asset.coins.Actinium
 bisq.asset.coins.Aeon
 bisq.asset.coins.Beam
-bisq.asset.coins.BitcoinRhodium
 bisq.asset.coins.Bitcoin$Mainnet
 bisq.asset.coins.Bitcoin$Regtest
+bisq.asset.coins.BitcoinRhodium
 bisq.asset.coins.Bitcoin$Testnet
 bisq.asset.coins.Bitmark
 bisq.asset.coins.Blur
@@ -25,10 +25,10 @@ bisq.asset.coins.Dogecoin
 bisq.asset.coins.Dragonglass
 bisq.asset.coins.Ether
 bisq.asset.coins.EtherClassic
-bisq.asset.coins.GambleCoin
-bisq.asset.coins.Grin
 bisq.asset.coins.FourtyTwo
+bisq.asset.coins.GambleCoin
 bisq.asset.coins.Gridcoin
+bisq.asset.coins.Grin
 bisq.asset.coins.Horizen
 bisq.asset.coins.IdaPay
 bisq.asset.coins.Iridium

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -4,6 +4,7 @@
 # See https://bisq.network/list-asset for complete instructions.
 bisq.asset.coins.Actinium
 bisq.asset.coins.Aeon
+bisq.asset.coins.Australiacash
 bisq.asset.coins.Beam
 bisq.asset.coins.BitcoinRhodium
 bisq.asset.coins.Bitcoin$Mainnet

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -41,6 +41,7 @@ bisq.asset.coins.MoX
 bisq.asset.coins.Namecoin
 bisq.asset.coins.Neos
 bisq.asset.coins.Noir
+bisq.asset.coins.Persona
 bisq.asset.coins.Pinkcoin
 bisq.asset.coins.PIVX
 bisq.asset.coins.PZDC

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -21,6 +21,7 @@ bisq.asset.coins.Croat
 bisq.asset.coins.Dash
 bisq.asset.coins.Decred
 bisq.asset.coins.Dextro
+bisq.asset.coins.DeepOnion
 bisq.asset.coins.Dogecoin
 bisq.asset.coins.Dragonglass
 bisq.asset.coins.Ether

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -21,8 +21,8 @@ bisq.asset.coins.Counterparty
 bisq.asset.coins.Croat
 bisq.asset.coins.Dash
 bisq.asset.coins.Decred
-bisq.asset.coins.Dextro
 bisq.asset.coins.DeepOnion
+bisq.asset.coins.Dextro
 bisq.asset.coins.Dogecoin
 bisq.asset.coins.Dragonglass
 bisq.asset.coins.Ether

--- a/assets/src/test/java/bisq/asset/coins/AustraliacashTest.java
+++ b/assets/src/test/java/bisq/asset/coins/AustraliacashTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class AustraliacashTest extends AbstractAssetTest {
+
+    public AustraliacashTest() {
+        super(new Australiacash());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("AYf2TGCoQ15HatyE99R3q9jVcXHLx1zRWW");
+        assertValidAddress("Aahw1A79we2jUbTaamP5YALh21GSxiWTZa");
+        assertValidAddress("ALp3R9W3QsCdqaNNcULySXN31dYvfvDkRU");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("1ALp3R9W3QsCdqaNNcULySXN31dYvfvDkRU");
+        assertInvalidAddress("ALp3R9W3QsCdrqaNNcULySXN31dYvfvDkRU");
+        assertInvalidAddress("ALp3R9W3QsCdqaNNcULySXN31dYvfvDkRU#");
+    }
+}

--- a/assets/src/test/java/bisq/asset/coins/DeepOnionTest.java
+++ b/assets/src/test/java/bisq/asset/coins/DeepOnionTest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class DeepOnionTest extends AbstractAssetTest {
+
+    public DeepOnionTest() {
+        super(new DeepOnion());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("DYQLyJ1CcxJyRBujtKdv2JDkQEkEkAzNNA");
+        assertValidAddress("DW7YKfPgm7fdTNGyyaSVfQhY7ccBoeVK5D");
+        assertValidAddress("DsA31xPpijxiCuTQeYMpMTQsTH1m2jTgtS");
+
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("1sA31xPpijxiCuTQeYMpMTQsTH1m2jTgtS");
+        assertInvalidAddress("DsA31xPpijxiCuTQeYMpMTQsTH1m2jTgtSd");
+        assertInvalidAddress("DsA31xPpijxiCuTQeYMpMTQsTH1m2jTgt#");
+    }
+}

--- a/assets/src/test/java/bisq/asset/coins/PersonaTest.java
+++ b/assets/src/test/java/bisq/asset/coins/PersonaTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class PersonaTest extends AbstractAssetTest {
+
+    public PersonaTest() {
+        super(new Persona());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("PV5PbsyhkM1RkN41QiSXy7cisbZ4kBzm51");
+        assertValidAddress("PJACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zA");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("");
+        assertInvalidAddress("LJACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zA");
+        assertInvalidAddress("TJACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zA");
+        assertInvalidAddress("PJACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zAA");
+        assertInvalidAddress("PlACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zA");
+        assertInvalidAddress("PIACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zA");
+        assertInvalidAddress("POACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zA");
+        assertInvalidAddress("P0ACMZ2tMMZzQ8H9mWPHJcB7uYP47BM2zA");
+    }
+}
+
+

--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -74,7 +74,7 @@ public class Version {
     // If objects are used for both network and database the network version is applied.
     // VERSION = 0.5.0 -> P2P_NETWORK_VERSION = 1
     @SuppressWarnings("ConstantConditions")
-    public static final int P2P_NETWORK_VERSION = 1;
+    public static final int P2P_NETWORK_VERSION = 2;
 
     // The version no. of the serialized data stored to disc. A change will break the serialization of old objects.
     // VERSION = 0.5.0 -> LOCAL_DB_VERSION = 1
@@ -83,7 +83,7 @@ public class Version {
     // The version no. of the current protocol. The offer holds that version.
     // A taker will check the version of the offers to see if his version is compatible.
     // VERSION = 0.5.0 -> TRADE_PROTOCOL_VERSION = 1
-    public static final int TRADE_PROTOCOL_VERSION = 1;
+    public static final int TRADE_PROTOCOL_VERSION = 2;
     private static int p2pMessageVersion;
 
     public static final String BSQ_TX_VERSION = "1";

--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -37,7 +37,7 @@ message NetworkEnvelope {
         PrefixedSealedAndSignedMessage prefixed_sealed_and_signed_message = 16;
 
         PayDepositRequest pay_deposit_request = 17;
-        PublishDepositTxRequest publish_deposit_tx_request = 18;
+        CompleteDepositTxRequest complete_deposit_tx_request = 18;
         DepositTxPublishedMessage deposit_tx_published_message = 19;
         CounterCurrencyTransferStartedMessage counter_currency_transfer_started_message = 20;
         PayoutTxPublishedMessage payout_tx_published_message = 21;
@@ -57,6 +57,9 @@ message NetworkEnvelope {
         AddPersistableNetworkPayloadMessage add_persistable_network_payload_message = 31;
         AckMessage ack_message = 32;
         RepublishGovernanceDataRequest republish_governance_data_request = 33;
+
+        SignTLPayoutTxMessage sign_t_l_payout_tx_message = 34;
+        PublishDepositTxRequest publish_deposit_tx_request = 35;
     }
 }
 
@@ -205,7 +208,23 @@ message PayDepositRequest {
     int64 current_date = 23;
 }
 
+// TODO impl data
+message SignTLPayoutTxMessage {
+    string trade_id = 1;
+    bytes deposit_tx = 2;
+    NodeAddress sender_node_address = 3;
+    string uid = 4;
+}
+
+// TODO impl data
 message PublishDepositTxRequest {
+    string trade_id = 1;
+    bytes deposit_tx = 2;
+    NodeAddress sender_node_address = 3;
+    string uid = 4;
+}
+
+message CompleteDepositTxRequest {
     string trade_id = 1;
     PaymentAccountPayload maker_payment_account_payload = 2;
     string maker_account_id = 3;

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -36,11 +36,11 @@ import bisq.core.offer.OfferPayload;
 import bisq.core.offer.messages.OfferAvailabilityRequest;
 import bisq.core.offer.messages.OfferAvailabilityResponse;
 import bisq.core.proto.CoreProtoResolver;
+import bisq.core.trade.messages.CompleteDepositTxRequest;
 import bisq.core.trade.messages.CounterCurrencyTransferStartedMessage;
 import bisq.core.trade.messages.DepositTxPublishedMessage;
 import bisq.core.trade.messages.PayDepositRequest;
 import bisq.core.trade.messages.PayoutTxPublishedMessage;
-import bisq.core.trade.messages.PublishDepositTxRequest;
 import bisq.core.trade.statistics.TradeStatistics;
 
 import bisq.network.p2p.AckMessage;
@@ -127,7 +127,7 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case DEPOSIT_TX_PUBLISHED_MESSAGE:
                     return DepositTxPublishedMessage.fromProto(proto.getDepositTxPublishedMessage(), messageVersion);
                 case PUBLISH_DEPOSIT_TX_REQUEST:
-                    return PublishDepositTxRequest.fromProto(proto.getPublishDepositTxRequest(), this, messageVersion);
+                    return CompleteDepositTxRequest.fromProto(proto.getPublishDepositTxRequest(), this, messageVersion);
                 case COUNTER_CURRENCY_TRANSFER_STARTED_MESSAGE:
                     return CounterCurrencyTransferStartedMessage.fromProto(proto.getCounterCurrencyTransferStartedMessage(), messageVersion);
                 case PAYOUT_TX_PUBLISHED_MESSAGE:

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -41,6 +41,8 @@ import bisq.core.trade.messages.CounterCurrencyTransferStartedMessage;
 import bisq.core.trade.messages.DepositTxPublishedMessage;
 import bisq.core.trade.messages.PayDepositRequest;
 import bisq.core.trade.messages.PayoutTxPublishedMessage;
+import bisq.core.trade.messages.PublishDepositTxRequest;
+import bisq.core.trade.messages.SignTLPayoutTxMessage;
 import bisq.core.trade.statistics.TradeStatistics;
 
 import bisq.network.p2p.AckMessage;
@@ -124,10 +126,14 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
 
                 case PAY_DEPOSIT_REQUEST:
                     return PayDepositRequest.fromProto(proto.getPayDepositRequest(), this, messageVersion);
+                case SIGN_T_L_PAYOUT_TX_MESSAGE:
+                    return SignTLPayoutTxMessage.fromProto(proto.getSignTLPayoutTxMessage(), messageVersion);
+                case PUBLISH_DEPOSIT_TX_REQUEST:
+                    return PublishDepositTxRequest.fromProto(proto.getPublishDepositTxRequest(), messageVersion);
                 case DEPOSIT_TX_PUBLISHED_MESSAGE:
                     return DepositTxPublishedMessage.fromProto(proto.getDepositTxPublishedMessage(), messageVersion);
-                case PUBLISH_DEPOSIT_TX_REQUEST:
-                    return CompleteDepositTxRequest.fromProto(proto.getPublishDepositTxRequest(), this, messageVersion);
+                case COMPLETE_DEPOSIT_TX_REQUEST:
+                    return CompleteDepositTxRequest.fromProto(proto.getCompleteDepositTxRequest(), this, messageVersion);
                 case COUNTER_CURRENCY_TRANSFER_STARTED_MESSAGE:
                     return CounterCurrencyTransferStartedMessage.fromProto(proto.getCounterCurrencyTransferStartedMessage(), messageVersion);
                 case PAYOUT_TX_PUBLISHED_MESSAGE:

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -120,6 +120,7 @@ public abstract class Trade implements Tradable, Model {
 
 
         // #################### Phase DEPOSIT_PAID
+        SELLER_TAKER_COMPLETED_DEPOSIT_TX(Phase.TAKER_FEE_PUBLISHED),
         TAKER_PUBLISHED_DEPOSIT_TX(Phase.DEPOSIT_PUBLISHED),
 
 

--- a/core/src/main/java/bisq/core/trade/messages/CompleteDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/CompleteDepositTxRequest.java
@@ -47,7 +47,7 @@ import javax.annotation.Nullable;
 // continue later to complete the deposit tx.
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class PublishDepositTxRequest extends TradeMessage implements MailboxMessage {
+public final class CompleteDepositTxRequest extends TradeMessage implements MailboxMessage {
     private final PaymentAccountPayload makerPaymentAccountPayload;
     private final String makerAccountId;
     private final byte[] makerMultiSigPubKey;
@@ -63,19 +63,19 @@ public final class PublishDepositTxRequest extends TradeMessage implements Mailb
     private final byte[] accountAgeWitnessSignatureOfPreparedDepositTx;
     private final long currentDate;
 
-    public PublishDepositTxRequest(String tradeId,
-                                   PaymentAccountPayload makerPaymentAccountPayload,
-                                   String makerAccountId,
-                                   byte[] makerMultiSigPubKey,
-                                   String makerContractAsJson,
-                                   String makerContractSignature,
-                                   String makerPayoutAddressString,
-                                   byte[] preparedDepositTx,
-                                   List<RawTransactionInput> makerInputs,
-                                   NodeAddress senderNodeAddress,
-                                   String uid,
-                                   @Nullable byte[] accountAgeWitnessSignatureOfPreparedDepositTx,
-                                   long currentDate) {
+    public CompleteDepositTxRequest(String tradeId,
+                                    PaymentAccountPayload makerPaymentAccountPayload,
+                                    String makerAccountId,
+                                    byte[] makerMultiSigPubKey,
+                                    String makerContractAsJson,
+                                    String makerContractSignature,
+                                    String makerPayoutAddressString,
+                                    byte[] preparedDepositTx,
+                                    List<RawTransactionInput> makerInputs,
+                                    NodeAddress senderNodeAddress,
+                                    String uid,
+                                    @Nullable byte[] accountAgeWitnessSignatureOfPreparedDepositTx,
+                                    long currentDate) {
         this(tradeId,
                 makerPaymentAccountPayload,
                 makerAccountId,
@@ -97,20 +97,20 @@ public final class PublishDepositTxRequest extends TradeMessage implements Mailb
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private PublishDepositTxRequest(String tradeId,
-                                    PaymentAccountPayload makerPaymentAccountPayload,
-                                    String makerAccountId,
-                                    byte[] makerMultiSigPubKey,
-                                    String makerContractAsJson,
-                                    String makerContractSignature,
-                                    String makerPayoutAddressString,
-                                    byte[] preparedDepositTx,
-                                    List<RawTransactionInput> makerInputs,
-                                    NodeAddress senderNodeAddress,
-                                    String uid,
-                                    int messageVersion,
-                                    @Nullable byte[] accountAgeWitnessSignatureOfPreparedDepositTx,
-                                    long currentDate) {
+    private CompleteDepositTxRequest(String tradeId,
+                                     PaymentAccountPayload makerPaymentAccountPayload,
+                                     String makerAccountId,
+                                     byte[] makerMultiSigPubKey,
+                                     String makerContractAsJson,
+                                     String makerContractSignature,
+                                     String makerPayoutAddressString,
+                                     byte[] preparedDepositTx,
+                                     List<RawTransactionInput> makerInputs,
+                                     NodeAddress senderNodeAddress,
+                                     String uid,
+                                     int messageVersion,
+                                     @Nullable byte[] accountAgeWitnessSignatureOfPreparedDepositTx,
+                                     long currentDate) {
         super(messageVersion, tradeId, uid);
         this.makerPaymentAccountPayload = makerPaymentAccountPayload;
         this.makerAccountId = makerAccountId;
@@ -148,12 +148,12 @@ public final class PublishDepositTxRequest extends TradeMessage implements Mailb
                 .build();
     }
 
-    public static PublishDepositTxRequest fromProto(PB.PublishDepositTxRequest proto, CoreProtoResolver coreProtoResolver, int messageVersion) {
+    public static CompleteDepositTxRequest fromProto(PB.PublishDepositTxRequest proto, CoreProtoResolver coreProtoResolver, int messageVersion) {
         List<RawTransactionInput> makerInputs = proto.getMakerInputsList().stream()
                 .map(RawTransactionInput::fromProto)
                 .collect(Collectors.toList());
 
-        return new PublishDepositTxRequest(proto.getTradeId(),
+        return new CompleteDepositTxRequest(proto.getTradeId(),
                 coreProtoResolver.fromProto(proto.getMakerPaymentAccountPayload()),
                 proto.getMakerAccountId(),
                 proto.getMakerMultiSigPubKey().toByteArray(),
@@ -172,7 +172,7 @@ public final class PublishDepositTxRequest extends TradeMessage implements Mailb
 
     @Override
     public String toString() {
-        return "PublishDepositTxRequest{" +
+        return "CompleteDepositTxRequest{" +
                 "\n     makerPaymentAccountPayload=" + makerPaymentAccountPayload +
                 ",\n     makerAccountId='" + makerAccountId + '\'' +
                 ",\n     makerMultiSigPubKey=" + Utilities.bytesAsHexString(makerMultiSigPubKey) +

--- a/core/src/main/java/bisq/core/trade/messages/CompleteDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/CompleteDepositTxRequest.java
@@ -130,7 +130,7 @@ public final class CompleteDepositTxRequest extends TradeMessage implements Mail
 
     @Override
     public PB.NetworkEnvelope toProtoNetworkEnvelope() {
-        final PB.PublishDepositTxRequest.Builder builder = PB.PublishDepositTxRequest.newBuilder()
+        final PB.CompleteDepositTxRequest.Builder builder = PB.CompleteDepositTxRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setMakerPaymentAccountPayload((PB.PaymentAccountPayload) makerPaymentAccountPayload.toProtoMessage())
                 .setMakerAccountId(makerAccountId)
@@ -147,11 +147,11 @@ public final class CompleteDepositTxRequest extends TradeMessage implements Mail
         builder.setCurrentDate(currentDate);
 
         return getNetworkEnvelopeBuilder()
-                .setPublishDepositTxRequest(builder)
+                .setCompleteDepositTxRequest(builder)
                 .build();
     }
 
-    public static CompleteDepositTxRequest fromProto(PB.PublishDepositTxRequest proto, CoreProtoResolver coreProtoResolver, int messageVersion) {
+    public static CompleteDepositTxRequest fromProto(PB.CompleteDepositTxRequest proto, CoreProtoResolver coreProtoResolver, int messageVersion) {
         List<RawTransactionInput> makerInputs = proto.getMakerInputsList().stream()
                 .map(RawTransactionInput::fromProto)
                 .collect(Collectors.toList());

--- a/core/src/main/java/bisq/core/trade/messages/CompleteDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/CompleteDepositTxRequest.java
@@ -42,6 +42,9 @@ import lombok.Value;
 
 import javax.annotation.Nullable;
 
+//TODO @Craig: that comment need to be updated with the new protocol and the message should probably change to a DirectMessage
+// instead of a MailboxMessage (TradeMessage implements already DirectMessage)
+
 // We use a MailboxMessage here because the taker has paid already the trade fee and it could be that
 // we lost connection to him but we are complete on our side. So even if the peer is offline he can
 // continue later to complete the deposit tx.

--- a/core/src/main/java/bisq/core/trade/messages/PublishDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/PublishDepositTxRequest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.messages;
+
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.app.Version;
+
+import io.bisq.generated.protobuffer.PB;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+//TODO implement
+@EqualsAndHashCode(callSuper = true)
+@Value
+public final class PublishDepositTxRequest extends TradeMessage {
+    private final NodeAddress senderNodeAddress;
+
+    public PublishDepositTxRequest(String tradeId,
+                                   NodeAddress senderNodeAddress,
+                                   String uid) {
+        this(tradeId,
+                senderNodeAddress,
+                uid,
+                Version.getP2PMessageVersion());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private PublishDepositTxRequest(String tradeId,
+                                    NodeAddress senderNodeAddress,
+                                    String uid,
+                                    int messageVersion) {
+        super(messageVersion, tradeId, uid);
+        this.senderNodeAddress = senderNodeAddress;
+    }
+
+
+    @Override
+    public PB.NetworkEnvelope toProtoNetworkEnvelope() {
+        return getNetworkEnvelopeBuilder()
+                .setPublishDepositTxRequest(PB.PublishDepositTxRequest.newBuilder()
+                        .setTradeId(tradeId)
+                        .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
+                        .setUid(uid))
+                .build();
+    }
+
+    public static PublishDepositTxRequest fromProto(PB.PublishDepositTxRequest proto, int messageVersion) {
+        return new PublishDepositTxRequest(proto.getTradeId(),
+                NodeAddress.fromProto(proto.getSenderNodeAddress()),
+                proto.getUid(),
+                messageVersion);
+    }
+
+
+    @Override
+    public String toString() {
+        return "PublishDepositTxRequest{" +
+                ",\n     senderNodeAddress=" + senderNodeAddress +
+                ",\n     uid='" + uid + '\'' +
+                "\n} " + super.toString();
+    }
+}

--- a/core/src/main/java/bisq/core/trade/messages/SignTLPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/SignTLPayoutTxMessage.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.messages;
+
+import bisq.network.p2p.MailboxMessage;
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.app.Version;
+
+import io.bisq.generated.protobuffer.PB;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+//TODO implement
+@EqualsAndHashCode(callSuper = true)
+@Value
+public final class SignTLPayoutTxMessage extends TradeMessage implements MailboxMessage {
+    private final NodeAddress senderNodeAddress;
+
+    public SignTLPayoutTxMessage(String tradeId,
+                                 NodeAddress senderNodeAddress,
+                                 String uid) {
+        this(tradeId,
+                senderNodeAddress,
+                uid,
+                Version.getP2PMessageVersion());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private SignTLPayoutTxMessage(String tradeId,
+                                  NodeAddress senderNodeAddress,
+                                  String uid,
+                                  int messageVersion) {
+        super(messageVersion, tradeId, uid);
+        this.senderNodeAddress = senderNodeAddress;
+    }
+
+
+    @Override
+    public PB.NetworkEnvelope toProtoNetworkEnvelope() {
+        return getNetworkEnvelopeBuilder()
+                .setDepositTxPublishedMessage(PB.DepositTxPublishedMessage.newBuilder()
+                        .setTradeId(tradeId)
+                        .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
+                        .setUid(uid))
+                .build();
+    }
+
+    public static SignTLPayoutTxMessage fromProto(PB.DepositTxPublishedMessage proto, int messageVersion) {
+        return new SignTLPayoutTxMessage(proto.getTradeId(),
+                NodeAddress.fromProto(proto.getSenderNodeAddress()),
+                proto.getUid(),
+                messageVersion);
+    }
+
+
+    @Override
+    public String toString() {
+        return "DepositTxPublishedMessage{" +
+                ",\n     senderNodeAddress=" + senderNodeAddress +
+                ",\n     uid='" + uid + '\'' +
+                "\n} " + super.toString();
+    }
+}

--- a/core/src/main/java/bisq/core/trade/messages/SignTLPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/SignTLPayoutTxMessage.java
@@ -17,7 +17,6 @@
 
 package bisq.core.trade.messages;
 
-import bisq.network.p2p.MailboxMessage;
 import bisq.network.p2p.NodeAddress;
 
 import bisq.common.app.Version;
@@ -30,7 +29,7 @@ import lombok.Value;
 //TODO implement
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class SignTLPayoutTxMessage extends TradeMessage implements MailboxMessage {
+public final class SignTLPayoutTxMessage extends TradeMessage {
     private final NodeAddress senderNodeAddress;
 
     public SignTLPayoutTxMessage(String tradeId,

--- a/core/src/main/java/bisq/core/trade/messages/SignTLPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/SignTLPayoutTxMessage.java
@@ -57,14 +57,14 @@ public final class SignTLPayoutTxMessage extends TradeMessage {
     @Override
     public PB.NetworkEnvelope toProtoNetworkEnvelope() {
         return getNetworkEnvelopeBuilder()
-                .setDepositTxPublishedMessage(PB.DepositTxPublishedMessage.newBuilder()
+                .setSignTLPayoutTxMessage(PB.SignTLPayoutTxMessage.newBuilder()
                         .setTradeId(tradeId)
                         .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
                         .setUid(uid))
                 .build();
     }
 
-    public static SignTLPayoutTxMessage fromProto(PB.DepositTxPublishedMessage proto, int messageVersion) {
+    public static SignTLPayoutTxMessage fromProto(PB.SignTLPayoutTxMessage proto, int messageVersion) {
         return new SignTLPayoutTxMessage(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
@@ -34,7 +34,7 @@ import bisq.core.trade.protocol.tasks.buyer_as_maker.BuyerAsMakerSignPayoutTx;
 import bisq.core.trade.protocol.tasks.maker.MakerCreateAndSignContract;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessPayDepositRequest;
-import bisq.core.trade.protocol.tasks.maker.MakerSendPublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.maker.MakerSendCompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.maker.MakerSetupDepositTxListener;
 import bisq.core.trade.protocol.tasks.maker.MakerVerifyTakerAccount;
 import bisq.core.trade.protocol.tasks.maker.MakerVerifyTakerFeePayment;
@@ -136,7 +136,7 @@ public class BuyerAsMakerProtocol extends TradeProtocol implements BuyerProtocol
                 MakerCreateAndSignContract.class,
                 BuyerAsMakerCreatesAndSignsDepositTx.class,
                 MakerSetupDepositTxListener.class,
-                MakerSendPublishDepositTxRequest.class
+                MakerSendCompleteDepositTxRequest.class
         );
         // We don't use a timeout here because if the DepositTxPublishedMessage does not arrive we
         // get the deposit tx set at MakerSetupDepositTxListener once it is seen in the bitcoin network

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
@@ -150,6 +150,20 @@ public class BuyerAsMakerProtocol extends TradeProtocol implements BuyerProtocol
     // Incoming message handling
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    private void handle(SignTLPayoutTxMessage tradeMessage, NodeAddress peerNodeAddress) {
+        processModel.setTradeMessage(tradeMessage);
+        processModel.setTempTradingPeerNodeAddress(peerNodeAddress);
+
+        TradeTaskRunner taskRunner = new TradeTaskRunner(buyerAsMakerTrade,
+                () -> handleTaskRunnerSuccess(tradeMessage, "handle SignTLPayoutTxMessage"),
+                errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
+
+        taskRunner.addTasks(
+                BuyerAsMakerProcessSignTLPayoutTxMessage.class
+        );
+        taskRunner.run();
+    }
+
     private void handle(DepositTxPublishedMessage tradeMessage, NodeAddress peerNodeAddress) {
         processModel.setTradeMessage(tradeMessage);
         processModel.setTempTradingPeerNodeAddress(peerNodeAddress);
@@ -205,20 +219,6 @@ public class BuyerAsMakerProtocol extends TradeProtocol implements BuyerProtocol
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Incoming message handling
     ///////////////////////////////////////////////////////////////////////////////////////////
-
-    private void handle(SignTLPayoutTxMessage tradeMessage, NodeAddress peerNodeAddress) {
-        processModel.setTradeMessage(tradeMessage);
-        processModel.setTempTradingPeerNodeAddress(peerNodeAddress);
-
-        TradeTaskRunner taskRunner = new TradeTaskRunner(buyerAsMakerTrade,
-                () -> handleTaskRunnerSuccess(tradeMessage, "handle SignTLPayoutTxMessage"),
-                errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
-
-        taskRunner.addTasks(
-                BuyerAsMakerProcessSignTLPayoutTxMessage.class
-        );
-        taskRunner.run();
-    }
 
     private void handle(PayoutTxPublishedMessage tradeMessage, NodeAddress peerNodeAddress) {
         processModel.setTradeMessage(tradeMessage);

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
@@ -32,7 +32,9 @@ import bisq.core.trade.protocol.tasks.buyer.BuyerSendCounterCurrencyTransferStar
 import bisq.core.trade.protocol.tasks.buyer.BuyerSetupPayoutTxListener;
 import bisq.core.trade.protocol.tasks.buyer_as_maker.BuyerAsMakerCreatesAndSignsDepositTx;
 import bisq.core.trade.protocol.tasks.buyer_as_maker.BuyerAsMakerProcessSignTLPayoutTxMessage;
+import bisq.core.trade.protocol.tasks.buyer_as_maker.BuyerAsMakerSendsPublishDepositTxMessage;
 import bisq.core.trade.protocol.tasks.buyer_as_maker.BuyerAsMakerSignPayoutTx;
+import bisq.core.trade.protocol.tasks.buyer_as_maker.BuyerAsMakerSignsTLPayoutTx;
 import bisq.core.trade.protocol.tasks.maker.MakerCreateAndSignContract;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessPayDepositRequest;
@@ -159,7 +161,9 @@ public class BuyerAsMakerProtocol extends TradeProtocol implements BuyerProtocol
                 errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
 
         taskRunner.addTasks(
-                BuyerAsMakerProcessSignTLPayoutTxMessage.class
+                BuyerAsMakerProcessSignTLPayoutTxMessage.class,
+                BuyerAsMakerSignsTLPayoutTx.class,
+                BuyerAsMakerSendsPublishDepositTxMessage.class
         );
         taskRunner.run();
     }

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -33,7 +33,7 @@ import bisq.core.trade.protocol.tasks.buyer_as_maker.BuyerAsMakerSignPayoutTx;
 import bisq.core.trade.protocol.tasks.buyer_as_taker.BuyerAsTakerCreatesDepositTxInputs;
 import bisq.core.trade.protocol.tasks.buyer_as_taker.BuyerAsTakerSignAndPublishDepositTx;
 import bisq.core.trade.protocol.tasks.taker.CreateTakerFeeTx;
-import bisq.core.trade.protocol.tasks.taker.TakerProcessPublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.taker.TakerProcessCompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.taker.TakerSelectMediator;
 import bisq.core.trade.protocol.tasks.taker.TakerSendDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.taker.TakerSendPayDepositRequest;
@@ -143,7 +143,7 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
                 },
                 errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
         taskRunner.addTasks(
-                TakerProcessPublishDepositTxRequest.class,
+                TakerProcessCompleteDepositTxRequest.class,
                 CheckIfPeerIsBanned.class,
                 TakerVerifyMakerAccount.class,
                 VerifyPeersAccountAgeWitness.class,

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -20,8 +20,8 @@ package bisq.core.trade.protocol;
 
 import bisq.core.trade.BuyerAsTakerTrade;
 import bisq.core.trade.Trade;
+import bisq.core.trade.messages.CompleteDepositTxRequest;
 import bisq.core.trade.messages.PayoutTxPublishedMessage;
-import bisq.core.trade.messages.PublishDepositTxRequest;
 import bisq.core.trade.messages.TradeMessage;
 import bisq.core.trade.protocol.tasks.CheckIfPeerIsBanned;
 import bisq.core.trade.protocol.tasks.PublishTradeStatistics;
@@ -91,8 +91,8 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
                 TradeMessage tradeMessage = (TradeMessage) networkEnvelope;
                 log.info("Received {} as MailboxMessage from {} with tradeId {} and uid {}",
                         tradeMessage.getClass().getSimpleName(), peerNodeAddress, tradeMessage.getTradeId(), tradeMessage.getUid());
-                if (tradeMessage instanceof PublishDepositTxRequest)
-                    handle((PublishDepositTxRequest) tradeMessage, peerNodeAddress);
+                if (tradeMessage instanceof CompleteDepositTxRequest)
+                    handle((CompleteDepositTxRequest) tradeMessage, peerNodeAddress);
                 else if (tradeMessage instanceof PayoutTxPublishedMessage) {
                     handle((PayoutTxPublishedMessage) tradeMessage, peerNodeAddress);
                 } else
@@ -132,14 +132,14 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
     // Incoming message handling
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private void handle(PublishDepositTxRequest tradeMessage, NodeAddress sender) {
+    private void handle(CompleteDepositTxRequest tradeMessage, NodeAddress sender) {
         processModel.setTradeMessage(tradeMessage);
         processModel.setTempTradingPeerNodeAddress(sender);
 
         TradeTaskRunner taskRunner = new TradeTaskRunner(buyerAsTakerTrade,
                 () -> {
                     stopTimeout();
-                    handleTaskRunnerSuccess(tradeMessage, "PublishDepositTxRequest");
+                    handleTaskRunnerSuccess(tradeMessage, "CompleteDepositTxRequest");
                 },
                 errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
         taskRunner.addTasks(
@@ -219,8 +219,8 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
         log.info("Received {} from {} with tradeId {} and uid {}",
                 tradeMessage.getClass().getSimpleName(), sender, tradeMessage.getTradeId(), tradeMessage.getUid());
 
-        if (tradeMessage instanceof PublishDepositTxRequest) {
-            handle((PublishDepositTxRequest) tradeMessage, sender);
+        if (tradeMessage instanceof CompleteDepositTxRequest) {
+            handle((CompleteDepositTxRequest) tradeMessage, sender);
         } else if (tradeMessage instanceof PayoutTxPublishedMessage) {
             handle((PayoutTxPublishedMessage) tradeMessage, sender);
         } else {

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
@@ -30,7 +30,7 @@ import bisq.core.trade.protocol.tasks.VerifyPeersAccountAgeWitness;
 import bisq.core.trade.protocol.tasks.maker.MakerCreateAndSignContract;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessPayDepositRequest;
-import bisq.core.trade.protocol.tasks.maker.MakerSendPublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.maker.MakerSendCompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.maker.MakerSetupDepositTxListener;
 import bisq.core.trade.protocol.tasks.maker.MakerVerifyTakerAccount;
 import bisq.core.trade.protocol.tasks.maker.MakerVerifyTakerFeePayment;
@@ -131,7 +131,7 @@ public class SellerAsMakerProtocol extends TradeProtocol implements SellerProtoc
                 MakerCreateAndSignContract.class,
                 SellerAsMakerCreatesAndSignsDepositTx.class,
                 MakerSetupDepositTxListener.class,
-                MakerSendPublishDepositTxRequest.class
+                MakerSendCompleteDepositTxRequest.class
         );
 
         // We don't start a timeout because if we don't receive the peers DepositTxPublishedMessage we still

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -33,7 +33,7 @@ import bisq.core.trade.protocol.tasks.seller.SellerSignAndFinalizePayoutTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCompletesDepositTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCreatesDepositTxInputs;
 import bisq.core.trade.protocol.tasks.taker.CreateTakerFeeTx;
-import bisq.core.trade.protocol.tasks.taker.TakerProcessPublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.taker.TakerProcessCompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.taker.TakerSelectMediator;
 import bisq.core.trade.protocol.tasks.taker.TakerSendDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.taker.TakerSendPayDepositRequest;
@@ -135,7 +135,7 @@ public class SellerAsTakerProtocol extends TradeProtocol implements SellerProtoc
                 errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
 
         taskRunner.addTasks(
-                TakerProcessPublishDepositTxRequest.class,
+                TakerProcessCompleteDepositTxRequest.class,
                 CheckIfPeerIsBanned.class,
                 TakerVerifyMakerAccount.class,
                 VerifyPeersAccountAgeWitness.class,

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -30,8 +30,8 @@ import bisq.core.trade.protocol.tasks.seller.SellerBroadcastPayoutTx;
 import bisq.core.trade.protocol.tasks.seller.SellerProcessCounterCurrencyTransferStartedMessage;
 import bisq.core.trade.protocol.tasks.seller.SellerSendPayoutTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.seller.SellerSignAndFinalizePayoutTx;
+import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCompletesDepositTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCreatesDepositTxInputs;
-import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerSignAndPublishDepositTx;
 import bisq.core.trade.protocol.tasks.taker.CreateTakerFeeTx;
 import bisq.core.trade.protocol.tasks.taker.TakerProcessPublishDepositTxRequest;
 import bisq.core.trade.protocol.tasks.taker.TakerSelectMediator;
@@ -141,7 +141,7 @@ public class SellerAsTakerProtocol extends TradeProtocol implements SellerProtoc
                 VerifyPeersAccountAgeWitness.class,
                 TakerVerifyMakerFeePayment.class,
                 TakerVerifyAndSignContract.class,
-                SellerAsTakerSignAndPublishDepositTx.class,
+                SellerAsTakerCompletesDepositTx.class,
                 TakerSendDepositTxPublishedMessage.class,
                 PublishTradeStatistics.class
         );

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -20,8 +20,8 @@ package bisq.core.trade.protocol;
 
 import bisq.core.trade.SellerAsTakerTrade;
 import bisq.core.trade.Trade;
+import bisq.core.trade.messages.CompleteDepositTxRequest;
 import bisq.core.trade.messages.CounterCurrencyTransferStartedMessage;
-import bisq.core.trade.messages.PublishDepositTxRequest;
 import bisq.core.trade.messages.TradeMessage;
 import bisq.core.trade.protocol.tasks.CheckIfPeerIsBanned;
 import bisq.core.trade.protocol.tasks.PublishTradeStatistics;
@@ -82,8 +82,8 @@ public class SellerAsTakerProtocol extends TradeProtocol implements SellerProtoc
                 TradeMessage tradeMessage = (TradeMessage) networkEnvelope;
                 log.info("Received {} as MailboxMessage from {} with tradeId {} and uid {}",
                         tradeMessage.getClass().getSimpleName(), peerNodeAddress, tradeMessage.getTradeId(), tradeMessage.getUid());
-                if (tradeMessage instanceof PublishDepositTxRequest)
-                    handle((PublishDepositTxRequest) tradeMessage, peerNodeAddress);
+                if (tradeMessage instanceof CompleteDepositTxRequest)
+                    handle((CompleteDepositTxRequest) tradeMessage, peerNodeAddress);
                 else if (tradeMessage instanceof CounterCurrencyTransferStartedMessage)
                     handle((CounterCurrencyTransferStartedMessage) tradeMessage, peerNodeAddress);
                 else
@@ -123,14 +123,14 @@ public class SellerAsTakerProtocol extends TradeProtocol implements SellerProtoc
     // Incoming message handling
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private void handle(PublishDepositTxRequest tradeMessage, NodeAddress sender) {
+    private void handle(CompleteDepositTxRequest tradeMessage, NodeAddress sender) {
         processModel.setTradeMessage(tradeMessage);
         processModel.setTempTradingPeerNodeAddress(sender);
 
         TradeTaskRunner taskRunner = new TradeTaskRunner(sellerAsTakerTrade,
                 () -> {
                     stopTimeout();
-                    handleTaskRunnerSuccess(tradeMessage, "PublishDepositTxRequest");
+                    handleTaskRunnerSuccess(tradeMessage, "CompleteDepositTxRequest");
                 },
                 errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
 
@@ -234,8 +234,8 @@ public class SellerAsTakerProtocol extends TradeProtocol implements SellerProtoc
         log.info("Received {} from {} with tradeId {} and uid {}",
                 tradeMessage.getClass().getSimpleName(), sender, tradeMessage.getTradeId(), tradeMessage.getUid());
 
-        if (tradeMessage instanceof PublishDepositTxRequest) {
-            handle((PublishDepositTxRequest) tradeMessage, sender);
+        if (tradeMessage instanceof CompleteDepositTxRequest) {
+            handle((CompleteDepositTxRequest) tradeMessage, sender);
         } else if (tradeMessage instanceof CounterCurrencyTransferStartedMessage) {
             handle((CounterCurrencyTransferStartedMessage) tradeMessage, sender);
         } else {

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -24,7 +24,6 @@ import bisq.core.trade.messages.CompleteDepositTxRequest;
 import bisq.core.trade.messages.CounterCurrencyTransferStartedMessage;
 import bisq.core.trade.messages.TradeMessage;
 import bisq.core.trade.protocol.tasks.CheckIfPeerIsBanned;
-import bisq.core.trade.protocol.tasks.PublishTradeStatistics;
 import bisq.core.trade.protocol.tasks.VerifyPeersAccountAgeWitness;
 import bisq.core.trade.protocol.tasks.seller.SellerBroadcastPayoutTx;
 import bisq.core.trade.protocol.tasks.seller.SellerProcessCounterCurrencyTransferStartedMessage;
@@ -32,10 +31,11 @@ import bisq.core.trade.protocol.tasks.seller.SellerSendPayoutTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.seller.SellerSignAndFinalizePayoutTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCompletesDepositTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCreatesDepositTxInputs;
+import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCreatesTLPayoutTx;
+import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerSendsTLPayoutTx;
 import bisq.core.trade.protocol.tasks.taker.CreateTakerFeeTx;
 import bisq.core.trade.protocol.tasks.taker.TakerProcessCompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.taker.TakerSelectMediator;
-import bisq.core.trade.protocol.tasks.taker.TakerSendDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.taker.TakerSendPayDepositRequest;
 import bisq.core.trade.protocol.tasks.taker.TakerVerifyAndSignContract;
 import bisq.core.trade.protocol.tasks.taker.TakerVerifyMakerAccount;
@@ -142,8 +142,12 @@ public class SellerAsTakerProtocol extends TradeProtocol implements SellerProtoc
                 TakerVerifyMakerFeePayment.class,
                 TakerVerifyAndSignContract.class,
                 SellerAsTakerCompletesDepositTx.class,
+                SellerAsTakerCreatesTLPayoutTx.class,
+                SellerAsTakerSendsTLPayoutTx.class
+
+                /*, //TODO those 2 tasks will be use later in the process
                 TakerSendDepositTxPublishedMessage.class,
-                PublishTradeStatistics.class
+                PublishTradeStatistics.class*/
         );
         taskRunner.run();
     }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerProcessSignTLPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerProcessSignTLPayoutTxMessage.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.tasks.buyer_as_maker;
+
+import bisq.core.trade.Trade;
+import bisq.core.trade.messages.SignTLPayoutTxMessage;
+import bisq.core.trade.protocol.tasks.TradeTask;
+import bisq.core.util.Validator;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Slf4j
+public class BuyerAsMakerProcessSignTLPayoutTxMessage extends TradeTask {
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public BuyerAsMakerProcessSignTLPayoutTxMessage(TaskRunner taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        try {
+            runInterceptHook();
+            log.debug("current trade state " + trade.getState());
+            SignTLPayoutTxMessage message = (SignTLPayoutTxMessage) processModel.getTradeMessage();
+            Validator.checkTradeId(processModel.getOfferId(), message);
+            checkNotNull(message);
+
+            // write data to models
+
+            // update to the latest peer address of our peer if the message is correct
+            trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
+
+
+            processModel.removeMailboxMessageAfterProcessing(trade);
+            complete();
+        } catch (Throwable t) {
+            failed(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerProcessSignTLPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerProcessSignTLPayoutTxMessage.java
@@ -37,6 +37,7 @@ public class BuyerAsMakerProcessSignTLPayoutTxMessage extends TradeTask {
 
     @Override
     protected void run() {
+        log.warn("Not impl.: BuyerAsMakerProcessSignTLPayoutTxMessage");
         try {
             runInterceptHook();
             log.debug("current trade state " + trade.getState());
@@ -49,8 +50,6 @@ public class BuyerAsMakerProcessSignTLPayoutTxMessage extends TradeTask {
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
-
-            processModel.removeMailboxMessageAfterProcessing(trade);
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerSendsPublishDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerSendsPublishDepositTxMessage.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.tasks.buyer_as_maker;
+
+import bisq.core.trade.Trade;
+import bisq.core.trade.messages.PublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.TradeTask;
+
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.SendDirectMessageListener;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import java.util.UUID;
+
+import lombok.extern.slf4j.Slf4j;
+
+// TODO impl
+@Slf4j
+public class BuyerAsMakerSendsPublishDepositTxMessage extends TradeTask {
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public BuyerAsMakerSendsPublishDepositTxMessage(TaskRunner taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        log.warn("Missing impl.: BuyerAsMakerSendsPublishDepositTxMessage");
+
+        try {
+            runInterceptHook();
+            final String id = processModel.getOfferId();
+            PublishDepositTxRequest message = new PublishDepositTxRequest(processModel.getOfferId(),
+                    processModel.getMyNodeAddress(),
+                    UUID.randomUUID().toString());
+
+            NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
+            log.info("Send {} to peer {}. tradeId={}, uid={}",
+                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
+            processModel.getP2PService().sendEncryptedDirectMessage(
+                    peersNodeAddress,
+                    processModel.getTradingPeer().getPubKeyRing(),
+                    message,
+                    new SendDirectMessageListener() {
+                        @Override
+                        public void onArrived() {
+                            log.info("{} arrived at peer {}. tradeId={}, uid={}",
+                                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
+
+                            //TODO set correct (new) state
+                            // trade.setState(Trade.State.TAKER_SAW_ARRIVED_DEPOSIT_TX_PUBLISHED_MSG);
+                            complete();
+                        }
+
+                        @Override
+                        public void onFault(String errorMessage) {
+                            log.error("{} failed: Peer {}. tradeId={}, uid={}, errorMessage={}",
+                                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid(), errorMessage);
+                            //TODO set correct (new) state
+                            // trade.setState(Trade.State.TAKER_SEND_FAILED_DEPOSIT_TX_PUBLISHED_MSG);
+                            appendToErrorMessage("Sending message failed: message=" + message + "\nerrorMessage=" + errorMessage);
+                            failed();
+                        }
+                    }
+            );
+        } catch (Throwable t) {
+            failed(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerSignsTLPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerSignsTLPayoutTx.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.tasks.buyer_as_maker;
+
+import bisq.core.trade.Trade;
+import bisq.core.trade.protocol.tasks.TradeTask;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class BuyerAsMakerSignsTLPayoutTx extends TradeTask {
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public BuyerAsMakerSignsTLPayoutTx(TaskRunner taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        log.warn("Not impl.: BuyerAsMakerSignsTLPayoutTx");
+        runInterceptHook();
+
+        complete();
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignAndPublishDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignAndPublishDepositTx.java
@@ -19,8 +19,8 @@ package bisq.core.trade.protocol.tasks.buyer_as_taker;
 
 import bisq.core.btc.exceptions.TxBroadcastException;
 import bisq.core.btc.model.AddressEntry;
-import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.model.RawTransactionInput;
+import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TxBroadcaster;
 import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.TradingPeer;
@@ -79,7 +79,7 @@ public class BuyerAsTakerSignAndPublishDepositTx extends TradeTask {
             checkArgument(Arrays.equals(buyerMultiSigPubKey, buyerMultiSigAddressEntry.getPubKey()),
                     "buyerMultiSigPubKey from AddressEntry must match the one from the trade data. trade id =" + id);
 
-            Transaction depositTx = processModel.getTradeWalletService().takerSignsAndPublishesDepositTx(
+            Transaction depositTx = processModel.getTradeWalletService().takerAsBuyerSignsAndPublishesDepositTx(
                     false,
                     contractHash,
                     processModel.getPreparedDepositTx(),

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSendCompleteDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSendCompleteDepositTxRequest.java
@@ -41,9 +41,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
-public class MakerSendPublishDepositTxRequest extends TradeTask {
+public class MakerSendCompleteDepositTxRequest extends TradeTask {
     @SuppressWarnings({"WeakerAccess", "unused"})
-    public MakerSendPublishDepositTxRequest(TaskRunner taskHandler, Trade trade) {
+    public MakerSendCompleteDepositTxRequest(TaskRunner taskHandler, Trade trade) {
         super(taskHandler, trade);
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSendCompleteDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSendCompleteDepositTxRequest.java
@@ -21,7 +21,7 @@ import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.trade.Trade;
-import bisq.core.trade.messages.PublishDepositTxRequest;
+import bisq.core.trade.messages.CompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.network.p2p.NodeAddress;
@@ -70,7 +70,7 @@ public class MakerSendCompleteDepositTxRequest extends TradeTask {
 
             byte[] sig = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), preparedDepositTx);
 
-            PublishDepositTxRequest message = new PublishDepositTxRequest(
+            CompleteDepositTxRequest message = new CompleteDepositTxRequest(
                     processModel.getOfferId(),
                     paymentAccountPayload,
                     processModel.getAccountId(),

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCompletesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCompletesDepositTx.java
@@ -94,7 +94,10 @@ public class SellerAsTakerCompletesDepositTx extends TradeTask {
             // with regtest we run into such issues, thus fixing it to make it more strict seems
             // reasonable.
             trade.setDepositTx(depositTx);
-            trade.setState(Trade.State.SELLER_TAKER_COMPLETED_DEPOSIT_TX);
+
+            // TODO need to added to PB before setting it
+            //trade.setState(Trade.State.SELLER_TAKER_COMPLETED_DEPOSIT_TX);
+
             walletService.swapTradeEntryToAvailableEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE);
 
             complete();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCompletesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCompletesDepositTx.java
@@ -94,7 +94,7 @@ public class SellerAsTakerCompletesDepositTx extends TradeTask {
             // with regtest we run into such issues, thus fixing it to make it more strict seems
             // reasonable.
             trade.setDepositTx(depositTx);
-            trade.setState(Trade.State.TAKER_PUBLISHED_DEPOSIT_TX);
+            trade.setState(Trade.State.SELLER_TAKER_COMPLETED_DEPOSIT_TX);
             walletService.swapTradeEntryToAvailableEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE);
 
             complete();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCompletesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCompletesDepositTx.java
@@ -41,9 +41,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
-public class SellerAsTakerSignAndPublishDepositTx extends TradeTask {
+public class SellerAsTakerCompletesDepositTx extends TradeTask {
     @SuppressWarnings({"WeakerAccess", "unused"})
-    public SellerAsTakerSignAndPublishDepositTx(TaskRunner taskHandler, Trade trade) {
+    public SellerAsTakerCompletesDepositTx(TaskRunner taskHandler, Trade trade) {
         super(taskHandler, trade);
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCreatesTLPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCreatesTLPayoutTx.java
@@ -33,6 +33,7 @@ public class SellerAsTakerCreatesTLPayoutTx extends TradeTask {
 
     @Override
     protected void run() {
+        log.warn("Not impl.: SellerAsTakerCreatesTLPayoutTx");
         runInterceptHook();
 
         // Bob creates now the alternative payout tx with spending the funds from the multisig address to the
@@ -40,6 +41,7 @@ public class SellerAsTakerCreatesTLPayoutTx extends TradeTask {
 
         //TODO create time locked payout tx from sellers side
         // Store tx in data models
+
         complete();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCreatesTLPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCreatesTLPayoutTx.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.tasks.seller_as_taker;
+
+import bisq.core.trade.Trade;
+import bisq.core.trade.protocol.tasks.TradeTask;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SellerAsTakerCreatesTLPayoutTx extends TradeTask {
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public SellerAsTakerCreatesTLPayoutTx(TaskRunner taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        runInterceptHook();
+
+        // Bob creates now the alternative payout tx with spending the funds from the multisig address to the
+        // donation address. He does not sign that tx yet. He send it to Alice.
+
+        //TODO create time locked payout tx from sellers side
+        // Store tx in data models
+        complete();
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerProcessPublishDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerProcessPublishDepositTxMessage.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.tasks.seller_as_taker;
+
+import bisq.core.trade.Trade;
+import bisq.core.trade.messages.PublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.TradeTask;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.core.util.Validator.checkTradeId;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Slf4j
+public class SellerAsTakerProcessPublishDepositTxMessage extends TradeTask {
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public SellerAsTakerProcessPublishDepositTxMessage(TaskRunner taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        log.warn("Missing impl.: SellerAsTakerProcessPublishDepositTxMessage");
+        try {
+            runInterceptHook();
+            log.debug("current trade state " + trade.getState());
+            PublishDepositTxRequest message = (PublishDepositTxRequest) processModel.getTradeMessage();
+            checkTradeId(processModel.getOfferId(), message);
+            checkNotNull(message);
+
+            complete();
+        } catch (Throwable t) {
+            failed(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerPublishesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerPublishesDepositTx.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.tasks.seller_as_taker;
+
+import bisq.core.btc.exceptions.TxBroadcastException;
+import bisq.core.btc.model.AddressEntry;
+import bisq.core.btc.wallet.TxBroadcaster;
+import bisq.core.trade.Contract;
+import bisq.core.trade.Trade;
+import bisq.core.trade.protocol.tasks.TradeTask;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import org.bitcoinj.core.Transaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SellerAsTakerPublishesDepositTx extends TradeTask {
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public SellerAsTakerPublishesDepositTx(TaskRunner taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        try {
+            runInterceptHook();
+
+            processModel.getTradeWalletService().broadcastTx(trade.getDepositTx(), new TxBroadcaster.Callback() {
+                @Override
+                public void onSuccess(Transaction transaction) {
+                    if (!completed) {
+                        // We set the depositTx before we change the state as the state change triggers code
+                        // which expected the tx to be available. That case will usually never happen as the
+                        // callback is called after the method call has returned but in some test scenarios
+                        // with regtest we run into such issues, thus fixing it to make it more stict seems
+                        // reasonable.
+                        trade.setDepositTx(transaction);
+                        trade.setState(Trade.State.TAKER_PUBLISHED_DEPOSIT_TX);
+                        processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(trade.getId(), AddressEntry.Context.RESERVED_FOR_TRADE);
+
+                        complete();
+                    } else {
+                        log.warn("We got the onSuccess callback called after the timeout has been triggered a complete().");
+                    }
+                }
+
+                @Override
+                public void onFailure(TxBroadcastException exception) {
+                    if (!completed) {
+                        failed(exception);
+                    } else {
+                        log.warn("We got the onFailure callback called after the timeout has been triggered a complete().");
+                    }
+                }
+            });
+        } catch (Throwable t) {
+            final Contract contract = trade.getContract();
+            if (contract != null)
+                contract.printDiff(processModel.getTradingPeer().getContractAsJson());
+            failed(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSendsTLPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSendsTLPayoutTx.java
@@ -40,6 +40,7 @@ public class SellerAsTakerSendsTLPayoutTx extends TradeTask {
 
     @Override
     protected void run() {
+        log.warn("Not impl.: SellerAsTakerSendsTLPayoutTx");
         try {
             runInterceptHook();
             final String id = processModel.getOfferId();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSendsTLPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSendsTLPayoutTx.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.tasks.seller_as_taker;
+
+import bisq.core.trade.Trade;
+import bisq.core.trade.messages.SignTLPayoutTxMessage;
+import bisq.core.trade.protocol.tasks.TradeTask;
+
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.SendMailboxMessageListener;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import java.util.UUID;
+
+import lombok.extern.slf4j.Slf4j;
+
+//TODO implement
+@Slf4j
+public class SellerAsTakerSendsTLPayoutTx extends TradeTask {
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public SellerAsTakerSendsTLPayoutTx(TaskRunner taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        try {
+            runInterceptHook();
+            final String id = processModel.getOfferId();
+            SignTLPayoutTxMessage message = new SignTLPayoutTxMessage(processModel.getOfferId(),
+                    processModel.getMyNodeAddress(),
+                    UUID.randomUUID().toString());
+            trade.setState(Trade.State.TAKER_SENT_DEPOSIT_TX_PUBLISHED_MSG);
+
+            NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
+            log.info("Send {} to peer {}. tradeId={}, uid={}",
+                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
+            processModel.getP2PService().sendEncryptedMailboxMessage(
+                    peersNodeAddress,
+                    processModel.getTradingPeer().getPubKeyRing(),
+                    message,
+                    new SendMailboxMessageListener() {
+                        @Override
+                        public void onArrived() {
+                            log.info("{} arrived at peer {}. tradeId={}, uid={}",
+                                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
+
+                            //TODO set correct (new) state
+                            // trade.setState(Trade.State.TAKER_SAW_ARRIVED_DEPOSIT_TX_PUBLISHED_MSG);
+                            complete();
+                        }
+
+                        @Override
+                        public void onStoredInMailbox() {
+                            log.info("{} stored in mailbox for peer {}. tradeId={}, uid={}",
+                                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
+                            //TODO set correct (new) state
+                            //trade.setState(Trade.State.TAKER_STORED_IN_MAILBOX_DEPOSIT_TX_PUBLISHED_MSG);
+                            complete();
+                        }
+
+                        @Override
+                        public void onFault(String errorMessage) {
+                            log.error("{} failed: Peer {}. tradeId={}, uid={}, errorMessage={}",
+                                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid(), errorMessage);
+                            //TODO set correct (new) state
+                            // trade.setState(Trade.State.TAKER_SEND_FAILED_DEPOSIT_TX_PUBLISHED_MSG);
+                            appendToErrorMessage("Sending message failed: message=" + message + "\nerrorMessage=" + errorMessage);
+                            failed();
+                        }
+                    }
+            );
+        } catch (Throwable t) {
+            failed(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSendsTLPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSendsTLPayoutTx.java
@@ -22,7 +22,7 @@ import bisq.core.trade.messages.SignTLPayoutTxMessage;
 import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.SendMailboxMessageListener;
+import bisq.network.p2p.SendDirectMessageListener;
 
 import bisq.common.taskrunner.TaskRunner;
 
@@ -51,11 +51,11 @@ public class SellerAsTakerSendsTLPayoutTx extends TradeTask {
             NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
             log.info("Send {} to peer {}. tradeId={}, uid={}",
                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
-            processModel.getP2PService().sendEncryptedMailboxMessage(
+            processModel.getP2PService().sendEncryptedDirectMessage(
                     peersNodeAddress,
                     processModel.getTradingPeer().getPubKeyRing(),
                     message,
-                    new SendMailboxMessageListener() {
+                    new SendDirectMessageListener() {
                         @Override
                         public void onArrived() {
                             log.info("{} arrived at peer {}. tradeId={}, uid={}",
@@ -63,15 +63,6 @@ public class SellerAsTakerSendsTLPayoutTx extends TradeTask {
 
                             //TODO set correct (new) state
                             // trade.setState(Trade.State.TAKER_SAW_ARRIVED_DEPOSIT_TX_PUBLISHED_MSG);
-                            complete();
-                        }
-
-                        @Override
-                        public void onStoredInMailbox() {
-                            log.info("{} stored in mailbox for peer {}. tradeId={}, uid={}",
-                                    message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
-                            //TODO set correct (new) state
-                            //trade.setState(Trade.State.TAKER_STORED_IN_MAILBOX_DEPOSIT_TX_PUBLISHED_MSG);
                             complete();
                         }
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignAndPublishDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignAndPublishDepositTx.java
@@ -17,11 +17,9 @@
 
 package bisq.core.trade.protocol.tasks.seller_as_taker;
 
-import bisq.core.btc.exceptions.TxBroadcastException;
 import bisq.core.btc.model.AddressEntry;
-import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.model.RawTransactionInput;
-import bisq.core.btc.wallet.TxBroadcaster;
+import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.trade.Contract;
 import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.TradingPeer;
@@ -80,7 +78,7 @@ public class SellerAsTakerSignAndPublishDepositTx extends TradeTask {
 
             TradingPeer tradingPeer = processModel.getTradingPeer();
 
-            Transaction depositTx = processModel.getTradeWalletService().takerSignsAndPublishesDepositTx(
+            Transaction depositTx = processModel.getTradeWalletService().sellerAsTakerSignsDepositTx(
                     true,
                     contractHash,
                     processModel.getPreparedDepositTx(),
@@ -88,41 +86,18 @@ public class SellerAsTakerSignAndPublishDepositTx extends TradeTask {
                     sellerInputs,
                     tradingPeer.getMultiSigPubKey(),
                     sellerMultiSigPubKey,
-                    trade.getArbitratorBtcPubKey(),
-                    new TxBroadcaster.Callback() {
-                        @Override
-                        public void onSuccess(Transaction transaction) {
-                            if (!completed) {
-                                // We set the depositTx before we change the state as the state change triggers code
-                                // which expected the tx to be available. That case will usually never happen as the
-                                // callback is called after the method call has returned but in some test scenarios
-                                // with regtest we run into such issues, thus fixing it to make it more stict seems
-                                // reasonable.
-                                trade.setDepositTx(transaction);
-                                log.trace("takerSignsAndPublishesDepositTx succeeded " + transaction);
-                                trade.setState(Trade.State.TAKER_PUBLISHED_DEPOSIT_TX);
-                                walletService.swapTradeEntryToAvailableEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE);
+                    trade.getArbitratorBtcPubKey());
 
-                                complete();
-                            } else {
-                                log.warn("We got the onSuccess callback called after the timeout has been triggered a complete().");
-                            }
-                        }
+            // We set the depositTx before we change the state as the state change triggers code
+            // which expected the tx to be available. That case will usually never happen as the
+            // callback is called after the method call has returned but in some test scenarios
+            // with regtest we run into such issues, thus fixing it to make it more strict seems
+            // reasonable.
+            trade.setDepositTx(depositTx);
+            trade.setState(Trade.State.TAKER_PUBLISHED_DEPOSIT_TX);
+            walletService.swapTradeEntryToAvailableEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE);
 
-                        @Override
-                        public void onFailure(TxBroadcastException exception) {
-                            if (!completed) {
-                                failed(exception);
-                            } else {
-                                log.warn("We got the onFailure callback called after the timeout has been triggered a complete().");
-                            }
-                        }
-                    });
-            if (trade.getDepositTx() == null) {
-                // We set the deposit tx in case we get the onFailure called. We cannot set it in the onFailure
-                // callback as the tx is returned by the method call where the callback is  used as an argument.
-                trade.setDepositTx(depositTx);
-            }
+            complete();
         } catch (Throwable t) {
             final Contract contract = trade.getContract();
             if (contract != null)

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerProcessCompleteDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerProcessCompleteDepositTxRequest.java
@@ -32,9 +32,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
-public class TakerProcessPublishDepositTxRequest extends TradeTask {
+public class TakerProcessCompleteDepositTxRequest extends TradeTask {
     @SuppressWarnings({"WeakerAccess", "unused"})
-    public TakerProcessPublishDepositTxRequest(TaskRunner taskHandler, Trade trade) {
+    public TakerProcessCompleteDepositTxRequest(TaskRunner taskHandler, Trade trade) {
         super(taskHandler, trade);
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerProcessPublishDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerProcessPublishDepositTxRequest.java
@@ -18,7 +18,7 @@
 package bisq.core.trade.protocol.tasks.taker;
 
 import bisq.core.trade.Trade;
-import bisq.core.trade.messages.PublishDepositTxRequest;
+import bisq.core.trade.messages.CompleteDepositTxRequest;
 import bisq.core.trade.protocol.TradingPeer;
 import bisq.core.trade.protocol.tasks.TradeTask;
 
@@ -43,29 +43,29 @@ public class TakerProcessPublishDepositTxRequest extends TradeTask {
         try {
             runInterceptHook();
             log.debug("current trade state " + trade.getState());
-            PublishDepositTxRequest publishDepositTxRequest = (PublishDepositTxRequest) processModel.getTradeMessage();
-            checkTradeId(processModel.getOfferId(), publishDepositTxRequest);
-            checkNotNull(publishDepositTxRequest);
+            CompleteDepositTxRequest completeDepositTxRequest = (CompleteDepositTxRequest) processModel.getTradeMessage();
+            checkTradeId(processModel.getOfferId(), completeDepositTxRequest);
+            checkNotNull(completeDepositTxRequest);
 
             final TradingPeer tradingPeer = processModel.getTradingPeer();
-            tradingPeer.setPaymentAccountPayload(checkNotNull(publishDepositTxRequest.getMakerPaymentAccountPayload()));
-            tradingPeer.setAccountId(nonEmptyStringOf(publishDepositTxRequest.getMakerAccountId()));
-            tradingPeer.setMultiSigPubKey(checkNotNull(publishDepositTxRequest.getMakerMultiSigPubKey()));
-            tradingPeer.setContractAsJson(nonEmptyStringOf(publishDepositTxRequest.getMakerContractAsJson()));
-            tradingPeer.setContractSignature(nonEmptyStringOf(publishDepositTxRequest.getMakerContractSignature()));
-            tradingPeer.setPayoutAddressString(nonEmptyStringOf(publishDepositTxRequest.getMakerPayoutAddressString()));
-            tradingPeer.setRawTransactionInputs(checkNotNull(publishDepositTxRequest.getMakerInputs()));
-            final byte[] preparedDepositTx = publishDepositTxRequest.getPreparedDepositTx();
+            tradingPeer.setPaymentAccountPayload(checkNotNull(completeDepositTxRequest.getMakerPaymentAccountPayload()));
+            tradingPeer.setAccountId(nonEmptyStringOf(completeDepositTxRequest.getMakerAccountId()));
+            tradingPeer.setMultiSigPubKey(checkNotNull(completeDepositTxRequest.getMakerMultiSigPubKey()));
+            tradingPeer.setContractAsJson(nonEmptyStringOf(completeDepositTxRequest.getMakerContractAsJson()));
+            tradingPeer.setContractSignature(nonEmptyStringOf(completeDepositTxRequest.getMakerContractSignature()));
+            tradingPeer.setPayoutAddressString(nonEmptyStringOf(completeDepositTxRequest.getMakerPayoutAddressString()));
+            tradingPeer.setRawTransactionInputs(checkNotNull(completeDepositTxRequest.getMakerInputs()));
+            final byte[] preparedDepositTx = completeDepositTxRequest.getPreparedDepositTx();
             processModel.setPreparedDepositTx(checkNotNull(preparedDepositTx));
 
             // Maker has to sign preparedDepositTx. He cannot manipulate the preparedDepositTx - so we avoid to have a
             // challenge protocol for passing the nonce we want to get signed.
-            tradingPeer.setAccountAgeWitnessNonce(publishDepositTxRequest.getPreparedDepositTx());
-            tradingPeer.setAccountAgeWitnessSignature(publishDepositTxRequest.getAccountAgeWitnessSignatureOfPreparedDepositTx());
+            tradingPeer.setAccountAgeWitnessNonce(completeDepositTxRequest.getPreparedDepositTx());
+            tradingPeer.setAccountAgeWitnessSignature(completeDepositTxRequest.getAccountAgeWitnessSignatureOfPreparedDepositTx());
 
-            tradingPeer.setCurrentDate(publishDepositTxRequest.getCurrentDate());
+            tradingPeer.setCurrentDate(completeDepositTxRequest.getCurrentDate());
 
-            checkArgument(publishDepositTxRequest.getMakerInputs().size() > 0);
+            checkArgument(completeDepositTxRequest.getMakerInputs().size() > 0);
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());

--- a/desktop/src/main/java/bisq/desktop/main/debug/DebugView.java
+++ b/desktop/src/main/java/bisq/desktop/main/debug/DebugView.java
@@ -49,7 +49,7 @@ import bisq.core.trade.protocol.tasks.seller_as_maker.SellerAsMakerCreatesAndSig
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCompletesDepositTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCreatesDepositTxInputs;
 import bisq.core.trade.protocol.tasks.taker.CreateTakerFeeTx;
-import bisq.core.trade.protocol.tasks.taker.TakerProcessPublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.taker.TakerProcessCompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.taker.TakerSelectMediator;
 import bisq.core.trade.protocol.tasks.taker.TakerSendDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.taker.TakerSendPayDepositRequest;
@@ -136,7 +136,7 @@ public class DebugView extends InitializableView<GridPane, Void> {
                         SellerAsTakerCreatesDepositTxInputs.class,
                         TakerSendPayDepositRequest.class,
 
-                        TakerProcessPublishDepositTxRequest.class,
+                        TakerProcessCompleteDepositTxRequest.class,
                         CheckIfPeerIsBanned.class,
                         TakerVerifyMakerAccount.class,
                         TakerVerifyMakerFeePayment.class,
@@ -163,7 +163,7 @@ public class DebugView extends InitializableView<GridPane, Void> {
                         BuyerAsTakerCreatesDepositTxInputs.class,
                         TakerSendPayDepositRequest.class,
 
-                        TakerProcessPublishDepositTxRequest.class,
+                        TakerProcessCompleteDepositTxRequest.class,
                         CheckIfPeerIsBanned.class,
                         TakerVerifyMakerAccount.class,
                         TakerVerifyMakerFeePayment.class,

--- a/desktop/src/main/java/bisq/desktop/main/debug/DebugView.java
+++ b/desktop/src/main/java/bisq/desktop/main/debug/DebugView.java
@@ -46,8 +46,8 @@ import bisq.core.trade.protocol.tasks.seller.SellerProcessCounterCurrencyTransfe
 import bisq.core.trade.protocol.tasks.seller.SellerSendPayoutTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.seller.SellerSignAndFinalizePayoutTx;
 import bisq.core.trade.protocol.tasks.seller_as_maker.SellerAsMakerCreatesAndSignsDepositTx;
+import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCompletesDepositTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCreatesDepositTxInputs;
-import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerSignAndPublishDepositTx;
 import bisq.core.trade.protocol.tasks.taker.CreateTakerFeeTx;
 import bisq.core.trade.protocol.tasks.taker.TakerProcessPublishDepositTxRequest;
 import bisq.core.trade.protocol.tasks.taker.TakerSelectMediator;
@@ -141,7 +141,7 @@ public class DebugView extends InitializableView<GridPane, Void> {
                         TakerVerifyMakerAccount.class,
                         TakerVerifyMakerFeePayment.class,
                         TakerVerifyAndSignContract.class,
-                        SellerAsTakerSignAndPublishDepositTx.class,
+                        SellerAsTakerCompletesDepositTx.class,
                         TakerSendDepositTxPublishedMessage.class,
 
                         SellerProcessCounterCurrencyTransferStartedMessage.class,

--- a/desktop/src/main/java/bisq/desktop/main/debug/DebugView.java
+++ b/desktop/src/main/java/bisq/desktop/main/debug/DebugView.java
@@ -37,7 +37,7 @@ import bisq.core.trade.protocol.tasks.buyer_as_taker.BuyerAsTakerSignAndPublishD
 import bisq.core.trade.protocol.tasks.maker.MakerCreateAndSignContract;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessDepositTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.maker.MakerProcessPayDepositRequest;
-import bisq.core.trade.protocol.tasks.maker.MakerSendPublishDepositTxRequest;
+import bisq.core.trade.protocol.tasks.maker.MakerSendCompleteDepositTxRequest;
 import bisq.core.trade.protocol.tasks.maker.MakerSetupDepositTxListener;
 import bisq.core.trade.protocol.tasks.maker.MakerVerifyTakerAccount;
 import bisq.core.trade.protocol.tasks.maker.MakerVerifyTakerFeePayment;
@@ -113,7 +113,7 @@ public class DebugView extends InitializableView<GridPane, Void> {
                         MakerCreateAndSignContract.class,
                         BuyerAsMakerCreatesAndSignsDepositTx.class,
                         MakerSetupDepositTxListener.class,
-                        MakerSendPublishDepositTxRequest.class,
+                        MakerSendCompleteDepositTxRequest.class,
 
                         MakerProcessDepositTxPublishedMessage.class,
                         MakerVerifyTakerAccount.class,
@@ -187,7 +187,7 @@ public class DebugView extends InitializableView<GridPane, Void> {
                         MakerCreateAndSignContract.class,
                         SellerAsMakerCreatesAndSignsDepositTx.class,
                         MakerSetupDepositTxListener.class,
-                        MakerSendPublishDepositTxRequest.class,
+                        MakerSendCompleteDepositTxRequest.class,
 
                         MakerProcessDepositTxPublishedMessage.class,
                         PublishTradeStatistics.class,

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -336,6 +336,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     private void updateChartData() {
         seriesBuy.getData().clear();
         seriesSell.getData().clear();
+        areaChart.getData().clear();
 
         final Optional<XYChart.Data> buyMinOptional = model.getBuyData().stream()
                 .min(Comparator.comparingDouble(o -> (double) o.getXValue()))
@@ -369,6 +370,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         seriesBuy.getData().addAll(model.getBuyData());
         //noinspection unchecked
         seriesSell.getData().addAll(model.getSellData());
+        areaChart.getData().addAll(seriesBuy, seriesSell);
     }
 
     private Tuple4<TableView<OfferListItem>, VBox, Button, Label> getOfferTable(OfferPayload.Direction direction) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -372,6 +372,9 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
 
                 // taker perspective
             case TAKER_RECEIVED_PUBLISH_DEPOSIT_TX_REQUEST:
+
+                //TODO we add that preliminary here. Need to be checked if that position is correct
+            case SELLER_TAKER_COMPLETED_DEPOSIT_TX:
                 // We don't have a UI state for that, we still have not a ready initiated trade
                 sellerState.set(UNDEFINED);
                 buyerState.set(BuyerState.UNDEFINED);


### PR DESCRIPTION
The PR add the Tasks and messages to implement the new trade protocol for the buyer as maker case.
It does not implement any of the new transactions yet.
It completes like a normal trade and just calls the "empty" tasks and send the additional messages.