### PR TITLE
Set active currencies as high chargeback risk

### DIFF
--- a/core/src/main/java/bisq/core/account/witness/AccountAgeRestrictions.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeRestrictions.java
@@ -55,7 +55,7 @@ public class AccountAgeRestrictions {
                                                     String currencyCode,
                                                     OfferPayload.Direction direction) {
         if (direction == OfferPayload.Direction.BUY &&
-                PaymentMethod.hasChargebackRisk(paymentAccount.getPaymentMethod()) &&
+                PaymentMethod.hasChargebackRisk(paymentAccount.getPaymentMethod(), currencyCode) &&
                 AccountAgeRestrictions.isMyAccountAgeImmature(accountAgeWitnessService, paymentAccount)) {
             return OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.value;
         } else {
@@ -68,11 +68,13 @@ public class AccountAgeRestrictions {
                                                   Offer offer,
                                                   String currencyCode,
                                                   OfferPayload.Direction direction) {
-        if (direction == OfferPayload.Direction.BUY && PaymentMethod.hasChargebackRisk(paymentAccount.getPaymentMethod()) &&
+        if (direction == OfferPayload.Direction.BUY &&
+                PaymentMethod.hasChargebackRisk(paymentAccount.getPaymentMethod(), currencyCode) &&
                 AccountAgeRestrictions.isMakersAccountAgeImmature(accountAgeWitnessService, offer)) {
             // Taker is seller
             return OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.value;
-        } else if (direction == OfferPayload.Direction.SELL && PaymentMethod.hasChargebackRisk(paymentAccount.getPaymentMethod()) &&
+        } else if (direction == OfferPayload.Direction.SELL &&
+                PaymentMethod.hasChargebackRisk(paymentAccount.getPaymentMethod(), currencyCode) &&
                 AccountAgeRestrictions.isMyAccountAgeImmature(accountAgeWitnessService, paymentAccount)) {
             // Taker is buyer
             return OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.value;

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -295,6 +295,19 @@ public class CurrencyUtil {
         return currencies;
     }
 
+    public static List<TradeCurrency> getMatureMarketCurrencies() {
+        ArrayList<TradeCurrency> currencies = new ArrayList<>(Arrays.asList(
+                new FiatCurrency("EUR"),
+                new FiatCurrency("USD"),
+                new FiatCurrency("GBP"),
+                new FiatCurrency("CAD"),
+                new FiatCurrency("AUD"),
+                new FiatCurrency("BRL")
+        ));
+        currencies.sort(Comparator.comparing(TradeCurrency::getCode));
+        return currencies;
+    }
+
     public static boolean isFiatCurrency(String currencyCode) {
         try {
             return currencyCode != null

--- a/core/src/main/java/bisq/core/offer/OfferRestrictions.java
+++ b/core/src/main/java/bisq/core/offer/OfferRestrictions.java
@@ -28,13 +28,13 @@ public class OfferRestrictions {
     public static boolean isOfferRisky(Offer offer) {
         return offer != null &&
                 offer.isBuyOffer() &&
-                PaymentMethod.hasChargebackRisk(offer.getPaymentMethod()) &&
+                PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode()) &&
                 isMinTradeAmountRisky(offer);
     }
 
     public static boolean isSellOfferRisky(Offer offer) {
         return offer != null &&
-                PaymentMethod.hasChargebackRisk(offer.getPaymentMethod()) &&
+                PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode()) &&
                 isMinTradeAmountRisky(offer);
     }
 
@@ -44,7 +44,7 @@ public class OfferRestrictions {
 
         Offer offer = trade.getOffer();
         return offer != null &&
-                PaymentMethod.hasChargebackRisk(offer.getPaymentMethod()) &&
+                PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode()) &&
                 trade.getTradeAmount() != null &&
                 isAmountRisky(trade.getTradeAmount());
     }

--- a/core/src/main/java/bisq/core/payment/ChargeBackRisk.java
+++ b/core/src/main/java/bisq/core/payment/ChargeBackRisk.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class ChargeBackRisk {
-    public boolean hasChargebackRisk(String id) {
-        return PaymentMethod.hasChargebackRisk(id);
+    public boolean hasChargebackRisk(String id, String currencyCode) {
+        return PaymentMethod.hasChargebackRisk(id, currencyCode);
     }
 }

--- a/core/src/main/java/bisq/core/payment/PaymentAccountUtil.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountUtil.java
@@ -67,7 +67,7 @@ public class PaymentAccountUtil {
     private static boolean isTakerAccountForOfferMature(Offer offer,
                                                         PaymentAccount takerPaymentAccount,
                                                         AccountAgeWitnessService accountAgeWitnessService) {
-        return !PaymentMethod.hasChargebackRisk(offer.getPaymentMethod()) ||
+        return !PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode()) ||
                 !OfferRestrictions.isMinTradeAmountRisky(offer) ||
                 (isTakerPaymentAccountValidForOffer(offer, takerPaymentAccount) &&
                         !AccountAgeRestrictions.isMyAccountAgeImmature(accountAgeWitnessService, takerPaymentAccount));
@@ -84,7 +84,10 @@ public class PaymentAccountUtil {
 
     private static boolean hasMyMatureAccountForBuyOffer(PaymentAccount myPaymentAccount,
                                                          AccountAgeWitnessService accountAgeWitnessService) {
-        return !PaymentMethod.hasChargebackRisk(myPaymentAccount.getPaymentMethod()) ||
+        if (myPaymentAccount.selectedTradeCurrency == null)
+            return false;
+        return !PaymentMethod.hasChargebackRisk(myPaymentAccount.getPaymentMethod(),
+                myPaymentAccount.selectedTradeCurrency.getCode()) ||
                 !AccountAgeRestrictions.isMyAccountAgeImmature(accountAgeWitnessService, myPaymentAccount);
     }
 

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -17,6 +17,7 @@
 
 package bisq.core.payment.payload;
 
+import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.payment.TradeLimits;
 
@@ -188,11 +189,6 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
             BLOCK_CHAINS_INSTANT = new PaymentMethod(BLOCK_CHAINS_INSTANT_ID, TimeUnit.HOURS.toMillis(1), DEFAULT_TRADE_LIMIT_VERY_LOW_RISK)
     ));
 
-    // Mature markets where chargeback risk is higher due to more liquidity
-    @Getter
-    private final static List<String> currencyWithChargebackRisk =
-            new ArrayList<>(Arrays.asList("EUR", "USD", "GBP", "CAD", "AUD"));
-
     static {
         paymentMethods.sort((o1, o2) -> {
             String id1 = o1.getId();
@@ -330,7 +326,8 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
     }
 
     public static boolean hasChargebackRisk(String id, String currencyCode) {
-        if (!currencyWithChargebackRisk.contains(currencyCode))
+        if (CurrencyUtil.getMatureMarketCurrencies().stream()
+            .noneMatch(c -> c.getCode().equals(currencyCode)))
             return false;
         return id.equals(PaymentMethod.SEPA_ID) ||
                 id.equals(PaymentMethod.SEPA_INSTANT_ID) ||

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -188,6 +188,11 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
             BLOCK_CHAINS_INSTANT = new PaymentMethod(BLOCK_CHAINS_INSTANT_ID, TimeUnit.HOURS.toMillis(1), DEFAULT_TRADE_LIMIT_VERY_LOW_RISK)
     ));
 
+    // Mature markets where chargeback risk is higher due to more liquidity
+    @Getter
+    private final static List<String> currencyWithChargebackRisk =
+            new ArrayList<>(Arrays.asList("EUR", "USD", "GBP", "CAD", "AUD"));
+
     static {
         paymentMethods.sort((o1, o2) -> {
             String id1 = o1.getId();
@@ -316,15 +321,17 @@ public final class PaymentMethod implements PersistablePayload, Comparable {
         return this.equals(BLOCK_CHAINS_INSTANT) || this.equals(BLOCK_CHAINS);
     }
 
-    public static boolean hasChargebackRisk(PaymentMethod paymentMethod) {
+    public static boolean hasChargebackRisk(PaymentMethod paymentMethod, String currencyCode) {
         if (paymentMethod == null)
             return false;
 
         String id = paymentMethod.getId();
-        return hasChargebackRisk(id);
+        return hasChargebackRisk(id, currencyCode);
     }
 
-    public static boolean hasChargebackRisk(String id) {
+    public static boolean hasChargebackRisk(String id, String currencyCode) {
+        if (!currencyWithChargebackRisk.contains(currencyCode))
+            return false;
         return id.equals(PaymentMethod.SEPA_ID) ||
                 id.equals(PaymentMethod.SEPA_INSTANT_ID) ||
                 id.equals(PaymentMethod.INTERAC_E_TRANSFER_ID) ||


### PR DESCRIPTION
Specify the currencies that are considered high risk for chargeback based on volume. As new markets grow we will probably have to add them as well, but it might be that some currencies don't have as much chargeback risk.

By allowing new markets to trade without any restrictions they get a chance to grow without too much pain of bootstrapping signed account witnesses.