### PR TITLE
Fixed memory leak in message throttle mechanism

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -378,9 +378,10 @@ public class Connection implements MessageListener {
                             .collect(Collectors.toList()).toString());
                 }
             }
-            // we limit to max 1000 (MSG_THROTTLE_PER_10SEC) entries
-            messageTimeStamps.remove(0);
         }
+        // we limit to max 1000 (MSG_THROTTLE_PER_10SEC) entries
+        while(messageTimeStamps.size() > MSG_THROTTLE_PER_10_SEC)
+            messageTimeStamps.remove(0);
 
         messageTimeStamps.add(new Tuple2<>(now, networkEnvelope));
         return violated;


### PR DESCRIPTION
mostly showed during seed node operations (as the seed nodes tend to run for longer than a client), however, every Bisq instance has been affected.

Made a test with MSG_THROTTLE_PER_10_SEC = 50:

_ | diff byte[] in 15min |
|:------|------:|
before | +700.000 |
after: | +100 |

fixes #599 - finally (and hopefully)