### PR TITLE
Handle dao state conflicts better

### DIFF
--- a/common/src/main/java/bisq/common/storage/FileManager.java
+++ b/common/src/main/java/bisq/common/storage/FileManager.java
@@ -162,14 +162,19 @@ public class FileManager<T extends PersistableEnvelope> {
         }
     }
 
-    public synchronized void removeAndBackupFile(String fileName) throws IOException {
-        File corruptedBackupDir = new File(Paths.get(dir.getAbsolutePath(), "backup_of_corrupted_data").toString());
+    public static void removeAndBackupFile(File dbDir, File storageFile, String fileName, String backupFolderName)
+            throws IOException {
+        File corruptedBackupDir = new File(Paths.get(dbDir.getAbsolutePath(), backupFolderName).toString());
         if (!corruptedBackupDir.exists())
             if (!corruptedBackupDir.mkdir())
                 log.warn("make dir failed");
 
-        File corruptedFile = new File(Paths.get(dir.getAbsolutePath(), "backup_of_corrupted_data", fileName).toString());
+        File corruptedFile = new File(Paths.get(dbDir.getAbsolutePath(), backupFolderName, fileName).toString());
         FileUtil.renameFile(storageFile, corruptedFile);
+    }
+
+    public synchronized void removeAndBackupFile(String fileName) throws IOException {
+        removeAndBackupFile(storageFile, dir, fileName, "backup_of_corrupted_data");
     }
 
     public synchronized void backupFile(String fileName, int numMaxBackupFiles) {

--- a/common/src/main/java/bisq/common/storage/FileManager.java
+++ b/common/src/main/java/bisq/common/storage/FileManager.java
@@ -174,7 +174,7 @@ public class FileManager<T extends PersistableEnvelope> {
     }
 
     public synchronized void removeAndBackupFile(String fileName) throws IOException {
-        removeAndBackupFile(storageFile, dir, fileName, "backup_of_corrupted_data");
+        removeAndBackupFile(dir, storageFile, fileName, "backup_of_corrupted_data");
     }
 
     public synchronized void backupFile(String fileName, int numMaxBackupFiles) {

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -910,7 +910,8 @@ settings.preferences.selectCurrencyNetwork=Select network
 setting.preferences.daoOptions=DAO options
 setting.preferences.dao.resync.label=Rebuild DAO state from genesis tx
 setting.preferences.dao.resync.button=Resync
-setting.preferences.dao.resync.popup=After an application restart the BSQ consensus state will be rebuilt from the genesis transaction.
+setting.preferences.dao.resync.popup=After an application restart the P2P network governance data will be reloaded from \
+  the seed nodes and the BSQ consensus state will be rebuilt from the genesis transaction.
 setting.preferences.dao.isDaoFullNode=Run Bisq as DAO full node
 setting.preferences.dao.rpcUser=RPC username
 setting.preferences.dao.rpcPw=RPC password
@@ -1904,11 +1905,9 @@ dao.monitor.requestAlHashes=Request all hashes
 dao.monitor.resync=Resync DAO state
 dao.monitor.table.header.cycleBlockHeight=Cycle / block height
 dao.monitor.table.cycleBlockHeight=Cycle {0} / block {1}
+dao.monitor.table.seedPeers=Seed node: {0}
 
 dao.monitor.daoState.headline=DAO state
-dao.monitor.daoState.daoStateInSync=Your local DAO state is in consensus with the network
-dao.monitor.daoState.daoStateNotInSync=Your local DAO state is not in consensus with the network. Please resync your \
-  DAO state.
 dao.monitor.daoState.table.headline=Chain of DAO state hashes
 dao.monitor.daoState.table.blockHeight=Block height
 dao.monitor.daoState.table.hash=Hash of DAO state
@@ -1920,9 +1919,6 @@ dao.monitor.daoState.utxoConflicts.sumUtxo=Sum of all UTXO: {0} BSQ
 dao.monitor.daoState.utxoConflicts.sumBsq=Sum of all BSQ: {0} BSQ
 
 dao.monitor.proposal.headline=Proposals state
-dao.monitor.proposal.daoStateInSync=Your local proposals state is in consensus with the network
-dao.monitor.proposal.daoStateNotInSync=Your local proposals state is not in consensus with the network. Please restart your \
-  application.
 dao.monitor.proposal.table.headline=Chain of proposal state hashes
 dao.monitor.proposal.conflictTable.headline=Proposal state hashes from peers in conflict
 
@@ -1930,11 +1926,13 @@ dao.monitor.proposal.table.hash=Hash of proposal state
 dao.monitor.proposal.table.prev=Previous hash
 dao.monitor.proposal.table.numProposals=No. proposals
 
+dao.monitor.isInConflictWithSeedNode=Your local data is not in consensus with at least one seed node. \
+  Please resync the DAO state.
+dao.monitor.isInConflictWithNonSeedNode=One of your peers is not in consensus with the network but your node \
+  is in sync with the seed nodes.
+dao.monitor.daoStateInSync=Your local node is in consensus with the network
 
 dao.monitor.blindVote.headline=Blind votes state
-dao.monitor.blindVote.daoStateInSync=Your local blind votes state is in consensus with the network
-dao.monitor.blindVote.daoStateNotInSync=Your local blind votes state is not in consensus with the network. Please restart your \
-  application.
 dao.monitor.blindVote.table.headline=Chain of blind vote state hashes
 dao.monitor.blindVote.conflictTable.headline=Blind vote state hashes from peers in conflict
 dao.monitor.blindVote.table.hash=Hash of blind vote state

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateInConflictListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateInConflictListItem.java
@@ -20,7 +20,11 @@ package bisq.desktop.main.dao.monitor;
 import bisq.core.dao.monitoring.model.StateHash;
 import bisq.core.locale.Res;
 
+import bisq.network.p2p.NodeAddress;
+
 import bisq.common.util.Utilities;
+
+import java.util.Set;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -36,10 +40,15 @@ public abstract class StateInConflictListItem<T extends StateHash> {
     private final String prevHash;
     private final T stateHash;
 
-    protected StateInConflictListItem(String peerAddress, T stateHash, int cycleIndex) {
+    protected StateInConflictListItem(String peerAddress, T stateHash, int cycleIndex,
+                                      Set<NodeAddress> seedNodeAddresses) {
         this.stateHash = stateHash;
-        this.peerAddress = peerAddress;
-        height = Res.get("dao.monitor.table.cycleBlockHeight", cycleIndex + 1, String.valueOf(stateHash.getHeight()));
+        this.peerAddress = seedNodeAddresses.stream().anyMatch(e -> e.getFullAddress().equals(peerAddress)) ?
+                Res.get("dao.monitor.table.seedPeers", peerAddress) :
+                peerAddress;
+        height = Res.get("dao.monitor.table.cycleBlockHeight",
+                cycleIndex + 1,
+                String.valueOf(stateHash.getHeight()));
         hash = Utilities.bytesAsHexString(stateHash.getHash());
         prevHash = stateHash.getPrevHash().length > 0 ?
                 Utilities.bytesAsHexString(stateHash.getPrevHash()) : "-";

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
@@ -42,8 +42,6 @@ import bisq.network.p2p.seed.SeedNodeRepository;
 
 import bisq.common.storage.FileManager;
 
-import javax.inject.Inject;
-
 import de.jensd.fx.fontawesome.AwesomeIcon;
 
 import javafx.scene.control.Button;
@@ -111,13 +109,12 @@ public abstract class StateMonitorView<StH extends StateHash,
     // Constructor, lifecycle
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    @Inject
-    public StateMonitorView(DaoStateService daoStateService,
-                            DaoFacade daoFacade,
-                            CycleService cycleService,
-                            PeriodService periodService,
-                            SeedNodeRepository seedNodeRepository,
-                            File storageDir) {
+    protected StateMonitorView(DaoStateService daoStateService,
+                               DaoFacade daoFacade,
+                               CycleService cycleService,
+                               PeriodService periodService,
+                               SeedNodeRepository seedNodeRepository,
+                               File storageDir) {
         this.daoStateService = daoStateService;
         this.daoFacade = daoFacade;
         this.cycleService = cycleService;

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
@@ -23,6 +23,7 @@ import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.AutoTooltipTableColumn;
 import bisq.desktop.components.TableGroupHeadline;
+import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
@@ -35,6 +36,11 @@ import bisq.core.dao.monitoring.model.StateHash;
 import bisq.core.dao.state.DaoStateListener;
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.locale.Res;
+
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.seed.SeedNodeRepository;
+
+import bisq.common.storage.FileManager;
 
 import javax.inject.Inject;
 
@@ -64,8 +70,12 @@ import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
 
+import java.io.File;
+
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @FxmlView
@@ -78,6 +88,8 @@ public abstract class StateMonitorView<StH extends StateHash,
     protected final DaoFacade daoFacade;
     protected final CycleService cycleService;
     protected final PeriodService periodService;
+    protected final Set<NodeAddress> seedNodeAddresses;
+    private final File storageDir;
 
     protected TextField statusTextField;
     protected Button resyncButton;
@@ -91,7 +103,8 @@ public abstract class StateMonitorView<StH extends StateHash,
 
     protected int gridRow = 0;
     private Subscription selectedItemSubscription;
-    protected final BooleanProperty isInConflict = new SimpleBooleanProperty();
+    protected final BooleanProperty isInConflictWithNonSeedNode = new SimpleBooleanProperty();
+    protected final BooleanProperty isInConflictWithSeedNode = new SimpleBooleanProperty();
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -102,11 +115,15 @@ public abstract class StateMonitorView<StH extends StateHash,
     public StateMonitorView(DaoStateService daoStateService,
                             DaoFacade daoFacade,
                             CycleService cycleService,
-                            PeriodService periodService) {
+                            PeriodService periodService,
+                            SeedNodeRepository seedNodeRepository,
+                            File storageDir) {
         this.daoStateService = daoStateService;
         this.daoFacade = daoFacade;
         this.cycleService = cycleService;
         this.periodService = periodService;
+        this.seedNodeAddresses = new HashSet<>(seedNodeRepository.getSeedNodeAddresses());
+        this.storageDir = storageDir;
     }
 
     @Override
@@ -124,8 +141,36 @@ public abstract class StateMonitorView<StH extends StateHash,
 
         daoStateService.addDaoStateListener(this);
 
-        resyncButton.visibleProperty().bind(isInConflict);
-        resyncButton.managedProperty().bind(isInConflict);
+        resyncButton.visibleProperty().bind(isInConflictWithSeedNode);
+        resyncButton.managedProperty().bind(isInConflictWithSeedNode);
+
+        resyncButton.setOnAction(ev -> {
+            try {
+                // We delete all consensus payload data and reset the daoState so it will rebuild from genesis.
+                // Deleting the daoState would cause to read the file from the resources and we would not rebuild from
+                // genesis if a snapshot exist!
+                long currentTime = System.currentTimeMillis();
+                String backupDirName = "out_of_sync_dao_data";
+                String newFileName = "BlindVoteStore_" + currentTime;
+                FileManager.removeAndBackupFile(storageDir, new File(storageDir, "BlindVoteStore"), newFileName, backupDirName);
+
+                newFileName = "ProposalStore_" + currentTime;
+                FileManager.removeAndBackupFile(storageDir, new File(storageDir, "ProposalStore"), newFileName, backupDirName);
+
+                // We also need to remove ballot list as it contains the proposals as well. It will be recreated at resync
+                newFileName = "BallotList_" + currentTime;
+                FileManager.removeAndBackupFile(storageDir, new File(storageDir, "BallotList"), newFileName, backupDirName);
+
+                daoFacade.resyncDao(() -> new Popup<>().attention(Res.get("setting.preferences.dao.resync.popup"))
+                        .useShutDownButton()
+                        .hideCloseButton()
+                        .show());
+            } catch (Throwable t) {
+                t.printStackTrace();
+                log.error(t.toString());
+                new Popup<>().error(t.toString()).show();
+            }
+        });
 
         if (daoStateService.isParseBlockChainComplete()) {
             onDataUpdate();
@@ -250,6 +295,17 @@ public abstract class StateMonitorView<StH extends StateHash,
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     protected void onDataUpdate() {
+        if (isInConflictWithSeedNode.get()) {
+            statusTextField.setText(Res.get("dao.monitor.isInConflictWithSeedNode"));
+            statusTextField.getStyleClass().add("dao-inConflict");
+        } else if (isInConflictWithNonSeedNode.get()) {
+            statusTextField.setText(Res.get("dao.monitor.isInConflictWithNonSeedNode"));
+            statusTextField.getStyleClass().remove("dao-inConflict");
+        } else {
+            statusTextField.setText(Res.get("dao.monitor.daoStateInSync"));
+            statusTextField.getStyleClass().remove("dao-inConflict");
+        }
+
         GUIUtil.setFitToRowsForTableView(tableView, 25, 28, 2, 5);
     }
 
@@ -455,7 +511,7 @@ public abstract class StateMonitorView<StH extends StateHash,
 
 
         column = new AutoTooltipTableColumn<>(getPeersTableHeader());
-        column.setMinWidth(80);
+        column.setMinWidth(150);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -479,7 +535,7 @@ public abstract class StateMonitorView<StH extends StateHash,
 
 
         column = new AutoTooltipTableColumn<>(getHashTableHeader());
-        column.setMinWidth(150);
+        column.setMinWidth(120);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -503,7 +559,7 @@ public abstract class StateMonitorView<StH extends StateHash,
 
 
         column = new AutoTooltipTableColumn<>(getPrevHashTableHeader());
-        column.setMinWidth(150);
+        column.setMinWidth(120);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {
@@ -527,7 +583,7 @@ public abstract class StateMonitorView<StH extends StateHash,
 
 
         column = new AutoTooltipTableColumn<>("");
-        column.setMinWidth(100);
+        column.setMinWidth(120);
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
                 new Callback<>() {

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/blindvotes/BlindVoteStateInConflictListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/blindvotes/BlindVoteStateInConflictListItem.java
@@ -21,6 +21,10 @@ import bisq.desktop.main.dao.monitor.StateInConflictListItem;
 
 import bisq.core.dao.monitoring.model.BlindVoteStateHash;
 
+import bisq.network.p2p.NodeAddress;
+
+import java.util.Set;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -31,8 +35,9 @@ import lombok.extern.slf4j.Slf4j;
 class BlindVoteStateInConflictListItem extends StateInConflictListItem<BlindVoteStateHash> {
     private final String numBlindVotes;
 
-    BlindVoteStateInConflictListItem(String peerAddress, BlindVoteStateHash stateHash, int cycleIndex) {
-        super(peerAddress, stateHash, cycleIndex);
+    BlindVoteStateInConflictListItem(String peerAddress, BlindVoteStateHash stateHash, int cycleIndex,
+                                     Set<NodeAddress> seedNodeAddresses) {
+        super(peerAddress, stateHash, cycleIndex, seedNodeAddresses);
 
         numBlindVotes = String.valueOf(stateHash.getNumBlindVotes());
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateInConflictListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateInConflictListItem.java
@@ -21,6 +21,10 @@ import bisq.desktop.main.dao.monitor.StateInConflictListItem;
 
 import bisq.core.dao.monitoring.model.DaoStateHash;
 
+import bisq.network.p2p.NodeAddress;
+
+import java.util.Set;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 @Value
 @EqualsAndHashCode(callSuper = true)
 class DaoStateInConflictListItem extends StateInConflictListItem<DaoStateHash> {
-    DaoStateInConflictListItem(String peerAddress, DaoStateHash stateHash, int cycleIndex) {
-        super(peerAddress, stateHash, cycleIndex);
+    DaoStateInConflictListItem(String peerAddress, DaoStateHash stateHash, int cycleIndex,
+                               Set<NodeAddress> seedNodeAddresses) {
+        super(peerAddress, stateHash, cycleIndex, seedNodeAddresses);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/proposals/ProposalStateInConflictListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/proposals/ProposalStateInConflictListItem.java
@@ -21,6 +21,10 @@ import bisq.desktop.main.dao.monitor.StateInConflictListItem;
 
 import bisq.core.dao.monitoring.model.ProposalStateHash;
 
+import bisq.network.p2p.NodeAddress;
+
+import java.util.Set;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -31,8 +35,9 @@ import lombok.extern.slf4j.Slf4j;
 class ProposalStateInConflictListItem extends StateInConflictListItem<ProposalStateHash> {
     private final String numProposals;
 
-    ProposalStateInConflictListItem(String peerAddress, ProposalStateHash stateHash, int cycleIndex) {
-        super(peerAddress, stateHash, cycleIndex);
+    ProposalStateInConflictListItem(String peerAddress, ProposalStateHash stateHash, int cycleIndex,
+                                    Set<NodeAddress> seedNodeAddresses) {
+        super(peerAddress, stateHash, cycleIndex, seedNodeAddresses);
 
         numProposals = String.valueOf(stateHash.getNumProposals());
     }


### PR DESCRIPTION
- Check if conflicting node is seed node or not. Show info in list entry
and only show resync button and red color in text if conflict is with
seed node.
- At resync move all p2p network data to a dedicated directory so they
will be reloaded from the seeds.