### PR TITLE
Fix get all bonds not returning not active bonds

### DIFF
--- a/core/src/main/java/bisq/core/dao/DaoFacade.java
+++ b/core/src/main/java/bisq/core/dao/DaoFacade.java
@@ -87,6 +87,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -530,8 +531,8 @@ public class DaoFacade implements DaoSetupService {
 
 
     public List<Bond> getAllBonds() {
-        List<Bond> bonds = bondedReputationRepository.getActiveBonds();
-        bonds.addAll(bondedRolesRepository.getActiveBonds());
+        List<Bond> bonds = new ArrayList<>(bondedReputationRepository.getBonds());
+        bonds.addAll(bondedRolesRepository.getBonds());
         return bonds;
     }
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1441,6 +1441,7 @@ dao.bond.reputation.unlock.details=Unlock amount: {0}\nUnlock time: {1} block(s)
 
 dao.bond.allBonds.header=All bonds
 
+dao.bond.bondInactive=Inactive Bond
 dao.bond.bondedReputation=Bonded Reputation
 dao.bond.bondedRoles=Bonded roles
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
@@ -340,7 +340,8 @@ public class ProposalDisplay {
                             bondType = Res.get("dao.bond.bondedReputation");
                             bondDetails = Utilities.bytesAsHexString(bond.getBondedAsset().getHash());
                         }
-
+                        if (!bond.isActive())
+                            bondDetails += " (" + Res.get("dao.bond.bondInactive") + ")";
                         return bondType + ": " + bondDetails;
                     }
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -415,6 +415,10 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
                 checkNotNull(proposalDisplay.confiscateBondComboBox,
                         "proposalDisplay.confiscateBondComboBox must not be null");
                 Bond bond = proposalDisplay.confiscateBondComboBox.getSelectionModel().getSelectedItem();
+
+                if (!bond.isActive())
+                    throw new ValidationException("Bond is not locked and can't be confiscated");
+
                 return daoFacade.getConfiscateBondProposalWithTransaction(name, link, bond.getLockupTxId());
             case GENERIC:
                 return daoFacade.getGenericProposalWithTransaction(name, link);


### PR DESCRIPTION
Fix #2522
The issue with this is that the proposal was for confiscating a bond which is not active, and the `getAllBonds` method returned only active bonds, so I changed it to return all bonds instead.

Now the proposals are showing up correctly.
<img width="907" alt="Screen Shot 2019-03-11 at 9 57 35" src="https://user-images.githubusercontent.com/10667901/54108635-2642e200-43e5-11e9-82e9-df1ebefb373f.png">
