### PR TITLE
Fix confirm lockup transaction prompt showing incorrect estimated time

### DIFF
--- a/core/src/main/java/bisq/core/util/BSFormatter.java
+++ b/core/src/main/java/bisq/core/util/BSFormatter.java
@@ -632,8 +632,9 @@ public class BSFormatter {
 
         if (showSeconds) {
             format += "H\' " + hours + ", \'m\' " + minutes + ", \'s\' " + seconds + "\'";
-        } else
+        } else {
             format += "H\' " + hours + ", \'m\' " + minutes + "\'";
+        }
 
         String duration = durationMillis > 0 ? DurationFormatUtils.formatDuration(durationMillis, format) : "";
 
@@ -646,10 +647,10 @@ public class BSFormatter {
             duration = duration.replace(", 0 seconds", "");
             duration = duration.replace(", 0 minutes", "");
             duration = duration.replace(", 0 hours", "");
-            duration = duration.replace("0 days", "");
-            duration = duration.replace("0 hours, ", "");
-            duration = duration.replace("0 minutes, ", "");
-            duration = duration.replace("0 seconds", "");
+            duration = StringUtils.replacePattern(duration, "^0 days, ", "");
+            duration = StringUtils.replacePattern(duration, "^0 hours, ", "");
+            duration = StringUtils.replacePattern(duration, "^0 minutes, ", "");
+            duration = StringUtils.replacePattern(duration, "^0 seconds, ", "");
         }
         return duration.trim();
     }

--- a/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
@@ -93,6 +93,13 @@ public class BSFormatterTest {
         assertEquals("1 hour, 0 minutes, 1 second", formatter.formatDurationAsWords(oneHour + oneSecond, true, true));
         assertEquals("1 hour, 0 minutes, 2 seconds", formatter.formatDurationAsWords(oneHour + oneSecond * 2, true, true));
         assertEquals("2 days, 21 hours, 28 minutes", formatter.formatDurationAsWords(oneDay * 2 + oneHour * 21 + oneMinute * 28));
+        assertEquals("110 days", formatter.formatDurationAsWords(oneDay * 110, false, false));
+        assertEquals("10 days, 10 hours, 10 minutes, 10 seconds", formatter.formatDurationAsWords(oneDay * 10 + oneHour * 10 + oneMinute * 10 + oneSecond * 10, true, false));
+        assertEquals("1 hour, 2 seconds", formatter.formatDurationAsWords(oneHour + oneSecond * 2, true, false));
+        assertEquals("1 hour", formatter.formatDurationAsWords(oneHour + oneSecond * 2, false, false));
+        assertEquals("0 hours, 0 minutes, 1 second", formatter.formatDurationAsWords(oneSecond, true, true));
+        assertEquals("1 second", formatter.formatDurationAsWords(oneSecond, true, false));
+        assertEquals("0 hours", formatter.formatDurationAsWords(oneSecond, false, false));
         assertEquals("", formatter.formatDurationAsWords(0));
         assertTrue(formatter.formatDurationAsWords(0).isEmpty());
     }


### PR DESCRIPTION
When attempting to lock up a bond, the confirmation prompt was showing an incorrect estimated time:
![image](https://user-images.githubusercontent.com/603793/57958906-56f83980-78b6-11e9-9465-fa4bd0301432.png)

This PR fixes the estimated time:
![image](https://user-images.githubusercontent.com/603793/57958915-5c558400-78b6-11e9-91b2-8d9e2427d2c7.png)

