### PR TITLE
Don't paint vertical grid lines on charts

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -1576,6 +1576,9 @@ textfield */
 #charts .default-color1.chart-series-area-fill, #charts-dao .default-color0.chart-series-area-fill {
     -fx-fill: -bs-buy-transparent;
 }
+.chart-vertical-grid-lines {
+    -fx-stroke: transparent;
+}
 
 #charts .axis-label {
     -fx-font-size: 0.769em;

--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -229,7 +229,7 @@
 #charts .axis, #price-chart .axis, #volume-chart .axis, #charts-dao .axis {
     -fx-tick-label-fill: -bs-color-gray-dim;
 }
-.chart-horizontal-grid-lines, .chart-vertical-grid-lines,
+.chart-horizontal-grid-lines,
 .chart-horizontal-zero-line, .chart-vertical-zero-line,
 .axis-tick-mark, .axis-minor-tick-mark {
     -fx-stroke: -bs-color-gray-0;


### PR DESCRIPTION
Looks cleaner without them IMO

<img width="1241" alt="Screen Shot 2019-09-03 at 20 26 40" src="https://user-images.githubusercontent.com/232186/64169645-382faa00-ce89-11e9-8c32-452a3a4689e3.png">
<img width="1216" alt="Screen Shot 2019-09-03 at 20 26 24" src="https://user-images.githubusercontent.com/232186/64169655-3b2a9a80-ce89-11e9-8289-db85ac518fde.png">
<img width="1192" alt="Screen Shot 2019-09-03 at 20 26 30" src="https://user-images.githubusercontent.com/232186/64169662-3cf45e00-ce89-11e9-8c9f-a0dca32d914f.png">
<img width="962" alt="Screen Shot 2019-09-03 at 20 27 00" src="https://user-images.githubusercontent.com/232186/64169664-3ebe2180-ce89-11e9-9351-c804bd14903f.png">
