### PR TITLE
Add support for Monero integrated addresses; fix #3242

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/Monero.java
+++ b/assets/src/main/java/bisq/asset/coins/Monero.java
@@ -25,6 +25,6 @@ import bisq.asset.CryptoNoteAddressValidator;
 public class Monero extends Coin {
 
     public Monero() {
-        super("Monero", "XMR", new CryptoNoteAddressValidator(18, 42));
+        super("Monero", "XMR", new CryptoNoteAddressValidator(18, 19, 42));
     }
 }

--- a/assets/src/test/java/bisq/asset/coins/MoneroTest.java
+++ b/assets/src/test/java/bisq/asset/coins/MoneroTest.java
@@ -31,6 +31,11 @@ public class MoneroTest extends AbstractAssetTest {
         assertValidAddress("4BJHitCigGy6giuYsJFP26KGkTKiQDJ6HJP1pan2ir2CCV8Twc2WWmo4fu1NVXt8XLGYAkjo5cJ3yH68Lfz9ZXEUJ9MeqPW");
         assertValidAddress("46tM15KsogEW5MiVmBn7waPF8u8ZsB6aHjJk7BAv1wvMKfWhQ2h2so5BCJ9cRakfPt5BFo452oy3K8UK6L2u2v7aJ3Nf7P2");
         assertValidAddress("86iQTnEqQ9mXJFvBvbY3KU5do5Jh2NCkpTcZsw3TMZ6oKNJhELvAreZFQ1p8EknRRTKPp2vg9fJvy47Q4ARVChjLMuUAFQJ");
+
+        // integrated addresses
+        assertValidAddress("4LL9oSLmtpccfufTMvppY6JwXNouMBzSkbLYfpAV5Usx3skxNgYeYTRj5UzqtReoS44qo9mtmXCqY45DJ852K5Jv2bYXZKKQePHES9khPK");
+        assertValidAddress("4GdoN7NCTi8a5gZug7PrwZNKjvHFmKeV11L6pNJPgj5QNEHsN6eeX3DaAQFwZ1ufD4LYCZKArktt113W7QjWvQ7CWD1FFMXoYHeE6M55P9");
+        assertValidAddress("4GdoN7NCTi8a5gZug7PrwZNKjvHFmKeV11L6pNJPgj5QNEHsN6eeX3DaAQFwZ1ufD4LYCZKArktt113W7QjWvQ7CW82yHFEGvSG3NJRNtH");
     }
 
     @Test


### PR DESCRIPTION
Monero integrated addresses will now pass address validation when adding a new altcoin account.