### PR TITLE
Set max buyer's security deposit to 20% instead of 10%

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
+++ b/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
@@ -59,7 +59,7 @@ public class Restrictions {
     }
 
     public static double getMaxBuyerSecurityDepositAsPercent() {
-        return 0.1; // 10% of trade amount. For a 1 BTC trade it is about 400 USD @ 4000 USD/BTC
+        return 0.2; // 20% of trade amount. For a 1 BTC trade it is about 800 USD @ 4000 USD/BTC
     }
 
     // We use MIN_BUYER_SECURITY_DEPOSIT as well as lower bound in case of small trade amounts.


### PR DESCRIPTION
A Bisq trader suggested that change to cover risks with volatility
for seller.