### PR TITLE
Suppress popup at shutdown when open offers are disabled

### DIFF
--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -40,6 +40,7 @@ import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.dao.governance.voteresult.MissingDataRequestService;
 import bisq.core.filter.FilterManager;
 import bisq.core.locale.Res;
+import bisq.core.offer.OpenOffer;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.user.Preferences;
 
@@ -326,7 +327,14 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
     }
 
     private void shutDownByUser() {
-        if (injector.getInstance(OpenOfferManager.class).getObservableList().isEmpty()) {
+        boolean hasOpenOffers = false;
+        for (OpenOffer openOffer : injector.getInstance(OpenOfferManager.class).getObservableList()) {
+            if (openOffer.getState().equals(OpenOffer.State.AVAILABLE)) {
+                hasOpenOffers = true;
+                break;
+            }
+        }
+        if (!hasOpenOffers) {
             // No open offers, so no need to show the popup.
             stop();
             return;


### PR DESCRIPTION
Issue: When shutting down the application with disabled open offers, the
confirmation popup was still being shown informing the user there are
open offers.

Fix: On shutdown, check all open offers and only show the popup if any
of them are enabled.

Fixes #2115