### PR TITLE
Bundle of envelopes

### DIFF
--- a/common/src/main/java/bisq/common/app/Capability.java
+++ b/common/src/main/java/bisq/common/app/Capability.java
@@ -32,5 +32,6 @@ public enum Capability {
     BLIND_VOTE,
     ACK_MSG,
     BSQ_BLOCK,
-    DAO_STATE
+    DAO_STATE,
+    ENVELOPE_OF_ENVELOPES
 }

--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -66,12 +66,18 @@ message NetworkEnvelope {
         NewBlindVoteStateHashMessage new_blind_vote_state_hash_message = 40;
         GetBlindVoteStateHashesRequest get_blind_vote_state_hashes_request = 41;
         GetBlindVoteStateHashesResponse get_blind_vote_state_hashes_response = 42;
+
+        EnvelopeOfEnvelopes envelope_of_envelopes = 43;
     }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // Implementations of NetworkEnvelope
 ///////////////////////////////////////////////////////////////////////////////////////////
+
+message EnvelopeOfEnvelopes {
+    repeated NetworkEnvelope envelopes = 1;
+}
 
 // get data
 

--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -67,7 +67,7 @@ message NetworkEnvelope {
         GetBlindVoteStateHashesRequest get_blind_vote_state_hashes_request = 41;
         GetBlindVoteStateHashesResponse get_blind_vote_state_hashes_response = 42;
 
-        EnvelopeOfEnvelopes envelope_of_envelopes = 43;
+        BundleOfEnvelopes bundle_of_envelopes = 43;
     }
 }
 
@@ -75,7 +75,7 @@ message NetworkEnvelope {
 // Implementations of NetworkEnvelope
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-message EnvelopeOfEnvelopes {
+message BundleOfEnvelopes {
     repeated NetworkEnvelope envelopes = 1;
 }
 

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -54,7 +54,7 @@ import bisq.core.trade.statistics.TradeStatistics;
 
 import bisq.network.p2p.AckMessage;
 import bisq.network.p2p.CloseConnectionMessage;
-import bisq.network.p2p.EnvelopeOfEnvelopes;
+import bisq.network.p2p.BundleOfEnvelopes;
 import bisq.network.p2p.PrefixedSealedAndSignedMessage;
 import bisq.network.p2p.peers.getdata.messages.GetDataResponse;
 import bisq.network.p2p.peers.getdata.messages.GetUpdatedDataRequest;
@@ -191,8 +191,8 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case GET_BLIND_VOTE_STATE_HASHES_RESPONSE:
                     return GetBlindVoteStateHashesResponse.fromProto(proto.getGetBlindVoteStateHashesResponse(), messageVersion);
 
-                case ENVELOPE_OF_ENVELOPES:
-                    return EnvelopeOfEnvelopes.fromProto(proto.getEnvelopeOfEnvelopes(), this, messageVersion);
+                case BUNDLE_OF_ENVELOPES:
+                    return BundleOfEnvelopes.fromProto(proto.getBundleOfEnvelopes(), this, messageVersion);
 
                 default:
                     throw new ProtobufferException("Unknown proto message case (PB.NetworkEnvelope). messageCase=" +

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -54,6 +54,7 @@ import bisq.core.trade.statistics.TradeStatistics;
 
 import bisq.network.p2p.AckMessage;
 import bisq.network.p2p.CloseConnectionMessage;
+import bisq.network.p2p.EnvelopeOfEnvelopes;
 import bisq.network.p2p.PrefixedSealedAndSignedMessage;
 import bisq.network.p2p.peers.getdata.messages.GetDataResponse;
 import bisq.network.p2p.peers.getdata.messages.GetUpdatedDataRequest;
@@ -189,6 +190,9 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                     return GetBlindVoteStateHashesRequest.fromProto(proto.getGetBlindVoteStateHashesRequest(), messageVersion);
                 case GET_BLIND_VOTE_STATE_HASHES_RESPONSE:
                     return GetBlindVoteStateHashesResponse.fromProto(proto.getGetBlindVoteStateHashesResponse(), messageVersion);
+
+                case ENVELOPE_OF_ENVELOPES:
+                    return EnvelopeOfEnvelopes.fromProto(proto.getEnvelopeOfEnvelopes(), this, messageVersion);
 
                 default:
                     throw new ProtobufferException("Unknown proto message case (PB.NetworkEnvelope). messageCase=" +

--- a/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
+++ b/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CoreNetworkCapabilities {
     public static void setSupportedCapabilities(BisqEnvironment bisqEnvironment) {
         Capabilities.app.addAll(Capability.TRADE_STATISTICS, Capability.TRADE_STATISTICS_2, Capability.ACCOUNT_AGE_WITNESS, Capability.ACK_MSG);
+        Capabilities.app.addAll(Capability.ENVELOPE_OF_ENVELOPES);
 
         if (BisqEnvironment.isDaoActivated(bisqEnvironment)) {
             Capabilities.app.addAll(Capability.PROPOSAL, Capability.BLIND_VOTE, Capability.BSQ_BLOCK, Capability.DAO_STATE);

--- a/p2p/src/main/java/bisq/network/p2p/BundleOfEnvelopes.java
+++ b/p2p/src/main/java/bisq/network/p2p/BundleOfEnvelopes.java
@@ -34,11 +34,11 @@ import lombok.Value;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class EnvelopeOfEnvelopes extends NetworkEnvelope implements ExtendedDataSizePermission {
+public final class BundleOfEnvelopes extends NetworkEnvelope implements ExtendedDataSizePermission {
 
     private final List<NetworkEnvelope> envelopes;
 
-    public EnvelopeOfEnvelopes() {
+    public BundleOfEnvelopes() {
         this(new ArrayList<>(), Version.getP2PMessageVersion());
     }
 
@@ -50,7 +50,7 @@ public final class EnvelopeOfEnvelopes extends NetworkEnvelope implements Extend
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private EnvelopeOfEnvelopes(List<NetworkEnvelope> envelopes, int messageVersion) {
+    private BundleOfEnvelopes(List<NetworkEnvelope> envelopes, int messageVersion) {
         super(messageVersion);
         this.envelopes = envelopes;
     }
@@ -59,13 +59,13 @@ public final class EnvelopeOfEnvelopes extends NetworkEnvelope implements Extend
     @Override
     public PB.NetworkEnvelope toProtoNetworkEnvelope() {
         return getNetworkEnvelopeBuilder()
-                .setEnvelopeOfEnvelopes(PB.EnvelopeOfEnvelopes.newBuilder().addAllEnvelopes(envelopes.stream()
+                .setBundleOfEnvelopes(PB.BundleOfEnvelopes.newBuilder().addAllEnvelopes(envelopes.stream()
                         .map(NetworkEnvelope::toProtoNetworkEnvelope)
                         .collect(Collectors.toList())))
                 .build();
     }
 
-    public static EnvelopeOfEnvelopes fromProto(PB.EnvelopeOfEnvelopes proto, NetworkProtoResolver resolver, int messageVersion) {
+    public static BundleOfEnvelopes fromProto(PB.BundleOfEnvelopes proto, NetworkProtoResolver resolver, int messageVersion) {
         List<NetworkEnvelope> envelopes = proto.getEnvelopesList()
                 .stream()
                 .map(envelope -> {
@@ -78,6 +78,6 @@ public final class EnvelopeOfEnvelopes extends NetworkEnvelope implements Extend
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
-        return new EnvelopeOfEnvelopes(envelopes, messageVersion);
+        return new BundleOfEnvelopes(envelopes, messageVersion);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/EnvelopeOfEnvelopes.java
+++ b/p2p/src/main/java/bisq/network/p2p/EnvelopeOfEnvelopes.java
@@ -34,7 +34,7 @@ import lombok.Value;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class EnvelopeOfEnvelopes extends NetworkEnvelope {
+public final class EnvelopeOfEnvelopes extends NetworkEnvelope implements ExtendedDataSizePermission {
 
     private final List<NetworkEnvelope> envelopes;
 

--- a/p2p/src/main/java/bisq/network/p2p/EnvelopeOfEnvelopes.java
+++ b/p2p/src/main/java/bisq/network/p2p/EnvelopeOfEnvelopes.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p;
+
+import bisq.common.app.Version;
+import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.network.NetworkEnvelope;
+import bisq.common.proto.network.NetworkProtoResolver;
+
+import io.bisq.generated.protobuffer.PB;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+public final class EnvelopeOfEnvelopes extends NetworkEnvelope {
+
+    private final List<NetworkEnvelope> envelopes;
+
+    public EnvelopeOfEnvelopes() {
+        this(new ArrayList<>(), Version.getP2PMessageVersion());
+    }
+
+    public void add(NetworkEnvelope networkEnvelope) {
+        envelopes.add(networkEnvelope);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private EnvelopeOfEnvelopes(List<NetworkEnvelope> envelopes, int messageVersion) {
+        super(messageVersion);
+        this.envelopes = envelopes;
+    }
+
+
+    @Override
+    public PB.NetworkEnvelope toProtoNetworkEnvelope() {
+        return getNetworkEnvelopeBuilder()
+                .setEnvelopeOfEnvelopes(PB.EnvelopeOfEnvelopes.newBuilder().addAllEnvelopes(envelopes.stream()
+                        .map(NetworkEnvelope::toProtoNetworkEnvelope)
+                        .collect(Collectors.toList())))
+                .build();
+    }
+
+    public static EnvelopeOfEnvelopes fromProto(PB.EnvelopeOfEnvelopes proto, NetworkProtoResolver resolver, int messageVersion) {
+        List<NetworkEnvelope> envelopes = proto.getEnvelopesList()
+                .stream()
+                .map(envelope -> {
+                    try {
+                        return resolver.fromProto(envelope);
+                    } catch (ProtobufferException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return new EnvelopeOfEnvelopes(envelopes, messageVersion);
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -193,7 +193,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         uid = UUID.randomUUID().toString();
         statistic = new Statistic();
 
-        if(connectionConfig == null)
+        if (connectionConfig == null)
             connectionConfig = new ConnectionConfig(MSG_THROTTLE_PER_SEC, MSG_THROTTLE_PER_10_SEC, SEND_MSG_THROTTLE_TRIGGER, SEND_MSG_THROTTLE_SLEEP);
         msgThrottlePerSec = connectionConfig.getMsgThrottlePerSec();
         msgThrottlePer10Sec = connectionConfig.getMsgThrottlePer10Sec();
@@ -287,11 +287,11 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                                 networkEnvelope.getClass().getSimpleName());
 
                         // check if BundleOfEnvelopes is supported
-                        if(getCapabilities().containsAll(new Capabilities(Capability.ENVELOPE_OF_ENVELOPES))) {
+                        if (getCapabilities().containsAll(new Capabilities(Capability.ENVELOPE_OF_ENVELOPES))) {
                             synchronized (lock) {
                                 // check if current envelope fits size
                                 // - no? create new envelope
-                                if(queueOfBundles.isEmpty() || queueOfBundles.element().toProtoNetworkEnvelope().getSerializedSize() + networkEnvelope.toProtoNetworkEnvelope().getSerializedSize() > MAX_PERMITTED_MESSAGE_SIZE * 0.9) {
+                                if (queueOfBundles.isEmpty() || queueOfBundles.element().toProtoNetworkEnvelope().getSerializedSize() + networkEnvelope.toProtoNetworkEnvelope().getSerializedSize() > MAX_PERMITTED_MESSAGE_SIZE * 0.9) {
                                     // - no? create a bucket
                                     queueOfBundles.add(new BundleOfEnvelopes());
 
@@ -432,8 +432,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         checkArgument(connection.equals(this));
 
-        if(networkEnvelope instanceof BundleOfEnvelopes)
-            for(NetworkEnvelope current : ((BundleOfEnvelopes) networkEnvelope).getEnvelopes()) {
+        if (networkEnvelope instanceof BundleOfEnvelopes)
+            for (NetworkEnvelope current : ((BundleOfEnvelopes) networkEnvelope).getEnvelopes()) {
                 UserThread.execute(() -> messageListeners.forEach(e -> e.onMessage(current, connection)));
             }
         else

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -294,7 +294,6 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                                 if(queueOfBundles.isEmpty() || queueOfBundles.element().toProtoNetworkEnvelope().getSerializedSize() + networkEnvelope.toProtoNetworkEnvelope().getSerializedSize() > MAX_PERMITTED_MESSAGE_SIZE * 0.9) {
                                     // - no? create a bucket
                                     queueOfBundles.add(new BundleOfEnvelopes());
-                                    System.err.println("added fresh container");
 
                                     // - and schedule it for sending
                                     lastSendTimeStamp += sendMsgThrottleSleep;

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -295,15 +295,17 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                                     // - no? create a bucket
                                     envelopeOfEnvelopes.add(new EnvelopeOfEnvelopes());
                                     System.err.println("added fresh container");
+
                                     // - and schedule it for sending
+                                    lastSendTimeStamp += sendMsgThrottleSleep;
+
                                     envelopeOfEnvelopesSender.schedule(() -> {
                                         if (!stopped) {
                                             synchronized (lock) {
-                                                lastSendTimeStamp = System.currentTimeMillis();
                                                 protoOutputStream.writeEnvelope(envelopeOfEnvelopes.poll());
                                             }
                                         }
-                                    }, sendMsgThrottleSleep, TimeUnit.MILLISECONDS);
+                                    }, lastSendTimeStamp - now, TimeUnit.MILLISECONDS);
                                 }
 
                                 // - yes? add to bucket


### PR DESCRIPTION
Seeing an oszillating pattern of broadcast message numbers in [monitoring](https://monitor.bisq.network/d/wTDl6T_iz/p2p-stats?refresh=30s&orgId=1), @ManfredKarrer and I suspected that the pattern might be caused by the DoS protection mechanisms in place.

This PR introduces a new message that containing a number of existing messages. The hopes are:
- less connection setup overhead on the network level leading to less network load and hopefully better performance
- not to spread the bursts of e.g. RefreshOffer messages over a long time

In case this change has a bad effect on network stability (although we do not believe it is going to) we can simply remove the newly created `Capability` in a future release and thus, quickly get rid of the feature.

I tested the code extensively by running
- 4 nodes locally
- they knew each other as seed nodes
- one of the nodes was connected to the live bisq network
- had this setup running for days for each iteration