### PR TITLE
Fix incorrect DAO full node check when loading PreferencesView

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -834,8 +834,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         String rpcPw = preferences.getRpcPw();
         int blockNotifyPort = preferences.getBlockNotifyPort();
         if (daoFullNode && (rpcUser == null || rpcUser.isEmpty() ||
-                rpcPw == null || rpcPw.isEmpty()) ||
-                blockNotifyPort <= 0) {
+                rpcPw == null || rpcPw.isEmpty() ||
+                blockNotifyPort <= 0)) {
             log.warn("You have full DAO node selected but have not provided the rpc username, password and " +
                     "block notify port. We reset daoFullNode to false");
             isDaoFullNodeToggleButton.setSelected(false);


### PR DESCRIPTION
When loading the preferences view, it would always log a warning
indicating that DAO full node is selected without providing required
parameters even though it wasn't selected.