### PR TITLE
Changed "Portfolio" to "Orders"

### DIFF
--- a/desktop/src/test/java/bisq/desktop/ComponentsDemo.java
+++ b/desktop/src/test/java/bisq/desktop/ComponentsDemo.java
@@ -75,7 +75,7 @@ public class ComponentsDemo extends Application {
         button.setDisable(true);
         button.getStyleClass().add("action-button");
 
-        Label label = new Label("PORTFOLIO");
+        Label label = new Label("ORDERS");
         label.setStyle("-fx-background-color: green");
 
         final JFXBadge jfxBadge = new JFXBadge(label);


### PR DESCRIPTION
The word "Portfolio" makes absolutely no sense at the menu when it's only supposed to show the open/closed orders. The portfolio usually refers to the distribution of your OWN funds, that you're not trading. It makes no sense at this point and it should be renamed as "Orders".