### PR TITLE
Fix "useless use of IPv6" in Tor socket

### DIFF
--- a/desktop/package/linux/package.sh
+++ b/desktop/package/linux/package.sh
@@ -108,6 +108,7 @@ $JAVA_HOME/bin/javapackager \
     -srcfiles desktop-$version-all.jar \
     -appclass bisq.desktop.app.BisqAppMain \
     -BjvmOptions=-Xss1280k \
+    -BjvmOptions=-Djava.net.preferIPv4Stack=true \
     -outfile Bisq-$version \
     -v
 
@@ -133,6 +134,7 @@ $JAVA_HOME/bin/javapackager \
     -srcfiles desktop-$version-all.jar \
     -appclass bisq.desktop.app.BisqAppMain \
     -BjvmOptions=-Xss1280k \
+    -BjvmOptions=-Djava.net.preferIPv4Stack=true \
     -outfile Bisq-$version \
     -v
 


### PR DESCRIPTION
Implements the "possible fix" described in issue #2840 by appending the directive `java.net.preferIPv4Stack=true` to the JVM options. 

Tested successfully on Debian 9 and Tails 3.14, using both native Tor and onion-grater. 