### PR TITLE
Make stateless BSFormatter functions static and remove dead code

### DIFF
--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -120,7 +120,7 @@ public class WalletAppSetup {
                             result = Res.get("mainView.footer.btcInfo",
                                     peers,
                                     Res.get("mainView.footer.btcInfo.synchronizingWith"),
-                                    getBtcNetworkAsString() + ": " + formatter.formatToPercentWithSymbol(percentage));
+                                    getBtcNetworkAsString() + ": " + BSFormatter.formatToPercentWithSymbol(percentage));
                         } else {
                             result = Res.get("mainView.footer.btcInfo",
                                     peers,

--- a/core/src/main/java/bisq/core/dao/presentation/DaoUtil.java
+++ b/core/src/main/java/bisq/core/dao/presentation/DaoUtil.java
@@ -40,8 +40,8 @@ public class DaoUtil {
         long now = new Date().getTime();
         SimpleDateFormat dateFormatter = new SimpleDateFormat("dd MMM", Locale.getDefault());
         SimpleDateFormat timeFormatter = new SimpleDateFormat("HH:mm", Locale.getDefault());
-        String startDateTime = formatter.formatDateTime(new Date(now + (start - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
-        String endDateTime = formatter.formatDateTime(new Date(now + (end - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
+        String startDateTime = BSFormatter.formatDateTime(new Date(now + (start - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
+        String endDateTime = BSFormatter.formatDateTime(new Date(now + (end - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
 
         return Res.get("dao.cycle.phaseDurationWithoutBlocks", start, end, startDateTime, endDateTime);
     }
@@ -53,9 +53,9 @@ public class DaoUtil {
         long now = new Date().getTime();
         SimpleDateFormat dateFormatter = new SimpleDateFormat("dd MMM", Locale.getDefault());
         SimpleDateFormat timeFormatter = new SimpleDateFormat("HH:mm", Locale.getDefault());
-        String startDateTime = formatter.formatDateTime(new Date(now + (start - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
-        String endDateTime = formatter.formatDateTime(new Date(now + (end - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
-        String durationTime = formatter.formatDurationAsWords(duration * 10 * 60 * 1000, false, false);
+        String startDateTime = BSFormatter.formatDateTime(new Date(now + (start - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
+        String endDateTime = BSFormatter.formatDateTime(new Date(now + (end - height) * 10 * 60 * 1000L), dateFormatter, timeFormatter);
+        String durationTime = BSFormatter.formatDurationAsWords(duration * 10 * 60 * 1000, false, false);
         return Res.get("dao.cycle.phaseDuration", duration, durationTime, start, end, startDateTime, endDateTime);
     }
 }

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -35,6 +35,7 @@ import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Issuance;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.dao.state.model.governance.ParamChange;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import org.bitcoinj.core.Coin;
@@ -923,7 +924,7 @@ public class DaoStateService implements DaoSetupService {
     }
 
     public double getParamValueAsPercentDouble(String paramValue) {
-        return bsqFormatter.parsePercentStringToDouble(paramValue);
+        return BSFormatter.parsePercentStringToDouble(paramValue);
     }
 
     public int getParamValueAsBlock(String paramValue) {

--- a/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
+++ b/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
@@ -180,9 +180,9 @@ public class MarketAlerts {
                             ratio = Math.abs(ratio);
                             String msg = Res.get("account.notifications.marketAlert.message.msg",
                                     direction,
-                                    formatter.getCurrencyPair(currencyCode),
+                                    BSFormatter.getCurrencyPair(currencyCode),
                                     formatter.formatPrice(offerPrice),
-                                    formatter.formatToPercentWithSymbol(ratio / 10000d),
+                                    BSFormatter.formatToPercentWithSymbol(ratio / 10000d),
                                     marketDir,
                                     Res.get(offer.getPaymentMethod().getId()),
                                     shortOfferId);

--- a/core/src/main/java/bisq/core/notifications/alerts/price/PriceAlert.java
+++ b/core/src/main/java/bisq/core/notifications/alerts/price/PriceAlert.java
@@ -70,8 +70,8 @@ public class PriceAlert {
                 if (priceAsLong > filter.getHigh() || priceAsLong < filter.getLow()) {
                     String msg = Res.get("account.notifications.priceAlert.message.msg",
                             currencyName,
-                            formatter.formatMarketPrice(priceAsDouble, currencyCode),
-                            formatter.getCurrencyPair(currencyCode));
+                            BSFormatter.formatMarketPrice(priceAsDouble, currencyCode),
+                            BSFormatter.getCurrencyPair(currencyCode));
                     MobileMessage message = new MobileMessage(Res.get("account.notifications.priceAlert.message.title", currencyName),
                             msg,
                             MobileMessageType.PRICE);

--- a/core/src/main/java/bisq/core/util/BSFormatter.java
+++ b/core/src/main/java/bisq/core/util/BSFormatter.java
@@ -20,7 +20,6 @@ package bisq.core.util;
 import bisq.core.app.BisqEnvironment;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.GlobalSettings;
-import bisq.core.locale.LanguageUtil;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.Price;
@@ -64,8 +63,7 @@ import org.jetbrains.annotations.NotNull;
 public class BSFormatter {
     public final static String RANGE_SEPARATOR = " - ";
 
-    protected boolean useMilliBit;
-    protected int scale = 3;
+    protected final static int scale = 3;
 
     // We don't support localized formatting. Format is always using "." as decimal mark and no grouping separator.
     // Input of "," as decimal mark (like in german locale) will be replaced with ".".
@@ -76,10 +74,10 @@ public class BSFormatter {
 
     //  protected String currencyCode = CurrencyUtil.getDefaultFiatCurrencyAsCode();
 
-    protected final MonetaryFormat fiatPriceFormat = new MonetaryFormat().shift(0).minDecimals(4).repeatOptionalDecimals(0, 0);
-    protected final MonetaryFormat fiatVolumeFormat = new MonetaryFormat().shift(0).minDecimals(2).repeatOptionalDecimals(0, 0);
-    protected final MonetaryFormat altcoinFormat = new MonetaryFormat().shift(0).minDecimals(8).repeatOptionalDecimals(0, 0);
-    protected final DecimalFormat decimalFormat = new DecimalFormat("#.#");
+    protected static final MonetaryFormat fiatPriceFormat = new MonetaryFormat().shift(0).minDecimals(4).repeatOptionalDecimals(0, 0);
+    protected static final MonetaryFormat fiatVolumeFormat = new MonetaryFormat().shift(0).minDecimals(2).repeatOptionalDecimals(0, 0);
+    protected static final MonetaryFormat altcoinFormat = new MonetaryFormat().shift(0).minDecimals(8).repeatOptionalDecimals(0, 0);
+    protected static final DecimalFormat decimalFormat = new DecimalFormat("#.#");
 
 
     @Inject
@@ -109,7 +107,11 @@ public class BSFormatter {
         return formatCoin(coin, decimalPlaces, decimalAligned, maxNumberOfDigits, coinFormat);
     }
 
-    public String formatCoin(Coin coin, int decimalPlaces, boolean decimalAligned, int maxNumberOfDigits, MonetaryFormat coinFormat) {
+    public static String formatCoin(Coin coin,
+                                    int decimalPlaces,
+                                    boolean decimalAligned,
+                                    int maxNumberOfDigits,
+                                    MonetaryFormat coinFormat) {
         String formattedCoin = "";
 
         if (coin != null) {
@@ -139,11 +141,11 @@ public class BSFormatter {
         return formatCoinWithCode(Coin.valueOf(value), coinFormat);
     }
 
-    public String formatCoinWithCode(long value, MonetaryFormat coinFormat) {
+    public static String formatCoinWithCode(long value, MonetaryFormat coinFormat) {
         return formatCoinWithCode(Coin.valueOf(value), coinFormat);
     }
 
-    public String formatCoinWithCode(Coin coin, MonetaryFormat coinFormat) {
+    public static String formatCoinWithCode(Coin coin, MonetaryFormat coinFormat) {
         if (coin != null) {
             try {
                 // we don't use the code feature from coinFormat as it does automatic switching between mBTC and BTC and
@@ -213,7 +215,7 @@ public class BSFormatter {
     // FIAT
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public String formatFiat(Fiat fiat, MonetaryFormat format, boolean appendCurrencyCode) {
+    private static String formatFiat(Fiat fiat, MonetaryFormat format, boolean appendCurrencyCode) {
         if (fiat != null) {
             try {
                 final String res = format.noCode().format(fiat).toString();
@@ -230,7 +232,7 @@ public class BSFormatter {
         }
     }
 
-    protected Fiat parseToFiat(String input, String currencyCode) {
+    protected static Fiat parseToFiat(String input, String currencyCode) {
         if (input != null && input.length() > 0) {
             try {
                 return Fiat.parseFiat(currencyCode, cleanDoubleInput(input));
@@ -253,7 +255,7 @@ public class BSFormatter {
      * @return
      */
 
-    public Fiat parseToFiatWithPrecision(String input, String currencyCode) {
+    public static Fiat parseToFiatWithPrecision(String input, String currencyCode) {
         if (input != null && input.length() > 0) {
             try {
                 return parseToFiat(new BigDecimal(cleanDoubleInput(input)).setScale(2, BigDecimal.ROUND_HALF_UP).toString(),
@@ -267,24 +269,12 @@ public class BSFormatter {
         return Fiat.valueOf(currencyCode, 0);
     }
 
-    public boolean isFiatAlteredWhenPrecisionApplied(String input, String currencyCode) {
-        return parseToFiat(input, currencyCode).equals(parseToFiatWithPrecision(input, currencyCode));
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Altcoin
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public String formatAltcoin(Altcoin altcoin) {
-        return formatAltcoin(altcoin, false);
-    }
-
-    public String formatAltcoinWithCode(Altcoin altcoin) {
-        return formatAltcoin(altcoin, true);
-    }
-
-    public String formatAltcoin(Altcoin altcoin, boolean appendCurrencyCode) {
+    private static String formatAltcoin(Altcoin altcoin, boolean appendCurrencyCode) {
         if (altcoin != null) {
             try {
                 String res = altcoinFormat.noCode().format(altcoin).toString();
@@ -320,7 +310,7 @@ public class BSFormatter {
     }
 
     @NotNull
-    public String fillUpPlacesWithEmptyStrings(String formattedNumber, int maxNumberOfDigits) {
+    public static String fillUpPlacesWithEmptyStrings(String formattedNumber, int maxNumberOfDigits) {
         //FIXME: temporary deactivate adding spaces in front of numbers as we don't use a monospace font right now.
         /*int numberOfPlacesToFill = maxNumberOfDigits - formattedNumber.length();
         for (int i = 0; i < numberOfPlacesToFill; i++) {
@@ -337,7 +327,7 @@ public class BSFormatter {
         return formatVolume(volume, fiatVolumeFormat, true);
     }
 
-    public String formatVolume(Volume volume, MonetaryFormat fiatVolumeFormat, boolean appendCurrencyCode) {
+    private static String formatVolume(Volume volume, MonetaryFormat fiatVolumeFormat, boolean appendCurrencyCode) {
         if (volume != null) {
             Monetary monetary = volume.getMonetary();
             if (monetary instanceof Fiat)
@@ -349,7 +339,7 @@ public class BSFormatter {
         }
     }
 
-    public String formatAltcoinVolume(Altcoin altcoin, boolean appendCurrencyCode) {
+    private static String formatAltcoinVolume(Altcoin altcoin, boolean appendCurrencyCode) {
         if (altcoin != null) {
             try {
                 // TODO quick hack...
@@ -371,11 +361,11 @@ public class BSFormatter {
         }
     }
 
-    public String formatVolumeLabel(String currencyCode) {
+    public static String formatVolumeLabel(String currencyCode) {
         return formatVolumeLabel(currencyCode, "");
     }
 
-    public String formatVolumeLabel(String currencyCode, String postFix) {
+    public static String formatVolumeLabel(String currencyCode, String postFix) {
         return Res.get("formatter.formatVolumeLabel",
                 currencyCode, postFix);
     }
@@ -411,7 +401,7 @@ public class BSFormatter {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
 
-    public String formatPrice(Price price, MonetaryFormat fiatPriceFormat, boolean appendCurrencyCode) {
+    public static String formatPrice(Price price, MonetaryFormat fiatPriceFormat, boolean appendCurrencyCode) {
         if (price != null) {
             Monetary monetary = price.getMonetary();
             if (monetary instanceof Fiat)
@@ -444,14 +434,14 @@ public class BSFormatter {
     // Market price
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public String formatMarketPrice(double price, String currencyCode) {
+    public static String formatMarketPrice(double price, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode))
             return formatMarketPrice(price, 2);
         else
             return formatMarketPrice(price, 8);
     }
 
-    public String formatMarketPrice(double price, int precision) {
+    public static String formatMarketPrice(double price, int precision) {
         return formatRoundedDoubleWithPrecision(price, precision);
     }
 
@@ -460,39 +450,35 @@ public class BSFormatter {
     // Other
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public String formatRoundedDoubleWithPrecision(double value, int precision) {
+    public static String formatRoundedDoubleWithPrecision(double value, int precision) {
         decimalFormat.setMinimumFractionDigits(precision);
         decimalFormat.setMaximumFractionDigits(precision);
         return decimalFormat.format(MathUtils.roundDouble(value, precision)).replace(",", ".");
     }
 
-    public String getDirectionWithCode(OfferPayload.Direction direction, String currencyCode) {
+    public static String getDirectionWithCode(OfferPayload.Direction direction, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode))
             return (direction == OfferPayload.Direction.BUY) ? Res.get("shared.buyCurrency", Res.getBaseCurrencyCode()) : Res.get("shared.sellCurrency", Res.getBaseCurrencyCode());
         else
             return (direction == OfferPayload.Direction.SELL) ? Res.get("shared.buyCurrency", currencyCode) : Res.get("shared.sellCurrency", currencyCode);
     }
 
-    public String getDirectionWithCodeDetailed(OfferPayload.Direction direction, String currencyCode) {
+    public static String getDirectionWithCodeDetailed(OfferPayload.Direction direction, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode))
             return (direction == OfferPayload.Direction.BUY) ? Res.get("shared.buyingBTCWith", currencyCode) : Res.get("shared.sellingBTCFor", currencyCode);
         else
             return (direction == OfferPayload.Direction.SELL) ? Res.get("shared.buyingCurrency", currencyCode) : Res.get("shared.sellingCurrency", currencyCode);
     }
 
-    public String arbitratorAddressesToString(List<NodeAddress> nodeAddresses) {
+    public static String arbitratorAddressesToString(List<NodeAddress> nodeAddresses) {
         return nodeAddresses.stream().map(NodeAddress::getFullAddress).collect(Collectors.joining(", "));
     }
 
-    public String languageCodesToString(List<String> languageLocales) {
-        return languageLocales.stream().map(LanguageUtil::getDisplayName).collect(Collectors.joining(", "));
-    }
-
-    public String formatDateTime(Date date) {
+    public static String formatDateTime(Date date) {
         return formatDateTime(date, true);
     }
 
-    public String formatDateTime(Date date, boolean useLocaleAndLocalTimezone) {
+    public static String formatDateTime(Date date, boolean useLocaleAndLocalTimezone) {
         Locale locale = useLocaleAndLocalTimezone ? getLocale() : Locale.US;
         DateFormat dateInstance = DateFormat.getDateInstance(DateFormat.DEFAULT, locale);
         DateFormat timeInstance = DateFormat.getTimeInstance(DateFormat.DEFAULT, locale);
@@ -503,7 +489,7 @@ public class BSFormatter {
         return formatDateTime(date, dateInstance, timeInstance);
     }
 
-    public String formatDateTime(Date date, DateFormat dateFormatter, DateFormat timeFormatter) {
+    public static String formatDateTime(Date date, DateFormat dateFormatter, DateFormat timeFormatter) {
         if (date != null) {
             return dateFormatter.format(date) + " " + timeFormatter.format(date);
         } else {
@@ -511,7 +497,7 @@ public class BSFormatter {
         }
     }
 
-    public String formatDateTimeSpan(Date dateFrom, Date dateTo) {
+    public static String formatDateTimeSpan(Date dateFrom, Date dateTo) {
         if (dateFrom != null && dateTo != null) {
             DateFormat dateFormatter = DateFormat.getDateInstance(DateFormat.DEFAULT, getLocale());
             DateFormat timeFormatter = DateFormat.getTimeInstance(DateFormat.DEFAULT, getLocale());
@@ -521,7 +507,7 @@ public class BSFormatter {
         }
     }
 
-    public String formatTime(Date date) {
+    public static String formatTime(Date date) {
         if (date != null) {
             DateFormat timeFormatter = DateFormat.getTimeInstance(DateFormat.DEFAULT, getLocale());
             return timeFormatter.format(date);
@@ -530,7 +516,7 @@ public class BSFormatter {
         }
     }
 
-    public String formatDate(Date date) {
+    public static String formatDate(Date date) {
         if (date != null) {
             DateFormat dateFormatter = DateFormat.getDateInstance(DateFormat.DEFAULT, getLocale());
             return dateFormatter.format(date);
@@ -539,40 +525,43 @@ public class BSFormatter {
         }
     }
 
-    public String formatToPercentWithSymbol(double value) {
+    public static String formatToPercentWithSymbol(double value) {
         return formatToPercent(value) + "%";
     }
 
-    public String formatPercentagePrice(double value) {
+    public static String formatPercentagePrice(double value) {
         return formatToPercentWithSymbol(value);
     }
 
-    public String formatToPercent(double value) {
+    public static String formatToPercent(double value) {
         DecimalFormat decimalFormat = new DecimalFormat("#.##");
         decimalFormat.setMinimumFractionDigits(2);
         decimalFormat.setMaximumFractionDigits(2);
         return decimalFormat.format(MathUtils.roundDouble(value * 100.0, 2)).replace(",", ".");
     }
 
-    public double parseNumberStringToDouble(String input) throws NumberFormatException {
+    public static double parseNumberStringToDouble(String input) throws NumberFormatException {
         return Double.parseDouble(cleanDoubleInput(input));
     }
 
-    public double parsePercentStringToDouble(String percentString) throws NumberFormatException {
+    public static double parsePercentStringToDouble(String percentString) throws NumberFormatException {
         String input = percentString.replace("%", "");
         input = cleanDoubleInput(input);
         double value = Double.parseDouble(input);
         return MathUtils.roundDouble(value / 100d, 4);
     }
 
-    public long parsePriceStringToLong(String currencyCode, String amount, int precision) {
+    public static long parsePriceStringToLong(BSFormatter bsFormatter,
+                                              String currencyCode,
+                                              String amount,
+                                              int precision) {
         if (amount == null || amount.isEmpty())
             return 0;
 
         long value = 0;
         try {
             double amountValue = Double.parseDouble(amount);
-            amount = formatRoundedDoubleWithPrecision(amountValue, precision);
+            amount = BSFormatter.formatRoundedDoubleWithPrecision(amountValue, precision);
             value = Price.parse(currencyCode, amount).getValue();
         } catch (NumberFormatException ignore) {
             // expected NumberFormatException if input is not a number
@@ -590,7 +579,7 @@ public class BSFormatter {
         return input.replace(",", ".");
     }
 
-    protected String cleanDoubleInput(String input) {
+    protected static String cleanDoubleInput(String input) {
         input = convertCharsForNumber(input);
         if (input.equals("."))
             input = input.replace(".", "0.");
@@ -605,7 +594,7 @@ public class BSFormatter {
         return input;
     }
 
-    public String formatAccountAge(long durationMillis) {
+    public static String formatAccountAge(long durationMillis) {
         durationMillis = Math.max(0, durationMillis);
         String day = Res.get("time.day").toLowerCase();
         String days = Res.get("time.days");
@@ -613,11 +602,11 @@ public class BSFormatter {
         return StringUtils.replaceOnce(DurationFormatUtils.formatDuration(durationMillis, format), "1 " + days, "1 " + day);
     }
 
-    public String formatDurationAsWords(long durationMillis) {
+    public static String formatDurationAsWords(long durationMillis) {
         return formatDurationAsWords(durationMillis, false, true);
     }
 
-    public String formatDurationAsWords(long durationMillis, boolean showSeconds, boolean showZeroValues) {
+    public static String formatDurationAsWords(long durationMillis, boolean showSeconds, boolean showZeroValues) {
         String format = "";
         String second = Res.get("time.second");
         String minute = Res.get("time.minute");
@@ -657,11 +646,11 @@ public class BSFormatter {
         return duration.trim();
     }
 
-    public String booleanToYesNo(boolean value) {
+    public static String booleanToYesNo(boolean value) {
         return value ? Res.get("shared.yes") : Res.get("shared.no");
     }
 
-    public String getDirectionBothSides(OfferPayload.Direction direction, String currencyCode) {
+    public static String getDirectionBothSides(OfferPayload.Direction direction, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             currencyCode = Res.getBaseCurrencyCode();
             return direction == OfferPayload.Direction.BUY ?
@@ -674,7 +663,7 @@ public class BSFormatter {
         }
     }
 
-    public String getDirectionForBuyer(boolean isMyOffer, String currencyCode) {
+    public static String getDirectionForBuyer(boolean isMyOffer, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String code = Res.getBaseCurrencyCode();
             return isMyOffer ?
@@ -687,7 +676,7 @@ public class BSFormatter {
         }
     }
 
-    public String getDirectionForSeller(boolean isMyOffer, String currencyCode) {
+    public static String getDirectionForSeller(boolean isMyOffer, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String code = Res.getBaseCurrencyCode();
             return isMyOffer ?
@@ -700,7 +689,7 @@ public class BSFormatter {
         }
     }
 
-    public String getDirectionForTakeOffer(OfferPayload.Direction direction, String currencyCode) {
+    public static String getDirectionForTakeOffer(OfferPayload.Direction direction, String currencyCode) {
         String baseCurrencyCode = Res.getBaseCurrencyCode();
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             return direction == OfferPayload.Direction.BUY ?
@@ -714,7 +703,7 @@ public class BSFormatter {
         }
     }
 
-    public String getOfferDirectionForCreateOffer(OfferPayload.Direction direction, String currencyCode) {
+    public static String getOfferDirectionForCreateOffer(OfferPayload.Direction direction, String currencyCode) {
         String baseCurrencyCode = Res.getBaseCurrencyCode();
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             return direction == OfferPayload.Direction.BUY ?
@@ -727,7 +716,7 @@ public class BSFormatter {
         }
     }
 
-    public String getRole(boolean isBuyerMakerAndSellerTaker, boolean isMaker, String currencyCode) {
+    public static String getRole(boolean isBuyerMakerAndSellerTaker, boolean isMaker, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String baseCurrencyCode = Res.getBaseCurrencyCode();
             if (isBuyerMakerAndSellerTaker)
@@ -751,7 +740,7 @@ public class BSFormatter {
 
     }
 
-    public String formatBytes(long bytes) {
+    public static String formatBytes(long bytes) {
         double kb = 1024;
         double mb = kb * kb;
         DecimalFormat decimalFormat = new DecimalFormat("#.##");
@@ -763,47 +752,32 @@ public class BSFormatter {
             return decimalFormat.format(bytes / mb) + " MB";
     }
 
-    public String getCurrencyPair(String currencyCode) {
+    public static String getCurrencyPair(String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode))
             return Res.getBaseCurrencyCode() + "/" + currencyCode;
         else
             return currencyCode + "/" + Res.getBaseCurrencyCode();
     }
 
-    public String getCounterCurrency(String currencyCode) {
+    public static String getCounterCurrency(String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode))
             return currencyCode;
         else
             return Res.getBaseCurrencyCode();
     }
 
-    public String getBaseCurrency(String currencyCode) {
-        if (CurrencyUtil.isCryptoCurrency(currencyCode))
-            return currencyCode;
-        else
-            return Res.getBaseCurrencyCode();
-    }
-
-    public String getCounterCurrencyAndCurrencyPair(String currencyCode) {
-        return getCounterCurrency(currencyCode) + " (" + getCurrencyPair(currencyCode) + ")";
-    }
-
-    public String getCurrencyNameAndCurrencyPair(String currencyCode) {
-        return CurrencyUtil.getNameByCode(currencyCode) + " (" + getCurrencyPair(currencyCode) + ")";
-    }
-
-    public String getPriceWithCurrencyCode(String currencyCode) {
+    public static String getPriceWithCurrencyCode(String currencyCode) {
         return getPriceWithCurrencyCode(currencyCode, "shared.priceInCurForCur");
     }
 
-    public String getPriceWithCurrencyCode(String currencyCode, String translationKey) {
+    public static String getPriceWithCurrencyCode(String currencyCode, String translationKey) {
         if (CurrencyUtil.isCryptoCurrency(currencyCode))
             return Res.get(translationKey, Res.getBaseCurrencyCode(), currencyCode);
         else
             return Res.get(translationKey, currencyCode, Res.getBaseCurrencyCode());
     }
 
-    public Locale getLocale() {
+    private static Locale getLocale() {
         return GlobalSettings.getLocale();
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -141,7 +141,7 @@ public class PeerInfoIcon extends Group {
         boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode());
 
         String accountAge = isFiatCurrency ?
-                peersAccountAge > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(peersAccountAge)) :
+                peersAccountAge > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(peersAccountAge)) :
                         Res.get("peerInfoIcon.tooltip.unknownAge") :
                 "";
         tooltipText = hasTraded ?
@@ -268,7 +268,7 @@ public class PeerInfoIcon extends Group {
                                     long makersAccountAge) {
         final String accountAgeTagEditor = isFiatCurrency ?
                 makersAccountAge > -1 ?
-                        formatter.formatAccountAge(makersAccountAge) :
+                        BSFormatter.formatAccountAge(makersAccountAge) :
                         Res.get("peerInfo.unknownAge") :
                 null;
         setOnMouseClicked(e -> new PeerInfoWithTagEditor(privateNotificationManager, offer, preferences, useDevPrivilegeKeys)

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -182,7 +182,7 @@ public abstract class PaymentMethodForm {
                 Res.get("payment.maxPeriodAndLimit",
                         getTimeText(hours),
                         formatter.formatCoinWithCode(Coin.valueOf(accountAgeWitnessService.getMyTradeLimit(paymentAccount, tradeCurrency.getCode()))),
-                        formatter.formatAccountAge(accountAge));
+                        BSFormatter.formatAccountAge(accountAge));
 
         if (isDisplayForm)
             addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.limitations"), limitationsText);

--- a/desktop/src/main/java/bisq/desktop/main/Chat/Chat.java
+++ b/desktop/src/main/java/bisq/desktop/main/Chat/Chat.java
@@ -404,7 +404,7 @@ public class Chat extends AnchorPane {
                                 AnchorPane.setLeftAnchor(statusHBox, padding);
                             }
                             AnchorPane.setBottomAnchor(statusHBox, 7d);
-                            headerLabel.setText(formatter.formatDateTime(new Date(message.getDate())));
+                            headerLabel.setText(BSFormatter.formatDateTime(new Date(message.getDate())));
                             messageLabel.setText(message.getMessage());
                             attachmentsBox.getChildren().clear();
                             if (allowAttachments &&

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -218,7 +218,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
                                 DontShowAgainLookup.dontShowAgain(key, true);
                                 new Popup<>().warning(Res.get("popup.warning.tradePeriod.halfReached",
                                         trade.getShortId(),
-                                        formatter.formatDateTime(maxTradePeriodDate)))
+                                        BSFormatter.formatDateTime(maxTradePeriodDate)))
                                         .show();
                             }
                             break;
@@ -228,7 +228,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
                                 DontShowAgainLookup.dontShowAgain(key, true);
                                 new Popup<>().warning(Res.get("popup.warning.tradePeriod.ended",
                                         trade.getShortId(),
-                                        formatter.formatDateTime(maxTradePeriodDate)))
+                                        BSFormatter.formatDateTime(maxTradePeriodDate)))
                                         .show();
                             }
                             break;

--- a/desktop/src/main/java/bisq/desktop/main/account/content/notifications/ManageMarketAlertsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/notifications/ManageMarketAlertsWindow.java
@@ -140,7 +140,7 @@ public class ManageMarketAlertsWindow extends Overlay<ManageMarketAlertsWindow> 
                             public void updateItem(final MarketAlertFilter item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty) {
-                                    setText(formatter.formatPercentagePrice(item.getTriggerValue() / 10000d));
+                                    setText(BSFormatter.formatPercentagePrice(item.getTriggerValue() / 10000d));
                                 } else {
                                     setText("");
                                 }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
@@ -347,7 +347,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
 
     private void onAddMarketAlert() {
         PaymentAccount paymentAccount = paymentAccountsComboBox.getSelectionModel().getSelectedItem();
-        double percentAsDouble = formatter.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText());
+        double percentAsDouble = BSFormatter.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText());
         int triggerValue = (int) Math.round(percentAsDouble * 10000);
         boolean isBuyOffer = offerTypeRadioButtonsToggleGroup.getSelectedToggle() == buyOffersRadioButton;
         MarketAlertFilter marketAlertFilter = new MarketAlertFilter(paymentAccount, triggerValue, isBuyOffer);
@@ -510,8 +510,8 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
         marketAlertTriggerFocusListener = (observable, oldValue, newValue) -> {
             if (oldValue && !newValue) {
                 try {
-                    double percentAsDouble = formatter.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText()) * 100;
-                    marketAlertTriggerInputTextField.setText(formatter.formatRoundedDoubleWithPrecision(percentAsDouble, 2) + "%");
+                    double percentAsDouble = BSFormatter.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText()) * 100;
+                    marketAlertTriggerInputTextField.setText(BSFormatter.formatRoundedDoubleWithPrecision(percentAsDouble, 2) + "%");
                 } catch (Throwable ignore) {
                 }
 
@@ -695,8 +695,8 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
                 currencyComboBox.getSelectionModel().select(optionalTradeCurrency.get());
                 onSelectedTradeCurrency();
 
-                priceAlertHighInputTextField.setText(formatter.formatMarketPrice(priceAlertFilter.getHigh() / 10000d, currencyCode));
-                priceAlertLowInputTextField.setText(formatter.formatMarketPrice(priceAlertFilter.getLow() / 10000d, currencyCode));
+                priceAlertHighInputTextField.setText(BSFormatter.formatMarketPrice(priceAlertFilter.getHigh() / 10000d, currencyCode));
+                priceAlertLowInputTextField.setText(BSFormatter.formatMarketPrice(priceAlertFilter.getLow() / 10000d, currencyCode));
             } else {
                 currencyComboBox.getSelectionModel().clearSelection();
             }
@@ -747,15 +747,15 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
         try {
             String inputValue = inputTextField.getText();
             if (inputValue != null && !inputValue.isEmpty() && selectedPriceAlertTradeCurrency != null) {
-                double priceAsDouble = formatter.parseNumberStringToDouble(inputValue);
+                double priceAsDouble = BSFormatter.parseNumberStringToDouble(inputValue);
                 String currencyCode = selectedPriceAlertTradeCurrency;
                 int precision = CurrencyUtil.isCryptoCurrency(currencyCode) ?
                         Altcoin.SMALLEST_UNIT_EXPONENT : 2;
                 // We want to use the converted value not the inout value as we apply the converted value at focus out.
                 // E.g. if input is 5555.5555 it will be rounded to  5555.55 and we use that as the value for comparing
                 // low and high price...
-                String stringValue = formatter.formatRoundedDoubleWithPrecision(priceAsDouble, precision);
-                return formatter.parsePriceStringToLong(currencyCode, stringValue, precision);
+                String stringValue = BSFormatter.formatRoundedDoubleWithPrecision(priceAsDouble, precision);
+                return BSFormatter.parsePriceStringToLong(formatter, currencyCode, stringValue, precision);
             } else {
                 return 0;
             }
@@ -768,11 +768,11 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
         try {
             String inputValue = inputTextField.getText();
             if (inputValue != null && !inputValue.isEmpty() && selectedPriceAlertTradeCurrency != null) {
-                double priceAsDouble = formatter.parseNumberStringToDouble(inputValue);
+                double priceAsDouble = BSFormatter.parseNumberStringToDouble(inputValue);
                 String currencyCode = selectedPriceAlertTradeCurrency;
                 int precision = CurrencyUtil.isCryptoCurrency(currencyCode) ?
                         Altcoin.SMALLEST_UNIT_EXPONENT : 2;
-                String stringValue = formatter.formatRoundedDoubleWithPrecision(priceAsDouble, precision);
+                String stringValue = BSFormatter.formatRoundedDoubleWithPrecision(priceAsDouble, precision);
                 inputTextField.setText(stringValue);
             }
         } catch (Throwable ignore) {

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
@@ -113,7 +113,7 @@ public class BondingViewUtils {
                     Coin miningFee = miningFeeAndTxSize.first;
                     int txSize = miningFeeAndTxSize.second;
                     BSFormatter formatter = new BSFormatter();
-                    String duration = formatter.formatDurationAsWords(lockupTime * 10 * 60 * 1000L, false, false);
+                    String duration = BSFormatter.formatDurationAsWords(lockupTime * 10 * 60 * 1000L, false, false);
                     new Popup<>().headLine(Res.get("dao.bond.reputation.lockup.headline"))
                             .confirmation(Res.get("dao.bond.reputation.lockup.details",
                                     bsqFormatter.formatCoinWithCode(lockupAmount),
@@ -174,7 +174,7 @@ public class BondingViewUtils {
                     Coin miningFee = miningFeeAndTxSize.first;
                     int txSize = miningFeeAndTxSize.second;
                     BSFormatter formatter = new BSFormatter();
-                    String duration = formatter.formatDurationAsWords(lockTime * 10 * 60 * 1000L, false, false);
+                    String duration = BSFormatter.formatDurationAsWords(lockTime * 10 * 60 * 1000L, false, false);
                     new Popup<>().headLine(Res.get("dao.bond.reputation.unlock.headline"))
                             .confirmation(Res.get("dao.bond.reputation.unlock.details",
                                     bsqFormatter.formatCoinWithCode(unlockAmount),

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondListItem.java
@@ -21,6 +21,7 @@ import bisq.core.dao.governance.bond.Bond;
 import bisq.core.dao.governance.bond.BondState;
 import bisq.core.dao.governance.bond.role.BondedRole;
 import bisq.core.locale.Res;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -58,7 +59,7 @@ class BondListItem {
             bondDetails = Utilities.bytesAsHexString(bond.getBondedAsset().getHash());
         }
         lockupTxId = bond.getLockupTxId();
-        lockupDateString = bond.getLockupDate() > 0 ? bsqFormatter.formatDateTime(new Date(bond.getLockupDate())) : "-";
+        lockupDateString = bond.getLockupDate() > 0 ? BSFormatter.formatDateTime(new Date(bond.getLockupDate())) : "-";
         bondState = bond.getBondState();
         bondStateString = Res.get("dao.bond.bondState." + bond.getBondState().name());
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationListItem.java
@@ -21,6 +21,7 @@ import bisq.core.dao.governance.bond.BondState;
 import bisq.core.dao.governance.bond.reputation.MyBondedReputation;
 import bisq.core.dao.governance.bond.reputation.MyReputation;
 import bisq.core.locale.Res;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -57,7 +58,7 @@ class MyReputationListItem {
         txId = myBondedReputation.getLockupTxId();
         amount = bsqFormatter.formatCoin(Coin.valueOf(myBondedReputation.getAmount()));
         lockupDate = new Date(myBondedReputation.getLockupDate());
-        lockupDateString = bsqFormatter.formatDateTime(lockupDate);
+        lockupDateString = BSFormatter.formatDateTime(lockupDate);
         lockTime = Integer.toString(myBondedReputation.getLockTime());
         lockupTxId = myBondedReputation.getLockupTxId();
         bondState = myBondedReputation.getBondState();

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RoleDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RoleDetailsWindow.java
@@ -24,6 +24,7 @@ import bisq.core.dao.DaoFacade;
 import bisq.core.dao.state.model.governance.BondedRoleType;
 import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.locale.Res;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import org.bitcoinj.core.Coin;
@@ -97,6 +98,6 @@ class RoleDetailsWindow extends Overlay<RoleDetailsWindow> {
                 bondedRoleType.getLink(), bondedRoleType.getLink(), 0);
 
         FormBuilder.addTopLabelTextField(gridPane, ++rowIndex, Res.get("dao.bond.details.isSingleton"),
-                bsqFormatter.booleanToYesNo(bondedRoleType.isAllowMultipleHolders()));
+                BSFormatter.booleanToYesNo(bondedRoleType.isAllowMultipleHolders()));
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/MyProofOfBurnListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/MyProofOfBurnListItem.java
@@ -21,6 +21,7 @@ import bisq.core.dao.governance.proofofburn.MyProofOfBurn;
 import bisq.core.dao.governance.proofofburn.ProofOfBurnService;
 import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.locale.Res;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -52,7 +53,7 @@ class MyProofOfBurnListItem {
         if (optionalTx.isPresent()) {
             Tx tx = optionalTx.get();
             date = new Date(tx.getTime());
-            dateAsString = bsqFormatter.formatDateTime(date);
+            dateAsString = BSFormatter.formatDateTime(date);
             amount = proofOfBurnService.getAmount(tx);
             amountAsString = bsqFormatter.formatCoinWithCode(Coin.valueOf(amount));
             txId = tx.getId();

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnListItem.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.dao.burnbsq.proofofburn;
 
 import bisq.core.dao.governance.proofofburn.ProofOfBurnService;
 import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -46,6 +47,6 @@ class ProofOfBurnListItem {
         hashAsHex = Utilities.bytesAsHexString(proofOfBurnService.getHashFromOpReturnData(tx));
         pubKey = Utilities.bytesAsHexString(proofOfBurnService.getPubKey(txId));
         date = new Date(tx.getTime());
-        dateAsString = bsqFormatter.formatDateTime(date);
+        dateAsString = BSFormatter.formatDateTime(date);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -718,7 +718,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                             public void updateItem(final ProposalsListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(bsqFormatter.formatDateTime(item.getProposal().getCreationDateAsDate()));
+                                    setText(BSFormatter.formatDateTime(item.getProposal().getCreationDateAsDate()));
                                 else
                                     setText("");
                             }

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -57,6 +57,7 @@ import bisq.core.dao.state.model.governance.Role;
 import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.dao.state.model.governance.Vote;
 import bisq.core.locale.Res;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.UserThread;
@@ -637,7 +638,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
                             public void updateItem(final ProposalListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(bsqFormatter.formatDateTime(item.getProposal().getCreationDateAsDate()));
+                                    setText(BSFormatter.formatDateTime(item.getProposal().getCreationDateAsDate()));
                                 else
                                     setText("");
                             }

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -38,6 +38,7 @@ import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.Timer;
@@ -367,7 +368,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
-                                    setText(bsqFormatter.formatDateTime(item.getDate()));
+                                    setText(BSFormatter.formatDateTime(item.getDate()));
                                 } else {
                                     setText("");
                                 }
@@ -630,7 +631,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                                 style = "dao-tx-type-issuance-icon";
                                                 int issuanceBlockHeight = daoFacade.getIssuanceBlockHeight(txId);
                                                 long blockTime = daoFacade.getBlockTime(issuanceBlockHeight);
-                                                String formattedDate = bsqFormatter.formatDateTime(new Date(blockTime));
+                                                String formattedDate = BSFormatter.formatDateTime(new Date(blockTime));
                                                 toolTipText = Res.get("dao.tx.issuanceFromCompReq.tooltip", formattedDate);
                                             } else {
                                                 awesomeIcon = AwesomeIcon.FILE_TEXT;
@@ -644,7 +645,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                                 style = "dao-tx-type-issuance-icon";
                                                 int issuanceBlockHeight = daoFacade.getIssuanceBlockHeight(txId);
                                                 long blockTime = daoFacade.getBlockTime(issuanceBlockHeight);
-                                                String formattedDate = bsqFormatter.formatDateTime(new Date(blockTime));
+                                                String formattedDate = BSFormatter.formatDateTime(new Date(blockTime));
                                                 toolTipText = Res.get("dao.tx.issuanceFromReimbursement.tooltip", formattedDate);
                                             } else {
                                                 awesomeIcon = AwesomeIcon.FILE_TEXT;

--- a/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
@@ -224,7 +224,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
         dateColumn.setComparator(Comparator.comparing(Dispute::getOpeningDate));
         buyerOnionAddressColumn.setComparator(Comparator.comparing(this::getBuyerOnionAddressColumnLabel));
         sellerOnionAddressColumn.setComparator(Comparator.comparing(this::getSellerOnionAddressColumnLabel));
-        marketColumn.setComparator((o1, o2) -> formatter.getCurrencyPair(o1.getContract().getOfferPayload().getCurrencyCode()).compareTo(o2.getContract().getOfferPayload().getCurrencyCode()));
+        marketColumn.setComparator((o1, o2) -> BSFormatter.getCurrencyPair(o1.getContract().getOfferPayload().getCurrencyCode()).compareTo(o2.getContract().getOfferPayload().getCurrencyCode()));
 
         dateColumn.setSortType(TableColumn.SortType.DESCENDING);
         tableView.getSortOrder().add(dateColumn);
@@ -257,7 +257,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                             .append(dispute0.getTradeId())
                             .append("\n")
                             .append("## Date: ")
-                            .append(formatter.formatDateTime(dispute0.getOpeningDate()))
+                            .append(BSFormatter.formatDateTime(dispute0.getOpeningDate()))
                             .append("\n")
                             .append("## Is support ticket: ")
                             .append(dispute0.isSupportTicket())
@@ -582,7 +582,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                             public void updateItem(final Dispute item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty)
-                                    setText(formatter.formatDateTime(item.getOpeningDate()));
+                                    setText(BSFormatter.formatDateTime(item.getOpeningDate()));
                                 else
                                     setText("");
                             }
@@ -693,7 +693,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
             if (buyerNodeAddress != null) {
                 String nrOfDisputes = disputeManager.getNrOfDisputes(true, contract);
                 long accountAge = accountAgeWitnessService.getAccountAge(contract.getBuyerPaymentAccountPayload(), contract.getBuyerPubKeyRing());
-                String age = formatter.formatAccountAge(accountAge);
+                String age = BSFormatter.formatAccountAge(accountAge);
                 String postFix = CurrencyUtil.isFiatCurrency(item.getContract().getOfferPayload().getCurrencyCode()) ? " / " + age : "";
                 return buyerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + postFix + ")";
             } else
@@ -710,7 +710,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
             if (sellerNodeAddress != null) {
                 String nrOfDisputes = disputeManager.getNrOfDisputes(false, contract);
                 long accountAge = accountAgeWitnessService.getAccountAge(contract.getSellerPaymentAccountPayload(), contract.getSellerPubKeyRing());
-                String age = formatter.formatAccountAge(accountAge);
+                String age = BSFormatter.formatAccountAge(accountAge);
                 String postFix = CurrencyUtil.isFiatCurrency(item.getContract().getOfferPayload().getCurrencyCode()) ? " / " + age : "";
                 return sellerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + postFix + ")";
             } else
@@ -736,7 +736,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                             public void updateItem(final Dispute item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty)
-                                    setText(formatter.getCurrencyPair(item.getContract().getOfferPayload().getCurrencyCode()));
+                                    setText(BSFormatter.getCurrencyPair(item.getContract().getOfferPayload().getCurrencyCode()));
                                 else
                                     setText("");
                             }

--- a/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
@@ -228,7 +228,7 @@ public class LockedView extends ActivatableView<VBox, Void> {
                         super.updateItem(item, empty);
                         if (item != null && !empty) {
                             if (getTradable(item).isPresent())
-                                setGraphic(new AutoTooltipLabel(formatter.formatDateTime(getTradable(item).get().getDate())));
+                                setGraphic(new AutoTooltipLabel(BSFormatter.formatDateTime(getTradable(item).get().getDate())));
                             else
                                 setGraphic(new AutoTooltipLabel(Res.get("shared.noDateAvailable")));
                         } else {

--- a/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
@@ -228,7 +228,7 @@ public class ReservedView extends ActivatableView<VBox, Void> {
                         super.updateItem(item, empty);
                         if (item != null && !empty) {
                             if (getTradable(item).isPresent())
-                                setGraphic(new AutoTooltipLabel(formatter.formatDateTime(getTradable(item).get().getDate())));
+                                setGraphic(new AutoTooltipLabel(BSFormatter.formatDateTime(getTradable(item).get().getDate())));
                             else
                                 setGraphic(new AutoTooltipLabel(Res.get("shared.noDateAvailable")));
                         } else {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -239,7 +239,7 @@ class TransactionsListItem {
         }
         // Use tx.getIncludedInBestChainAt() when available, otherwise use tx.getUpdateTime()
         date = transaction.getIncludedInBestChainAt() != null ? transaction.getIncludedInBestChainAt() : transaction.getUpdateTime();
-        dateString = formatter.formatDateTime(date);
+        dateString = BSFormatter.formatDateTime(date);
 
         isDustAttackTx = received && valueSentToMe.value < ignoreDustThreshold;
         if (isDustAttackTx) {

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -183,8 +183,8 @@ public class MarketView extends ActivatableViewAndModel<TabPane, Activatable> {
                 .map(trade -> {
                     StringBuilder sb = new StringBuilder();
                     sb.append("Trade ID: ").append(trade.getOfferId()).append("\n")
-                            .append("Date: ").append(formatter.formatDateTime(trade.getTradeDate())).append("\n")
-                            .append("Market: ").append(formatter.getCurrencyPair(trade.getCurrencyCode())).append("\n")
+                            .append("Date: ").append(BSFormatter.formatDateTime(trade.getTradeDate())).append("\n")
+                            .append("Market: ").append(BSFormatter.getCurrencyPair(trade.getCurrencyCode())).append("\n")
                             .append("Price: ").append(formatter.formatPrice(trade.getTradePrice())).append("\n")
                             .append("Amount: ").append(formatter.formatCoin(trade.getTradeAmount())).append("\n")
                             .append("Volume: ").append(formatter.formatVolume(trade.getTradeVolume())).append("\n")
@@ -205,7 +205,7 @@ public class MarketView extends ActivatableViewAndModel<TabPane, Activatable> {
                     StringBuilder sb = new StringBuilder();
                     sb.append("Offer ID: ").append(offer.getId()).append("\n")
                             .append("Type: ").append(offer.getDirection().name()).append("\n")
-                            .append("Market: ").append(formatter.getCurrencyPair(offer.getCurrencyCode())).append("\n")
+                            .append("Market: ").append(BSFormatter.getCurrencyPair(offer.getCurrencyCode())).append("\n")
                             .append("Price: ").append(formatter.formatPrice(offer.getPrice())).append("\n")
                             .append("Amount: ").append(formatter.formatAmount(offer)).append(" BTC\n")
                             .append("Payment method: ").append(Res.get(offer.getPaymentMethod().getId())).append("\n")

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -223,15 +223,15 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                         public String toString(Number object) {
                             final double doubleValue = (double) object;
                             if (CurrencyUtil.isCryptoCurrency(model.getCurrencyCode())) {
-                                final String withCryptoPrecision = formatter.formatRoundedDoubleWithPrecision(doubleValue, cryptoPrecision);
+                                final String withCryptoPrecision = BSFormatter.formatRoundedDoubleWithPrecision(doubleValue, cryptoPrecision);
                                 if (withCryptoPrecision.equals("0.000")) {
                                     cryptoPrecision = 8;
-                                    return formatter.formatRoundedDoubleWithPrecision(doubleValue, cryptoPrecision);
+                                    return BSFormatter.formatRoundedDoubleWithPrecision(doubleValue, cryptoPrecision);
                                 } else {
                                     return withCryptoPrecision;
                                 }
                             } else {
-                                return formatter.formatRoundedDoubleWithPrecision(doubleValue, 2);
+                                return BSFormatter.formatRoundedDoubleWithPrecision(doubleValue, 2);
                             }
                         }
 
@@ -268,7 +268,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
 
                         priceColumnLabel.set(Res.get("shared.priceWithCur", code));
                     }
-                    xAxis.setLabel(formatter.getPriceWithCurrencyCode(code));
+                    xAxis.setLabel(BSFormatter.getPriceWithCurrencyCode(code));
 
                     seriesBuy.setName(leftHeaderLabel.getText() + "   ");
                     seriesSell.setName(rightHeaderLabel.getText());

--- a/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
@@ -185,7 +185,7 @@ class SpreadViewModel extends ActivatableViewModel {
                                 .multiply(BigDecimal.valueOf(10000))
                                 .divide(marketPriceAsBigDecimal, RoundingMode.HALF_UP)
                                 .doubleValue() / 10000;
-                        percentage = formatter.formatPercentagePrice(percentageValue);
+                        percentage = BSFormatter.formatPercentagePrice(percentageValue);
                     }
                 } catch (Throwable t) {
                     try {

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -239,7 +239,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                         String code = selectedTradeCurrency.getCode();
                         volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amountWithCur", code)));
 
-                        priceColumnLabel.set(formatter.getPriceWithCurrencyCode(code));
+                        priceColumnLabel.set(BSFormatter.getPriceWithCurrencyCode(code));
 
                         tableView.getColumns().remove(marketColumn);
                     }
@@ -345,7 +345,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 double doubleValue = (double) object;
                 if (CurrencyUtil.isCryptoCurrency(currencyCode)) {
                     final double value = MathUtils.scaleDownByPowerOf10(doubleValue, 8);
-                    return formatter.formatRoundedDoubleWithPrecision(value, 8);
+                    return BSFormatter.formatRoundedDoubleWithPrecision(value, 8);
                 } else {
                     return formatter.formatPrice(Price.valueOf(currencyCode, MathUtils.doubleToLong(doubleValue)));
                 }
@@ -362,7 +362,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             public String toString(Number object) {
                 if (CurrencyUtil.isCryptoCurrency(model.getCurrencyCode())) {
                     final double value = MathUtils.scaleDownByPowerOf10((long) object, 8);
-                    return formatter.formatRoundedDoubleWithPrecision(value, 8);
+                    return BSFormatter.formatRoundedDoubleWithPrecision(value, 8);
                 } else {
                     return formatter.formatPrice(Price.valueOf(model.getCurrencyCode(), (long) object));
                 }
@@ -568,7 +568,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                             public void updateItem(final TradeStatistics2 item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(formatter.formatDateTime(item.getTradeDate()));
+                                    setText(BSFormatter.formatDateTime(item.getTradeDate()));
                                 else
                                     setText("");
                             }
@@ -597,7 +597,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                             public void updateItem(final TradeStatistics2 item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(formatter.getCurrencyPair(item.getCurrencyCode()));
+                                    setText(BSFormatter.getCurrencyPair(item.getCurrencyCode()));
                                 else
                                     setText("");
                             }
@@ -744,7 +744,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @NotNull
     private String getDirectionLabel(TradeStatistics2 item) {
-        return formatter.getDirectionWithCode(OfferPayload.Direction.valueOf(item.getDirection().name()), item.getCurrencyCode());
+        return BSFormatter.getDirectionWithCode(OfferPayload.Direction.valueOf(item.getDirection().name()), item.getCurrencyCode());
     }
 
     @NotNull

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -567,11 +567,11 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void addBindings() {
-        priceCurrencyLabel.textProperty().bind(createStringBinding(() -> btcFormatter.getCounterCurrency(model.tradeCurrencyCode.get()), model.tradeCurrencyCode));
+        priceCurrencyLabel.textProperty().bind(createStringBinding(() -> BSFormatter.getCounterCurrency(model.tradeCurrencyCode.get()), model.tradeCurrencyCode));
 
         marketBasedPriceLabel.prefWidthProperty().bind(priceCurrencyLabel.widthProperty());
         volumeCurrencyLabel.textProperty().bind(model.tradeCurrencyCode);
-        priceDescriptionLabel.textProperty().bind(createStringBinding(() -> btcFormatter.getPriceWithCurrencyCode(model.tradeCurrencyCode.get(), "shared.fixedPriceInCurForCur"), model.tradeCurrencyCode));
+        priceDescriptionLabel.textProperty().bind(createStringBinding(() -> BSFormatter.getPriceWithCurrencyCode(model.tradeCurrencyCode.get(), "shared.fixedPriceInCurForCur"), model.tradeCurrencyCode));
         volumeDescriptionLabel.textProperty().bind(createStringBinding(model.volumeDescriptionLabel::get, model.tradeCurrencyCode, model.volumeDescriptionLabel));
         amountTextField.textProperty().bindBidirectional(model.amount);
         minAmountTextField.textProperty().bindBidirectional(model.minAmount);

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -315,7 +315,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                         if (marketPrice != null && marketPrice.isRecentExternalPriceAvailable()) {
                             double marketPriceAsDouble = marketPrice.getPrice();
                             try {
-                                double priceAsDouble = btcFormatter.parseNumberStringToDouble(price.get());
+                                double priceAsDouble = BSFormatter.parseNumberStringToDouble(price.get());
                                 double relation = priceAsDouble / marketPriceAsDouble;
                                 final OfferPayload.Direction compareDirection = CurrencyUtil.isCryptoCurrency(currencyCode) ?
                                         OfferPayload.Direction.SELL :
@@ -323,7 +323,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                                 double percentage = dataModel.getDirection() == compareDirection ? 1 - relation : relation - 1;
                                 percentage = MathUtils.roundDouble(percentage, 4);
                                 dataModel.setMarketPriceMargin(percentage);
-                                marketPriceMargin.set(btcFormatter.formatToPercent(percentage));
+                                marketPriceMargin.set(BSFormatter.formatToPercent(percentage));
                                 applyMakerFee();
                             } catch (NumberFormatException t) {
                                 marketPriceMargin.set("");
@@ -341,7 +341,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             if (inputIsMarketBasedPrice) {
                 try {
                     if (!newValue.isEmpty() && !newValue.equals("-")) {
-                        double percentage = btcFormatter.parsePercentStringToDouble(newValue);
+                        double percentage = BSFormatter.parsePercentStringToDouble(newValue);
                         if (percentage >= 1 || percentage <= -1) {
                             new Popup<>().warning(Res.get("popup.warning.tooLargePercentageValue") + "\n" +
                                     Res.get("popup.warning.examplePercentageValue"))
@@ -364,7 +364,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                                         Altcoin.SMALLEST_UNIT_EXPONENT : Fiat.SMALLEST_UNIT_EXPONENT;
                                 // protect from triggering unwanted updates
                                 ignorePriceStringListener = true;
-                                price.set(btcFormatter.formatRoundedDoubleWithPrecision(targetPrice, precision));
+                                price.set(BSFormatter.formatRoundedDoubleWithPrecision(targetPrice, precision));
                                 ignorePriceStringListener = false;
                                 setPriceToModel();
                                 dataModel.setMarketPriceMargin(percentage);
@@ -461,7 +461,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
         securityDepositAsDoubleListener = (ov, oldValue, newValue) -> {
             if (newValue != null) {
-                buyerSecurityDeposit.set(btcFormatter.formatToPercent((double) newValue));
+                buyerSecurityDeposit.set(BSFormatter.formatToPercent((double) newValue));
                 if (dataModel.getAmount().get() != null)
                     buyerSecurityDepositInBTC.set(btcFormatter.formatCoinWithCode(dataModel.getBuyerSecurityDepositAsCoin()));
             } else {
@@ -520,7 +520,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
                 tradeFeeInBsqWithFiat.set(Res.get("createOffer.tradeFee.fiatAndPercent",
                         feeInFiatAsString,
-                        btcFormatter.formatToPercentWithSymbol(percent)));
+                        BSFormatter.formatToPercentWithSymbol(percent)));
             }
         }
         tradeFeeCurrencyCode.set(dataModel.isCurrencyForMakerFeeBtc() ? Res.getBaseCurrencyCode() : "BSQ");
@@ -601,7 +601,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 isBuy ? Res.get("shared.buy") : Res.get("shared.sell"));
 
         securityDepositValidator.setPaymentAccount(dataModel.paymentAccount);
-        buyerSecurityDeposit.set(btcFormatter.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
+        buyerSecurityDeposit.set(BSFormatter.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
         buyerSecurityDepositLabel.set(getSecurityDepositLabel());
 
         applyMakerFee();
@@ -812,7 +812,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 // field wasn't set manually
                 inputIsMarketBasedPrice = true;
             }
-        marketPriceMargin.set(btcFormatter.formatRoundedDoubleWithPrecision(dataModel.getMarketPriceMargin() * 100, 2));
+        marketPriceMargin.set(BSFormatter.formatRoundedDoubleWithPrecision(dataModel.getMarketPriceMargin() * 100, 2));
 
         // We want to trigger a recalculation of the volume
         UserThread.execute(() -> {
@@ -865,20 +865,20 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             if (result.isValid) {
                 double defaultSecurityDeposit = Restrictions.getDefaultBuyerSecurityDepositAsPercent(getPaymentAccount());
                 String key = "buyerSecurityDepositIsLowerAsDefault";
-                double depositAsDouble = btcFormatter.parsePercentStringToDouble(buyerSecurityDeposit.get());
+                double depositAsDouble = BSFormatter.parsePercentStringToDouble(buyerSecurityDeposit.get());
                 if (preferences.showAgain(key) && depositAsDouble < defaultSecurityDeposit) {
                     String postfix = dataModel.isBuyOffer() ?
                             Res.get("createOffer.tooLowSecDeposit.makerIsBuyer") :
                             Res.get("createOffer.tooLowSecDeposit.makerIsSeller");
                     new Popup<>()
                             .warning(Res.get("createOffer.tooLowSecDeposit.warning",
-                                    btcFormatter.formatToPercentWithSymbol(defaultSecurityDeposit)) + "\n\n" + postfix)
+                                    BSFormatter.formatToPercentWithSymbol(defaultSecurityDeposit)) + "\n\n" + postfix)
                             .width(800)
                             .actionButtonText(Res.get("createOffer.resetToDefault"))
                             .onAction(() -> {
                                 dataModel.setBuyerSecurityDeposit(defaultSecurityDeposit);
                                 ignoreSecurityDepositStringListener = true;
-                                buyerSecurityDeposit.set(btcFormatter.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
+                                buyerSecurityDeposit.set(BSFormatter.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
                                 ignoreSecurityDepositStringListener = false;
                             })
                             .closeButtonText(Res.get("createOffer.useLowerValue"))
@@ -895,7 +895,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     private void applyBuyerSecurityDepositOnFocusOut() {
         setBuyerSecurityDepositToModel();
         ignoreSecurityDepositStringListener = true;
-        buyerSecurityDeposit.set(btcFormatter.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
+        buyerSecurityDeposit.set(BSFormatter.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
         ignoreSecurityDepositStringListener = false;
     }
 
@@ -905,7 +905,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     public boolean isPriceInRange() {
         if (marketPriceMargin.get() != null && !marketPriceMargin.get().isEmpty()) {
-            if (Math.abs(btcFormatter.parsePercentStringToDouble(marketPriceMargin.get())) > preferences.getMaxPriceDistanceInPercent()) {
+            if (Math.abs(BSFormatter.parsePercentStringToDouble(marketPriceMargin.get())) > preferences.getMaxPriceDistanceInPercent()) {
                 displayPriceOutOfRangePopup();
                 return false;
             } else {
@@ -919,7 +919,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     private void displayPriceOutOfRangePopup() {
         Popup popup = new Popup<>();
         popup.warning(Res.get("createOffer.priceOutSideOfDeviation",
-                btcFormatter.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())))
+                BSFormatter.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())))
                 .actionButtonText(Res.get("createOffer.changePrice"))
                 .onAction(popup::hide)
                 .closeButtonTextWithGoTo("navigation.settings.preferences")
@@ -1129,7 +1129,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     private void setBuyerSecurityDepositToModel() {
         if (buyerSecurityDeposit.get() != null && !buyerSecurityDeposit.get().isEmpty()) {
-            dataModel.setBuyerSecurityDeposit(btcFormatter.parsePercentStringToDouble(buyerSecurityDeposit.get()));
+            dataModel.setBuyerSecurityDeposit(BSFormatter.parsePercentStringToDouble(buyerSecurityDeposit.get()));
         } else {
             dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent(getPaymentAccount()));
         }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -226,8 +226,8 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         tableView.setPlaceholder(placeholder);
 
         marketColumn.setComparator((o1, o2) -> {
-            String str1 = formatter.getCurrencyPair(o1.getOffer().getCurrencyCode());
-            String str2 = formatter.getCurrencyPair(o2.getOffer().getCurrencyCode());
+            String str1 = BSFormatter.getCurrencyPair(o1.getOffer().getCurrencyCode());
+            String str2 = BSFormatter.getCurrencyPair(o2.getOffer().getCurrencyCode());
             return str1 != null && str2 != null ? str1.compareTo(str2) : 0;
         });
         priceColumn.setComparator((o1, o2) -> {
@@ -324,7 +324,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                             tableView.getColumns().add(0, marketColumn);
                     } else {
                         volumeColumn.setTitleWithHelpText(Res.get("offerbook.volume", code), Res.get("shared.amountHelp"));
-                        priceColumn.setTitle(formatter.getPriceWithCurrencyCode(code));
+                        priceColumn.setTitle(BSFormatter.getPriceWithCurrencyCode(code));
                         priceColumn.getStyleClass().add("first-column");
 
                         tableView.getColumns().remove(marketColumn);
@@ -573,7 +573,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 final long tradeLimit = model.accountAgeWitnessService.getMyTradeLimit(account.get(), offer.getCurrencyCode());
                 new Popup<>()
                         .warning(Res.get("offerbook.warning.tradeLimitNotMatching",
-                                formatter.formatAccountAge(model.accountAgeWitnessService.getMyAccountAge(account.get().getPaymentAccountPayload())),
+                                BSFormatter.formatAccountAge(model.accountAgeWitnessService.getMyAccountAge(account.get().getPaymentAccountPayload())),
                                 formatter.formatCoinWithCode(Coin.valueOf(tradeLimit)),
                                 formatter.formatCoinWithCode(offer.getMinAmount())))
                         .show();
@@ -693,7 +693,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty)
-                                    setText(formatter.getCurrencyPair(item.getOffer().getCurrencyCode()));
+                                    setText(BSFormatter.getCurrencyPair(item.getOffer().getCurrencyCode()));
                                 else
                                     setText("");
                             }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -359,7 +359,7 @@ class OfferBookViewModel extends ActivatableViewModel {
     }
 
     String getAbsolutePriceMargin(Offer offer) {
-        return formatter.formatPercentagePrice(Math.abs(offer.getMarketPriceMargin()));
+        return BSFormatter.formatPercentagePrice(Math.abs(offer.getMarketPriceMargin()));
     }
 
     private String formatPrice(Offer offer, boolean decimalAligned) {
@@ -369,12 +369,12 @@ class OfferBookViewModel extends ActivatableViewModel {
     private String formatMarketPriceMargin(Offer offer, boolean decimalAligned) {
         String postFix = "";
         if (offer.isUseMarketBasedPrice()) {
-            postFix = " (" + formatter.formatPercentagePrice(offer.getMarketPriceMargin()) + ")";
+            postFix = " (" + BSFormatter.formatPercentagePrice(offer.getMarketPriceMargin()) + ")";
 
         }
 
         if (decimalAligned) {
-            postFix = formatter.fillUpPlacesWithEmptyStrings(postFix, maxPlacesForMarketPriceMargin.get());
+            postFix = BSFormatter.fillUpPlacesWithEmptyStrings(postFix, maxPlacesForMarketPriceMargin.get());
         }
 
         return postFix;
@@ -471,7 +471,7 @@ class OfferBookViewModel extends ActivatableViewModel {
     }
 
     String getDirectionLabelTooltip(Offer offer) {
-        return formatter.getDirectionWithCodeDetailed(offer.getMirroredDirection(), offer.getCurrencyCode());
+        return BSFormatter.getDirectionWithCodeDetailed(offer.getMirroredDirection(), offer.getCurrencyCode());
     }
 
     Optional<PaymentAccount> getMostMaturePaymentAccountForOffer(Offer offer) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -278,7 +278,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         String currencyCode = model.dataModel.getCurrencyCode();
         volumeCurrencyLabel.setText(currencyCode);
-        priceDescriptionLabel.setText(formatter.getPriceWithCurrencyCode(currencyCode));
+        priceDescriptionLabel.setText(BSFormatter.getPriceWithCurrencyCode(currencyCode));
         volumeDescriptionLabel.setText(model.volumeDescriptionLabel.get());
 
         if (model.getPossiblePaymentAccounts().size() > 1) {
@@ -616,7 +616,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         totalToPayTextField.textProperty().bind(model.totalToPay);
         addressTextField.amountAsCoinProperty().bind(model.dataModel.getMissingCoin());
         amountTextField.validationResultProperty().bind(model.amountValidationResult);
-        priceCurrencyLabel.textProperty().bind(createStringBinding(() -> formatter.getCounterCurrency(model.dataModel.getCurrencyCode())));
+        priceCurrencyLabel.textProperty().bind(createStringBinding(() -> BSFormatter.getCounterCurrency(model.dataModel.getCurrencyCode())));
         priceAsPercentageLabel.prefWidthProperty().bind(priceCurrencyLabel.widthProperty());
         nextButton.disableProperty().bind(model.isNextButtonDisabled);
         tradeFeeInBtcLabel.textProperty().bind(model.tradeFeeInBtcWithFiat);

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -206,7 +206,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
 
         amountRange = btcFormatter.formatCoin(offer.getMinAmount()) + " - " + btcFormatter.formatCoin(offer.getAmount());
         price = btcFormatter.formatPrice(dataModel.tradePrice);
-        marketPriceMargin = btcFormatter.formatToPercent(offer.getMarketPriceMargin());
+        marketPriceMargin = BSFormatter.formatToPercent(offer.getMarketPriceMargin());
         paymentLabel = Res.get("takeOffer.fundsBox.paymentLabel", offer.getShortId());
 
         checkNotNull(dataModel.getAddressEntry(), "dataModel.getAddressEntry() must not be null");
@@ -316,7 +316,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
 
                 tradeFeeInBsqWithFiat.set(Res.get("createOffer.tradeFee.fiatAndPercent",
                         feeInFiatAsString,
-                        btcFormatter.formatToPercentWithSymbol(percent)));
+                        BSFormatter.formatToPercentWithSymbol(percent)));
             }
         }
         tradeFeeDescription.set(DevEnv.isDaoActivated() ? Res.get("createOffer.tradeFee.descriptionBSQEnabled") :

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
@@ -133,15 +133,15 @@ public class ContractWindow extends Overlay<ContractWindow> {
         addConfirmationLabelTextFieldWithCopyIcon(gridPane, rowIndex, Res.get("shared.offerId"), offer.getId(),
                 Layout.TWICE_FIRST_ROW_DISTANCE).second.setMouseTransparent(false);
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("contractWindow.dates"),
-                formatter.formatDateTime(offer.getDate()) + " / " + formatter.formatDateTime(dispute.getTradeDate()));
+                BSFormatter.formatDateTime(offer.getDate()) + " / " + BSFormatter.formatDateTime(dispute.getTradeDate()));
         String currencyCode = offer.getCurrencyCode();
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.offerType"),
-                formatter.getDirectionBothSides(offer.getDirection(), currencyCode));
+                BSFormatter.getDirectionBothSides(offer.getDirection(), currencyCode));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradePrice"),
                 formatter.formatPrice(contract.getTradePrice()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradeAmount"),
                 formatter.formatCoinWithCode(contract.getTradeAmount()));
-        addConfirmationLabelLabel(gridPane, ++rowIndex, formatter.formatVolumeLabel(currencyCode, ":"),
+        addConfirmationLabelLabel(gridPane, ++rowIndex, BSFormatter.formatVolumeLabel(currencyCode, ":"),
                 formatter.formatVolumeWithCode(contract.getTradeVolume()));
         String securityDeposit = Res.getWithColAndCap("shared.buyer") +
                 " " +
@@ -261,7 +261,7 @@ public class ContractWindow extends Overlay<ContractWindow> {
     private String getAccountAge(PaymentAccountPayload paymentAccountPayload, PubKeyRing pubKeyRing, String currencyCode) {
         long age = accountAgeWitnessService.getAccountAge(paymentAccountPayload, pubKeyRing);
         return CurrencyUtil.isFiatCurrency(currencyCode) ?
-                age > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(age)) :
+                age > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(age)) :
                         Res.get("peerInfoIcon.tooltip.unknownAge") :
                 "";
     }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -249,7 +249,7 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         addTitledGroupBg(gridPane, ++rowIndex, 17, Res.get("disputeSummaryWindow.title")).getStyleClass().add("last");
         addConfirmationLabelLabel(gridPane, rowIndex, Res.get("shared.tradeId"), dispute.getShortTradeId(),
                 Layout.TWICE_FIRST_ROW_DISTANCE);
-        addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("disputeSummaryWindow.openDate"), formatter.formatDateTime(dispute.getOpeningDate()));
+        addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("disputeSummaryWindow.openDate"), BSFormatter.formatDateTime(dispute.getOpeningDate()));
         if (dispute.isDisputeOpenerIsMaker()) {
             if (dispute.isDisputeOpenerIsBuyer())
                 role = Res.get("support.buyerOfferer");
@@ -566,13 +566,13 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
                     disputeResult.setLoserPublisher(isLoserPublisherCheckBox.isSelected());
                     disputeResult.setCloseDate(new Date());
                     String text = Res.get("disputeSummaryWindow.close.msg",
-                            formatter.formatDateTime(disputeResult.getCloseDate()),
+                            BSFormatter.formatDateTime(disputeResult.getCloseDate()),
                             role,
-                            formatter.booleanToYesNo(disputeResult.tamperProofEvidenceProperty().get()),
+                            BSFormatter.booleanToYesNo(disputeResult.tamperProofEvidenceProperty().get()),
                             role,
-                            formatter.booleanToYesNo(disputeResult.idVerificationProperty().get()),
+                            BSFormatter.booleanToYesNo(disputeResult.idVerificationProperty().get()),
                             role,
-                            formatter.booleanToYesNo(disputeResult.screenCastProperty().get()),
+                            BSFormatter.booleanToYesNo(disputeResult.screenCastProperty().get()),
                             formatter.formatCoinWithCode(disputeResult.getBuyerPayoutAmount()),
                             formatter.formatCoinWithCode(disputeResult.getSellerPayoutAmount()),
                             disputeResult.summaryNotesProperty().get());

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
@@ -170,17 +170,17 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
         double firstRowDistance = Layout.TWICE_FIRST_ROW_DISTANCE;
         if (takeOfferHandlerOptional.isPresent()) {
             addConfirmationLabelLabel(gridPane, rowIndex, offerTypeLabel,
-                    formatter.getDirectionForTakeOffer(direction, currencyCode), firstRowDistance);
+                    BSFormatter.getDirectionForTakeOffer(direction, currencyCode), firstRowDistance);
             fiatDirectionInfo = direction == OfferPayload.Direction.BUY ? toReceive : toSpend;
             btcDirectionInfo = direction == OfferPayload.Direction.SELL ? toReceive : toSpend;
         } else if (placeOfferHandlerOptional.isPresent()) {
             addConfirmationLabelLabel(gridPane, rowIndex, offerTypeLabel,
-                    formatter.getOfferDirectionForCreateOffer(direction, currencyCode), firstRowDistance);
+                    BSFormatter.getOfferDirectionForCreateOffer(direction, currencyCode), firstRowDistance);
             fiatDirectionInfo = direction == OfferPayload.Direction.SELL ? toReceive : toSpend;
             btcDirectionInfo = direction == OfferPayload.Direction.BUY ? toReceive : toSpend;
         } else {
             addConfirmationLabelLabel(gridPane, rowIndex, offerTypeLabel,
-                    formatter.getDirectionBothSides(direction, currencyCode), firstRowDistance);
+                    BSFormatter.getDirectionBothSides(direction, currencyCode), firstRowDistance);
         }
         String btcAmount = Res.get("shared.btcAmount");
         if (takeOfferHandlerOptional.isPresent()) {
@@ -210,7 +210,7 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
             if (offer.isUseMarketBasedPrice()) {
                 addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, formatter.formatPrice(price) +
                         " " + Res.get("offerDetailsWindow.distance",
-                        formatter.formatPercentagePrice(offer.getMarketPriceMargin())));
+                        BSFormatter.formatPercentagePrice(offer.getMarketPriceMargin())));
             } else {
                 addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, formatter.formatPrice(price));
             }
@@ -307,7 +307,7 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
         addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("offerDetailsWindow.makersOnion"),
                 offer.getMakerNodeAddress().getFullAddress());
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("offerDetailsWindow.creationDate"),
-                formatter.formatDateTime(offer.getDate()));
+                BSFormatter.formatDateTime(offer.getDate()));
         String value = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(offer.getBuyerSecurityDeposit()) +
@@ -322,7 +322,7 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
                     CountryUtil.getNameAndCode(countryCode));
 
         addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("offerDetailsWindow.acceptedArbitrators"),
-                formatter.arbitratorAddressesToString(offer.getArbitratorNodeAddresses()));
+                BSFormatter.arbitratorAddressesToString(offer.getArbitratorNodeAddresses()));
         if (offer.getOfferFeePaymentTxId() != null)
             addLabelTxIdTextField(gridPane, ++rowIndex, Res.get("shared.makerFeeTxId"), offer.getOfferFeePaymentTxId());
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
@@ -34,6 +34,7 @@ import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Proposal;
 import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
+import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Tuple2;
@@ -240,7 +241,7 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
-                                    setText(bsqFormatter.formatDateTime(item.getBlindVoteDate()));
+                                    setText(BSFormatter.formatDateTime(item.getBlindVoteDate()));
                                 } else {
                                     setText("");
                                 }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -134,12 +134,12 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         String offerType = Res.get("shared.offerType");
         if (tradeManager.isBuyer(offer)) {
             addConfirmationLabelLabel(gridPane, rowIndex, offerType,
-                    formatter.getDirectionForBuyer(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
+                    BSFormatter.getDirectionForBuyer(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
             fiatDirectionInfo = toSpend;
             btcDirectionInfo = toReceive;
         } else {
             addConfirmationLabelLabel(gridPane, rowIndex, offerType,
-                    formatter.getDirectionForSeller(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
+                    BSFormatter.getDirectionForSeller(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
             fiatDirectionInfo = toReceive;
             btcDirectionInfo = toSpend;
         }
@@ -198,7 +198,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         addConfirmationLabelTextFieldWithCopyIcon(gridPane, rowIndex, Res.get("shared.tradeId"),
                 trade.getId(), Layout.TWICE_FIRST_ROW_AND_GROUP_DISTANCE);
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("tradeDetailsWindow.tradeDate"),
-                formatter.formatDateTime(trade.getDate()));
+                BSFormatter.formatDateTime(trade.getDate()));
         String securityDeposit = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(offer.getBuyerSecurityDeposit()) +
@@ -226,7 +226,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
                 String paymentDetails = buyerPaymentAccountPayload.getPaymentDetails();
                 long age = accountAgeWitnessService.getAccountAge(buyerPaymentAccountPayload, contract.getBuyerPubKeyRing());
                 buyersAccountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
-                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(age)) :
+                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :
                         "";
 
@@ -240,7 +240,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
                 String paymentDetails = sellerPaymentAccountPayload.getPaymentDetails();
                 long age = accountAgeWitnessService.getAccountAge(sellerPaymentAccountPayload, contract.getSellerPubKeyRing());
                 sellersAccountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
-                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", formatter.formatAccountAge(age)) :
+                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :
                         "";
                 String postFix = sellersAccountAge.isEmpty() ? "" : " / " + sellersAccountAge;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesViewModel.java
@@ -123,18 +123,18 @@ class ClosedTradesViewModel extends ActivatableWithDataModel<ClosedTradesDataMod
     }
 
     String getDirectionLabel(ClosedTradableListItem item) {
-        return (item != null) ? formatter.getDirectionWithCode(dataModel.getDirection(item.getTradable().getOffer()), item.getTradable().getOffer().getCurrencyCode()) : "";
+        return (item != null) ? BSFormatter.getDirectionWithCode(dataModel.getDirection(item.getTradable().getOffer()), item.getTradable().getOffer().getCurrencyCode()) : "";
     }
 
     String getDate(ClosedTradableListItem item) {
-        return formatter.formatDateTime(item.getTradable().getDate());
+        return BSFormatter.formatDateTime(item.getTradable().getDate());
     }
 
     String getMarketLabel(ClosedTradableListItem item) {
         if ((item == null))
             return "";
 
-        return formatter.getCurrencyPair(item.getTradable().getOffer().getCurrencyCode());
+        return BSFormatter.getCurrencyPair(item.getTradable().getOffer().getCurrencyCode());
     }
 
     String getState(ClosedTradableListItem item) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
@@ -73,7 +73,7 @@ class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
 
     public void onInvalidateMarketPriceMargin() {
         marketPriceMargin.set("0.00%");
-        marketPriceMargin.set(btcFormatter.formatToPercent(dataModel.getMarketPriceMargin()));
+        marketPriceMargin.set(BSFormatter.formatToPercent(dataModel.getMarketPriceMargin()));
     }
 
     public void onInvalidatePrice() {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesViewModel.java
@@ -65,18 +65,18 @@ class FailedTradesViewModel extends ActivatableWithDataModel<FailedTradesDataMod
     }
 
     String getDirectionLabel(FailedTradesListItem item) {
-        return (item != null) ? formatter.getDirectionWithCode(dataModel.getDirection(item.getTrade().getOffer()), item.getTrade().getOffer().getCurrencyCode()) : "";
+        return (item != null) ? BSFormatter.getDirectionWithCode(dataModel.getDirection(item.getTrade().getOffer()), item.getTrade().getOffer().getCurrencyCode()) : "";
     }
 
     String getMarketLabel(FailedTradesListItem item) {
         if ((item == null))
             return "";
 
-        return formatter.getCurrencyPair(item.getTrade().getOffer().getCurrencyCode());
+        return BSFormatter.getCurrencyPair(item.getTrade().getOffer().getCurrencyCode());
     }
 
     String getDate(FailedTradesListItem item) {
-        return formatter.formatDateTime(item.getTrade().getDate());
+        return BSFormatter.formatDateTime(item.getTrade().getDate());
     }
 
     String getState(FailedTradesListItem item) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
@@ -83,7 +83,7 @@ class OpenOffersViewModel extends ActivatableWithDataModel<OpenOffersDataModel> 
         if (price != null) {
             String postFix = "";
             if (offer.isUseMarketBasedPrice())
-                postFix = " (" + formatter.formatPercentagePrice(offer.getMarketPriceMargin()) + ")";
+                postFix = " (" + BSFormatter.formatPercentagePrice(offer.getMarketPriceMargin()) + ")";
             return formatter.formatPrice(price) + postFix;
         } else {
             return Res.get("shared.na");
@@ -98,18 +98,18 @@ class OpenOffersViewModel extends ActivatableWithDataModel<OpenOffersDataModel> 
         if ((item == null))
             return "";
 
-        return formatter.getDirectionWithCode(dataModel.getDirection(item.getOffer()), item.getOffer().getCurrencyCode());
+        return BSFormatter.getDirectionWithCode(dataModel.getDirection(item.getOffer()), item.getOffer().getCurrencyCode());
     }
 
     String getMarketLabel(OpenOfferListItem item) {
         if ((item == null))
             return "";
 
-        return formatter.getCurrencyPair(item.getOffer().getCurrencyCode());
+        return BSFormatter.getCurrencyPair(item.getOffer().getCurrencyCode());
     }
 
     String getDate(OpenOfferListItem item) {
-        return formatter.formatDateTime(item.getOffer().getDate());
+        return BSFormatter.formatDateTime(item.getOffer().getDate());
     }
 
     boolean isDeactivated(OpenOfferListItem item) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -493,7 +493,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                             public void updateItem(final PendingTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty) {
-                                    setGraphic(new AutoTooltipLabel(formatter.formatDateTime(item.getTrade().getDate())));
+                                    setGraphic(new AutoTooltipLabel(BSFormatter.formatDateTime(item.getTrade().getDate())));
                                 } else {
                                     setGraphic(null);
                                 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -198,7 +198,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
         if ((item == null))
             return "";
 
-        return btcFormatter.getCurrencyPair(item.getTrade().getOffer().getCurrencyCode());
+        return BSFormatter.getCurrencyPair(item.getTrade().getOffer().getCurrencyCode());
     }
 
     private long getMaxTradePeriod() {
@@ -220,7 +220,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     }
 
     public String getRemainingTradeDurationAsWords() {
-        return btcFormatter.formatDurationAsWords(Math.max(0, getRemainingTradeDuration()));
+        return BSFormatter.formatDurationAsWords(Math.max(0, getRemainingTradeDuration()));
     }
 
     public double getRemainingTradeDurationAsPercentage() {
@@ -233,7 +233,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     }
 
     public String getDateForOpenDispute() {
-        return btcFormatter.formatDateTime(new Date(new Date().getTime() + getRemainingTradeDuration()));
+        return BSFormatter.formatDateTime(new Date(new Date().getTime() + getRemainingTradeDuration()));
     }
 
     public boolean showWarning() {
@@ -251,7 +251,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
         Contract contract = trade.getContract();
         if (contract != null) {
             Offer offer = trade.getOffer();
-            return btcFormatter.getRole(contract.isBuyerMakerAndSellerTaker(), dataModel.isMaker(offer), offer.getCurrencyCode());
+            return BSFormatter.getRole(contract.isBuyerMakerAndSellerTaker(), dataModel.isMaker(offer), offer.getCurrencyCode());
         } else {
             return "";
         }

--- a/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
@@ -138,12 +138,12 @@ public class MarketPricePresentation {
     }
 
     private void setupMarketPriceFeed() {
-        priceFeedService.requestPriceFeed(price -> marketPrice.set(formatter.formatMarketPrice(price, priceFeedService.getCurrencyCode())),
+        priceFeedService.requestPriceFeed(price -> marketPrice.set(BSFormatter.formatMarketPrice(price, priceFeedService.getCurrencyCode())),
                 (errorMessage, throwable) -> marketPrice.set(Res.get("shared.na")));
 
         marketPriceBinding = EasyBind.combine(
                 marketPriceCurrencyCode, marketPrice,
-                (currencyCode, price) -> formatter.getCurrencyPair(currencyCode) + ": " + price);
+                (currencyCode, price) -> BSFormatter.getCurrencyPair(currencyCode) + ": " + price);
 
         marketPriceBinding.subscribe((observable, oldValue, newValue) -> {
             if (newValue != null && !newValue.equals(oldValue)) {
@@ -195,14 +195,14 @@ public class MarketPricePresentation {
             MarketPrice marketPrice = priceFeedService.getMarketPrice(currencyCode);
             String priceString;
             if (marketPrice != null && marketPrice.isPriceAvailable()) {
-                priceString = formatter.formatMarketPrice(marketPrice.getPrice(), currencyCode);
+                priceString = BSFormatter.formatMarketPrice(marketPrice.getPrice(), currencyCode);
                 item.setPriceAvailable(true);
                 item.setExternallyProvidedPrice(marketPrice.isExternallyProvidedPrice());
             } else {
                 priceString = Res.get("shared.na");
                 item.setPriceAvailable(false);
             }
-            item.setDisplayString(formatter.getCurrencyPair(currencyCode) + ": " + priceString);
+            item.setDisplayString(BSFormatter.getCurrencyPair(currencyCode) + ": " + priceString);
 
             final String code = item.currencyCode;
             if (selectedPriceFeedComboBoxItemProperty.get() != null &&

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -277,8 +277,8 @@ public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activ
         totalTrafficTextField.textProperty().bind(EasyBind.combine(Statistic.totalSentBytesProperty(),
                 Statistic.totalReceivedBytesProperty(),
                 (sent, received) -> Res.get("settings.net.sentReceived",
-                        formatter.formatBytes((long) sent),
-                        formatter.formatBytes((long) received))));
+                        BSFormatter.formatBytes((long) sent),
+                        BSFormatter.formatBytes((long) received))));
 
         sortedList.comparatorProperty().bind(tableView.comparatorProperty());
         tableView.setItems(sortedList);

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/P2pNetworkListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/P2pNetworkListItem.java
@@ -62,9 +62,9 @@ public class P2pNetworkListItem {
         this.statistic = connection.getStatistic();
 
         sentBytesSubscription = EasyBind.subscribe(statistic.sentBytesProperty(),
-                e -> sentBytes.set(formatter.formatBytes((long) e)));
+                e -> sentBytes.set(BSFormatter.formatBytes((long) e)));
         receivedBytesSubscription = EasyBind.subscribe(statistic.receivedBytesProperty(),
-                e -> receivedBytes.set(formatter.formatBytes((long) e)));
+                e -> receivedBytes.set(BSFormatter.formatBytes((long) e)));
         onionAddressSubscription = EasyBind.subscribe(connection.getPeersNodeAddressProperty(),
                 nodeAddress -> onionAddress.set(nodeAddress != null ? nodeAddress.getFullAddress() : Res.get("settings.net.notKnownYet")));
         roundTripTimeSubscription = EasyBind.subscribe(statistic.roundTripTimeProperty(),
@@ -118,7 +118,7 @@ public class P2pNetworkListItem {
     }
 
     public String getCreationDate() {
-        return formatter.formatDateTime(statistic.getCreationDate());
+        return BSFormatter.formatDateTime(statistic.getCreationDate());
     }
 
     public String getOnionAddress() {

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -30,7 +30,6 @@ import bisq.desktop.util.ImageUtil;
 import bisq.desktop.util.Layout;
 
 import bisq.core.app.BisqEnvironment;
-import bisq.core.btc.BaseCurrencyNetwork;
 import bisq.core.btc.wallet.Restrictions;
 import bisq.core.dao.DaoFacade;
 import bisq.core.dao.DaoOptionKeys;
@@ -315,22 +314,22 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
         deviationListener = (observable, oldValue, newValue) -> {
             try {
-                double value = formatter.parsePercentStringToDouble(newValue);
+                double value = BSFormatter.parsePercentStringToDouble(newValue);
                 final double maxDeviation = 0.5;
                 if (value <= maxDeviation) {
                     preferences.setMaxPriceDistanceInPercent(value);
                 } else {
                     new Popup<>().warning(Res.get("setting.preferences.deviationToLarge", maxDeviation * 100)).show();
-                    UserThread.runAfter(() -> deviationInputTextField.setText(formatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                    UserThread.runAfter(() -> deviationInputTextField.setText(BSFormatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
                 }
             } catch (NumberFormatException t) {
                 log.error("Exception at parseDouble deviation: " + t.toString());
-                UserThread.runAfter(() -> deviationInputTextField.setText(formatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                UserThread.runAfter(() -> deviationInputTextField.setText(BSFormatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
             }
         };
         deviationFocusedListener = (observable1, oldValue1, newValue1) -> {
             if (oldValue1 && !newValue1)
-                UserThread.runAfter(() -> deviationInputTextField.setText(formatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                UserThread.runAfter(() -> deviationInputTextField.setText(BSFormatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
         };
 
         // ignoreTraders
@@ -746,7 +745,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         });
         blockChainExplorerComboBox.setOnAction(e -> preferences.setBlockChainExplorer(blockChainExplorerComboBox.getSelectionModel().getSelectedItem()));
 
-        deviationInputTextField.setText(formatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent()));
+        deviationInputTextField.setText(BSFormatter.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent()));
         deviationInputTextField.textProperty().addListener(deviationListener);
         deviationInputTextField.focusedProperty().addListener(deviationFocusedListener);
 

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -686,7 +686,7 @@ public class GUIUtil {
     }
 
     public static String getPercentage(Coin part, Coin total, BSFormatter formatter) {
-        return formatter.formatToPercentWithSymbol((double) part.value / (double) total.value);
+        return BSFormatter.formatToPercentWithSymbol((double) part.value / (double) total.value);
     }
 
     public static <T> T getParentOfType(Node node, Class<T> t) {

--- a/desktop/src/main/java/bisq/desktop/util/validation/SecurityDepositValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/SecurityDepositValidator.java
@@ -58,11 +58,11 @@ public class SecurityDepositValidator extends NumberValidator {
 
     private ValidationResult validateIfNotTooLowPercentageValue(String input) {
         try {
-            double percentage = formatter.parsePercentStringToDouble(input);
+            double percentage = BSFormatter.parsePercentStringToDouble(input);
             double minPercentage = Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount);
             if (percentage < minPercentage)
                 return new ValidationResult(false,
-                        Res.get("validation.inputTooSmall", formatter.formatToPercentWithSymbol(minPercentage)));
+                        Res.get("validation.inputTooSmall", BSFormatter.formatToPercentWithSymbol(minPercentage)));
             else
                 return new ValidationResult(true);
         } catch (Throwable t) {
@@ -72,11 +72,11 @@ public class SecurityDepositValidator extends NumberValidator {
 
     private ValidationResult validateIfNotTooHighPercentageValue(String input) {
         try {
-            double percentage = formatter.parsePercentStringToDouble(input);
+            double percentage = BSFormatter.parsePercentStringToDouble(input);
             double maxPercentage = Restrictions.getMaxBuyerSecurityDepositAsPercent(paymentAccount);
             if (percentage > maxPercentage)
                 return new ValidationResult(false,
-                        Res.get("validation.inputTooLarge", formatter.formatToPercentWithSymbol(maxPercentage)));
+                        Res.get("validation.inputTooLarge", BSFormatter.formatToPercentWithSymbol(maxPercentage)));
             else
                 return new ValidationResult(true);
         } catch (Throwable t) {

--- a/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
@@ -61,13 +61,13 @@ public class BSFormatterTest {
 
     @Test
     public void testIsValid() {
-        assertEquals("0 days", formatter.formatAccountAge(TimeUnit.HOURS.toMillis(23)));
-        assertEquals("0 days", formatter.formatAccountAge(0));
-        assertEquals("0 days", formatter.formatAccountAge(-1));
-        assertEquals("1 day", formatter.formatAccountAge(TimeUnit.DAYS.toMillis(1)));
-        assertEquals("2 days", formatter.formatAccountAge(TimeUnit.DAYS.toMillis(2)));
-        assertEquals("30 days", formatter.formatAccountAge(TimeUnit.DAYS.toMillis(30)));
-        assertEquals("60 days", formatter.formatAccountAge(TimeUnit.DAYS.toMillis(60)));
+        assertEquals("0 days", BSFormatter.formatAccountAge(TimeUnit.HOURS.toMillis(23)));
+        assertEquals("0 days", BSFormatter.formatAccountAge(0));
+        assertEquals("0 days", BSFormatter.formatAccountAge(-1));
+        assertEquals("1 day", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(1)));
+        assertEquals("2 days", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(2)));
+        assertEquals("30 days", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(30)));
+        assertEquals("60 days", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(60)));
     }
 
     @Test
@@ -77,23 +77,23 @@ public class BSFormatterTest {
         long oneMinute = TimeUnit.MINUTES.toMillis(1);
         long oneSecond = TimeUnit.SECONDS.toMillis(1);
 
-        assertEquals("1 hour, 0 minutes", formatter.formatDurationAsWords(oneHour));
-        assertEquals("1 day, 0 hours, 0 minutes", formatter.formatDurationAsWords(oneDay));
-        assertEquals("2 days, 0 hours, 1 minute", formatter.formatDurationAsWords(oneDay * 2 + oneMinute));
-        assertEquals("2 days, 0 hours, 2 minutes", formatter.formatDurationAsWords(oneDay * 2 + oneMinute * 2));
-        assertEquals("1 hour, 0 minutes, 0 seconds", formatter.formatDurationAsWords(oneHour, true, true));
-        assertEquals("1 hour, 0 minutes, 1 second", formatter.formatDurationAsWords(oneHour + oneSecond, true, true));
-        assertEquals("1 hour, 0 minutes, 2 seconds", formatter.formatDurationAsWords(oneHour + oneSecond * 2, true, true));
-        assertEquals("2 days, 21 hours, 28 minutes", formatter.formatDurationAsWords(oneDay * 2 + oneHour * 21 + oneMinute * 28));
-        assertEquals("110 days", formatter.formatDurationAsWords(oneDay * 110, false, false));
-        assertEquals("10 days, 10 hours, 10 minutes, 10 seconds", formatter.formatDurationAsWords(oneDay * 10 + oneHour * 10 + oneMinute * 10 + oneSecond * 10, true, false));
-        assertEquals("1 hour, 2 seconds", formatter.formatDurationAsWords(oneHour + oneSecond * 2, true, false));
-        assertEquals("1 hour", formatter.formatDurationAsWords(oneHour + oneSecond * 2, false, false));
-        assertEquals("0 hours, 0 minutes, 1 second", formatter.formatDurationAsWords(oneSecond, true, true));
-        assertEquals("1 second", formatter.formatDurationAsWords(oneSecond, true, false));
-        assertEquals("0 hours", formatter.formatDurationAsWords(oneSecond, false, false));
-        assertEquals("", formatter.formatDurationAsWords(0));
-        assertTrue(formatter.formatDurationAsWords(0).isEmpty());
+        assertEquals("1 hour, 0 minutes", BSFormatter.formatDurationAsWords(oneHour));
+        assertEquals("1 day, 0 hours, 0 minutes", BSFormatter.formatDurationAsWords(oneDay));
+        assertEquals("2 days, 0 hours, 1 minute", BSFormatter.formatDurationAsWords(oneDay * 2 + oneMinute));
+        assertEquals("2 days, 0 hours, 2 minutes", BSFormatter.formatDurationAsWords(oneDay * 2 + oneMinute * 2));
+        assertEquals("1 hour, 0 minutes, 0 seconds", BSFormatter.formatDurationAsWords(oneHour, true, true));
+        assertEquals("1 hour, 0 minutes, 1 second", BSFormatter.formatDurationAsWords(oneHour + oneSecond, true, true));
+        assertEquals("1 hour, 0 minutes, 2 seconds", BSFormatter.formatDurationAsWords(oneHour + oneSecond * 2, true, true));
+        assertEquals("2 days, 21 hours, 28 minutes", BSFormatter.formatDurationAsWords(oneDay * 2 + oneHour * 21 + oneMinute * 28));
+        assertEquals("110 days", BSFormatter.formatDurationAsWords(oneDay * 110, false, false));
+        assertEquals("10 days, 10 hours, 10 minutes, 10 seconds", BSFormatter.formatDurationAsWords(oneDay * 10 + oneHour * 10 + oneMinute * 10 + oneSecond * 10, true, false));
+        assertEquals("1 hour, 2 seconds", BSFormatter.formatDurationAsWords(oneHour + oneSecond * 2, true, false));
+        assertEquals("1 hour", BSFormatter.formatDurationAsWords(oneHour + oneSecond * 2, false, false));
+        assertEquals("0 hours, 0 minutes, 1 second", BSFormatter.formatDurationAsWords(oneSecond, true, true));
+        assertEquals("1 second", BSFormatter.formatDurationAsWords(oneSecond, true, false));
+        assertEquals("0 hours", BSFormatter.formatDurationAsWords(oneSecond, false, false));
+        assertEquals("", BSFormatter.formatDurationAsWords(0));
+        assertTrue(BSFormatter.formatDurationAsWords(0).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Making these functions static is a preparation for extraction.

Reducing the public interface of the BSFormatter instances reduces coupling and enables moving these functions to places where it makes more sense for them to live.