### PR TITLE
Allow host as bitcoinRegtestHost parameter

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -482,9 +482,9 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
                 .describedAs(format("%s|%s|%s", BTC_MAINNET, BTC_TESTNET, BTC_REGTEST));
 
         parser.accepts(BtcOptionKeys.REG_TEST_HOST,
-                format("(default: %s)", RegTestHost.DEFAULT))
+                format("Bitcoin regtest host when using BTC_REGTEST network (default: %s)", RegTestHost.DEFAULT_HOST))
                 .withRequiredArg()
-                .ofType(RegTestHost.class);
+                .describedAs("host");
 
         parser.accepts(BtcOptionKeys.BTC_NODES,
                 "Custom nodes used for BitcoinJ as comma separated IP addresses.")

--- a/core/src/main/java/bisq/core/btc/BitcoinModule.java
+++ b/core/src/main/java/bisq/core/btc/BitcoinModule.java
@@ -42,6 +42,8 @@ import com.google.inject.name.Names;
 
 import java.io.File;
 
+import java.util.Arrays;
+
 import static com.google.inject.name.Names.named;
 
 public class BitcoinModule extends AppModule {
@@ -51,7 +53,13 @@ public class BitcoinModule extends AppModule {
 
     @Override
     protected void configure() {
-        bind(RegTestHost.class).toInstance(environment.getProperty(BtcOptionKeys.REG_TEST_HOST, RegTestHost.class, RegTestHost.DEFAULT));
+        String regTestHost = environment.getProperty(BtcOptionKeys.REG_TEST_HOST, String.class, RegTestHost.DEFAULT_HOST);
+        if (Arrays.asList("localhost", "127.0.0.1").contains(regTestHost)) {
+            bind(RegTestHost.class).toInstance(RegTestHost.LOCALHOST);
+        } else {
+            bind(RegTestHost.class).toInstance(RegTestHost.REMOTE_HOST);
+        }
+        RegTestHost.HOST = regTestHost;
 
         bindConstant().annotatedWith(named(UserAgent.NAME_KEY)).to(environment.getRequiredProperty(UserAgent.NAME_KEY));
         bindConstant().annotatedWith(named(UserAgent.VERSION_KEY)).to(environment.getRequiredProperty(UserAgent.VERSION_KEY));

--- a/core/src/main/java/bisq/core/btc/setup/RegTestHost.java
+++ b/core/src/main/java/bisq/core/btc/setup/RegTestHost.java
@@ -21,9 +21,9 @@ public enum RegTestHost {
 
     NONE,
     LOCALHOST,
-    REG_TEST_SERVER; // 188.226.179.109
+    REMOTE_HOST;
 
-    public static final RegTestHost DEFAULT = LOCALHOST;
-    public static final String SERVER_IP = "188.226.179.109";
+    public static final String DEFAULT_HOST = "localhost";
+    public static String HOST = DEFAULT_HOST;
 
 }

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -235,7 +235,7 @@ public class WalletsSetup {
             walletConfig.setMinBroadcastConnections(1);
             if (regTestHost == RegTestHost.LOCALHOST) {
                 walletConfig.setPeerNodesForLocalHost();
-            } else if (regTestHost == RegTestHost.REG_TEST_SERVER) {
+            } else if (regTestHost == RegTestHost.REMOTE_HOST) {
                 walletConfig.setMinBroadcastConnections(1);
                 configPeerNodesForRegTestServer();
             } else {
@@ -315,7 +315,7 @@ public class WalletsSetup {
 
     private void configPeerNodesForRegTestServer() {
         try {
-            walletConfig.setPeerNodes(new PeerAddress(InetAddress.getByName(RegTestHost.SERVER_IP), params.getPort()));
+            walletConfig.setPeerNodes(new PeerAddress(InetAddress.getByName(RegTestHost.HOST), params.getPort()));
         } catch (UnknownHostException e) {
             log.error(e.toString());
             e.printStackTrace();


### PR DESCRIPTION
When using a remote regtest host, instead of having to pass
REG_TEST_SERVER to the bitcoinRegtestHost parameter and hard code the
host address within the code, allow the host to be specified by the
bitcoinRegtestHost parameter.