### PR TITLE
Change wrong name for Siacoin in removed crypto list

### DIFF
--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -148,7 +148,7 @@ public class CurrencyUtil {
         currencies.add(new CryptoCurrency("BCH", "Bitcoin Cash"));
         currencies.add(new CryptoCurrency("BCHC", "Bitcoin Clashic"));
         currencies.add(new CryptoCurrency("ACH", "AchieveCoin"));
-        currencies.add(new CryptoCurrency("SC", "SpaceCash"));
+        currencies.add(new CryptoCurrency("SC", "Siacoin"));
         currencies.add(new CryptoCurrency("PPI", "PiedPiper Coin"));
         currencies.add(new CryptoCurrency("PEPECASH", "Pepe Cash"));
         currencies.add(new CryptoCurrency("GRC", "Gridcoin"));


### PR DESCRIPTION
Fixes #2625.