### PR TITLE
Remove Log.traceCall methods

### DIFF
--- a/common/src/main/java/bisq/common/app/Log.java
+++ b/common/src/main/java/bisq/common/app/Log.java
@@ -91,26 +91,4 @@ public class Log {
     public static void setCustomLogLevel(String pattern, Level logLevel) {
         ((Logger) LoggerFactory.getLogger(pattern)).setLevel(logLevel);
     }
-
-    public static void traceCall() {
-        if (LoggerFactory.getLogger(Log.class).isTraceEnabled()) {
-            StackTraceElement stackTraceElement = new Throwable().getStackTrace()[1];
-            String methodName = stackTraceElement.getMethodName();
-            if (methodName.equals("<init>"))
-                methodName = "Constructor ";
-            String className = stackTraceElement.getClassName();
-            LoggerFactory.getLogger(className).trace("Called: {}", methodName);
-        }
-    }
-
-    public static void traceCall(String message) {
-        if (LoggerFactory.getLogger(Log.class).isTraceEnabled()) {
-            StackTraceElement stackTraceElement = new Throwable().getStackTrace()[1];
-            String methodName = stackTraceElement.getMethodName();
-            if (methodName.equals("<init>"))
-                methodName = "Constructor ";
-            String className = stackTraceElement.getClassName();
-            LoggerFactory.getLogger(className).trace("Called: {} [{}]", methodName, message);
-        }
-    }
 }

--- a/common/src/main/java/bisq/common/storage/FileManager.java
+++ b/common/src/main/java/bisq/common/storage/FileManager.java
@@ -133,7 +133,6 @@ public class FileManager<T extends PersistableEnvelope> {
     }
 
     public synchronized void removeFile(String fileName) {
-        log.debug("removeFile" + fileName);
         File file = new File(dir, fileName);
         boolean result = file.delete();
         if (!result)

--- a/common/src/main/java/bisq/common/storage/Storage.java
+++ b/common/src/main/java/bisq/common/storage/Storage.java
@@ -114,7 +114,6 @@ public class Storage<T extends PersistableEnvelope> {
     // Save delayed and on a background thread
     public void queueUpForSave(T persistable) {
         if (persistable != null) {
-            log.trace("save " + fileName);
             checkNotNull(storageFile, "storageFile = null. Call setupFileStorage before using read/write.");
 
             fileManager.saveLater(persistable);
@@ -125,7 +124,6 @@ public class Storage<T extends PersistableEnvelope> {
 
     public void queueUpForSave(T persistable, long delayInMilli) {
         if (persistable != null) {
-            log.trace("save " + fileName);
             checkNotNull(storageFile, "storageFile = null. Call setupFileStorage before using read/write.");
 
             fileManager.saveLater(persistable, delayInMilli);

--- a/common/src/main/java/bisq/common/taskrunner/TaskRunner.java
+++ b/common/src/main/java/bisq/common/taskrunner/TaskRunner.java
@@ -82,7 +82,6 @@ public class TaskRunner<T extends Model> {
     }
 
     void handleComplete() {
-        log.trace("Task completed: " + currentTask.getSimpleName());
         sharedModel.persist();
         next();
     }

--- a/core/src/main/java/bisq/core/alert/AlertManager.java
+++ b/core/src/main/java/bisq/core/alert/AlertManager.java
@@ -121,7 +121,7 @@ public class AlertManager {
             user.setDevelopersAlert(alert);
             boolean result = p2PService.addProtectedStorageEntry(alert, true);
             if (result) {
-                log.trace("Add alertMessage to network was successful. AlertMessage = " + alert);
+                log.trace("Add alertMessage to network was successful. AlertMessage={}", alert);
             }
 
         }
@@ -132,7 +132,7 @@ public class AlertManager {
         Alert alert = user.getDevelopersAlert();
         if (isKeyValid(privKeyString) && alert != null) {
             if (p2PService.removeData(alert, true))
-                log.trace("Remove alertMessage from network was successful. AlertMessage = " + alert);
+                log.trace("Remove alertMessage from network was successful. AlertMessage={}", alert);
 
             user.setDevelopersAlert(null);
             return true;

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -258,7 +258,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
             // We need to delay it as the stage is not created yet and so popups would not be shown.
             if (DevEnv.isDevMode())
                 UserThread.runAfter(() -> {
-                    log.error("Error at PersistedDataHost.apply: " + t.toString());
+                    log.error("Error at PersistedDataHost.apply: {}", t.toString());
                     throw t;
                 }, 2);
         }

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -464,7 +464,6 @@ public class BisqSetup {
         Thread checkCryptoThread = new Thread(() -> {
             try {
                 Thread.currentThread().setName("checkCryptoThread");
-                log.trace("Run crypto test");
                 // just use any simple dummy msg
                 Ping payload = new Ping(1, 1);
                 SealedAndSigned sealedAndSigned = EncryptionService.encryptHybridWithSignature(payload,

--- a/core/src/main/java/bisq/core/app/SetupUtils.java
+++ b/core/src/main/java/bisq/core/app/SetupUtils.java
@@ -54,7 +54,6 @@ public class SetupUtils {
             public void run() {
                 try {
                     Thread.currentThread().setName("checkCryptoThread");
-                    log.trace("Run crypto test");
                     // just use any simple dummy msg
                     Ping payload = new Ping(1, 1);
                     SealedAndSigned sealedAndSigned = EncryptionService.encryptHybridWithSignature(payload,

--- a/core/src/main/java/bisq/core/app/misc/AppSetupWithP2P.java
+++ b/core/src/main/java/bisq/core/app/misc/AppSetupWithP2P.java
@@ -77,7 +77,6 @@ public class AppSetupWithP2P extends AppSetup {
         // we apply at startup the reading of persisted data but don't want to get it triggered in the constructor
         persistedDataHosts.forEach(e -> {
             try {
-                log.info("call readPersisted at " + e.getClass().getSimpleName());
                 e.readPersisted();
             } catch (Throwable e1) {
                 log.error("readPersisted error", e1);
@@ -120,7 +119,7 @@ public class AppSetupWithP2P extends AppSetup {
                 if (connection.getPeerType() == Connection.PeerType.SEED_NODE &&
                         closeConnectionReason == CloseConnectionReason.RULE_VIOLATION) {
                     log.warn("RULE_VIOLATION onDisconnect closeConnectionReason=" + closeConnectionReason);
-                    log.warn("RULE_VIOLATION onDisconnect connection=" + connection);
+                    log.warn("RULE_VIOLATION onDisconnect connection={}", connection);
                 }
             }
 

--- a/core/src/main/java/bisq/core/btc/nodes/SeedPeersSocks5Dns.java
+++ b/core/src/main/java/bisq/core/btc/nodes/SeedPeersSocks5Dns.java
@@ -162,7 +162,7 @@ public class SeedPeersSocks5Dns implements PeerDiscovery {
             InetAddress addrResolved = proxySocket.getInetAddress();
             proxySocket.close();
             if (addrResolved != null) {
-                log.debug("Resolved " + addr.getHostString() + " to " + addrResolved.getHostAddress());
+                //log.debug("Resolved " + addr.getHostString() + " to " + addrResolved.getHostAddress());
                 return new InetSocketAddress(addrResolved, addr.getPort());
             } else {
                 // note: .onion nodes fall in here when proxy is Tor. But they have no IP address.

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -33,7 +33,6 @@ import bisq.network.Socks5ProxyProvider;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.handlers.ExceptionHandler;
 import bisq.common.handlers.ResultHandler;
 import bisq.common.storage.FileUtil;
@@ -170,8 +169,6 @@ public class WalletsSetup {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void initialize(@Nullable DeterministicSeed seed, ResultHandler resultHandler, ExceptionHandler exceptionHandler) {
-        Log.traceCall();
-
         // Tell bitcoinj to execute event handlers on the JavaFX UI thread. This keeps things simple and means
         // we cannot forget to switch threads when adding event handlers. Unfortunately, the DownloadListener
         // we give to the app kit is currently an exception and runs on a library thread. It'll get fixed in

--- a/core/src/main/java/bisq/core/btc/wallet/BtcCoinSelector.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcCoinSelector.java
@@ -64,7 +64,6 @@ class BtcCoinSelector extends BisqDefaultCoinSelector {
             Address address = WalletService.getAddressFromOutput(output);
             boolean containsAddress = addresses.contains(address);
             if (!containsAddress)
-                log.trace("addresses not containing address " + addresses + " / " + address);
             return containsAddress;
         } else {
             log.warn("transactionOutput.getScriptPubKey() not isSentToAddress or isPayToScriptHash");

--- a/core/src/main/java/bisq/core/btc/wallet/BtcCoinSelector.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcCoinSelector.java
@@ -62,9 +62,7 @@ class BtcCoinSelector extends BisqDefaultCoinSelector {
     protected boolean isTxOutputSpendable(TransactionOutput output) {
         if (WalletService.isOutputScriptConvertibleToAddress(output)) {
             Address address = WalletService.getAddressFromOutput(output);
-            boolean containsAddress = addresses.contains(address);
-            if (!containsAddress)
-            return containsAddress;
+            return addresses.contains(address);
         } else {
             log.warn("transactionOutput.getScriptPubKey() not isSentToAddress or isPayToScriptHash");
             return false;

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -177,14 +177,14 @@ public class TradeWalletService {
                                              boolean doBroadcast,
                                              @Nullable TxBroadcaster.Callback callback)
             throws InsufficientMoneyException, AddressFormatException {
-        log.debug("fundingAddress " + fundingAddress.toString());
-        log.debug("reservedForTradeAddress " + reservedForTradeAddress.toString());
-        log.debug("changeAddress " + changeAddress.toString());
-        log.info("reservedFundsForOffer " + reservedFundsForOffer.toPlainString());
-        log.debug("useSavingsWallet " + useSavingsWallet);
-        log.info("tradingFee " + tradingFee.toPlainString());
-        log.info("txFee " + txFee.toPlainString());
-        log.debug("feeReceiverAddresses " + feeReceiverAddresses);
+        log.debug("fundingAddress {}", fundingAddress.toString());
+        log.debug("reservedForTradeAddress {}", reservedForTradeAddress.toString());
+        log.debug("changeAddress {}", changeAddress.toString());
+        log.info("reservedFundsForOffer {}", reservedFundsForOffer.toPlainString());
+        log.debug("useSavingsWallet {}", useSavingsWallet);
+        log.info("tradingFee {}", tradingFee.toPlainString());
+        log.info("txFee {}", txFee.toPlainString());
+        log.debug("feeReceiverAddresses {}", feeReceiverAddresses);
         Transaction tradingFeeTx = new Transaction(params);
         SendRequest sendRequest = null;
         try {
@@ -240,12 +240,12 @@ public class TradeWalletService {
             TransactionVerificationException, WalletException,
             InsufficientMoneyException, AddressFormatException {
 
-        log.debug("preparedBsqTx " + preparedBsqTx.toString());
-        log.debug("fundingAddress " + fundingAddress.toString());
-        log.debug("changeAddress " + changeAddress.toString());
-        log.debug("reservedFundsForOffer " + reservedFundsForOffer.toPlainString());
-        log.debug("useSavingsWallet " + useSavingsWallet);
-        log.debug("txFee " + txFee.toPlainString());
+        log.debug("preparedBsqTx {}", preparedBsqTx.toString());
+        log.debug("fundingAddress {}", fundingAddress.toString());
+        log.debug("changeAddress {}", changeAddress.toString());
+        log.debug("reservedFundsForOffer {}", reservedFundsForOffer.toPlainString());
+        log.debug("useSavingsWallet {}", useSavingsWallet);
+        log.debug("txFee {}", txFee.toPlainString());
 
         // preparedBsqTx has following structure:
         // inputs [1-n] BSQ inputs
@@ -337,9 +337,9 @@ public class TradeWalletService {
     public InputsAndChangeOutput takerCreatesDepositsTxInputs(Transaction takeOfferFeeTx, Coin inputAmount, Coin txFee, Address takersAddress) throws
             TransactionVerificationException {
         log.debug("takerCreatesDepositsTxInputs called");
-        log.debug("inputAmount " + inputAmount.toFriendlyString());
-        log.debug("txFee " + txFee.toFriendlyString());
-        log.debug("takersAddress " + takersAddress.toString());
+        log.debug("inputAmount {}", inputAmount.toFriendlyString());
+        log.debug("txFee {}", txFee.toFriendlyString());
+        log.debug("takersAddress {}", takersAddress.toString());
 
         // We add the mining fee 2 times to the deposit tx:
         // 1. Will be spent when publishing the deposit tx (paid by buyer)
@@ -430,17 +430,17 @@ public class TradeWalletService {
                                                                          byte[] arbitratorPubKey)
             throws SigningException, TransactionVerificationException, WalletException, AddressFormatException {
         log.debug("makerCreatesAndSignsDepositTx called");
-        log.debug("makerIsBuyer " + makerIsBuyer);
-        log.debug("makerInputAmount " + makerInputAmount.toFriendlyString());
-        log.debug("msOutputAmount " + msOutputAmount.toFriendlyString());
-        log.debug("takerRawInputs " + takerRawTransactionInputs.toString());
-        log.debug("takerChangeOutputValue " + takerChangeOutputValue);
-        log.debug("takerChangeAddressString " + takerChangeAddressString);
-        log.debug("makerAddress " + makerAddress);
-        log.debug("makerChangeAddress " + makerChangeAddress);
-        log.debug("buyerPubKey " + ECKey.fromPublicOnly(buyerPubKey).toString());
-        log.debug("sellerPubKey " + ECKey.fromPublicOnly(sellerPubKey).toString());
-        log.debug("arbitratorPubKey " + ECKey.fromPublicOnly(arbitratorPubKey).toString());
+        log.debug("makerIsBuyer {}", makerIsBuyer);
+        log.debug("makerInputAmount {}", makerInputAmount.toFriendlyString());
+        log.debug("msOutputAmount {}", msOutputAmount.toFriendlyString());
+        log.debug("takerRawInputs {}", takerRawTransactionInputs.toString());
+        log.debug("takerChangeOutputValue {}", takerChangeOutputValue);
+        log.debug("takerChangeAddressString {}", takerChangeAddressString);
+        log.debug("makerAddress {}", makerAddress);
+        log.debug("makerChangeAddress {}", makerChangeAddress);
+        log.debug("buyerPubKey {}", ECKey.fromPublicOnly(buyerPubKey).toString());
+        log.debug("sellerPubKey {}", ECKey.fromPublicOnly(sellerPubKey).toString());
+        log.debug("arbitratorPubKey {}", ECKey.fromPublicOnly(arbitratorPubKey).toString());
 
         checkArgument(!takerRawTransactionInputs.isEmpty());
 
@@ -574,13 +574,13 @@ public class TradeWalletService {
         Transaction makersDepositTx = new Transaction(params, makersDepositTxSerialized);
 
         log.debug("signAndPublishDepositTx called");
-        log.debug("takerIsSeller " + takerIsSeller);
-        log.debug("makersDepositTx " + makersDepositTx.toString());
-        log.debug("buyerConnectedOutputsForAllInputs " + buyerInputs.toString());
-        log.debug("sellerConnectedOutputsForAllInputs " + sellerInputs.toString());
-        log.debug("buyerPubKey " + ECKey.fromPublicOnly(buyerPubKey).toString());
-        log.debug("sellerPubKey " + ECKey.fromPublicOnly(sellerPubKey).toString());
-        log.debug("arbitratorPubKey " + ECKey.fromPublicOnly(arbitratorPubKey).toString());
+        log.debug("takerIsSeller {}", takerIsSeller);
+        log.debug("makersDepositTx {}", makersDepositTx.toString());
+        log.debug("buyerConnectedOutputsForAllInputs {}", buyerInputs.toString());
+        log.debug("sellerConnectedOutputsForAllInputs {}", sellerInputs.toString());
+        log.debug("buyerPubKey {}", ECKey.fromPublicOnly(buyerPubKey).toString());
+        log.debug("sellerPubKey {}", ECKey.fromPublicOnly(sellerPubKey).toString());
+        log.debug("arbitratorPubKey {}", ECKey.fromPublicOnly(arbitratorPubKey).toString());
 
         checkArgument(!buyerInputs.isEmpty());
         checkArgument(!sellerInputs.isEmpty());
@@ -618,9 +618,9 @@ public class TradeWalletService {
         // Check if OP_RETURN output with contract hash matches the one from the maker
         TransactionOutput contractHashOutput = new TransactionOutput(params, makersDepositTx, Coin.ZERO,
                 ScriptBuilder.createOpReturnScript(contractHash).getProgram());
-        log.debug("contractHashOutput " + contractHashOutput);
+        log.debug("contractHashOutput {}", contractHashOutput);
         TransactionOutput makersContractHashOutput = makersDepositTx.getOutputs().get(1);
-        log.debug("makersContractHashOutput " + makersContractHashOutput);
+        log.debug("makersContractHashOutput {}", makersContractHashOutput);
         if (!makersContractHashOutput.getScriptPubKey().equals(contractHashOutput.getScriptPubKey()))
             throw new TransactionVerificationException("Maker's transaction output for the contract hash is not matching takers version.");
 
@@ -675,11 +675,11 @@ public class TradeWalletService {
                                      byte[] arbitratorPubKey)
             throws AddressFormatException, TransactionVerificationException {
         log.trace("sellerSignsPayoutTx called");
-        log.trace("depositTx " + depositTx.toString());
-        log.trace("buyerPayoutAmount " + buyerPayoutAmount.toFriendlyString());
-        log.trace("sellerPayoutAmount " + sellerPayoutAmount.toFriendlyString());
-        log.trace("buyerPayoutAddressString " + buyerPayoutAddressString);
-        log.trace("sellerPayoutAddressString " + sellerPayoutAddressString);
+        log.trace("depositTx {}", depositTx.toString());
+        log.trace("buyerPayoutAmount {}", buyerPayoutAmount.toFriendlyString());
+        log.trace("sellerPayoutAmount {}", sellerPayoutAmount.toFriendlyString());
+        log.trace("buyerPayoutAddressString {}", buyerPayoutAddressString);
+        log.trace("sellerPayoutAddressString {}", sellerPayoutAddressString);
         log.trace("multiSigKeyPair (not displayed for security reasons)");
         log.info("buyerPubKey HEX=" + ECKey.fromPublicOnly(buyerPubKey).getPublicKeyAsHex());
         log.info("sellerPubKey HEX=" + ECKey.fromPublicOnly(sellerPubKey).getPublicKeyAsHex());
@@ -737,17 +737,17 @@ public class TradeWalletService {
                                                        byte[] arbitratorPubKey)
             throws AddressFormatException, TransactionVerificationException, WalletException {
         log.trace("buyerSignsAndFinalizesPayoutTx called");
-        log.trace("depositTx " + depositTx.toString());
-        log.trace("buyerSignature r " + ECKey.ECDSASignature.decodeFromDER(buyerSignature).r.toString());
-        log.trace("buyerSignature s " + ECKey.ECDSASignature.decodeFromDER(buyerSignature).s.toString());
-        log.trace("buyerPayoutAmount " + buyerPayoutAmount.toFriendlyString());
-        log.trace("sellerPayoutAmount " + sellerPayoutAmount.toFriendlyString());
-        log.trace("buyerPayoutAddressString " + buyerPayoutAddressString);
-        log.trace("sellerPayoutAddressString " + sellerPayoutAddressString);
+        log.trace("depositTx {}", depositTx.toString());
+        log.trace("buyerSignature r {}", ECKey.ECDSASignature.decodeFromDER(buyerSignature).r.toString());
+        log.trace("buyerSignature s {}", ECKey.ECDSASignature.decodeFromDER(buyerSignature).s.toString());
+        log.trace("buyerPayoutAmount {}", buyerPayoutAmount.toFriendlyString());
+        log.trace("sellerPayoutAmount {}", sellerPayoutAmount.toFriendlyString());
+        log.trace("buyerPayoutAddressString {}", buyerPayoutAddressString);
+        log.trace("sellerPayoutAddressString {}", sellerPayoutAddressString);
         log.trace("multiSigKeyPair (not displayed for security reasons)");
-        log.info("buyerPubKey " + ECKey.fromPublicOnly(buyerPubKey).toString());
-        log.info("sellerPubKey " + ECKey.fromPublicOnly(sellerPubKey).toString());
-        log.info("arbitratorPubKey " + ECKey.fromPublicOnly(arbitratorPubKey).toString());
+        log.info("buyerPubKey {}", ECKey.fromPublicOnly(buyerPubKey).toString());
+        log.info("sellerPubKey {}", ECKey.fromPublicOnly(sellerPubKey).toString());
+        log.info("arbitratorPubKey {}", ECKey.fromPublicOnly(arbitratorPubKey).toString());
 
         Transaction payoutTx = createPayoutTx(depositTx,
                 buyerPayoutAmount,
@@ -817,15 +817,15 @@ public class TradeWalletService {
             throws AddressFormatException, TransactionVerificationException {
         Transaction depositTx = new Transaction(params, depositTxSerialized);
         log.trace("signDisputedPayoutTx called");
-        log.trace("depositTx " + depositTx.toString());
-        log.trace("buyerPayoutAmount " + buyerPayoutAmount.toFriendlyString());
-        log.trace("sellerPayoutAmount " + sellerPayoutAmount.toFriendlyString());
-        log.trace("buyerAddressString " + buyerAddressString);
-        log.trace("sellerAddressString " + sellerAddressString);
+        log.trace("depositTx {}", depositTx.toString());
+        log.trace("buyerPayoutAmount {}", buyerPayoutAmount.toFriendlyString());
+        log.trace("sellerPayoutAmount {}", sellerPayoutAmount.toFriendlyString());
+        log.trace("buyerAddressString {}", buyerAddressString);
+        log.trace("sellerAddressString {}", sellerAddressString);
         log.trace("arbitratorKeyPair (not displayed for security reasons)");
-        log.info("buyerPubKey " + ECKey.fromPublicOnly(buyerPubKey).toString());
-        log.info("sellerPubKey " + ECKey.fromPublicOnly(sellerPubKey).toString());
-        log.info("arbitratorPubKey " + ECKey.fromPublicOnly(arbitratorPubKey).toString());
+        log.info("buyerPubKey {}", ECKey.fromPublicOnly(buyerPubKey).toString());
+        log.info("sellerPubKey {}", ECKey.fromPublicOnly(sellerPubKey).toString());
+        log.info("arbitratorPubKey {}", ECKey.fromPublicOnly(arbitratorPubKey).toString());
 
         // Our MS is index 0
         TransactionOutput p2SHMultiSigOutput = depositTx.getOutput(0);
@@ -884,17 +884,17 @@ public class TradeWalletService {
         Transaction depositTx = new Transaction(params, depositTxSerialized);
 
         log.trace("signAndFinalizeDisputedPayoutTx called");
-        log.trace("depositTx " + depositTx);
-        log.trace("arbitratorSignature r " + ECKey.ECDSASignature.decodeFromDER(arbitratorSignature).r.toString());
-        log.trace("arbitratorSignature s " + ECKey.ECDSASignature.decodeFromDER(arbitratorSignature).s.toString());
-        log.trace("buyerPayoutAmount " + buyerPayoutAmount.toFriendlyString());
-        log.trace("sellerPayoutAmount " + sellerPayoutAmount.toFriendlyString());
-        log.trace("buyerAddressString " + buyerAddressString);
-        log.trace("sellerAddressString " + sellerAddressString);
+        log.trace("depositTx {}", depositTx);
+        log.trace("arbitratorSignature r {}", ECKey.ECDSASignature.decodeFromDER(arbitratorSignature).r.toString());
+        log.trace("arbitratorSignature s {}", ECKey.ECDSASignature.decodeFromDER(arbitratorSignature).s.toString());
+        log.trace("buyerPayoutAmount {}", buyerPayoutAmount.toFriendlyString());
+        log.trace("sellerPayoutAmount {}", sellerPayoutAmount.toFriendlyString());
+        log.trace("buyerAddressString {}", buyerAddressString);
+        log.trace("sellerAddressString {}", sellerAddressString);
         log.trace("tradersMultiSigKeyPair (not displayed for security reasons)");
-        log.info("buyerPubKey " + ECKey.fromPublicOnly(buyerPubKey).toString());
-        log.info("sellerPubKey " + ECKey.fromPublicOnly(sellerPubKey).toString());
-        log.info("arbitratorPubKey " + ECKey.fromPublicOnly(arbitratorPubKey).toString());
+        log.info("buyerPubKey {}", ECKey.fromPublicOnly(buyerPubKey).toString());
+        log.info("sellerPubKey {}", ECKey.fromPublicOnly(sellerPubKey).toString());
+        log.info("arbitratorPubKey {}", ECKey.fromPublicOnly(arbitratorPubKey).toString());
 
 
         TransactionOutput p2SHMultiSigOutput = depositTx.getOutput(0);
@@ -953,20 +953,20 @@ public class TradeWalletService {
                                                        TxBroadcaster.Callback callback)
             throws AddressFormatException, TransactionVerificationException, WalletException {
         log.info("signAndPublishPayoutTx called");
-        log.info("depositTxHex " + depositTxHex);
-        log.info("buyerPayoutAmount " + buyerPayoutAmount.toFriendlyString());
-        log.info("sellerPayoutAmount " + sellerPayoutAmount.toFriendlyString());
-        log.info("arbitratorPayoutAmount " + arbitratorPayoutAmount.toFriendlyString());
-        log.info("buyerAddressString " + buyerAddressString);
-        log.info("sellerAddressString " + sellerAddressString);
-        log.info("arbitratorAddressString " + arbitratorAddressString);
+        log.info("depositTxHex {}", depositTxHex);
+        log.info("buyerPayoutAmount {}", buyerPayoutAmount.toFriendlyString());
+        log.info("sellerPayoutAmount {}", sellerPayoutAmount.toFriendlyString());
+        log.info("arbitratorPayoutAmount {}", arbitratorPayoutAmount.toFriendlyString());
+        log.info("buyerAddressString {}", buyerAddressString);
+        log.info("sellerAddressString {}", sellerAddressString);
+        log.info("arbitratorAddressString {}", arbitratorAddressString);
         log.info("buyerPrivateKeyAsHex (not displayed for security reasons)");
         log.info("sellerPrivateKeyAsHex (not displayed for security reasons)");
         log.info("arbitratorPrivateKeyAsHex (not displayed for security reasons)");
-        log.info("buyerPubKeyAsHex " + buyerPubKeyAsHex);
-        log.info("sellerPubKeyAsHex " + sellerPubKeyAsHex);
-        log.info("arbitratorPubKeyAsHex " + arbitratorPubKeyAsHex);
-        log.info("P2SHMultiSigOutputScript " + P2SHMultiSigOutputScript);
+        log.info("buyerPubKeyAsHex {}", buyerPubKeyAsHex);
+        log.info("sellerPubKeyAsHex {}", sellerPubKeyAsHex);
+        log.info("arbitratorPubKeyAsHex {}", arbitratorPubKeyAsHex);
+        log.info("P2SHMultiSigOutputScript {}", P2SHMultiSigOutputScript);
 
         checkNotNull((buyerPrivateKeyAsHex != null || sellerPrivateKeyAsHex != null), "either buyerPrivateKeyAsHex or sellerPrivateKeyAsHex must not be null");
 

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -29,8 +29,6 @@ import bisq.core.btc.setup.WalletConfig;
 import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.locale.Res;
 
-import bisq.common.app.Log;
-
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
@@ -1056,8 +1054,6 @@ public class TradeWalletService {
      * @throws VerificationException
      */
     public Transaction addTxToWallet(Transaction transaction) throws VerificationException {
-        Log.traceCall("transaction " + transaction.toString());
-
         // We need to recreate the transaction otherwise we get a null pointer...
         Transaction result = new Transaction(params, transaction.bitcoinSerialize());
         result.getConfidence(Context.get()).setSource(TransactionConfidence.Source.SELF);
@@ -1073,8 +1069,6 @@ public class TradeWalletService {
      * @throws VerificationException
      */
     public Transaction addTxToWallet(byte[] serializedTransaction) throws VerificationException {
-        Log.traceCall();
-
         // We need to recreate the tx otherwise we get a null pointer...
         Transaction transaction = new Transaction(params, serializedTransaction);
         transaction.getConfidence(Context.get()).setSource(TransactionConfidence.Source.NETWORK);

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -1072,7 +1072,6 @@ public class TradeWalletService {
         // We need to recreate the tx otherwise we get a null pointer...
         Transaction transaction = new Transaction(params, serializedTransaction);
         transaction.getConfidence(Context.get()).setSource(TransactionConfidence.Source.NETWORK);
-        log.trace("transaction from serializedTransaction: " + transaction.toString());
 
         if (wallet != null)
             wallet.receivePending(transaction, null, true);

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -197,7 +197,6 @@ public abstract class WalletService {
 
     public static void checkWalletConsistency(Wallet wallet) throws WalletException {
         try {
-            log.trace("Check if wallet is consistent before commit.");
             checkNotNull(wallet);
             checkState(wallet.isConsistent());
         } catch (Throwable t) {
@@ -209,7 +208,6 @@ public abstract class WalletService {
 
     public static void verifyTransaction(Transaction transaction) throws TransactionVerificationException {
         try {
-            log.trace("Verify transaction " + transaction);
             transaction.verify();
         } catch (Throwable t) {
             t.printStackTrace();
@@ -226,7 +224,6 @@ public abstract class WalletService {
 
     public static void checkScriptSig(Transaction transaction, TransactionInput input, int inputIndex) throws TransactionVerificationException {
         try {
-            log.trace("Verifies that this script (interpreted as a scriptSig) correctly spends the given scriptPubKey. Check input at index: " + inputIndex);
             checkNotNull(input.getConnectedOutput(), "input.getConnectedOutput() must not be null");
             input.getScriptSig().correctlySpends(transaction, inputIndex, input.getConnectedOutput().getScriptPubKey(), Script.ALL_VERIFY_FLAGS);
         } catch (Throwable t) {

--- a/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
+++ b/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
@@ -161,7 +161,6 @@ public class ExportJsonFilesService implements DaoSetupService {
 
             Futures.addCallback(future, new FutureCallback<>() {
                 public void onSuccess(Void ignore) {
-                    log.trace("onSuccess");
                 }
 
                 public void onFailure(@NotNull Throwable throwable) {

--- a/core/src/main/java/bisq/core/dao/node/full/network/FullNodeNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/node/full/network/FullNodeNetworkService.java
@@ -145,7 +145,6 @@ public class FullNodeNetworkService implements MessageListener, PeerManager.List
                                 @Override
                                 public void onComplete() {
                                     getBlocksRequestHandlers.remove(uid);
-                                    log.trace("requestDataHandshake completed.\n\tConnection={}", connection);
                                 }
 
                                 @Override

--- a/core/src/main/java/bisq/core/dao/node/full/network/FullNodeNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/node/full/network/FullNodeNetworkService.java
@@ -32,7 +32,6 @@ import bisq.network.p2p.peers.Broadcaster;
 import bisq.network.p2p.peers.PeerManager;
 
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 
 import javax.inject.Inject;
@@ -96,7 +95,6 @@ public class FullNodeNetworkService implements MessageListener, PeerManager.List
 
     @SuppressWarnings("Duplicates")
     public void shutDown() {
-        Log.traceCall();
         stopped = true;
         networkNode.removeMessageListener(this);
         peerManager.removeListener(this);
@@ -138,7 +136,6 @@ public class FullNodeNetworkService implements MessageListener, PeerManager.List
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof GetBlocksRequest) {
             // We received a GetBlocksRequest from a liteNode
-            Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
             if (!stopped) {
                 final String uid = connection.getUid();
                 if (!getBlocksRequestHandlers.containsKey(uid)) {

--- a/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
+++ b/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
@@ -29,7 +29,6 @@ import bisq.network.p2p.network.NetworkNode;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -90,7 +89,6 @@ class GetBlocksRequestHandler {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void onGetBlocksRequest(GetBlocksRequest getBlocksRequest, final Connection connection) {
-        Log.traceCall(getBlocksRequest + "\n\tconnection=" + connection);
         List<Block> blocks = new LinkedList<>(daoStateService.getBlocksFromBlockHeight(getBlocksRequest.getFromBlockHeight()));
         List<RawBlock> rawBlocks = blocks.stream().map(RawBlock::fromBlock).collect(Collectors.toList());
         GetBlocksResponse getBlocksResponse = new GetBlocksResponse(rawBlocks, getBlocksRequest.getNonce());

--- a/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
@@ -350,7 +350,7 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
             NodeAddress nodeAddress = peersNodeAddressOptional.get();
             removeFromRequestBlocksHandlerMap(nodeAddress);
         } else {
-            log.trace("closeHandler: nodeAddress not set in connection " + connection);
+            log.trace("closeHandler: nodeAddress not set in connection {}", connection);
         }
     }
 

--- a/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
@@ -32,7 +32,6 @@ import bisq.network.p2p.seed.SeedNodeRepository;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.util.Tuple2;
 
@@ -125,7 +124,6 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
 
     @SuppressWarnings("Duplicates")
     public void shutDown() {
-        Log.traceCall();
         stopped = true;
         stopRetryTimer();
         networkNode.removeMessageListener(this);
@@ -165,12 +163,10 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
 
     @Override
     public void onConnection(Connection connection) {
-        Log.traceCall();
     }
 
     @Override
     public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
-        Log.traceCall();
         closeHandler(connection);
 
         if (peerManager.isNodeBanned(closeConnectionReason, connection)) {
@@ -192,7 +188,6 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
 
     @Override
     public void onAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopRetryTimer();
         stopped = true;
@@ -202,7 +197,6 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
 
     @Override
     public void onNewConnectionAfterAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopped = false;
         tryWithNewSeedNode(lastRequestedBlockHeight);
@@ -309,7 +303,6 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void tryWithNewSeedNode(int startBlockHeight) {
-        Log.traceCall();
         if (retryTimer == null) {
             retryCounter++;
             if (retryCounter <= MAX_RETRY) {

--- a/core/src/main/java/bisq/core/dao/node/lite/network/RequestBlocksHandler.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/network/RequestBlocksHandler.java
@@ -29,7 +29,6 @@ import bisq.network.p2p.peers.PeerManager;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -169,7 +168,6 @@ public class RequestBlocksHandler implements MessageListener {
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof GetBlocksResponse) {
             if (connection.getPeersNodeAddressOptional().isPresent() && connection.getPeersNodeAddressOptional().get().equals(nodeAddress)) {
-                Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
                 if (!stopped) {
                     GetBlocksResponse getBlocksResponse = (GetBlocksResponse) networkEnvelope;
                     if (getBlocksResponse.getRequestNonce() == nonce) {
@@ -214,7 +212,6 @@ public class RequestBlocksHandler implements MessageListener {
     }
 
     private void cleanup() {
-        Log.traceCall();
         stopped = true;
         networkNode.removeMessageListener(this);
         stopTimeoutTimer();

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -257,7 +257,7 @@ public class FilterManager {
 
             boolean result = p2PService.addProtectedStorageEntry(filter, true);
             if (result)
-                log.trace("Add filter to network was successful. FilterMessage = " + filter);
+                log.trace("Add filter to network was successful. FilterMessage = {}", filter);
 
         }
         return isKeyValid;
@@ -269,7 +269,7 @@ public class FilterManager {
             if (filter == null) {
                 log.warn("Developers filter is null");
             } else if (p2PService.removeData(filter, true)) {
-                log.trace("Remove filter from network was successful. FilterMessage = " + filter);
+                log.trace("Remove filter from network was successful. FilterMessage = {}", filter);
                 user.setDevelopersFilter(null);
             } else {
                 log.warn("Filter remove failed");

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -383,7 +383,7 @@ public class CurrencyUtil {
         try {
             return Currency.getInstance(currencyCode).getDisplayName();
         } catch (Throwable t) {
-            log.debug("No currency name available " + t.getMessage());
+            log.debug("No currency name available {}", t.getMessage());
             return currencyCode;
         }
     }

--- a/core/src/main/java/bisq/core/locale/Res.java
+++ b/core/src/main/java/bisq/core/locale/Res.java
@@ -115,7 +115,7 @@ public class Res {
                     .replace("Bitcoin", baseCurrencyName)
                     .replace("bitcoin", baseCurrencyNameLowerCase);
         } catch (MissingResourceException e) {
-            log.warn("Missing resource for key: " + key);
+            log.warn("Missing resource for key: {}", key);
             e.printStackTrace();
             if (DevEnv.isDevMode())
                 UserThread.runAfter(() -> {

--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -134,7 +134,6 @@ public class OfferBookService {
     public void addOffer(Offer offer, ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
         boolean result = p2PService.addProtectedStorageEntry(offer.getOfferPayload(), true);
         if (result) {
-            log.trace("Add offer to network was successful. OfferPayload ID = " + offer.getId());
             resultHandler.handleResult();
         } else {
             errorMessageHandler.handleErrorMessage("Add offer failed");
@@ -144,7 +143,6 @@ public class OfferBookService {
     public void refreshTTL(OfferPayload offerPayload, ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
         boolean result = p2PService.refreshTTL(offerPayload, true);
         if (result) {
-            log.trace("Refresh TTL was successful. OfferPayload ID = " + offerPayload.getId());
             resultHandler.handleResult();
         } else {
             errorMessageHandler.handleErrorMessage("Refresh TTL failed.");
@@ -161,7 +159,6 @@ public class OfferBookService {
 
     public void removeOffer(OfferPayload offerPayload, @Nullable ResultHandler resultHandler, @Nullable ErrorMessageHandler errorMessageHandler) {
         if (p2PService.removeData(offerPayload, true)) {
-            log.trace("Remove offer from network was successful. OfferPayload ID = " + offerPayload.getId());
             if (resultHandler != null)
                 resultHandler.handleResult();
         } else {

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -48,7 +48,6 @@ import bisq.network.p2p.peers.PeerManager;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
@@ -678,7 +677,6 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     private void republishOffers() {
         int size = openOffers.size();
         final ArrayList<OpenOffer> openOffersList = new ArrayList<>(openOffers.getList());
-        Log.traceCall("Number of offer for republish: " + size);
         if (!stopped) {
             stopPeriodicRefreshOffersTimer();
             for (int i = 0; i < size; i++) {
@@ -728,7 +726,6 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     }
 
     private void startPeriodicRepublishOffersTimer() {
-        Log.traceCall();
         stopped = false;
         if (periodicRepublishOffersTimer == null)
             periodicRepublishOffersTimer = UserThread.runPeriodically(() -> {
@@ -745,15 +742,12 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     }
 
     private void startPeriodicRefreshOffersTimer() {
-        Log.traceCall();
         stopped = false;
         // refresh sufficiently before offer would expire
         if (periodicRefreshOffersTimer == null)
             periodicRefreshOffersTimer = UserThread.runPeriodically(() -> {
                         if (!stopped) {
                             int size = openOffers.size();
-                            Log.traceCall("Number of offer for refresh: " + size);
-
                             //we clone our list as openOffers might change during our delayed call
                             final ArrayList<OpenOffer> openOffersList = new ArrayList<>(openOffers.getList());
                             for (int i = 0; i < size; i++) {

--- a/core/src/main/java/bisq/core/offer/availability/OfferAvailabilityProtocol.java
+++ b/core/src/main/java/bisq/core/offer/availability/OfferAvailabilityProtocol.java
@@ -71,7 +71,6 @@ public class OfferAvailabilityProtocol {
                 Validator.nonEmptyStringOf(offerMessage.offerId);
                 if (networkEnvelope instanceof OfferAvailabilityResponse
                         && model.getOffer().getId().equals(offerMessage.offerId)) {
-                    log.trace("handle OfferAvailabilityResponse = " + networkEnvelope.getClass().getSimpleName() + " from " + peersNodeAddress);
                     handleOfferAvailabilityResponse((OfferAvailabilityResponse) networkEnvelope, peersNodeAddress);
                 }
             }

--- a/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
@@ -329,7 +329,7 @@ public class AccountAgeWitnessService {
 
         // Check if the peers trade limit is not less than the trade amount
         if (!verifyPeersTradeLimit(trade, peersWitness, peersCurrentDate, errorMessageHandler)) {
-            log.error("verifyPeersTradeLimit failed: peersPaymentAccountPayload " + peersPaymentAccountPayload);
+            log.error("verifyPeersTradeLimit failed: peersPaymentAccountPayload {}", peersPaymentAccountPayload);
             return false;
         }
         // Check if the signature is correct

--- a/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
@@ -30,7 +30,6 @@ import bisq.network.http.HttpClient;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.handlers.FaultHandler;
 import bisq.common.util.MathUtils;
 import bisq.common.util.Tuple2;
@@ -393,7 +392,6 @@ public class PriceFeedService {
     }
 
     private void requestAllPrices(PriceProvider provider, Runnable resultHandler, FaultHandler faultHandler) {
-        Log.traceCall();
         PriceRequest priceRequest = new PriceRequest();
         SettableFuture<Tuple2<Map<String, Long>, Map<String, MarketPrice>>> future = priceRequest.requestAllPrices(provider);
         Futures.addCallback(future, new FutureCallback<Tuple2<Map<String, Long>, Map<String, MarketPrice>>>() {

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -44,7 +44,6 @@ import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
 
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.ProtoUtil;
@@ -504,7 +503,6 @@ public abstract class Trade implements Tradable, Model {
                      KeyRing keyRing,
                      boolean useSavingsWallet,
                      Coin fundsNeededForTrade) {
-        Log.traceCall();
         processModel.onAllServicesInitialized(offer,
                 tradeManager,
                 openOfferManager,
@@ -639,7 +637,6 @@ public abstract class Trade implements Tradable, Model {
     }
 
     public void setDisputeState(DisputeState disputeState) {
-        Log.traceCall("disputeState=" + disputeState + "\n\ttrade=" + this);
         boolean changed = this.disputeState != disputeState;
         this.disputeState = disputeState;
         disputeStateProperty.set(disputeState);

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -49,7 +49,6 @@ import bisq.network.p2p.P2PService;
 
 import bisq.common.Clock;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.crypto.KeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.FaultHandler;
@@ -224,7 +223,6 @@ public class TradeManager implements PersistedDataHost {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void onAllServicesInitialized() {
-        Log.traceCall();
         if (p2PService.isBootstrapped())
             initPendingTrades();
         else
@@ -252,8 +250,6 @@ public class TradeManager implements PersistedDataHost {
     }
 
     private void initPendingTrades() {
-        Log.traceCall();
-
         List<Trade> addTradeToFailedTradesList = new ArrayList<>();
         List<Trade> removePreparedTradeList = new ArrayList<>();
         tradesForStatistics = new ArrayList<>();

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -111,7 +111,6 @@ public abstract class TradeProtocol {
     }
 
     private void cleanup() {
-        log.debug("cleanup " + this);
         stopTimeout();
         trade.stateProperty().removeListener(stateChangeListener);
         // We removed that from here earlier as it broke the trade process in some non critical error cases.
@@ -120,7 +119,7 @@ public abstract class TradeProtocol {
     }
 
     public void applyMailboxMessage(DecryptedMessageWithPubKey decryptedMessageWithPubKey, Trade trade) {
-        log.debug("applyMailboxMessage " + decryptedMessageWithPubKey.getNetworkEnvelope());
+        log.debug("applyMailboxMessage {}", decryptedMessageWithPubKey.getNetworkEnvelope());
         if (processModel.getTradingPeer().getPubKeyRing() != null &&
                 decryptedMessageWithPubKey.getSignaturePubKey().equals(processModel.getTradingPeer().getPubKeyRing().getSignaturePubKey())) {
             processModel.setDecryptedMessageWithPubKey(decryptedMessageWithPubKey);
@@ -157,7 +156,7 @@ public abstract class TradeProtocol {
     }
 
     protected void handleTaskRunnerSuccess(@Nullable TradeMessage tradeMessage, String info) {
-        log.debug("handleTaskRunnerSuccess " + info);
+        log.debug("handleTaskRunnerSuccess {}", info);
 
         sendAckMessage(tradeMessage, true, null);
     }
@@ -231,7 +230,7 @@ public abstract class TradeProtocol {
 
     private void cleanupTradableOnFault() {
         final Trade.State state = trade.getState();
-        log.warn("cleanupTradableOnFault tradeState=" + state);
+        log.warn("cleanupTradableOnFault tradeState={}", state);
         TradeManager tradeManager = processModel.getTradeManager();
         if (trade.isInPreparation()) {
             // no funds left. we just clean up the trade list

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -67,7 +67,7 @@ public abstract class TradeProtocol {
             PublicKey signaturePubKey = decryptedMessageWithPubKey.getSignaturePubKey();
             if (tradingPeerPubKeyRing != null && signaturePubKey.equals(tradingPeerPubKeyRing.getSignaturePubKey())) {
                 NetworkEnvelope networkEnvelope = decryptedMessageWithPubKey.getNetworkEnvelope();
-                log.trace("handleNewMessage: message = " + networkEnvelope.getClass().getSimpleName() + " from " + peersNodeAddress);
+                log.trace("handleNewMessage: message = {} from {}", networkEnvelope.getClass().getSimpleName(), peersNodeAddress);
                 if (networkEnvelope instanceof TradeMessage) {
                     TradeMessage tradeMessage = (TradeMessage) networkEnvelope;
                     nonEmptyStringOf(tradeMessage.getTradeId());

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerCreateAndSignContract.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerCreateAndSignContract.java
@@ -94,7 +94,6 @@ public class MakerCreateAndSignContract extends TradeTask {
                     taker.getMultiSigPubKey()
             );
             String contractAsJson = Utilities.objectToJson(contract);
-            log.trace("Contract as json:{}", contractAsJson);
             String signature = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), contractAsJson);
 
             trade.setContract(contract);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerPublishFeeTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerPublishFeeTx.java
@@ -80,7 +80,6 @@ public class TakerPublishFeeTx extends TradeTask {
                             public void onSuccess(@Nullable Transaction transaction) {
                                 if (!completed) {
                                     if (transaction != null) {
-                                        log.debug("Successfully sent tx with id " + transaction.getHashAsString());
                                         trade.setTakerFeeTxId(transaction.getHashAsString());
                                         processModel.setTakeOfferFeeTx(transaction);
                                         trade.setState(Trade.State.TAKER_PUBLISHED_TAKER_FEE_TX);

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -353,7 +353,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                     walletsManager.publishAndCommitBsqTx(txWithBtcFee, txType, new TxBroadcaster.Callback() {
                         @Override
                         public void onSuccess(Transaction transaction) {
-                            log.debug("Successfully sent tx with id " + txWithBtcFee.getHashAsString());
+                            log.debug("Successfully sent tx with id {}", txWithBtcFee.getHashAsString());
                         }
 
                         @Override

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -352,7 +352,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                                     @Override
                                     public void onSuccess(@javax.annotation.Nullable Transaction transaction) {
                                         if (transaction != null) {
-                                            log.debug("onWithdraw onSuccess tx ID:" + transaction.getHashAsString());
+                                            log.debug("onWithdraw onSuccess tx ID:{}", transaction.getHashAsString());
                                         } else {
                                             log.error("onWithdraw transaction is null");
                                         }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
@@ -113,7 +113,7 @@ public class OfferBook {
                     .map(OfferBookListItem::new)
                     .collect(Collectors.toList()));
 
-            log.debug("offerBookListItems.size " + offerBookListItems.size());
+            log.debug("offerBookListItems.size {}", offerBookListItems.size());
             fillOfferCountMaps();
         } catch (Throwable t) {
             t.printStackTrace();

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
@@ -488,7 +488,7 @@ class TakeOfferDataModel extends OfferDataModel {
                 totalToPayAsCoin.set(feeAndSecDeposit);
 
             updateBalance();
-            log.debug("totalToPayAsCoin " + totalToPayAsCoin.get().toFriendlyString());
+            log.debug("totalToPayAsCoin {}", totalToPayAsCoin.get().toFriendlyString());
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -380,7 +380,6 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void applyOfferState(Offer.State state) {
-        log.debug("applyOfferState state = " + state);
         offerWarning.set(null);
 
         // We have 2 situations handled here:
@@ -459,8 +458,6 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     }
 
     private void applyTradeState(Trade.State tradeState) {
-        log.debug("applyTradeState state = " + tradeState);
-
         if (trade.isDepositPublished()) {
             if (trade.getDepositTx() != null) {
                 if (takeOfferSucceededHandler != null)

--- a/desktop/src/main/java/bisq/desktop/main/overlays/notifications/NotificationCenter.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/notifications/NotificationCenter.java
@@ -35,7 +35,6 @@ import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
 
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 
 import com.google.inject.Inject;
 
@@ -217,7 +216,6 @@ public class NotificationCenter {
     }
 
     private void onDisputeStateChanged(Trade trade, Trade.DisputeState disputeState) {
-        Log.traceCall(disputeState.toString());
         String message = null;
         if (disputeManager.findOwnDispute(trade.getId()).isPresent()) {
             String disputeOrTicket = disputeManager.findOwnDispute(trade.getId()).get().isSupportTicket() ?

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/EmptyWalletWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/EmptyWalletWindow.java
@@ -238,7 +238,7 @@ public class EmptyWalletWindow extends Overlay<EmptyWalletWindow> {
                         },
                         (errorMessage) -> {
                             emptyWalletButton.setDisable(false);
-                            log.debug("wallet empty failed " + errorMessage);
+                            log.error("wallet empty failed {}", errorMessage);
                         });
             } catch (InsufficientMoneyException | AddressFormatException e1) {
                 e1.printStackTrace();

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
@@ -308,7 +308,7 @@ public class BisqInstaller {
                         .loadUrl(installerFileDescriptor.getLoadUrl().concat(suffix))
                         .build());
             } else {
-                log.debug("We have already a file with the key: " + key.getId());
+                log.debug("We have already a file with the key: {}", key.getId());
             }
         }
         return result;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/BuyerSubView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/BuyerSubView.java
@@ -25,8 +25,6 @@ import bisq.desktop.main.portfolio.pendingtrades.steps.buyer.BuyerStep4View;
 
 import bisq.core.locale.Res;
 
-import bisq.common.app.Log;
-
 import org.fxmisc.easybind.EasyBind;
 
 public class BuyerSubView extends TradeSubView {
@@ -73,7 +71,6 @@ public class BuyerSubView extends TradeSubView {
     @Override
     protected void onViewStateChanged(PendingTradesViewModel.State viewState) {
         if (viewState != null) {
-            Log.traceCall(viewState.toString());
             PendingTradesViewModel.BuyerState buyerState = (PendingTradesViewModel.BuyerState) viewState;
 
             step1.setDisabled();

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -44,7 +44,6 @@ import bisq.core.user.Preferences;
 
 import bisq.network.p2p.P2PService;
 
-import bisq.common.app.Log;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
@@ -348,7 +347,6 @@ public class PendingTradesDataModel extends ActivatableDataModel {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void onListChanged() {
-        Log.traceCall();
         list.clear();
         list.addAll(tradeManager.getTradableList().stream().map(PendingTradesListItem::new).collect(Collectors.toList()));
 
@@ -438,7 +436,6 @@ public class PendingTradesDataModel extends ActivatableDataModel {
     }
 
     private void doOpenDispute(boolean isSupportTicket, Transaction depositTx) {
-        Log.traceCall("depositTx=" + depositTx);
         byte[] depositTxSerialized = null;
         byte[] payoutTxSerialized = null;
         String depositTxHashAsString = null;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -37,7 +37,6 @@ import bisq.network.p2p.P2PService;
 
 import bisq.common.Clock;
 import bisq.common.app.DevEnv;
-import bisq.common.app.Log;
 
 import org.bitcoinj.core.Coin;
 
@@ -345,7 +344,6 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void onTradeStateChanged(Trade.State tradeState) {
-        Log.traceCall(tradeState.toString());
         log.debug("UI tradeState={}, id={}",
                 tradeState,
                 trade != null ? trade.getShortId() : "trade is null");

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/SellerSubView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/SellerSubView.java
@@ -25,8 +25,6 @@ import bisq.desktop.main.portfolio.pendingtrades.steps.seller.SellerStep4View;
 
 import bisq.core.locale.Res;
 
-import bisq.common.app.Log;
-
 import org.fxmisc.easybind.EasyBind;
 
 public class SellerSubView extends TradeSubView {
@@ -72,7 +70,6 @@ public class SellerSubView extends TradeSubView {
     @Override
     protected void onViewStateChanged(PendingTradesViewModel.State viewState) {
         if (viewState != null) {
-            Log.traceCall(viewState.toString());
             PendingTradesViewModel.SellerState sellerState = (PendingTradesViewModel.SellerState) viewState;
 
             step1.setDisabled();

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -31,7 +31,6 @@ import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
 
 import bisq.common.Clock;
-import bisq.common.app.Log;
 import bisq.common.util.Tuple3;
 
 import de.jensd.fx.fontawesome.AwesomeDude;
@@ -183,7 +182,6 @@ public abstract class TradeStepView extends AnchorPane {
     }
 
     public void deactivate() {
-        Log.traceCall();
         if (txIdSubscription != null)
             txIdSubscription.unsubscribe();
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep4View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep4View.java
@@ -44,7 +44,6 @@ import bisq.core.util.validation.BtcAddressValidator;
 
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
-import bisq.common.app.Log;
 import bisq.common.handlers.FaultHandler;
 import bisq.common.handlers.ResultHandler;
 
@@ -113,7 +112,6 @@ public class BuyerStep4View extends TradeStepView {
 
     @Override
     public void deactivate() {
-        Log.traceCall();
         super.deactivate();
         //withdrawAddressTextField.focusedProperty().removeListener(focusedPropertyListener);
         // withdrawButton.disableProperty().unbind();

--- a/monitor/src/main/java/bisq/monitor/metric/P2PRoundTripTime.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PRoundTripTime.java
@@ -17,18 +17,6 @@
 
 package bisq.monitor.metric;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
-import org.jetbrains.annotations.NotNull;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
-
-import bisq.common.proto.network.NetworkEnvelope;
-import bisq.core.proto.network.CoreNetworkProtoResolver;
 import bisq.monitor.AvailableTor;
 import bisq.monitor.Metric;
 import bisq.monitor.Monitor;
@@ -36,6 +24,9 @@ import bisq.monitor.OnionParser;
 import bisq.monitor.Reporter;
 import bisq.monitor.StatisticsHelper;
 import bisq.monitor.ThreadGate;
+
+import bisq.core.proto.network.CoreNetworkProtoResolver;
+
 import bisq.network.p2p.CloseConnectionMessage;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.CloseConnectionReason;
@@ -46,7 +37,22 @@ import bisq.network.p2p.network.SetupListener;
 import bisq.network.p2p.network.TorNetworkNode;
 import bisq.network.p2p.peers.keepalive.messages.Ping;
 import bisq.network.p2p.peers.keepalive.messages.Pong;
+
+import bisq.common.proto.network.NetworkEnvelope;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import lombok.extern.slf4j.Slf4j;
+
+import org.jetbrains.annotations.NotNull;
 
 @Slf4j
 public class P2PRoundTripTime extends Metric implements MessageListener, SetupListener {
@@ -107,7 +113,6 @@ public class P2PRoundTripTime extends Metric implements MessageListener, SetupLi
                         @Override
                         public void onSuccess(Connection connection) {
                             connection.addMessageListener(P2PRoundTripTime.this);
-                            log.debug("Send ping to " + connection + " succeeded.");
                         }
 
                         @Override

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
@@ -17,31 +17,15 @@
 
 package bisq.monitor.metric;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import org.jetbrains.annotations.NotNull;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
-
-import bisq.common.proto.network.NetworkEnvelope;
-import bisq.core.proto.network.CoreNetworkProtoResolver;
 import bisq.monitor.AvailableTor;
 import bisq.monitor.Metric;
 import bisq.monitor.Monitor;
 import bisq.monitor.OnionParser;
 import bisq.monitor.Reporter;
 import bisq.monitor.ThreadGate;
+
+import bisq.core.proto.network.CoreNetworkProtoResolver;
+
 import bisq.network.p2p.CloseConnectionMessage;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.CloseConnectionReason;
@@ -56,16 +40,38 @@ import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
+import bisq.common.proto.network.NetworkEnvelope;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+
 import java.net.MalformedURLException;
 
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.extern.slf4j.Slf4j;
+
+import org.jetbrains.annotations.NotNull;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Contacts a list of hosts and asks them for all the data excluding persisted messages. The
  * answers are then compiled into buckets of message types. Based on these
  * buckets, the Metric reports (for each host) the message types observed and
  * their number.
- * 
+ *
  * @author Florian Reimair
  *
  */
@@ -191,7 +197,6 @@ public class P2PSeedNodeSnapshot extends Metric implements MessageListener, Setu
                             @Override
                             public void onSuccess(Connection connection) {
                                 connection.addMessageListener(P2PSeedNodeSnapshot.this);
-                                log.debug("Send PreliminaryDataRequest to " + connection + " succeeded.");
                             }
 
                             @Override

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -47,7 +47,6 @@ import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
@@ -187,7 +186,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void start(@Nullable P2PServiceListener listener) {
-        Log.traceCall();
         if (listener != null)
             addP2PServiceListener(listener);
 
@@ -195,7 +193,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     public void onAllServicesInitialized() {
-        Log.traceCall();
         if (networkNode.getNodeAddress() != null) {
             maybeProcessAllMailboxEntries();
         } else {
@@ -208,7 +205,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     public void shutDown(Runnable shutDownCompleteHandler) {
-        Log.traceCall();
         if (!shutDownInProgress) {
             shutDownInProgress = true;
 
@@ -273,8 +269,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     ///////////////////////////////////////////////////////////////////////////////////////////
     @Override
     public void onTorNodeReady() {
-        Log.traceCall();
-
         socks5ProxyProvider.setSocks5ProxyInternal(networkNode);
 
         boolean seedNodesAvailable = requestDataManager.requestPreliminaryData();
@@ -291,8 +285,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
     @Override
     public void onHiddenServicePublished() {
-        Log.traceCall();
-
         checkArgument(networkNode.getNodeAddress() != null, "Address must be set when we have the hidden service ready");
 
         hiddenServicePublished.set(true);
@@ -302,7 +294,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
     @Override
     public void onSetupFailed(Throwable throwable) {
-        Log.traceCall();
         p2pServiceListeners.stream().forEach(e -> e.onSetupFailed(throwable));
     }
 
@@ -313,7 +304,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
     // Called from networkReadyBinding
     private void onNetworkReady() {
-        Log.traceCall();
         networkReadySubscription.unsubscribe();
 
         Optional<NodeAddress> seedNodeOfPreliminaryDataRequest = requestDataManager.getNodeAddressOfPreliminaryDataRequest();
@@ -383,7 +373,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
     @Override
     public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
-        Log.traceCall();
         numConnectedPeers.set(networkNode.getAllConnections().size());
         //TODO check if still needed and why
         UserThread.runAfter(() -> numConnectedPeers.set(networkNode.getAllConnections().size()), 3);
@@ -401,7 +390,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     @Override
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof PrefixedSealedAndSignedMessage) {
-            Log.traceCall("\n\t" + networkEnvelope.toString() + "\n\tconnection=" + connection);
             // Seed nodes don't have set the encryptionService
             try {
                 PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage = (PrefixedSealedAndSignedMessage) networkEnvelope;
@@ -522,7 +510,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
         NodeAddress nodeAddress = networkNode.getNodeAddress();
         // Seed nodes don't receive mailbox network_messages
         if (nodeAddress != null && !seedNodeRepository.isSeedNode(nodeAddress)) {
-            Log.traceCall();
             MailboxStoragePayload mailboxStoragePayload = protectedMailboxStorageEntry.getMailboxStoragePayload();
             PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage = mailboxStoragePayload.getPrefixedSealedAndSignedMessage();
             if (verifyAddressPrefixHash(prefixedSealedAndSignedMessage)) {
@@ -665,8 +652,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     private void addMailboxData(MailboxStoragePayload expirableMailboxStoragePayload,
                                 PublicKey receiversPublicKey,
                                 SendMailboxMessageListener sendMailboxMessageListener) {
-        Log.traceCall();
-
         if (isBootstrapped()) {
             if (!networkNode.getAllConnections().isEmpty()) {
                 try {
@@ -755,7 +740,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     private void delayedRemoveEntryFromMailbox(DecryptedMessageWithPubKey decryptedMessageWithPubKey) {
-        Log.traceCall();
         if (!isBootstrapped()) {
             // We don't throw an NetworkNotReadyException here.
             // This case should not happen anyway as we check for isBootstrapped in the callers.
@@ -799,7 +783,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     public boolean addProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload, boolean isDataOwner) {
-        Log.traceCall();
         if (isBootstrapped()) {
             try {
                 ProtectedStorageEntry protectedStorageEntry = p2PDataStorage.getProtectedStorageEntry(protectedStoragePayload, keyRing.getSignatureKeyPair());
@@ -814,7 +797,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     public boolean refreshTTL(ProtectedStoragePayload protectedStoragePayload, boolean isDataOwner) {
-        Log.traceCall();
         if (isBootstrapped()) {
             try {
                 RefreshOfferMessage refreshTTLMessage = p2PDataStorage.getRefreshTTLMessage(protectedStoragePayload, keyRing.getSignatureKeyPair());
@@ -829,7 +811,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     public boolean removeData(ProtectedStoragePayload protectedStoragePayload, boolean isDataOwner) {
-        Log.traceCall();
         if (isBootstrapped()) {
             try {
                 ProtectedStorageEntry protectedStorageEntry = p2PDataStorage.getProtectedStorageEntry(protectedStoragePayload, keyRing.getSignatureKeyPair());

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -797,7 +797,7 @@ public class Connection implements MessageListener {
                         }
 
                         Connection connection = checkNotNull(sharedModel.connection, "connection must not be null");
-                        log.trace("InputHandler waiting for incoming network_messages.\n\tConnection=" + connection);
+                        log.trace("InputHandler waiting for incoming network_messages.\n\tConnection={}", connection);
 
                         // Throttle inbound network_messages
                         long now = System.currentTimeMillis();

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -38,7 +38,6 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 import bisq.common.Proto;
 import bisq.common.UserThread;
 import bisq.common.app.Capabilities;
-import bisq.common.app.Log;
 import bisq.common.app.Version;
 import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.network.NetworkEnvelope;
@@ -238,8 +237,6 @@ public class Connection implements MessageListener {
         if (!stopped) {
             if (noCapabilityRequiredOrCapabilityIsSupported(networkEnvelope)) {
                 try {
-                    Log.traceCall();
-
                     // Throttle outbound network_messages
                     long now = System.currentTimeMillis();
                     long elapsed = now - lastSendTimeStamp;
@@ -505,7 +502,6 @@ public class Connection implements MessageListener {
             if (closeConnectionReason.sendCloseMessage) {
                 new Thread(() -> {
                     Thread.currentThread().setName("Connection:SendCloseConnectionMessage-" + this.uid);
-                    Log.traceCall("sendCloseConnectionMessage");
                     try {
                         String reason = closeConnectionReason == CloseConnectionReason.RULE_VIOLATION ?
                                 sharedModel.getRuleViolation().name() : closeConnectionReason.name();

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -212,8 +212,6 @@ public class Connection implements MessageListener {
             if (peersNodeAddress != null)
                 setPeersNodeAddress(peersNodeAddress);
 
-            log.trace("New connection created: " + this.toString());
-
             UserThread.execute(() -> connectionListener.onConnection(this));
         } catch (Throwable e) {
             handleException(e);

--- a/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
@@ -20,7 +20,6 @@ package bisq.network.p2p.network;
 import bisq.network.p2p.NodeAddress;
 
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkProtoResolver;
 
 import java.net.ServerSocket;
@@ -77,12 +76,10 @@ public class LocalhostNetworkNode extends NetworkNode {
 
         // simulate tor connection delay
         UserThread.runAfter(() -> {
-            Log.traceCall("torNode created");
             setupListeners.stream().forEach(SetupListener::onTorNodeReady);
 
             // simulate tor HS publishing delay
             UserThread.runAfter(() -> {
-                Log.traceCall("hiddenService created");
                 try {
                     startServer(new ServerSocket(servicePort));
                 } catch (IOException e) {

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -219,7 +219,7 @@ public abstract class NetworkNode implements MessageListener {
         Optional<InboundConnection> inboundConnectionOptional = lookupInBoundConnection(peersNodeAddress);
         if (inboundConnectionOptional.isPresent()) {
             InboundConnection connection = inboundConnectionOptional.get();
-            log.trace("We have found a connection in inBoundConnections. Connection.uid=" + connection.getUid());
+            log.trace("We have found a connection in inBoundConnections. Connection.uid={}", connection.getUid());
             if (connection.isStopped()) {
                 log.warn("We have a connection which is already stopped in inBoundConnections. Connection.uid=" + connection.getUid());
                 inBoundConnections.remove(connection);
@@ -237,7 +237,7 @@ public abstract class NetworkNode implements MessageListener {
         Optional<OutboundConnection> outboundConnectionOptional = lookupOutBoundConnection(peersNodeAddress);
         if (outboundConnectionOptional.isPresent()) {
             OutboundConnection connection = outboundConnectionOptional.get();
-            log.trace("We have found a connection in outBoundConnections. Connection.uid=" + connection.getUid());
+            log.trace("We have found a connection in outBoundConnections. Connection.uid={}", connection.getUid());
             if (connection.isStopped()) {
                 log.warn("We have a connection which is already stopped in outBoundConnections. Connection.uid=" + connection.getUid());
                 outBoundConnections.remove(connection);
@@ -394,7 +394,7 @@ public abstract class NetworkNode implements MessageListener {
 
             @Override
             public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
-                log.trace("onDisconnect at server socket connectionListener\n\tconnection={}" + connection);
+                log.trace("onDisconnect at server socket connectionListener\n\tconnection={}", connection);
                 //noinspection SuspiciousMethodCalls
                 inBoundConnections.remove(connection);
                 printInboundConnections();

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -20,7 +20,6 @@ package bisq.network.p2p.network;
 import bisq.network.p2p.NodeAddress;
 
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.util.Utilities;
@@ -258,7 +257,6 @@ public abstract class NetworkNode implements MessageListener {
 
 
     public SettableFuture<Connection> sendMessage(Connection connection, NetworkEnvelope networkEnvelope) {
-        Log.traceCall("\n\tmessage=" + Utilities.toTruncatedString(networkEnvelope) + "\n\tconnection=" + connection);
         // connection.sendMessage might take a bit (compression, write to stream), so we use a thread to not block
         ListenableFuture<Connection> future = executorService.submit(() -> {
             Thread.currentThread().setName("NetworkNode:SendMessage-to-" + connection.getUid());
@@ -307,7 +305,6 @@ public abstract class NetworkNode implements MessageListener {
 
 
     public void shutDown(Runnable shutDownCompleteHandler) {
-        Log.traceCall();
         if (!shutDownInProgress) {
             shutDownInProgress = true;
             if (server != null) {

--- a/p2p/src/main/java/bisq/network/p2p/network/Server.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Server.java
@@ -74,8 +74,8 @@ class Server implements Runnable {
                         log.debug("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" +
                                 "Server created new inbound connection:"
                                 + "\nlocalPort/port=" + serverSocket.getLocalPort()
-                                + "/" + socket.getPort()
-                                + "\nconnection.uid=" + connection.getUid()
+                                + "/{}" +
+                                "\nconnection.uid={}", socket.getPort(), connection.getUid()
                                 + "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n");
 
                         if (!stopped)

--- a/p2p/src/main/java/bisq/network/p2p/network/Server.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Server.java
@@ -17,7 +17,6 @@
 
 package bisq.network.p2p.network;
 
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkProtoResolver;
 
 import java.net.ServerSocket;
@@ -51,7 +50,6 @@ class Server implements Runnable {
                   ConnectionListener connectionListener,
                   NetworkProtoResolver networkProtoResolver) {
         this.networkProtoResolver = networkProtoResolver;
-        Log.traceCall();
         this.serverSocket = serverSocket;
         this.messageListener = messageListener;
         this.connectionListener = connectionListener;
@@ -59,7 +57,6 @@ class Server implements Runnable {
 
     @Override
     public void run() {
-        Log.traceCall();
         try {
             // Thread created by NetworkNode
             Thread.currentThread().setName("Server-" + serverSocket.getLocalPort());
@@ -98,7 +95,6 @@ class Server implements Runnable {
     }
 
     public void shutDown() {
-        Log.traceCall();
         if (!stopped) {
             stopped = true;
 

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -22,7 +22,6 @@ import bisq.network.p2p.Utils;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.util.Utilities;
 
@@ -150,7 +149,6 @@ public class TorNetworkNode extends NetworkNode {
     }
 
     public void shutDown(@Nullable Runnable shutDownCompleteHandler) {
-        Log.traceCall();
         BooleanProperty torNetworkNodeShutDown = torNetworkNodeShutDown();
         BooleanProperty networkNodeShutDown = networkNodeShutDown();
         BooleanProperty shutDownTimerTriggered = shutDownTimerTriggered();
@@ -225,7 +223,6 @@ public class TorNetworkNode extends NetworkNode {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void restartTor(String errorMessage) {
-        Log.traceCall();
         log.info("Restarting Tor");
         restartCounter++;
         if (restartCounter <= MAX_RESTART_ATTEMPTS) {
@@ -249,8 +246,6 @@ public class TorNetworkNode extends NetworkNode {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void createTorAndHiddenService(int localPort, int servicePort) {
-        Log.traceCall();
-
         ListenableFuture<Void> future = executorService.submit(() -> {
             try {
                 // get tor
@@ -270,7 +265,6 @@ public class TorNetworkNode extends NetworkNode {
                             @Override
                             public void run() {
                                 try {
-                                    Log.traceCall("hiddenService created");
                                     nodeAddressProperty.set(new NodeAddress(hiddenServiceSocket.getServiceName() + ":" + hiddenServiceSocket.getHiddenServicePort()));
                                     startServer(socket);
                                     UserThread.execute(() -> setupListeners.forEach(SetupListener::onHiddenServicePublished));

--- a/p2p/src/main/java/bisq/network/p2p/peers/BroadcastHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/BroadcastHandler.java
@@ -24,7 +24,6 @@ import bisq.network.p2p.storage.messages.BroadcastMessage;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.util.Utilities;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -117,8 +116,6 @@ public class BroadcastHandler implements PeerManager.Listener {
         this.resultHandler = resultHandler;
         this.listener = listener;
 
-        Log.traceCall("Sender=" + sender + "\n\t" +
-                "Message=" + Utilities.toTruncatedString(message));
         Set<Connection> connectedPeersSet = networkNode.getConfirmedConnections()
                 .stream()
                 .filter(connection -> !connection.getPeersNodeAddressOptional().get().equals(sender))

--- a/p2p/src/main/java/bisq/network/p2p/peers/BroadcastHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/BroadcastHandler.java
@@ -167,15 +167,12 @@ public class BroadcastHandler implements PeerManager.Listener {
             if (!connection.isStopped()) {
                 if (connection.noCapabilityRequiredOrCapabilityIsSupported(message)) {
                     NodeAddress nodeAddress = connection.getPeersNodeAddressOptional().get();
-                    log.trace("Broadcast message to " + nodeAddress + ".");
                     SettableFuture<Connection> future = networkNode.sendMessage(connection, message);
                     Futures.addCallback(future, new FutureCallback<Connection>() {
                         @Override
                         public void onSuccess(Connection connection) {
                             numOfCompletedBroadcasts++;
                             if (!stopped) {
-                                log.trace("Broadcast to " + nodeAddress + " succeeded.");
-
                                 if (listener != null)
                                     listener.onBroadcasted(message, numOfCompletedBroadcasts);
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/Broadcaster.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/Broadcaster.java
@@ -21,9 +21,6 @@ import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.NetworkNode;
 import bisq.network.p2p.storage.messages.BroadcastMessage;
 
-import bisq.common.app.Log;
-import bisq.common.util.Utilities;
-
 import javax.inject.Inject;
 
 import java.util.Set;
@@ -60,9 +57,6 @@ public class Broadcaster implements BroadcastHandler.ResultHandler {
 
     public void broadcast(BroadcastMessage message, @Nullable NodeAddress sender,
                           @Nullable BroadcastHandler.Listener listener, boolean isDataOwner) {
-        Log.traceCall("Sender=" + sender + "\n\t" +
-                "Message=" + Utilities.toTruncatedString(message));
-
         BroadcastHandler broadcastHandler = new BroadcastHandler(networkNode, peerManager);
         broadcastHandler.broadcast(message, sender, this, listener, isDataOwner);
         broadcastHandlers.add(broadcastHandler);

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -32,7 +32,6 @@ import bisq.network.p2p.seed.SeedNodeRepository;
 import bisq.common.Clock;
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.persistable.PersistedDataHost;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
 import bisq.common.storage.Storage;
@@ -161,8 +160,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     public void shutDown() {
-        Log.traceCall();
-
         networkNode.removeConnectionListener(this);
         clock.removeListener(listener);
         stopCheckMaxConnectionsTimer();
@@ -301,7 +298,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private boolean checkMaxConnections() {
-        Log.traceCall("maxConnections=" + maxConnections);
         Set<Connection> allConnections = networkNode.getAllConnections();
         int size = allConnections.size();
         log.info("We have {} connections open. Our limit is {}", size, maxConnections);
@@ -366,7 +362,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private void removeAnonymousPeers() {
-        Log.traceCall();
         networkNode.getAllConnections().stream()
                 .filter(connection -> !connection.hasPeersNodeAddress())
                 .forEach(connection -> UserThread.runAfter(() -> {
@@ -382,7 +377,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private void removeSuperfluousSeedNodes() {
-        Log.traceCall();
         if (networkNode.getConfirmedConnections().size() > disconnectFromSeedNode) {
             List<Connection> seedNodes = networkNode.getConfirmedConnections().stream()
                     .filter(this::isSeedNode)
@@ -426,7 +420,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private void removeTooOldReportedPeers() {
-        Log.traceCall();
         List<Peer> reportedPeersClone = new ArrayList<>(reportedPeers);
         Set<Peer> reportedPeersToRemove = reportedPeersClone.stream()
                 .filter(reportedPeer -> new Date().getTime() - reportedPeer.getDate().getTime() > MAX_AGE)
@@ -460,7 +453,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private void purgeReportedPeersIfExceeds() {
-        Log.traceCall();
         int size = reportedPeers.size();
         if (size > MAX_REPORTED_PEERS) {
             log.info("We have already {} reported peers which exceeds our limit of {}." +
@@ -532,7 +524,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private void removeTooOldPersistedPeers() {
-        Log.traceCall();
         Set<Peer> persistedPeersToRemove = persistedPeers.stream()
                 .filter(reportedPeer -> new Date().getTime() - reportedPeer.getDate().getTime() > MAX_AGE)
                 .collect(Collectors.toSet());
@@ -540,7 +531,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private void purgePersistedPeersIfExceeds() {
-        Log.traceCall();
         int size = persistedPeers.size();
         int limit = MAX_PERSISTED_PEERS;
         if (size > limit) {
@@ -611,7 +601,6 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     public void handleConnectionFault(NodeAddress nodeAddress, @Nullable Connection connection) {
-        Log.traceCall("nodeAddress=" + nodeAddress);
         log.debug("handleConnectionFault called: nodeAddress=" + nodeAddress);
         boolean doRemovePersistedPeer = false;
         removeReportedPeer(nodeAddress);

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -345,7 +345,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
                 candidates.sort((o1, o2) -> ((Long) o1.getStatistic().getLastActivityTimestamp()).compareTo(((Long) o2.getStatistic().getLastActivityTimestamp())));
                 Connection connection = candidates.remove(0);
                 log.info("checkMaxConnections: Num candidates for shut down={}. We close oldest connection: {}", candidates.size(), connection);
-                log.debug("We are going to shut down the oldest connection.\n\tconnection=" + connection.toString());
+                log.debug("We are going to shut down the oldest connection.\n\tconnection={}", connection.toString());
                 if (!connection.isStopped())
                     connection.shutDown(CloseConnectionReason.TOO_MANY_CONNECTIONS_OPEN, () -> UserThread.runAfter(this::checkMaxConnections, 100, TimeUnit.MILLISECONDS));
                 return true;
@@ -370,7 +370,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
                     // because he needs longer for the HS publishing
                     if (!connection.hasPeersNodeAddress() && !connection.isStopped()) {
                         log.debug("We close the connection as the peer address is still unknown.\n\t" +
-                                "connection=" + connection);
+                                "connection={}", connection);
                         connection.shutDown(CloseConnectionReason.UNKNOWN_PEER_ADDRESS);
                     }
                 }, REMOVE_ANONYMOUS_PEER_SEC));
@@ -386,7 +386,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
                 seedNodes.sort((o1, o2) -> ((Long) o1.getStatistic().getLastActivityTimestamp()).compareTo(((Long) o2.getStatistic().getLastActivityTimestamp())));
                 log.debug("Number of seed node connections to disconnect. Current size=" + seedNodes.size());
                 Connection connection = seedNodes.get(0);
-                log.debug("We are going to shut down the oldest connection.\n\tconnection=" + connection.toString());
+                log.debug("We are going to shut down the oldest connection.\n\tconnection={}", connection.toString());
                 connection.shutDown(CloseConnectionReason.TOO_MANY_SEED_NODES_CONNECTED,
                         () -> UserThread.runAfter(this::removeSuperfluousSeedNodes, 200, TimeUnit.MILLISECONDS));
             }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
@@ -31,7 +31,6 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.util.Utilities;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -92,8 +91,6 @@ public class GetDataRequestHandler {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void handle(GetDataRequest getDataRequest, final Connection connection) {
-        Log.traceCall(getDataRequest + "\n\tconnection=" + connection);
-
         GetDataResponse getDataResponse = new GetDataResponse(getFilteredProtectedStorageEntries(getDataRequest, connection),
                 getFilteredPersistableNetworkPayload(getDataRequest, connection),
                 getDataRequest.getNonce(),

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -35,7 +35,6 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkPayload;
 
@@ -114,7 +113,6 @@ class RequestDataHandler implements MessageListener {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void requestData(NodeAddress nodeAddress, boolean isPreliminaryDataRequest) {
-        Log.traceCall("nodeAddress=" + nodeAddress);
         peersNodeAddress = nodeAddress;
         if (!stopped) {
             GetDataRequest getDataRequest;
@@ -196,7 +194,6 @@ class RequestDataHandler implements MessageListener {
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof GetDataResponse) {
             if (connection.getPeersNodeAddressOptional().isPresent() && connection.getPeersNodeAddressOptional().get().equals(peersNodeAddress)) {
-                Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
                 if (!stopped) {
                     GetDataResponse getDataResponse = (GetDataResponse) networkEnvelope;
                     Map<String, Set<NetworkPayload>> payloadByClassName = new HashMap<>();
@@ -327,7 +324,6 @@ class RequestDataHandler implements MessageListener {
     }
 
     private void cleanup() {
-        Log.traceCall();
         stopped = true;
         networkNode.removeMessageListener(this);
         stopTimeoutTimer();

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -32,7 +32,6 @@ import bisq.network.p2p.storage.P2PDataStorage;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 
 import com.google.inject.name.Named;
@@ -133,7 +132,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     }
 
     public void shutDown() {
-        Log.traceCall();
         stopped = true;
         stopRetryTimer();
         networkNode.removeMessageListener(this);
@@ -152,7 +150,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     }
 
     public boolean requestPreliminaryData() {
-        Log.traceCall();
         ArrayList<NodeAddress> nodeAddresses = new ArrayList<>(seedNodeAddresses);
         if (!nodeAddresses.isEmpty()) {
             Collections.shuffle(nodeAddresses);
@@ -174,7 +171,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     }
 
     public void requestUpdateData() {
-        Log.traceCall();
         checkArgument(nodeAddressOfPreliminaryDataRequest.isPresent(), "nodeAddressOfPreliminaryDataRequest must be present");
         dataUpdateRequested = true;
         isPreliminaryDataRequest = false;
@@ -214,12 +210,10 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
 
     @Override
     public void onConnection(Connection connection) {
-        Log.traceCall();
     }
 
     @Override
     public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
-        Log.traceCall();
         closeHandler(connection);
 
         if (peerManager.isNodeBanned(closeConnectionReason, connection) && connection.getPeersNodeAddressOptional().isPresent()) {
@@ -240,7 +234,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
 
     @Override
     public void onAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopRetryTimer();
         stopped = true;
@@ -249,7 +242,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
 
     @Override
     public void onNewConnectionAfterAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopped = false;
         restart();
@@ -257,7 +249,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
 
     @Override
     public void onAwakeFromStandby() {
-        Log.traceCall();
         closeAllHandlers();
         stopped = false;
         if (!networkNode.getAllConnections().isEmpty())
@@ -272,7 +263,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     @Override
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof GetDataRequest) {
-            Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
             if (!stopped) {
                 if (peerManager.isSeedNode(connection))
                     connection.setPeerType(Connection.PeerType.SEED_NODE);
@@ -324,7 +314,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void requestData(NodeAddress nodeAddress, List<NodeAddress> remainingNodeAddresses) {
-        Log.traceCall("nodeAddress=" + nodeAddress + " /  remainingNodeAddresses=" + remainingNodeAddresses);
         if (!stopped) {
             if (!handlerMap.containsKey(nodeAddress)) {
                 RequestDataHandler requestDataHandler = new RequestDataHandler(networkNode, dataStorage, peerManager,
@@ -417,7 +406,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void restart() {
-        Log.traceCall();
         if (retryTimer == null) {
             retryTimer = UserThread.runAfter(() -> {
                         log.trace("retryTimer called");

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -408,7 +408,6 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     private void restart() {
         if (retryTimer == null) {
             retryTimer = UserThread.runAfter(() -> {
-                        log.trace("retryTimer called");
                         stopped = false;
 
                         stopRetryTimer();
@@ -473,7 +472,7 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                 handlerMap.remove(nodeAddress);
             }
         } else {
-            log.trace("closeRequestDataHandler: nodeAddress not set in connection " + connection);
+            log.trace("closeRequestDataHandler: nodeAddress not set in connection {}", connection);
         }
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveHandler.java
@@ -107,7 +107,6 @@ class KeepAliveHandler implements MessageListener {
                 @Override
                 public void onSuccess(Connection connection) {
                     if (!stopped) {
-                        log.trace("Send " + ping + " to " + connection + " succeeded.");
                         KeepAliveHandler.this.connection = connection;
                         connection.addMessageListener(KeepAliveHandler.this);
                     } else {
@@ -148,7 +147,6 @@ class KeepAliveHandler implements MessageListener {
                 Pong pong = (Pong) networkEnvelope;
                 if (pong.getRequestNonce() == nonce) {
                     int roundTripTime = (int) (System.currentTimeMillis() - sendTs);
-                    log.trace("roundTripTime=" + roundTripTime + "\n\tconnection=" + connection);
                     connection.getStatistic().setRoundTripTime(roundTripTime);
                     cleanup();
                     listener.onComplete();

--- a/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveHandler.java
@@ -26,7 +26,6 @@ import bisq.network.p2p.peers.keepalive.messages.Pong;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -100,7 +99,6 @@ class KeepAliveHandler implements MessageListener {
     }
 
     private void sendPing(Connection connection) {
-        Log.traceCall("connection=" + connection + " / this=" + this);
         if (!stopped) {
             Ping ping = new Ping(nonce, connection.getStatistic().roundTripTimeProperty().get());
             sendTs = System.currentTimeMillis();
@@ -146,7 +144,6 @@ class KeepAliveHandler implements MessageListener {
     @Override
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof Pong) {
-            Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
             if (!stopped) {
                 Pong pong = (Pong) networkEnvelope;
                 if (pong.getRequestNonce() == nonce) {

--- a/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveManager.java
@@ -112,7 +112,6 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
                 Futures.addCallback(future, new FutureCallback<Connection>() {
                     @Override
                     public void onSuccess(Connection connection) {
-                        log.trace("Pong sent successfully");
                     }
 
                     @Override

--- a/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/keepalive/KeepAliveManager.java
@@ -29,7 +29,6 @@ import bisq.network.p2p.peers.keepalive.messages.Pong;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 
 import javax.inject.Inject;
@@ -77,7 +76,6 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
     }
 
     public void shutDown() {
-        Log.traceCall();
         stopped = true;
         networkNode.removeMessageListener(this);
         networkNode.removeConnectionListener(this);
@@ -103,7 +101,6 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
     @Override
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof Ping) {
-            Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
             if (!stopped) {
                 Ping ping = (Ping) networkEnvelope;
 
@@ -144,12 +141,10 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
 
     @Override
     public void onConnection(Connection connection) {
-        Log.traceCall();
     }
 
     @Override
     public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
-        Log.traceCall();
         closeHandler(connection);
     }
 
@@ -164,7 +159,6 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
 
     @Override
     public void onAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopKeepAliveTimer();
         stopped = true;
@@ -173,7 +167,6 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
 
     @Override
     public void onNewConnectionAfterAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopped = false;
         restart();
@@ -181,7 +174,6 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
 
     @Override
     public void onAwakeFromStandby() {
-        Log.traceCall();
         closeAllHandlers();
         stopped = false;
         if (!networkNode.getAllConnections().isEmpty())
@@ -203,7 +195,6 @@ public class KeepAliveManager implements MessageListener, ConnectionListener, Pe
 
     private void keepAlive() {
         if (!stopped) {
-            Log.traceCall();
             networkNode.getConfirmedConnections().stream()
                     .filter(connection -> connection instanceof OutboundConnection &&
                             connection.getStatistic().getLastActivityAge() > LAST_ACTIVITY_AGE_MS)

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/GetPeersRequestHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/GetPeersRequestHandler.java
@@ -26,7 +26,6 @@ import bisq.network.p2p.peers.peerexchange.messages.GetPeersResponse;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -84,8 +83,6 @@ class GetPeersRequestHandler {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void handle(GetPeersRequest getPeersRequest, final Connection connection) {
-        Log.traceCall("getPeersRequest=" + getPeersRequest + "\n\tconnection=" + connection + "\n\tthis=" + this);
-
         checkArgument(connection.getPeersNodeAddressOptional().isPresent(),
                 "The peers address must have been already set at the moment");
         GetPeersResponse getPeersResponse = new GetPeersResponse(getPeersRequest.getNonce(),

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
@@ -129,7 +129,6 @@ class PeerExchangeHandler implements MessageListener {
 
                             PeerExchangeHandler.this.connection = connection;
                             connection.addMessageListener(PeerExchangeHandler.this);
-                            log.trace("Send " + getPeersRequest + " to " + nodeAddress + " succeeded.");
                         } else {
                             log.trace("We have stopped that handler already. We ignore that sendGetPeersRequest.onSuccess call.");
                         }

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
@@ -28,7 +28,6 @@ import bisq.network.p2p.peers.peerexchange.messages.GetPeersResponse;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -88,7 +87,6 @@ class PeerExchangeHandler implements MessageListener {
     }
 
     public void cancel() {
-        Log.traceCall();
         cleanup();
     }
 
@@ -164,7 +162,6 @@ class PeerExchangeHandler implements MessageListener {
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof GetPeersResponse) {
             if (!stopped) {
-                Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
                 GetPeersResponse getPeersResponse = (GetPeersResponse) networkEnvelope;
                 if (peerManager.isSeedNode(connection))
                     connection.setPeerType(Connection.PeerType.SEED_NODE);
@@ -192,7 +189,6 @@ class PeerExchangeHandler implements MessageListener {
 
     @SuppressWarnings("UnusedParameters")
     private void handleFault(String errorMessage, CloseConnectionReason closeConnectionReason, NodeAddress nodeAddress) {
-        Log.traceCall();
         cleanup();
        /* if (connection == null)
             peerManager.shutDownConnection(nodeAddress, closeConnectionReason);
@@ -204,7 +200,6 @@ class PeerExchangeHandler implements MessageListener {
     }
 
     private void cleanup() {
-        Log.traceCall();
         stopped = true;
         if (connection != null)
             connection.removeMessageListener(this);

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -29,7 +29,6 @@ import bisq.network.p2p.seed.SeedNodeRepository;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
-import bisq.common.app.Log;
 import bisq.common.proto.network.NetworkEnvelope;
 
 import javax.inject.Inject;
@@ -88,7 +87,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
     }
 
     public void shutDown() {
-        Log.traceCall();
         stopped = true;
         networkNode.removeMessageListener(this);
         networkNode.removeConnectionListener(this);
@@ -134,7 +132,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
 
     @Override
     public void onConnection(Connection connection) {
-        Log.traceCall();
     }
 
     @Override
@@ -165,7 +162,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
 
     @Override
     public void onAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopPeriodicTimer();
         stopRetryTimer();
@@ -175,7 +171,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
 
     @Override
     public void onNewConnectionAfterAllConnectionsLost() {
-        Log.traceCall();
         closeAllHandlers();
         stopped = false;
         restart();
@@ -183,7 +178,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
 
     @Override
     public void onAwakeFromStandby() {
-        Log.traceCall();
         closeAllHandlers();
         stopped = false;
         if (!networkNode.getAllConnections().isEmpty())
@@ -198,7 +192,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
     @Override
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof GetPeersRequest) {
-            Log.traceCall(networkEnvelope.toString() + "\n\tconnection=" + connection);
             if (!stopped) {
                 if (peerManager.isSeedNode(connection))
                     connection.setPeerType(Connection.PeerType.SEED_NODE);
@@ -291,7 +284,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
     }
 
     private void requestWithAvailablePeers() {
-        Log.traceCall();
         if (!stopped) {
             if (!peerManager.hasSufficientConnections()) {
                 // We create a new list of not connected candidates
@@ -401,7 +393,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
     }
 
     private void closeHandler(Connection connection) {
-        Log.traceCall();
         Optional<NodeAddress> peersNodeAddressOptional = connection.getPeersNodeAddressOptional();
         if (peersNodeAddressOptional.isPresent()) {
             NodeAddress nodeAddress = peersNodeAddressOptional.get();
@@ -415,7 +406,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
     }
 
     private void closeAllHandlers() {
-        Log.traceCall();
         handlerMap.values().stream().forEach(PeerExchangeHandler::cancel);
         handlerMap.clear();
     }

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -302,7 +302,7 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
                 list.addAll(filteredSeedNodeAddresses);
 
                 log.debug("Number of peers in list for connectToMorePeers: {}", list.size());
-                log.trace("Filtered connectToMorePeers list: list=" + list);
+                log.trace("Filtered connectToMorePeers list: list={}", list);
                 if (!list.isEmpty()) {
                     // Don't shuffle as we want the seed nodes at the last entries
                     NodeAddress nextCandidate = list.get(0);
@@ -400,8 +400,6 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
                 handlerMap.get(nodeAddress).cancel();
                 handlerMap.remove(nodeAddress);
             }
-        } else {
-            log.trace("closeHandler: nodeAddress not set in connection " + connection);
         }
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -220,7 +220,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     @Override
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof BroadcastMessage) {
-            Log.traceCall(Utilities.toTruncatedString(networkEnvelope) + "\n\tconnection=" + connection);
             connection.getPeersNodeAddressOptional().ifPresent(peersNodeAddress -> {
                 if (networkEnvelope instanceof AddDataMessage) {
                     addProtectedStorageEntry(((AddDataMessage) networkEnvelope).getProtectedStorageEntry(), peersNodeAddress, null, false);
@@ -338,13 +337,11 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
     public boolean addProtectedStorageEntry(ProtectedStorageEntry protectedStorageEntry, @Nullable NodeAddress sender,
                                             @Nullable BroadcastHandler.Listener listener, boolean isDataOwner) {
-        Log.traceCall("with allowBroadcast=true");
         return addProtectedStorageEntry(protectedStorageEntry, sender, listener, isDataOwner, true);
     }
 
     public boolean addProtectedStorageEntry(ProtectedStorageEntry protectedStorageEntry, @Nullable NodeAddress sender,
                                             @Nullable BroadcastHandler.Listener listener, boolean isDataOwner, boolean allowBroadcast) {
-        Log.traceCall("with allowBroadcast=" + allowBroadcast);
         final ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
         boolean sequenceNrValid = isSequenceNrValid(protectedStorageEntry.getSequenceNumber(), hashOfPayload);
@@ -400,8 +397,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     }
 
     public boolean refreshTTL(RefreshOfferMessage refreshTTLMessage, @Nullable NodeAddress sender, boolean isDataOwner) {
-        Log.traceCall();
-
         byte[] hashOfDataAndSeqNr = refreshTTLMessage.getHashOfDataAndSeqNr();
         byte[] signature = refreshTTLMessage.getSignature();
         ByteArray hashOfPayload = new ByteArray(refreshTTLMessage.getHashOfPayload());
@@ -444,7 +439,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     }
 
     public boolean remove(ProtectedStorageEntry protectedStorageEntry, @Nullable NodeAddress sender, boolean isDataOwner) {
-        Log.traceCall();
         final ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
         boolean containsKey = map.containsKey(hashOfPayload);
@@ -482,7 +476,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
     @SuppressWarnings("UnusedReturnValue")
     public boolean removeMailboxData(ProtectedMailboxStorageEntry protectedMailboxStorageEntry, @Nullable NodeAddress sender, boolean isDataOwner) {
-        Log.traceCall();
         ByteArray hashOfData = get32ByteHashAsByteArray(protectedMailboxStorageEntry.getProtectedStoragePayload());
         boolean containsKey = map.containsKey(hashOfData);
         if (!containsKey)

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -594,7 +594,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
                 return false;
             }
         } else {
-            log.trace("Sequence number is valid (!sequenceNumberMap.containsKey(hashOfData)). sequenceNumber = " + newSequenceNumber);
             return true;
         }
     }
@@ -624,7 +623,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
                 return false;
             }
         } else {
-            log.trace("Sequence number has increased (!sequenceNumberMap.containsKey(hashOfData)). sequenceNumber = " + newSequenceNumber + " / hashOfData=" + hashOfData.toString());
             return true;
         }
     }
@@ -768,7 +766,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             });
             sb.append("\n------------------------------------------------------------\n");
             log.debug(sb.toString());
-            log.debug("Data set " + info + " operation: size=" + map.values().size());
+            //log.debug("Data set " + info + " operation: size=" + map.values().size());
         }
     }
 

--- a/p2p/src/test/java/bisq/network/p2p/DummySeedNode.java
+++ b/p2p/src/test/java/bisq/network/p2p/DummySeedNode.java
@@ -65,7 +65,6 @@ public class DummySeedNode {
     private Level logLevel = Level.WARN;
 
     public DummySeedNode(String defaultUserDataDir) {
-        Log.traceCall("defaultUserDataDir=" + defaultUserDataDir);
         this.defaultUserDataDir = defaultUserDataDir;
     }
 


### PR DESCRIPTION
Florian reported that they consume quite a bit of performance.As
they have not been used for development testing since long we should
better remove those.