### PR TITLE
Extract helper classes from BSFormatter

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -35,8 +35,8 @@ import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Issuance;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.dao.state.model.governance.ParamChange;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
+import bisq.core.util.ParsingUtils;
 
 import org.bitcoinj.core.Coin;
 
@@ -924,7 +924,7 @@ public class DaoStateService implements DaoSetupService {
     }
 
     public double getParamValueAsPercentDouble(String paramValue) {
-        return BSFormatter.parsePercentStringToDouble(paramValue);
+        return ParsingUtils.parsePercentStringToDouble(paramValue);
     }
 
     public int getParamValueAsBlock(String paramValue) {

--- a/core/src/main/java/bisq/core/monetary/Altcoin.java
+++ b/core/src/main/java/bisq/core/monetary/Altcoin.java
@@ -17,7 +17,7 @@
 
 package bisq.core.monetary;
 
-import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 
 import org.bitcoinj.core.Monetary;
 import org.bitcoinj.utils.MonetaryFormat;
@@ -89,7 +89,7 @@ public final class Altcoin implements Monetary, Comparable<Altcoin> {
      * @throws IllegalArgumentException if you try to specify fractional satoshis, or a value out of range.
      */
     public static Altcoin parseAltcoin(final String currencyCode, String input) {
-        String cleaned = BSFormatter.convertCharsForNumber(input);
+        String cleaned = ParsingUtils.convertCharsForNumber(input);
         try {
             long val = new BigDecimal(cleaned).movePointRight(SMALLEST_UNIT_EXPONENT)
                     .toBigIntegerExact().longValue();

--- a/core/src/main/java/bisq/core/monetary/Price.java
+++ b/core/src/main/java/bisq/core/monetary/Price.java
@@ -18,7 +18,7 @@
 package bisq.core.monetary;
 
 import bisq.core.locale.CurrencyUtil;
-import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
@@ -58,7 +58,7 @@ public class Price extends MonetaryWrapper implements Comparable<Price> {
      * @return The parsed Price.
      */
     public static Price parse(String currencyCode, String input) {
-        String cleaned = BSFormatter.convertCharsForNumber(input);
+        String cleaned = ParsingUtils.convertCharsForNumber(input);
         if (CurrencyUtil.isFiatCurrency(currencyCode))
             return new Price(Fiat.parseFiat(currencyCode, cleaned));
         else

--- a/core/src/main/java/bisq/core/monetary/Volume.java
+++ b/core/src/main/java/bisq/core/monetary/Volume.java
@@ -18,7 +18,7 @@
 package bisq.core.monetary;
 
 import bisq.core.locale.CurrencyUtil;
-import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 
 import org.bitcoinj.core.Monetary;
 import org.bitcoinj.utils.Fiat;
@@ -36,7 +36,7 @@ public class Volume extends MonetaryWrapper implements Comparable<Volume> {
     }
 
     public static Volume parse(String input, String currencyCode) {
-        String cleaned = BSFormatter.convertCharsForNumber(input);
+        String cleaned = ParsingUtils.convertCharsForNumber(input);
         if (CurrencyUtil.isFiatCurrency(currencyCode))
             return new Volume(Fiat.parseFiat(currencyCode, cleaned));
         else

--- a/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
+++ b/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
@@ -181,7 +181,7 @@ public class MarketAlerts {
                             String msg = Res.get("account.notifications.marketAlert.message.msg",
                                     direction,
                                     BSFormatter.getCurrencyPair(currencyCode),
-                                    formatter.formatPrice(offerPrice),
+                                    BSFormatter.formatPrice(offerPrice),
                                     BSFormatter.formatToPercentWithSymbol(ratio / 10000d),
                                     marketDir,
                                     Res.get(offer.getPaymentMethod().getId()),

--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -306,17 +306,6 @@ public class OfferUtil {
         }
     }
 
-    public static String getFeeWithFiatAmount(Coin makerFeeAsCoin, Optional<Volume> optionalFeeInFiat, BSFormatter formatter) {
-        String fee = makerFeeAsCoin != null ? formatter.formatCoinWithCode(makerFeeAsCoin) : Res.get("shared.na");
-        String feeInFiatAsString;
-        if (optionalFeeInFiat != null && optionalFeeInFiat.isPresent()) {
-            feeInFiatAsString = formatter.formatVolumeWithCode(optionalFeeInFiat.get());
-        } else {
-            feeInFiatAsString = Res.get("shared.na");
-        }
-        return Res.get("feeOptionWindow.fee", fee, feeInFiatAsString);
-    }
-
 
     public static Map<String, String> getExtraDataMap(AccountAgeWitnessService accountAgeWitnessService,
                                                       ReferralIdService referralIdService,

--- a/core/src/main/java/bisq/core/util/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/BsqFormatter.java
@@ -61,12 +61,12 @@ public class BsqFormatter extends BSFormatter {
         GlobalSettings.localeProperty().addListener((observable, oldValue, newValue) -> setFormatter(newValue));
         setFormatter(GlobalSettings.getLocale());
 
-        btcCoinFormat = super.coinFormat;
+        btcCoinFormat = super.monetaryFormat;
 
         final String baseCurrencyCode = BisqEnvironment.getBaseCurrencyNetwork().getCurrencyCode();
         switch (baseCurrencyCode) {
             case "BTC":
-                coinFormat = new MonetaryFormat().shift(6).code(6, "BSQ").minDecimals(2);
+                monetaryFormat = new MonetaryFormat().shift(6).code(6, "BSQ").minDecimals(2);
                 break;
             default:
                 throw new RuntimeException("baseCurrencyCode not defined. baseCurrencyCode=" + baseCurrencyCode);
@@ -123,11 +123,11 @@ public class BsqFormatter extends BSFormatter {
     }
 
     public String formatBSQSatoshis(long satoshi) {
-        return super.formatCoin(satoshi, coinFormat);
+        return super.formatCoin(satoshi, monetaryFormat);
     }
 
     public String formatBSQSatoshisWithCode(long satoshi) {
-        return super.formatCoinWithCode(satoshi, coinFormat);
+        return super.formatCoinWithCode(satoshi, monetaryFormat);
     }
 
     public String formatBTCSatoshis(long satoshi) {
@@ -147,7 +147,7 @@ public class BsqFormatter extends BSFormatter {
     }
 
     public Coin parseToBTC(String input) {
-        return super.parseToCoin(input, btcCoinFormat);
+        return ParsingUtils.parseToCoin(input, btcCoinFormat);
     }
 
     public void validateBtcInput(String input) throws ProposalValidationException {
@@ -155,12 +155,12 @@ public class BsqFormatter extends BSFormatter {
     }
 
     public void validateBsqInput(String input) throws ProposalValidationException {
-        validateCoinInput(input, this.coinFormat);
+        validateCoinInput(input, this.monetaryFormat);
     }
 
     private void validateCoinInput(String input, MonetaryFormat coinFormat) throws ProposalValidationException {
         try {
-            coinFormat.parse(cleanDoubleInput(input));
+            coinFormat.parse(ParsingUtils.cleanDoubleInput(input));
         } catch (Throwable t) {
             throw new ProposalValidationException("Invalid format for a " + coinFormat.code() + " value");
         }
@@ -172,11 +172,11 @@ public class BsqFormatter extends BSFormatter {
                 // In case we add a new param old clients will not know that enum and fall back to UNDEFINED.
                 return Res.get("shared.na");
             case BSQ:
-                return formatCoinWithCode(parseToCoin(value));
+                return formatCoinWithCode(ParsingUtils.parseToCoin(value, this));
             case BTC:
                 return formatBTCWithCode(parseToBTC(value));
             case PERCENT:
-                return formatToPercentWithSymbol(parsePercentStringToDouble(value));
+                return formatToPercentWithSymbol(ParsingUtils.parsePercentStringToDouble(value));
             case BLOCK:
                 return Res.get("dao.param.blocks", Integer.parseInt(value));
             case ADDRESS:
@@ -190,7 +190,7 @@ public class BsqFormatter extends BSFormatter {
     public Coin parseParamValueToCoin(Param param, String inputValue) {
         switch (param.getParamType()) {
             case BSQ:
-                return parseToCoin(inputValue);
+                return ParsingUtils.parseToCoin(inputValue, this);
             case BTC:
                 return parseToBTC(inputValue);
             default:
@@ -216,7 +216,7 @@ public class BsqFormatter extends BSFormatter {
             case BTC:
                 return formatBTC(parseParamValueToCoin(param, inputValue));
             case PERCENT:
-                return formatToPercent(parsePercentStringToDouble(inputValue));
+                return formatToPercent(ParsingUtils.parsePercentStringToDouble(inputValue));
             case BLOCK:
                 return Integer.toString(parseParamValueToBlocks(param, inputValue));
             case ADDRESS:

--- a/core/src/main/java/bisq/core/util/ParsingUtils.java
+++ b/core/src/main/java/bisq/core/util/ParsingUtils.java
@@ -1,0 +1,83 @@
+package bisq.core.util;
+
+import bisq.core.monetary.Price;
+
+import bisq.common.util.MathUtils;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.MonetaryFormat;
+
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ParsingUtils {
+    public static Coin parseToCoin(String input, BSFormatter bsFormatter) {
+        return parseToCoin(input, bsFormatter.getMonetaryFormat());
+    }
+
+    public static Coin parseToCoin(String input, MonetaryFormat coinFormat) {
+        if (input != null && input.length() > 0) {
+            try {
+                return coinFormat.parse(cleanDoubleInput(input));
+            } catch (Throwable t) {
+                log.warn("Exception at parseToBtc: " + t.toString());
+                return Coin.ZERO;
+            }
+        } else {
+            return Coin.ZERO;
+        }
+    }
+
+    public static double parseNumberStringToDouble(String input) throws NumberFormatException {
+        return Double.parseDouble(cleanDoubleInput(input));
+    }
+
+    public static double parsePercentStringToDouble(String percentString) throws NumberFormatException {
+        String input = percentString.replace("%", "");
+        input = cleanDoubleInput(input);
+        double value = Double.parseDouble(input);
+        return MathUtils.roundDouble(value / 100d, 4);
+    }
+
+    public static long parsePriceStringToLong(String currencyCode, String amount, int precision) {
+        if (amount == null || amount.isEmpty())
+            return 0;
+
+        long value = 0;
+        try {
+            double amountValue = Double.parseDouble(amount);
+            amount = BSFormatter.formatRoundedDoubleWithPrecision(amountValue, precision);
+            value = Price.parse(currencyCode, amount).getValue();
+        } catch (NumberFormatException ignore) {
+            // expected NumberFormatException if input is not a number
+        } catch (Throwable t) {
+            log.error("parsePriceStringToLong: " + t.toString());
+        }
+
+        return value;
+    }
+
+    public static String convertCharsForNumber(String input) {
+        // Some languages like finnish use the long dash for the minus
+        input = input.replace("−", "-");
+        input = StringUtils.deleteWhitespace(input);
+        return input.replace(",", ".");
+    }
+
+    public static String cleanDoubleInput(String input) {
+        input = convertCharsForNumber(input);
+        if (input.equals("."))
+            input = input.replace(".", "0.");
+        if (input.equals("-."))
+            input = input.replace("-.", "-0.");
+        // don't use String.valueOf(Double.parseDouble(input)) as return value as it gives scientific
+        // notation (1.0E-6) which screw up coinFormat.parse
+        //noinspection ResultOfMethodCallIgnored
+        // Just called to check if we have a valid double, throws exception otherwise
+        //noinspection ResultOfMethodCallIgnored
+        Double.parseDouble(input);
+        return input;
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -18,6 +18,7 @@
 package bisq.desktop.components;
 
 import bisq.desktop.main.overlays.editor.PeerInfoWithTagEditor;
+import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.alert.PrivateNotificationManager;
@@ -141,7 +142,7 @@ public class PeerInfoIcon extends Group {
         boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode());
 
         String accountAge = isFiatCurrency ?
-                peersAccountAge > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(peersAccountAge)) :
+                peersAccountAge > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(peersAccountAge)) :
                         Res.get("peerInfoIcon.tooltip.unknownAge") :
                 "";
         tooltipText = hasTraded ?
@@ -268,7 +269,7 @@ public class PeerInfoIcon extends Group {
                                     long makersAccountAge) {
         final String accountAgeTagEditor = isFiatCurrency ?
                 makersAccountAge > -1 ?
-                        BSFormatter.formatAccountAge(makersAccountAge) :
+                        DisplayUtils.formatAccountAge(makersAccountAge) :
                         Res.get("peerInfo.unknownAge") :
                 null;
         setOnMouseClicked(e -> new PeerInfoWithTagEditor(privateNotificationManager, offer, preferences, useDevPrivilegeKeys)

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -21,6 +21,7 @@ import bisq.desktop.components.AutoTooltipCheckBox;
 import bisq.desktop.components.InfoTextField;
 import bisq.desktop.components.InputTextField;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.Layout;
 
@@ -182,7 +183,7 @@ public abstract class PaymentMethodForm {
                 Res.get("payment.maxPeriodAndLimit",
                         getTimeText(hours),
                         formatter.formatCoinWithCode(Coin.valueOf(accountAgeWitnessService.getMyTradeLimit(paymentAccount, tradeCurrency.getCode()))),
-                        BSFormatter.formatAccountAge(accountAge));
+                        DisplayUtils.formatAccountAge(accountAge));
 
         if (isDisplayForm)
             addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.limitations"), limitationsText);

--- a/desktop/src/main/java/bisq/desktop/main/Chat/Chat.java
+++ b/desktop/src/main/java/bisq/desktop/main/Chat/Chat.java
@@ -24,6 +24,7 @@ import bisq.desktop.components.BusyAnimation;
 import bisq.desktop.components.TableGroupHeadline;
 import bisq.desktop.components.TextFieldWithIcon;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.arbitration.Attachment;
@@ -404,7 +405,7 @@ public class Chat extends AnchorPane {
                                 AnchorPane.setLeftAnchor(statusHBox, padding);
                             }
                             AnchorPane.setBottomAnchor(statusHBox, 7d);
-                            headerLabel.setText(BSFormatter.formatDateTime(new Date(message.getDate())));
+                            headerLabel.setText(DisplayUtils.formatDateTime(new Date(message.getDate())));
                             messageLabel.setText(message.getMessage());
                             attachmentsBox.getChildren().clear();
                             if (allowAttachments &&

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -37,6 +37,7 @@ import bisq.desktop.main.offer.SellOfferView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.portfolio.PortfolioView;
 import bisq.desktop.main.settings.SettingsView;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Transitions;
 
 import bisq.core.dao.monitoring.DaoStateMonitoringService;
@@ -522,14 +523,14 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             res = Res.get("mainView.marketPrice.tooltip",
                     "https://bitcoinaverage.com",
                     "",
-                    formatter.formatTime(model.getPriceFeedService().getLastRequestTimeStampBtcAverage()),
+                    DisplayUtils.formatTime(model.getPriceFeedService().getLastRequestTimeStampBtcAverage()),
                     model.getPriceFeedService().getProviderNodeAddress());
         } else {
             String altcoinExtra = "\n" + Res.get("mainView.marketPrice.tooltip.altcoinExtra");
             res = Res.get("mainView.marketPrice.tooltip",
                     "https://poloniex.com",
                     altcoinExtra,
-                    formatter.formatTime(model.getPriceFeedService().getLastRequestTimeStampPoloniex()),
+                    DisplayUtils.formatTime(model.getPriceFeedService().getLastRequestTimeStampPoloniex()),
                     model.getPriceFeedService().getProviderNodeAddress());
         }
         return res;

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -32,6 +32,7 @@ import bisq.desktop.main.overlays.windows.WalletPasswordWindow;
 import bisq.desktop.main.overlays.windows.downloadupdate.DisplayUpdateDownloadWindow;
 import bisq.desktop.main.presentation.DaoPresentation;
 import bisq.desktop.main.presentation.MarketPricePresentation;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -218,7 +219,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
                                 DontShowAgainLookup.dontShowAgain(key, true);
                                 new Popup<>().warning(Res.get("popup.warning.tradePeriod.halfReached",
                                         trade.getShortId(),
-                                        BSFormatter.formatDateTime(maxTradePeriodDate)))
+                                        DisplayUtils.formatDateTime(maxTradePeriodDate)))
                                         .show();
                             }
                             break;
@@ -228,7 +229,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupCompleteList
                                 DontShowAgainLookup.dontShowAgain(key, true);
                                 new Popup<>().warning(Res.get("popup.warning.tradePeriod.ended",
                                         trade.getShortId(),
-                                        BSFormatter.formatDateTime(maxTradePeriodDate)))
+                                        DisplayUtils.formatDateTime(maxTradePeriodDate)))
                                         .show();
                             }
                             break;

--- a/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
@@ -48,6 +48,7 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.InputValidator;
 
 import bisq.common.UserThread;
@@ -347,7 +348,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
 
     private void onAddMarketAlert() {
         PaymentAccount paymentAccount = paymentAccountsComboBox.getSelectionModel().getSelectedItem();
-        double percentAsDouble = BSFormatter.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText());
+        double percentAsDouble = ParsingUtils.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText());
         int triggerValue = (int) Math.round(percentAsDouble * 10000);
         boolean isBuyOffer = offerTypeRadioButtonsToggleGroup.getSelectedToggle() == buyOffersRadioButton;
         MarketAlertFilter marketAlertFilter = new MarketAlertFilter(paymentAccount, triggerValue, isBuyOffer);
@@ -510,7 +511,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
         marketAlertTriggerFocusListener = (observable, oldValue, newValue) -> {
             if (oldValue && !newValue) {
                 try {
-                    double percentAsDouble = BSFormatter.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText()) * 100;
+                    double percentAsDouble = ParsingUtils.parsePercentStringToDouble(marketAlertTriggerInputTextField.getText()) * 100;
                     marketAlertTriggerInputTextField.setText(BSFormatter.formatRoundedDoubleWithPrecision(percentAsDouble, 2) + "%");
                 } catch (Throwable ignore) {
                 }
@@ -747,7 +748,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
         try {
             String inputValue = inputTextField.getText();
             if (inputValue != null && !inputValue.isEmpty() && selectedPriceAlertTradeCurrency != null) {
-                double priceAsDouble = BSFormatter.parseNumberStringToDouble(inputValue);
+                double priceAsDouble = ParsingUtils.parseNumberStringToDouble(inputValue);
                 String currencyCode = selectedPriceAlertTradeCurrency;
                 int precision = CurrencyUtil.isCryptoCurrency(currencyCode) ?
                         Altcoin.SMALLEST_UNIT_EXPONENT : 2;
@@ -755,7 +756,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
                 // E.g. if input is 5555.5555 it will be rounded to  5555.55 and we use that as the value for comparing
                 // low and high price...
                 String stringValue = BSFormatter.formatRoundedDoubleWithPrecision(priceAsDouble, precision);
-                return BSFormatter.parsePriceStringToLong(formatter, currencyCode, stringValue, precision);
+                return ParsingUtils.parsePriceStringToLong(currencyCode, stringValue, precision);
             } else {
                 return 0;
             }
@@ -768,7 +769,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
         try {
             String inputValue = inputTextField.getText();
             if (inputValue != null && !inputValue.isEmpty() && selectedPriceAlertTradeCurrency != null) {
-                double priceAsDouble = BSFormatter.parseNumberStringToDouble(inputValue);
+                double priceAsDouble = ParsingUtils.parseNumberStringToDouble(inputValue);
                 String currencyCode = selectedPriceAlertTradeCurrency;
                 int precision = CurrencyUtil.isCryptoCurrency(currencyCode) ?
                         Altcoin.SMALLEST_UNIT_EXPONENT : 2;

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondListItem.java
@@ -17,11 +17,12 @@
 
 package bisq.desktop.main.dao.bonding.bonds;
 
+import bisq.desktop.util.DisplayUtils;
+
 import bisq.core.dao.governance.bond.Bond;
 import bisq.core.dao.governance.bond.BondState;
 import bisq.core.dao.governance.bond.role.BondedRole;
 import bisq.core.locale.Res;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -59,7 +60,7 @@ class BondListItem {
             bondDetails = Utilities.bytesAsHexString(bond.getBondedAsset().getHash());
         }
         lockupTxId = bond.getLockupTxId();
-        lockupDateString = bond.getLockupDate() > 0 ? BSFormatter.formatDateTime(new Date(bond.getLockupDate())) : "-";
+        lockupDateString = bond.getLockupDate() > 0 ? DisplayUtils.formatDateTime(new Date(bond.getLockupDate())) : "-";
         bondState = bond.getBondState();
         bondStateString = Res.get("dao.bond.bondState." + bond.getBondState().name());
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationListItem.java
@@ -17,11 +17,12 @@
 
 package bisq.desktop.main.dao.bonding.reputation;
 
+import bisq.desktop.util.DisplayUtils;
+
 import bisq.core.dao.governance.bond.BondState;
 import bisq.core.dao.governance.bond.reputation.MyBondedReputation;
 import bisq.core.dao.governance.bond.reputation.MyReputation;
 import bisq.core.locale.Res;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -58,7 +59,7 @@ class MyReputationListItem {
         txId = myBondedReputation.getLockupTxId();
         amount = bsqFormatter.formatCoin(Coin.valueOf(myBondedReputation.getAmount()));
         lockupDate = new Date(myBondedReputation.getLockupDate());
-        lockupDateString = BSFormatter.formatDateTime(lockupDate);
+        lockupDateString = DisplayUtils.formatDateTime(lockupDate);
         lockTime = Integer.toString(myBondedReputation.getLockTime());
         lockupTxId = myBondedReputation.getLockupTxId();
         bondState = myBondedReputation.getBondState();

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
@@ -38,6 +38,7 @@ import bisq.core.dao.governance.bond.reputation.MyBondedReputation;
 import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
 import bisq.core.util.BsqFormatter;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.HexStringValidator;
 import bisq.core.util.validation.IntegerValidator;
 
@@ -170,7 +171,7 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
         bsqWalletService.addBsqBalanceListener(this);
 
         lockupButton.setOnAction((event) -> {
-            Coin lockupAmount = bsqFormatter.parseToCoin(amountInputTextField.getText());
+            Coin lockupAmount = ParsingUtils.parseToCoin(amountInputTextField.getText(), bsqFormatter);
             int lockupTime = Integer.parseInt(timeInputTextField.getText());
             byte[] salt = Utilities.decodeFromHex(saltInputTextField.getText());
             bondingViewUtils.lockupBondForReputation(lockupAmount,

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RoleDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RoleDetailsWindow.java
@@ -18,13 +18,13 @@
 package bisq.desktop.main.dao.bonding.roles;
 
 import bisq.desktop.main.overlays.Overlay;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.FormBuilder;
 
 import bisq.core.dao.DaoFacade;
 import bisq.core.dao.state.model.governance.BondedRoleType;
 import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.locale.Res;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import org.bitcoinj.core.Coin;
@@ -98,6 +98,6 @@ class RoleDetailsWindow extends Overlay<RoleDetailsWindow> {
                 bondedRoleType.getLink(), bondedRoleType.getLink(), 0);
 
         FormBuilder.addTopLabelTextField(gridPane, ++rowIndex, Res.get("dao.bond.details.isSingleton"),
-                BSFormatter.booleanToYesNo(bondedRoleType.isAllowMultipleHolders()));
+                DisplayUtils.booleanToYesNo(bondedRoleType.isAllowMultipleHolders()));
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
@@ -36,6 +36,7 @@ import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
+import bisq.core.util.ParsingUtils;
 
 import bisq.common.app.DevEnv;
 
@@ -273,7 +274,7 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
     }
 
     private Coin getListingFee() {
-        return bsqFormatter.parseToCoin(feeAmountInputTextField.getText());
+        return ParsingUtils.parseToCoin(feeAmountInputTextField.getText(), bsqFormatter);
     }
 
     private void doPublishFeeTx(Transaction transaction) {

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/MyProofOfBurnListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/MyProofOfBurnListItem.java
@@ -17,11 +17,12 @@
 
 package bisq.desktop.main.dao.burnbsq.proofofburn;
 
+import bisq.desktop.util.DisplayUtils;
+
 import bisq.core.dao.governance.proofofburn.MyProofOfBurn;
 import bisq.core.dao.governance.proofofburn.ProofOfBurnService;
 import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.locale.Res;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -53,7 +54,7 @@ class MyProofOfBurnListItem {
         if (optionalTx.isPresent()) {
             Tx tx = optionalTx.get();
             date = new Date(tx.getTime());
-            dateAsString = BSFormatter.formatDateTime(date);
+            dateAsString = DisplayUtils.formatDateTime(date);
             amount = proofOfBurnService.getAmount(tx);
             amountAsString = bsqFormatter.formatCoinWithCode(Coin.valueOf(amount));
             txId = tx.getId();

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnListItem.java
@@ -17,9 +17,10 @@
 
 package bisq.desktop.main.dao.burnbsq.proofofburn;
 
+import bisq.desktop.util.DisplayUtils;
+
 import bisq.core.dao.governance.proofofburn.ProofOfBurnService;
 import bisq.core.dao.state.model.blockchain.Tx;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Utilities;
@@ -47,6 +48,6 @@ class ProofOfBurnListItem {
         hashAsHex = Utilities.bytesAsHexString(proofOfBurnService.getHashFromOpReturnData(tx));
         pubKey = Utilities.bytesAsHexString(proofOfBurnService.getPubKey(txId));
         date = new Date(tx.getTime());
-        dateAsString = BSFormatter.formatDateTime(date);
+        dateAsString = DisplayUtils.formatDateTime(date);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
@@ -38,6 +38,7 @@ import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.InputValidator;
 
 import bisq.common.app.DevEnv;
@@ -273,7 +274,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
     }
 
     private Coin getAmountFee() {
-        return bsqFormatter.parseToCoin(amountInputTextField.getText());
+        return ParsingUtils.parseToCoin(amountInputTextField.getText(), bsqFormatter);
     }
 
     private void doPublishFeeTx(Transaction transaction, String preImageAsString) {

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
@@ -308,7 +308,7 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
         Optional<Price> optionalBsqPrice = priceFeedService.getBsqPrice();
         if (optionalBsqPrice.isPresent()) {
             Price bsqPrice = optionalBsqPrice.get();
-            marketPriceLabel.setText(bsqFormatter.formatPrice(bsqPrice) + " BSQ/BTC");
+            marketPriceLabel.setText(BSFormatter.formatPrice(bsqPrice) + " BSQ/BTC");
 
             marketCapTextField.setText(bsqFormatter.formatMarketCap(priceFeedService.getMarketPrice("BSQ"),
                     priceFeedService.getMarketPrice(preferences.getPreferredTradeCurrency().getCode()),

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -52,6 +52,7 @@ import bisq.core.dao.state.model.governance.Role;
 import bisq.core.locale.Res;
 import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
+import bisq.core.util.ParsingUtils;
 
 import bisq.asset.Asset;
 
@@ -395,13 +396,13 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
                         "proposalDisplay.requestedBsqTextField must not be null");
                 return daoFacade.getCompensationProposalWithTransaction(name,
                         link,
-                        bsqFormatter.parseToCoin(proposalDisplay.requestedBsqTextField.getText()));
+                        ParsingUtils.parseToCoin(proposalDisplay.requestedBsqTextField.getText(), bsqFormatter));
             case REIMBURSEMENT_REQUEST:
                 checkNotNull(proposalDisplay.requestedBsqTextField,
                         "proposalDisplay.requestedBsqTextField must not be null");
                 return daoFacade.getReimbursementProposalWithTransaction(name,
                         link,
-                        bsqFormatter.parseToCoin(proposalDisplay.requestedBsqTextField.getText()));
+                        ParsingUtils.parseToCoin(proposalDisplay.requestedBsqTextField.getText(), bsqFormatter));
             case CHANGE_PARAM:
                 checkNotNull(proposalDisplay.paramComboBox,
                         "proposalDisplay.paramComboBox must no tbe null");

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -55,6 +55,7 @@ import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
+import bisq.core.util.ParsingUtils;
 
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
@@ -463,7 +464,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
     }
 
     private void onVote() {
-        Coin stake = bsqFormatter.parseToCoin(stakeInputTextField.getText());
+        Coin stake = ParsingUtils.parseToCoin(stakeInputTextField.getText(), bsqFormatter);
         try {
             // We create a dummy tx to get the miningFee for displaying it at the confirmation popup
             Tuple2<Coin, Integer> miningFeeAndTxSize = daoFacade.getBlindVoteMiningFeeAndTxSize(stake);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -30,6 +30,7 @@ import bisq.desktop.components.TxIdTextField;
 import bisq.desktop.main.dao.governance.PhasesView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.SelectProposalWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
 import bisq.desktop.util.validation.BsqValidator;
@@ -718,7 +719,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                             public void updateItem(final ProposalsListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(BSFormatter.formatDateTime(item.getProposal().getCreationDateAsDate()));
+                                    setText(DisplayUtils.formatDateTime(item.getProposal().getCreationDateAsDate()));
                                 else
                                     setText("");
                             }

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -26,6 +26,7 @@ import bisq.desktop.components.TableGroupHeadline;
 import bisq.desktop.main.dao.governance.PhasesView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.ProposalResultsWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
@@ -57,7 +58,6 @@ import bisq.core.dao.state.model.governance.Role;
 import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.dao.state.model.governance.Vote;
 import bisq.core.locale.Res;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.UserThread;
@@ -638,7 +638,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
                             public void updateItem(final ProposalListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(BSFormatter.formatDateTime(item.getProposal().getCreationDateAsDate()));
+                                    setText(DisplayUtils.formatDateTime(item.getProposal().getCreationDateAsDate()));
                                 else
                                     setText("");
                             }

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -47,6 +47,7 @@ import bisq.core.locale.Res;
 import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 import bisq.core.util.CoinUtil;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.BtcAddressValidator;
 
 import bisq.network.p2p.P2PService;
@@ -234,7 +235,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
             // TODO break up in methods
             if (GUIUtil.isReadyForTxBroadcast(p2PService, walletsSetup)) {
                 String receiversAddressString = bsqFormatter.getAddressFromBsqAddress(receiversAddressInputTextField.getText()).toString();
-                Coin receiverAmount = bsqFormatter.parseToCoin(amountInputTextField.getText());
+                Coin receiverAmount = ParsingUtils.parseToCoin(amountInputTextField.getText(), bsqFormatter);
                 try {
                     Transaction preparedSendTx = bsqWalletService.getPreparedSendBsqTx(receiversAddressString, receiverAmount);
                     Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx, true);

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -24,6 +24,7 @@ import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.AutoTooltipTableColumn;
 import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.main.dao.wallet.BsqBalanceUtil;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.GUIUtil;
 
@@ -38,7 +39,6 @@ import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.Timer;
@@ -368,7 +368,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
-                                    setText(BSFormatter.formatDateTime(item.getDate()));
+                                    setText(DisplayUtils.formatDateTime(item.getDate()));
                                 } else {
                                     setText("");
                                 }
@@ -631,7 +631,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                                 style = "dao-tx-type-issuance-icon";
                                                 int issuanceBlockHeight = daoFacade.getIssuanceBlockHeight(txId);
                                                 long blockTime = daoFacade.getBlockTime(issuanceBlockHeight);
-                                                String formattedDate = BSFormatter.formatDateTime(new Date(blockTime));
+                                                String formattedDate = DisplayUtils.formatDateTime(new Date(blockTime));
                                                 toolTipText = Res.get("dao.tx.issuanceFromCompReq.tooltip", formattedDate);
                                             } else {
                                                 awesomeIcon = AwesomeIcon.FILE_TEXT;
@@ -645,7 +645,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                                 style = "dao-tx-type-issuance-icon";
                                                 int issuanceBlockHeight = daoFacade.getIssuanceBlockHeight(txId);
                                                 long blockTime = daoFacade.getBlockTime(issuanceBlockHeight);
-                                                String formattedDate = BSFormatter.formatDateTime(new Date(blockTime));
+                                                String formattedDate = DisplayUtils.formatDateTime(new Date(blockTime));
                                                 toolTipText = Res.get("dao.tx.issuanceFromReimbursement.tooltip", formattedDate);
                                             } else {
                                                 awesomeIcon = AwesomeIcon.FILE_TEXT;

--- a/desktop/src/main/java/bisq/desktop/main/disputes/arbitrator/ArbitratorDisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/disputes/arbitrator/ArbitratorDisputeView.java
@@ -22,6 +22,7 @@ import bisq.desktop.main.disputes.trader.TraderDisputeView;
 import bisq.desktop.main.overlays.windows.ContractWindow;
 import bisq.desktop.main.overlays.windows.DisputeSummaryWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
+import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.alert.PrivateNotificationManager;
@@ -79,7 +80,7 @@ public class ArbitratorDisputeView extends TraderDisputeView {
         // If in arbitrator view we must only display disputes where we are selected as arbitrator (must not receive others anyway)
         filteredList.setPredicate(dispute -> {
             boolean matchesTradeId = dispute.getTradeId().contains(filterString);
-            boolean matchesDate = formatter.formatDate(dispute.getOpeningDate()).contains(filterString);
+            boolean matchesDate = DisplayUtils.formatDate(dispute.getOpeningDate()).contains(filterString);
             boolean isBuyerOnion = dispute.getContract().getBuyerNodeAddress().getFullAddress().contains(filterString);
             boolean isSellerOnion = dispute.getContract().getSellerNodeAddress().getFullAddress().contains(filterString);
             boolean matchesBuyersPaymentAccountData = dispute.getContract().getBuyerPaymentAccountPayload().getPaymentDetails().contains(filterString);

--- a/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/disputes/trader/TraderDisputeView.java
@@ -30,6 +30,7 @@ import bisq.desktop.main.overlays.windows.ContractWindow;
 import bisq.desktop.main.overlays.windows.DisputeSummaryWindow;
 import bisq.desktop.main.overlays.windows.SendPrivateNotificationWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -257,7 +258,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                             .append(dispute0.getTradeId())
                             .append("\n")
                             .append("## Date: ")
-                            .append(BSFormatter.formatDateTime(dispute0.getOpeningDate()))
+                            .append(DisplayUtils.formatDateTime(dispute0.getOpeningDate()))
                             .append("\n")
                             .append("## Is support ticket: ")
                             .append(dispute0.isSupportTicket())
@@ -582,7 +583,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
                             public void updateItem(final Dispute item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty)
-                                    setText(BSFormatter.formatDateTime(item.getOpeningDate()));
+                                    setText(DisplayUtils.formatDateTime(item.getOpeningDate()));
                                 else
                                     setText("");
                             }
@@ -693,7 +694,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
             if (buyerNodeAddress != null) {
                 String nrOfDisputes = disputeManager.getNrOfDisputes(true, contract);
                 long accountAge = accountAgeWitnessService.getAccountAge(contract.getBuyerPaymentAccountPayload(), contract.getBuyerPubKeyRing());
-                String age = BSFormatter.formatAccountAge(accountAge);
+                String age = DisplayUtils.formatAccountAge(accountAge);
                 String postFix = CurrencyUtil.isFiatCurrency(item.getContract().getOfferPayload().getCurrencyCode()) ? " / " + age : "";
                 return buyerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + postFix + ")";
             } else
@@ -710,7 +711,7 @@ public class TraderDisputeView extends ActivatableView<VBox, Void> {
             if (sellerNodeAddress != null) {
                 String nrOfDisputes = disputeManager.getNrOfDisputes(false, contract);
                 long accountAge = accountAgeWitnessService.getAccountAge(contract.getSellerPaymentAccountPayload(), contract.getSellerPubKeyRing());
-                String age = BSFormatter.formatAccountAge(accountAge);
+                String age = DisplayUtils.formatAccountAge(accountAge);
                 String postFix = CurrencyUtil.isFiatCurrency(item.getContract().getOfferPayload().getCurrencyCode()) ? " / " + age : "";
                 return sellerNodeAddress.getHostNameWithoutPostFix() + " (" + nrOfDisputes + postFix + ")";
             } else

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
@@ -36,6 +36,7 @@ import bisq.core.locale.Res;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
@@ -232,7 +233,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
 
         walletService.addBalanceListener(balanceListener);
         amountTextFieldSubscription = EasyBind.subscribe(amountTextField.textProperty(), t -> {
-            addressTextField.setAmountAsCoin(formatter.parseToCoin(t));
+            addressTextField.setAmountAsCoin(ParsingUtils.parseToCoin(t, formatter));
             updateQRCode();
         });
 
@@ -301,7 +302,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
     }
 
     private Coin getAmountAsCoin() {
-        return formatter.parseToCoin(amountTextField.getText());
+        return ParsingUtils.parseToCoin(amountTextField.getText(), formatter);
     }
 
     @NotNull

--- a/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
@@ -23,6 +23,7 @@ import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.btc.listeners.BalanceListener;
@@ -228,7 +229,7 @@ public class LockedView extends ActivatableView<VBox, Void> {
                         super.updateItem(item, empty);
                         if (item != null && !empty) {
                             if (getTradable(item).isPresent())
-                                setGraphic(new AutoTooltipLabel(BSFormatter.formatDateTime(getTradable(item).get().getDate())));
+                                setGraphic(new AutoTooltipLabel(DisplayUtils.formatDateTime(getTradable(item).get().getDate())));
                             else
                                 setGraphic(new AutoTooltipLabel(Res.get("shared.noDateAvailable")));
                         } else {

--- a/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
@@ -23,6 +23,7 @@ import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.btc.listeners.BalanceListener;
@@ -228,7 +229,7 @@ public class ReservedView extends ActivatableView<VBox, Void> {
                         super.updateItem(item, empty);
                         if (item != null && !empty) {
                             if (getTradable(item).isPresent())
-                                setGraphic(new AutoTooltipLabel(BSFormatter.formatDateTime(getTradable(item).get().getDate())));
+                                setGraphic(new AutoTooltipLabel(DisplayUtils.formatDateTime(getTradable(item).get().getDate())));
                             else
                                 setGraphic(new AutoTooltipLabel(Res.get("shared.noDateAvailable")));
                         } else {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.funds.transactions;
 
 import bisq.desktop.components.indicator.TxConfidenceIndicator;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.btc.listeners.TxConfidenceListener;
@@ -239,7 +240,7 @@ class TransactionsListItem {
         }
         // Use tx.getIncludedInBestChainAt() when available, otherwise use tx.getUpdateTime()
         date = transaction.getIncludedInBestChainAt() != null ? transaction.getIncludedInBestChainAt() : transaction.getUpdateTime();
-        dateString = BSFormatter.formatDateTime(date);
+        dateString = DisplayUtils.formatDateTime(date);
 
         isDustAttackTx = received && valueSentToMe.value < ignoreDustThreshold;
         if (isDustAttackTx) {

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -41,6 +41,7 @@ import bisq.core.trade.TradeManager;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
 import bisq.core.util.CoinUtil;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.BtcAddressValidator;
 
 import bisq.network.p2p.P2PService;
@@ -246,7 +247,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
         amountListener = (observable, oldValue, newValue) -> {
             if (amountTextField.focusedProperty().get()) {
                 try {
-                    amountAsCoin = formatter.parseToCoin(amountTextField.getText());
+                    amountAsCoin = ParsingUtils.parseToCoin(amountTextField.getText(), formatter);
                 } catch (Throwable t) {
                     log.error("Error at amountTextField input. " + t.toString());
                 }

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -31,6 +31,7 @@ import bisq.desktop.main.market.trades.TradesChartsView;
 import bisq.desktop.main.offer.offerbook.OfferBook;
 import bisq.desktop.main.offer.offerbook.OfferBookListItem;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.Res;
 import bisq.core.offer.OfferPayload;
@@ -183,11 +184,11 @@ public class MarketView extends ActivatableViewAndModel<TabPane, Activatable> {
                 .map(trade -> {
                     StringBuilder sb = new StringBuilder();
                     sb.append("Trade ID: ").append(trade.getOfferId()).append("\n")
-                            .append("Date: ").append(BSFormatter.formatDateTime(trade.getTradeDate())).append("\n")
+                            .append("Date: ").append(DisplayUtils.formatDateTime(trade.getTradeDate())).append("\n")
                             .append("Market: ").append(BSFormatter.getCurrencyPair(trade.getCurrencyCode())).append("\n")
-                            .append("Price: ").append(formatter.formatPrice(trade.getTradePrice())).append("\n")
+                            .append("Price: ").append(BSFormatter.formatPrice(trade.getTradePrice())).append("\n")
                             .append("Amount: ").append(formatter.formatCoin(trade.getTradeAmount())).append("\n")
-                            .append("Volume: ").append(formatter.formatVolume(trade.getTradeVolume())).append("\n")
+                            .append("Volume: ").append(DisplayUtils.formatVolume(trade.getTradeVolume())).append("\n")
                             .append("Payment method: ").append(Res.get(trade.getOfferPaymentMethod())).append("\n")
                             .append("ReferralID: ").append(trade.getExtraDataMap().get(OfferPayload.REFERRAL_ID));
                     return sb.toString();
@@ -206,8 +207,8 @@ public class MarketView extends ActivatableViewAndModel<TabPane, Activatable> {
                     sb.append("Offer ID: ").append(offer.getId()).append("\n")
                             .append("Type: ").append(offer.getDirection().name()).append("\n")
                             .append("Market: ").append(BSFormatter.getCurrencyPair(offer.getCurrencyCode())).append("\n")
-                            .append("Price: ").append(formatter.formatPrice(offer.getPrice())).append("\n")
-                            .append("Amount: ").append(formatter.formatAmount(offer)).append(" BTC\n")
+                            .append("Price: ").append(BSFormatter.formatPrice(offer.getPrice())).append("\n")
+                            .append("Amount: ").append(DisplayUtils.formatAmount(offer, formatter)).append(" BTC\n")
                             .append("Payment method: ").append(Res.get(offer.getPaymentMethod().getId())).append("\n")
                             .append("ReferralID: ").append(offer.getOfferPayload().getExtraDataMap().get(OfferPayload.REFERRAL_ID));
                     return sb.toString();

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -26,6 +26,7 @@ import bisq.desktop.main.settings.SettingsView;
 import bisq.desktop.main.settings.preferences.PreferencesView;
 import bisq.desktop.util.CurrencyList;
 import bisq.desktop.util.CurrencyListItem;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -254,7 +255,7 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     }
 
     private String formatPrice(Offer offer, boolean decimalAligned) {
-        return formatter.formatPrice(offer.getPrice(), decimalAligned, offer.isBuyOffer() ? maxPlacesForBuyPrice.get() : maxPlacesForSellPrice.get());
+        return DisplayUtils.formatPrice(offer.getPrice(), decimalAligned, offer.isBuyOffer() ? maxPlacesForBuyPrice.get() : maxPlacesForSellPrice.get());
     }
 
     public String getVolume(Offer offer) {
@@ -262,7 +263,7 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     }
 
     private String formatVolume(Offer offer, boolean decimalAligned) {
-        return formatter.formatVolume(offer, decimalAligned, offer.isBuyOffer() ? maxPlacesForBuyVolume.get() : maxPlacesForSellVolume.get(), false);
+        return DisplayUtils.formatVolume(offer, decimalAligned, offer.isBuyOffer() ? maxPlacesForBuyVolume.get() : maxPlacesForSellVolume.get(), false);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -27,6 +27,7 @@ import bisq.desktop.components.ColoredDecimalPlacesWithZerosText;
 import bisq.desktop.main.market.trades.charts.price.CandleStickChart;
 import bisq.desktop.main.market.trades.charts.volume.VolumeChart;
 import bisq.desktop.util.CurrencyListItem;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.locale.CurrencyUtil;
@@ -347,7 +348,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                     final double value = MathUtils.scaleDownByPowerOf10(doubleValue, 8);
                     return BSFormatter.formatRoundedDoubleWithPrecision(value, 8);
                 } else {
-                    return formatter.formatPrice(Price.valueOf(currencyCode, MathUtils.doubleToLong(doubleValue)));
+                    return BSFormatter.formatPrice(Price.valueOf(currencyCode, MathUtils.doubleToLong(doubleValue)));
                 }
             }
 
@@ -364,7 +365,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                     final double value = MathUtils.scaleDownByPowerOf10((long) object, 8);
                     return BSFormatter.formatRoundedDoubleWithPrecision(value, 8);
                 } else {
-                    return formatter.formatPrice(Price.valueOf(model.getCurrencyCode(), (long) object));
+                    return BSFormatter.formatPrice(Price.valueOf(model.getCurrencyCode(), (long) object));
                 }
             }
 
@@ -480,9 +481,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 long index = MathUtils.doubleToLong((double) object);
                 long time = model.getTimeFromTickIndex(index);
                 if (model.tickUnit.ordinal() <= TradesChartsViewModel.TickUnit.DAY.ordinal())
-                    return index % 4 == 0 ? formatter.formatDate(new Date(time)) : "";
+                    return index % 4 == 0 ? DisplayUtils.formatDate(new Date(time)) : "";
                 else
-                    return index % 3 == 0 ? formatter.formatTime(new Date(time)) : "";
+                    return index % 3 == 0 ? DisplayUtils.formatTime(new Date(time)) : "";
             }
 
             @Override
@@ -568,7 +569,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                             public void updateItem(final TradeStatistics2 item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(BSFormatter.formatDateTime(item.getTradeDate()));
+                                    setText(DisplayUtils.formatDateTime(item.getTradeDate()));
                                 else
                                     setText("");
                             }
@@ -621,7 +622,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                             public void updateItem(final TradeStatistics2 item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(formatter.formatPrice(item.getTradePrice()));
+                                    setText(BSFormatter.formatPrice(item.getTradePrice()));
                                 else
                                     setText("");
                             }
@@ -671,8 +672,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                                 super.updateItem(item, empty);
                                 if (item != null)
                                     setText(model.showAllTradeCurrenciesProperty.get() ?
-                                            formatter.formatVolumeWithCode(item.getTradeVolume()) :
-                                            formatter.formatVolume(item.getTradeVolume()));
+                                            DisplayUtils.formatVolumeWithCode(item.getTradeVolume()) :
+                                            DisplayUtils.formatVolume(item.getTradeVolume()));
                                 else
                                     setText("");
                             }
@@ -744,7 +745,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @NotNull
     private String getDirectionLabel(TradeStatistics2 item) {
-        return BSFormatter.getDirectionWithCode(OfferPayload.Direction.valueOf(item.getDirection().name()), item.getCurrencyCode());
+        return DisplayUtils.getDirectionWithCode(OfferPayload.Direction.valueOf(item.getDirection().name()), item.getCurrencyCode());
     }
 
     @NotNull

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -25,6 +25,7 @@ import bisq.desktop.main.settings.SettingsView;
 import bisq.desktop.main.settings.preferences.PreferencesView;
 import bisq.desktop.util.CurrencyList;
 import bisq.desktop.util.CurrencyListItem;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.locale.CryptoCurrency;
@@ -345,12 +346,12 @@ class TradesChartsViewModel extends ActivatableViewModel {
         final Date dateFrom = new Date(getTimeFromTickIndex(tick));
         final Date dateTo = new Date(getTimeFromTickIndex(tick + 1));
         String dateString = tickUnit.ordinal() > TickUnit.DAY.ordinal() ?
-                formatter.formatDateTimeSpan(dateFrom, dateTo) :
-                formatter.formatDate(dateFrom) + " - " + formatter.formatDate(dateTo);
+                DisplayUtils.formatDateTimeSpan(dateFrom, dateTo) :
+                DisplayUtils.formatDate(dateFrom) + " - " + DisplayUtils.formatDate(dateTo);
         return new CandleData(tick, open, close, high, low, averagePrice, medianPrice, accumulatedAmount, accumulatedVolume,
                 numTrades, isBullish, dateString);
     }
-    
+
 	Long findMedian(Long[] prices) {
 		int middle = prices.length / 2;
 		long median;

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -17,6 +17,8 @@
 
 package bisq.desktop.main.offer;
 
+import bisq.desktop.util.DisplayUtils;
+
 import bisq.core.account.witness.AccountAgeRestrictions;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.arbitration.Arbitrator;
@@ -646,7 +648,7 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
                 !price.get().isZero() &&
                 allowAmountUpdate) {
             try {
-                Coin value = btcFormatter.reduceTo4Decimals(price.get().getAmountByVolume(volume.get()));
+                Coin value = DisplayUtils.reduceTo4Decimals(price.get().getAmountByVolume(volume.get()), btcFormatter);
                 if (isHalCashAccount())
                     value = OfferUtil.getAdjustedAmountForHalCash(value, price.get(), getMaxTradeLimit());
                 else if (CurrencyUtil.isFiatCurrency(tradeCurrencyCode.get()))

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -25,6 +25,7 @@ import bisq.desktop.main.funds.deposit.DepositView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.settings.SettingsView;
 import bisq.desktop.main.settings.preferences.PreferencesView;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.validation.AltcoinValidator;
 import bisq.desktop.util.validation.BsqValidator;
@@ -441,7 +442,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         priceListener = (ov, oldValue, newValue) -> {
             ignorePriceStringListener = true;
             if (newValue != null)
-                price.set(btcFormatter.formatPrice(newValue));
+                price.set(BSFormatter.formatPrice(newValue));
             else
                 price.set("");
 
@@ -451,7 +452,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         volumeListener = (ov, oldValue, newValue) -> {
             ignoreVolumeStringListener = true;
             if (newValue != null)
-                volume.set(btcFormatter.formatVolume(newValue));
+                volume.set(DisplayUtils.formatVolume(newValue));
             else
                 volume.set("");
 
@@ -492,7 +493,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             Coin makerFeeInBtc = dataModel.getMakerFeeInBtc();
             Optional<Volume> optionalBtcFeeInFiat = OfferUtil.getFeeInUserFiatCurrency(makerFeeInBtc,
                     true, preferences, priceFeedService, bsqFormatter);
-            String btcFeeWithFiatAmount = OfferUtil.getFeeWithFiatAmount(makerFeeInBtc, optionalBtcFeeInFiat, btcFormatter);
+            String btcFeeWithFiatAmount = DisplayUtils.getFeeWithFiatAmount(makerFeeInBtc, optionalBtcFeeInFiat, btcFormatter);
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBtcWithFiat.set(btcFeeWithFiatAmount);
             } else {
@@ -502,14 +503,14 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             Coin makerFeeInBsq = dataModel.getMakerFeeInBsq();
             Optional<Volume> optionalBsqFeeInFiat = OfferUtil.getFeeInUserFiatCurrency(makerFeeInBsq,
                     false, preferences, priceFeedService, bsqFormatter);
-            String bsqFeeWithFiatAmount = OfferUtil.getFeeWithFiatAmount(makerFeeInBsq, optionalBsqFeeInFiat, bsqFormatter);
+            String bsqFeeWithFiatAmount = DisplayUtils.getFeeWithFiatAmount(makerFeeInBsq, optionalBsqFeeInFiat, bsqFormatter);
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBsqWithFiat.set(bsqFeeWithFiatAmount);
             } else {
                 // Before DAO is enabled we show fee as fiat and % in second line
                 String feeInFiatAsString;
                 if (optionalBtcFeeInFiat != null && optionalBtcFeeInFiat.isPresent()) {
-                    feeInFiatAsString = btcFormatter.formatVolumeWithCode(optionalBtcFeeInFiat.get());
+                    feeInFiatAsString = DisplayUtils.formatVolumeWithCode(optionalBtcFeeInFiat.get());
                 } else {
                     feeInFiatAsString = Res.get("shared.na");
                 }
@@ -757,7 +758,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
                 if (dataModel.getMinVolume().get() != null) {
                     InputValidator.ValidationResult minVolumeResult = isVolumeInputValid(
-                            btcFormatter.formatVolume(dataModel.getMinVolume().get()));
+                            DisplayUtils.formatVolume(dataModel.getMinVolume().get()));
 
                     volumeValidationResult.set(minVolumeResult);
 
@@ -788,7 +789,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 setPriceToModel();
                 ignorePriceStringListener = true;
                 if (dataModel.getPrice().get() != null)
-                    price.set(btcFormatter.formatPrice(dataModel.getPrice().get()));
+                    price.set(BSFormatter.formatPrice(dataModel.getPrice().get()));
                 ignorePriceStringListener = false;
                 dataModel.calculateVolume();
                 dataModel.calculateAmount();
@@ -836,7 +837,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                     else if (CurrencyUtil.isFiatCurrency(tradeCurrencyCode.get()))
                         volume = OfferUtil.getRoundedFiatVolume(volume);
 
-                    this.volume.set(btcFormatter.formatVolume(volume));
+                    this.volume.set(DisplayUtils.formatVolume(volume));
                 }
 
                 ignoreVolumeStringListener = false;
@@ -1062,7 +1063,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     private void setAmountToModel() {
         if (amount.get() != null && !amount.get().isEmpty()) {
-            Coin amount = btcFormatter.parseToCoinWith4Decimals(this.amount.get());
+            Coin amount = DisplayUtils.parseToCoinWith4Decimals(this.amount.get(), btcFormatter);
 
             long maxTradeLimit = dataModel.getMaxTradeLimit();
             Price price = dataModel.getPrice().get();
@@ -1086,7 +1087,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     private void setMinAmountToModel() {
         if (minAmount.get() != null && !minAmount.get().isEmpty()) {
-            Coin minAmount = btcFormatter.parseToCoinWith4Decimals(this.minAmount.get());
+            Coin minAmount = DisplayUtils.parseToCoinWith4Decimals(this.minAmount.get(), btcFormatter);
 
             Price price = dataModel.getPrice().get();
             long maxTradeLimit = dataModel.getMaxTradeLimit();
@@ -1188,7 +1189,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 dataModel.getPrice().get() != null &&
                 dataModel.getPrice().get().getValue() != 0 &&
                 isVolumeInputValid(volume.get()).isValid &&
-                isVolumeInputValid(btcFormatter.formatVolume(dataModel.getMinVolume().get())).isValid &&
+                isVolumeInputValid(DisplayUtils.formatVolume(dataModel.getMinVolume().get())).isValid &&
                 dataModel.isMinAmountLessOrEqualAmount();
 
         isNextButtonDisabled.set(!inputDataValid);
@@ -1207,4 +1208,5 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     private BSFormatter getFormatterForMakerFee() {
         return dataModel.isCurrencyForMakerFeeBtc() ? btcFormatter : bsqFormatter;
     }
+
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -53,6 +53,7 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.InputValidator;
 
 import bisq.network.p2p.P2PService;
@@ -316,7 +317,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                         if (marketPrice != null && marketPrice.isRecentExternalPriceAvailable()) {
                             double marketPriceAsDouble = marketPrice.getPrice();
                             try {
-                                double priceAsDouble = BSFormatter.parseNumberStringToDouble(price.get());
+                                double priceAsDouble = ParsingUtils.parseNumberStringToDouble(price.get());
                                 double relation = priceAsDouble / marketPriceAsDouble;
                                 final OfferPayload.Direction compareDirection = CurrencyUtil.isCryptoCurrency(currencyCode) ?
                                         OfferPayload.Direction.SELL :
@@ -342,7 +343,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             if (inputIsMarketBasedPrice) {
                 try {
                     if (!newValue.isEmpty() && !newValue.equals("-")) {
-                        double percentage = BSFormatter.parsePercentStringToDouble(newValue);
+                        double percentage = ParsingUtils.parsePercentStringToDouble(newValue);
                         if (percentage >= 1 || percentage <= -1) {
                             new Popup<>().warning(Res.get("popup.warning.tooLargePercentageValue") + "\n" +
                                     Res.get("popup.warning.examplePercentageValue"))
@@ -866,7 +867,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             if (result.isValid) {
                 double defaultSecurityDeposit = Restrictions.getDefaultBuyerSecurityDepositAsPercent(getPaymentAccount());
                 String key = "buyerSecurityDepositIsLowerAsDefault";
-                double depositAsDouble = BSFormatter.parsePercentStringToDouble(buyerSecurityDeposit.get());
+                double depositAsDouble = ParsingUtils.parsePercentStringToDouble(buyerSecurityDeposit.get());
                 if (preferences.showAgain(key) && depositAsDouble < defaultSecurityDeposit) {
                     String postfix = dataModel.isBuyOffer() ?
                             Res.get("createOffer.tooLowSecDeposit.makerIsBuyer") :
@@ -906,7 +907,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     public boolean isPriceInRange() {
         if (marketPriceMargin.get() != null && !marketPriceMargin.get().isEmpty()) {
-            if (Math.abs(BSFormatter.parsePercentStringToDouble(marketPriceMargin.get())) > preferences.getMaxPriceDistanceInPercent()) {
+            if (Math.abs(ParsingUtils.parsePercentStringToDouble(marketPriceMargin.get())) > preferences.getMaxPriceDistanceInPercent()) {
                 displayPriceOutOfRangePopup();
                 return false;
             } else {
@@ -1130,7 +1131,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     private void setBuyerSecurityDepositToModel() {
         if (buyerSecurityDeposit.get() != null && !buyerSecurityDeposit.get().isEmpty()) {
-            dataModel.setBuyerSecurityDeposit(BSFormatter.parsePercentStringToDouble(buyerSecurityDeposit.get()));
+            dataModel.setBuyerSecurityDeposit(ParsingUtils.parsePercentStringToDouble(buyerSecurityDeposit.get()));
         } else {
             dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent(getPaymentAccount()));
         }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -37,6 +37,7 @@ import bisq.desktop.main.funds.withdrawal.WithdrawalView;
 import bisq.desktop.main.offer.OfferView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
@@ -573,7 +574,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 final long tradeLimit = model.accountAgeWitnessService.getMyTradeLimit(account.get(), offer.getCurrencyCode());
                 new Popup<>()
                         .warning(Res.get("offerbook.warning.tradeLimitNotMatching",
-                                BSFormatter.formatAccountAge(model.accountAgeWitnessService.getMyAccountAge(account.get().getPaymentAccountPayload())),
+                                DisplayUtils.formatAccountAge(model.accountAgeWitnessService.getMyAccountAge(account.get().getPaymentAccountPayload())),
                                 formatter.formatCoinWithCode(Coin.valueOf(tradeLimit)),
                                 formatter.formatCoinWithCode(offer.getMinAmount())))
                         .show();

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -22,6 +22,7 @@ import bisq.desktop.common.model.ActivatableViewModel;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.settings.SettingsView;
 import bisq.desktop.main.settings.preferences.PreferencesView;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -341,7 +342,7 @@ class OfferBookViewModel extends ActivatableViewModel {
     }
 
     private String formatAmount(Offer offer, boolean decimalAligned) {
-        return formatter.formatAmount(offer, GUIUtil.AMOUNT_DECIMALS, decimalAligned, maxPlacesForAmount.get());
+        return DisplayUtils.formatAmount(offer, GUIUtil.AMOUNT_DECIMALS, decimalAligned, maxPlacesForAmount.get(), formatter);
     }
 
 
@@ -363,7 +364,7 @@ class OfferBookViewModel extends ActivatableViewModel {
     }
 
     private String formatPrice(Offer offer, boolean decimalAligned) {
-        return formatter.formatPrice(offer.getPrice(), decimalAligned, maxPlacesForPrice.get());
+        return DisplayUtils.formatPrice(offer.getPrice(), decimalAligned, maxPlacesForPrice.get());
     }
 
     private String formatMarketPriceMargin(Offer offer, boolean decimalAligned) {
@@ -390,7 +391,7 @@ class OfferBookViewModel extends ActivatableViewModel {
         if (offerVolume != null && minOfferVolume != null) {
             String postFix = showAllTradeCurrenciesProperty.get() ? " " + offer.getCurrencyCode() : "";
             decimalAligned = decimalAligned && !showAllTradeCurrenciesProperty.get();
-            return formatter.formatVolume(offer, decimalAligned, maxPlacesForVolume.get()) + postFix;
+            return DisplayUtils.formatVolume(offer, decimalAligned, maxPlacesForVolume.get()) + postFix;
         } else {
             return Res.get("shared.na");
         }

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -24,6 +24,7 @@ import bisq.desktop.main.MainView;
 import bisq.desktop.main.funds.FundsView;
 import bisq.desktop.main.funds.deposit.DepositView;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.validation.BtcValidator;
 
@@ -205,7 +206,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
         }
 
         amountRange = btcFormatter.formatCoin(offer.getMinAmount()) + " - " + btcFormatter.formatCoin(offer.getAmount());
-        price = btcFormatter.formatPrice(dataModel.tradePrice);
+        price = BSFormatter.formatPrice(dataModel.tradePrice);
         marketPriceMargin = BSFormatter.formatToPercent(offer.getMarketPriceMargin());
         paymentLabel = Res.get("takeOffer.fundsBox.paymentLabel", offer.getShortId());
 
@@ -288,7 +289,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
             Coin makerFeeInBtc = dataModel.getTakerFeeInBtc();
             Optional<Volume> optionalBtcFeeInFiat = OfferUtil.getFeeInUserFiatCurrency(makerFeeInBtc,
                     true, preferences, priceFeedService, bsqFormatter);
-            String btcFeeWithFiatAmount = OfferUtil.getFeeWithFiatAmount(makerFeeInBtc, optionalBtcFeeInFiat, btcFormatter);
+            String btcFeeWithFiatAmount = DisplayUtils.getFeeWithFiatAmount(makerFeeInBtc, optionalBtcFeeInFiat, btcFormatter);
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBtcWithFiat.set(btcFeeWithFiatAmount);
             } else {
@@ -298,14 +299,14 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
             Coin makerFeeInBsq = dataModel.getTakerFeeInBsq();
             Optional<Volume> optionalBsqFeeInFiat = OfferUtil.getFeeInUserFiatCurrency(makerFeeInBsq,
                     false, preferences, priceFeedService, bsqFormatter);
-            String bsqFeeWithFiatAmount = OfferUtil.getFeeWithFiatAmount(makerFeeInBsq, optionalBsqFeeInFiat, bsqFormatter);
+            String bsqFeeWithFiatAmount = DisplayUtils.getFeeWithFiatAmount(makerFeeInBsq, optionalBsqFeeInFiat, bsqFormatter);
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBsqWithFiat.set(bsqFeeWithFiatAmount);
             } else {
                 // Before DAO is enabled we show fee as fiat and % in second line
                 String feeInFiatAsString;
                 if (optionalBtcFeeInFiat != null && optionalBtcFeeInFiat.isPresent()) {
-                    feeInFiatAsString = btcFormatter.formatVolumeWithCode(optionalBtcFeeInFiat.get());
+                    feeInFiatAsString = DisplayUtils.formatVolumeWithCode(optionalBtcFeeInFiat.get());
                 } else {
                     feeInFiatAsString = Res.get("shared.na");
                 }
@@ -334,7 +335,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
             InputValidator.ValidationResult result = isBtcInputValid(amount.get());
             amountValidationResult.set(result);
             if (result.isValid) {
-                showWarningInvalidBtcDecimalPlaces.set(!btcFormatter.hasBtcValidDecimals(userInput));
+                showWarningInvalidBtcDecimalPlaces.set(!DisplayUtils.hasBtcValidDecimals(userInput, btcFormatter));
                 // only allow max 4 decimal places for btc values
                 setAmountToModel();
                 // reformat input
@@ -503,7 +504,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void addBindings() {
-        volume.bind(createStringBinding(() -> btcFormatter.formatVolume(dataModel.volume.get()), dataModel.volume));
+        volume.bind(createStringBinding(() -> DisplayUtils.formatVolume(dataModel.volume.get()), dataModel.volume));
 
         if (dataModel.getDirection() == OfferPayload.Direction.SELL) {
             volumeDescriptionLabel.set(Res.get("createOffer.amountPriceBox.buy.volumeDescription", dataModel.getCurrencyCode()));
@@ -626,7 +627,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
 
     private void setAmountToModel() {
         if (amount.get() != null && !amount.get().isEmpty()) {
-            Coin amount = btcFormatter.parseToCoinWith4Decimals(this.amount.get());
+            Coin amount = DisplayUtils.parseToCoinWith4Decimals(this.amount.get(), btcFormatter);
             long maxTradeLimit = dataModel.getMaxTradeLimit();
             Price price = dataModel.tradePrice;
             if (price != null) {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.overlays.windows;
 import bisq.desktop.components.BisqTextArea;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.overlays.Overlay;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Layout;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -133,16 +134,16 @@ public class ContractWindow extends Overlay<ContractWindow> {
         addConfirmationLabelTextFieldWithCopyIcon(gridPane, rowIndex, Res.get("shared.offerId"), offer.getId(),
                 Layout.TWICE_FIRST_ROW_DISTANCE).second.setMouseTransparent(false);
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("contractWindow.dates"),
-                BSFormatter.formatDateTime(offer.getDate()) + " / " + BSFormatter.formatDateTime(dispute.getTradeDate()));
+                DisplayUtils.formatDateTime(offer.getDate()) + " / " + DisplayUtils.formatDateTime(dispute.getTradeDate()));
         String currencyCode = offer.getCurrencyCode();
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.offerType"),
-                BSFormatter.getDirectionBothSides(offer.getDirection(), currencyCode));
+                DisplayUtils.getDirectionBothSides(offer.getDirection(), currencyCode));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradePrice"),
-                formatter.formatPrice(contract.getTradePrice()));
+                BSFormatter.formatPrice(contract.getTradePrice()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradeAmount"),
                 formatter.formatCoinWithCode(contract.getTradeAmount()));
-        addConfirmationLabelLabel(gridPane, ++rowIndex, BSFormatter.formatVolumeLabel(currencyCode, ":"),
-                formatter.formatVolumeWithCode(contract.getTradeVolume()));
+        addConfirmationLabelLabel(gridPane, ++rowIndex, DisplayUtils.formatVolumeLabel(currencyCode, ":"),
+                DisplayUtils.formatVolumeWithCode(contract.getTradeVolume()));
         String securityDeposit = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(offer.getBuyerSecurityDeposit()) +
@@ -261,7 +262,7 @@ public class ContractWindow extends Overlay<ContractWindow> {
     private String getAccountAge(PaymentAccountPayload paymentAccountPayload, PubKeyRing pubKeyRing, String currencyCode) {
         long age = accountAgeWitnessService.getAccountAge(paymentAccountPayload, pubKeyRing);
         return CurrencyUtil.isFiatCurrency(currencyCode) ?
-                age > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(age)) :
+                age > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(age)) :
                         Res.get("peerInfoIcon.tooltip.unknownAge") :
                 "";
     }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -23,6 +23,7 @@ import bisq.desktop.components.BisqTextArea;
 import bisq.desktop.components.InputTextField;
 import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Layout;
 
 import bisq.core.arbitration.Dispute;
@@ -249,7 +250,7 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         addTitledGroupBg(gridPane, ++rowIndex, 17, Res.get("disputeSummaryWindow.title")).getStyleClass().add("last");
         addConfirmationLabelLabel(gridPane, rowIndex, Res.get("shared.tradeId"), dispute.getShortTradeId(),
                 Layout.TWICE_FIRST_ROW_DISTANCE);
-        addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("disputeSummaryWindow.openDate"), BSFormatter.formatDateTime(dispute.getOpeningDate()));
+        addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("disputeSummaryWindow.openDate"), DisplayUtils.formatDateTime(dispute.getOpeningDate()));
         if (dispute.isDisputeOpenerIsMaker()) {
             if (dispute.isDisputeOpenerIsBuyer())
                 role = Res.get("support.buyerOfferer");
@@ -265,9 +266,9 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradeAmount"),
                 formatter.formatCoinWithCode(contract.getTradeAmount()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradePrice"),
-                formatter.formatPrice(contract.getTradePrice()));
+                BSFormatter.formatPrice(contract.getTradePrice()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradeVolume"),
-                formatter.formatVolumeWithCode(contract.getTradeVolume()));
+                DisplayUtils.formatVolumeWithCode(contract.getTradeVolume()));
         String securityDeposit = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(contract.getOfferPayload().getBuyerSecurityDeposit()) +
@@ -566,13 +567,13 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
                     disputeResult.setLoserPublisher(isLoserPublisherCheckBox.isSelected());
                     disputeResult.setCloseDate(new Date());
                     String text = Res.get("disputeSummaryWindow.close.msg",
-                            BSFormatter.formatDateTime(disputeResult.getCloseDate()),
+                            DisplayUtils.formatDateTime(disputeResult.getCloseDate()),
                             role,
-                            BSFormatter.booleanToYesNo(disputeResult.tamperProofEvidenceProperty().get()),
+                            DisplayUtils.booleanToYesNo(disputeResult.tamperProofEvidenceProperty().get()),
                             role,
-                            BSFormatter.booleanToYesNo(disputeResult.idVerificationProperty().get()),
+                            DisplayUtils.booleanToYesNo(disputeResult.idVerificationProperty().get()),
                             role,
-                            BSFormatter.booleanToYesNo(disputeResult.screenCastProperty().get()),
+                            DisplayUtils.booleanToYesNo(disputeResult.screenCastProperty().get()),
                             formatter.formatCoinWithCode(disputeResult.getBuyerPayoutAmount()),
                             formatter.formatCoinWithCode(disputeResult.getSellerPayoutAmount()),
                             disputeResult.summaryNotesProperty().get());

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -37,6 +37,7 @@ import bisq.core.locale.Res;
 import bisq.core.offer.Offer;
 import bisq.core.trade.Contract;
 import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 
 import bisq.common.UserThread;
 import bisq.common.util.Tuple2;
@@ -357,8 +358,8 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
     }
 
     private boolean isPayoutAmountValid() {
-        Coin buyerAmount = formatter.parseToCoin(buyerPayoutAmountInputTextField.getText());
-        Coin sellerAmount = formatter.parseToCoin(sellerPayoutAmountInputTextField.getText());
+        Coin buyerAmount = ParsingUtils.parseToCoin(buyerPayoutAmountInputTextField.getText(), formatter);
+        Coin sellerAmount = ParsingUtils.parseToCoin(sellerPayoutAmountInputTextField.getText(), formatter);
         Contract contract = dispute.getContract();
         Coin tradeAmount = contract.getTradeAmount();
         Offer offer = new Offer(contract.getOfferPayload());
@@ -371,8 +372,8 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
 
     private void applyCustomAmounts(InputTextField inputTextField) {
         Contract contract = dispute.getContract();
-        Coin buyerAmount = formatter.parseToCoin(buyerPayoutAmountInputTextField.getText());
-        Coin sellerAmount = formatter.parseToCoin(sellerPayoutAmountInputTextField.getText());
+        Coin buyerAmount = ParsingUtils.parseToCoin(buyerPayoutAmountInputTextField.getText(), formatter);
+        Coin sellerAmount = ParsingUtils.parseToCoin(sellerPayoutAmountInputTextField.getText(), formatter);
         Offer offer = new Offer(contract.getOfferPayload());
         Coin available = contract.getTradeAmount().
                 add(offer.getBuyerSecurityDeposit())

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
@@ -22,6 +22,7 @@ import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.BusyAnimation;
 import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Layout;
 
 import bisq.core.locale.BankUtil;
@@ -170,49 +171,49 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
         double firstRowDistance = Layout.TWICE_FIRST_ROW_DISTANCE;
         if (takeOfferHandlerOptional.isPresent()) {
             addConfirmationLabelLabel(gridPane, rowIndex, offerTypeLabel,
-                    BSFormatter.getDirectionForTakeOffer(direction, currencyCode), firstRowDistance);
+                    DisplayUtils.getDirectionForTakeOffer(direction, currencyCode), firstRowDistance);
             fiatDirectionInfo = direction == OfferPayload.Direction.BUY ? toReceive : toSpend;
             btcDirectionInfo = direction == OfferPayload.Direction.SELL ? toReceive : toSpend;
         } else if (placeOfferHandlerOptional.isPresent()) {
             addConfirmationLabelLabel(gridPane, rowIndex, offerTypeLabel,
-                    BSFormatter.getOfferDirectionForCreateOffer(direction, currencyCode), firstRowDistance);
+                    DisplayUtils.getOfferDirectionForCreateOffer(direction, currencyCode), firstRowDistance);
             fiatDirectionInfo = direction == OfferPayload.Direction.SELL ? toReceive : toSpend;
             btcDirectionInfo = direction == OfferPayload.Direction.BUY ? toReceive : toSpend;
         } else {
             addConfirmationLabelLabel(gridPane, rowIndex, offerTypeLabel,
-                    BSFormatter.getDirectionBothSides(direction, currencyCode), firstRowDistance);
+                    DisplayUtils.getDirectionBothSides(direction, currencyCode), firstRowDistance);
         }
         String btcAmount = Res.get("shared.btcAmount");
         if (takeOfferHandlerOptional.isPresent()) {
             addConfirmationLabelLabel(gridPane, ++rowIndex, btcAmount + btcDirectionInfo,
                     formatter.formatCoinWithCode(tradeAmount));
-            addConfirmationLabelLabel(gridPane, ++rowIndex, formatter.formatVolumeLabel(currencyCode) + fiatDirectionInfo,
-                    formatter.formatVolumeWithCode(offer.getVolumeByAmount(tradeAmount)));
+            addConfirmationLabelLabel(gridPane, ++rowIndex, DisplayUtils.formatVolumeLabel(currencyCode) + fiatDirectionInfo,
+                    DisplayUtils.formatVolumeWithCode(offer.getVolumeByAmount(tradeAmount)));
         } else {
             addConfirmationLabelLabel(gridPane, ++rowIndex, btcAmount + btcDirectionInfo,
                     formatter.formatCoinWithCode(offer.getAmount()));
             addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("offerDetailsWindow.minBtcAmount"),
                     formatter.formatCoinWithCode(offer.getMinAmount()));
-            String volume = formatter.formatVolumeWithCode(offer.getVolume());
+            String volume = DisplayUtils.formatVolumeWithCode(offer.getVolume());
             String minVolume = "";
             if (offer.getVolume() != null && offer.getMinVolume() != null &&
                     !offer.getVolume().equals(offer.getMinVolume()))
-                minVolume = " " + Res.get("offerDetailsWindow.min", formatter.formatVolumeWithCode(offer.getMinVolume()));
+                minVolume = " " + Res.get("offerDetailsWindow.min", DisplayUtils.formatVolumeWithCode(offer.getMinVolume()));
             addConfirmationLabelLabel(gridPane, ++rowIndex,
-                    formatter.formatVolumeLabel(currencyCode) + fiatDirectionInfo, volume + minVolume);
+                    DisplayUtils.formatVolumeLabel(currencyCode) + fiatDirectionInfo, volume + minVolume);
         }
 
         String priceLabel = Res.get("shared.price");
         if (takeOfferHandlerOptional.isPresent()) {
-            addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, formatter.formatPrice(tradePrice));
+            addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, BSFormatter.formatPrice(tradePrice));
         } else {
             Price price = offer.getPrice();
             if (offer.isUseMarketBasedPrice()) {
-                addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, formatter.formatPrice(price) +
+                addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, BSFormatter.formatPrice(price) +
                         " " + Res.get("offerDetailsWindow.distance",
                         BSFormatter.formatPercentagePrice(offer.getMarketPriceMargin())));
             } else {
-                addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, formatter.formatPrice(price));
+                addConfirmationLabelLabel(gridPane, ++rowIndex, priceLabel, BSFormatter.formatPrice(price));
             }
         }
         final PaymentMethod paymentMethod = offer.getPaymentMethod();
@@ -307,7 +308,7 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
         addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("offerDetailsWindow.makersOnion"),
                 offer.getMakerNodeAddress().getFullAddress());
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("offerDetailsWindow.creationDate"),
-                BSFormatter.formatDateTime(offer.getDate()));
+                DisplayUtils.formatDateTime(offer.getDate()));
         String value = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(offer.getBuyerSecurityDeposit()) +

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
@@ -25,6 +25,7 @@ import bisq.desktop.components.TableGroupHeadline;
 import bisq.desktop.main.dao.governance.ProposalDisplay;
 import bisq.desktop.main.dao.governance.result.VoteListItem;
 import bisq.desktop.main.overlays.TabbedOverlay;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
 
@@ -34,7 +35,6 @@ import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Proposal;
 import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
-import bisq.core.util.BSFormatter;
 import bisq.core.util.BsqFormatter;
 
 import bisq.common.util.Tuple2;
@@ -241,7 +241,7 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
-                                    setText(BSFormatter.formatDateTime(item.getBlindVoteDate()));
+                                    setText(DisplayUtils.formatDateTime(item.getBlindVoteDate()));
                                 } else {
                                     setText("");
                                 }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -21,6 +21,7 @@ import bisq.desktop.components.BisqTextArea;
 import bisq.desktop.components.TextFieldWithCopyIcon;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.overlays.Overlay;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Layout;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -134,12 +135,12 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         String offerType = Res.get("shared.offerType");
         if (tradeManager.isBuyer(offer)) {
             addConfirmationLabelLabel(gridPane, rowIndex, offerType,
-                    BSFormatter.getDirectionForBuyer(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
+                    DisplayUtils.getDirectionForBuyer(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
             fiatDirectionInfo = toSpend;
             btcDirectionInfo = toReceive;
         } else {
             addConfirmationLabelLabel(gridPane, rowIndex, offerType,
-                    BSFormatter.getDirectionForSeller(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
+                    DisplayUtils.getDirectionForSeller(myOffer, offer.getCurrencyCode()), Layout.TWICE_FIRST_ROW_DISTANCE);
             fiatDirectionInfo = toReceive;
             btcDirectionInfo = toSpend;
         }
@@ -147,10 +148,10 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.btcAmount") + btcDirectionInfo,
                 formatter.formatCoinWithCode(trade.getTradeAmount()));
         addConfirmationLabelLabel(gridPane, ++rowIndex,
-                formatter.formatVolumeLabel(offer.getCurrencyCode()) + fiatDirectionInfo,
-                formatter.formatVolumeWithCode(trade.getTradeVolume()));
+                DisplayUtils.formatVolumeLabel(offer.getCurrencyCode()) + fiatDirectionInfo,
+                DisplayUtils.formatVolumeWithCode(trade.getTradeVolume()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradePrice"),
-                formatter.formatPrice(trade.getTradePrice()));
+                BSFormatter.formatPrice(trade.getTradePrice()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.paymentMethod"),
                 Res.get(offer.getPaymentMethod().getId()));
 
@@ -198,7 +199,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         addConfirmationLabelTextFieldWithCopyIcon(gridPane, rowIndex, Res.get("shared.tradeId"),
                 trade.getId(), Layout.TWICE_FIRST_ROW_AND_GROUP_DISTANCE);
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("tradeDetailsWindow.tradeDate"),
-                BSFormatter.formatDateTime(trade.getDate()));
+                DisplayUtils.formatDateTime(trade.getDate()));
         String securityDeposit = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(offer.getBuyerSecurityDeposit()) +
@@ -226,7 +227,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
                 String paymentDetails = buyerPaymentAccountPayload.getPaymentDetails();
                 long age = accountAgeWitnessService.getAccountAge(buyerPaymentAccountPayload, contract.getBuyerPubKeyRing());
                 buyersAccountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
-                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(age)) :
+                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :
                         "";
 
@@ -240,7 +241,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
                 String paymentDetails = sellerPaymentAccountPayload.getPaymentDetails();
                 long age = accountAgeWitnessService.getAccountAge(sellerPaymentAccountPayload, contract.getSellerPubKeyRing());
                 sellersAccountAge = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
-                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", BSFormatter.formatAccountAge(age)) :
+                        age > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(age)) :
                                 Res.get("peerInfoIcon.tooltip.unknownAge") :
                         "";
                 String postFix = sellersAccountAge.isEmpty() ? "" : " / " + sellersAccountAge;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
@@ -26,6 +26,7 @@ import bisq.desktop.components.InputTextField;
 import bisq.desktop.components.PeerInfoIcon;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.alert.PrivateNotificationManager;
@@ -317,7 +318,7 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
 
             Offer offer = item.getTradable().getOffer();
             boolean matchesId = offer.getId().contains(filterString);
-            boolean matchesOfferDate = formatter.formatDate(offer.getDate()).contains(filterString);
+            boolean matchesOfferDate = DisplayUtils.formatDate(offer.getDate()).contains(filterString);
             boolean isMakerOnion = offer.getMakerNodeAddress().getFullAddress().contains(filterString);
 
             if (item.getTradable() instanceof Trade) {
@@ -327,7 +328,7 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
                 boolean matchesSellersPaymentAccountData = false;
 
                 Trade trade = (Trade) item.getTradable();
-                boolean matchesTradeDate = formatter.formatDate(trade.getTakeOfferDate()).contains(filterString);
+                boolean matchesTradeDate = DisplayUtils.formatDate(trade.getTakeOfferDate()).contains(filterString);
                 Contract contract = trade.getContract();
                 if (contract != null) {
                     isBuyerOnion = contract.getBuyerNodeAddress().getFullAddress().contains(filterString);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesViewModel.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.portfolio.closedtrades;
 
 import bisq.desktop.common.model.ActivatableWithDataModel;
 import bisq.desktop.common.model.ViewModel;
+import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.locale.Res;
@@ -68,14 +69,14 @@ class ClosedTradesViewModel extends ActivatableWithDataModel<ClosedTradesDataMod
             return "";
         Tradable tradable = item.getTradable();
         if (tradable instanceof Trade)
-            return formatter.formatPrice(((Trade) tradable).getTradePrice());
+            return BSFormatter.formatPrice(((Trade) tradable).getTradePrice());
         else
-            return formatter.formatPrice(tradable.getOffer().getPrice());
+            return BSFormatter.formatPrice(tradable.getOffer().getPrice());
     }
 
     String getVolume(ClosedTradableListItem item) {
         if (item != null && item.getTradable() instanceof Trade)
-            return formatter.formatVolumeWithCode(((Trade) item.getTradable()).getTradeVolume());
+            return DisplayUtils.formatVolumeWithCode(((Trade) item.getTradable()).getTradeVolume());
         else if (item != null && item.getTradable() instanceof OpenOffer)
             return "-";
         else
@@ -123,11 +124,11 @@ class ClosedTradesViewModel extends ActivatableWithDataModel<ClosedTradesDataMod
     }
 
     String getDirectionLabel(ClosedTradableListItem item) {
-        return (item != null) ? BSFormatter.getDirectionWithCode(dataModel.getDirection(item.getTradable().getOffer()), item.getTradable().getOffer().getCurrencyCode()) : "";
+        return (item != null) ? DisplayUtils.getDirectionWithCode(dataModel.getDirection(item.getTradable().getOffer()), item.getTradable().getOffer().getCurrencyCode()) : "";
     }
 
     String getDate(ClosedTradableListItem item) {
-        return BSFormatter.formatDateTime(item.getTradable().getDate());
+        return DisplayUtils.formatDateTime(item.getTradable().getDate());
     }
 
     String getMarketLabel(ClosedTradableListItem item) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
@@ -77,8 +77,8 @@ class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
     }
 
     public void onInvalidatePrice() {
-        price.set(btcFormatter.formatPrice(null));
-        price.set(btcFormatter.formatPrice(dataModel.getPrice().get()));
+        price.set(BSFormatter.formatPrice(null));
+        price.set(BSFormatter.formatPrice(dataModel.getPrice().get()));
     }
 
     public boolean isSecurityDepositValid() {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesViewModel.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.portfolio.failedtrades;
 
 import bisq.desktop.common.model.ActivatableWithDataModel;
 import bisq.desktop.common.model.ViewModel;
+import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.Res;
 import bisq.core.util.BSFormatter;
@@ -54,18 +55,18 @@ class FailedTradesViewModel extends ActivatableWithDataModel<FailedTradesDataMod
     }
 
     String getPrice(FailedTradesListItem item) {
-        return (item != null) ? formatter.formatPrice(item.getTrade().getTradePrice()) : "";
+        return (item != null) ? BSFormatter.formatPrice(item.getTrade().getTradePrice()) : "";
     }
 
     String getVolume(FailedTradesListItem item) {
         if (item != null && item.getTrade() != null)
-            return formatter.formatVolumeWithCode(item.getTrade().getTradeVolume());
+            return DisplayUtils.formatVolumeWithCode(item.getTrade().getTradeVolume());
         else
             return "";
     }
 
     String getDirectionLabel(FailedTradesListItem item) {
-        return (item != null) ? BSFormatter.getDirectionWithCode(dataModel.getDirection(item.getTrade().getOffer()), item.getTrade().getOffer().getCurrencyCode()) : "";
+        return (item != null) ? DisplayUtils.getDirectionWithCode(dataModel.getDirection(item.getTrade().getOffer()), item.getTrade().getOffer().getCurrencyCode()) : "";
     }
 
     String getMarketLabel(FailedTradesListItem item) {
@@ -76,7 +77,7 @@ class FailedTradesViewModel extends ActivatableWithDataModel<FailedTradesDataMod
     }
 
     String getDate(FailedTradesListItem item) {
-        return BSFormatter.formatDateTime(item.getTrade().getDate());
+        return DisplayUtils.formatDateTime(item.getTrade().getDate());
     }
 
     String getState(FailedTradesListItem item) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.portfolio.openoffer;
 
 import bisq.desktop.common.model.ActivatableWithDataModel;
 import bisq.desktop.common.model.ViewModel;
+import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.Res;
 import bisq.core.monetary.Price;
@@ -71,7 +72,7 @@ class OpenOffersViewModel extends ActivatableWithDataModel<OpenOffersDataModel> 
     }
 
     String getAmount(OpenOfferListItem item) {
-        return (item != null) ? formatter.formatAmount(item.getOffer()) : "";
+        return (item != null) ? DisplayUtils.formatAmount(item.getOffer(), formatter) : "";
     }
 
     String getPrice(OpenOfferListItem item) {
@@ -84,21 +85,21 @@ class OpenOffersViewModel extends ActivatableWithDataModel<OpenOffersDataModel> 
             String postFix = "";
             if (offer.isUseMarketBasedPrice())
                 postFix = " (" + BSFormatter.formatPercentagePrice(offer.getMarketPriceMargin()) + ")";
-            return formatter.formatPrice(price) + postFix;
+            return BSFormatter.formatPrice(price) + postFix;
         } else {
             return Res.get("shared.na");
         }
     }
 
     String getVolume(OpenOfferListItem item) {
-        return (item != null) ? formatter.formatVolume(item.getOffer(), false, 0) + " " + item.getOffer().getCurrencyCode() : "";
+        return (item != null) ? DisplayUtils.formatVolume(item.getOffer(), false, 0) + " " + item.getOffer().getCurrencyCode() : "";
     }
 
     String getDirectionLabel(OpenOfferListItem item) {
         if ((item == null))
             return "";
 
-        return BSFormatter.getDirectionWithCode(dataModel.getDirection(item.getOffer()), item.getOffer().getCurrencyCode());
+        return DisplayUtils.getDirectionWithCode(dataModel.getDirection(item.getOffer()), item.getOffer().getCurrencyCode());
     }
 
     String getMarketLabel(OpenOfferListItem item) {
@@ -109,7 +110,7 @@ class OpenOffersViewModel extends ActivatableWithDataModel<OpenOffersDataModel> 
     }
 
     String getDate(OpenOfferListItem item) {
-        return BSFormatter.formatDateTime(item.getOffer().getDate());
+        return DisplayUtils.formatDateTime(item.getOffer().getDate());
     }
 
     boolean isDeactivated(OpenOfferListItem item) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -26,6 +26,7 @@ import bisq.desktop.main.Chat.Chat;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.CssTheme;
 
@@ -493,7 +494,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                             public void updateItem(final PendingTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty) {
-                                    setGraphic(new AutoTooltipLabel(BSFormatter.formatDateTime(item.getTrade().getDate())));
+                                    setGraphic(new AutoTooltipLabel(DisplayUtils.formatDateTime(item.getTrade().getDate())));
                                 } else {
                                     setGraphic(null);
                                 }
@@ -536,7 +537,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                             public void updateItem(final PendingTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty)
-                                    setGraphic(new AutoTooltipLabel(formatter.formatPrice(item.getPrice())));
+                                    setGraphic(new AutoTooltipLabel(BSFormatter.formatPrice(item.getPrice())));
                                 else
                                     setGraphic(null);
                             }
@@ -557,7 +558,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                             public void updateItem(final PendingTradesListItem item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty)
-                                    setGraphic(new AutoTooltipLabel(formatter.formatVolumeWithCode(item.getTrade().getTradeVolume())));
+                                    setGraphic(new AutoTooltipLabel(DisplayUtils.formatVolumeWithCode(item.getTrade().getTradeVolume())));
                                 else
                                     setGraphic(null);
                             }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.portfolio.pendingtrades;
 
 import bisq.desktop.common.model.ActivatableWithDataModel;
 import bisq.desktop.common.model.ViewModel;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -233,7 +234,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     }
 
     public String getDateForOpenDispute() {
-        return BSFormatter.formatDateTime(new Date(new Date().getTime() + getRemainingTradeDuration()));
+        return DisplayUtils.formatDateTime(new Date(new Date().getTime() + getRemainingTradeDuration()));
     }
 
     public boolean showWarning() {
@@ -278,7 +279,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     }
 
     public String getFiatVolume() {
-        return dataModel.getTrade() != null ? btcFormatter.formatVolumeWithCode(dataModel.getTrade().getTradeVolume()) : "";
+        return dataModel.getTrade() != null ? DisplayUtils.formatVolumeWithCode(dataModel.getTrade().getTradeVolume()) : "";
     }
 
     public String getTxFee() {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -49,6 +49,7 @@ import bisq.desktop.components.paymentmethods.WesternUnionForm;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import bisq.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Layout;
 
 import bisq.core.locale.CurrencyUtil;
@@ -500,7 +501,7 @@ public class BuyerStep2View extends TradeStepView {
             String fees = Res.get("portfolio.pending.step2_buyer.fees");
             String id = trade.getShortId();
             String paddedId = " " + id + " ";
-            String amount = model.btcFormatter.formatVolumeWithCode(trade.getTradeVolume());
+            String amount = DisplayUtils.formatVolumeWithCode(trade.getTradeVolume());
             if (paymentAccountPayload instanceof AssetsAccountPayload) {
                 //noinspection UnusedAssignment
                 message += Res.get("portfolio.pending.step2_buyer.altcoin",

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -23,6 +23,7 @@ import bisq.desktop.components.TitledGroupBg;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import bisq.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Layout;
 
 import bisq.core.locale.CurrencyUtil;
@@ -320,7 +321,7 @@ public class SellerStep3View extends TradeStepView {
         //noinspection UnusedAssignment
         String key = "confirmPayment" + trade.getId();
         String message = "";
-        String tradeVolumeWithCode = model.btcFormatter.formatVolumeWithCode(trade.getTradeVolume());
+        String tradeVolumeWithCode = DisplayUtils.formatVolumeWithCode(trade.getTradeVolume());
         String currencyName = CurrencyUtil.getNameByCode(trade.getOffer().getCurrencyCode());
         String part1 = Res.get("portfolio.pending.step3_seller.part", currencyName);
         String id = trade.getShortId();

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/P2pNetworkListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/P2pNetworkListItem.java
@@ -17,6 +17,8 @@
 
 package bisq.desktop.main.settings.network;
 
+import bisq.desktop.util.DisplayUtils;
+
 import bisq.core.locale.Res;
 import bisq.core.util.BSFormatter;
 
@@ -118,7 +120,7 @@ public class P2pNetworkListItem {
     }
 
     public String getCreationDate() {
-        return BSFormatter.formatDateTime(statistic.getCreationDate());
+        return DisplayUtils.formatDateTime(statistic.getCreationDate());
     }
 
     public String getOnionAddress() {

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -47,6 +47,7 @@ import bisq.core.provider.fee.FeeService;
 import bisq.core.user.BlockChainExplorer;
 import bisq.core.user.Preferences;
 import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.IntegerValidator;
 
 import bisq.common.UserThread;
@@ -314,7 +315,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
         deviationListener = (observable, oldValue, newValue) -> {
             try {
-                double value = BSFormatter.parsePercentStringToDouble(newValue);
+                double value = ParsingUtils.parsePercentStringToDouble(newValue);
                 final double maxDeviation = 0.5;
                 if (value <= maxDeviation) {
                     preferences.setMaxPriceDistanceInPercent(value);

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -9,6 +9,7 @@ import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
@@ -265,7 +266,7 @@ public class DisplayUtils {
      */
     public static Coin parseToCoinWith4Decimals(String input, BSFormatter bsFormatter) {
         try {
-            return Coin.valueOf(new BigDecimal(bsFormatter.parseToCoin(BSFormatter.cleanDoubleInput(input)).value).setScale(-scale - 1,
+            return Coin.valueOf(new BigDecimal(ParsingUtils.parseToCoin(ParsingUtils.cleanDoubleInput(input), bsFormatter).value).setScale(-scale - 1,
                     BigDecimal.ROUND_HALF_UP).setScale(scale + 1, BigDecimal.ROUND_HALF_UP).toBigInteger().longValue());
         } catch (Throwable t) {
             if (input != null && input.length() > 0)
@@ -275,7 +276,7 @@ public class DisplayUtils {
     }
 
     public static boolean hasBtcValidDecimals(String input, BSFormatter bsFormatter) {
-        return bsFormatter.parseToCoin(input).equals(parseToCoinWith4Decimals(input, bsFormatter));
+        return ParsingUtils.parseToCoin(input, bsFormatter).equals(parseToCoinWith4Decimals(input, bsFormatter));
     }
 
     /**
@@ -286,6 +287,6 @@ public class DisplayUtils {
      * @return The transformed coin
      */
     public static Coin reduceTo4Decimals(Coin coin, BSFormatter bsFormatter) {
-        return bsFormatter.parseToCoin(bsFormatter.formatCoin(coin));
+        return ParsingUtils.parseToCoin(bsFormatter.formatCoin(coin), bsFormatter);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -1,0 +1,291 @@
+package bisq.desktop.util;
+
+import bisq.core.locale.CurrencyUtil;
+import bisq.core.locale.GlobalSettings;
+import bisq.core.locale.Res;
+import bisq.core.monetary.Altcoin;
+import bisq.core.monetary.Price;
+import bisq.core.monetary.Volume;
+import bisq.core.offer.Offer;
+import bisq.core.offer.OfferPayload;
+import bisq.core.util.BSFormatter;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Monetary;
+import org.bitcoinj.utils.Fiat;
+import org.bitcoinj.utils.MonetaryFormat;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
+import java.text.DateFormat;
+
+import java.math.BigDecimal;
+
+import java.util.Date;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DisplayUtils {
+    private final static int scale = 3;
+    private static final MonetaryFormat fiatVolumeFormat = new MonetaryFormat().shift(0).minDecimals(2).repeatOptionalDecimals(0, 0);
+
+    public static String formatDateTime(Date date) {
+        return BSFormatter.formatDateTime(date, true);
+    }
+
+    public static String formatDateTimeSpan(Date dateFrom, Date dateTo) {
+        if (dateFrom != null && dateTo != null) {
+            DateFormat dateFormatter = DateFormat.getDateInstance(DateFormat.DEFAULT, GlobalSettings.getLocale());
+            DateFormat timeFormatter = DateFormat.getTimeInstance(DateFormat.DEFAULT, GlobalSettings.getLocale());
+            return dateFormatter.format(dateFrom) + " " + timeFormatter.format(dateFrom) + BSFormatter.RANGE_SEPARATOR + timeFormatter.format(dateTo);
+        } else {
+            return "";
+        }
+    }
+
+    public static String formatTime(Date date) {
+        if (date != null) {
+            DateFormat timeFormatter = DateFormat.getTimeInstance(DateFormat.DEFAULT, GlobalSettings.getLocale());
+            return timeFormatter.format(date);
+        } else {
+            return "";
+        }
+    }
+
+    public static String formatDate(Date date) {
+        if (date != null) {
+            DateFormat dateFormatter = DateFormat.getDateInstance(DateFormat.DEFAULT, GlobalSettings.getLocale());
+            return dateFormatter.format(date);
+        } else {
+            return "";
+        }
+    }
+
+    public static String formatAccountAge(long durationMillis) {
+        durationMillis = Math.max(0, durationMillis);
+        String day = Res.get("time.day").toLowerCase();
+        String days = Res.get("time.days");
+        String format = "d\' " + days + "\'";
+        return StringUtils.replaceOnce(DurationFormatUtils.formatDuration(durationMillis, format), "1 " + days, "1 " + day);
+    }
+
+    public static String booleanToYesNo(boolean value) {
+        return value ? Res.get("shared.yes") : Res.get("shared.no");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Volume
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public static String formatVolume(Offer offer, Boolean decimalAligned, int maxNumberOfDigits) {
+        return formatVolume(offer, decimalAligned, maxNumberOfDigits, true);
+    }
+
+    public static String formatVolume(Offer offer, Boolean decimalAligned, int maxNumberOfDigits, boolean showRange) {
+        String formattedVolume = offer.isRange() && showRange ? formatVolume(offer.getMinVolume()) + BSFormatter.RANGE_SEPARATOR + formatVolume(offer.getVolume()) : formatVolume(offer.getVolume());
+
+        if (decimalAligned) {
+            formattedVolume = BSFormatter.fillUpPlacesWithEmptyStrings(formattedVolume, maxNumberOfDigits);
+        }
+        return formattedVolume;
+    }
+
+    public static String formatVolume(Volume volume) {
+        return formatVolume(volume, fiatVolumeFormat, false);
+    }
+
+    private static String formatVolume(Volume volume, MonetaryFormat fiatVolumeFormat, boolean appendCurrencyCode) {
+        if (volume != null) {
+            Monetary monetary = volume.getMonetary();
+            if (monetary instanceof Fiat)
+                return BSFormatter.formatFiat((Fiat) monetary, fiatVolumeFormat, appendCurrencyCode);
+            else
+                return BSFormatter.formatAltcoinVolume((Altcoin) monetary, appendCurrencyCode);
+        } else {
+            return "";
+        }
+    }
+
+    public static String formatVolumeWithCode(Volume volume) {
+        return formatVolume(volume, fiatVolumeFormat, true);
+    }
+
+    public static String formatVolumeLabel(String currencyCode) {
+        return formatVolumeLabel(currencyCode, "");
+    }
+
+    public static String formatVolumeLabel(String currencyCode, String postFix) {
+        return Res.get("formatter.formatVolumeLabel",
+                currencyCode, postFix);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Offer direction
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public static String getDirectionWithCode(OfferPayload.Direction direction, String currencyCode) {
+        if (CurrencyUtil.isFiatCurrency(currencyCode))
+            return (direction == OfferPayload.Direction.BUY) ? Res.get("shared.buyCurrency", Res.getBaseCurrencyCode()) : Res.get("shared.sellCurrency", Res.getBaseCurrencyCode());
+        else
+            return (direction == OfferPayload.Direction.SELL) ? Res.get("shared.buyCurrency", currencyCode) : Res.get("shared.sellCurrency", currencyCode);
+    }
+
+    public static String getDirectionBothSides(OfferPayload.Direction direction, String currencyCode) {
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            currencyCode = Res.getBaseCurrencyCode();
+            return direction == OfferPayload.Direction.BUY ?
+                    Res.get("formatter.makerTaker", currencyCode, Res.get("shared.buyer"), currencyCode, Res.get("shared.seller")) :
+                    Res.get("formatter.makerTaker", currencyCode, Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"));
+        } else {
+            return direction == OfferPayload.Direction.SELL ?
+                    Res.get("formatter.makerTaker", currencyCode, Res.get("shared.buyer"), currencyCode, Res.get("shared.seller")) :
+                    Res.get("formatter.makerTaker", currencyCode, Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"));
+        }
+    }
+
+    public static String getDirectionForBuyer(boolean isMyOffer, String currencyCode) {
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            String code = Res.getBaseCurrencyCode();
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.buying"), code, Res.get("shared.selling"), code) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.buying"), code, Res.get("shared.selling"), code);
+        } else {
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.selling"), currencyCode, Res.get("shared.buying"), currencyCode) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.selling"), currencyCode, Res.get("shared.buying"), currencyCode);
+        }
+    }
+
+    public static String getDirectionForSeller(boolean isMyOffer, String currencyCode) {
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            String code = Res.getBaseCurrencyCode();
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.selling"), code, Res.get("shared.buying"), code) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.selling"), code, Res.get("shared.buying"), code);
+        } else {
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.buying"), currencyCode, Res.get("shared.selling"), currencyCode) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.buying"), currencyCode, Res.get("shared.selling"), currencyCode);
+        }
+    }
+
+    public static String getDirectionForTakeOffer(OfferPayload.Direction direction, String currencyCode) {
+        String baseCurrencyCode = Res.getBaseCurrencyCode();
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            return direction == OfferPayload.Direction.BUY ?
+                    Res.get("formatter.youAre", Res.get("shared.selling"), baseCurrencyCode, Res.get("shared.buying"), currencyCode) :
+                    Res.get("formatter.youAre", Res.get("shared.buying"), baseCurrencyCode, Res.get("shared.selling"), currencyCode);
+        } else {
+
+            return direction == OfferPayload.Direction.SELL ?
+                    Res.get("formatter.youAre", Res.get("shared.selling"), currencyCode, Res.get("shared.buying"), baseCurrencyCode) :
+                    Res.get("formatter.youAre", Res.get("shared.buying"), currencyCode, Res.get("shared.selling"), baseCurrencyCode);
+        }
+    }
+
+    public static String getOfferDirectionForCreateOffer(OfferPayload.Direction direction, String currencyCode) {
+        String baseCurrencyCode = Res.getBaseCurrencyCode();
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            return direction == OfferPayload.Direction.BUY ?
+                    Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.buy"), baseCurrencyCode) :
+                    Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.sell"), baseCurrencyCode);
+        } else {
+            return direction == OfferPayload.Direction.SELL ?
+                    Res.get("formatter.youAreCreatingAnOffer.altcoin", Res.get("shared.buy"), currencyCode, Res.get("shared.selling"), baseCurrencyCode) :
+                    Res.get("formatter.youAreCreatingAnOffer.altcoin", Res.get("shared.sell"), currencyCode, Res.get("shared.buying"), baseCurrencyCode);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Amount
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public static String formatAmount(Offer offer, BSFormatter formatter) {
+        return formatAmount(offer, false, formatter);
+    }
+
+    private static String formatAmount(Offer offer, boolean decimalAligned, BSFormatter bsFormatter) {
+        String formattedAmount = offer.isRange() ? bsFormatter.formatCoin(offer.getMinAmount()) + BSFormatter.RANGE_SEPARATOR + bsFormatter.formatCoin(offer.getAmount()) : bsFormatter.formatCoin(offer.getAmount());
+        if (decimalAligned) {
+            formattedAmount = BSFormatter.fillUpPlacesWithEmptyStrings(formattedAmount, 15);
+        }
+        return formattedAmount;
+    }
+
+    public static String formatAmount(Offer offer,
+                                      int decimalPlaces,
+                                      boolean decimalAligned,
+                                      int maxPlaces,
+                                      BSFormatter bsFormatter) {
+        String formattedAmount = offer.isRange() ? bsFormatter.formatCoin(offer.getMinAmount(), decimalPlaces) + BSFormatter.RANGE_SEPARATOR + bsFormatter.formatCoin(offer.getAmount(), decimalPlaces) : bsFormatter.formatCoin(offer.getAmount(), decimalPlaces);
+
+        if (decimalAligned) {
+            formattedAmount = BSFormatter.fillUpPlacesWithEmptyStrings(formattedAmount, maxPlaces);
+        }
+        return formattedAmount;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Other
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public static String formatPrice(Price price, Boolean decimalAligned, int maxPlaces) {
+        String formattedPrice = BSFormatter.formatPrice(price);
+
+        if (decimalAligned) {
+            formattedPrice = BSFormatter.fillUpPlacesWithEmptyStrings(formattedPrice, maxPlaces);
+        }
+        return formattedPrice;
+    }
+
+    public static String getFeeWithFiatAmount(Coin makerFeeAsCoin,
+                                              Optional<Volume> optionalFeeInFiat,
+                                              BSFormatter formatter) {
+        String fee = makerFeeAsCoin != null ? formatter.formatCoinWithCode(makerFeeAsCoin) : Res.get("shared.na");
+        String feeInFiatAsString;
+        if (optionalFeeInFiat != null && optionalFeeInFiat.isPresent()) {
+            feeInFiatAsString = formatVolumeWithCode(optionalFeeInFiat.get());
+        } else {
+            feeInFiatAsString = Res.get("shared.na");
+        }
+        return Res.get("feeOptionWindow.fee", fee, feeInFiatAsString);
+    }
+
+    /**
+     * Converts to a coin with max. 4 decimal places. Last place gets rounded.
+     * 0.01234 -> 0.0123
+     * 0.01235 -> 0.0124
+     *
+     * @param input
+     * @param bsFormatter
+     * @return
+     */
+    public static Coin parseToCoinWith4Decimals(String input, BSFormatter bsFormatter) {
+        try {
+            return Coin.valueOf(new BigDecimal(bsFormatter.parseToCoin(BSFormatter.cleanDoubleInput(input)).value).setScale(-scale - 1,
+                    BigDecimal.ROUND_HALF_UP).setScale(scale + 1, BigDecimal.ROUND_HALF_UP).toBigInteger().longValue());
+        } catch (Throwable t) {
+            if (input != null && input.length() > 0)
+                log.warn("Exception at parseToCoinWith4Decimals: " + t.toString());
+            return Coin.ZERO;
+        }
+    }
+
+    public static boolean hasBtcValidDecimals(String input, BSFormatter bsFormatter) {
+        return bsFormatter.parseToCoin(input).equals(parseToCoinWith4Decimals(input, bsFormatter));
+    }
+
+    /**
+     * Transform a coin with the properties defined in the format (used to reduce decimal places)
+     *
+     * @param coin The coin which should be transformed
+     * @param bsFormatter
+     * @return The transformed coin
+     */
+    public static Coin reduceTo4Decimals(Coin coin, BSFormatter bsFormatter) {
+        return bsFormatter.parseToCoin(bsFormatter.formatCoin(coin));
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/util/validation/BsqValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/BsqValidator.java
@@ -21,6 +21,7 @@ import bisq.core.btc.wallet.Restrictions;
 import bisq.core.locale.Res;
 import bisq.core.util.BsqFormatter;
 import bisq.core.util.CoinUtil;
+import bisq.core.util.ParsingUtils;
 
 import org.bitcoinj.core.Coin;
 
@@ -53,7 +54,7 @@ public class BsqValidator extends AltcoinValidator {
     public BsqValidator(BsqFormatter bsqFormatter) {
         this.bsqFormatter = bsqFormatter;
         // Limit to avoid overflows
-        setMaxValue(bsqFormatter.parseToCoin("10000000"));
+        setMaxValue(ParsingUtils.parseToCoin("10000000", bsqFormatter));
     }
 
     public void setMinValue(@NotNull Coin minValue) {
@@ -94,7 +95,7 @@ public class BsqValidator extends AltcoinValidator {
     }
 
     private ValidationResult validateIfAboveDust(String input) {
-        final Coin coin = bsqFormatter.parseToCoin(input);
+        final Coin coin = ParsingUtils.parseToCoin(input, bsqFormatter);
         if (Restrictions.isAboveDust(coin))
             return new ValidationResult(true);
         else
@@ -113,7 +114,7 @@ public class BsqValidator extends AltcoinValidator {
 
     private ValidationResult validateIfNotExceedsMaxBtcValue(String input) {
         try {
-            final Coin coin = bsqFormatter.parseToCoin(input);
+            final Coin coin = ParsingUtils.parseToCoin(input, bsqFormatter);
             if (maxValue != null && coin.compareTo(maxValue) > 0)
                 return new ValidationResult(false, Res.get("validation.btc.toLarge", bsqFormatter.formatCoinWithCode(maxValue)));
             else
@@ -125,7 +126,7 @@ public class BsqValidator extends AltcoinValidator {
 
     private ValidationResult validateIfSufficientAvailableBalance(String input) {
         try {
-            final Coin coin = bsqFormatter.parseToCoin(input);
+            final Coin coin = ParsingUtils.parseToCoin(input, bsqFormatter);
             if (availableBalance != null && availableBalance.compareTo(coin) < 0)
                 return new ValidationResult(false, Res.get("validation.bsq.insufficientBalance",
                         bsqFormatter.formatCoinWithCode(availableBalance)));
@@ -138,7 +139,7 @@ public class BsqValidator extends AltcoinValidator {
 
     private ValidationResult validateIfNotBelowMinValue(String input) {
         try {
-            final Coin coin = bsqFormatter.parseToCoin(input);
+            final Coin coin = ParsingUtils.parseToCoin(input, bsqFormatter);
             if (minValue != null && coin.compareTo(minValue) < 0)
                 return new ValidationResult(false, Res.get("validation.bsq.amountBelowMinAmount",
                         bsqFormatter.formatCoinWithCode(minValue)));

--- a/desktop/src/main/java/bisq/desktop/util/validation/NumberValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/NumberValidator.java
@@ -18,7 +18,7 @@
 package bisq.desktop.util.validation;
 
 import bisq.core.locale.Res;
-import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.InputValidator;
 
 /**
@@ -30,7 +30,7 @@ import bisq.core.util.validation.InputValidator;
 public abstract class NumberValidator extends InputValidator {
 
     protected String cleanInput(String input) {
-        return BSFormatter.convertCharsForNumber(input);
+        return ParsingUtils.convertCharsForNumber(input);
     }
 
     protected ValidationResult validateIfNumber(String input) {

--- a/desktop/src/main/java/bisq/desktop/util/validation/SecurityDepositValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/SecurityDepositValidator.java
@@ -21,6 +21,7 @@ import bisq.core.btc.wallet.Restrictions;
 import bisq.core.locale.Res;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.util.BSFormatter;
+import bisq.core.util.ParsingUtils;
 
 import javax.inject.Inject;
 
@@ -58,7 +59,7 @@ public class SecurityDepositValidator extends NumberValidator {
 
     private ValidationResult validateIfNotTooLowPercentageValue(String input) {
         try {
-            double percentage = BSFormatter.parsePercentStringToDouble(input);
+            double percentage = ParsingUtils.parsePercentStringToDouble(input);
             double minPercentage = Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount);
             if (percentage < minPercentage)
                 return new ValidationResult(false,
@@ -72,7 +73,7 @@ public class SecurityDepositValidator extends NumberValidator {
 
     private ValidationResult validateIfNotTooHighPercentageValue(String input) {
         try {
-            double percentage = BSFormatter.parsePercentStringToDouble(input);
+            double percentage = ParsingUtils.parsePercentStringToDouble(input);
             double maxPercentage = Restrictions.getMaxBuyerSecurityDepositAsPercent(paymentAccount);
             if (percentage > maxPercentage)
                 return new ValidationResult(false,

--- a/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/BSFormatterTest.java
@@ -60,17 +60,6 @@ public class BSFormatterTest {
     }
 
     @Test
-    public void testIsValid() {
-        assertEquals("0 days", BSFormatter.formatAccountAge(TimeUnit.HOURS.toMillis(23)));
-        assertEquals("0 days", BSFormatter.formatAccountAge(0));
-        assertEquals("0 days", BSFormatter.formatAccountAge(-1));
-        assertEquals("1 day", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(1)));
-        assertEquals("2 days", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(2)));
-        assertEquals("30 days", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(30)));
-        assertEquals("60 days", BSFormatter.formatAccountAge(TimeUnit.DAYS.toMillis(60)));
-    }
-
-    @Test
     public void testFormatDurationAsWords() {
         long oneDay = TimeUnit.DAYS.toMillis(1);
         long oneHour = TimeUnit.HOURS.toMillis(1);
@@ -98,8 +87,8 @@ public class BSFormatterTest {
 
     @Test
     public void testFormatPrice() {
-        assertEquals("100.0000", formatter.formatPrice(make(usdPrice)));
-        assertEquals("7098.4700", formatter.formatPrice(make(usdPrice.but(with(priceString, "7098.4700")))));
+        assertEquals("100.0000", BSFormatter.formatPrice(make(usdPrice)));
+        assertEquals("7098.4700", BSFormatter.formatPrice(make(usdPrice.but(with(priceString, "7098.4700")))));
     }
 
     @Test
@@ -109,91 +98,5 @@ public class BSFormatterTest {
         assertEquals("1.00", formatter.formatCoin(oneBitcoin, 5));
         assertEquals("0.000001", formatter.formatCoin(make(a(CoinMaker.Coin).but(with(satoshis, 100L)))));
         assertEquals("0.00000001", formatter.formatCoin(make(a(CoinMaker.Coin).but(with(satoshis, 1L)))));
-    }
-
-    @Test
-    public void testFormatVolume() {
-        assertEquals("1.00", formatter.formatVolume(make(btcUsdOffer), true, 4));
-        assertEquals("100.00", formatter.formatVolume(make(usdVolume)));
-        assertEquals("1774.62", formatter.formatVolume(make(usdVolume.but(with(volumeString, "1774.62")))));
-    }
-
-    @Test
-    public void testFormatSameVolume() {
-        Offer offer = mock(Offer.class);
-        Volume btc = Volume.parse("0.10", "BTC");
-        when(offer.getMinVolume()).thenReturn(btc);
-        when(offer.getVolume()).thenReturn(btc);
-
-        assertEquals("0.10000000", formatter.formatVolume(offer.getVolume()));
-    }
-
-    @Test
-    public void testFormatDifferentVolume() {
-        Offer offer = mock(Offer.class);
-        Volume btcMin = Volume.parse("0.10", "BTC");
-        Volume btcMax = Volume.parse("0.25", "BTC");
-        when(offer.isRange()).thenReturn(true);
-        when(offer.getMinVolume()).thenReturn(btcMin);
-        when(offer.getVolume()).thenReturn(btcMax);
-
-        assertEquals("0.10000000 - 0.25000000", formatter.formatVolume(offer, false, 0));
-    }
-
-    @Test
-    public void testFormatNullVolume() {
-        Offer offer = mock(Offer.class);
-        when(offer.getMinVolume()).thenReturn(null);
-        when(offer.getVolume()).thenReturn(null);
-
-        assertEquals("", formatter.formatVolume(offer.getVolume()));
-    }
-
-    @Test
-    public void testFormatSameAmount() {
-        Offer offer = mock(Offer.class);
-        when(offer.getMinAmount()).thenReturn(Coin.valueOf(10000000));
-        when(offer.getAmount()).thenReturn(Coin.valueOf(10000000));
-
-        assertEquals("0.10", formatter.formatAmount(offer));
-    }
-
-    @Test
-    public void testFormatDifferentAmount() {
-        OfferPayload offerPayload = mock(OfferPayload.class);
-        Offer offer = new Offer(offerPayload);
-        when(offerPayload.getMinAmount()).thenReturn(10000000L);
-        when(offerPayload.getAmount()).thenReturn(20000000L);
-
-        assertEquals("0.10 - 0.20", formatter.formatAmount(offer));
-    }
-
-    @Test
-    public void testFormatAmountWithAlignmenWithDecimals() {
-        OfferPayload offerPayload = mock(OfferPayload.class);
-        Offer offer = new Offer(offerPayload);
-        when(offerPayload.getMinAmount()).thenReturn(10000000L);
-        when(offerPayload.getAmount()).thenReturn(20000000L);
-
-        assertEquals("0.1000 - 0.2000", formatter.formatAmount(offer, 4, true, 15));
-    }
-
-    @Test
-    public void testFormatAmountWithAlignmenWithDecimalsNoRange() {
-        OfferPayload offerPayload = mock(OfferPayload.class);
-        Offer offer = new Offer(offerPayload);
-        when(offerPayload.getMinAmount()).thenReturn(10000000L);
-        when(offerPayload.getAmount()).thenReturn(10000000L);
-
-        assertEquals("0.1000", formatter.formatAmount(offer, 4, true, 15));
-    }
-
-    @Test
-    public void testFormatNullAmount() {
-        Offer offer = mock(Offer.class);
-        when(offer.getMinAmount()).thenReturn(null);
-        when(offer.getAmount()).thenReturn(null);
-
-        assertEquals("", formatter.formatAmount(offer));
     }
 }

--- a/desktop/src/test/java/bisq/desktop/util/DisplayUtilsTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/DisplayUtilsTest.java
@@ -1,0 +1,132 @@
+package bisq.desktop.util;
+
+import bisq.core.locale.Res;
+import bisq.core.monetary.Volume;
+import bisq.core.offer.Offer;
+import bisq.core.offer.OfferPayload;
+import bisq.core.util.BSFormatter;
+
+import org.bitcoinj.core.Coin;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static bisq.desktop.maker.OfferMaker.btcUsdOffer;
+import static bisq.desktop.maker.VolumeMaker.usdVolume;
+import static bisq.desktop.maker.VolumeMaker.volumeString;
+import static com.natpryce.makeiteasy.MakeItEasy.make;
+import static com.natpryce.makeiteasy.MakeItEasy.with;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DisplayUtilsTest {
+    private final BSFormatter formatter = new BSFormatter();
+
+    @Before
+    public void setUp() {
+        Locale.setDefault(new Locale("en", "US"));
+        Res.setBaseCurrencyCode("BTC");
+        Res.setBaseCurrencyName("Bitcoin");
+    }
+
+    @Test
+    public void testFormatAccountAge() {
+        assertEquals("0 days", DisplayUtils.formatAccountAge(TimeUnit.HOURS.toMillis(23)));
+        assertEquals("0 days", DisplayUtils.formatAccountAge(0));
+        assertEquals("0 days", DisplayUtils.formatAccountAge(-1));
+        assertEquals("1 day", DisplayUtils.formatAccountAge(TimeUnit.DAYS.toMillis(1)));
+        assertEquals("2 days", DisplayUtils.formatAccountAge(TimeUnit.DAYS.toMillis(2)));
+        assertEquals("30 days", DisplayUtils.formatAccountAge(TimeUnit.DAYS.toMillis(30)));
+        assertEquals("60 days", DisplayUtils.formatAccountAge(TimeUnit.DAYS.toMillis(60)));
+    }
+
+    @Test
+    public void testFormatVolume() {
+        assertEquals("1.00", DisplayUtils.formatVolume(make(btcUsdOffer), true, 4));
+        assertEquals("100.00", DisplayUtils.formatVolume(make(usdVolume)));
+        assertEquals("1774.62", DisplayUtils.formatVolume(make(usdVolume.but(with(volumeString, "1774.62")))));
+    }
+
+    @Test
+    public void testFormatSameVolume() {
+        Offer offer = mock(Offer.class);
+        Volume btc = Volume.parse("0.10", "BTC");
+        when(offer.getMinVolume()).thenReturn(btc);
+        when(offer.getVolume()).thenReturn(btc);
+
+        assertEquals("0.10000000", DisplayUtils.formatVolume(offer.getVolume()));
+    }
+
+    @Test
+    public void testFormatDifferentVolume() {
+        Offer offer = mock(Offer.class);
+        Volume btcMin = Volume.parse("0.10", "BTC");
+        Volume btcMax = Volume.parse("0.25", "BTC");
+        when(offer.isRange()).thenReturn(true);
+        when(offer.getMinVolume()).thenReturn(btcMin);
+        when(offer.getVolume()).thenReturn(btcMax);
+
+        assertEquals("0.10000000 - 0.25000000", DisplayUtils.formatVolume(offer, false, 0));
+    }
+
+    @Test
+    public void testFormatNullVolume() {
+        Offer offer = mock(Offer.class);
+        when(offer.getMinVolume()).thenReturn(null);
+        when(offer.getVolume()).thenReturn(null);
+
+        assertEquals("", DisplayUtils.formatVolume(offer.getVolume()));
+    }
+
+    @Test
+    public void testFormatSameAmount() {
+        Offer offer = mock(Offer.class);
+        when(offer.getMinAmount()).thenReturn(Coin.valueOf(10000000));
+        when(offer.getAmount()).thenReturn(Coin.valueOf(10000000));
+
+        assertEquals("0.10", DisplayUtils.formatAmount(offer, formatter));
+    }
+
+    @Test
+    public void testFormatDifferentAmount() {
+        OfferPayload offerPayload = mock(OfferPayload.class);
+        Offer offer = new Offer(offerPayload);
+        when(offerPayload.getMinAmount()).thenReturn(10000000L);
+        when(offerPayload.getAmount()).thenReturn(20000000L);
+
+        assertEquals("0.10 - 0.20", DisplayUtils.formatAmount(offer, formatter));
+    }
+
+    @Test
+    public void testFormatAmountWithAlignmenWithDecimals() {
+        OfferPayload offerPayload = mock(OfferPayload.class);
+        Offer offer = new Offer(offerPayload);
+        when(offerPayload.getMinAmount()).thenReturn(10000000L);
+        when(offerPayload.getAmount()).thenReturn(20000000L);
+
+        assertEquals("0.1000 - 0.2000", DisplayUtils.formatAmount(offer, 4, true, 15, formatter));
+    }
+
+    @Test
+    public void testFormatAmountWithAlignmenWithDecimalsNoRange() {
+        OfferPayload offerPayload = mock(OfferPayload.class);
+        Offer offer = new Offer(offerPayload);
+        when(offerPayload.getMinAmount()).thenReturn(10000000L);
+        when(offerPayload.getAmount()).thenReturn(10000000L);
+
+        assertEquals("0.1000", DisplayUtils.formatAmount(offer, 4, true, 15, formatter));
+    }
+
+    @Test
+    public void testFormatNullAmount() {
+        Offer offer = mock(Offer.class);
+        when(offer.getMinAmount()).thenReturn(null);
+        when(offer.getAmount()).thenReturn(null);
+
+        assertEquals("", DisplayUtils.formatAmount(offer, formatter));
+    }
+}


### PR DESCRIPTION
Next step in removing BSFormatter. Here I extract 2 classes.

DisplayUtils which lives in the desktop project and has all methods that are only used in desktop. This is to reduce the number of dependencies going from desktop -> core.

ParsingUtils which has all the parsing related methods (ie is not formatting).

Link to tracking issue https://github.com/bisq-network/bisq/issues/3240