### PR TITLE
Display BSQ marketcap using preferred currency

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/dashboard/BsqDashboardView.java
@@ -223,7 +223,8 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
             priceTextField.setText(bsqFormatter.formatPrice(bsqPrice) + " BSQ/BTC");
 
             marketCapTextField.setText(bsqFormatter.formatMarketCap(priceFeedService.getMarketPrice("BSQ"),
-                    priceFeedService.getMarketPrice("USD"), availableAmount));
+                    priceFeedService.getMarketPrice(preferences.getPreferredTradeCurrency().getCode()),
+                    availableAmount));
         } else {
             priceTextField.setText(Res.get("shared.na"));
             marketCapTextField.setText(Res.get("shared.na"));


### PR DESCRIPTION
In the BSQ dashboard view, the market capitalisation is shown in USD.
Instead, use the user's preferred currency.