### PR TITLE
Add utm parameters to bisq.network links

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -178,6 +178,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
         BalanceWithConfirmationTextField.setWalletService(btcWalletService);
 
         GUIUtil.setFeeService(feeService);
+        GUIUtil.setPreferences(preferences);
 
         setupHandlers();
         bisqSetup.addBisqSetupCompleteListener(this);


### PR DESCRIPTION
To be able to learn if we are communicating the DAO within the client properly.
Also it adds the client language as campaign parameter to learn which translations are most important for the desktop client right now.