### PR TITLE
List Ndau (XND)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Ndau.java
+++ b/assets/src/main/java/bisq/asset/coins/Ndau.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright © 2019 Oneiro NA, Inc.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Coin;
+import bisq.asset.RegexAddressValidator;
+
+
+public class Ndau extends Coin {
+
+    public Ndau() {
+        // note: ndau addresses contain an internal checksum which was deemed too complicated to include here.
+        // this regex performs superficial validation, but there is a large space of addresses marked valid
+        // by this regex which are not in fact valid ndau addresses. For actual ndau address validation,
+        // use the Address class in github.com/oneiro-ndev/ndauj (java) or github.com/oneiro-ndev/ndaumath/pkg/address (go).
+        super("ndau", "XND", new RegexAddressValidator("nd[anexbm][abcdefghijkmnpqrstuvwxyz23456789]{45}"));
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -71,6 +71,7 @@ bisq.asset.coins.MoX
 bisq.asset.coins.Myce
 bisq.asset.coins.Namecoin
 bisq.asset.coins.Navcoin
+bisq.asset.coins.Ndau
 bisq.asset.coins.Noir
 bisq.asset.coins.ParsiCoin
 bisq.asset.coins.Particl

--- a/assets/src/test/java/bisq/asset/coins/NdauTest.java
+++ b/assets/src/test/java/bisq/asset/coins/NdauTest.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright © 2019 Oneiro NA, Inc.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class NdauTest extends AbstractAssetTest {
+    public NdauTest() {super(new Ndau());}
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("ndaaacj4gbv5xgwikt6adcujqyvd37ksadj4mg9v3jqtbe9f");
+        assertValidAddress("ndnbeju3vmcxf9n96rb652eaeri79anqz47budnw8vwv3nyv");
+        assertValidAddress("ndeatpdkx5stu28n3v6pie96bma5k8pzbvbdpu8dchyn46nw");
+        assertValidAddress("ndxix97gyubjrkqbu4a5m3kpxyz4qhap3c3ui7359pzskwv4");
+        assertValidAddress("ndbjhkkcvj88beqcamr439z6d6icm5mjwth5r7vrgfbnxktr");
+        assertValidAddress("ndmpdkab97bi4ea73scjh6xpt8njjjhha4rarpr2zzzrv88u");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("ndaaacj4gbv5xgwikt6adcujqyvd37ksadj4mg9v3jqtbe9");
+        assertInvalidAddress("ndnbeju3vmcxf9n96rb652eaeri79anqz47budnw8vwv3nyvw");
+        assertInvalidAddress("ndpatpdkx5stu28n3v6pie96bma5k8pzbvbdpu8dchyn46nw");
+        assertInvalidAddress("ndx1x97gyubjrkqbu4a5m3kpxyz4qhap3c3ui7359pzskwv4");
+        assertInvalidAddress("ndbjhklcvj88beqcamr439z6d6icm5mjwth5r7vrgfbnxktr");
+        assertInvalidAddress("ndmpdkab97bi4ea73scjh6xpt8njjjhhaArarpr2zzzrv88u");
+    }
+}


### PR DESCRIPTION
- Official project URL: https://ndau.io/
- Official block explorer URL: https://explorer.service.ndau.tech

~~Note: as ndau address validation is fairly complicated, this PR adds
a dependency to a library which handles this. This library can be
inspected at https://github.com/oneiro-ndev/ndauj. It is licensed
under the LGPL 3.0.~~

This code has been removed.