### PR TITLE
Reduce size of chart axis font to fit Japanese string

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -1547,6 +1547,7 @@ textfield */
 #charts .axis, #price-chart .axis, #volume-chart .axis, #charts-dao .axis {
     -fx-tick-label-fill: -bs-rd-font-lighter;
     -fx-tick-label-font-size: 0.769em;
+    -fx-font-size: 0.880em;
 }
 
 #charts .chart-plot-background, #charts-dao .chart-plot-background {


### PR DESCRIPTION
Before:
<img width="1172" alt="Screen Shot 2019-09-03 at 21 22 39" src="https://user-images.githubusercontent.com/232186/64174356-0a9c2e00-ce94-11e9-9a79-0db25828ce28.png">

After:
<img width="1176" alt="Screen Shot 2019-09-03 at 21 45 18" src="https://user-images.githubusercontent.com/232186/64174400-26073900-ce94-11e9-9c5c-85713bba251e.png">
