### PR TITLE
Fix max available stake for voting showing negative

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -271,6 +271,8 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         Coin blindVoteFee = BlindVoteConsensus.getFee(daoStateService, daoStateService.getChainHeight());
         if (isBlindVotePhaseButNotLastBlock()) {
             Coin availableForVoting = availableConfirmedBalance.subtract(blindVoteFee);
+            if (availableForVoting.isNegative())
+                availableForVoting = Coin.valueOf(0);
             stakeInputTextField.setPromptText(Res.get("dao.proposal.myVote.stake.prompt",
                     bsqFormatter.formatCoinWithCode(availableForVoting)));
         } else


### PR DESCRIPTION
When attempting to vote on proposals with insufficient BSQ,
the max available stake for voting was showing a negative value.

![image](https://user-images.githubusercontent.com/603793/55460688-7148b300-55a7-11e9-930f-89360b04f5c0.png)