### PR TITLE
Fix incorrect transaction size shown for bonding

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
@@ -119,7 +119,7 @@ public class BondingViewUtils {
                                     duration,
                                     formatter.formatCoinWithCode(miningFee),
                                     CoinUtil.getFeePerByte(miningFee, txSize),
-                                    txSize
+                                    txSize / 1000d
                             ))
                             .actionButtonText(Res.get("shared.yes"))
                             .onAction(() -> publishLockupTx(lockupAmount, lockupTime, lockupReason, hash, resultHandler))
@@ -180,7 +180,7 @@ public class BondingViewUtils {
                                     duration,
                                     formatter.formatCoinWithCode(miningFee),
                                     CoinUtil.getFeePerByte(miningFee, txSize),
-                                    txSize
+                                    txSize / 1000d
                             ))
                             .actionButtonText(Res.get("shared.yes"))
                             .onAction(() -> publishUnlockTx(lockupTxId, resultHandler))


### PR DESCRIPTION
When locking up or unlocking a bond, the displayed transaction size was
in bytes, but the prompt was indicating it was Kb. So adjust the value
so it is shown as Kb.

Before:
![image](https://user-images.githubusercontent.com/603793/55610742-71c48380-5738-11e9-953d-07a2a285a5b8.png)

After:
![image](https://user-images.githubusercontent.com/603793/55610776-830d9000-5738-11e9-9488-a9354f8affd5.png)