### PR TITLE
Improve handling when unable to connect to tor

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -355,6 +355,10 @@ public class BisqSetup {
         return walletAppSetup.getBtcSplashSyncIconId();
     }
 
+    public BooleanProperty getUseTorForBTC() {
+        return walletAppSetup.getUseTorForBTC();
+    }
+
     // P2P
     public StringProperty getP2PNetworkInfo() {
         return p2PNetworkSetup.getP2PNetworkInfo();
@@ -484,6 +488,11 @@ public class BisqSetup {
         };
 
         Timer startupTimeout = UserThread.runAfter(() -> {
+            if (p2PNetworkSetup.p2pNetworkFailed.get()) {
+                // Skip this timeout action if the p2p network setup failed
+                // since a p2p network error prompt will be shown containing the error message
+                return;
+            }
             log.warn("startupTimeout called");
             if (walletsManager.areWalletsEncrypted())
                 walletInitialized.addListener(walletInitializedListener);

--- a/core/src/main/java/bisq/core/app/P2PNetworkSetup.java
+++ b/core/src/main/java/bisq/core/app/P2PNetworkSetup.java
@@ -65,6 +65,8 @@ public class P2PNetworkSetup {
     final StringProperty p2pNetworkWarnMsg = new SimpleStringProperty();
     @Getter
     final BooleanProperty updatedDataReceived = new SimpleBooleanProperty();
+    @Getter
+    final BooleanProperty p2pNetworkFailed = new SimpleBooleanProperty();
 
     @Inject
     public P2PNetworkSetup(PriceFeedService priceFeedService,
@@ -194,11 +196,12 @@ public class P2PNetworkSetup {
 
             @Override
             public void onSetupFailed(Throwable throwable) {
-                log.warn("onSetupFailed");
+                log.error("onSetupFailed");
                 p2pNetworkWarnMsg.set(Res.get("mainView.p2pNetworkWarnMsg.connectionToP2PFailed", throwable.getMessage()));
                 splashP2PNetworkAnimationVisible.set(false);
                 bootstrapWarning.set(Res.get("mainView.bootstrapWarning.bootstrappingToP2PFailed"));
                 p2pNetworkLabelId.set("splash-error-state-msg");
+                p2pNetworkFailed.set(true);
             }
 
             @Override

--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -32,8 +32,10 @@ import javax.inject.Inject;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.monadic.MonadicBinding;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -68,6 +70,8 @@ public class WalletAppSetup {
     private final StringProperty btcInfo = new SimpleStringProperty(Res.get("mainView.footer.btcInfo.initializing"));
     @Getter
     private int numBtcPeers = 0;
+    @Getter
+    private final BooleanProperty useTorForBTC = new SimpleBooleanProperty();
 
     @Inject
     public WalletAppSetup(WalletsManager walletsManager,
@@ -80,6 +84,7 @@ public class WalletAppSetup {
         this.bisqEnvironment = bisqEnvironment;
         this.preferences = preferences;
         this.formatter = formatter;
+        this.useTorForBTC.set(preferences.getUseTorForBitcoinJ());
     }
 
     void init(@Nullable Consumer<String> chainFileLockedExceptionHandler,

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -495,6 +495,13 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
         splashP2PNetworkLabel.getStyleClass().add("sub-info");
         splashP2PNetworkLabel.textProperty().bind(model.getP2PNetworkInfo());
 
+        Button showTorNetworkSettingsButton = new AutoTooltipButton(Res.get("settings.net.openTorSettingsButton"));
+        showTorNetworkSettingsButton.setVisible(false);
+        showTorNetworkSettingsButton.setManaged(false);
+        showTorNetworkSettingsButton.setOnAction(e -> {
+            model.getTorNetworkSettingsWindow().show();
+        });
+
         splashP2PNetworkBusyAnimation = new BusyAnimation(false);
 
         splashP2PNetworkErrorMsgListener = (ov, oldValue, newValue) -> {
@@ -504,20 +511,19 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
                 splashP2PNetworkLabel.getStyleClass().add("error-text");
                 splashP2PNetworkBusyAnimation.setDisable(true);
                 splashP2PNetworkBusyAnimation.stop();
+                showTorNetworkSettingsButton.setVisible(true);
+                showTorNetworkSettingsButton.setManaged(true);
+                if (model.getUseTorForBTC().get()) {
+                    // If using tor for BTC, hide the BTC status since tor is not working
+                    btcSyncIndicator.setVisible(false);
+                    btcSplashInfo.setVisible(false);
+                }
             } else if (model.getSplashP2PNetworkAnimationVisible().get()) {
                 splashP2PNetworkBusyAnimation.setDisable(false);
                 splashP2PNetworkBusyAnimation.play();
             }
         };
         model.getP2pNetworkWarnMsg().addListener(splashP2PNetworkErrorMsgListener);
-
-
-        Button showTorNetworkSettingsButton = new AutoTooltipButton(Res.get("settings.net.openTorSettingsButton"));
-        showTorNetworkSettingsButton.setVisible(false);
-        showTorNetworkSettingsButton.setManaged(false);
-        showTorNetworkSettingsButton.setOnAction(e -> {
-            model.getTorNetworkSettingsWindow().show();
-        });
 
         ImageView splashP2PNetworkIcon = new ImageView();
         splashP2PNetworkIcon.setId("image-connection-tor");
@@ -528,6 +534,11 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
         Timer showTorNetworkSettingsTimer = UserThread.runAfter(() -> {
             showTorNetworkSettingsButton.setVisible(true);
             showTorNetworkSettingsButton.setManaged(true);
+            if (btcSyncIndicator.progressProperty().getValue() <= 0) {
+                // If no progress has been made, hide the BTC status since tor is not working
+                btcSyncIndicator.setVisible(false);
+                btcSplashInfo.setVisible(false);
+            }
         }, SHOW_TOR_SETTINGS_DELAY_SEC);
 
         splashP2PNetworkIconIdListener = (ov, oldValue, newValue) -> {

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -510,6 +510,10 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
         return bisqSetup.getBtcSplashSyncIconId();
     }
 
+    BooleanProperty getUseTorForBTC() {
+        return bisqSetup.getUseTorForBTC();
+    }
+
     // P2P
     StringProperty getP2PNetworkInfo() {
         return bisqSetup.getP2PNetworkInfo();

--- a/p2p/src/main/java/bisq/network/p2p/network/SetupListener.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/SetupListener.java
@@ -22,7 +22,6 @@ public interface SetupListener {
 
     void onHiddenServicePublished();
 
-    @SuppressWarnings("unused")
     void onSetupFailed(Throwable throwable);
 
     void onRequestCustomBridges();

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -288,13 +288,13 @@ public class TorNetworkNode extends NetworkNode {
                 log.error("Tor node creation failed: " + (e.getCause() != null ? e.getCause().toString() : e.toString()));
                 restartTor(e.getMessage());
             } catch (IOException e) {
-                log.error("Could not connect to running Tor: "
-                        + e.getMessage());
-
-                // Seems a bit harsh, but since we cannot connect to Tor, we cannot do nothing.
+                log.error("Could not connect to running Tor: " + e.getMessage());
+                // Since we cannot connect to Tor, we cannot do nothing.
                 // Furthermore, we have no hidden services started yet, so there is no graceful
                 // shutdown needed either
-                System.exit(1);
+                UserThread.execute(() -> {
+                    setupListeners.stream().forEach(s -> s.onSetupFailed(new RuntimeException(e.getMessage())));
+                });
             } catch (Throwable ignore) {
             }
 
@@ -306,8 +306,7 @@ public class TorNetworkNode extends NetworkNode {
 
             public void onFailure(@NotNull Throwable throwable) {
                 UserThread.execute(() -> {
-                    log.error("Hidden service creation failed" + throwable);
-                    restartTor(throwable.getMessage());
+                    log.error("Hidden service creation failed: " + throwable);
                 });
             }
         });


### PR DESCRIPTION
Issue: If an IOException is raised when attempting to create
tor and the hidden service, the application will just quit without
any indication to the user. One particular scenario where this occurs
is mentioned in https://github.com/bisq-network/bisq/issues/2398.

Cause: There is an explicit statement to exit the application when an
IOException is raised.

Fix: Rather than just exit the application, show an error message
and inform the user what went wrong.