### PR TITLE
Add txId to proposal display

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
@@ -55,6 +55,7 @@ import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.dao.state.model.governance.Vote;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
+import bisq.core.user.Preferences;
 import bisq.core.util.BsqFormatter;
 import bisq.core.util.validation.InputValidator;
 import bisq.core.util.validation.UrlInputValidator;
@@ -107,6 +108,7 @@ public class ProposalDisplay {
     @Nullable
     private final ChangeParamValidator changeParamValidator;
     private final Navigation navigation;
+    private final Preferences preferences;
 
     @Nullable
     private TextField proposalFeeTextField, comboBoxValueTextField, requiredBondForRoleTextField;
@@ -143,12 +145,13 @@ public class ProposalDisplay {
     private VBox linkWithIconContainer, comboBoxValueContainer, myVoteBox, voteResultBox;
 
     public ProposalDisplay(GridPane gridPane, BsqFormatter bsqFormatter, DaoFacade daoFacade,
-                           @Nullable ChangeParamValidator changeParamValidator, Navigation navigation) {
+                           @Nullable ChangeParamValidator changeParamValidator, Navigation navigation, @Nullable Preferences preferences) {
         this.gridPane = gridPane;
         this.bsqFormatter = bsqFormatter;
         this.daoFacade = daoFacade;
         this.changeParamValidator = changeParamValidator;
         this.navigation = navigation;
+        this.preferences = preferences;
 
         // focusOutListener = observable -> inputChangedListeners.forEach(Runnable::run);
 
@@ -489,7 +492,7 @@ public class ProposalDisplay {
         if (txHyperlinkWithIcon != null) {
             txHyperlinkWithIcon.setText(proposal.getTxId());
             txHyperlinkWithIcon.setOnAction(e ->
-                    GUIUtil.openWebPage("https://explorer.bisq.network/testnet/tx.html?tx=" + proposal.getTxId()));
+                    GUIUtil.openTxInBsqBlockExplorer(proposal.getTxId(), preferences));
         }
 
         if (proposal instanceof CompensationProposal) {

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
@@ -127,6 +127,7 @@ public class ProposalDisplay {
     @Getter
     private int gridRow;
     private HyperlinkWithIcon linkHyperlinkWithIcon;
+    private HyperlinkWithIcon txHyperlinkWithIcon;
     private int gridRowStartIndex;
     private final List<Runnable> inputChangedListeners = new ArrayList<>();
     @Getter
@@ -218,6 +219,14 @@ public class ProposalDisplay {
 
         linkWithIconContainer.setVisible(false);
         linkWithIconContainer.setManaged(false);
+
+        if (!isMakeProposalScreen) {
+            Tuple3<Label, HyperlinkWithIcon, VBox> uidTuple = addTopLabelHyperlinkWithIcon(gridPane, ++gridRow,
+                    Res.get("dao.proposal.display.txId"), "", "", 0);
+            txHyperlinkWithIcon = uidTuple.second;
+            // TODO HyperlinkWithIcon does not scale automatically (button base, -> make anchorpane as base)
+            txHyperlinkWithIcon.prefWidthProperty().bind(nameTextField.widthProperty());
+        }
 
         int comboBoxValueTextFieldIndex = -1;
         switch (proposalType) {
@@ -475,6 +484,12 @@ public class ProposalDisplay {
             linkWithIconContainer.setManaged(true);
             linkHyperlinkWithIcon.setText(proposal.getLink());
             linkHyperlinkWithIcon.setOnAction(e -> GUIUtil.openWebPage(proposal.getLink()));
+        }
+
+        if (txHyperlinkWithIcon != null) {
+            txHyperlinkWithIcon.setText(proposal.getTxId());
+            txHyperlinkWithIcon.setOnAction(e ->
+                    GUIUtil.openWebPage("https://explorer.bisq.network/testnet/tx.html?tx=" + proposal.getTxId()));
         }
 
         if (proposal instanceof CompensationProposal) {

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -432,7 +432,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
 
     private void addProposalDisplay() {
         if (selectedProposalType != null) {
-            proposalDisplay = new ProposalDisplay(root, bsqFormatter, daoFacade, changeParamValidator, navigation);
+            proposalDisplay = new ProposalDisplay(root, bsqFormatter, daoFacade, changeParamValidator, navigation, null);
 
             proposalDisplay.createAllFields(Res.get("dao.proposal.create.new"), alwaysVisibleGridRowIndex, Layout.GROUP_DISTANCE,
                     selectedProposalType, true);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -683,7 +683,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
 
     private void createEmptyProposalDisplay() {
         proposalDisplay = new ProposalDisplay(proposalDisplayGridPane, bsqFormatter, daoFacade,
-                changeParamValidator, navigation);
+                changeParamValidator, navigation, preferences);
         proposalDisplayView = proposalDisplay.getView();
         GridPane.setMargin(proposalDisplayView, new Insets(0, -10, 0, -10));
         GridPane.setRowIndex(proposalDisplayView, ++gridRow);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -445,7 +445,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
     private ProposalDisplay createProposalDisplay(EvaluatedProposal evaluatedProposal, Ballot ballot) {
         Proposal proposal = evaluatedProposal.getProposal();
         ProposalDisplay proposalDisplay = new ProposalDisplay(new GridPane(), bsqFormatter,
-                daoFacade, null, navigation);
+                daoFacade, null, navigation, preferences);
 
         ScrollPane proposalDisplayView = proposalDisplay.getView();
         GridPane.setMargin(proposalDisplayView, new Insets(0, -10, -15, -10));


### PR DESCRIPTION
Fix: #2510 
Added a transaction ID field to the Proposal Display screen, with a link to the transaction on the Bisq explorer.
<img width="1312" alt="screen shot 2019-03-08 at 12 03 20" src="https://user-images.githubusercontent.com/10667901/54022099-63676400-419a-11e9-90d1-0849ba9fe320.png">
