### PR TITLE
Add "squash commits" to contributor's workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ All Bisq contributors submit changes via pull requests. The workflow is as follo
  - Fork the repository
  - Create a topic branch from the `master` branch
  - Commit patches
+ - Squash redundant or unnecessary commits
  - Submit a pull request from your topic branch back to the `master` branch of the main repository
 
 Pull requests should be focused on a single change. Do not mix, for example, refactorings with a bug fix or implementation of a new feature. This practice makes it easier for fellow contributors to review each pull request on its merits and and to give a clear ACK/NACK (see below).
@@ -72,6 +73,10 @@ https://help.github.com/articles/signing-commits-with-gpg/ for instructions.
 ### Use an editor that supports Editorconfig
 
 The [.editorconfig](.editorconfig) settings in this repository ensure consistent management of whitespace, line endings and more. Most modern editors support it natively or with plugin. See http://editorconfig.org for details. See also [bisq-network/style#10](https://github.com/bisq-network/style/issues/10).
+
+### Keep the git history clean
+
+It's very important to keep the git history clear, light and easily browsable. This means contributors must make sure their pull requests include only meaningful commits (if they are redundant or were added after a review, they should be removed) and _no merge commits_.
 
 ### Additional style guidelines
 


### PR DESCRIPTION
At the moment the git history of all repos is not properly handled. This is a first step to introduce a better workflow where contributors squash their own commits; but maintainers could squash as well if the contributor doesn't/cannot.

See bisq-network/style#14