### PR TITLE
Improve JAVA_HOME override

### DIFF
--- a/desktop/package/linux/package.sh
+++ b/desktop/package/linux/package.sh
@@ -7,6 +7,12 @@
 #   - Ensure JAVA_HOME below is pointing to OracleJDK 10 directory
 
 version=0.9.3-SNAPSHOT
+if [ ! -f "$JAVA_HOME/bin/javapackager" ] && [ -d "/usr/lib/jvm/jdk-10.0.2" ]; then
+    JAVA_HOME=/usr/lib/jvm/jdk-10.0.2
+else
+    echo Javapackager not found. Update JAVA_HOME variable to point to OracleJDK.
+    exit 1
+fi
 
 base_dir=$( cd "$(dirname "$0")" ; pwd -P )/../../..
 src_dir=$base_dir/desktop/package
@@ -24,7 +30,7 @@ if [ ! -f "$base_dir/desktop/package/desktop-$version-all.jar" ]; then
     jar_file=$base_dir/desktop/build/libs/desktop-$version-all.jar
     if [ ! -f "$jar_file" ]; then
         echo No jar file available at $jar_file
-        exit 1
+        exit 2
     fi
 
     tmp=$base_dir/desktop/build/libs/tmp
@@ -97,7 +103,7 @@ $JAVA_HOME/bin/javapackager \
 
 if [ ! -f "$base_dir/desktop/package/linux/bisq-$version.deb" ]; then
     echo No deb file found at $base_dir/desktop/package/linux/bisq-$version.deb
-    exit 2
+    exit 3
 fi
 
 # FIXME: My Ubuntu somehow also deletes the lower case file

--- a/desktop/package/windows/package.bat
+++ b/desktop/package/windows/package.bat
@@ -9,6 +9,13 @@
 @echo off
 
 set version=0.9.3-SNAPSHOT
+if not exist "%JAVA_HOME%\bin\javapackager.exe" (
+    if not exist "%ProgramFiles%\Java\jdk-10.0.2" (
+        echo Javapackager not found. Update JAVA_HOME variable to point to OracleJDK.
+        exit /B 1
+    )
+    set JAVA_HOME=%ProgramFiles%\Java\jdk-10.0.2
+)
 set package_dir=%~dp0..
 for /F "tokens=1,2,3 delims=.-" %%a in ("%version%") do (
    set file_version=%%a.%%b.%%c
@@ -31,7 +38,7 @@ if exist "%~dp0..\..\..\desktop\build\libs\desktop-%version%-all.jar" (
     set jar_filename=desktop-%version%-all.jar
 ) else (
     echo No jar file available in %~dp0..\..\..\desktop\build\libs
-    exit /B 1
+    exit /B 2
 )
 
 if not exist "%TEMP%\7za920\7za.exe" (
@@ -105,7 +112,7 @@ call "%JAVA_HOME%\bin\javapackager.exe" -deploy ^
 
 if not exist "%package_dir%\windows\Bisq-%version%.exe" (
     echo No exe file found at %package_dir%\windows\Bisq-%version%.exe
-    exit /B 2
+    exit /B 3
 )
 
 echo SHA256 of %package_dir%\windows\Bisq-%version%.exe:


### PR DESCRIPTION
Check to see if javapackager exists prior to overriding JAVA_HOME
in package scripts.