### PR TITLE
Add nodeaddress and capabilities at getblocks request

### DIFF
--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -317,6 +317,8 @@ message PrivateNotificationMessage {
 message GetBlocksRequest {
     int32 from_block_height = 1;
     int32 nonce = 2;
+    NodeAddress sender_node_address = 3;
+    repeated int32 supported_capabilities = 4;
 }
 
 message GetBlocksResponse {

--- a/core/src/main/java/bisq/core/dao/node/lite/network/RequestBlocksHandler.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/network/RequestBlocksHandler.java
@@ -108,7 +108,7 @@ public class RequestBlocksHandler implements MessageListener {
 
     public void requestBlocks() {
         if (!stopped) {
-            GetBlocksRequest getBlocksRequest = new GetBlocksRequest(startBlockHeight, nonce);
+            GetBlocksRequest getBlocksRequest = new GetBlocksRequest(startBlockHeight, nonce, networkNode.getNodeAddress());
             log.debug("getBlocksRequest " + getBlocksRequest);
             if (timeoutTimer == null) {
                 timeoutTimer = UserThread.runAfter(() -> {  // setup before sending to avoid race conditions

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -149,7 +149,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
     // mutable data, set from other threads but not changed internally.
     @Getter
-    private Optional<NodeAddress> peersNodeAddressOptional = Optional.<NodeAddress>empty();
+    private Optional<NodeAddress> peersNodeAddressOptional = Optional.empty();
     @Getter
     private volatile boolean stopped;
 
@@ -791,17 +791,19 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         // 4. DirectMessage (implements SendersNodeAddressMessage)
                         if (networkEnvelope instanceof SendersNodeAddressMessage) {
                             NodeAddress senderNodeAddress = ((SendersNodeAddressMessage) networkEnvelope).getSenderNodeAddress();
-                            Optional<NodeAddress> peersNodeAddressOptional = getPeersNodeAddressOptional();
-                            if (peersNodeAddressOptional.isPresent()) {
-                                // If we have already the peers address we check again if it matches our stored one
-                                checkArgument(peersNodeAddressOptional.get().equals(senderNodeAddress),
-                                        "senderNodeAddress not matching connections peer address.\n\t" +
-                                                "message=" + networkEnvelope);
-                            } else {
-                                // We must not shut down a banned peer at that moment as it would trigger a connection termination
-                                // and we could not send the CloseConnectionMessage.
-                                // We check for a banned peer inside setPeersNodeAddress() and shut down if banned.
-                                setPeersNodeAddress(senderNodeAddress);
+                            if (senderNodeAddress != null) {
+                                Optional<NodeAddress> peersNodeAddressOptional = getPeersNodeAddressOptional();
+                                if (peersNodeAddressOptional.isPresent()) {
+                                    // If we have already the peers address we check again if it matches our stored one
+                                    checkArgument(peersNodeAddressOptional.get().equals(senderNodeAddress),
+                                            "senderNodeAddress not matching connections peer address.\n\t" +
+                                                    "message=" + networkEnvelope);
+                                } else {
+                                    // We must not shut down a banned peer at that moment as it would trigger a connection termination
+                                    // and we could not send the CloseConnectionMessage.
+                                    // We check for a banned peer inside setPeersNodeAddress() and shut down if banned.
+                                    setPeersNodeAddress(senderNodeAddress);
+                                }
                             }
                         }
 

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -754,8 +754,12 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         return;
                     }
 
-                    if (networkEnvelope instanceof SupportedCapabilitiesMessage)
-                        capabilities.set(((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities());
+                    if (networkEnvelope instanceof SupportedCapabilitiesMessage) {
+                        Capabilities supportedCapabilities = ((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities();
+                        if (supportedCapabilities != null) {
+                            capabilities.set(supportedCapabilities);
+                        }
+                    }
 
                     if (networkEnvelope instanceof CloseConnectionMessage) {
                         // If we get a CloseConnectionMessage we shut down

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
@@ -42,7 +42,6 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode(callSuper = true)
 @Value
 public final class PreliminaryGetDataRequest extends GetDataRequest implements AnonymousMessage, SupportedCapabilitiesMessage {
-    // ordinals of enum
     @Nullable
     private final Capabilities supportedCapabilities;
 
@@ -81,9 +80,13 @@ public final class PreliminaryGetDataRequest extends GetDataRequest implements A
     }
 
     public static PreliminaryGetDataRequest fromProto(PB.PreliminaryGetDataRequest proto, int messageVersion) {
+        Capabilities supportedCapabilities = proto.getSupportedCapabilitiesList().isEmpty() ?
+                null :
+                Capabilities.fromIntList(proto.getSupportedCapabilitiesList());
+
         return new PreliminaryGetDataRequest(proto.getNonce(),
                 ProtoUtil.byteSetFromProtoByteStringList(proto.getExcludedKeysList()),
-                Capabilities.fromIntList(proto.getSupportedCapabilitiesList()),
+                supportedCapabilities,
                 messageVersion);
     }
 }


### PR DESCRIPTION
When we request at startup the blocks from a seed which has not yet
received out capabilities or node address we will not get a response.
We do not want to depend on the state in the getData domain in the
p2p network by using only a seed which has already responded but we
prefer to make sure the seednode will get all the data by our request
to be able to respond.