### PR TITLE
Add ISSUANCE_LIMIT param and check for max issuance per cycle

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/param/Param.java
+++ b/core/src/main/java/bisq/core/dao/governance/param/Param.java
@@ -125,6 +125,7 @@ public enum Param {
     // Using BSQ as type is not really the best option but we don't want to introduce a new ParamType just for that one Param.
     // As the end rules is in fact BSQ it is not completely incorrect as well.
     BONDED_ROLE_FACTOR("1000", ParamType.BSQ, 2, 2),
+    ISSUANCE_LIMIT("200000", ParamType.BSQ, 2, 2), // Max. issuance+reimbursement per cycle.
 
     // The last block in the proposal and vote phases are not shown to the user as he cannot make a tx there as it would be
     // confirmed in the next block which would be the following break phase. To hide that complexity we show only the

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1409,6 +1409,8 @@ dao.param.MAX_TRADE_LIMIT=Max. trade limit in BTC
 
 # suppress inspection "UnusedProperty"
 dao.param.BONDED_ROLE_FACTOR=Bonded role unit factor in BSQ
+# suppress inspection "UnusedProperty"
+dao.param.ISSUANCE_LIMIT=Issuance limit per cycle in BSQ
 
 dao.param.currentValue=Current value: {0}
 dao.param.blocks={0} blocks


### PR DESCRIPTION
We limit the possible max. issuance (including reimbursements) to the
valued defined in the ISSUANCE_LIMIT param.
In case we exceed that limit the whole cycle becomes invalid.

The main reason for that feature is limitation of max.
damage in case that an attacker manages to create unjustified issuance.

For valid cases we consider such a case as social consensus problem as
the majority of voters should be aware of that limit before they
accept such a high issuance. If known in advance that an extraordinary
high issuance is expected the DAO parameter can be changed.