### PR TITLE
Temporarily disable onion host for @KanoczTomas's BTC node

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -69,7 +69,7 @@ public class BtcNodes {
                         new BtcNode("btc2.sqrrm.net", "i3a5xtzfm4xwtybd.onion", "81.171.22.143", BtcNode.DEFAULT_PORT, "@sqrrm"),
 
                         // KanoczTomas
-                        new BtcNode("btc.ispol.sk", "mbm6ffx6j5ygi2ck.onion", "193.58.196.212", BtcNode.DEFAULT_PORT, "@KanoczTomas"),
+                        new BtcNode("btc.ispol.sk", null, "193.58.196.212", BtcNode.DEFAULT_PORT, "@KanoczTomas"),
 
                         // Devin Bileck
                         new BtcNode("btc1.dnsalias.net", "lva54pnbq2nsmjyr.onion", "165.227.34.198", BtcNode.DEFAULT_PORT, "@devinbileck"),


### PR DESCRIPTION
My monitoring system is reporting that the Tor hidden service for this BTC node becomes unreachable every few minutes - I'm guessing it's a firewall configuration issue on their side, but since I have no way to contact them I'm submitting this PR to temporarily remove it for now until the issue can be resolved. Hopefully if someone can contact @KanoczTomas to fix it we won't need to merge this PR :)

<img width="666" alt="Screen Shot 2019-09-15 at 9 55 51" src="https://user-images.githubusercontent.com/232186/64915363-a46eaf80-d79f-11e9-81b9-fcee483d7f88.png">
