### PR TITLE
Fix CSS styling bug caused by using Text() instead of Label()

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/ColoredDecimalPlacesWithZerosText.java
+++ b/desktop/src/main/java/bisq/desktop/components/ColoredDecimalPlacesWithZerosText.java
@@ -33,13 +33,13 @@ public class ColoredDecimalPlacesWithZerosText extends HBox {
         super();
 
         if (numberOfZerosToColorize <= 0) {
-            getChildren().addAll(new Text(number));
+            getChildren().addAll(new Label(number));
         } else if (number.contains(BSFormatter.RANGE_SEPARATOR)) {
             String[] splitNumber = number.split(BSFormatter.RANGE_SEPARATOR);
             Tuple2<Label, Label> numbers = getSplittedNumberNodes(splitNumber[0], numberOfZerosToColorize);
             getChildren().addAll(numbers.first, numbers.second);
 
-            getChildren().add(new Text(BSFormatter.RANGE_SEPARATOR));
+            getChildren().add(new Label(BSFormatter.RANGE_SEPARATOR));
 
             numbers = getSplittedNumberNodes(splitNumber[1], numberOfZerosToColorize);
             getChildren().addAll(numbers.first, numbers.second);


### PR DESCRIPTION
Before:
<img width="289" alt="Screen Shot 2019-09-02 at 22 58 53" src="https://user-images.githubusercontent.com/232186/64133285-02021400-ce10-11e9-902a-dddc47dfd4c4.png">
After:
<img width="298" alt="Screen Shot 2019-09-03 at 5 59 30" src="https://user-images.githubusercontent.com/232186/64133287-04646e00-ce10-11e9-9294-3f4b80e68b21.png">

Also fixes it here:
<img width="750" alt="Screen Shot 2019-09-03 at 5 57 21" src="https://user-images.githubusercontent.com/232186/64133299-1514e400-ce10-11e9-90cb-7a86cf294498.png">
