### PR TITLE
Improve handling of editing of offers with invalid security deposit

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -493,6 +493,7 @@ editOffer.confirmEdit=Confirm: Edit offer
 editOffer.publishOffer=Publishing your offer.
 editOffer.failed=Editing of offer failed:\n{0}
 editOffer.success=Your offer has been successfully edited.
+editOffer.invalidDeposit=The buyer's security deposit is not within the constraints defined by the Bisq DAO and can no longer be edited.
 
 ####################################################################
 # Portfolio

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -84,7 +84,7 @@ import static javafx.beans.binding.Bindings.createStringBinding;
 public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> extends ActivatableWithDataModel<M> {
     private final BtcValidator btcValidator;
     private final BsqValidator bsqValidator;
-    private final SecurityDepositValidator securityDepositValidator;
+    protected final SecurityDepositValidator securityDepositValidator;
     private final P2PService p2PService;
     private final WalletsSetup walletsSetup;
     private final PriceFeedService priceFeedService;
@@ -104,7 +104,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     public final StringProperty amount = new SimpleStringProperty();
     public final StringProperty minAmount = new SimpleStringProperty();
-    final StringProperty buyerSecurityDeposit = new SimpleStringProperty();
+    protected final StringProperty buyerSecurityDeposit = new SimpleStringProperty();
     final StringProperty buyerSecurityDepositInBTC = new SimpleStringProperty();
     final StringProperty buyerSecurityDepositLabel = new SimpleStringProperty();
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
@@ -148,11 +148,15 @@ public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
         model.onStartEditOffer(errorMessage -> {
             log.error(errorMessage);
             new Popup<>().warning(Res.get("editOffer.failed", errorMessage))
-                    .onClose(() -> {
-                        close();
-                    })
+                    .onClose(this::close)
                     .show();
         });
+
+        if (!model.isSecurityDepositValid()) {
+            new Popup<>().warning(Res.get("editOffer.invalidDeposit"))
+                    .onClose(this::close)
+                    .show();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
@@ -80,4 +80,8 @@ class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
         price.set(btcFormatter.formatPrice(null));
         price.set(btcFormatter.formatPrice(dataModel.getPrice().get()));
     }
+
+    public boolean isSecurityDepositValid() {
+        return securityDepositValidator.validate(buyerSecurityDeposit.get()).isValid;
+    }
 }


### PR DESCRIPTION
Shows warning popup when offer with invalid security deposit is edited.
@m52go Could you please review the text? Thanks!
<img width="1268" alt="Bildschirmfoto 2019-04-18 um 13 19 24" src="https://user-images.githubusercontent.com/170962/56357844-2650b180-61dd-11e9-9131-deceaf839f5a.png">
