### PR TITLE
use singleton annotation instead of binding as singleton

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ configure(project(':common')) {
         compile "ch.qos.logback:logback-classic:$logbackVersion"
         compile 'com.google.code.findbugs:jsr305:3.0.2'
         compile 'com.google.guava:guava:20.0'
-        compile('com.google.inject:guice:4.1.0') {
+        compile('com.google.inject:guice:4.2.2') {
             exclude(module: 'guava')
         }
         compile("com.github.bisq-network.bitcoinj:bitcoinj-core:$bitcoinjVersion") {

--- a/core/src/main/java/bisq/core/util/BSFormatter.java
+++ b/core/src/main/java/bisq/core/util/BSFormatter.java
@@ -38,6 +38,7 @@ import org.bitcoinj.utils.Fiat;
 import org.bitcoinj.utils.MonetaryFormat;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
@@ -59,6 +60,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 @Slf4j
+@Singleton
 public class BSFormatter {
     public final static String RANGE_SEPARATOR = " - ";
 

--- a/core/src/main/java/bisq/core/util/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/BsqFormatter.java
@@ -35,6 +35,7 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.utils.MonetaryFormat;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -44,6 +45,7 @@ import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Singleton
 public class BsqFormatter extends BSFormatter {
     @SuppressWarnings("PointlessBooleanExpression")
     private static final boolean useBsqAddressFormat = true || !DevEnv.isDevMode();

--- a/desktop/src/main/java/bisq/desktop/DesktopModule.java
+++ b/desktop/src/main/java/bisq/desktop/DesktopModule.java
@@ -18,26 +18,12 @@
 package bisq.desktop;
 
 import bisq.desktop.common.fxml.FxmlViewLoader;
-import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.ViewFactory;
 import bisq.desktop.common.view.ViewLoader;
 import bisq.desktop.common.view.guice.InjectorViewFactory;
-import bisq.desktop.main.dao.bonding.BondingViewUtils;
-import bisq.desktop.main.funds.transactions.DisplayedTransactionsFactory;
-import bisq.desktop.main.funds.transactions.TradableRepository;
-import bisq.desktop.main.funds.transactions.TransactionAwareTradableFactory;
-import bisq.desktop.main.funds.transactions.TransactionListItemFactory;
-import bisq.desktop.main.offer.offerbook.OfferBook;
-import bisq.desktop.main.overlays.notifications.NotificationCenter;
-import bisq.desktop.main.overlays.windows.TorNetworkSettingsWindow;
-import bisq.desktop.main.presentation.DaoPresentation;
-import bisq.desktop.main.presentation.MarketPricePresentation;
-import bisq.desktop.util.Transitions;
 
 import bisq.core.app.AppOptionKeys;
 import bisq.core.locale.Res;
-import bisq.core.util.BSFormatter;
-import bisq.core.util.BsqFormatter;
 
 import bisq.common.app.AppModule;
 
@@ -57,32 +43,10 @@ public class DesktopModule extends AppModule {
 
     @Override
     protected void configure() {
-        bind(InjectorViewFactory.class).in(Singleton.class);
         bind(ViewFactory.class).to(InjectorViewFactory.class);
-        bind(CachingViewLoader.class).in(Singleton.class);
 
         bind(ResourceBundle.class).toInstance(Res.getResourceBundle());
         bind(ViewLoader.class).to(FxmlViewLoader.class).in(Singleton.class);
-        bind(CachingViewLoader.class).in(Singleton.class);
-
-        bind(Navigation.class).in(Singleton.class);
-        bind(NotificationCenter.class).in(Singleton.class);
-
-        bind(OfferBook.class).in(Singleton.class);
-        bind(BSFormatter.class).in(Singleton.class);
-        bind(BsqFormatter.class).in(Singleton.class);
-        bind(TorNetworkSettingsWindow.class).in(Singleton.class);
-        bind(MarketPricePresentation.class).in(Singleton.class);
-        bind(DaoPresentation.class).in(Singleton.class);
-
-        bind(Transitions.class).in(Singleton.class);
-
-        bind(TradableRepository.class).in(Singleton.class);
-        bind(TransactionListItemFactory.class).in(Singleton.class);
-        bind(TransactionAwareTradableFactory.class).in(Singleton.class);
-        bind(DisplayedTransactionsFactory.class).in(Singleton.class);
-
-        bind(BondingViewUtils.class).in(Singleton.class);
 
         bindConstant().annotatedWith(Names.named(AppOptionKeys.APP_NAME_KEY)).to(environment.getRequiredProperty(AppOptionKeys.APP_NAME_KEY));
     }

--- a/desktop/src/main/java/bisq/desktop/Navigation.java
+++ b/desktop/src/main/java/bisq/desktop/Navigation.java
@@ -28,6 +28,8 @@ import bisq.common.storage.Storage;
 
 import com.google.inject.Inject;
 
+import javax.inject.Singleton;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -41,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 @Slf4j
+@Singleton
 public final class Navigation implements PersistedDataHost {
     private static final ViewPath DEFAULT_VIEW_PATH = ViewPath.to(MainView.class, MarketView.class);
 

--- a/desktop/src/main/java/bisq/desktop/common/fxml/FxmlViewLoader.java
+++ b/desktop/src/main/java/bisq/desktop/common/fxml/FxmlViewLoader.java
@@ -26,6 +26,7 @@ import bisq.desktop.common.view.ViewLoader;
 import org.springframework.core.annotation.AnnotationUtils;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import javafx.fxml.FXMLLoader;
 
@@ -38,6 +39,7 @@ import java.util.ResourceBundle;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.springframework.core.annotation.AnnotationUtils.getDefaultValue;
 
+@Singleton
 public class FxmlViewLoader implements ViewLoader {
 
     private final ViewFactory viewFactory;

--- a/desktop/src/main/java/bisq/desktop/common/view/CachingViewLoader.java
+++ b/desktop/src/main/java/bisq/desktop/common/view/CachingViewLoader.java
@@ -18,9 +18,11 @@
 package bisq.desktop.common.view;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.util.HashMap;
 
+@Singleton
 public class CachingViewLoader implements ViewLoader {
 
     private final HashMap<Object, View> cache = new HashMap<>();

--- a/desktop/src/main/java/bisq/desktop/common/view/guice/InjectorViewFactory.java
+++ b/desktop/src/main/java/bisq/desktop/common/view/guice/InjectorViewFactory.java
@@ -21,8 +21,11 @@ import bisq.desktop.common.view.ViewFactory;
 
 import com.google.inject.Injector;
 
+import javax.inject.Singleton;
+
 import com.google.common.base.Preconditions;
 
+@Singleton
 public class InjectorViewFactory implements ViewFactory {
 
     private Injector injector;

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
@@ -47,6 +47,7 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -56,6 +57,7 @@ import lombok.extern.slf4j.Slf4j;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
+@Singleton
 public class BondingViewUtils {
     private final P2PService p2PService;
     private final MyReputationListService myReputationListService;

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/DisplayedTransactionsFactory.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/DisplayedTransactionsFactory.java
@@ -20,7 +20,9 @@ package bisq.desktop.main.funds.transactions;
 import bisq.core.btc.wallet.BtcWalletService;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class DisplayedTransactionsFactory {
     private final BtcWalletService btcWalletService;
     private final TradableRepository tradableRepository;

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TradableRepository.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TradableRepository.java
@@ -24,11 +24,13 @@ import bisq.core.trade.closed.ClosedTradableManager;
 import bisq.core.trade.failed.FailedTradesManager;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
+@Singleton
 public class TradableRepository {
     private final OpenOfferManager openOfferManager;
     private final TradeManager tradeManager;

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareTradableFactory.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareTradableFactory.java
@@ -23,7 +23,9 @@ import bisq.core.trade.Tradable;
 import bisq.core.trade.Trade;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class TransactionAwareTradableFactory {
     private final DisputeManager disputeManager;
 

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionListItemFactory.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionListItemFactory.java
@@ -27,11 +27,13 @@ import bisq.core.util.BSFormatter;
 import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.util.Optional;
 
 import javax.annotation.Nullable;
 
+@Singleton
 public class TransactionListItemFactory {
     private final BtcWalletService btcWalletService;
     private final BsqWalletService bsqWalletService;

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
@@ -22,6 +22,7 @@ import bisq.core.offer.OfferBookService;
 import bisq.core.trade.TradeManager;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -42,6 +43,7 @@ import static bisq.core.offer.OfferPayload.Direction.BUY;
  * It also use OfferRepository.Listener as the lists items class and we don't want to get any dependency out of the
  * package for that.
  */
+@Singleton
 @Slf4j
 public class OfferBook {
     private final OfferBookService offerBookService;

--- a/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
@@ -173,7 +173,7 @@ public abstract class Overlay<T extends Overlay> {
     private HPos buttonAlignment = HPos.RIGHT;
 
     protected Optional<Runnable> closeHandlerOptional = Optional.<Runnable>empty();
-    protected Optional<Runnable> actionHandlerOptional = Optional.<Runnable>empty();
+    protected Optional<Runnable> actionHandlerOptional = Optional.empty();
     protected Optional<Runnable> secondaryActionHandlerOptional = Optional.<Runnable>empty();
     protected ChangeListener<Number> positionListener;
 
@@ -438,7 +438,7 @@ public abstract class Overlay<T extends Overlay> {
 
     public T useShutDownButton() {
         this.actionButtonText = Res.get("shared.shutDown");
-        this.actionHandlerOptional = Optional.of(BisqApp.getShutDownHandler());
+        this.actionHandlerOptional = Optional.ofNullable(BisqApp.getShutDownHandler());
         //noinspection unchecked
         return (T) this;
     }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/notifications/NotificationCenter.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/notifications/NotificationCenter.java
@@ -38,6 +38,8 @@ import bisq.common.UserThread;
 
 import com.google.inject.Inject;
 
+import javax.inject.Singleton;
+
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
@@ -54,6 +56,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 @Slf4j
+@Singleton
 public class NotificationCenter {
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TorNetworkSettingsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TorNetworkSettingsWindow.java
@@ -38,6 +38,7 @@ import bisq.common.util.Tuple4;
 import bisq.common.util.Utilities;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -72,6 +73,7 @@ import lombok.extern.slf4j.Slf4j;
 import static bisq.desktop.util.FormBuilder.*;
 
 @Slf4j
+@Singleton
 public class TorNetworkSettingsWindow extends Overlay<TorNetworkSettingsWindow> {
 
     public enum BridgeOption {

--- a/desktop/src/main/java/bisq/desktop/main/presentation/DaoPresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/DaoPresentation.java
@@ -12,6 +12,7 @@ import bisq.core.user.Preferences;
 import bisq.common.app.DevEnv;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -25,6 +26,7 @@ import javafx.collections.MapChangeListener;
 
 import lombok.Getter;
 
+@Singleton
 public class DaoPresentation implements DaoStateListener {
 
     public static final String DAO_NEWS = "daoNewsVersion1.0.0";

--- a/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
@@ -35,6 +35,7 @@ import bisq.core.util.BSFormatter;
 import bisq.common.UserThread;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
@@ -60,6 +61,7 @@ import java.util.stream.Collectors;
 
 import lombok.Getter;
 
+@Singleton
 public class MarketPricePresentation {
     private final Preferences preferences;
     private final BSFormatter formatter;

--- a/desktop/src/main/java/bisq/desktop/util/Transitions.java
+++ b/desktop/src/main/java/bisq/desktop/util/Transitions.java
@@ -22,6 +22,7 @@ import bisq.core.user.Preferences;
 import bisq.common.UserThread;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import javafx.animation.FadeTransition;
 import javafx.animation.Interpolator;
@@ -39,6 +40,7 @@ import javafx.event.EventHandler;
 
 import javafx.util.Duration;
 
+@Singleton
 public class Transitions {
 
     public final static int DEFAULT_DURATION = 600;

--- a/desktop/src/test/java/bisq/desktop/GuiceSetupTest.java
+++ b/desktop/src/test/java/bisq/desktop/GuiceSetupTest.java
@@ -2,23 +2,72 @@ package bisq.desktop;
 
 import bisq.desktop.app.BisqAppModule;
 import bisq.desktop.common.view.CachingViewLoader;
+import bisq.desktop.common.view.ViewLoader;
+import bisq.desktop.common.view.guice.InjectorViewFactory;
+import bisq.desktop.main.dao.bonding.BondingViewUtils;
+import bisq.desktop.main.funds.transactions.DisplayedTransactionsFactory;
+import bisq.desktop.main.funds.transactions.TradableRepository;
+import bisq.desktop.main.funds.transactions.TransactionAwareTradableFactory;
+import bisq.desktop.main.funds.transactions.TransactionListItemFactory;
+import bisq.desktop.main.offer.offerbook.OfferBook;
+import bisq.desktop.main.overlays.notifications.NotificationCenter;
+import bisq.desktop.main.overlays.windows.TorNetworkSettingsWindow;
+import bisq.desktop.main.presentation.DaoPresentation;
+import bisq.desktop.main.presentation.MarketPricePresentation;
+import bisq.desktop.util.Transitions;
 
 import bisq.core.app.AvoidStandbyModeService;
 import bisq.core.app.BisqEnvironment;
+import bisq.core.locale.CurrencyUtil;
+import bisq.core.locale.Res;
+import bisq.core.util.BSFormatter;
+import bisq.core.util.BsqFormatter;
 
 import org.springframework.mock.env.MockPropertySource;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertSame;
+
 public class GuiceSetupTest {
+
+    private Injector injector;
+
+    @Before
+    public void setUp() {
+        Res.setup();
+        CurrencyUtil.setup();
+
+        injector = Guice.createInjector(new BisqAppModule(new BisqEnvironment(new MockPropertySource())));
+    }
+
     @Test
     public void testGuiceSetup() {
-        BisqAppModule module = new BisqAppModule(new BisqEnvironment(new MockPropertySource()));
-        Injector injector = Guice.createInjector(module);
-        injector.getInstance(CachingViewLoader.class);
         injector.getInstance(AvoidStandbyModeService.class);
+        assertSingleton(OfferBook.class);
+        assertSingleton(CachingViewLoader.class);
+        assertSingleton(Navigation.class);
+        assertSingleton(InjectorViewFactory.class);
+        assertSingleton(NotificationCenter.class);
+        assertSingleton(BSFormatter.class);
+        assertSingleton(BsqFormatter.class);
+        assertSingleton(TorNetworkSettingsWindow.class);
+        assertSingleton(MarketPricePresentation.class);
+        assertSingleton(ViewLoader.class);
+        assertSingleton(DaoPresentation.class);
+        assertSingleton(Transitions.class);
+        assertSingleton(TradableRepository.class);
+        assertSingleton(TransactionListItemFactory.class);
+        assertSingleton(TransactionAwareTradableFactory.class);
+        assertSingleton(DisplayedTransactionsFactory.class);
+        assertSingleton(BondingViewUtils.class);
+    }
+
+    private void assertSingleton(Class type) {
+        assertSame(injector.getInstance(type), injector.getInstance(type));
     }
 }

--- a/desktop/src/test/java/bisq/desktop/GuiceSetupTest.java
+++ b/desktop/src/test/java/bisq/desktop/GuiceSetupTest.java
@@ -1,0 +1,24 @@
+package bisq.desktop;
+
+import bisq.desktop.app.BisqAppModule;
+import bisq.desktop.common.view.CachingViewLoader;
+
+import bisq.core.app.AvoidStandbyModeService;
+import bisq.core.app.BisqEnvironment;
+
+import org.springframework.mock.env.MockPropertySource;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import org.junit.Test;
+
+public class GuiceSetupTest {
+    @Test
+    public void testGuiceSetup() {
+        BisqAppModule module = new BisqAppModule(new BisqEnvironment(new MockPropertySource()));
+        Injector injector = Guice.createInjector(module);
+        injector.getInstance(CachingViewLoader.class);
+        injector.getInstance(AvoidStandbyModeService.class);
+    }
+}

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -42,7 +42,6 @@ dependencyVerification {
         'ch.qos.logback:logback-core:4cd46fa17d77057b39160058df2f21ebbc2aded51d0edcc25d2c1cecc042a005',
         'com.google.code.findbugs:jsr305:766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7',
         'com.google.guava:guava:36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8',
-        'com.google.inject:guice:9b9df27a5b8c7864112b4137fd92b36c3f1395bfe57be42fedf2f520ead1a93e',
         'com.github.bisq-network.bitcoinj:bitcoinj-core:f979c2187e61ee3b08dd4cbfc49a149734cff64c045d29ed112f2e12f34068a3',
         'com.github.JesusMcCloud.netlayer:tor:35cf892e6ce3a8d942cfd2b589cfbde5aed31d49777aee873d6614e134df0b42',
         'org.jetbrains.kotlin:kotlin-stdlib-jdk8:193ab7813e4d249f2ea4fc1b968fea8c2126bcbeeb5d6127050ce1b93dbaa7c2',

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -42,6 +42,7 @@ dependencyVerification {
         'ch.qos.logback:logback-core:4cd46fa17d77057b39160058df2f21ebbc2aded51d0edcc25d2c1cecc042a005',
         'com.google.code.findbugs:jsr305:766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7',
         'com.google.guava:guava:36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8',
+        'com.google.inject:guice:d258ff1bd9b8b527872f8402648226658ad3149f1f40e74b0566d69e7e042fbc',
         'com.github.bisq-network.bitcoinj:bitcoinj-core:f979c2187e61ee3b08dd4cbfc49a149734cff64c045d29ed112f2e12f34068a3',
         'com.github.JesusMcCloud.netlayer:tor:35cf892e6ce3a8d942cfd2b589cfbde5aed31d49777aee873d6614e134df0b42',
         'org.jetbrains.kotlin:kotlin-stdlib-jdk8:193ab7813e4d249f2ea4fc1b968fea8c2126bcbeeb5d6127050ce1b93dbaa7c2',
@@ -79,4 +80,3 @@ dependencyVerification {
         'org.jetbrains.kotlin:kotlin-stdlib-common:4b161ef619eee0d1a49b1c4f0c4a8e46f4e342573efd8e0106a765f47475fe39',
     ]
 }
-


### PR DESCRIPTION
this is the correct way to do it. the way it is currently done means
that if a component is not declared in a module, guice still finds it
but does not use the singleton lifecycle

binding as singleton in the module is meant to be used for classes that
we don't have the sourcecode for (i.e. jdk classes)

also update guice because the current version has some incompatibilites with our asm lib and outputs internal errors when the wiring fails. 

this pr only converts the components that were declared in the desktop module. will convert the others later. 