### PR TITLE
Fix missing removal of old or invalid proposals

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/votereveal/VoteRevealService.java
+++ b/core/src/main/java/bisq/core/dao/governance/votereveal/VoteRevealService.java
@@ -242,7 +242,6 @@ public class VoteRevealService implements DaoStateListener, DaoSetupService {
             // If we are not in the right phase we just add an empty hash (still need to have the hash as otherwise we
             // would not recognize the tx as vote reveal tx)
             byte[] hashOfBlindVoteList = inBlindVotePhase ? getHashOfBlindVoteList() : new byte[20];
-            log.info("revealVote: Sha256Ripemd160 hash of hashOfBlindVoteList " + Utilities.bytesAsHexString(hashOfBlindVoteList));
             byte[] opReturnData = VoteRevealConsensus.getOpReturnData(hashOfBlindVoteList, myVote.getSecretKey());
 
             // We search for my unspent stake output.


### PR DESCRIPTION
- If a proposal had a tx which is not in our BSQ state it was not removed
- If a tx was outdated (> 60 days old) it was only removed if we are
in proposal phase. We added check for past cycle to cover those as well.