### PR TITLE
Remove cbeams pricenode from ProvidersRepository

### DIFF
--- a/core/src/main/java/bisq/core/provider/ProvidersRepository.java
+++ b/core/src/main/java/bisq/core/provider/ProvidersRepository.java
@@ -44,7 +44,6 @@ public class ProvidersRepository {
             "http://xc3nh4juf2hshy7e.onion/",   // @emzy
             "http://ceaanhbvluug4we6.onion/",   // @mrosseel
             "http://44mgyoe2b6oqiytt.onion/",   // @devinbileck
-            "http://5bmpx76qllutpcyp.onion/",   // @cbeams
             "http://62nvujg5iou3vu3i.onion/"    // @alexej996
     );
 


### PR DESCRIPTION
The BitcoinAverage developer plan API keys in use for this node have
recently expired. Given that we already have four other pricenodes
up and running, there's no compelling reason to keep this fifth one in
place and to pay for hosting and API keys for it every month.

bisq-network/roles#14 will be updated accordingly.