### PR TITLE
Fix bugs in SearchComboBox (improve autocomplete)

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/SearchComboBox.java
+++ b/desktop/src/main/java/bisq/desktop/components/SearchComboBox.java
@@ -19,7 +19,17 @@ package bisq.desktop.components;
 
 import bisq.common.UserThread;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.jfoenix.controls.JFXComboBox;
+import com.jfoenix.skins.JFXComboBoxListViewSkin;
+
+import javafx.scene.control.skin.ComboBoxListViewSkin;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+import javafx.event.Event;
+import javafx.event.EventHandler;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -28,31 +38,117 @@ import javafx.collections.transformation.FilteredList;
 public class SearchComboBox<T> extends JFXComboBox<T> {
     @SuppressWarnings("CanBeFinal")
     private FilteredList<T> filteredList;
+    private ComboBoxListViewSkin comboBoxListViewSkin;
 
     public SearchComboBox() {
         this(FXCollections.observableArrayList());
     }
 
-    private SearchComboBox(final ObservableList<T> items) {
-        super(new FilteredList<>(items));
-
-        filteredList = new FilteredList<>(items);
+    private SearchComboBox(ObservableList<T> items) {
+        super(items);
         setEditable(true);
+        setEmptySkinToGetMoreControlOverListView();
+        fixSpaceKey();
+        wrapItemsInFilteredList();
+        reactToQueryChanges();
+    }
 
-        itemsProperty().addListener((observable, oldValue, newValue) -> {
-            filteredList = new FilteredList<>(newValue);
+    // The ComboBox API does not provide enough control over the underlying
+    // ListView that is used as a dropdown. The only way to get this control
+    // is to set custom ListViewSkin. Default skin is null and so useless.
+    private void setEmptySkinToGetMoreControlOverListView() {
+        comboBoxListViewSkin = new JFXComboBoxListViewSkin<>(this);
+        setSkin(comboBoxListViewSkin);
+    }
+
+    // By default pressing [SPACE] caused editor text to reset. The solution
+    // is to suppress relevant event on the underlying ListViewSkin.
+    private void fixSpaceKey() {
+        comboBoxListViewSkin.getPopupContent().addEventFilter(KeyEvent.ANY, (KeyEvent event) -> {
+            if (event.getCode() == KeyCode.SPACE)
+                event.consume();
+        });
+    }
+
+    // Whenever ComboBox.setItems() is called we need to intercept it
+    // and wrap the physical list in a FilteredList view.
+    // The default predicate is null meaning no filtering occurs.
+    private void wrapItemsInFilteredList() {
+        itemsProperty().addListener((obsValue, oldList, newList) -> {
+            filteredList = new FilteredList<>(newList);
             setItems(filteredList);
         });
-        getEditor().textProperty().addListener((observable, oldValue, newValue) -> {
-            if (filteredList.stream().noneMatch(item -> getConverter().toString(item).equals(newValue))) {
+    }
+
+    // Whenever query changes we need to reset the list-filter and refresh the ListView
+    private void reactToQueryChanges() {
+        getEditor().textProperty().addListener((observable, oldQuery, query) -> {
+            var exactMatch = unfilteredItems().stream().anyMatch(item -> asString(item).equalsIgnoreCase(query));
+            if (!exactMatch) {
                 UserThread.execute(() -> {
-                    filteredList.setPredicate(item -> newValue.isEmpty() ||
-                            getConverter().toString(item).toLowerCase().contains(newValue.toLowerCase()));
-                    hide();
-                    setVisibleRowCount(Math.min(12, filteredList.size()));
-                    show();
+                    if (query.isEmpty())
+                        removeFilter();
+                    else
+                        filterBy(query);
+                    forceRedraw();
                 });
             }
         });
+    }
+
+    private ObservableList<T> unfilteredItems() {
+        return (ObservableList<T>) filteredList.getSource();
+    }
+
+    private String asString(T item) {
+        return getConverter().toString(item);
+    }
+
+    private int filteredItemsSize() {
+        return filteredList.size();
+    }
+
+    private void removeFilter() {
+        filteredList.setPredicate(null);
+    }
+
+    private void filterBy(String query) {
+        filteredList.setPredicate(item ->
+                StringUtils.containsIgnoreCase(asString(item), query)
+        );
+    }
+
+     /**
+      * Triggered when value change is *confirmed*. In practical terms
+      * this is when user clicks item on the dropdown or hits [ENTER]
+      * while typing in the text.
+      *
+      * This is in contrast to onAction event that is triggered
+      * on every (unconfirmed) value change. The onAction is not really
+      * suitable for the search enabled ComboBox.
+     */
+    public final void setOnChangeConfirmed(EventHandler<Event> eh) {
+        setOnHidden(e -> {
+            var selectedItem = getSelectionModel().getSelectedItem();
+            var selectedItemText = asString(selectedItem);
+            var inputText = getEditor().getText();
+            if (inputText.equals(selectedItemText)) {
+                eh.handle(e);
+            }
+        });
+    }
+
+    private void forceRedraw() {
+        setVisibleRowCount(Math.min(10, filteredItemsSize()));
+        if (filteredItemsSize() > 0) {
+            comboBoxListViewSkin.getPopupContent().autosize();
+            show();
+        } else {
+            hide();
+        }
+    }
+
+    public void deactivate() {
+        setOnHidden(null);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
@@ -19,6 +19,7 @@ package bisq.desktop.components.paymentmethods;
 
 import bisq.desktop.components.InputTextField;
 import bisq.desktop.components.NewBadge;
+import bisq.desktop.components.SearchComboBox;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.Layout;
@@ -228,7 +229,7 @@ public class AssetsForm extends PaymentMethodForm {
         });
 
         currencyComboBox.setItems(FXCollections.observableArrayList(CurrencyUtil.getActiveSortedCryptoCurrencies(assetService, filterManager)));
-        currencyComboBox.setVisibleRowCount(Math.min(currencyComboBox.getItems().size(), 15));
+        currencyComboBox.setVisibleRowCount(Math.min(currencyComboBox.getItems().size(), 10));
         currencyComboBox.setConverter(new StringConverter<TradeCurrency>() {
             @Override
             public String toString(TradeCurrency tradeCurrency) {
@@ -243,11 +244,10 @@ public class AssetsForm extends PaymentMethodForm {
                 return tradeCurrencyOptional.orElse(null);
             }
         });
-        currencyComboBox.setOnAction(e -> {
 
+        ((SearchComboBox) currencyComboBox).setOnChangeConfirmed(e -> {
             addressInputTextField.resetValidation();
             addressInputTextField.validate();
-
             paymentAccount.setSingleTradeCurrency(currencyComboBox.getSelectionModel().getSelectedItem());
             updateFromInputs();
         });


### PR DESCRIPTION
Bisq's `SearchComboBox` implements a simple autocomplete. It is used on the "add new altcoin account" form.

This fixes the following bugs in the `SearchComboBox`:

* no more dropdown flickering (fixed hide+show hack)
* space key no longer resets the text input
* unconfirmed changes no longer affect the form
* empty list no longer renders empty dropdown

This PR is the first step towards using autocomplete more widely in the project. Once merged I will attempt to address https://github.com/bisq-network/bisq/issues/2712 (but can't promise anything).