### PR TITLE
typo in usuario

### DIFF
--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -1872,7 +1872,7 @@ showWalletDataWindow.includePrivKeys=Incluir claves privadas:
 
 # We do not translate the tac because of the legal nature. We would need translations checked by lawyers
 # in each language which is too expensive atm.
-tacWindow.headline=Acuerdo de usario
+tacWindow.headline=Acuerdo de usuario
 tacWindow.agree=Estoy de acuerdo
 tacWindow.disagree=No estoy de acuerdo, salir
 tacWindow.arbitrationSystem=Sistema arbitraje


### PR DESCRIPTION
There is a typo in the Spanish word usuario.