### PR TITLE
Show valuation in BTC balance tooltips

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -97,6 +97,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
     private final DaoPresentation daoPresentation;
     private final P2PService p2PService;
     private final TradeManager tradeManager;
+    @Getter
     private final Preferences preferences;
     private final PrivateNotificationManager privateNotificationManager;
     private final WalletPasswordWindow walletPasswordWindow;
@@ -589,6 +590,10 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
 
     IntegerProperty getMarketPriceUpdated() {
         return marketPricePresentation.getMarketPriceUpdated();
+    }
+
+    StringProperty getMarketPrice() {
+        return marketPricePresentation.getMarketPrice();
     }
 
     public ObservableList<PriceFeedComboBoxItem> getPriceFeedComboBoxItems() {

--- a/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
@@ -237,4 +237,8 @@ public class MarketPricePresentation {
     public IntegerProperty getMarketPriceUpdated() {
         return marketPriceUpdated;
     }
+
+    public StringProperty getMarketPrice() {
+        return marketPrice;
+    }
 }


### PR DESCRIPTION
When hovering over the available, reserved, and locked BTC balances
in the main view, show the market price valuation based on your
preferred currency.

![image](https://user-images.githubusercontent.com/603793/53609230-c5acdd00-3b7a-11e9-95ed-d1807cf0e739.png)

Fixes https://github.com/bisq-network/bisq/issues/1770