### PR TITLE
List Navcoin (NAV)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Navcoin.java
+++ b/assets/src/main/java/bisq/asset/coins/Navcoin.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class Navcoin extends Coin {
+    public Navcoin() {
+        super("Navcoin", "NAV", new Base58BitcoinAddressValidator(new NavcoinParams()));
+    }
+
+    public static class NavcoinParams extends NetworkParametersAdapter {
+        public NavcoinParams() {
+            this.addressHeader = 53;
+            this.p2shHeader = 85;
+            this.acceptableAddressCodes = new int[]{this.addressHeader, this.p2shHeader};
+        }
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -61,6 +61,7 @@ bisq.asset.coins.Monero
 bisq.asset.coins.MonetaryUnit
 bisq.asset.coins.MoX
 bisq.asset.coins.Namecoin
+bisq.asset.coins.Navcoin
 bisq.asset.coins.Neos
 bisq.asset.coins.Noir
 bisq.asset.coins.Persona

--- a/assets/src/test/java/bisq/asset/coins/NavcoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/NavcoinTest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class NavcoinTest extends AbstractAssetTest {
+
+    public NavcoinTest() {
+        super(new Navcoin());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("NNR93HzmuhYKZ4Tnc9TGoD2DK6TVzXG9P7");
+        assertValidAddress("NSm5NyCe5BFRuV3gFY5VcfhxWx7GTu9U9F");
+        assertValidAddress("NaSdzJ64o8DQo5DMPexVrL4PYFCBZqcmsW");
+
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("NNR93HzmuhYKZ4Tnc9TGoD2DK6TVzXG9P");
+        assertInvalidAddress("NNR93HzmuhYKZ4TnO9TGoD2DK6TVzXG9P8");
+        assertInvalidAddress("NNR93HzmuhYKZ4Tnc9TGoD2DK6TVzXG9P71");
+    }
+}


### PR DESCRIPTION
- Official project URL: http://www.navcoin.org
- Official block explorer URL: http://www.navexplorer.com

This PR includes the changes necessary to re-enable support of Navcoin in Bisq.
Many community members expressed their interest in seeing the coin supported again after the implementation of the last new features like Community Fund, Cold Staking or the novel privacy method ZeroCT.