### PR TITLE
Add missing check to prevent re-selection of proposal

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -587,7 +587,10 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                 break;
         }
 
-        if (selectedItem == null && listItems.size() > 0 && selectProposalWindow.isDisplayed()) {
+        if (selectedItem == null &&
+                listItems.size() > 0 &&
+                selectProposalWindow.isDisplayed() &&
+                !shownVoteOnProposalWindowForTxId.equals("")) {
             Proposal proposal = selectProposalWindow.getProposal();
 
             Optional<ProposalsListItem> proposalsListItem = listItems.stream()


### PR DESCRIPTION
To be able to re-select a proposal that was clicked before, without selecting a different proposal.