### PR TITLE
Download rpm package on RedHat-based Linux

### DIFF
--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -171,6 +171,14 @@ public class Utilities {
         return getOSName().contains("linux");
     }
 
+    public static boolean isDebianLinux() {
+        return isLinux() && new File("/etc/debian_version").isFile();
+    }
+
+    public static boolean isRedHatLinux() {
+        return isLinux() && new File("/etc/redhat-release").isFile();
+    }
+
     private static String getOSName() {
         return System.getProperty("os.name").toLowerCase(Locale.US);
     }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
@@ -63,7 +63,7 @@ public class BisqInstaller {
     private static final String DOWNLOAD_HOST_URL = "https://github.com/bisq-network/exchange/releases/download/";
 
     public boolean isSupportedOS() {
-        return Utilities.isOSX() || Utilities.isWindows() || Utilities.isLinux();
+        return Utilities.isOSX() || Utilities.isWindows() || Utilities.isDebianLinux() || Utilities.isRedHatLinux();
     }
 
     public Optional<DownloadTask> download(String version) {
@@ -211,10 +211,12 @@ public class BisqInstaller {
             fileName = prefix + version + ".dmg";
         else if (Utilities.isWindows())
             fileName = prefix + Utilities.getOSArchitecture() + "bit-" + version + ".exe";
-        else if (Utilities.isLinux())
+        else if (Utilities.isDebianLinux())
             fileName = prefix + Utilities.getOSArchitecture() + "bit-" + version + ".deb";
+        else if (Utilities.isRedHatLinux())
+            fileName = prefix + Utilities.getOSArchitecture() + "bit-" + version + ".rpm";
         else
-            throw new RuntimeException("No suitable OS found, use osCheck before calling this method.");
+            throw new RuntimeException("No suitable install package available for your OS.");
 
         return FileDescriptor.builder()
                 .type(DownloadType.INSTALLER)


### PR DESCRIPTION
Currently, the download update task will download the deb package for
any Linux distribution. Not only is this incorrect, but now that we are
able to provide an rpm package (see #2200), the download update task
needs to be able to differentiate Linux distributions and provide
the appropriate package.

The download update task will now differentiate between Debian and
RedHat based distributions (the two distributions for which we have an
install package) and download the appropriate package.

In addition, the isSupportedOS method was changed to exclusively check
for Debian and RedHat based distributions, as opposed to just Linux in
general. This means that any other distribution will encounter the
following error, which seems appropriate:

> Unable to determine the correct installer. Please download and verify
manually at https://bisq.network/downloads