### PR TITLE
Replace "P2P network" with "Bisq network" in GUI

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -249,7 +249,7 @@ mainView.footer.btcInfo.synchronizingWith=Synchronizing with
 mainView.footer.btcInfo.synchronizedWith=Synchronized with
 mainView.footer.btcInfo.connectingTo=Connecting to
 mainView.footer.btcInfo.connectionFailed=connection failed
-mainView.footer.p2pInfo=P2P network peers: {0}
+mainView.footer.p2pInfo=Bisq network peers: {0}
 mainView.footer.daoFullNode=DAO full node
 
 mainView.bootstrapState.connectionToTorNetwork=(1/4) Connecting to Tor network...
@@ -259,10 +259,10 @@ mainView.bootstrapState.initialDataReceived=(4/4) Initial data received
 
 mainView.bootstrapWarning.noSeedNodesAvailable=No seed nodes available
 mainView.bootstrapWarning.noNodesAvailable=No seed nodes and peers available
-mainView.bootstrapWarning.bootstrappingToP2PFailed=Bootstrapping to P2P network failed
+mainView.bootstrapWarning.bootstrappingToP2PFailed=Bootstrapping to Bisq network failed
 
 mainView.p2pNetworkWarnMsg.noNodesAvailable=There are no seed nodes or persisted peers available for requesting data.\nPlease check your internet connection or try to restart the application.
-mainView.p2pNetworkWarnMsg.connectionToP2PFailed=Connecting to the P2P network failed (reported error: {0}).\nPlease check your internet connection or try to restart the application.
+mainView.p2pNetworkWarnMsg.connectionToP2PFailed=Connecting to the Bisq network failed (reported error: {0}).\nPlease check your internet connection or try to restart the application.
 
 mainView.walletServiceErrorMsg.timeout=Connecting to the Bitcoin network failed because of a timeout.
 mainView.walletServiceErrorMsg.connectionError=Connection to the Bitcoin network failed because of an error: {0}
@@ -945,7 +945,7 @@ settings.preferences.selectCurrencyNetwork=Select network
 setting.preferences.daoOptions=DAO options
 setting.preferences.dao.resync.label=Rebuild DAO state from genesis tx
 setting.preferences.dao.resync.button=Resync
-setting.preferences.dao.resync.popup=After an application restart the P2P network governance data will be reloaded from \
+setting.preferences.dao.resync.popup=After an application restart the Bisq network governance data will be reloaded from \
   the seed nodes and the BSQ consensus state will be rebuilt from the genesis transaction.
 setting.preferences.dao.isDaoFullNode=Run Bisq as DAO full node
 setting.preferences.dao.rpcUser=RPC username
@@ -958,7 +958,7 @@ setting.preferences.dao.fullNodeInfo.ok=Open docs page
 setting.preferences.dao.fullNodeInfo.cancel=No, I stick with lite node mode
 
 settings.net.btcHeader=Bitcoin network
-settings.net.p2pHeader=P2P network
+settings.net.p2pHeader=Bisq network
 settings.net.onionAddressLabel=My onion address
 settings.net.btcNodesLabel=Use custom Bitcoin Core nodes
 settings.net.bitcoinPeersLabel=Connected peers
@@ -1052,9 +1052,9 @@ account.arbitratorRegistration.register=Register arbitrator
 account.arbitratorRegistration.revoke=Revoke registration
 account.arbitratorRegistration.info.msg=Please note that you need to stay available for 15 days after revoking as there might be trades which are using you as arbitrator. The max. allowed trade period is 8 days and the dispute process might take up to 7 days.
 account.arbitratorRegistration.warn.min1Language=You need to set at least 1 language.\nWe added the default language for you.
-account.arbitratorRegistration.removedSuccess=You have successfully removed your arbitrator from the P2P network.
+account.arbitratorRegistration.removedSuccess=You have successfully removed your arbitrator from the Bisq network.
 account.arbitratorRegistration.removedFailed=Could not remove arbitrator.{0}
-account.arbitratorRegistration.registerSuccess=You have successfully registered your arbitrator to the P2P network.
+account.arbitratorRegistration.registerSuccess=You have successfully registered your arbitrator to the Bisq network.
 account.arbitratorRegistration.registerFailed=Could not register arbitrator.{0}
 
 account.arbitratorSelection.minOneArbitratorRequired=You need to set at least 1 language.\nWe added the default language for you.
@@ -1487,7 +1487,7 @@ dao.results.cycle.value.postFix.isDefaultValue=(default value)
 dao.results.cycle.value.postFix.hasChanged=(has been changed in voting)
 
 dao.results.invalidVotes=We had invalid votes in that voting cycle. That can happen if a vote was \
-  not distributed well in the P2P network.\n{0}
+  not distributed well in the Bisq network.\n{0}
 
 # suppress inspection "UnusedProperty"
 dao.phase.PHASE_UNDEFINED=Undefined


### PR DESCRIPTION
Rationale: it is not obvious whether "P2P network" in GUI refers to Bitcoin network, Tor network, traded altcoin network, or Bisq.

![Screenshot from 2019-08-15 23-31-32](https://user-images.githubusercontent.com/54061429/63129364-9a4a6d00-bfb7-11e9-800e-00c1a82fed28.png)

![Screenshot from 2019-08-15 23-32-46](https://user-images.githubusercontent.com/54061429/63129373-a1717b00-bfb7-11e9-819f-3bc773f9602a.png)
