### PR TITLE
Initial block sync fixes

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/BsqNode.java
+++ b/core/src/main/java/bisq/core/dao/node/BsqNode.java
@@ -239,7 +239,9 @@ public abstract class BsqNode implements DaoSetupService {
                 // We take only first element after sorting (so it is the block with the next height) to avoid that
                 // we would repeat calls in recursions in case we  would iterate the list.
                 pendingBlocks.sort(Comparator.comparing(RawBlock::getHeight));
-                doParseBlock(pendingBlocks.get(0));
+                RawBlock nextPending = pendingBlocks.get(0);
+                if (nextPending.getHeight() == daoStateService.getChainHeight() + 1)
+                    doParseBlock(nextPending);
             }
 
             return Optional.of(block);

--- a/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
@@ -76,7 +76,7 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
     public interface Listener {
         void onNoSeedNodeAvailable();
 
-        void onRequestedBlocksReceived(GetBlocksResponse getBlocksResponse);
+        void onRequestedBlocksReceived(GetBlocksResponse getBlocksResponse, Runnable onParsingComplete);
 
         void onNewBlockReceived(NewBlockBroadcastMessage newBlockBroadcastMessage);
 
@@ -269,11 +269,12 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
                                     if (startBlockHeight >= lastReceivedBlockHeight) {
                                         lastReceivedBlockHeight = startBlockHeight;
 
-                                        // After we received the blocks we allow to disconnect seed nodes.
-                                        // We delay 20 seconds to allow multiple requests to finish.
-                                        UserThread.runAfter(() -> peerManager.setAllowDisconnectSeedNodes(true), 20);
-
-                                        listeners.forEach(listener -> listener.onRequestedBlocksReceived(getBlocksResponse));
+                                        listeners.forEach(listener -> listener.onRequestedBlocksReceived(getBlocksResponse,
+                                                () -> {
+                                                    // After we received the blocks we allow to disconnect seed nodes.
+                                                    // We delay 20 seconds to allow multiple requests to finish.
+                                                    UserThread.runAfter(() -> peerManager.setAllowDisconnectSeedNodes(true), 20);
+                                                }));
                                     } else {
                                         log.warn("We got a response which is already obsolete because we receive a " +
                                                 "response from a request with a higher block height. " +


### PR DESCRIPTION
The fix to continue requesting blocks is essential if we are to go ahead with the limit of 6000 blocks max per request.