### PR TITLE
List Fujicoin (FJC)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Fujicoin.java
+++ b/assets/src/main/java/bisq/asset/coins/Fujicoin.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class Fujicoin extends Coin {
+    public Fujicoin() {
+        super("Fujicoin", "FJC", new Base58BitcoinAddressValidator(new FujicoinParams()));
+    }
+	   public static class FujicoinParams extends NetworkParametersAdapter {
+
+        public FujicoinParams() {
+            addressHeader = 36;
+            p2shHeader = 16;
+            acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+        }
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -28,6 +28,7 @@ bisq.asset.coins.Dragonglass
 bisq.asset.coins.Ether
 bisq.asset.coins.EtherClassic
 bisq.asset.coins.FourtyTwo
+bisq.asset.coins.Fujicoin
 bisq.asset.coins.GambleCoin
 bisq.asset.coins.Gridcoin
 bisq.asset.coins.Grin

--- a/assets/src/test/java/bisq/asset/coins/FujicoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/FujicoinTest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class FujicoinTest extends AbstractAssetTest {
+
+    public FujicoinTest() {
+        super(new Fujicoin());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("FpEbvwxhmer2zSvqh61JtLiffu8Tk2abdo");
+        assertValidAddress("7gcLWi78MFJ9akMzTAiug3uArvPch5LB6q");
+        assertValidAddress("FrjN1LLWJj1DWVooBCdybBvmaEAqxMuuq8");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem");
+        assertInvalidAddress("FpEbvwxhmer2zSvqh61JtLiffu8Tk2abda");
+        assertInvalidAddress("7gcLWi78MFJ9akMzTAiug3uArvPch5LB6a");
+        assertInvalidAddress("fc1q3s2fc2xqgush29urtfdj0vhcj96h8424zyl6wa");
+    }
+}


### PR DESCRIPTION
- Official project URL: https://www.fujicoin.org/
- Official block explorer URL: https://explorer.fujicoin.org/