### PR TITLE
Fix windows install custom translations

### DIFF
--- a/desktop/package/windows/Bisq.iss
+++ b/desktop/package/windows/Bisq.iss
@@ -1,6 +1,6 @@
-;This file will be executed next to the application bundle image
+﻿;This file will be executed next to the application bundle image
 ;I.e. current directory will contain folder Bisq with application files
-;Note: This file must use UTF-8 encoding
+;Note: This file must use UTF-8 encoding with BOM for the unicode custom messages to be displayed properly
 
 #define SourceDir GetEnv('package_dir') + '\windows'
 #define AppVersion GetEnv('version')


### PR DESCRIPTION
The Bisq.iss file must be saved using UTF-8 encoding with BOM for the unicode custom messages to be displayed properly.

For example, the v0.9.3 release on Windows 7 French has the following issues:

- Launching the installer with the application running shows the following incorrect message text:
![image](https://user-images.githubusercontent.com/603793/50862535-b6ff3200-1350-11e9-8976-af3b0c5afa4f.png)

- Observing the application within the control panel shows the following incorrect message text:
![image](https://user-images.githubusercontent.com/603793/50862873-a8fde100-1351-11e9-9865-e89b41601539.png)

Note, this issue only affects the custom messages contained within the Bisq.iss file, not the general translations within the installer.