### PR TITLE
Add Docker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ Follow the step-by-step instructions at https://bisq.network/get-started.
 ## Contribute to Bisq
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and the [developer docs](docs#readme).
+
+## Build from source
+
+For instructions on how to build from source, see [docs/build.md](docs/build.md)
+
+## Run with Docker
+
+To run Bisq using Docker, see [docker/](docker#readme).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:10-jdk
+
+# This docker image should be used with
+# `docker run ... -v /path/to/host/dir:/root/.local/share/Bisq` in order to
+# persist Bisq configuration to the host.
+
+RUN apt-get update \
+  && apt-get install -y x11-apps \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /src && git clone https://github.com/bisq-network/bisq /src/bisq
+WORKDIR /src/bisq
+RUN ./gradlew build
+VOLUME /home/root/.local/share/Bisq

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+# Running Bisq using Docker
+
+Running Bisq using Docker has currently only been tested using Linux.
+
+## Build the image
+
+```sh
+docker build -t bisq .
+```
+
+## Running Bisq
+
+To ensure that your Bisq configuration is persisted to the host
+to survive between `docker run` invocations,
+we create a directory and then bind-mount it into the container.
+
+```sh
+if [ ! -d "${HOME}/.local/share/Bisq" ]; then
+  mkdir -p ~/.local/share/Bisq
+fi
+
+docker run -ti --rm \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -e DISPLAY=$DISPLAY \
+  -v $HOME/.local/share/Bisq:/root/.local/share/Bisq:rw \
+  bisq ./bisq-desktop
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,3 +25,14 @@ docker run -ti --rm \
   -v $HOME/.local/share/Bisq:/root/.local/share/Bisq:rw \
   bisq ./bisq-desktop
 ```
+
+## Troubleshooting
+
+#### I see "Exception in thread "main" java.lang.UnsupportedOperationException: Unable to open DISPLAY" when I start the Docker container.
+
+You may need to modify your X11 access; try running 
+```sh
+xhost +
+```
+
+and then retrying the `docker run` command.


### PR DESCRIPTION
Running Bisq under Docker is appealing because it (probably?) isolates the host from any malicious behavior that may have somehow gotten into Bisq. This pull adds Docker configuration and instructions. It's only been tested using a Linux system running X11.