### PR TITLE
Fix performance issue in BsqWalletService

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/bond/role/BondedRolesRepository.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/role/BondedRolesRepository.java
@@ -60,7 +60,7 @@ public class BondedRolesRepository extends BondRepository<BondedRole, Role> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public boolean isMyRole(Role role) {
-        Set<String> myWalletTransactionIds = bsqWalletService.getWalletTransactions().stream()
+        Set<String> myWalletTransactionIds = bsqWalletService.getClonedWalletTransactions().stream()
                 .map(Transaction::getHashAsString)
                 .collect(Collectors.toSet());
         return getAcceptedBondedRoleProposalStream()


### PR DESCRIPTION
The updateBsqWalletTransactions method got called at each block for all
transactions. During block download that wasted a lot of cpu and
led to stuck UI thread and lost connections.
The updateBsqBalance is not cheap (a few ms) and called for 100s of txs
at each block was very problematic.
Furthermore the listeners on the walletTransactions observableList got
triggered which made the situation worse.

We changed the observableList to a ArrayList and use a listener which
gets called after the list is updated.
We also make sure the onTransactionConfidenceChanged listener is not
calling updateBsqWalletTransactions if bsq parsing is not complete and
if the depth of the tx is > 1.
In the updateBsqWalletTransactions method we use a flag and a delay
to ensure that the updateBsqBalance is not called more then once
in 100 ms.

We changed also the getter to return a cloned version of the list to
avoid potential concurrent modification exceptions at clients.

Closes #3175