### PR TITLE
Purge saved trades that failed market price check

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -161,7 +161,7 @@ public class BisqSetup {
     private Consumer<String> cryptoSetupFailedHandler, chainFileLockedExceptionHandler,
             spvFileCorruptedHandler, lockedUpFundsHandler, daoErrorMessageHandler, daoWarnMessageHandler,
             filterWarningHandler, displaySecurityRecommendationHandler, displayLocalhostHandler,
-            wrongOSArchitectureHandler;
+            wrongOSArchitectureHandler, cleanupDone;
     @Setter
     @Nullable
     private Consumer<Boolean> displayTorNetworkSettingsHandler;
@@ -283,6 +283,9 @@ public class BisqSetup {
     }
 
     public void start() {
+        if (cleanupDone != null)
+            cleanupDone.accept("Cleanup done, shutting down");
+
         maybeReSyncSPVChain();
         maybeShowTac();
     }

--- a/core/src/main/java/bisq/core/trade/TradableList.java
+++ b/core/src/main/java/bisq/core/trade/TradableList.java
@@ -71,6 +71,7 @@ public final class TradableList<T extends Tradable> implements PersistableEnvelo
     private TradableList(Storage<TradableList<T>> storage, List<T> list) {
         this.storage = storage;
         this.list.addAll(list);
+        storage.queueUpForSave();
     }
 
     @Override
@@ -107,6 +108,8 @@ public final class TradableList<T extends Tradable> implements PersistableEnvelo
                             throw new ProtobufferRuntimeException("Unknown messageCase. tradable.getMessageCase() = " + tradable.getMessageCase());
                     }
                 })
+                // This is a fix for saved failed trades that shouldn't have been saved. The usage of the error message
+                // is was the only way I know to make sure not to remove any trades that should remain.
                 .filter(tradable -> {
                     if (tradable instanceof Trade) {
                         Trade trade = (Trade) tradable;

--- a/core/src/main/java/bisq/core/trade/TradableList.java
+++ b/core/src/main/java/bisq/core/trade/TradableList.java
@@ -116,6 +116,8 @@ public final class TradableList<T extends Tradable> implements PersistableEnvelo
                         boolean toPurge = trade.getErrorMessage() != null &&
                                 trade.getErrorMessage().startsWith("An error occurred at task: MakerProcessPayDepositRequest\n" +
                                         "Taker's trade price is too far away from our calculated price based on the market price.");
+                        if (toPurge)
+                            log.info("Purging bad trade record id={}", trade.getId());
                         return !toPurge;
                     }
                     return true;

--- a/core/src/main/java/bisq/core/trade/TradableList.java
+++ b/core/src/main/java/bisq/core/trade/TradableList.java
@@ -107,6 +107,16 @@ public final class TradableList<T extends Tradable> implements PersistableEnvelo
                             throw new ProtobufferRuntimeException("Unknown messageCase. tradable.getMessageCase() = " + tradable.getMessageCase());
                     }
                 })
+                .filter(tradable -> {
+                    if (tradable instanceof Trade) {
+                        Trade trade = (Trade) tradable;
+                        boolean toPurge = trade.getErrorMessage() != null &&
+                                trade.getErrorMessage().startsWith("An error occurred at task: MakerProcessPayDepositRequest\n" +
+                                        "Taker's trade price is too far away from our calculated price based on the market price.");
+                        return !toPurge;
+                    }
+                    return true;
+                })
                 .collect(Collectors.toList());
 
         return new TradableList<>(storage, list);

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -282,6 +282,13 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void setupHandlers() {
+        bisqSetup.setCleanupDone(msg -> {
+            UserThread.execute(() -> new Popup<>().warning(msg)
+                    .useShutDownButton()
+                    .hideCloseButton()
+                    .show());
+        });
+
         bisqSetup.setDisplayTacHandler(acceptedHandler -> UserThread.runAfter(() -> {
             //noinspection FunctionalExpressionCanBeFolded
             tacWindow.onAction(acceptedHandler::run).show();


### PR DESCRIPTION
This is a way to clean saved failed take offers due to price disagreement. I don't know if there is any other signature apart from the errormessage to uniquely identify such saved failed trades so the matching for purges is done on the error message string.