### PR TITLE
Fix AckMessage failure

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -628,7 +628,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                 log.warn("We don't send the message because the peer does not support the required capability. " +
                         "peersNodeAddress={}", peersNodeAddress);
 
-            return result;
+            return !result;
         }
 
         log.warn("We don't have the peer in our persisted peers so we don't know his capabilities. " +


### PR DESCRIPTION
When taking an offer, ack messages for
OfferAvailablilityRequest/Response were failing to be sent with the
following error.

> Jun-23 22:35:38.129 [JavaFX Application Thread] ERROR
> b.c.o.a.OfferAvailabilityProtocol: AckMessage for
> OfferAvailabilityResponse failed. AckMessage=AckMessage{
>      uid='8779f9ae-22e9-4f16-bbbb-4da89fe23cdf',
>      senderNodeAddress=localhost:3333,
>      sourceType=OFFER_MESSAGE,
>      sourceMsgClassName='OfferAvailabilityResponse',
>      sourceUid='df1a50c5-c6e7-4c81-8ad4-a100d622a053',
>      sourceId='pexluolj-2e5e5d9f-5aca-4a3d-b66a-60b72afe3d2c-112',
>      success=true,
>      errorMessage='null'
> } NetworkEnvelope{
>      messageVersion=12
> }, makersNodeAddress=localhost:3632, errorMessage=We did not send the
> EncryptedMessage because the peer does not support the capability.