### PR TITLE
List burnt BlackCoin (BLK-BURNT)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/BurntBlackCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/BurntBlackCoin.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AltCoinAccountDisclaimer;
+import bisq.asset.Coin;
+import bisq.asset.RegexAddressValidator;
+
+@AltCoinAccountDisclaimer("account.altcoin.popup.blk-burnt.msg")
+public class BurntBlackCoin extends Coin {
+    public static final short PAYLOAD_LIMIT = 15000;
+
+    public BurntBlackCoin() {
+        super("Burnt BlackCoin",
+              "BLK-BURNT",
+              new RegexAddressValidator(String.format("(?:[0-9a-z]{2}?){1,%d}+", 2 * PAYLOAD_LIMIT)));
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -21,6 +21,7 @@ bisq.asset.coins.Blur
 bisq.asset.coins.BSQ$Mainnet
 bisq.asset.coins.BSQ$Regtest
 bisq.asset.coins.BSQ$Testnet
+bisq.asset.coins.BurntBlackCoin
 bisq.asset.coins.Byteball
 bisq.asset.coins.Cash2
 bisq.asset.coins.Chaucha

--- a/assets/src/test/java/bisq/asset/coins/BurntBlackCoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/BurntBlackCoinTest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+import java.util.Collections;
+import org.junit.Test;
+
+public class BurntBlackCoinTest extends AbstractAssetTest {
+
+    public BurntBlackCoinTest() {
+        super(new BurntBlackCoin());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("4b");
+        assertValidAddress("536865206d616b657320796f75206275726e207769746820612077617665206f66206865722068616e64");
+        String longAddress = String.join("", Collections.nCopies(2 * BurntBlackCoin.PAYLOAD_LIMIT, "af"));
+        assertValidAddress(longAddress);
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("AF");
+        assertInvalidAddress("afa");
+        assertInvalidAddress("B4Wa1C8zFgkSY4daLg8jWnxuKpw7UmWFoo");
+        String tooLongAddress = String.join("", Collections.nCopies(2 * BurntBlackCoin.PAYLOAD_LIMIT + 1, "af"));
+        assertInvalidAddress(tooLongAddress);
+    }
+}

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1196,6 +1196,17 @@ Failure to provide the required information to the arbitrator will result in los
 ParsiCoin sender bears 100% of the burden of responsibility in verifying transactions to an arbitrator. \n\n\
 If you do not understand these requirements, do not trade on Bisq. First, seek help at the ParsiCoin Discord (https://discord.gg/c7qmFNh).
 
+account.altcoin.popup.blk-burnt.msg=To trade burnt blackcoins, you need to know the following:\n\n\
+Burnt blackcoins are unspendable. To trade them on Bisq, output scripts need to be in the form: \
+OP_RETURN OP_PUSHDATA, followed by associated data bytes which, after being hex-encoded, constitute addresses. \
+For example, burnt blackcoins with an address 666f6f (“foo” in UTF-8) will have the following script:\n\n\
+OP_RETURN OP_PUSHDATA 666f6f\n\n\
+To create burnt blackcoins, one may use the “burn” RPC command available in some wallets.\n\n\
+For possible use cases, one may look at https://ibo.laboratorium.ee .\n\n\
+As burnt blackcoins are unspendable, they can not be reselled. “Selling” burnt blackcoins means \
+burning ordinary blackcoins (with associated data equal to the destination address).\n\n\
+In case of a dispute, the BLK seller needs to provide the transaction hash.
+
 account.fiat.yourFiatAccounts=Your national currency accounts
 
 account.backup.title=Backup wallet


### PR DESCRIPTION
- Official project URL: https://blackcoin.org/
- Block explorer URL: https://chainz.cryptoid.info/blk/

For context, see https://bisq.community/t/best-way-to-add-an-ibo/7477 .