### PR TITLE
Improve payout layout for arbitration

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -394,21 +394,24 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
 
     private void addPayoutAmountTextFields() {
         buyerPayoutAmountInputTextField = new InputTextField();
+        buyerPayoutAmountInputTextField.setLabelFloat(true);
         buyerPayoutAmountInputTextField.setEditable(false);
         buyerPayoutAmountInputTextField.setPromptText(Res.get("disputeSummaryWindow.payoutAmount.buyer"));
 
         sellerPayoutAmountInputTextField = new InputTextField();
+        sellerPayoutAmountInputTextField.setLabelFloat(true);
         sellerPayoutAmountInputTextField.setPromptText(Res.get("disputeSummaryWindow.payoutAmount.seller"));
         sellerPayoutAmountInputTextField.setEditable(false);
 
         isLoserPublisherCheckBox = new AutoTooltipCheckBox(Res.get("disputeSummaryWindow.payoutAmount.invert"));
 
         VBox vBox = new VBox();
-        vBox.setSpacing(10);
+        vBox.setSpacing(15);
         vBox.getChildren().addAll(buyerPayoutAmountInputTextField, sellerPayoutAmountInputTextField, isLoserPublisherCheckBox);
-
-        VBox vBox2 = addTopLabelWithVBox(gridPane, rowIndex, Res.get("disputeSummaryWindow.payout"), vBox, 10).second;
-        GridPane.setColumnIndex(vBox2, 1);
+        GridPane.setMargin(vBox, new Insets(Layout.FIRST_ROW_AND_GROUP_DISTANCE, 0, 0, 0));
+        GridPane.setRowIndex(vBox, rowIndex);
+        GridPane.setColumnIndex(vBox, 1);
+        gridPane.getChildren().add(vBox);
     }
 
     private void addReasonControls() {


### PR DESCRIPTION
Instead of
![bildschirmfoto 2019-02-18 um 18 33 22](https://user-images.githubusercontent.com/170962/52968663-318a8b00-33ae-11e9-86e5-cf612371984b.png)
buyer and seller amount have a floating top label if set
![bildschirmfoto 2019-02-18 um 18 48 56](https://user-images.githubusercontent.com/170962/52968692-46671e80-33ae-11e9-9ca3-2e1d780cd061.png)
