### PR TITLE
Remove CapabilityRequiringPayload from GetBlocksRequest

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
+++ b/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
@@ -21,10 +21,8 @@ import bisq.network.p2p.DirectMessage;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.SendersNodeAddressMessage;
 import bisq.network.p2p.SupportedCapabilitiesMessage;
-import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
 
 import bisq.common.app.Capabilities;
-import bisq.common.app.Capability;
 import bisq.common.app.Version;
 import bisq.common.proto.network.NetworkEnvelope;
 
@@ -36,12 +34,17 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+// TODO We remove CapabilityRequiringPayload as it would cause problems if the lite node connects to a new seed node and
+// they have not exchanged capabilities already. We need to improve capability handling the we can re-enable it again.
+// As this message is sent any only to seed nodes it does not has any effect. Even if a lite node receives it it will be
+// simply ignored.
+
 // This message is sent only to full DAO nodes
 @EqualsAndHashCode(callSuper = true)
 @Getter
 @Slf4j
 public final class GetBlocksRequest extends NetworkEnvelope implements DirectMessage, SendersNodeAddressMessage,
-        CapabilityRequiringPayload, SupportedCapabilitiesMessage {
+        /*CapabilityRequiringPayload, */SupportedCapabilitiesMessage {
     private final int fromBlockHeight;
     private final int nonce;
 
@@ -105,10 +108,10 @@ public final class GetBlocksRequest extends NetworkEnvelope implements DirectMes
                 messageVersion);
     }
 
-    @Override
-    public Capabilities getRequiredCapabilities() {
-        return new Capabilities(Capability.DAO_FULL_NODE);
-    }
+//    @Override
+//    public Capabilities getRequiredCapabilities() {
+//        return new Capabilities(Capability.DAO_FULL_NODE);
+//    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
We remove CapabilityRequiringPayload as it would cause problems if the
lite node connects to a new seed node and they have not exchanged
capabilities already. We need to improve capability handling the we
can re-enable it again. As this message is sent any only to seed nodes
it does not has any effect. Even if a lite node receives it it will
be simply ignored.