### PR TITLE
Add missing check if capability is not empty before checking mandatory capabilities

### DIFF
--- a/common/src/main/java/bisq/common/app/Capabilities.java
+++ b/common/src/main/java/bisq/common/app/Capabilities.java
@@ -118,7 +118,7 @@ public class Capabilities {
     }
 
     public static boolean hasMandatoryCapability(Capabilities capabilities) {
-        return capabilities.isEmpty() || capabilities.capabilities.stream().anyMatch(c -> c == mandatoryCapability);
+        return capabilities.capabilities.stream().anyMatch(c -> c == mandatoryCapability);
     }
 
     @Override

--- a/common/src/main/java/bisq/common/app/Capabilities.java
+++ b/common/src/main/java/bisq/common/app/Capabilities.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * hold a set of capabilities and offers appropriate comparison methods.
@@ -32,6 +33,7 @@ import lombok.EqualsAndHashCode;
  * @author Florian Reimair
  */
 @EqualsAndHashCode
+@Slf4j
 public class Capabilities {
 
     /**
@@ -116,7 +118,7 @@ public class Capabilities {
     }
 
     public static boolean hasMandatoryCapability(Capabilities capabilities) {
-        return capabilities.capabilities.stream().anyMatch(c -> c == mandatoryCapability);
+        return capabilities.isEmpty() || capabilities.capabilities.stream().anyMatch(c -> c == mandatoryCapability);
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/network/CloseConnectionReason.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/CloseConnectionReason.java
@@ -45,7 +45,8 @@ public enum CloseConnectionReason {
     // illegal requests
     RULE_VIOLATION(true, false),
     PEER_BANNED(true, false),
-    INVALID_CLASS_RECEIVED(false, false);
+    INVALID_CLASS_RECEIVED(false, false),
+    MANDATORY_CAPABILITIES_NOT_SUPPORTED(false, false);
 
     public final boolean sendCloseMessage;
     public final boolean isIntended;

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -799,13 +799,14 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         Capabilities supportedCapabilities = ((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities();
                         if (supportedCapabilities != null) {
                             if (!capabilities.equals(supportedCapabilities)) {
+                                capabilities.set(supportedCapabilities);
+
                                 // Capabilities can be empty. We only check for mandatory if we get some capabilities.
                                 if (!capabilities.isEmpty() && !Capabilities.hasMandatoryCapability(capabilities)) {
                                     shutDown(CloseConnectionReason.MANDATORY_CAPABILITIES_NOT_SUPPORTED);
                                     return;
                                 }
 
-                                capabilities.set(supportedCapabilities);
                                 capabilitiesListeners.forEach(weakListener -> {
                                     SupportedCapabilitiesListener supportedCapabilitiesListener = weakListener.get();
                                     if (supportedCapabilitiesListener != null) {

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -799,8 +799,9 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         Capabilities supportedCapabilities = ((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities();
                         if (supportedCapabilities != null) {
                             if (!capabilities.equals(supportedCapabilities)) {
-                                if (!Capabilities.hasMandatoryCapability(capabilities)) {
-                                    shutDown(CloseConnectionReason.RULE_VIOLATION);
+                                // Capabilities can be empty. We only check for mandatory if we get some capabilities.
+                                if (!capabilities.isEmpty() && !Capabilities.hasMandatoryCapability(capabilities)) {
+                                    shutDown(CloseConnectionReason.MANDATORY_CAPABILITIES_NOT_SUPPORTED);
                                     return;
                                 }
 


### PR DESCRIPTION
We do not get the capabilities with all network messages so we have to
skip the test if the mandatory capability is included if capabilities
is empty.

fixes #3161 thus, deprecates and therefore closes #3163 