### PR TITLE
Revert DAO changes to add bonded role for Analytics Operator

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
@@ -53,7 +53,7 @@ public enum BondedRoleType {
 
     // operators
     WEBSITE_OPERATOR(50, 110, "https://bisq.network/roles/12", true),
-    ANALYTICS_OPERATOR(2, 110, "https://bisq.network/roles/88", true),
+    ANALYTICS_OPERATOR(1, 110, "https://bisq.network/roles/88", true),
     FORUM_OPERATOR(50, 110, "https://bisq.network/roles/19", true),
     SEED_NODE_OPERATOR(20, 110, "https://bisq.network/roles/15", true),
     DATA_RELAY_NODE_OPERATOR(20, 110, "https://bisq.network/roles/14", true),

--- a/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
@@ -53,7 +53,6 @@ public enum BondedRoleType {
 
     // operators
     WEBSITE_OPERATOR(50, 110, "https://bisq.network/roles/12", true),
-    ANALYTICS_OPERATOR(1, 110, "https://bisq.network/roles/88", true),
     FORUM_OPERATOR(50, 110, "https://bisq.network/roles/19", true),
     SEED_NODE_OPERATOR(20, 110, "https://bisq.network/roles/15", true),
     DATA_RELAY_NODE_OPERATOR(20, 110, "https://bisq.network/roles/14", true),

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1657,8 +1657,6 @@ dao.bond.bondedRoleType.NETLAYER_MAINTAINER=Netlayer maintainer
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.WEBSITE_OPERATOR=Website operator
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ANALYTICS_OPERATOR=Analytics operator
-# suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.FORUM_OPERATOR=Forum operator
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.SEED_NODE_OPERATOR=Seed node operator


### PR DESCRIPTION
We decided to revert this, per discussion in https://github.com/bisq-network/proposals/issues/115