### PR TITLE
Fix wrong calculation of percentage based security deposit

### DIFF
--- a/core/src/main/java/bisq/core/util/CoinUtil.java
+++ b/core/src/main/java/bisq/core/util/CoinUtil.java
@@ -49,8 +49,19 @@ public class CoinUtil {
      * @return The percentage value as double (e.g. 1% is 0.01)
      */
     public static double getAsPercentPerBtc(Coin value) {
-        double asDouble = value != null ? (double) value.value : 0;
-        double btcAsDouble = (double) Coin.COIN.value;
+        return getAsPercentPerBtc(value, Coin.COIN);
+    }
+
+    /**
+     * @param part Btc amount to be converted to percent value, based on total value passed.
+     *              E.g. 0.1 BTC is 25% (of 0.4 BTC)
+     * @param total Total Btc amount the percentage part is calculated from
+     *
+     * @return The percentage value as double (e.g. 1% is 0.01)
+     */
+    public static double getAsPercentPerBtc(Coin part, Coin total) {
+        double asDouble = part != null ? (double) part.value : 0;
+        double btcAsDouble = total != null ? (double) total.value : 1;
         return MathUtils.roundDouble(asDouble / btcAsDouble, 4);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
@@ -114,7 +114,7 @@ class EditOfferDataModel extends MutableOfferDataModel {
         CurrencyUtil.getTradeCurrency(offer.getCurrencyCode())
                 .ifPresent(c -> this.tradeCurrency = c);
         tradeCurrencyCode.set(offer.getCurrencyCode());
-        buyerSecurityDeposit.set(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit()));
+        buyerSecurityDeposit.set(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount()));
 
         this.initialState = openOffer.getState();
         PaymentAccount tmpPaymentAccount = user.getPaymentAccount(openOffer.getOffer().getMakerPaymentAccountId());


### PR DESCRIPTION
Only affects editing of an existing offer and was introduced in v0.9.5.
It wasn't detected until now as we increased the minimum security deposit with v1.0.0.

Fixes #2713.