### PR TITLE
make rpc host configurable

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqEnvironment.java
+++ b/core/src/main/java/bisq/core/app/BisqEnvironment.java
@@ -191,13 +191,12 @@ public class BisqEnvironment extends StandardEnvironment {
     @Getter
     protected List<String> bannedSeedNodes, bannedBtcNodes, bannedPriceRelayNodes;
 
-    protected final String btcNodes, seedNodes, ignoreDevMsg, useDevPrivilegeKeys, useDevMode, useTorForBtc, rpcUser,
-            rpcPassword, rpcPort, rpcBlockNotificationPort, dumpBlockchainData, fullDaoNode,
+    protected final String btcNodes, seedNodes, ignoreDevMsg, useDevPrivilegeKeys, useDevMode, useTorForBtc, rpcUser, rpcPassword,
+            rpcHost, rpcPort, rpcBlockNotificationPort, dumpBlockchainData, fullDaoNode,
             banList, dumpStatistics, maxMemory, socks5ProxyBtcAddress,
             torRcFile, torRcOptions, externalTorControlPort, externalTorPassword, externalTorCookieFile,
-            socks5ProxyHttpAddress, useAllProvidedNodes, numConnectionForBtc, genesisTxId, genesisBlockHeight,
-            genesisTotalSupply, referralId, daoActivated, msgThrottlePerSec, msgThrottlePer10Sec, sendMsgThrottleTrigger,
-            sendMsgThrottleSleep, ignoreLocalBtcNode;
+            socks5ProxyHttpAddress, useAllProvidedNodes, numConnectionForBtc, genesisTxId, genesisBlockHeight, genesisTotalSupply,
+            referralId, daoActivated, msgThrottlePerSec, msgThrottlePer10Sec, sendMsgThrottleTrigger, sendMsgThrottleSleep, ignoreLocalBtcNode;
 
     protected final boolean externalTorUseSafeCookieAuthentication, torStreamIsolation;
 
@@ -305,6 +304,9 @@ public class BisqEnvironment extends StandardEnvironment {
                 "";
         rpcPassword = commandLineProperties.containsProperty(DaoOptionKeys.RPC_PASSWORD) ?
                 (String) commandLineProperties.getProperty(DaoOptionKeys.RPC_PASSWORD) :
+                "";
+        rpcHost = commandLineProperties.containsProperty(DaoOptionKeys.RPC_HOST) ?
+                (String) commandLineProperties.getProperty(DaoOptionKeys.RPC_HOST) :
                 "";
         rpcPort = commandLineProperties.containsProperty(DaoOptionKeys.RPC_PORT) ?
                 (String) commandLineProperties.getProperty(DaoOptionKeys.RPC_PORT) :
@@ -504,6 +506,7 @@ public class BisqEnvironment extends StandardEnvironment {
 
                 setProperty(DaoOptionKeys.RPC_USER, rpcUser);
                 setProperty(DaoOptionKeys.RPC_PASSWORD, rpcPassword);
+                setProperty(DaoOptionKeys.RPC_HOST, rpcHost);
                 setProperty(DaoOptionKeys.RPC_PORT, rpcPort);
                 setProperty(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT, rpcBlockNotificationPort);
                 setProperty(DaoOptionKeys.DUMP_BLOCKCHAIN_DATA, dumpBlockchainData);

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -541,6 +541,10 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
                 "Bitcoind rpc password")
                 .withRequiredArg();
 
+        parser.accepts(DaoOptionKeys.RPC_HOST,
+                "Bitcoind rpc host")
+                .withRequiredArg();
+
         parser.accepts(DaoOptionKeys.RPC_PORT,
                 "Bitcoind rpc port")
                 .withRequiredArg();

--- a/core/src/main/java/bisq/core/dao/DaoModule.java
+++ b/core/src/main/java/bisq/core/dao/DaoModule.java
@@ -225,6 +225,7 @@ public class DaoModule extends AppModule {
         // Options
         bindConstant().annotatedWith(named(DaoOptionKeys.RPC_USER)).to(environment.getRequiredProperty(DaoOptionKeys.RPC_USER));
         bindConstant().annotatedWith(named(DaoOptionKeys.RPC_PASSWORD)).to(environment.getRequiredProperty(DaoOptionKeys.RPC_PASSWORD));
+        bindConstant().annotatedWith(named(DaoOptionKeys.RPC_HOST)).to(environment.getRequiredProperty(DaoOptionKeys.RPC_HOST));
         bindConstant().annotatedWith(named(DaoOptionKeys.RPC_PORT)).to(environment.getRequiredProperty(DaoOptionKeys.RPC_PORT));
         bindConstant().annotatedWith(named(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT))
                 .to(environment.getRequiredProperty(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT));

--- a/core/src/main/java/bisq/core/dao/DaoOptionKeys.java
+++ b/core/src/main/java/bisq/core/dao/DaoOptionKeys.java
@@ -25,6 +25,7 @@ public class DaoOptionKeys {
     public static final String RPC_PASSWORD = "rpcPassword";
     public static final String RPC_PORT = "rpcPort";
     public static final String RPC_BLOCK_NOTIFICATION_PORT = "rpcBlockNotificationPort";
+    public static final String RPC_HOST = "rpcHost";
 
     public static final String DUMP_BLOCKCHAIN_DATA = "dumpBlockchainData";
     public static final String FULL_DAO_NODE = "fullDaoNode";

--- a/core/src/main/java/bisq/core/dao/node/full/RpcService.java
+++ b/core/src/main/java/bisq/core/dao/node/full/RpcService.java
@@ -72,8 +72,9 @@ import org.jetbrains.annotations.NotNull;
 public class RpcService {
     private final String rpcUser;
     private final String rpcPassword;
+    private final String rpcHost;
     private final String rpcPort;
-    private final int blockNotifyPort;
+    private final String rpcBlockPort;
 
     private BtcdClient client;
     private BtcdDaemon daemon;
@@ -90,22 +91,28 @@ public class RpcService {
     @SuppressWarnings("WeakerAccess")
     @Inject
     public RpcService(Preferences preferences,
-                      @Named(DaoOptionKeys.RPC_PORT) String rpcPort) {
+                      @Named(DaoOptionKeys.RPC_HOST) String rpcHost,
+                      @Named(DaoOptionKeys.RPC_PORT) String rpcPort,
+                      @Named(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT) String rpcBlockPort) {
         this.rpcUser = preferences.getRpcUser();
         this.rpcPassword = preferences.getRpcPw();
-        this.blockNotifyPort = preferences.getBlockNotifyPort();
 
         // mainnet is 8332, testnet 18332, regtest 18443
+        boolean isHostSet = rpcHost != null && !rpcHost.isEmpty();
         boolean isPortSet = rpcPort != null && !rpcPort.isEmpty();
         boolean isMainnet = BisqEnvironment.getBaseCurrencyNetwork().isMainnet();
         boolean isTestnet = BisqEnvironment.getBaseCurrencyNetwork().isTestnet();
         boolean isDaoBetaNet = BisqEnvironment.getBaseCurrencyNetwork().isDaoBetaNet();
+        log.info("The value of rpchost is {}", rpcHost);
+        this.rpcHost = isHostSet ? rpcHost : "127.0.0.1";
         this.rpcPort = isPortSet ? rpcPort :
                 isMainnet || isDaoBetaNet ? "8332" :
                         isTestnet ? "18332" :
                                         "18443"; // regtest
+        this.rpcBlockPort = rpcBlockPort != null && !rpcBlockPort.isEmpty() ? rpcBlockPort : "5125";
 
-        log.info("Version of btcd-cli4j library: {}", BtcdCli4jVersion.VERSION);
+        log.info("Starting RPCService with btcd-cli4j version {} on {}:{} with user {}", BtcdCli4jVersion.VERSION,
+                this.rpcHost, this.rpcPort, this.rpcUser);
     }
 
 
@@ -121,12 +128,12 @@ public class RpcService {
                 CloseableHttpClient httpProvider = HttpClients.custom().setConnectionManager(cm).build();
                 Properties nodeConfig = new Properties();
                 nodeConfig.setProperty("node.bitcoind.rpc.protocol", "http");
-                nodeConfig.setProperty("node.bitcoind.rpc.host", "127.0.0.1");
+                nodeConfig.setProperty("node.bitcoind.rpc.host", rpcHost);
                 nodeConfig.setProperty("node.bitcoind.rpc.auth_scheme", "Basic");
                 nodeConfig.setProperty("node.bitcoind.rpc.user", rpcUser);
                 nodeConfig.setProperty("node.bitcoind.rpc.password", rpcPassword);
                 nodeConfig.setProperty("node.bitcoind.rpc.port", rpcPort);
-                nodeConfig.setProperty("node.bitcoind.notification.block.port", String.valueOf(blockNotifyPort));
+                nodeConfig.setProperty("node.bitcoind.notification.block.port", rpcBlockPort);
                 nodeConfig.setProperty("node.bitcoind.notification.alert.port", String.valueOf(bisq.network.p2p.Utils.findFreeSystemPort()));
                 nodeConfig.setProperty("node.bitcoind.notification.wallet.port", String.valueOf(bisq.network.p2p.Utils.findFreeSystemPort()));
 


### PR DESCRIPTION
What: 
* make the rpc host configurable
* rename blockNotifyPort to rpcBlockPort
* add information to log text on RpcService startup

Why: 
when using docker (or different servers), the bitcoin full node and seednode run on different ip's. 
