### PR TITLE
Auto remove whitespace in the IBAN input field

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/SepaForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/SepaForm.java
@@ -22,6 +22,7 @@ import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.Layout;
 import bisq.desktop.util.validation.BICValidator;
 import bisq.desktop.util.validation.IBANValidator;
+import bisq.desktop.util.normalization.IBANNormalizer;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.locale.Country;
@@ -39,6 +40,7 @@ import bisq.core.util.validation.InputValidator;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
 
@@ -95,6 +97,7 @@ public class SepaForm extends GeneralSepaForm {
         });
 
         ibanInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, IBAN);
+        ibanInputTextField.setTextFormatter(new TextFormatter<>(new IBANNormalizer()));
         ibanInputTextField.setValidator(ibanValidator);
         ibanInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
             sepaAccount.setIban(newValue);

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/SepaInstantForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/SepaInstantForm.java
@@ -22,6 +22,7 @@ import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.Layout;
 import bisq.desktop.util.validation.BICValidator;
 import bisq.desktop.util.validation.IBANValidator;
+import bisq.desktop.util.normalization.IBANNormalizer;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.locale.Country;
@@ -39,6 +40,7 @@ import bisq.core.util.validation.InputValidator;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
 
@@ -95,6 +97,7 @@ public class SepaInstantForm extends GeneralSepaForm {
         });
 
         ibanInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, IBAN);
+        ibanInputTextField.setTextFormatter(new TextFormatter<>(new IBANNormalizer()));
         ibanInputTextField.setValidator(ibanValidator);
         ibanInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
             sepaInstantAccount.setIban(newValue);

--- a/desktop/src/main/java/bisq/desktop/util/normalization/IBANNormalizer.java
+++ b/desktop/src/main/java/bisq/desktop/util/normalization/IBANNormalizer.java
@@ -1,0 +1,15 @@
+package bisq.desktop.util.normalization;
+
+import javafx.util.StringConverter;
+
+public class IBANNormalizer extends StringConverter<String> {
+    @Override
+    public String toString(String s) {
+        return s;
+    }
+
+    @Override
+    public String fromString(String s) {
+        return s.replaceAll("\\s+", "");
+    }
+}


### PR DESCRIPTION
When adding a payment account Bisq requires IBAN to be whitespace free.

It is annoying for the user to manually clean pasted IBAN of spaces. In online banking IBAN-s are usually displayed **with** spaces for better readability.

This commit auto-removes whitespace when user is leaving the input field, right before validation, effectively allowing to paste real world IBAN-s.