### PR TITLE
Fix incorrect required BSQ amount in warning text

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -557,7 +557,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
             if (requireChangeOutput) {
                 checkArgument(change.isPositive(),
                         "This transaction requires a mandatory BSQ change output. " +
-                                "At least " + Restrictions.getMinNonDustOutput().add(fee) + " " +
+                                "At least " + Restrictions.getMinNonDustOutput().add(fee).value / 100d + " " +
                                 "BSQ is needed for this transaction");
             }
 
@@ -565,7 +565,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
                 checkArgument(Restrictions.isAboveDust(change),
                         "The change output of " + change.value / 100d + " BSQ is below the min. dust value of "
                                 + Restrictions.getMinNonDustOutput().value / 100d +
-                                ". At least " + Restrictions.getMinNonDustOutput().add(fee) + " " +
+                                ". At least " + Restrictions.getMinNonDustOutput().add(fee).value / 100d + " " +
                                 "BSQ is needed for this transaction");
                 tx.addOutput(change, getChangeAddress());
             }


### PR DESCRIPTION
When submitting a proposal with insufficient BSQ balance, the warning
message showed an incorrect required BSQ amount. The amount needed to be
divided by 100 (1 BSQ = 100 satoshis).

![image](https://user-images.githubusercontent.com/603793/55516968-c62a0f00-5623-11e9-869f-22824054ee3a.png)
