### PR TITLE
Remove old capability requirements

### DIFF
--- a/common/src/main/java/bisq/common/app/Capability.java
+++ b/common/src/main/java/bisq/common/app/Capability.java
@@ -23,14 +23,14 @@ package bisq.common.app;
 // We don't use the Enum in any serialized data, as changes in the enum would break backwards compatibility. We use the ordinal integer instead.
 // Sequence in the enum must not be changed (append only).
 public enum Capability {
-    TRADE_STATISTICS,
-    TRADE_STATISTICS_2,
-    ACCOUNT_AGE_WITNESS,
+    @Deprecated TRADE_STATISTICS,       // Not required anymore as no old clients out there not having that support
+    @Deprecated TRADE_STATISTICS_2,     // Not required anymore as no old clients out there not having that support
+    @Deprecated ACCOUNT_AGE_WITNESS,    // Not required anymore as no old clients out there not having that support
     SEED_NODE,
     DAO_FULL_NODE,
     PROPOSAL,
     BLIND_VOTE,
-    ACK_MSG,
+    @Deprecated ACK_MSG,                // Not required anymore as no old clients out there not having that support
     RECEIVE_BSQ_BLOCK,
     DAO_STATE,
     BUNDLE_OF_ENVELOPES,

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitness.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitness.java
@@ -18,13 +18,10 @@
 package bisq.core.account.witness;
 
 import bisq.network.p2p.storage.P2PDataStorage;
-import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
 import bisq.network.p2p.storage.payload.DateTolerantPayload;
 import bisq.network.p2p.storage.payload.LazyProcessedPayload;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 
-import bisq.common.app.Capabilities;
-import bisq.common.app.Capability;
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.util.Utilities;
 
@@ -43,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 // so only the newly added objects since the last release will be retrieved over the P2P network.
 @Slf4j
 @Value
-public class AccountAgeWitness implements LazyProcessedPayload, PersistableNetworkPayload, PersistableEnvelope, DateTolerantPayload, CapabilityRequiringPayload {
+public class AccountAgeWitness implements LazyProcessedPayload, PersistableNetworkPayload, PersistableEnvelope, DateTolerantPayload {
     private static final long TOLERANCE = TimeUnit.DAYS.toMillis(1);
 
     private final byte[] hash;                      // Ripemd160(Sha256(concatenated accountHash, signature and sigPubKey)); 20 bytes
@@ -98,12 +95,6 @@ public class AccountAgeWitness implements LazyProcessedPayload, PersistableNetwo
     @Override
     public boolean verifyHashSize() {
         return hash.length == 20;
-    }
-
-    // Pre 0.6 version don't know the new message type and throw an error which leads to disconnecting the peer.
-    @Override
-    public Capabilities getRequiredCapabilities() {
-        return new Capabilities(Capability.ACCOUNT_AGE_WITNESS);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/network/messages/RepublishGovernanceDataRequest.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/network/messages/RepublishGovernanceDataRequest.java
@@ -28,6 +28,8 @@ import bisq.common.proto.network.NetworkEnvelope;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+
+// This message is sent only to full DAO nodes
 @EqualsAndHashCode(callSuper = true)
 @Getter
 public final class RepublishGovernanceDataRequest extends NetworkEnvelope implements DirectMessage, CapabilityRequiringPayload {

--- a/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
+++ b/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+// This message is sent only to full DAO nodes
 @EqualsAndHashCode(callSuper = true)
 @Getter
 @Slf4j

--- a/core/src/main/java/bisq/core/dao/node/messages/NewBlockBroadcastMessage.java
+++ b/core/src/main/java/bisq/core/dao/node/messages/NewBlockBroadcastMessage.java
@@ -30,6 +30,7 @@ import bisq.common.proto.network.NetworkEnvelope;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+// This message is sent only to lite DAO nodes (full nodes get block from their local bitcoind)
 @EqualsAndHashCode(callSuper = true)
 @Getter
 public final class NewBlockBroadcastMessage extends BroadcastMessage implements CapabilityRequiringPayload {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -24,12 +24,9 @@ import bisq.core.monetary.Volume;
 import bisq.core.offer.OfferPayload;
 import bisq.core.offer.OfferUtil;
 
-import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
 import bisq.network.p2p.storage.payload.LazyProcessedPayload;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 
-import bisq.common.app.Capabilities;
-import bisq.common.app.Capability;
 import bisq.common.crypto.Hash;
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.util.ExtraDataMapValidator;
@@ -63,7 +60,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 @Value
-public final class TradeStatistics2 implements LazyProcessedPayload, PersistableNetworkPayload, PersistableEnvelope, CapabilityRequiringPayload {
+public final class TradeStatistics2 implements LazyProcessedPayload, PersistableNetworkPayload, PersistableEnvelope {
     public static final String ARBITRATOR_ADDRESS = "arbAddr";
 
     private final OfferPayload.Direction direction;
@@ -212,11 +209,6 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
-
-    @Override
-    public Capabilities getRequiredCapabilities() {
-        return new Capabilities(Capability.TRADE_STATISTICS_2);
-    }
 
     @Override
     public byte[] getHash() {

--- a/p2p/src/main/java/bisq/network/p2p/AckMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/AckMessage.java
@@ -17,11 +17,8 @@
 
 package bisq.network.p2p;
 
-import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
 import bisq.network.p2p.storage.payload.ExpirablePayload;
 
-import bisq.common.app.Capabilities;
-import bisq.common.app.Capability;
 import bisq.common.app.Version;
 import bisq.common.proto.ProtoUtil;
 import bisq.common.proto.network.NetworkEnvelope;
@@ -42,7 +39,7 @@ import javax.annotation.Nullable;
 @Value
 @Slf4j
 public final class AckMessage extends NetworkEnvelope implements MailboxMessage, PersistablePayload,
-        ExpirablePayload, CapabilityRequiringPayload {
+        ExpirablePayload {
 
     private final String uid;
     private final NodeAddress senderNodeAddress;
@@ -147,11 +144,6 @@ public final class AckMessage extends NetworkEnvelope implements MailboxMessage,
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
-
-    @Override
-    public Capabilities getRequiredCapabilities() {
-        return new Capabilities(Capability.ACK_MSG);
-    }
 
     @Override
     public long getTTL() {


### PR DESCRIPTION
We leave the DAO related capabilities as it might be useful in future for flexibility if there is a use case for a non-DAO node.