### PR TITLE
Add missing pricenode project generated shell script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,8 @@ configure([project(':desktop'),
            project(':monitor'),
            project(':relay'),
            project(':seednode'),
-           project(':statsnode')]) {
+           project(':statsnode'),
+           project(':pricenode')]) {
 
     apply plugin: 'application'
 


### PR DESCRIPTION
When generating shell scripts in the root project directory, the
pricenode project was missing.