### PR TITLE
Update mobile notification relay node DEV_URL IP address

### DIFF
--- a/core/src/main/java/bisq/core/notifications/MobileNotificationService.java
+++ b/core/src/main/java/bisq/core/notifications/MobileNotificationService.java
@@ -59,7 +59,7 @@ public class MobileNotificationService {
     // duplicated in relay and here. Must not be changed.
     private static final String SUCCESS = "success";
     private static final String DEV_URL_LOCALHOST = "http://localhost:8080/";
-    private static final String DEV_URL = "http://198.211.125.72:8080/";
+    private static final String DEV_URL = "http://165.227.40.124:8080/";
     private static final String URL = "http://jtboonrvwmq7frkj.onion/";
     private static final String BISQ_MESSAGE_IOS_MAGIC = "BisqMessageiOS";
     private static final String BISQ_MESSAGE_ANDROID_MAGIC = "BisqMessageAndroid";


### PR DESCRIPTION
I have taken over the relay node from Manfred. The onion address
remains the same, but the IP address used in the DEV_URL has
changed.

See bisq-network/roles#82