### PR TITLE
Update default fiat and crypto currencies

### DIFF
--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -86,8 +86,7 @@ public class CurrencyUtil {
         list.add(new FiatCurrency("GBP"));
         list.add(new FiatCurrency("CAD"));
         list.add(new FiatCurrency("AUD"));
-        list.add(new FiatCurrency("RUB"));
-        list.add(new FiatCurrency("INR"));
+        list.add(new FiatCurrency("BRL"));
 
         list.sort(TradeCurrency::compareTo);
 

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -123,23 +123,8 @@ public class CurrencyUtil {
 
     public static List<CryptoCurrency> getMainCryptoCurrencies() {
         final List<CryptoCurrency> result = new ArrayList<>();
-        result.add(new CryptoCurrency("XRC", "Bitcoin Rhodium"));
-
-        if (DevEnv.isDaoTradingActivated())
-            result.add(new CryptoCurrency("BSQ", "BSQ"));
-
-        result.add(new CryptoCurrency("BEAM", "Beam"));
-        result.add(new CryptoCurrency("DASH", "Dash"));
-        result.add(new CryptoCurrency("DCR", "Decred"));
-        result.add(new CryptoCurrency("ETH", "Ether"));
-        result.add(new CryptoCurrency("GRIN", "Grin"));
-        result.add(new CryptoCurrency("LTC", "Litecoin"));
-        result.add(new CryptoCurrency("XMR", "Monero"));
-        result.add(new CryptoCurrency("NMC", "Namecoin"));
-        result.add(new CryptoCurrency("SF", "Siafund"));
-        result.add(new CryptoCurrency("ZEC", "Zcash"));
+        result.add(new CryptoCurrency("BSQ", "BSQ"));
         result.sort(TradeCurrency::compareTo);
-
         return result;
     }
 

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -235,7 +235,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             preferredTradeCurrency = checkNotNull(CurrencyUtil.getCurrencyByCountryCode(prefPayload.getUserCountry().code),
                     "preferredTradeCurrency must not be null");
             prefPayload.setPreferredTradeCurrency(preferredTradeCurrency);
-            setFiatCurrencies(CurrencyUtil.getMainFiatCurrencies());
+            setFiatCurrencies(new ArrayList<>(Collections.singletonList((FiatCurrency) preferredTradeCurrency)));
             setCryptoCurrencies(CurrencyUtil.getMainCryptoCurrencies());
 
             switch (baseCurrencyNetwork.getCurrencyCode()) {


### PR DESCRIPTION
Within the settings, the default list of displayed national currencies and altcoins is outdated, in terms of top traded, and most are unnecessary to be displayed for most users and a nuisance to have to remove (which I am sure is the first thing most users do).

I have updated it so that the preferred currency and only displayed national currency is chosen based on the users locale/county code, and the only altcoin displayed by default is BSQ. If the user wants anything else it is up to them to add it.

Before:
![image](https://user-images.githubusercontent.com/603793/64097328-d2bcab80-cd18-11e9-9bdb-e6fae2984b09.png)

After:
![image](https://user-images.githubusercontent.com/603793/64097198-6e015100-cd18-11e9-99f7-4639facc1434.png)