### PR TITLE
log stacktrace to logfile when a task fails

### DIFF
--- a/common/src/main/java/bisq/common/taskrunner/Task.java
+++ b/common/src/main/java/bisq/common/taskrunner/Task.java
@@ -64,9 +64,8 @@ public abstract class Task<T extends Model> {
     }
 
     protected void failed(Throwable t) {
-        t.printStackTrace();
-        appendExceptionToErrorMessage(t);
-        failed();
+        log.error(errorMessage, t);
+        taskHandler.handleErrorMessage(errorMessage);
     }
 
     protected void failed() {


### PR DESCRIPTION
when investigating https://github.com/bisq-network/bisq/issues/2987 i noticed that we log stack traces to stdout instead of the log file. this pr fixes that. 
