### PR TITLE
Prevent NullPointerException in ProposalsView

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -209,7 +209,10 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         sortedList.comparatorProperty().bind(tableView.comparatorProperty());
         tableView.setPrefHeight(100);
         root.getScene().heightProperty().addListener(sceneHeightListener);
-        UserThread.execute(() -> updateTableHeight(root.getScene().getHeight()));
+        UserThread.execute(() -> {
+            if (root.getScene() != null)
+                updateTableHeight(root.getScene().getHeight());
+        });
 
         stakeInputTextField.textProperty().addListener(stakeListener);
         voteButton.setOnAction(e -> onVote());


### PR DESCRIPTION
When activating the ProposalsView, the table height is updated on the
user thread. Sometimes the scene is unavailable and causes a
NullPointerException. This should at least prevent the exception.

Fixes #2883 and #3116