### PR TITLE
Fix DAO sync issue requiring a manual kill-and-restart

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
+++ b/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
@@ -39,8 +39,7 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode(callSuper = true)
 @Getter
 @Slf4j
-public final class GetBlocksRequest extends NetworkEnvelope implements DirectMessage, SendersNodeAddressMessage,
-        CapabilityRequiringPayload, SupportedCapabilitiesMessage {
+public final class GetBlocksRequest extends NetworkEnvelope implements DirectMessage, SendersNodeAddressMessage, SupportedCapabilitiesMessage {
     private final int fromBlockHeight;
     private final int nonce;
 
@@ -104,10 +103,15 @@ public final class GetBlocksRequest extends NetworkEnvelope implements DirectMes
                 messageVersion);
     }
 
-    @Override
-    public Capabilities getRequiredCapabilities() {
-        return new Capabilities(Capability.DAO_FULL_NODE);
-    }
+    /**
+     * This GetBlocksRequest is no CapabilityRequiringPayload, because if it is, our DAO sync at startup is not going to work.
+     * That is because when a fresh connection to a seed node is created, the connection does not know its capabilities yet.
+     * A GetBlocksRequest is therefore not sent by the connection class as long as it is a CapabilityRequiringPayload.
+     */
+//    @Override
+//    public Capabilities getRequiredCapabilities() {
+//        return new Capabilities(Capability.DAO_FULL_NODE);
+//    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
This PR prevents the Bisq application to never get its DAO status updated without a force-kill and restart of the application over and over again.

This fix is not final, however, this core issue is not easily resolved. The DAO sync logic tries one seed node after another until the DAO status is received. The very first attempt targets the seed node that already delivered the initial data. However, when the first attempt fails for whatever reason, other seed nodes are tried. The issue is that even if a connection can be summoned to such a seed node, the local Bisq client does not know its capabilities (these only get updated once a node responds with a suitable message), the DAO sync message, however, requires a capability. Bottom line is, the local Bisq app does not send the DAO sync message to seed nodes other than the initial one.

This PR fixes the issue by having the DAO sync message not requiring any capabilities. As this change only affects clients and not other nodes, this does not change the attack surface of the Bisq network.

fixes #3094