### PR TITLE
Add removed deprecated payment methods again as it would break trade history

### DIFF
--- a/core/src/main/java/bisq/core/payment/CashAppAccount.java
+++ b/core/src/main/java/bisq/core/payment/CashAppAccount.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment;
+
+import bisq.core.locale.FiatCurrency;
+import bisq.core.payment.payload.CashAppAccountPayload;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.payment.payload.PaymentMethod;
+
+import lombok.EqualsAndHashCode;
+
+// Removed due too high chargeback risk
+// Cannot be deleted as it would break old trade history entries
+@Deprecated
+@EqualsAndHashCode(callSuper = true)
+public final class CashAppAccount extends PaymentAccount {
+    public CashAppAccount() {
+        super(PaymentMethod.CASH_APP);
+        setSingleTradeCurrency(new FiatCurrency("USD"));
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new CashAppAccountPayload(paymentMethod.getId(), id);
+    }
+
+    public void setCashTag(String cashTag) {
+        ((CashAppAccountPayload) paymentAccountPayload).setCashTag(cashTag);
+    }
+
+    public String getCashTag() {
+        return ((CashAppAccountPayload) paymentAccountPayload).getCashTag();
+    }
+}

--- a/core/src/main/java/bisq/core/payment/OKPayAccount.java
+++ b/core/src/main/java/bisq/core/payment/OKPayAccount.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment;
+
+import bisq.core.locale.CurrencyUtil;
+import bisq.core.payment.payload.OKPayAccountPayload;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.payment.payload.PaymentMethod;
+
+import lombok.EqualsAndHashCode;
+
+// Cannot be deleted as it would break old trade history entries
+@Deprecated
+@EqualsAndHashCode(callSuper = true)
+public final class OKPayAccount extends PaymentAccount {
+    public OKPayAccount() {
+        super(PaymentMethod.OK_PAY);
+
+        // Incorrect call but we don't want to keep Deprecated code in CurrencyUtil if not needed...
+        tradeCurrencies.addAll(CurrencyUtil.getAllUpholdCurrencies());
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new OKPayAccountPayload(paymentMethod.getId(), id);
+    }
+
+    public void setAccountNr(String accountNr) {
+        ((OKPayAccountPayload) paymentAccountPayload).setAccountNr(accountNr);
+    }
+
+    public String getAccountNr() {
+        return ((OKPayAccountPayload) paymentAccountPayload).getAccountNr();
+    }
+}

--- a/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
@@ -76,6 +76,15 @@ public class PaymentAccountFactory {
                 return new AdvancedCashAccount();
             case PaymentMethod.BLOCK_CHAINS_INSTANT_ID:
                 return new InstantCryptoCurrencyAccount();
+
+            // Cannot be deleted as it would break old trade history entries
+            case PaymentMethod.OK_PAY_ID:
+                return new OKPayAccount();
+            case PaymentMethod.CASH_APP_ID:
+                return new CashAppAccount();
+            case PaymentMethod.VENMO_ID:
+                return new VenmoAccount();
+
             default:
                 throw new RuntimeException("Not supported PaymentMethod: " + paymentMethod);
         }

--- a/core/src/main/java/bisq/core/payment/VenmoAccount.java
+++ b/core/src/main/java/bisq/core/payment/VenmoAccount.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment;
+
+import bisq.core.locale.FiatCurrency;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.payment.payload.VenmoAccountPayload;
+
+import lombok.EqualsAndHashCode;
+
+// Removed due too high chargeback risk
+// Cannot be deleted as it would break old trade history entries
+@Deprecated
+@EqualsAndHashCode(callSuper = true)
+public final class VenmoAccount extends PaymentAccount {
+    public VenmoAccount() {
+        super(PaymentMethod.VENMO);
+        setSingleTradeCurrency(new FiatCurrency("USD"));
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new VenmoAccountPayload(paymentMethod.getId(), id);
+    }
+
+    public void setVenmoUserName(String venmoUserName) {
+        ((VenmoAccountPayload) paymentAccountPayload).setVenmoUserName(venmoUserName);
+    }
+
+    public String getVenmoUserName() {
+        return ((VenmoAccountPayload) paymentAccountPayload).getVenmoUserName();
+    }
+
+    public void setHolderName(String holderName) {
+        ((VenmoAccountPayload) paymentAccountPayload).setHolderName(holderName);
+    }
+
+    public String getHolderName() {
+        return ((VenmoAccountPayload) paymentAccountPayload).getHolderName();
+    }
+}

--- a/core/src/main/java/bisq/core/payment/payload/CashAppAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CashAppAccountPayload.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import bisq.core.locale.Res;
+
+import io.bisq.generated.protobuffer.PB;
+
+import com.google.protobuf.Message;
+
+import org.springframework.util.CollectionUtils;
+
+import java.nio.charset.Charset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+// Cannot be deleted as it would break old trade history entries
+// Removed due too high chargeback risk
+@Deprecated
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Setter
+@Getter
+@Slf4j
+public final class CashAppAccountPayload extends PaymentAccountPayload {
+    private String cashTag = "";
+
+    public CashAppAccountPayload(String paymentMethod, String id) {
+        super(paymentMethod, id);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private CashAppAccountPayload(String paymentMethod,
+                                  String id,
+                                  String cashTag,
+                                  long maxTradePeriod,
+                                  Map<String, String> excludeFromJsonDataMap) {
+        super(paymentMethod,
+                id,
+                maxTradePeriod,
+                excludeFromJsonDataMap);
+
+        this.cashTag = cashTag;
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        return getPaymentAccountPayloadBuilder()
+                .setCashAppAccountPayload(PB.CashAppAccountPayload.newBuilder()
+                        .setCashTag(cashTag))
+                .build();
+    }
+
+    public static CashAppAccountPayload fromProto(PB.PaymentAccountPayload proto) {
+        return new CashAppAccountPayload(proto.getPaymentMethodId(),
+                proto.getId(),
+                proto.getCashAppAccountPayload().getCashTag(),
+                proto.getMaxTradePeriod(),
+                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public String getPaymentDetails() {
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account") + " " + cashTag;
+    }
+
+    @Override
+    public String getPaymentDetailsForTradePopup() {
+        return getPaymentDetails();
+    }
+
+    @Override
+    public byte[] getAgeWitnessInputData() {
+        return super.getAgeWitnessInputData(cashTag.getBytes(Charset.forName("UTF-8")));
+    }
+}

--- a/core/src/main/java/bisq/core/payment/payload/OKPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/OKPayAccountPayload.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import bisq.core.locale.Res;
+
+import io.bisq.generated.protobuffer.PB;
+
+import com.google.protobuf.Message;
+
+import org.springframework.util.CollectionUtils;
+
+import java.nio.charset.Charset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+// Cannot be deleted as it would break old trade history entries
+@Deprecated
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Setter
+@Getter
+@Slf4j
+public final class OKPayAccountPayload extends PaymentAccountPayload {
+    private String accountNr = "";
+
+    public OKPayAccountPayload(String paymentMethod, String id) {
+        super(paymentMethod, id);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private OKPayAccountPayload(String paymentMethod,
+                                String id,
+                                String accountNr,
+                                long maxTradePeriod,
+                                Map<String, String> excludeFromJsonDataMap) {
+        super(paymentMethod,
+                id,
+                maxTradePeriod,
+                excludeFromJsonDataMap);
+
+        this.accountNr = accountNr;
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        return getPaymentAccountPayloadBuilder()
+                .setOKPayAccountPayload(PB.OKPayAccountPayload.newBuilder()
+                        .setAccountNr(accountNr))
+                .build();
+    }
+
+    public static OKPayAccountPayload fromProto(PB.PaymentAccountPayload proto) {
+        return new OKPayAccountPayload(proto.getPaymentMethodId(),
+                proto.getId(),
+                proto.getOKPayAccountPayload().getAccountNr(),
+                proto.getMaxTradePeriod(),
+                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public String getPaymentDetails() {
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.no") + " " + accountNr;
+    }
+
+    @Override
+    public String getPaymentDetailsForTradePopup() {
+        return getPaymentDetails();
+    }
+
+    @Override
+    public byte[] getAgeWitnessInputData() {
+        return super.getAgeWitnessInputData(accountNr.getBytes(Charset.forName("UTF-8")));
+    }
+}

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -129,11 +129,11 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
 
     // Cannot be deleted as it would break old trade history entries
     @Deprecated
-    public static PaymentMethod OK_PAY;
+    public static PaymentMethod OK_PAY = getDummyPaymentMethod(OK_PAY_ID);
     @Deprecated
-    public static PaymentMethod CASH_APP; // Removed due too high chargeback risk
+    public static PaymentMethod CASH_APP = getDummyPaymentMethod(CASH_APP_ID); // Removed due too high chargeback risk
     @Deprecated
-    public static PaymentMethod VENMO; // Removed due too high chargeback risk
+    public static PaymentMethod VENMO = getDummyPaymentMethod(VENMO_ID); // Removed due too high chargeback risk
 
     // The limit and duration assignment must not be changed as that could break old offers (if amount would be higher
     // than new trade limit) and violate the maker expectation when he created the offer (duration).

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -91,6 +91,14 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
     public static final String ADVANCED_CASH_ID = "ADVANCED_CASH";
     public static final String BLOCK_CHAINS_INSTANT_ID = "BLOCK_CHAINS_INSTANT";
 
+    // Cannot be deleted as it would break old trade history entries
+    @Deprecated
+    public static final String OK_PAY_ID = "OK_PAY";
+    @Deprecated
+    public static final String CASH_APP_ID = "CASH_APP"; // Removed due too high chargeback risk
+    @Deprecated
+    public static final String VENMO_ID = "VENMO";  // Removed due too high chargeback risk
+
     public static PaymentMethod UPHOLD;
     public static PaymentMethod MONEY_BEAM;
     public static PaymentMethod POPMONEY;
@@ -118,6 +126,14 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
     public static PaymentMethod PROMPT_PAY;
     public static PaymentMethod ADVANCED_CASH;
     public static PaymentMethod BLOCK_CHAINS_INSTANT;
+
+    // Cannot be deleted as it would break old trade history entries
+    @Deprecated
+    public static PaymentMethod OK_PAY;
+    @Deprecated
+    public static PaymentMethod CASH_APP; // Removed due too high chargeback risk
+    @Deprecated
+    public static PaymentMethod VENMO; // Removed due too high chargeback risk
 
     // The limit and duration assignment must not be changed as that could break old offers (if amount would be higher
     // than new trade limit) and violate the maker expectation when he created the offer (duration).

--- a/core/src/main/java/bisq/core/payment/payload/VenmoAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/VenmoAccountPayload.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import bisq.core.locale.Res;
+
+import io.bisq.generated.protobuffer.PB;
+
+import com.google.protobuf.Message;
+
+import org.springframework.util.CollectionUtils;
+
+import java.nio.charset.Charset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+// Cannot be deleted as it would break old trade history entries
+// Removed due too high chargeback risk
+@Deprecated
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Setter
+@Getter
+@Slf4j
+public final class VenmoAccountPayload extends PaymentAccountPayload {
+    private String venmoUserName = "";
+    private String holderName = "";
+
+    public VenmoAccountPayload(String paymentMethod, String id) {
+        super(paymentMethod, id);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private VenmoAccountPayload(String paymentMethod,
+                                String id,
+                                String venmoUserName,
+                                String holderName,
+                                long maxTradePeriod,
+                                Map<String, String> excludeFromJsonDataMap) {
+        super(paymentMethod,
+                id,
+                maxTradePeriod,
+                excludeFromJsonDataMap);
+
+        this.venmoUserName = venmoUserName;
+        this.holderName = holderName;
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        return getPaymentAccountPayloadBuilder()
+                .setVenmoAccountPayload(PB.VenmoAccountPayload.newBuilder()
+                        .setVenmoUserName(venmoUserName)
+                        .setHolderName(holderName))
+                .build();
+    }
+
+    public static VenmoAccountPayload fromProto(PB.PaymentAccountPayload proto) {
+        return new VenmoAccountPayload(proto.getPaymentMethodId(),
+                proto.getId(),
+                proto.getVenmoAccountPayload().getVenmoUserName(),
+                proto.getVenmoAccountPayload().getHolderName(),
+                proto.getMaxTradePeriod(),
+                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public String getPaymentDetails() {
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.owner") + " " + holderName + ", " +
+                Res.getWithCol("payment.venmo.venmoUserName") + " " + venmoUserName;
+    }
+
+    @Override
+    public String getPaymentDetailsForTradePopup() {
+        return getPaymentDetails();
+    }
+
+    @Override
+    public byte[] getAgeWitnessInputData() {
+        return super.getAgeWitnessInputData(venmoUserName.getBytes(Charset.forName("UTF-8")));
+    }
+}

--- a/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -22,6 +22,7 @@ import bisq.core.dao.governance.proposal.storage.appendonly.ProposalPayload;
 import bisq.core.payment.AccountAgeWitness;
 import bisq.core.payment.payload.AdvancedCashAccountPayload;
 import bisq.core.payment.payload.AliPayAccountPayload;
+import bisq.core.payment.payload.CashAppAccountPayload;
 import bisq.core.payment.payload.CashDepositAccountPayload;
 import bisq.core.payment.payload.ChaseQuickPayAccountPayload;
 import bisq.core.payment.payload.ClearXchangeAccountPayload;
@@ -34,6 +35,7 @@ import bisq.core.payment.payload.InteracETransferAccountPayload;
 import bisq.core.payment.payload.MoneyBeamAccountPayload;
 import bisq.core.payment.payload.MoneyGramAccountPayload;
 import bisq.core.payment.payload.NationalBankAccountPayload;
+import bisq.core.payment.payload.OKPayAccountPayload;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PerfectMoneyAccountPayload;
 import bisq.core.payment.payload.PopmoneyAccountPayload;
@@ -46,6 +48,7 @@ import bisq.core.payment.payload.SpecificBanksAccountPayload;
 import bisq.core.payment.payload.SwishAccountPayload;
 import bisq.core.payment.payload.USPostalMoneyOrderAccountPayload;
 import bisq.core.payment.payload.UpholdAccountPayload;
+import bisq.core.payment.payload.VenmoAccountPayload;
 import bisq.core.payment.payload.WeChatPayAccountPayload;
 import bisq.core.payment.payload.WesternUnionAccountPayload;
 import bisq.core.trade.statistics.TradeStatistics2;
@@ -135,6 +138,15 @@ public class CoreProtoResolver implements ProtoResolver {
                     return AdvancedCashAccountPayload.fromProto(proto);
                 case INSTANT_CRYPTO_CURRENCY_ACCOUNT_PAYLOAD:
                     return InstantCryptoCurrencyPayload.fromProto(proto);
+
+                // Cannot be deleted as it would break old trade history entries
+                case O_K_PAY_ACCOUNT_PAYLOAD:
+                    return OKPayAccountPayload.fromProto(proto);
+                case CASH_APP_ACCOUNT_PAYLOAD:
+                    return CashAppAccountPayload.fromProto(proto);
+                case VENMO_ACCOUNT_PAYLOAD:
+                    return VenmoAccountPayload.fromProto(proto);
+
                 default:
                     throw new ProtobufferRuntimeException("Unknown proto message case(PB.PaymentAccountPayload). messageCase=" + messageCase);
             }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2591,6 +2591,15 @@ ADVANCED_CASH=Advanced Cash
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Altcoins Instant
 
+# Deprecated: Cannot be deleted as it would break old trade history entries
+# suppress inspection "UnusedProperty"
+OK_PAY=OKPay
+# suppress inspection "UnusedProperty"
+CASH_APP=Cash App
+# suppress inspection "UnusedProperty"
+VENMO=Venmo
+
+
 # suppress inspection "UnusedProperty"
 UPHOLD_SHORT=Uphold
 # suppress inspection "UnusedProperty"
@@ -2629,6 +2638,14 @@ PROMPT_PAY_SHORT=PromptPay
 ADVANCED_CASH_SHORT=Advanced Cash
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Altcoins Instant
+
+# Deprecated: Cannot be deleted as it would break old trade history entries
+# suppress inspection "UnusedProperty"
+OK_PAY_SHORT=OKPay
+# suppress inspection "UnusedProperty"
+CASH_APP_SHORT=Cash App
+# suppress inspection "UnusedProperty"
+VENMO_SHORT=Venmo
 
 
 ####################################################################

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -229,7 +229,7 @@ public class Connection extends Capabilities implements Runnable, MessageListene
                     long now = System.currentTimeMillis();
                     long elapsed = now - lastSendTimeStamp;
                     if (elapsed < sendMsgThrottleTrigger) {
-                        log.warn("We got 2 sendMessage requests in less than {} ms. We set the thread to sleep " +
+                        log.debug("We got 2 sendMessage requests in less than {} ms. We set the thread to sleep " +
                                         "for {} ms to avoid flooding our peer. lastSendTimeStamp={}, now={}, elapsed={}, networkEnvelope={}",
                                 sendMsgThrottleTrigger, sendMsgThrottleSleep, lastSendTimeStamp, now, elapsed,
                                 networkEnvelope.getClass().getSimpleName());


### PR DESCRIPTION


We got some reports that the trade history was gone and it turned out
the removal of the deprecated payment methods caused an exception when
reading the persisted closed trades. So we have to keep that code to not
break old db files.