### PR TITLE
Doichain: set p2shHeader.

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Doichain.java
+++ b/assets/src/main/java/bisq/asset/coins/Doichain.java
@@ -30,7 +30,8 @@ public class Doichain extends Coin {
     public static class DoichainParams extends NetworkParametersAdapter {
         public DoichainParams() {
             addressHeader = 52;
-            acceptableAddressCodes = new int[]{addressHeader};
+            p2shHeader = 13;
+            acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
         }
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/DoichainTest.java
+++ b/assets/src/test/java/bisq/asset/coins/DoichainTest.java
@@ -30,6 +30,7 @@ public class DoichainTest extends AbstractAssetTest {
     public void testValidAddresses() {
         assertValidAddress("NGHV9LstnZfrkGx5QJmYhEepbzc66W7LN5");
         assertValidAddress("N4jeY9YhU49qHN5wUv7HBxeVZrFg32XFy7");
+        assertValidAddress("6a6xk7Ff6XbgrNWhSwn7nM394KZJNt7JuV");
     }
 
     @Test


### PR DESCRIPTION
See https://github.com/Doichain/core/blob/master/src/chainparams.cpp#L181

Not setting the p2shHeader makes the p2shHeader to be 0, that has problems on address validation on bitcoinj 0.15