### PR TITLE
List Credits (CRDS)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Credits.java
+++ b/assets/src/main/java/bisq/asset/coins/Credits.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AddressValidationResult;
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class Credits extends Coin {
+
+    public Credits() {
+        super("Credits", "CRDS", new CreditsAddressValidator());
+    }
+
+
+    public static class CreditsAddressValidator extends Base58BitcoinAddressValidator {
+
+        public CreditsAddressValidator() {
+            super(new CreditsParams());
+        }
+
+        @Override
+        public AddressValidationResult validate(String address) {
+            if (!address.matches("^[C][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+                return AddressValidationResult.invalidStructure();
+
+            return super.validate(address);
+        }
+    }
+
+
+    public static class CreditsParams extends NetworkParametersAdapter {
+
+        public CreditsParams() {
+            addressHeader = 28;
+            p2shHeader = 5;
+            acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+        }
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -18,6 +18,7 @@ bisq.asset.coins.BSQ$Testnet
 bisq.asset.coins.Byteball
 bisq.asset.coins.Chaucha
 bisq.asset.coins.Counterparty
+bisq.asset.coins.Credits
 bisq.asset.coins.Croat
 bisq.asset.coins.Dash
 bisq.asset.coins.Decred

--- a/assets/src/test/java/bisq/asset/coins/CreditsTest.java
+++ b/assets/src/test/java/bisq/asset/coins/CreditsTest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class CreditsTest extends AbstractAssetTest {
+
+    public CreditsTest() {
+        super(new Credits());
+    }
+
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("CfXBhPhSxx1wqxGQCryfgn6iU1M1XFUuCo");
+        assertValidAddress("CMde7YERCFWkCL2W5i8uyJmnpCVj8Chhww");
+        assertValidAddress("CcbqU3MLZuGAED2CuhUkquyJxKaSJqv6Vb");
+        assertValidAddress("CKaig5pznaUgiLqe6WkoCNGagNMhNLtqhK");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("1fXBhPhSxx1wqxGQCryfgn6iU1M1XFUuCo32");
+        assertInvalidAddress("CMde7YERCFWkCL2W5i8uyJmnpCVj8Chh");
+        assertInvalidAddress("CcbqU3MLZuGAED2CuhUkquyJxKaSJqv6V6#");
+        assertInvalidAddress("bKaig5pznaUgiLqe6WkoCNGagNMhNLtqhKkggg");
+    }
+}


### PR DESCRIPTION
Request to Re-list Credits(CRDS)
We would like to request to be re-listed because credits will be de-listed from CryptoBridge on the 1st of Feb leaving only BarterDex as a trading platform for the credits community.
There has also been a recent release to v1.3.0.0 https://github.com/CRDS/Credits

- Official project URL: https://crds.co/
- Official block explorer URL: https://explorer.crds.co/