### PR TITLE
Update bond lockup prompt

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1411,9 +1411,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Lockup
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Sperren
 dao.bond.reputation.lockup.headline=Sperrung-Transaktion bestätigen
-dao.bond.reputation.lockup.details=Gesperrter Betrag: {0}\nSperr Zeit: {1} Blöcke(Block)\n\nSind Sie sicher, dass Sie fortfahren möchten?
+dao.bond.reputation.lockup.details=Gesperrter Betrag: {0}\nSperr Zeit: {1} Blöcke(Block) (≈{2})\n\nSind Sie sicher, dass Sie fortfahren möchten?
 dao.bond.reputation.unlock.headline=Entsperrung-Transaktion bestätigen
-dao.bond.reputation.unlock.details=Entsperrter Betrag: {0}\nSperr Zeit: {1} Blöcke(Block)\n\nSind Sie sicher, dass Sie fortfahren möchten?
+dao.bond.reputation.unlock.details=Entsperrter Betrag: {0}\nSperr Zeit: {1} Blöcke(Block) (≈{2})\n\nSind Sie sicher, dass Sie fortfahren möchten?
 
 dao.bond.allBonds.header=Alle Pfänder
 

--- a/core/src/main/resources/i18n/displayStrings_el.properties
+++ b/core/src/main/resources/i18n/displayStrings_el.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Lockup
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Bloquear
 dao.bond.reputation.lockup.headline=Confirmar transacción de bloqueo
-dao.bond.reputation.lockup.details=Cantidad bloqueada: {0}\nTiempo de bloqueo: {1} bloque(s)\n\nEstá seguro de que quiere proceder?
+dao.bond.reputation.lockup.details=Cantidad bloqueada: {0}\nTiempo de bloqueo: {1} bloque(s) (≈{2})\n\nEstá seguro de que quiere proceder?
 dao.bond.reputation.unlock.headline=Confirmar desbloqueo de transacción
-dao.bond.reputation.unlock.details=Cantidad a desbloquear: {0}\nTiempo de bloqueo: {1} bloque(s)\n\nEstá seguro de que quiere proceder?
+dao.bond.reputation.unlock.details=Cantidad a desbloquear: {0}\nTiempo de bloqueo: {1} bloque(s) (≈{2})\n\nEstá seguro de que quiere proceder?
 
 dao.bond.allBonds.header=Todos los bonos
 

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=داده تصادفی
 dao.bond.reputation.hash=تابع درهم ساز (هش)
 dao.bond.reputation.lockupButton=قفل کردن
 dao.bond.reputation.lockup.headline=تایید تراکنش قفل کردن وجه
-dao.bond.reputation.lockup.details=مقدار وجه قفل شده: {0}\nمدت زمان قفل ماندن: ({1}) بلاک\n\nآیا از ادامه دادن مطمئنید؟
+dao.bond.reputation.lockup.details=مقدار وجه قفل شده: {0}\nمدت زمان قفل ماندن: ({1}) بلاک (≈{2})\n\nآیا از ادامه دادن مطمئنید؟
 dao.bond.reputation.unlock.headline=تایید تراکنش رها کردن وجه
-dao.bond.reputation.unlock.details=مقدار رها شدن وجه: {0}\nمدت زمان قفل شدن: ({1}) بلاک\n\nآیا از ادامه دادن مطمئنید؟
+dao.bond.reputation.unlock.details=مقدار رها شدن وجه: {0}\nمدت زمان قفل شدن: ({1}) بلاک (≈{2})\n\nآیا از ادامه دادن مطمئنید؟
 
 dao.bond.allBonds.header=همه ضمانت‌ها
 

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Lockup
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/core/src/main/resources/i18n/displayStrings_hu.properties
+++ b/core/src/main/resources/i18n/displayStrings_hu.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Lockup
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Sal
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Travar
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/core/src/main/resources/i18n/displayStrings_ro.properties
+++ b/core/src/main/resources/i18n/displayStrings_ro.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Lockup
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/core/src/main/resources/i18n/displayStrings_ru.properties
+++ b/core/src/main/resources/i18n/displayStrings_ru.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Соль
 dao.bond.reputation.hash=Хеш
 dao.bond.reputation.lockupButton=Запереть
 dao.bond.reputation.lockup.headline=Подтвердить транзакцию блокировки
-dao.bond.reputation.lockup.details=Запереть сумму: {0}\nВремя блокировки: {1} блок(ов) \n\nДействительно желаете продолжить?
+dao.bond.reputation.lockup.details=Запереть сумму: {0}\nВремя блокировки: {1} блок(ов) (≈{2})\n\nДействительно желаете продолжить?
 dao.bond.reputation.unlock.headline=Подтвердить транзакцию разблокировки
-dao.bond.reputation.unlock.details=Отпереть сумму: {0}\nВремя блокировки: {1} блок(ов)\n\nДействительно желаете продолжить?
+dao.bond.reputation.unlock.details=Отпереть сумму: {0}\nВремя блокировки: {1} блок(ов) (≈{2})\n\nДействительно желаете продолжить?
 
 dao.bond.allBonds.header=Все гарантийные депозиты
 

--- a/core/src/main/resources/i18n/displayStrings_sr.properties
+++ b/core/src/main/resources/i18n/displayStrings_sr.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Lockup
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=ข้อมูลแบบสุ่ม
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=ล็อค
 dao.bond.reputation.lockup.headline=ยืนยันล็อคการทำรายการ
-dao.bond.reputation.lockup.details=ล็อคจำนวน: {0}\nล็อคเวลา: {1} บล็อก\n\nคุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?
+dao.bond.reputation.lockup.details=ล็อคจำนวน: {0}\nล็อคเวลา: {1} บล็อก (≈{2})\n\nคุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?
 dao.bond.reputation.unlock.headline=ยืนยันการปลดล็อกธุรกรรม
-dao.bond.reputation.unlock.details=จำนวนที่ปลดล็อค: {0}\nเวลาในการล็อค: {1} บล็อก (s)\n\nคุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ
+dao.bond.reputation.unlock.details=จำนวนที่ปลดล็อค: {0}\nเวลาในการล็อค: {1} บล็อก (s) (≈{2})\n\nคุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ
 
 dao.bond.allBonds.header=การค้ำประกันทั้งหมด
 

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Khóa
 dao.bond.reputation.lockup.headline=Xác nhận giao dịch khóa
-dao.bond.reputation.lockup.details=Số lượng khóa: {0}\nThời gian khóa: {1} khối\n\nBạn có thực sự muốn tiếp tục?
+dao.bond.reputation.lockup.details=Số lượng khóa: {0}\nThời gian khóa: {1} khối (≈{2})\n\nBạn có thực sự muốn tiếp tục?
 dao.bond.reputation.unlock.headline=Xác nhận giao dịch mở khóa
-dao.bond.reputation.unlock.details=Số lượng mở khóa: {0}\nThời gian mở khóa: {1} khối\n\nBạn có thực sự muốn tiếp tục?
+dao.bond.reputation.unlock.details=Số lượng mở khóa: {0}\nThời gian mở khóa: {1} khối (≈{2})\n\nBạn có thực sự muốn tiếp tục?
 
 dao.bond.allBonds.header=Tất cả cách tài sản đảm bảo
 

--- a/core/src/main/resources/i18n/displayStrings_zh.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh.properties
@@ -1227,9 +1227,9 @@ dao.bond.reputation.salt=Salt
 dao.bond.reputation.hash=Hash
 dao.bond.reputation.lockupButton=Lockup
 dao.bond.reputation.lockup.headline=Confirm lockup transaction
-dao.bond.reputation.lockup.details=Lockup amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.lockup.details=Lockup amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 dao.bond.reputation.unlock.headline=Confirm unlock transaction
-dao.bond.reputation.unlock.details=Unlock amount: {0}\nLockup time: {1} block(s)\n\nAre you sure you want to proceed?
+dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s) (≈{2})\n\nAre you sure you want to proceed?
 
 dao.bond.allBonds.header=All bonds
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
@@ -34,6 +34,7 @@ import bisq.core.dao.state.model.blockchain.TxOutput;
 import bisq.core.dao.state.model.governance.BondedRoleType;
 import bisq.core.dao.state.model.governance.Role;
 import bisq.core.locale.Res;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.network.p2p.P2PService;
@@ -100,10 +101,13 @@ public class BondingViewUtils {
                             Consumer<String> resultHandler) {
         if (GUIUtil.isReadyForTxBroadcast(p2PService, walletsSetup)) {
             if (!DevEnv.isDevMode()) {
+                BSFormatter formatter = new BSFormatter();
+                String duration = formatter.formatDurationAsWords(lockupTime * 10 * 60 * 1000L, false, false);
                 new Popup<>().headLine(Res.get("dao.bond.reputation.lockup.headline"))
                         .confirmation(Res.get("dao.bond.reputation.lockup.details",
                                 bsqFormatter.formatCoinWithCode(lockupAmount),
-                                lockupTime
+                                lockupTime,
+                                duration
                         ))
                         .actionButtonText(Res.get("shared.yes"))
                         .onAction(() -> publishLockupTx(hash, lockupAmount, lockupTime, lockupReason, resultHandler))
@@ -143,10 +147,13 @@ public class BondingViewUtils {
 
             try {
                 if (!DevEnv.isDevMode()) {
+                    BSFormatter formatter = new BSFormatter();
+                    String duration = formatter.formatDurationAsWords(lockTime * 10 * 60 * 1000L, false, false);
                     new Popup<>().headLine(Res.get("dao.bond.reputation.unlock.headline"))
                             .confirmation(Res.get("dao.bond.reputation.unlock.details",
                                     bsqFormatter.formatCoinWithCode(unlockAmount),
-                                    lockTime
+                                    lockTime,
+                                    duration
                             ))
                             .actionButtonText(Res.get("shared.yes"))
                             .onAction(() -> publishUnlockTx(lockupTxId, resultHandler))


### PR DESCRIPTION
- Changed display string from "lockup time" to "unlock time" otherwise it may be confused with how long it takes to lock up the bond.
- Included estimated time duration (e.g. days) for the unlock time.

For reference, this is what the lockup prompt looked like before:
![image](https://user-images.githubusercontent.com/603793/53674002-de32fb00-3c3f-11e9-9988-f434a63faa07.png)

This is what it looks like now:
![image](https://user-images.githubusercontent.com/603793/53674006-e3904580-3c3f-11e9-9ba4-edfb0fbd4ba5.png)

And the unlock prompt now:
![image](https://user-images.githubusercontent.com/603793/53674018-f6a31580-3c3f-11e9-99eb-ebea986d7dc4.png)