### PR TITLE
Fix incorrect progress listener for spv file resync

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -466,7 +466,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
 
         btcSyncIndicator = new JFXProgressBar();
         btcSyncIndicator.setPrefWidth(305);
-        btcSyncIndicator.progressProperty().bind(model.getBtcSyncProgress());
+        btcSyncIndicator.progressProperty().bind(model.getCombinedSyncProgress());
 
         ImageView btcSyncIcon = new ImageView();
         btcSyncIcon.setVisible(false);
@@ -606,7 +606,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
         ProgressBar blockchainSyncIndicator = new JFXProgressBar(-1);
         blockchainSyncIndicator.setPrefWidth(80);
         blockchainSyncIndicator.setMaxHeight(10);
-        blockchainSyncIndicator.progressProperty().bind(model.getBtcSyncProgress());
+        blockchainSyncIndicator.progressProperty().bind(model.getCombinedSyncProgress());
 
         model.getWalletServiceErrorMsg().addListener((ov, oldValue, newValue) -> {
             if (newValue != null) {
@@ -623,7 +623,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
             }
         });
 
-        model.getBtcSyncProgress().addListener((ov, oldValue, newValue) -> {
+        model.getCombinedSyncProgress().addListener((ov, oldValue, newValue) -> {
             if ((double) newValue >= 1) {
                 blockchainSyncIndicator.setVisible(false);
                 blockchainSyncIndicator.setManaged(false);

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -423,10 +423,10 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
     private void showFirstPopupIfResyncSPVRequested() {
         Popup firstPopup = new Popup<>();
         firstPopup.information(Res.get("settings.net.reSyncSPVAfterRestart")).show();
-        if (getBtcSyncProgress().get() == 1) {
+        if (bisqSetup.getBtcSyncProgress().get() == 1) {
             showSecondPopupIfResyncSPVRequested(firstPopup);
         } else {
-            getBtcSyncProgress().addListener((observable, oldValue, newValue) -> {
+            bisqSetup.getBtcSyncProgress().addListener((observable, oldValue, newValue) -> {
                 if ((double) newValue == 1)
                     showSecondPopupIfResyncSPVRequested(firstPopup);
             });
@@ -525,7 +525,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
         return combinedInfo;
     }
 
-    DoubleProperty getBtcSyncProgress() {
+    DoubleProperty getCombinedSyncProgress() {
         return combinedSyncProgress;
     }
 


### PR DESCRIPTION
- Rename model.getBtcSyncProgress() to model.getCombinedSyncProgress()
to reflect correct property
- Use bisqSetup.getBtcSyncProgress() instead of
getCombinedSyncProgress() in showFirstPopupIfResyncSPVRequested as we
need to listen to btc progress only not DAO progress.

@ripcurlx This is a bug fix for spv file resync.