### PR TITLE
Show close button when creating offer without required account

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -408,11 +408,12 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                         createOfferButton.setDisable(true);
                         offerActionHandler.onCreateOffer(model.getSelectedTradeCurrency());
                     })
-                    .closeButtonText(Res.get("offerbook.setupNewAccount"))
-                    .onClose(() -> {
+                    .secondaryActionButtonText(Res.get("offerbook.setupNewAccount"))
+                    .onSecondaryAction(() -> {
                         navigation.setReturnPath(navigation.getCurrentPath());
                         navigation.navigateTo(MainView.class, AccountView.class, FiatAccountsView.class);
                     })
+                    .width(725)
                     .show();
         } else if (!model.hasAcceptedArbitrators()) {
             new Popup<>().warning(Res.get("popup.warning.noArbitratorsAvailable")).show();


### PR DESCRIPTION
Issue: When attempting to create an offer without a trading account for
the selected currency, a prompt is shown asking the user whether to still
create an offer or to create a new account. But this prompt is missing a
cancel/close button in case you don't want to do either action. And
pressing Esc on the keyboard proceeds to create the account.
![image](https://user-images.githubusercontent.com/603793/55036019-98671980-4fd6-11e9-8337-450e0a0e411f.png)

Cause: The close button on the prompt was renamed and being used to
create a new account.

Fix: Use the close button as a close button and add a secondary action
button to create a new account. The popup width was increased to
accommodate the long button text without being truncated.
![image](https://user-images.githubusercontent.com/603793/55036026-9d2bcd80-4fd6-11e9-815f-f75f25f404b0.png)