### PR TITLE
Do not specify indirect module dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -294,9 +294,7 @@ configure(project(':desktop')) {
     sourceSets.main.resources.srcDirs += ['src/main/java'] // to copy fxml and css files
 
     dependencies {
-        compile project(':p2p')
         compile project(':core')
-        compile project(':common')
         compile "org.controlsfx:controlsfx:$controlsfxVersion"
         compile "org.reactfx:reactfx:$reactfxVersion"
         compile "net.glxn:qrgen:$qrgenVersion"


### PR DESCRIPTION
One is supposed to only specify direct dependencies in `build.gradle`. This commit removes two superfluous deps statements for the `desktop` module. Other modules already follow the convention.

This does **not** remove any dependencies - it only cleans up how they are specified.

The build does work fine after the change and `desktop` app does run as expected.