### PR TITLE
Update insufficient BTC warning for issuance proposals

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1846,8 +1846,14 @@ dao.proposal.create.missingBsqFundsForBond=You don''t have sufficient BSQ funds 
   Missing: {0}
 
 dao.proposal.create.missingMinerFeeFunds=You don''t have sufficient BTC funds for creating the proposal transaction. \
-  Any BSQ transaction require also a miner fee in BTC.\n\
+  All BSQ transactions require a miner fee in BTC.\n\
   Missing: {0}
+
+dao.proposal.create.missingIssuanceFunds=You don''t have sufficient BTC funds for creating the proposal transaction. \
+  All BSQ transactions require a miner fee in BTC, and issuance transactions also require BTC for the requested BSQ \
+  amount ({0} Satoshis/BSQ).\n\
+  Missing: {1}
+
 dao.feeTx.confirm=Confirm {0} transaction
 dao.feeTx.confirm.details={0} fee: {1}\n\
   Mining fee: {2} ({3} Satoshis/byte)\n\

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -310,8 +310,14 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
                 new Popup<>().warning(Res.get("dao.proposal.create.missingBsqFunds",
                         bsqFormatter.formatCoinWithCode(e.missing))).show();
             } else {
-                new Popup<>().warning(Res.get("dao.proposal.create.missingMinerFeeFunds",
-                        btcFormatter.formatCoinWithCode(e.missing))).show();
+                if (type.equals(ProposalType.COMPENSATION_REQUEST) || type.equals(ProposalType.REIMBURSEMENT_REQUEST)) {
+                    new Popup<>().warning(Res.get("dao.proposal.create.missingIssuanceFunds",
+                            100,
+                            btcFormatter.formatCoinWithCode(e.missing))).show();
+                } else {
+                    new Popup<>().warning(Res.get("dao.proposal.create.missingMinerFeeFunds",
+                            btcFormatter.formatCoinWithCode(e.missing))).show();
+                }
             }
         } catch (ProposalValidationException e) {
             String message;


### PR DESCRIPTION
When attempting to submit a compensation request or reimbursement
request with insufficient BTC, the warning message only indicated that
BTC is required for mining fees. It did not indicate that BTC is also
required for the BSQ issuance.
![image](https://user-images.githubusercontent.com/603793/55584887-37c49480-56da-11e9-8c93-b9d6cc708d88.png)

So another display string was added and displayed when submitting an
issuance proposal with insufficient BTC funds available.
![image](https://user-images.githubusercontent.com/603793/55584900-3f843900-56da-11e9-88e1-48849372ceb1.png)