### PR TITLE
Add MacOS support in install_java.sh script

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,7 +1,7 @@
 # Building Bisq
 
 _You will need [OpenJDK 10](https://jdk.java.net/10/) installed and configured as the default system JDK to complete the following instructions. See the `scripts` directory for scripts that can be used to install and configure the JDK automatically._
-
+> TIP: If you are on MacOS, run the script with this command `. scripts/install_java.sh`.
 
 ## Clone
 

--- a/docs/idea-import.md
+++ b/docs/idea-import.md
@@ -12,6 +12,7 @@ Most Bisq contributors use IDEA for development. The following instructions have
  1. In the `Import Project from Gradle` screen, check the `Use auto-import` option and click `OK`
  1. When prompted whether to overwrite the existing `.idea` directory, click `Yes`
  1. In the `Project` tool window, right click on the root-level `.idea` folder, select `Git->Revert...` and click OK in the dialog that appears (to restore source-controlled `.idea` configuration files that get overwritten during project import)
+ 1. If you did not yet setup JDK10 in IntelliJ, Go to `File -> Project Structure -> Project` and under the `Project SDK` option locate your JAVA_HOME folder, then in `Project language level` beneath select `10 - ...`.
  1. Go to `Build->Build Project`. Everything should build cleanly. You should be able to run tests, run `main` methods in any component, etc.
 
 > TIP: If you encounter compilation errors in IDEA related to the `io.bisq.generated.protobuffer.PB` class, it is probably because you didn't build Bisq at the command line as instructed above. You need to run the `generateProto` task in the `common` project. You can do this via the Gradle tool window in IDEA, or you can do it the command line with `./gradlew :common:generateProto`. Once you've done that, run `Build->Build Project` again and you should have no errors.

--- a/scripts/install_java.sh
+++ b/scripts/install_java.sh
@@ -3,40 +3,80 @@
 # It will also configure it as the default system JDK.
 # If you need to change to another default JDK for another purpose later, you can use the
 # following commands and select the default JDK:
+# Linux:
 #     update-alternatives --config java
 #     update-alternatives --config javac
+# MacOS:
+#     echo 'export JAVA_HOME=/Library/Java/JavaVirtualMachines/<ENTER_NEW_JDK>/Contents/Home' >>~/.bash_profile
+#     echo 'export PATH=$JAVA_HOME/bin:$PATH' >>~/.bash_profile
+#     source ~/.bash_profile
 
-JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
-JDK_FILENAME=openjdk-10.0.2_linux-x64_bin.tar.gz
-JDK_URL=https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz
 
-# Determine which package manager to use depending on the distribution
-declare -A osInfo;
-osInfo[/etc/redhat-release]=yum
-osInfo[/etc/arch-release]=pacman
-osInfo[/etc/gentoo-release]=emerge
-osInfo[/etc/SuSE-release]=zypp
-osInfo[/etc/debian_version]=apt-get
-for f in ${!osInfo[@]}
-do
-    if [[ -f $f ]]; then
-        PACKAGE_MANAGER=${osInfo[$f]}
-        break
-    fi
-done
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     
+        JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
+        JDK_FILENAME=openjdk-10.0.2_linux-x64_bin.tar.gz
+        JDK_URL=https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz
 
-if [ ! -d "$JAVA_HOME" ]; then
-    # Ensure curl is installed since it may not be
-    $PACKAGE_MANAGER -y install curl
+        # Determine which package manager to use depending on the distribution
+        declare -A osInfo;
+        osInfo[/etc/redhat-release]=yum
+        osInfo[/etc/arch-release]=pacman
+        osInfo[/etc/gentoo-release]=emerge
+        osInfo[/etc/SuSE-release]=zypp
+        osInfo[/etc/debian_version]=apt-get
 
-    curl -L -O $JDK_URL
-    mkdir -p $JAVA_HOME
-    tar -zxf $JDK_FILENAME -C $JAVA_HOME --strip 1
-    rm $JDK_FILENAME
+        for f in ${!osInfo[@]}
+        do
+            if [[ -f $f ]]; then
+                PACKAGE_MANAGER=${osInfo[$f]}
+                break
+            fi
+        done
 
-    update-alternatives --install /usr/bin/java java $JAVA_HOME/bin/java 2000
-    update-alternatives --install /usr/bin/javac javac $JAVA_HOME/bin/javac 2000
-fi
+        if [ ! -d "$JAVA_HOME" ]; then
+            # Ensure curl is installed since it may not be
+            $PACKAGE_MANAGER -y install curl
 
-update-alternatives --set java $JAVA_HOME/bin/java
-update-alternatives --set javac $JAVA_HOME/bin/javac
+            curl -L -O $JDK_URL
+            mkdir -p $JAVA_HOME
+            tar -zxf $JDK_FILENAME -C $JAVA_HOME --strip 1
+            rm $JDK_FILENAME
+
+            update-alternatives --install /usr/bin/java java $JAVA_HOME/bin/java 2000
+            update-alternatives --install /usr/bin/javac javac $JAVA_HOME/bin/javac 2000
+        fi
+
+        update-alternatives --set java $JAVA_HOME/bin/java
+        update-alternatives --set javac $JAVA_HOME/bin/javac
+        ;;
+    Darwin*)
+        JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-10.0.2.jdk/Contents/Home
+        JDK_FILENAME=openjdk-10.0.2_osx-x64_bin.tar.gz
+        JDK_URL=https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_osx-x64_bin.tar.gz
+        if [ ! -d "$JAVA_HOME" ]; then
+            if [[ $(command -v brew) == "" ]]; then
+                echo "Installing Hombrew"
+                /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+            else
+                echo "Updating Homebrew"
+                brew update
+            fi
+
+            brew install curl
+            curl -L -O $JDK_URL
+            sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-10.0.2.jdk | sudo bash
+            gunzip -c $JDK_FILENAME | tar xopf -
+            sudo mv jdk-10.0.2.jdk/* /Library/Java/JavaVirtualMachines/openjdk-10.0.2.jdk
+            sudo rmdir jdk-10.0.2.jdk
+            rm $JDK_FILENAME
+        fi
+
+        echo export JAVA_HOME=$JAVA_HOME >>~/.bash_profile
+        echo export PATH=$JAVA_HOME/bin:$PATH >>~/.bash_profile
+        source ~/.bash_profile
+        ;;
+    *)          machine="UNKNOWN:${unameOut}"
+esac
+java -version


### PR DESCRIPTION
Modified the `scripts/install_java.sh` script to support MacOS.
Added a step of setting the JDK in IntelliJ IDEA to the `import-idea` doc.