### PR TITLE
Fix dao sync text after restore from seed

### DIFF
--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -117,7 +117,7 @@ public class WalletAppSetup {
                         } else if (percentage > 0.0) {
                             result = Res.get("mainView.footer.btcInfo",
                                     peers,
-                                    Res.get("mainView.footer.btcInfo.synchronizedWith"),
+                                    Res.get("mainView.footer.btcInfo.synchronizingWith"),
                                     getBtcNetworkAsString() + ": " + formatter.formatToPercentWithSymbol(percentage));
                         } else {
                             result = Res.get("mainView.footer.btcInfo",

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -241,6 +241,7 @@ mainView.footer.localhostBitcoinNode=(localhost)
 mainView.footer.btcInfo=Bitcoin network peers: {0} / {1} {2}
 mainView.footer.btcInfo.initializing=Connecting to Bitcoin network
 mainView.footer.bsqInfo.synchronizing=/ Synchronizing DAO
+mainView.footer.btcInfo.synchronizingWith=Synchronizing with
 mainView.footer.btcInfo.synchronizedWith=Synchronized with
 mainView.footer.btcInfo.connectingTo=Connecting to
 mainView.footer.btcInfo.connectionFailed=connection failed

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -270,13 +270,23 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
             chainSyncIndicator.setManaged(!synced);
             if (synced) {
                 chainHeightLabel.setText(Res.get("dao.wallet.chainHeightSynced",
-                        currentBlockHeight,
-                        walletChainHeight));
+                        currentBlockHeight));
             } else {
                 chainSyncIndicator.setProgress(progress);
-                chainHeightLabel.setText(Res.get("dao.wallet.chainHeightSyncing",
-                        currentBlockHeight,
-                        walletChainHeight));
+                if (walletChainHeight > currentBlockHeight) {
+                    // Normally we get the latest block height from BitcoinJ as the target height,
+                    // and we request BSQ blocks from seed nodes up to latest block
+                    chainHeightLabel.setText(Res.get("dao.wallet.chainHeightSyncing",
+                            currentBlockHeight,
+                            walletChainHeight));
+                } else {
+                    // But when restoring from seed, we receive the latest block height
+                    // from the seed nodes while BitcoinJ has not received all blocks yet and
+                    // is still syncing
+                    chainHeightLabel.setText(Res.get("dao.wallet.chainHeightSyncing",
+                            walletChainHeight,
+                            currentBlockHeight));
+                }
             }
         } else {
             chainHeightLabel.setText(Res.get("dao.wallet.chainHeightSyncing",


### PR DESCRIPTION
After restoring from seed, the text shown under DAO /
BSQ Wallet / Transactions displays an incorrect progress - the numbers
are swapped. For example:
"Awaiting blocks... Verified 575,868 blocks out of 554,857"

Normally we get the latest block height from BitcoinJ as the
target height, and we request BSQ blocks from seed nodes up to latest
block.

But when restoring from seed, we receive the latest block height
from the seed nodes while BitcoinJ has not received all blocks yet and
is still syncing.

Fixes https://github.com/bisq-network/bisq/issues/2825