### PR TITLE
List LitecoinPlus (LCP)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/LitecoinPlus.java
+++ b/assets/src/main/java/bisq/asset/coins/LitecoinPlus.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class LitecoinPlus extends Coin {
+
+    public LitecoinPlus() {
+        super("LitecoinPlus", "LCP", new Base58BitcoinAddressValidator(new LitecoinPlusMainNetParams()));
+    }
+
+    public static class LitecoinPlusMainNetParams extends NetworkParametersAdapter {
+        public LitecoinPlusMainNetParams() {
+            this.addressHeader = 75;
+            this.p2shHeader = 8;
+            this.acceptableAddressCodes = new int[]{this.addressHeader, this.p2shHeader};
+        }
+    }
+}
+

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -46,6 +46,7 @@ bisq.asset.coins.IdaPay
 bisq.asset.coins.Iridium
 bisq.asset.coins.Kekcoin
 bisq.asset.coins.Litecoin
+bisq.asset.coins.LitecoinPlus
 bisq.asset.coins.LitecoinZ
 bisq.asset.coins.Lytix
 bisq.asset.coins.Mask

--- a/assets/src/test/java/bisq/asset/coins/LitecoinPlusTest.java
+++ b/assets/src/test/java/bisq/asset/coins/LitecoinPlusTest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class LitecoinPlusTest extends AbstractAssetTest {
+
+    public LitecoinPlusTest() {
+        super(new LitecoinPlus());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("XGnikpGiuDTaxq9vPfDF9m9VfTpv4SnNN5");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("1LgfapHEPhZbRF9pMd5WPT35hFXcZS1USrW");
+        assertInvalidAddress("LgfapHEPhZbdRF9pMd5WPT35hFXcZS1USrW");
+        assertInvalidAddress("LgfapHEPhZbRF9pMd5WPT35hFXcZS1USrW#");
+    }
+}
+


### PR DESCRIPTION
Author: Simone Lussardi <simone.lussardi@learn-digital.com>
Date:   Wed Feb 13 18:15:00 2019 +0800

- Official project URL: https://litecoinplus.co
- Official block explorer URL: http://lcp.altcoinwarz.com

PS: we are in the process of remaking the block explorer page because of some bugs in that software, but the count of blocks in the bottom/right corner is always correct, just the list is not always ordered and delayed sometimes. This is the alpha version of the new explorer:
http://65.102.140.122:4004/