### PR TITLE
also run tests on jdk12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ jdk:
     - openjdk12
 
 before_install:
-  grep -v '^#' assets/src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
+    grep -v '^#' assets/src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
 notifications:
-  slack:
-    on_success: change
-    on_failure: always
-    rooms:
-      - secure: EzlqWTBuhb3FCfApjUXaShWgsWOVDwMXI7ISMiVBkcl2VFISYs/lc/7Qjr7rdy4iqQOQXMcUPHdwMUp0diX+GxiSjLARjUpKIvNOPswZWBL+3Z1h28jyOwtHRviZbM1EU0BZROrr+ODyTNz2lf+L1iXTkpSvk50o5JAnAkumsPw=
+    slack:
+        on_success: change
+        on_failure: always
+        rooms:
+            -   secure: EzlqWTBuhb3FCfApjUXaShWgsWOVDwMXI7ISMiVBkcl2VFISYs/lc/7Qjr7rdy4iqQOQXMcUPHdwMUp0diX+GxiSjLARjUpKIvNOPswZWBL+3Z1h28jyOwtHRviZbM1EU0BZROrr+ODyTNz2lf+L1iXTkpSvk50o5JAnAkumsPw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
-jdk: openjdk10
+jdk:
+    - openjdk10
+    - openjdk12
+
 before_install:
   grep -v '^#' assets/src/main/resources/META-INF/services/bisq.asset.Asset | sort --check --dictionary-order --ignore-case
 notifications:


### PR DESCRIPTION
Right now the build works on 10, 11 and 12, and the desktop app runs on 10 and 11, and with some minor problems on jdk12.
It makes no sense to ever officially support JDK11 because it is as unsupported as 10.
So I think we should run CI on jdk 10 to make sure we can build official binaries, and jdk 12 to make sure anyone with a supported JDK can contribute. 