### PR TITLE
improve the signedwitnessservicetest

### DIFF
--- a/core/src/main/java/bisq/core/account/sign/SignedWitness.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitness.java
@@ -29,7 +29,6 @@ import bisq.common.crypto.Hash;
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.util.Utilities;
 
-
 import com.google.protobuf.ByteString;
 
 import org.bitcoinj.core.Coin;
@@ -72,8 +71,8 @@ public class SignedWitness implements LazyProcessedPayload, PersistableNetworkPa
         this.date = date;
         this.tradeAmount = tradeAmount;
 
-        // The hash is only using the data which do not change in repeated trades between same users (no date or amount).
-        // We only want to store the first and oldest one and will ignore others. That will help also to protect privacy
+        // The hash is only using the data which does not change in repeated trades between identical users (no date or amount).
+        // We only want to store the first and oldest one and will ignore others. That will also help to protect privacy
         // so that the total number of trades is not revealed. We use putIfAbsent when we store the data so first
         // object will win. We consider one signed trade with one peer enough and do not consider repeated trades with
         // same peer to add more security as if that one would be colluding it would be not detected anyway. The total
@@ -86,7 +85,7 @@ public class SignedWitness implements LazyProcessedPayload, PersistableNetworkPa
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
-    // PROTO BUFFER
+    // PROTOBUF
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
@@ -102,7 +101,7 @@ public class SignedWitness implements LazyProcessedPayload, PersistableNetworkPa
         return protobuf.PersistableNetworkPayload.newBuilder().setSignedWitness(builder).build();
     }
 
-    public protobuf.SignedWitness toProtoSignedWitness() {
+    protobuf.SignedWitness toProtoSignedWitness() {
         return toProtoMessage().getSignedWitness();
     }
 
@@ -149,7 +148,7 @@ public class SignedWitness implements LazyProcessedPayload, PersistableNetworkPa
     // Getters
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public P2PDataStorage.ByteArray getHashAsByteArray() {
+    P2PDataStorage.ByteArray getHashAsByteArray() {
         return new P2PDataStorage.ByteArray(hash);
     }
 

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -108,8 +108,6 @@ public class SignedWitnessServiceTest {
 
     @Test
     public void testIsValidAccountAgeWitnessOk() {
-
-
         SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
         SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
@@ -125,8 +123,6 @@ public class SignedWitnessServiceTest {
 
     @Test
     public void testIsValidAccountAgeWitnessArbitratorSignatureProblem() {
-
-
         signature1 = new byte[]{1, 2, 3};
 
         SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
@@ -144,8 +140,6 @@ public class SignedWitnessServiceTest {
 
     @Test
     public void testIsValidAccountAgeWitnessPeerSignatureProblem() {
-
-
         signature2 = new byte[]{1, 2, 3};
 
         SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
@@ -163,8 +157,6 @@ public class SignedWitnessServiceTest {
 
     @Test
     public void testIsValidAccountAgeWitnessDateTooSoonProblem() {
-
-
         date3 = getTodayMinusNDays(63);
 
         SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
@@ -182,8 +174,6 @@ public class SignedWitnessServiceTest {
 
     @Test
     public void testIsValidAccountAgeWitnessDateTooLateProblem() {
-
-
         date3 = getTodayMinusNDays(3);
 
         SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -89,13 +89,9 @@ public class SignedWitnessServiceTest {
         KeyPair peer1KeyPair = Sig.generateKeyPair();
         KeyPair peer2KeyPair = Sig.generateKeyPair();
         KeyPair peer3KeyPair = Sig.generateKeyPair();
-        String account1DataHashAsHexString = Utilities.encodeToHex(account1DataHash);
-        String account2DataHashAsHexString = Utilities.encodeToHex(account2DataHash);
-        String account3DataHashAsHexString = Utilities.encodeToHex(account3DataHash);
-        String signature1String = arbitrator1Key.signMessage(account1DataHashAsHexString);
-        signature1 = signature1String.getBytes(Charsets.UTF_8);
-        signature2 = Sig.sign(peer1KeyPair.getPrivate(), account2DataHashAsHexString.getBytes(Charsets.UTF_8));
-        signature3 = Sig.sign(peer2KeyPair.getPrivate(), account3DataHashAsHexString.getBytes(Charsets.UTF_8));
+        signature1 = arbitrator1Key.signMessage(Utilities.encodeToHex(account1DataHash)).getBytes(Charsets.UTF_8);
+        signature2 = Sig.sign(peer1KeyPair.getPrivate(), Utilities.encodeToHex(account2DataHash).getBytes(Charsets.UTF_8));
+        signature3 = Sig.sign(peer2KeyPair.getPrivate(), Utilities.encodeToHex(account3DataHash).getBytes(Charsets.UTF_8));
         date1 = getTodayMinusNDays(95);
         date2 = getTodayMinusNDays(64);
         date3 = getTodayMinusNDays(33);

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -38,10 +38,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -127,43 +128,7 @@ public class SignedWitnessServiceTest {
 
     @Test
     public void testIsValidAccountAgeWitnessOk() {
-        testIsValidAccountAgeWitness(false, false, false, false);
-    }
 
-    @Test
-    public void testIsValidAccountAgeWitnessArbitratorSignatureProblem() {
-        testIsValidAccountAgeWitness(true, false, false, false);
-    }
-
-    @Test
-    public void testIsValidAccountAgeWitnessPeerSignatureProblem() {
-        testIsValidAccountAgeWitness(false, true, false, false);
-    }
-
-    @Test
-    public void testIsValidAccountAgeWitnessDateTooSoonProblem() {
-        testIsValidAccountAgeWitness(false, false, true, false);
-    }
-
-    @Test
-    public void testIsValidAccountAgeWitnessDateTooLateProblem() {
-        testIsValidAccountAgeWitness(false, false, false, true);
-    }
-
-    private void testIsValidAccountAgeWitness(boolean signature1Problem, boolean signature2Problem, boolean date3TooSoonProblem, boolean date3TooLateProblem) {
-
-
-        if (signature1Problem) {
-            signature1 = new byte[]{1, 2, 3};
-        }
-        if (signature2Problem) {
-            signature2 = new byte[]{1, 2, 3};
-        }
-        if (date3TooSoonProblem) {
-            date3 = getTodayMinusNDays(63);
-        } else if (date3TooLateProblem) {
-            date3 = getTodayMinusNDays(3);
-        }
 
         SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
@@ -173,9 +138,85 @@ public class SignedWitnessServiceTest {
         service.addToMap(sw2);
         service.addToMap(sw3);
 
-        Assert.assertEquals(!signature1Problem, service.isValidAccountAgeWitness(aew1));
-        Assert.assertEquals(!signature1Problem && !signature2Problem, service.isValidAccountAgeWitness(aew2));
-        Assert.assertEquals(!signature1Problem && !signature2Problem && !date3TooSoonProblem && !date3TooLateProblem, service.isValidAccountAgeWitness(aew3));
+        assertTrue(service.isValidAccountAgeWitness(aew1));
+        assertTrue(service.isValidAccountAgeWitness(aew2));
+        assertTrue(service.isValidAccountAgeWitness(aew3));
+    }
+
+    @Test
+    public void testIsValidAccountAgeWitnessArbitratorSignatureProblem() {
+
+
+        signature1 = new byte[]{1, 2, 3};
+
+        SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
+        SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
+        SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
+
+        service.addToMap(sw1);
+        service.addToMap(sw2);
+        service.addToMap(sw3);
+
+        assertFalse(service.isValidAccountAgeWitness(aew1));
+        assertFalse(service.isValidAccountAgeWitness(aew2));
+        assertFalse(service.isValidAccountAgeWitness(aew3));
+    }
+
+    @Test
+    public void testIsValidAccountAgeWitnessPeerSignatureProblem() {
+
+
+        signature2 = new byte[]{1, 2, 3};
+
+        SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
+        SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
+        SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
+
+        service.addToMap(sw1);
+        service.addToMap(sw2);
+        service.addToMap(sw3);
+
+        assertTrue(service.isValidAccountAgeWitness(aew1));
+        assertFalse(service.isValidAccountAgeWitness(aew2));
+        assertFalse(service.isValidAccountAgeWitness(aew3));
+    }
+
+    @Test
+    public void testIsValidAccountAgeWitnessDateTooSoonProblem() {
+
+
+        date3 = getTodayMinusNDays(63);
+
+        SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
+        SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
+        SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
+
+        service.addToMap(sw1);
+        service.addToMap(sw2);
+        service.addToMap(sw3);
+
+        assertTrue(service.isValidAccountAgeWitness(aew1));
+        assertTrue(service.isValidAccountAgeWitness(aew2));
+        assertFalse(service.isValidAccountAgeWitness(aew3));
+    }
+
+    @Test
+    public void testIsValidAccountAgeWitnessDateTooLateProblem() {
+
+
+        date3 = getTodayMinusNDays(3);
+
+        SignedWitness sw1 = new SignedWitness(true, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
+        SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
+        SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
+
+        service.addToMap(sw1);
+        service.addToMap(sw2);
+        service.addToMap(sw3);
+
+        assertTrue(service.isValidAccountAgeWitness(aew1));
+        assertTrue(service.isValidAccountAgeWitness(aew2));
+        assertFalse(service.isValidAccountAgeWitness(aew3));
     }
 
 
@@ -226,14 +267,14 @@ public class SignedWitnessServiceTest {
         service.addToMap(sw2);
         service.addToMap(sw3);
 
-        Assert.assertFalse(service.isValidAccountAgeWitness(aew3));
+        assertFalse(service.isValidAccountAgeWitness(aew3));
     }
 
 
     @Test
     public void testIsValidAccountAgeWitnessLongLoop() throws Exception {
         AccountAgeWitness aew = null;
-        KeyPair signerKeyPair = Sig.generateKeyPair();
+        KeyPair signerKeyPair;
         KeyPair signedKeyPair = Sig.generateKeyPair();
         int iterations = 1002;
         for (int i = 0; i < iterations; i++) {
@@ -262,7 +303,7 @@ public class SignedWitnessServiceTest {
             SignedWitness sw = new SignedWitness(i == 0, accountDataHash, signature, signerPubKey, witnessOwnerPubKey, date, tradeAmount);
             service.addToMap(sw);
         }
-        Assert.assertFalse(service.isValidAccountAgeWitness(aew));
+        assertFalse(service.isValidAccountAgeWitness(aew));
     }
 
 

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -37,7 +37,6 @@ import java.time.temporal.ChronoUnit;
 
 import java.util.Date;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,20 +51,9 @@ public class SignedWitnessServiceTest {
     private byte[] account1DataHash;
     private byte[] account2DataHash;
     private byte[] account3DataHash;
-    private long account1CreationTime;
-    private long account2CreationTime;
-    private long account3CreationTime;
     private AccountAgeWitness aew1;
     private AccountAgeWitness aew2;
     private AccountAgeWitness aew3;
-    private ECKey arbitrator1Key;
-    private KeyPair peer1KeyPair;
-    private KeyPair peer2KeyPair;
-    private KeyPair peer3KeyPair;
-    private String account1DataHashAsHexString;
-    private String account2DataHashAsHexString;
-    private String account3DataHashAsHexString;
-    private String signature1String;
     private byte[] signature1;
     private byte[] signature2;
     private byte[] signature3;
@@ -91,26 +79,26 @@ public class SignedWitnessServiceTest {
         account1DataHash = org.bitcoinj.core.Utils.sha256hash160(new byte[]{1});
         account2DataHash = org.bitcoinj.core.Utils.sha256hash160(new byte[]{2});
         account3DataHash = org.bitcoinj.core.Utils.sha256hash160(new byte[]{3});
-        account1CreationTime = getTodayMinusNDays(96);
-        account2CreationTime = getTodayMinusNDays(66);
-        account3CreationTime = getTodayMinusNDays(36);
+        long account1CreationTime = getTodayMinusNDays(96);
+        long account2CreationTime = getTodayMinusNDays(66);
+        long account3CreationTime = getTodayMinusNDays(36);
         aew1 = new AccountAgeWitness(account1DataHash, account1CreationTime);
         aew2 = new AccountAgeWitness(account2DataHash, account2CreationTime);
         aew3 = new AccountAgeWitness(account3DataHash, account3CreationTime);
-        arbitrator1Key = new ECKey();
-        peer1KeyPair = Sig.generateKeyPair();
-        peer2KeyPair = Sig.generateKeyPair();
-        peer3KeyPair = Sig.generateKeyPair();
-        account1DataHashAsHexString = Utilities.encodeToHex(account1DataHash);
-        account2DataHashAsHexString = Utilities.encodeToHex(account2DataHash);
-        account3DataHashAsHexString = Utilities.encodeToHex(account3DataHash);
-        signature1String = arbitrator1Key.signMessage(account1DataHashAsHexString);
+        ECKey arbitrator1Key = new ECKey();
+        KeyPair peer1KeyPair = Sig.generateKeyPair();
+        KeyPair peer2KeyPair = Sig.generateKeyPair();
+        KeyPair peer3KeyPair = Sig.generateKeyPair();
+        String account1DataHashAsHexString = Utilities.encodeToHex(account1DataHash);
+        String account2DataHashAsHexString = Utilities.encodeToHex(account2DataHash);
+        String account3DataHashAsHexString = Utilities.encodeToHex(account3DataHash);
+        String signature1String = arbitrator1Key.signMessage(account1DataHashAsHexString);
         signature1 = signature1String.getBytes(Charsets.UTF_8);
         signature2 = Sig.sign(peer1KeyPair.getPrivate(), account2DataHashAsHexString.getBytes(Charsets.UTF_8));
+        signature3 = Sig.sign(peer2KeyPair.getPrivate(), account3DataHashAsHexString.getBytes(Charsets.UTF_8));
         date1 = getTodayMinusNDays(95);
         date2 = getTodayMinusNDays(64);
         date3 = getTodayMinusNDays(33);
-        signature3 = Sig.sign(peer2KeyPair.getPrivate(), account3DataHashAsHexString.getBytes(Charsets.UTF_8));
         signer1PubKey = arbitrator1Key.getPubKey();
         signer2PubKey = Sig.getPublicKeyBytes(peer1KeyPair.getPublic());
         signer3PubKey = Sig.getPublicKeyBytes(peer2KeyPair.getPublic());
@@ -120,10 +108,6 @@ public class SignedWitnessServiceTest {
         tradeAmount1 = 1000;
         tradeAmount2 = 1001;
         tradeAmount3 = 1001;
-    }
-
-    @After
-    public void tearDown() {
     }
 
     @Test
@@ -299,8 +283,7 @@ public class SignedWitnessServiceTest {
             }
             byte[] witnessOwnerPubKey = Sig.getPublicKeyBytes(signedKeyPair.getPublic());
             long date = getTodayMinusNDays((iterations - i) * (SignedWitnessService.CHARGEBACK_SAFETY_DAYS + 1));
-            long tradeAmount = 1000;
-            SignedWitness sw = new SignedWitness(i == 0, accountDataHash, signature, signerPubKey, witnessOwnerPubKey, date, tradeAmount);
+            SignedWitness sw = new SignedWitness(i == 0, accountDataHash, signature, signerPubKey, witnessOwnerPubKey, date, tradeAmount1);
             service.addToMap(sw);
         }
         assertFalse(service.isValidAccountAgeWitness(aew));

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SignedWitnessServiceTest {
-    private SignedWitnessService service;
+    private SignedWitnessService signedWitnessService;
     private byte[] account1DataHash;
     private byte[] account2DataHash;
     private byte[] account3DataHash;
@@ -75,7 +75,7 @@ public class SignedWitnessServiceTest {
         AppendOnlyDataStoreService appendOnlyDataStoreService = mock(AppendOnlyDataStoreService.class);
         ArbitratorManager arbitratorManager = mock(ArbitratorManager.class);
         when(arbitratorManager.isPublicKeyInList(any())).thenReturn(true);
-        service = new SignedWitnessService(null, null, null, arbitratorManager, null, appendOnlyDataStoreService);
+        signedWitnessService = new SignedWitnessService(null, null, null, arbitratorManager, null, appendOnlyDataStoreService);
         account1DataHash = org.bitcoinj.core.Utils.sha256hash160(new byte[]{1});
         account2DataHash = org.bitcoinj.core.Utils.sha256hash160(new byte[]{2});
         account3DataHash = org.bitcoinj.core.Utils.sha256hash160(new byte[]{3});
@@ -118,13 +118,13 @@ public class SignedWitnessServiceTest {
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
         SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
 
-        service.addToMap(sw1);
-        service.addToMap(sw2);
-        service.addToMap(sw3);
+        signedWitnessService.addToMap(sw1);
+        signedWitnessService.addToMap(sw2);
+        signedWitnessService.addToMap(sw3);
 
-        assertTrue(service.isValidAccountAgeWitness(aew1));
-        assertTrue(service.isValidAccountAgeWitness(aew2));
-        assertTrue(service.isValidAccountAgeWitness(aew3));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew1));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew2));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew3));
     }
 
     @Test
@@ -137,13 +137,13 @@ public class SignedWitnessServiceTest {
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
         SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
 
-        service.addToMap(sw1);
-        service.addToMap(sw2);
-        service.addToMap(sw3);
+        signedWitnessService.addToMap(sw1);
+        signedWitnessService.addToMap(sw2);
+        signedWitnessService.addToMap(sw3);
 
-        assertFalse(service.isValidAccountAgeWitness(aew1));
-        assertFalse(service.isValidAccountAgeWitness(aew2));
-        assertFalse(service.isValidAccountAgeWitness(aew3));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew1));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew2));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew3));
     }
 
     @Test
@@ -156,13 +156,13 @@ public class SignedWitnessServiceTest {
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
         SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
 
-        service.addToMap(sw1);
-        service.addToMap(sw2);
-        service.addToMap(sw3);
+        signedWitnessService.addToMap(sw1);
+        signedWitnessService.addToMap(sw2);
+        signedWitnessService.addToMap(sw3);
 
-        assertTrue(service.isValidAccountAgeWitness(aew1));
-        assertFalse(service.isValidAccountAgeWitness(aew2));
-        assertFalse(service.isValidAccountAgeWitness(aew3));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew1));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew2));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew3));
     }
 
     @Test
@@ -175,13 +175,13 @@ public class SignedWitnessServiceTest {
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
         SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
 
-        service.addToMap(sw1);
-        service.addToMap(sw2);
-        service.addToMap(sw3);
+        signedWitnessService.addToMap(sw1);
+        signedWitnessService.addToMap(sw2);
+        signedWitnessService.addToMap(sw3);
 
-        assertTrue(service.isValidAccountAgeWitness(aew1));
-        assertTrue(service.isValidAccountAgeWitness(aew2));
-        assertFalse(service.isValidAccountAgeWitness(aew3));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew1));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew2));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew3));
     }
 
     @Test
@@ -194,13 +194,13 @@ public class SignedWitnessServiceTest {
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
         SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
 
-        service.addToMap(sw1);
-        service.addToMap(sw2);
-        service.addToMap(sw3);
+        signedWitnessService.addToMap(sw1);
+        signedWitnessService.addToMap(sw2);
+        signedWitnessService.addToMap(sw3);
 
-        assertTrue(service.isValidAccountAgeWitness(aew1));
-        assertTrue(service.isValidAccountAgeWitness(aew2));
-        assertFalse(service.isValidAccountAgeWitness(aew3));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew1));
+        assertTrue(signedWitnessService.isValidAccountAgeWitness(aew2));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew3));
     }
 
 
@@ -247,11 +247,11 @@ public class SignedWitnessServiceTest {
         SignedWitness sw2 = new SignedWitness(false, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
         SignedWitness sw3 = new SignedWitness(false, account3DataHash, signature3, signer3PubKey, witnessOwner3PubKey, date3, tradeAmount3);
 
-        service.addToMap(sw1);
-        service.addToMap(sw2);
-        service.addToMap(sw3);
+        signedWitnessService.addToMap(sw1);
+        signedWitnessService.addToMap(sw2);
+        signedWitnessService.addToMap(sw3);
 
-        assertFalse(service.isValidAccountAgeWitness(aew3));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew3));
     }
 
 
@@ -284,9 +284,9 @@ public class SignedWitnessServiceTest {
             byte[] witnessOwnerPubKey = Sig.getPublicKeyBytes(signedKeyPair.getPublic());
             long date = getTodayMinusNDays((iterations - i) * (SignedWitnessService.CHARGEBACK_SAFETY_DAYS + 1));
             SignedWitness sw = new SignedWitness(i == 0, accountDataHash, signature, signerPubKey, witnessOwnerPubKey, date, tradeAmount1);
-            service.addToMap(sw);
+            signedWitnessService.addToMap(sw);
         }
-        assertFalse(service.isValidAccountAgeWitness(aew));
+        assertFalse(signedWitnessService.isValidAccountAgeWitness(aew));
     }
 
 

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessTest.java
@@ -1,0 +1,39 @@
+package bisq.core.account.sign;
+
+import bisq.common.crypto.Sig;
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Utils;
+
+import com.google.common.base.Charsets;
+
+import java.security.KeyPair;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+
+import protobuf.PersistableNetworkPayload;
+
+public class SignedWitnessTest {
+    @Test
+    public void testProtoRoundTrip() {
+        ECKey arbitrator1Key = new ECKey();
+
+        KeyPair peer1KeyPair = Sig.generateKeyPair();
+        byte[] witnessOwner1PubKey = Sig.getPublicKeyBytes(peer1KeyPair.getPublic());
+
+        byte[] witnessHash = Utils.sha256hash160(new byte[]{1});
+        byte[] signature1 = arbitrator1Key.signMessage(Utilities.encodeToHex(witnessHash)).getBytes(Charsets.UTF_8);
+        SignedWitness signedWitness = new SignedWitness(true, witnessHash, signature1, arbitrator1Key.getPubKey(), witnessOwner1PubKey, Instant.now().getEpochSecond(), 100);
+        PersistableNetworkPayload proto = signedWitness.toProtoMessage();
+        assertEquals(signedWitness, SignedWitness.fromProto(proto.getSignedWitness()));
+
+    }
+
+}

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessTest.java
@@ -8,31 +8,23 @@ import org.bitcoinj.core.Utils;
 
 import com.google.common.base.Charsets;
 
-import java.security.KeyPair;
-
 import java.time.Instant;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-
-
-import protobuf.PersistableNetworkPayload;
-
 public class SignedWitnessTest {
     @Test
     public void testProtoRoundTrip() {
         ECKey arbitrator1Key = new ECKey();
 
-        KeyPair peer1KeyPair = Sig.generateKeyPair();
-        byte[] witnessOwner1PubKey = Sig.getPublicKeyBytes(peer1KeyPair.getPublic());
+        byte[] witnessOwner1PubKey = Sig.getPublicKeyBytes(Sig.generateKeyPair().getPublic());
 
         byte[] witnessHash = Utils.sha256hash160(new byte[]{1});
-        byte[] signature1 = arbitrator1Key.signMessage(Utilities.encodeToHex(witnessHash)).getBytes(Charsets.UTF_8);
-        SignedWitness signedWitness = new SignedWitness(true, witnessHash, signature1, arbitrator1Key.getPubKey(), witnessOwner1PubKey, Instant.now().getEpochSecond(), 100);
-        PersistableNetworkPayload proto = signedWitness.toProtoMessage();
-        assertEquals(signedWitness, SignedWitness.fromProto(proto.getSignedWitness()));
+        byte[] witnessHashSignature = arbitrator1Key.signMessage(Utilities.encodeToHex(witnessHash)).getBytes(Charsets.UTF_8);
+        SignedWitness signedWitness = new SignedWitness(true, witnessHash, witnessHashSignature, arbitrator1Key.getPubKey(), witnessOwner1PubKey, Instant.now().getEpochSecond(), 100);
+        assertEquals(signedWitness, SignedWitness.fromProto(signedWitness.toProtoMessage().getSignedWitness()));
 
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
@@ -40,6 +40,7 @@ public class AppendOnlyDataStoreService {
 
     // We do not add PersistableNetworkPayloadListService to the services list as it it deprecated and used only to
     // transfer old persisted data to the new data structure.
+    @SuppressWarnings("deprecation")
     private PersistableNetworkPayloadListService persistableNetworkPayloadListService;
 
 
@@ -47,6 +48,7 @@ public class AppendOnlyDataStoreService {
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    @SuppressWarnings("deprecation")
     @Inject
     public AppendOnlyDataStoreService(PersistableNetworkPayloadListService persistableNetworkPayloadListService) {
         this.persistableNetworkPayloadListService = persistableNetworkPayloadListService;
@@ -82,8 +84,6 @@ public class AppendOnlyDataStoreService {
     public void put(P2PDataStorage.ByteArray hashAsByteArray, PersistableNetworkPayload payload) {
         services.stream()
                 .filter(service -> service.canHandle(payload))
-                .forEach(service -> {
-                    service.putIfAbsent(hashAsByteArray, payload);
-                });
+                .forEach(service -> service.putIfAbsent(hashAsByteArray, payload));
     }
 }


### PR DESCRIPTION
Tests should contain no conditional logic (no `if`s) and be self contained (not call private methods)
that way the test is easier to read without context switches.