### PR TITLE
Don't dump blockchain data during initial parsing

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
+++ b/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
@@ -134,7 +134,8 @@ public class ExportJsonFilesService implements DaoSetupService {
     }
 
     public void maybeExportToJson() {
-        if (dumpBlockchainData) {
+        if (dumpBlockchainData &&
+                daoStateService.isParseBlockChainComplete()) {
             // We store the data we need once we write the data to disk (in the thread) locally.
             // Access to daoStateService is single threaded, we must not access daoStateService from the thread.
             List<JsonTxOutput> allJsonTxOutputs = new ArrayList<>();


### PR DESCRIPTION
Avoid dumping blockchain after every parsed block during initial parsing, it's really slow.