### PR TITLE
Fix account age display of peer

### DIFF
--- a/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
@@ -22,6 +22,7 @@ import bisq.core.offer.Offer;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.trade.Trade;
+import bisq.core.trade.protocol.TradingPeer;
 import bisq.core.user.User;
 
 import bisq.network.p2p.BootstrapListener;
@@ -283,6 +284,20 @@ public class AccountAgeWitnessService {
                 Optional.empty();
         return witnessByHashAsHex
                 .map(accountAgeWitness -> getAccountAge(accountAgeWitness, peersCurrentDate))
+                .orElse(-1L);
+    }
+
+    public long getTradingPeersAccountAge(Trade trade) {
+        TradingPeer tradingPeer = trade.getProcessModel().getTradingPeer();
+        if (tradingPeer.getPaymentAccountPayload() == null || tradingPeer.getPubKeyRing() == null) {
+            // unexpected
+            return -1;
+        }
+        PaymentAccountPayload peersPaymentAccountPayload = tradingPeer.getPaymentAccountPayload();
+        PubKeyRing peersPubKeyRing = tradingPeer.getPubKeyRing();
+
+        Optional<AccountAgeWitness> witness = findWitness(peersPaymentAccountPayload, peersPubKeyRing);
+        return witness.map(accountAgeWitness -> getAccountAge(accountAgeWitness, new Date()))
                 .orElse(-1L);
     }
 

--- a/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
@@ -161,7 +161,7 @@ public class AccountAgeWitnessService {
         return new AccountAgeWitness(hash, new Date().getTime());
     }
 
-    private Optional<AccountAgeWitness> findWitness(PaymentAccountPayload paymentAccountPayload, PubKeyRing pubKeyRing) {
+    public Optional<AccountAgeWitness> findWitness(PaymentAccountPayload paymentAccountPayload, PubKeyRing pubKeyRing) {
         byte[] accountInputDataWithSalt = getAccountInputDataWithSalt(paymentAccountPayload);
         byte[] hash = Hash.getSha256Ripemd160hash(Utilities.concatenateByteArrays(accountInputDataWithSalt,
                 pubKeyRing.getSignaturePubKeyBytes()));

--- a/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
@@ -189,6 +189,12 @@ public class AccountAgeWitnessService {
         return now.getTime() - accountAgeWitness.getDate();
     }
 
+    public long getAccountAge(PaymentAccountPayload paymentAccountPayload, PubKeyRing pubKeyRing) {
+        return findWitness(paymentAccountPayload, pubKeyRing)
+                .map(accountAgeWitness -> getAccountAge(accountAgeWitness, new Date()))
+                .orElse(-1L);
+    }
+
     public AccountAge getAccountAgeCategory(long accountAge) {
         if (accountAge < TimeUnit.DAYS.toMillis(30)) {
             return AccountAge.LESS_ONE_MONTH;
@@ -293,12 +299,8 @@ public class AccountAgeWitnessService {
             // unexpected
             return -1;
         }
-        PaymentAccountPayload peersPaymentAccountPayload = tradingPeer.getPaymentAccountPayload();
-        PubKeyRing peersPubKeyRing = tradingPeer.getPubKeyRing();
 
-        Optional<AccountAgeWitness> witness = findWitness(peersPaymentAccountPayload, peersPubKeyRing);
-        return witness.map(accountAgeWitness -> getAccountAge(accountAgeWitness, new Date()))
-                .orElse(-1L);
+        return getAccountAge(tradingPeer.getPaymentAccountPayload(), tradingPeer.getPubKeyRing());
     }
 
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1986,6 +1986,7 @@ contractWindow.title=Dispute details
 contractWindow.dates=Offer date / Trade date
 contractWindow.btcAddresses=Bitcoin address BTC buyer / BTC seller
 contractWindow.onions=Network address BTC buyer / BTC seller
+contractWindow.accountAge=Account age BTC buyer / BTC seller
 contractWindow.numDisputes=No. of disputes BTC buyer / BTC seller
 contractWindow.contractHash=Contract hash
 

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -23,17 +23,12 @@ import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.offer.Offer;
-import bisq.core.payment.AccountAgeWitness;
 import bisq.core.payment.AccountAgeWitnessService;
-import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.trade.Trade;
-import bisq.core.trade.protocol.TradingPeer;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
 
 import bisq.network.p2p.NodeAddress;
-
-import bisq.common.crypto.PubKeyRing;
 
 import javafx.scene.Group;
 import javafx.scene.canvas.Canvas;
@@ -51,7 +46,6 @@ import java.security.NoSuchAlgorithmException;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -254,17 +248,7 @@ public class PeerInfoIcon extends Group {
                 return -1;
             }
 
-            TradingPeer tradingPeer = trade.getProcessModel().getTradingPeer();
-            if (tradingPeer.getPaymentAccountPayload() == null || tradingPeer.getPubKeyRing() == null) {
-                // unexpected
-                return -1;
-            }
-            PaymentAccountPayload peersPaymentAccountPayload = tradingPeer.getPaymentAccountPayload();
-            PubKeyRing peersPubKeyRing = tradingPeer.getPubKeyRing();
-
-            Optional<AccountAgeWitness> witness = accountAgeWitnessService.findWitness(peersPaymentAccountPayload, peersPubKeyRing);
-            return witness.map(accountAgeWitness -> accountAgeWitnessService.getAccountAge(accountAgeWitness, new Date()))
-                    .orElse(-1L);
+            return accountAgeWitnessService.getTradingPeersAccountAge(trade);
         } else {
             checkNotNull(offer, "Offer must not be null if trade is null.");
 

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
@@ -9,10 +9,22 @@ import bisq.core.util.BSFormatter;
 import bisq.network.p2p.NodeAddress;
 
 public class PeerInfoIconSmall extends PeerInfoIcon {
-    public PeerInfoIconSmall(NodeAddress nodeAddress, String role, Offer offer, Preferences preferences, AccountAgeWitnessService accountAgeWitnessService, BSFormatter formatter, boolean useDevPrivilegeKeys) {
+    public PeerInfoIconSmall(NodeAddress nodeAddress,
+                             String role, Offer offer,
+                             Preferences preferences,
+                             AccountAgeWitnessService accountAgeWitnessService,
+                             BSFormatter formatter,
+                             boolean useDevPrivilegeKeys) {
         // We don't want to show number of trades in that case as it would be unreadable.
         // Also we don't need the privateNotificationManager as no interaction will take place with this icon.
-        super(nodeAddress, role, 0, null, offer, preferences, accountAgeWitnessService, formatter, useDevPrivilegeKeys);
+        super(nodeAddress, role,
+                0,
+                null,
+                offer,
+                preferences,
+                accountAgeWitnessService,
+                formatter,
+                useDevPrivilegeKeys);
     }
 
     @Override
@@ -21,7 +33,13 @@ public class PeerInfoIconSmall extends PeerInfoIcon {
     }
 
     @Override
-    protected void addMouseListener(int numTrades, PrivateNotificationManager privateNotificationManager, Offer offer, Preferences preferences, BSFormatter formatter, boolean useDevPrivilegeKeys, boolean isFiatCurrency, long makersAccountAge) {
+    protected void addMouseListener(int numTrades,
+                                    PrivateNotificationManager privateNotificationManager,
+                                    Offer offer, Preferences preferences,
+                                    BSFormatter formatter,
+                                    boolean useDevPrivilegeKeys,
+                                    boolean isFiatCurrency,
+                                    long makersAccountAge) {
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/disputes/arbitrator/ArbitratorDisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/disputes/arbitrator/ArbitratorDisputeView.java
@@ -26,6 +26,7 @@ import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
 import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.app.AppOptionKeys;
 import bisq.core.arbitration.DisputeManager;
+import bisq.core.payment.AccountAgeWitnessService;
 import bisq.core.trade.TradeManager;
 import bisq.core.util.BSFormatter;
 
@@ -41,14 +42,28 @@ import javax.inject.Inject;
 public class ArbitratorDisputeView extends TraderDisputeView {
 
     @Inject
-    public ArbitratorDisputeView(DisputeManager disputeManager, KeyRing keyRing, TradeManager tradeManager,
-                                 BSFormatter formatter, DisputeSummaryWindow disputeSummaryWindow,
+    public ArbitratorDisputeView(DisputeManager disputeManager,
+                                 KeyRing keyRing,
+                                 TradeManager tradeManager,
+                                 BSFormatter formatter,
+                                 DisputeSummaryWindow disputeSummaryWindow,
                                  PrivateNotificationManager privateNotificationManager,
-                                 ContractWindow contractWindow, TradeDetailsWindow tradeDetailsWindow,
-                                 P2PService p2PService, @Named(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
-        super(disputeManager, keyRing, tradeManager, formatter,
-                disputeSummaryWindow, privateNotificationManager, contractWindow,
-                tradeDetailsWindow, p2PService, useDevPrivilegeKeys);
+                                 ContractWindow contractWindow,
+                                 TradeDetailsWindow tradeDetailsWindow,
+                                 P2PService p2PService,
+                                 AccountAgeWitnessService accountAgeWitnessService,
+                                 @Named(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
+        super(disputeManager,
+                keyRing,
+                tradeManager,
+                formatter,
+                disputeSummaryWindow,
+                privateNotificationManager,
+                contractWindow,
+                tradeDetailsWindow,
+                p2PService,
+                accountAgeWitnessService,
+                useDevPrivilegeKeys);
     }
 
     @Override
@@ -65,8 +80,8 @@ public class ArbitratorDisputeView extends TraderDisputeView {
         filteredList.setPredicate(dispute -> {
             boolean matchesTradeId = dispute.getTradeId().contains(filterString);
             boolean matchesDate = formatter.formatDate(dispute.getOpeningDate()).contains(filterString);
-            boolean isBuyerOnion = getBuyerOnionAddressColumnLabel(dispute).contains(filterString);
-            boolean isSellerOnion = getSellerOnionAddressColumnLabel(dispute).contains(filterString);
+            boolean isBuyerOnion = dispute.getContract().getBuyerNodeAddress().getFullAddress().contains(filterString);
+            boolean isSellerOnion = dispute.getContract().getSellerNodeAddress().getFullAddress().contains(filterString);
             boolean matchesBuyersPaymentAccountData = dispute.getContract().getBuyerPaymentAccountPayload().getPaymentDetails().contains(filterString);
             boolean matchesSellersPaymentAccountData = dispute.getContract().getSellerPaymentAccountPayload().getPaymentDetails().contains(filterString);
 

--- a/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
@@ -41,6 +41,7 @@ import bisq.core.arbitration.Attachment;
 import bisq.core.arbitration.Dispute;
 import bisq.core.arbitration.DisputeManager;
 import bisq.core.arbitration.messages.DisputeCommunicationMessage;
+import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.payment.AccountAgeWitnessService;
 import bisq.core.trade.Contract;
@@ -1223,7 +1224,8 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                 String nrOfDisputes = disputeManager.getNrOfDisputes(true, contract);
                 long accountAge = accountAgeWitnessService.getAccountAge(contract.getBuyerPaymentAccountPayload(), contract.getBuyerPubKeyRing());
                 String age = formatter.formatAccountAge(accountAge);
-                return buyerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + " / " + age + ")";
+                String postFix = CurrencyUtil.isFiatCurrency(item.getContract().getOfferPayload().getCurrencyCode()) ? " / " + age : "";
+                return buyerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + postFix + ")";
             } else
                 return Res.get("shared.na");
         } else {
@@ -1239,7 +1241,8 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                 String nrOfDisputes = disputeManager.getNrOfDisputes(false, contract);
                 long accountAge = accountAgeWitnessService.getAccountAge(contract.getSellerPaymentAccountPayload(), contract.getSellerPubKeyRing());
                 String age = formatter.formatAccountAge(accountAge);
-                return sellerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + " / " + age + ")";
+                String postFix = CurrencyUtil.isFiatCurrency(item.getContract().getOfferPayload().getCurrencyCode()) ? " / " + age : "";
+                return sellerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + postFix + ")";
             } else
                 return Res.get("shared.na");
         } else {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
@@ -90,7 +90,10 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
     @Nullable
     private String accountAge;
 
-    public PeerInfoWithTagEditor(PrivateNotificationManager privateNotificationManager, Offer offer, Preferences preferences, boolean useDevPrivilegeKeys) {
+    public PeerInfoWithTagEditor(PrivateNotificationManager privateNotificationManager,
+                                 Offer offer,
+                                 Preferences preferences,
+                                 boolean useDevPrivilegeKeys) {
         this.privateNotificationManager = privateNotificationManager;
         this.offer = offer;
         this.preferences = preferences;

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -27,7 +27,6 @@ import bisq.core.arbitration.DisputeManager;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.offer.Offer;
-import bisq.core.payment.AccountAgeWitness;
 import bisq.core.payment.AccountAgeWitnessService;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.trade.Contract;
@@ -58,9 +57,6 @@ import javafx.geometry.Insets;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.value.ChangeListener;
-
-import java.util.Date;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -226,9 +222,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         if (contract != null) {
             if (buyerPaymentAccountPayload != null) {
                 String paymentDetails = buyerPaymentAccountPayload.getPaymentDetails();
-                Optional<AccountAgeWitness> witness = accountAgeWitnessService.findWitness(buyerPaymentAccountPayload, contract.getBuyerPubKeyRing());
-                long age = witness.map(accountAgeWitness -> accountAgeWitnessService.getAccountAge(accountAgeWitness, new Date()))
-                        .orElse(-1L);
+                long age = accountAgeWitnessService.getAccountAge(buyerPaymentAccountPayload, contract.getBuyerPubKeyRing());
                 String accountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
                         age > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :
@@ -240,9 +234,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
             }
             if (sellerPaymentAccountPayload != null) {
                 String paymentDetails = sellerPaymentAccountPayload.getPaymentDetails();
-                Optional<AccountAgeWitness> witness = accountAgeWitnessService.findWitness(sellerPaymentAccountPayload, contract.getSellerPubKeyRing());
-                long age = witness.map(accountAgeWitness -> accountAgeWitnessService.getAccountAge(accountAgeWitness, new Date()))
-                        .orElse(-1L);
+                long age = accountAgeWitnessService.getAccountAge(sellerPaymentAccountPayload, contract.getSellerPubKeyRing());
                 String accountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
                         age > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -73,6 +73,8 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
     private Trade trade;
     private ChangeListener<Number> changeListener;
     private TextArea textArea;
+    private String buyersAccountAge;
+    private String sellersAccountAge;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -223,25 +225,28 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
             if (buyerPaymentAccountPayload != null) {
                 String paymentDetails = buyerPaymentAccountPayload.getPaymentDetails();
                 long age = accountAgeWitnessService.getAccountAge(buyerPaymentAccountPayload, contract.getBuyerPubKeyRing());
-                String accountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
+                buyersAccountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
                         age > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :
                         "";
+
+                String postFix = buyersAccountAge.isEmpty() ? "" : " / " + buyersAccountAge;
                 TextFieldWithCopyIcon tf = addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex,
                         Res.get("shared.paymentDetails", Res.get("shared.buyer")),
-                        paymentDetails + " / " + accountAge).second;
+                        paymentDetails + postFix).second;
                 tf.setTooltip(new Tooltip(tf.getText()));
             }
             if (sellerPaymentAccountPayload != null) {
                 String paymentDetails = sellerPaymentAccountPayload.getPaymentDetails();
                 long age = accountAgeWitnessService.getAccountAge(sellerPaymentAccountPayload, contract.getSellerPubKeyRing());
-                String accountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
+                sellersAccountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
                         age > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :
                         "";
+                String postFix = sellersAccountAge.isEmpty() ? "" : " / " + sellersAccountAge;
                 TextFieldWithCopyIcon tf = addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex,
                         Res.get("shared.paymentDetails", Res.get("shared.seller")),
-                        paymentDetails + " / " + accountAge).second;
+                        paymentDetails + postFix).second;
                 tf.setTooltip(new Tooltip(tf.getText()));
             }
             if (buyerPaymentAccountPayload == null && sellerPaymentAccountPayload == null)
@@ -273,6 +278,11 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
                 String contractAsJson = trade.getContractAsJson();
                 contractAsJson += "\n\nBuyerMultiSigPubKeyHex: " + Utils.HEX.encode(contract.getBuyerMultiSigPubKey());
                 contractAsJson += "\nSellerMultiSigPubKeyHex: " + Utils.HEX.encode(contract.getSellerMultiSigPubKey());
+                if (CurrencyUtil.isFiatCurrency(offer.getCurrencyCode())) {
+                    contractAsJson += "\nBuyersAccountAge: " + buyersAccountAge;
+                    contractAsJson += "\nSellersAccountAge: " + sellersAccountAge;
+                }
+
                 textArea.setText(contractAsJson);
                 textArea.setPrefHeight(50);
                 textArea.setEditable(false);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
@@ -32,7 +32,6 @@ import bisq.core.app.AppOptionKeys;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
-import bisq.core.offer.Offer;
 import bisq.core.offer.OpenOffer;
 import bisq.core.trade.Tradable;
 import bisq.core.trade.Trade;
@@ -48,8 +47,6 @@ import com.googlecode.jcsv.writer.CSVEntryConverter;
 import com.google.inject.name.Named;
 
 import javax.inject.Inject;
-
-import com.google.common.base.Preconditions;
 
 import javafx.fxml.FXML;
 
@@ -335,14 +332,12 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
                                     Trade trade = (Trade) newItem.getTradable();
                                     int numPastTrades = model.getNumPastTrades(trade);
                                     final NodeAddress tradingPeerNodeAddress = trade.getTradingPeerNodeAddress();
-                                    final Offer offer = trade.getOffer();
-                                    Preconditions.checkNotNull(offer, "Offer must not be null");
                                     String role = Res.get("peerInfoIcon.tooltip.tradePeer");
                                     Node peerInfoIcon = new PeerInfoIcon(tradingPeerNodeAddress,
                                             role,
                                             numPastTrades,
                                             privateNotificationManager,
-                                            offer,
+                                            trade,
                                             preferences,
                                             model.accountAgeWitnessService,
                                             formatter,

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -28,7 +28,6 @@ import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
 import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.app.AppOptionKeys;
 import bisq.core.locale.Res;
-import bisq.core.offer.Offer;
 import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
@@ -69,8 +68,6 @@ import javafx.collections.transformation.SortedList;
 import javafx.util.Callback;
 
 import java.util.Comparator;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @FxmlView
 public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTradesViewModel> {
@@ -488,14 +485,12 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                                     final Trade trade = newItem.getTrade();
                                     final NodeAddress tradingPeerNodeAddress = trade.getTradingPeerNodeAddress();
                                     int numPastTrades = model.getNumPastTrades(trade);
-                                    final Offer offer = trade.getOffer();
-                                    checkNotNull(offer, "Offer must not be null in PendingTradesView");
                                     String role = Res.get("peerInfoIcon.tooltip.tradePeer");
                                     Node peerInfoIcon = new PeerInfoIcon(tradingPeerNodeAddress,
                                             role,
                                             numPastTrades,
                                             privateNotificationManager,
-                                            offer,
+                                            trade,
                                             preferences,
                                             model.accountAgeWitnessService,
                                             formatter,


### PR DESCRIPTION
We only showed makers account age before also at trade screens.
This PR fixes that so that the trade peers account age is displayed at
the peer info icon.