### PR TITLE
Handle #2659, no output for asset fee tx

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -150,7 +150,7 @@ public class BtcWalletService extends WalletService {
 
     public Transaction completePreparedBurnBsqTx(Transaction preparedBurnFeeTx, byte[] opReturnData)
             throws WalletException, InsufficientMoneyException, TransactionVerificationException {
-        return completePreparedProposalTx(preparedBurnFeeTx, opReturnData, null, null);
+        return completePreparedBsqTx(preparedBurnFeeTx, false, opReturnData);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Avoid creating tx with no outputs apart from opreturn.
Use completePreparedBsqTx instead of completePreparedProposalTx for
asset fee txs as it's more appropriate and also handles the no
output issue.