### PR TITLE
Show BSQ trading fee more explicitly when funding your offer

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -373,6 +373,7 @@ createOffer.fundsBox.networkFee=Mining fee
 createOffer.fundsBox.placeOfferSpinnerInfo=Offer publishing is in progress ...
 createOffer.fundsBox.paymentLabel=Bisq trade with ID {0}
 createOffer.fundsBox.fundsStructure=({0} security deposit, {1} trade fee, {2} mining fee)
+createOffer.fundsBox.fundsStructure.BSQ=({0} security deposit, {1} mining fee) + {2} trade fee
 createOffer.success.headline=Your offer has been published
 createOffer.success.info=You can manage your open offers at \"Portfolio/My open offers\".
 createOffer.info.sellAtMarketPrice=You will always sell at market price as the price of your offer will be continuously updated.
@@ -391,6 +392,7 @@ createOffer.alreadyFunded=You had already funded that offer.\nYour funds have be
 createOffer.createOfferFundWalletInfo.headline=Fund your offer
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Trade amount: {0} \n
+createOffer.createOfferFundWalletInfo.feesWithBSQ={0} and {1}
 createOffer.createOfferFundWalletInfo.msg=You need to deposit {0} to this offer.\n\nThose funds are reserved in your local wallet and will get locked into the multisig deposit address once someone takes your offer.\n\nThe amount is the sum of:\n{1}- Your security deposit: {2}\n- Trading fee: {3}\n- Mining fee: {4}\n\nYou can choose between two options when funding your trade:\n- Use your Bisq wallet (convenient, but transactions may be linkable) OR\n- Transfer from an external wallet (potentially more private)\n\nYou will see all funding options and details after closing this popup.
 
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)

--- a/desktop/src/main/java/bisq/desktop/components/FundsTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/FundsTextField.java
@@ -52,7 +52,7 @@ public class FundsTextField extends InfoTextField {
         textField.textProperty().bind(Bindings.concat(textProperty(), " ", fundsStructure));
 
         Label copyIcon = getIcon(AwesomeIcon.COPY);
-        copyIcon.setLayoutY(3);
+        copyIcon.setLayoutY(5);
         copyIcon.getStyleClass().addAll("icon", "highlight");
         Tooltip.install(copyIcon, new Tooltip(Res.get("shared.copyToClipboard")));
         copyIcon.setOnMouseClicked(e -> {

--- a/desktop/src/main/java/bisq/desktop/components/FundsTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/FundsTextField.java
@@ -21,11 +21,11 @@ import bisq.core.locale.Res;
 
 import bisq.common.util.Utilities;
 
-import de.jensd.fx.fontawesome.AwesomeDude;
 import de.jensd.fx.fontawesome.AwesomeIcon;
 
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
+import javafx.scene.layout.AnchorPane;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleStringProperty;
@@ -33,6 +33,8 @@ import javafx.beans.property.StringProperty;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static bisq.desktop.util.FormBuilder.getIcon;
 
 public class FundsTextField extends InfoTextField {
     public static final Logger log = LoggerFactory.getLogger(FundsTextField.class);
@@ -49,11 +51,10 @@ public class FundsTextField extends InfoTextField {
         textField.textProperty().unbind();
         textField.textProperty().bind(Bindings.concat(textProperty(), " ", fundsStructure));
 
-        Label copyIcon = new Label();
+        Label copyIcon = getIcon(AwesomeIcon.COPY);
         copyIcon.setLayoutY(3);
         copyIcon.getStyleClass().addAll("icon", "highlight");
         Tooltip.install(copyIcon, new Tooltip(Res.get("shared.copyToClipboard")));
-        AwesomeDude.setIcon(copyIcon, AwesomeIcon.COPY);
         copyIcon.setOnMouseClicked(e -> {
             String text = getText();
             if (text != null && text.length() > 0) {
@@ -68,9 +69,9 @@ public class FundsTextField extends InfoTextField {
             }
         });
 
-        setRightAnchor(copyIcon, 30.0);
-        setRightAnchor(infoIcon, 62.0);
-        setRightAnchor(textField, 55.0);
+        AnchorPane.setRightAnchor(copyIcon, 30.0);
+        AnchorPane.setRightAnchor(infoIcon, 62.0);
+        AnchorPane.setRightAnchor(textField, 55.0);
 
         getChildren().add(copyIcon);
     }

--- a/desktop/src/main/java/bisq/desktop/components/InfoTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/InfoTextField.java
@@ -94,6 +94,7 @@ public class InfoTextField extends AnchorPane {
         currentIcon = infoIcon;
 
         hideIcons();
+        setActionHandlers(node);
     }
 
     public void setContentForPrivacyPopOver(Node node) {

--- a/desktop/src/main/java/bisq/desktop/components/InfoTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/InfoTextField.java
@@ -66,11 +66,11 @@ public class InfoTextField extends AnchorPane {
         textField.setId("info-field");
 
         infoIcon = getIcon(AwesomeIcon.INFO_SIGN);
-        infoIcon.setLayoutY(3);
+        infoIcon.setLayoutY(5);
         infoIcon.getStyleClass().addAll("icon", "info");
 
         privacyIcon = getIcon(AwesomeIcon.EYE_CLOSE);
-        privacyIcon.setLayoutY(3);
+        privacyIcon.setLayoutY(5);
         privacyIcon.getStyleClass().addAll("icon", "info");
 
         AnchorPane.setRightAnchor(infoIcon, 7.0);

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -83,7 +83,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class MutableOfferDataModel extends OfferDataModel implements BsqBalanceListener {
@@ -503,9 +502,15 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
     }
 
     void requestTxFee() {
+        requestTxFee(() -> {
+        });
+    }
+
+    void requestTxFee(Runnable actionHandler) {
         feeService.requestFees(() -> {
             txFeeFromFeeService = feeService.getTxFee(feeTxSize);
             calculateTotalToPay();
+            actionHandler.run();
         });
     }
 
@@ -626,7 +631,7 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
     }
 
     void calculateTotalToPay() {
-        // Maker does not pay the tx fee for the trade txs because the mining fee might be different when maker
+        // Maker does not pay the mining fee for the trade txs because the mining fee might be different when maker
         // created the offer and reserved his funds, so that would not work well with dynamic fees.
         // The mining fee for the createOfferFee tx is deducted from the createOfferFee and not visible to the trader
         final Coin makerFee = getMakerFee();

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -414,8 +414,9 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
                 String key = "createOfferFundWalletInfo";
                 String tradeAmountText = model.isSellOffer() ?
                         Res.get("createOffer.createOfferFundWalletInfo.tradeAmount", model.getTradeAmount()) : "";
+
                 String message = Res.get("createOffer.createOfferFundWalletInfo.msg",
-                        model.totalToPay.get(),
+                        model.getTotalToPayInfo(),
                         tradeAmountText,
                         model.getSecurityDepositInfo(),
                         model.getTradeFee(),
@@ -427,8 +428,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
                         .show();
             }
 
-            totalToPayTextField.setFundsStructure(Res.get("createOffer.fundsBox.fundsStructure",
-                    model.getSecurityDepositWithCode(), model.getMakerFeePercentage(), model.getTxFeePercentage()));
+            totalToPayTextField.setFundsStructure(model.getFundsStructure());
             totalToPayTextField.setContentForInfoPopOver(createInfoPopover());
         });
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -409,7 +409,28 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
         advancedOptionsBox.setVisible(false);
         advancedOptionsBox.setManaged(false);
 
-        model.onShowPayFundsScreen();
+        model.onShowPayFundsScreen(() -> {
+            if (!DevEnv.isDevMode()) {
+                String key = "createOfferFundWalletInfo";
+                String tradeAmountText = model.isSellOffer() ?
+                        Res.get("createOffer.createOfferFundWalletInfo.tradeAmount", model.getTradeAmount()) : "";
+                String message = Res.get("createOffer.createOfferFundWalletInfo.msg",
+                        model.totalToPay.get(),
+                        tradeAmountText,
+                        model.getSecurityDepositInfo(),
+                        model.getTradeFee(),
+                        model.getTxFee()
+                );
+                new Popup<>().headLine(Res.get("createOffer.createOfferFundWalletInfo.headline"))
+                        .instruction(message)
+                        .dontShowAgainId(key)
+                        .show();
+            }
+
+            totalToPayTextField.setFundsStructure(Res.get("createOffer.fundsBox.fundsStructure",
+                    model.getSecurityDepositWithCode(), model.getMakerFeePercentage(), model.getTxFeePercentage()));
+            totalToPayTextField.setContentForInfoPopOver(createInfoPopover());
+        });
 
         paymentAccountsComboBox.setDisable(true);
 
@@ -431,21 +452,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
                     .useIUnderstandButton()
                     .dontShowAgainId(key)
                     .show();
-
-            key = "createOfferFundWalletInfo";
-            String tradeAmountText = model.isSellOffer() ?
-                    Res.get("createOffer.createOfferFundWalletInfo.tradeAmount", model.getTradeAmount()) : "";
-            String message = Res.get("createOffer.createOfferFundWalletInfo.msg",
-                    model.totalToPay.get(),
-                    tradeAmountText,
-                    model.getSecurityDepositInfo(),
-                    model.getTradeFee(),
-                    model.getTxFee()
-            );
-            new Popup<>().headLine(Res.get("createOffer.createOfferFundWalletInfo.headline"))
-                    .instruction(message)
-                    .dontShowAgainId(key)
-                    .show();
         }
 
         waitingForFundsSpinner.play();
@@ -456,10 +462,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
         qrCodeImageView.setVisible(true);
         balanceTextField.setVisible(true);
         cancelButton2.setVisible(true);
-
-        totalToPayTextField.setFundsStructure(Res.get("createOffer.fundsBox.fundsStructure",
-                model.getSecurityDepositWithCode(), model.getMakerFeePercentage(), model.getTxFeePercentage()));
-        totalToPayTextField.setContentForInfoPopOver(createInfoPopover());
 
         final byte[] imageBytes = QRCode
                 .from(getBitcoinURI())

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -948,6 +948,18 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             return totalToPay + " + " + bsqFormatter.formatCoinWithCode(dataModel.getMakerFee());
     }
 
+    public String getFundsStructure() {
+        String fundsStructure;
+        if (dataModel.isCurrencyForMakerFeeBtc()) {
+            fundsStructure = Res.get("createOffer.fundsBox.fundsStructure",
+                    getSecurityDepositWithCode(), getMakerFeePercentage(), getTxFeePercentage());
+        } else {
+            fundsStructure = Res.get("createOffer.fundsBox.fundsStructure.BSQ",
+                    getSecurityDepositWithCode(), getTxFeePercentage(), bsqFormatter.formatCoinWithCode(dataModel.getMakerFee()));
+        }
+        return fundsStructure;
+    }
+
     public String getTxFee() {
         Coin txFeeAsCoin = dataModel.getTxFee();
         return btcFormatter.formatCoinWithCode(txFeeAsCoin) +

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -34,7 +34,6 @@ import bisq.desktop.util.validation.FiatVolumeValidator;
 import bisq.desktop.util.validation.MonetaryValidator;
 import bisq.desktop.util.validation.SecurityDepositValidator;
 
-import bisq.core.app.BisqEnvironment;
 import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.btc.wallet.Restrictions;
 import bisq.core.locale.CurrencyUtil;
@@ -667,9 +666,9 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         updateButtonDisableState();
     }
 
-    void onShowPayFundsScreen() {
+    void onShowPayFundsScreen(Runnable actionHandler) {
         dataModel.estimateTxSize();
-        dataModel.requestTxFee();
+        dataModel.requestTxFee(actionHandler);
         showPayFundsScreenDisplayed.set(true);
         updateSpinnerInfo();
     }


### PR DESCRIPTION
- Fixes #2075.
- Fixes wrong total funds value in info popup and funds tooltip
- Fixes missing info icon in Funds needed field
- Fixes positioning of info icons