### PR TITLE
Fix BTC status incorrectly hidden on splash screen

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -610,11 +610,6 @@ public class MainView extends InitializableView<StackPane, MainViewModel> {
         Timer showTorNetworkSettingsTimer = UserThread.runAfter(() -> {
             showTorNetworkSettingsButton.setVisible(true);
             showTorNetworkSettingsButton.setManaged(true);
-            if (btcSyncIndicator.progressProperty().getValue() <= 0) {
-                // If no progress has been made, hide the BTC status since tor is not working
-                btcSyncIndicator.setVisible(false);
-                btcSplashInfo.setVisible(false);
-            }
         }, SHOW_TOR_SETTINGS_DELAY_SEC);
 
         splashP2PNetworkIconIdListener = (ov, oldValue, newValue) -> {


### PR DESCRIPTION
Issue: When launching a new Bisq instance (i.e. new data directory) and
remaining on the user agreement screen for >90 seconds while reading it,
once you accept the agreement the BTC status was not being shown
on the splash screen.
![image](https://user-images.githubusercontent.com/603793/54773294-83e5e400-4bc6-11e9-8f0c-1666fc8d1e2f.png)

Cause: showTorNetworkSettingsTimer gets triggered after 90 seconds
and since Tor is not started until after accepting the user agreement,
it was incorrectly assuming that Tor is not working and as a result
hiding the BTC status.

Fix: Don't hide the BTC status in showTorNetworkSettingsTimer.
![image](https://user-images.githubusercontent.com/603793/54773299-89432e80-4bc6-11e9-93ee-c3d1d4da1498.png)

If there is an issue with Tor, splashP2PNetworkErrorMsgListener handles
hiding the BTC status.
![image](https://user-images.githubusercontent.com/603793/54773343-9bbd6800-4bc6-11e9-9327-4ede800751d4.png)