### PR TITLE
Allow tor to be used with regtest

### DIFF
--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -446,8 +446,9 @@ public class WalletConfig extends AbstractIdleService {
             // before we're actually connected the broadcast waits for an appropriate number of connections.
             if (peerAddresses != null) {
                 for (PeerAddress addr : peerAddresses) vPeerGroup.addAddress(addr);
-                log.info("We try to connect to {} btc nodes", numConnectionForBtc);
-                vPeerGroup.setMaxConnections(Math.min(numConnectionForBtc, peerAddresses.length));
+                int maxConnections = Math.min(numConnectionForBtc, peerAddresses.length);
+                log.info("We try to connect to {} btc nodes", maxConnections);
+                vPeerGroup.setMaxConnections(maxConnections);
                 peerAddresses = null;
             } else if (!params.equals(RegTestParams.get())) {
                 vPeerGroup.addPeerDiscovery(discovery != null ? discovery : new DnsDiscovery(params));

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -236,7 +236,6 @@ public class WalletsSetup {
             if (regTestHost == RegTestHost.LOCALHOST) {
                 walletConfig.setPeerNodesForLocalHost();
             } else if (regTestHost == RegTestHost.REMOTE_HOST) {
-                walletConfig.setMinBroadcastConnections(1);
                 configPeerNodesForRegTestServer();
             } else {
                 configPeerNodes(socks5Proxy);
@@ -315,7 +314,11 @@ public class WalletsSetup {
 
     private void configPeerNodesForRegTestServer() {
         try {
-            walletConfig.setPeerNodes(new PeerAddress(InetAddress.getByName(RegTestHost.HOST), params.getPort()));
+            if (RegTestHost.HOST.endsWith(".onion")) {
+                walletConfig.setPeerNodes(new PeerAddress(RegTestHost.HOST, params.getPort()));
+            } else {
+                walletConfig.setPeerNodes(new PeerAddress(InetAddress.getByName(RegTestHost.HOST), params.getPort()));
+            }
         } catch (UnknownHostException e) {
             log.error(e.toString());
             e.printStackTrace();

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -697,7 +697,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         // On testnet there are very few Bitcoin tor nodes and we don't provide tor nodes.
         if ((!BisqEnvironment.getBaseCurrencyNetwork().isMainnet()
                 || bisqEnvironment.isBitcoinLocalhostNodeRunning())
-                && bisqEnvironment.getProperty(BtcOptionKeys.USE_TOR_FOR_BTC).isEmpty())
+                && (useTorFlagFromOptions == null || useTorFlagFromOptions.isEmpty()))
             return false;
         else
             return prefPayload.isUseTorForBitcoinJ();

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -692,10 +692,12 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     }
 
     public boolean getUseTorForBitcoinJ() {
-        // We override the useTorForBitcoinJ and set it to false if we detected a localhost node or if we are not on mainnet.
-        // At testnet there are very few Bitcoin tor nodes and we don't provide tor nodes.
-        if (!BisqEnvironment.getBaseCurrencyNetwork().isMainnet()
+        // We override the useTorForBitcoinJ and set it to false if we detected a localhost node or if we are not on mainnet,
+        // unless the useTorForBtc parameter is explicitly provided.
+        // On testnet there are very few Bitcoin tor nodes and we don't provide tor nodes.
+        if ((!BisqEnvironment.getBaseCurrencyNetwork().isMainnet()
                 || bisqEnvironment.isBitcoinLocalhostNodeRunning())
+                && bisqEnvironment.getProperty(BtcOptionKeys.USE_TOR_FOR_BTC).isEmpty())
             return false;
         else
             return prefPayload.isUseTorForBitcoinJ();


### PR DESCRIPTION
In order to simulate a realistic environment for testing purposes, this will allow tor to be used with regtest. Use the bitcoinRegtestHost parameter and specify a tor .onion address as well as include the --useTorForBtc=true parameter.