### PR TITLE
Fix bug UI treats rejected proposals as accepted

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
+++ b/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
@@ -33,6 +33,7 @@ import bisq.core.dao.state.model.blockchain.BaseTx;
 import bisq.core.dao.state.model.blockchain.Block;
 import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.dao.state.model.blockchain.TxType;
+import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.RemoveAssetProposal;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.trade.statistics.TradeStatistics2;
@@ -286,7 +287,7 @@ public class AssetService implements DaoSetupService, DaoStateListener {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public boolean wasAssetRemovedByVoting(String tickerSymbol) {
-        boolean isRemoved = getRemoveAssetProposalStream()
+        boolean isRemoved = getAcceptedRemoveAssetProposalStream()
                 .anyMatch(proposal -> proposal.getTickerSymbol().equals(tickerSymbol));
         if (isRemoved)
             log.info("Asset '{}' was removed", CurrencyUtil.getNameAndCode(tickerSymbol));
@@ -306,9 +307,10 @@ public class AssetService implements DaoSetupService, DaoStateListener {
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private Stream<RemoveAssetProposal> getRemoveAssetProposalStream() {
+    private Stream<RemoveAssetProposal> getAcceptedRemoveAssetProposalStream() {
         return daoStateService.getEvaluatedProposalList().stream()
                 .filter(evaluatedProposal -> evaluatedProposal.getProposal() instanceof RemoveAssetProposal)
+                .filter(EvaluatedProposal::isAccepted)
                 .map(e -> ((RemoveAssetProposal) e.getProposal()));
     }
 

--- a/core/src/main/java/bisq/core/dao/governance/bond/role/BondedRolesRepository.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/role/BondedRolesRepository.java
@@ -22,6 +22,7 @@ import bisq.core.dao.governance.bond.BondConsensus;
 import bisq.core.dao.governance.bond.BondRepository;
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.dao.state.model.blockchain.TxOutput;
+import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Proposal;
 import bisq.core.dao.state.model.governance.Role;
 import bisq.core.dao.state.model.governance.RoleProposal;
@@ -62,7 +63,7 @@ public class BondedRolesRepository extends BondRepository<BondedRole, Role> {
         Set<String> myWalletTransactionIds = bsqWalletService.getWalletTransactions().stream()
                 .map(Transaction::getHashAsString)
                 .collect(Collectors.toSet());
-        return getBondedRoleProposalStream()
+        return getAcceptedBondedRoleProposalStream()
                 .filter(roleProposal -> roleProposal.getRole().equals(role))
                 .map(Proposal::getTxId)
                 .anyMatch(myWalletTransactionIds::contains);
@@ -107,6 +108,13 @@ public class BondedRolesRepository extends BondRepository<BondedRole, Role> {
     private Stream<RoleProposal> getBondedRoleProposalStream() {
         return daoStateService.getEvaluatedProposalList().stream()
                 .filter(evaluatedProposal -> evaluatedProposal.getProposal() instanceof RoleProposal)
+                .map(e -> ((RoleProposal) e.getProposal()));
+    }
+
+    private Stream<RoleProposal> getAcceptedBondedRoleProposalStream() {
+        return daoStateService.getEvaluatedProposalList().stream()
+                .filter(evaluatedProposal -> evaluatedProposal.getProposal() instanceof RoleProposal)
+                .filter(EvaluatedProposal::isAccepted)
                 .map(e -> ((RoleProposal) e.getProposal()));
     }
 }


### PR DESCRIPTION
This fixes #2479, fixes #2480.

The issue was that the function returned a list of all proposals from the requested type, without filtering out the rejected proposals.
I added filtering to make sure it returns only accepted proposals.