### PR TITLE
Delete tor files at startup

### DIFF
--- a/core/src/main/java/bisq/core/CoreModule.java
+++ b/core/src/main/java/bisq/core/CoreModule.java
@@ -23,6 +23,7 @@ import bisq.core.app.AvoidStandbyModeService;
 import bisq.core.app.BisqEnvironment;
 import bisq.core.app.BisqSetup;
 import bisq.core.app.P2PNetworkSetup;
+import bisq.core.app.TorSetup;
 import bisq.core.app.WalletAppSetup;
 import bisq.core.arbitration.ArbitratorModule;
 import bisq.core.btc.BitcoinModule;
@@ -80,6 +81,7 @@ public class CoreModule extends AppModule {
     @Override
     protected void configure() {
         bind(BisqSetup.class).in(Singleton.class);
+        bind(TorSetup.class).in(Singleton.class);
         bind(P2PNetworkSetup.class).in(Singleton.class);
         bind(WalletAppSetup.class).in(Singleton.class);
 

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -150,6 +150,7 @@ public class BisqSetup {
     private final VoteResultService voteResultService;
     private final AssetTradeActivityCheck tradeActivityCheck;
     private final AssetService assetService;
+    private final TorSetup torSetup;
     private final BSFormatter formatter;
     @Setter
     @Nullable
@@ -226,6 +227,7 @@ public class BisqSetup {
                      VoteResultService voteResultService,
                      AssetTradeActivityCheck tradeActivityCheck,
                      AssetService assetService,
+                     TorSetup torSetup,
                      BSFormatter formatter) {
 
 
@@ -264,6 +266,7 @@ public class BisqSetup {
         this.voteResultService = voteResultService;
         this.tradeActivityCheck = tradeActivityCheck;
         this.assetService = assetService;
+        this.torSetup = torSetup;
         this.formatter = formatter;
     }
 
@@ -286,6 +289,7 @@ public class BisqSetup {
     }
 
     private void step3() {
+        torSetup.cleanupTorFiles();
         readMapsFromResources();
         checkCryptoSetup();
         checkForCorrectOSArchitecture();

--- a/core/src/main/java/bisq/core/app/TorSetup.java
+++ b/core/src/main/java/bisq/core/app/TorSetup.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.app;
+
+import bisq.network.NetworkOptionKeys;
+
+import bisq.common.handlers.ErrorMessageHandler;
+import bisq.common.storage.FileUtil;
+
+import com.google.inject.name.Named;
+
+import javax.inject.Inject;
+
+import java.nio.file.Paths;
+
+import java.io.File;
+import java.io.IOException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+
+@Slf4j
+public class TorSetup {
+    private File torDir;
+
+    @Inject
+    public TorSetup(@Named(NetworkOptionKeys.TOR_DIR) File torDir) {
+        this.torDir = torDir;
+    }
+
+    public void cleanupTorFiles() {
+        cleanupTorFiles(null, null);
+    }
+
+    // We get sometimes Tor startup problems which is related to some tor files in the tor directory. It happens
+    // more often if the application got killed (not graceful shutdown).
+    // Creating all tor files newly takes about 3-4 sec. longer and it does not benefit from cache files.
+    // TODO: We should fix those startup problems in the netlayer library, once fixed there we can remove that call at the
+    // Bisq startup again.
+    public void cleanupTorFiles(@Nullable Runnable resultHandler, @Nullable ErrorMessageHandler errorMessageHandler) {
+        File hiddenservice = new File(Paths.get(torDir.getAbsolutePath(), "hiddenservice").toString());
+        try {
+            FileUtil.deleteDirectory(torDir, hiddenservice, true);
+            if (resultHandler != null)
+                resultHandler.run();
+        } catch (IOException e) {
+            e.printStackTrace();
+            log.error(e.toString());
+            if (errorMessageHandler != null)
+                errorMessageHandler.handleErrorMessage(e.toString());
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/app/misc/AppSetupWithP2P.java
+++ b/core/src/main/java/bisq/core/app/misc/AppSetupWithP2P.java
@@ -18,6 +18,7 @@
 package bisq.core.app.misc;
 
 import bisq.core.app.SetupUtils;
+import bisq.core.app.TorSetup;
 import bisq.core.filter.FilterManager;
 import bisq.core.payment.AccountAgeWitnessService;
 import bisq.core.trade.statistics.TradeStatisticsManager;
@@ -46,6 +47,7 @@ public class AppSetupWithP2P extends AppSetup {
     protected final P2PService p2PService;
     protected final AccountAgeWitnessService accountAgeWitnessService;
     protected final FilterManager filterManager;
+    private final TorSetup torSetup;
     protected BooleanProperty p2pNetWorkReady;
     protected final TradeStatisticsManager tradeStatisticsManager;
     protected ArrayList<PersistedDataHost> persistedDataHosts;
@@ -56,21 +58,24 @@ public class AppSetupWithP2P extends AppSetup {
                            P2PService p2PService,
                            TradeStatisticsManager tradeStatisticsManager,
                            AccountAgeWitnessService accountAgeWitnessService,
-                           FilterManager filterManager) {
+                           FilterManager filterManager,
+                           TorSetup torSetup) {
         super(encryptionService, keyRing);
         this.p2PService = p2PService;
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.accountAgeWitnessService = accountAgeWitnessService;
         this.filterManager = filterManager;
+        this.torSetup = torSetup;
         this.persistedDataHosts = new ArrayList<>();
     }
 
     @Override
     public void initPersistedDataHosts() {
+        torSetup.cleanupTorFiles();
         persistedDataHosts.add(p2PService);
 
         // we apply at startup the reading of persisted data but don't want to get it triggered in the constructor
-        persistedDataHosts.stream().forEach(e -> {
+        persistedDataHosts.forEach(e -> {
             try {
                 log.info("call readPersisted at " + e.getClass().getSimpleName());
                 e.readPersisted();

--- a/core/src/main/java/bisq/core/app/misc/AppSetupWithP2PAndDAO.java
+++ b/core/src/main/java/bisq/core/app/misc/AppSetupWithP2PAndDAO.java
@@ -17,6 +17,7 @@
 
 package bisq.core.app.misc;
 
+import bisq.core.app.TorSetup;
 import bisq.core.dao.DaoOptionKeys;
 import bisq.core.dao.DaoSetup;
 import bisq.core.dao.governance.ballot.BallotListService;
@@ -57,13 +58,15 @@ public class AppSetupWithP2PAndDAO extends AppSetupWithP2P {
                                  MyProposalListService myProposalListService,
                                  MyReputationListService myReputationListService,
                                  MyProofOfBurnListService myProofOfBurnListService,
+                                 TorSetup torSetup,
                                  @Named(DaoOptionKeys.DAO_ACTIVATED) boolean daoActivated) {
         super(encryptionService,
                 keyRing,
                 p2PService,
                 tradeStatisticsManager,
                 accountAgeWitnessService,
-                filterManager);
+                filterManager,
+                torSetup);
 
         this.daoSetup = daoSetup;
 

--- a/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
@@ -20,6 +20,7 @@ package bisq.core.app.misc;
 import bisq.core.alert.AlertModule;
 import bisq.core.app.AppOptionKeys;
 import bisq.core.app.BisqEnvironment;
+import bisq.core.app.TorSetup;
 import bisq.core.arbitration.ArbitratorModule;
 import bisq.core.btc.BitcoinModule;
 import bisq.core.dao.DaoModule;
@@ -74,6 +75,7 @@ public class ModuleForAppWithP2p extends AppModule {
         bind(PersistenceProtoResolver.class).to(CorePersistenceProtoResolver.class).in(Singleton.class);
         bind(Preferences.class).in(Singleton.class);
         bind(BridgeAddressProvider.class).to(Preferences.class).in(Singleton.class);
+        bind(TorSetup.class).in(Singleton.class);
 
         bind(SeedNodeAddressLookup.class).in(Singleton.class);
         bind(SeedNodeRepository.class).to(DefaultSeedNodeRepository.class).in(Singleton.class);


### PR DESCRIPTION
We get sometimes Tor startup problems which is related to some tor
files in the tor directory. It happens more often if the application
got killed (not graceful shutdown).
Creating all tor files newly takes about 3-4 sec. longer and it does
not benefit from cache files.
TODO: We should fix those startup problems in the netlayer library,
once fixed there we can remove that call at the
Bisq startup again.