### PR TITLE
rename XDR ticker (conflict with ISO 4217)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/XDR.java
+++ b/assets/src/main/java/bisq/asset/coins/XDR.java
@@ -22,7 +22,7 @@ import bisq.asset.Coin;
 public class XDR extends Coin {
 
     public XDR() {
-        super("XDR", "XDR", new Mile.MileAddressValidator());
+        super("XDR", "XDR0", new Mile.MileAddressValidator());
     }
 
 }


### PR DESCRIPTION
See #2503 