### PR TITLE
Fix Windows system tray icon resolution

### DIFF
--- a/desktop/src/main/java/bisq/desktop/app/SystemTray.java
+++ b/desktop/src/main/java/bisq/desktop/app/SystemTray.java
@@ -106,11 +106,16 @@ public class SystemTray {
         try {
             BufferedImage trayIconImage = ImageIO.read(getClass().getResource(path));
             TrayIcon trayIcon = new TrayIcon(trayIconImage);
-            // On Windows and Linux the icon needs to be scaled
+            // On Windows and Linux the icon needs to be resized
             // On macOS we get the correct size from the provided image
             if (!Utilities.isOSX()) {
-                int trayIconWidth = trayIcon.getSize().width;
-                trayIcon = new TrayIcon(trayIconImage.getScaledInstance(trayIconWidth, -1, Image.SCALE_SMOOTH));
+                if (ImageUtil.isRetina()) {
+                    // Using auto sizing provides better results with high resolution
+                    trayIcon.setImageAutoSize(true);
+                } else {
+                    // Using scaling provides better results with low resolution
+                    trayIcon = new TrayIcon(trayIconImage.getScaledInstance(trayIcon.getSize().width, -1, Image.SCALE_SMOOTH));
+                }
             }
 
             trayIcon.setPopupMenu(popupMenu);


### PR DESCRIPTION
For high resolution, using auto sizing provides better results.

Fixes https://github.com/bisq-network/bisq/issues/1996