### PR TITLE
periodical UpdateDataReq for Seednodes

### DIFF
--- a/common/src/main/java/bisq/common/app/Capabilities.java
+++ b/common/src/main/java/bisq/common/app/Capabilities.java
@@ -93,6 +93,10 @@ public class Capabilities {
         return containsAll(capabilities.capabilities);
     }
 
+    public boolean containsAll(Capability... capabilities) {
+        return this.capabilities.containsAll(Arrays.asList(capabilities));
+    }
+
     public boolean isEmpty() {
         return capabilities.isEmpty();
     }

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -311,6 +311,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                 "seedNodeOfPreliminaryDataRequest must be present");
 
         requestDataManager.requestUpdateData();
+        UserThread.runPeriodically(() -> requestDataManager.requestUpdateData(), 1, TimeUnit.HOURS);
 
         // If we start up first time we don't have any peers so we need to request from seed node.
         // As well it can be that the persisted peer list is outdated with dead peers.

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -47,6 +47,8 @@ import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.UserThread;
+import bisq.common.app.Capabilities;
+import bisq.common.app.Capability;
 import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
@@ -311,7 +313,8 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                 "seedNodeOfPreliminaryDataRequest must be present");
 
         requestDataManager.requestUpdateData();
-        UserThread.runPeriodically(() -> requestDataManager.requestUpdateData(), 1, TimeUnit.HOURS);
+        if (Capabilities.app.containsAll(Capability.SEED_NODE))
+            UserThread.runPeriodically(() -> requestDataManager.requestUpdateData(), 1, TimeUnit.HOURS);
 
         // If we start up first time we don't have any peers so we need to request from seed node.
         // As well it can be that the persisted peer list is outdated with dead peers.

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -35,6 +35,8 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
+import bisq.common.app.Capabilities;
+import bisq.common.app.Capability;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkPayload;
 
@@ -60,6 +62,12 @@ class RequestDataHandler implements MessageListener {
     private static final long TIMEOUT = 90;
     private NodeAddress peersNodeAddress;
 
+    /**
+     * when we are run as a seed node, we spawn a RequestDataHandler every hour. However, we do not want to receive
+     * {@link PersistableNetworkPayload}s (for now, as there are hardly any cases where such data goes out of sync). This
+     * flag indicates whether we already received our first set of {@link PersistableNetworkPayload}s.
+     */
+    private static boolean firstRequest = true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Listener
@@ -219,7 +227,11 @@ class RequestDataHandler implements MessageListener {
                         });
                         log.info("Processing {} protectedStorageEntries took {} ms.", counter.get(), System.currentTimeMillis() - ts);
 
-                        if (persistableNetworkPayloadSet != null) {
+                        // engage the firstRequest logic only if we are a seed node. Normal clients get here twice at most.
+                        if (!Capabilities.app.containsAll(Capability.SEED_NODE))
+                            firstRequest = true;
+
+                        if (persistableNetworkPayloadSet != null && firstRequest) {
                             ts = System.currentTimeMillis();
                             persistableNetworkPayloadSet.forEach(e -> {
                                 if (e instanceof LazyProcessedPayload) {
@@ -241,6 +253,7 @@ class RequestDataHandler implements MessageListener {
 
                         cleanup();
                         listener.onComplete();
+                        firstRequest = false;
                     } else {
                         log.warn("Nonce not matching. That can happen rarely if we get a response after a canceled " +
                                         "handshake (timeout causes connection close but peer might have sent a msg before " +


### PR DESCRIPTION
This PR introduces a recurring syncronization with other seed nodes if Bisq is run in seed node-mode. In detail, every seed node issues an UpdateDataRequest to the connected seed nodes once every hour, receives data such as it would during restart. By having the same effect as a restart but without having to wait 24h and being offline for some time, this PR deprecates https://github.com/bisq-network/bisq/tree/seednode_temporaryfix.

I did a lot of debugging and analyzing in order to get this thing up and running. First and foremost, I found that by counting the unique messages of all seed nodes together results in a higher number of messages than any seed node has on its own. In other words, no seed node has every message. Here is a graph with distinct snapshots: 
![Screenshot from 2019-09-04 18-51-24](https://user-images.githubusercontent.com/1070734/64275141-33303080-cf45-11e9-896a-47047c6f7a41.png)

Secondly, I monitored the proposed fix over periods of time to see how the number evolve. I only monitored Offer- and MailboxStoragePayloads, as the other messages are pretty much in sync (according to https://monitor.bisq.network/d/wTDl6T_iz/p2p-stats). The graphs below denote the number of messages on their y-axis, the time of measurement on the x-axis, the "got-" values reflect the number of messages received from a seed node during a periodical UpdateDataRequest, the "have-" values denote the number of messages we already have.
![Screenshot from 2019-08-30 10-05-09](https://user-images.githubusercontent.com/1070734/64275387-b8b3e080-cf45-11e9-9a3c-7ed668f8b055.png)
![Screenshot from 2019-08-30 10-05-22](https://user-images.githubusercontent.com/1070734/64275378-b6ea1d00-cf45-11e9-8299-ff0e567aecd8.png)
![Screenshot from 2019-08-30 10-05-29](https://user-images.githubusercontent.com/1070734/64275369-b3569600-cf45-11e9-87e3-70658faf6c36.png)
![Screenshot from 2019-09-05 08-03-23](https://user-images.githubusercontent.com/1070734/64315933-b1c3b700-cfb3-11e9-9a5a-e1a80ddbf13e.png)
![Screenshot from 2019-09-06 16-36-54](https://user-images.githubusercontent.com/1070734/64436430-9d231400-d0c4-11e9-93af-0304f701c988.png)
![Screenshot from 2019-09-09 18-41-25](https://user-images.githubusercontent.com/1070734/64549671-7cabc180-d331-11e9-9088-c4ac306443b4.png)

All in all, it seems that the recurring querying of other seed nodes might fill in the missing messages just fine. I even believe that we might get rid of at least some arbitration cases, where MailboxMessages simply did not arrive at the receiver. However, I suggest a slow adoption as we had our difficulties with these attempts in the past.



