### PR TITLE
Remove bitcoin4-fullnode.csg.uzh.ch / 192.41.136.217 btcnode

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -82,8 +82,7 @@ public class BtcNodes {
                         new BtcNode("node130.hnl.wiz.biz", "jiuuuislm7ooesic.onion", "103.99.168.130", BtcNode.DEFAULT_PORT, "@wiz"),
 
                         // others
-                        new BtcNode("btc.jochen-hoenicke.de", "sslnjjhnmwllysv4.onion", "88.198.39.205", BtcNode.DEFAULT_PORT, "@jhoenicke"),
-                        new BtcNode("bitcoin4-fullnode.csg.uzh.ch", null, "192.41.136.217", BtcNode.DEFAULT_PORT, "@tbocek") // requested onion
+                        new BtcNode("btc.jochen-hoenicke.de", "sslnjjhnmwllysv4.onion", "88.198.39.205", BtcNode.DEFAULT_PORT, "@jhoenicke")
                 ) :
                 new ArrayList<>();
     }


### PR DESCRIPTION
This btcnode operated by @tbocek also seems to have stability issues, and does not currently have an *.onion hostname. I've reached out to the operator by email, but until the stability and lack of *.onion hostname issues are resolved, I think it should be removed for now.

<img width="711" alt="Screen Shot 2019-09-15 at 11 01 12" src="https://user-images.githubusercontent.com/232186/64915705-2d89e480-d7a8-11e9-8d51-eda97a73e627.png">