### PR TITLE
Update MobileModel parseDescriptor to support iPhone 11

### DIFF
--- a/core/src/main/java/bisq/core/notifications/MobileModel.java
+++ b/core/src/main/java/bisq/core/notifications/MobileModel.java
@@ -131,7 +131,7 @@ public class MobileModel {
         iPad Pro 12.9 Inch 2. Generation
         iPad Pro 10.5 Inch
         */
-        // iPhone 6 does not support isContentAvailable, iPhone 7 does.
+        // iPhone 6 does not support isContentAvailable, iPhone 6s and 7 does.
         // We don't know for other versions, but lets assume all above iPhone 6 are ok.
         if (descriptor != null) {
             String[] descriptorTokens = descriptor.split(" ");
@@ -143,14 +143,17 @@ public class MobileModel {
                     if (Arrays.asList(validVersions).contains(versionString)) {
                         return true;
                     }
+                    String versionSuffix = "";
                     if (versionString.matches("\\d[^\\d]")) {
+                        versionSuffix = versionString.substring(1);
                         versionString = versionString.substring(0, 1);
                     } else if (versionString.matches("\\d{2}[^\\d]")) {
+                        versionSuffix = versionString.substring(2);
                         versionString = versionString.substring(0, 2);
                     }
                     try {
                         int version = Integer.parseInt(versionString);
-                        return version > 5;
+                        return version > 6 || (version == 6 && versionSuffix.equalsIgnoreCase("s"));
                     } catch (Throwable ignore) {
                     }
                 } else {

--- a/core/src/main/java/bisq/core/notifications/MobileModel.java
+++ b/core/src/main/java/bisq/core/notifications/MobileModel.java
@@ -22,6 +22,8 @@ import javax.inject.Singleton;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.Arrays;
+
 import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -107,6 +109,12 @@ public class MobileModel {
         iPhone 8
         iPhone 8 Plus
         iPhone X
+        iPhone XS
+        iPhone XS Max
+        iPhone XR
+        iPhone 11
+        iPhone 11 Pro
+        iPhone 11 Pro Max
         iPad 2
         iPad 3
         iPad 4
@@ -131,9 +139,15 @@ public class MobileModel {
                 String model = descriptorTokens[0];
                 if (model.equals("iPhone")) {
                     String versionString = descriptorTokens[1];
-                    versionString = versionString.substring(0, 1);
-                    if (versionString.equals("X") || versionString.equals("SE"))
+                    String[] validVersions = {"X", "XS", "XR"};
+                    if (Arrays.asList(validVersions).contains(versionString)) {
                         return true;
+                    }
+                    if (versionString.matches("\\d[^\\d]")) {
+                        versionString = versionString.substring(0, 1);
+                    } else if (versionString.matches("\\d{2}[^\\d]")) {
+                        versionString = versionString.substring(0, 2);
+                    }
                     try {
                         int version = Integer.parseInt(versionString);
                         return version > 5;

--- a/core/src/test/java/bisq/core/notifications/MobileModelTest.java
+++ b/core/src/test/java/bisq/core/notifications/MobileModelTest.java
@@ -54,6 +54,14 @@ public class MobileModelTest {
                 new Tuple2<>("iPhone 8", true),
                 new Tuple2<>("iPhone 8 Plus", true),
                 new Tuple2<>("iPhone X", true),
+                new Tuple2<>("iPhone XS", true),
+                new Tuple2<>("iPhone XS Max", true),
+                new Tuple2<>("iPhone XR", true),
+                new Tuple2<>("iPhone 11", true),
+                new Tuple2<>("iPhone 11 Pro", true),
+                new Tuple2<>("iPhone 11 Pro Max", true),
+                new Tuple2<>("iPhone 11S", true), // not sure if this model will exist, but based on past versioning it is possible
+                                                  // need to ensure it will be parsed correctly just in case
 
                 new Tuple2<>("iPad 2", false),
                 new Tuple2<>("iPad 3", false),
@@ -74,8 +82,7 @@ public class MobileModelTest {
         );
 
         list.forEach(tuple -> {
-            log.error(tuple.toString());
-
+            log.info(tuple.toString());
             assertEquals("tuple: " + tuple, mobileModel.parseDescriptor(tuple.first), tuple.second);
         });
 

--- a/core/src/test/java/bisq/core/notifications/MobileModelTest.java
+++ b/core/src/test/java/bisq/core/notifications/MobileModelTest.java
@@ -43,8 +43,8 @@ public class MobileModelTest {
                 new Tuple2<>("iPhone 5c", false),
                 new Tuple2<>("iPhone 5s", false),
 
-                new Tuple2<>("iPhone 6", true),
-                new Tuple2<>("iPhone 6 Plus", true),
+                new Tuple2<>("iPhone 6", false),
+                new Tuple2<>("iPhone 6 Plus", false),
                 new Tuple2<>("iPhone 6s", true),
                 new Tuple2<>("iPhone 6s Plus", true),
 


### PR DESCRIPTION
This is just something I stumbled upon during a review.

It was parsing only the first digit of the version and using that in a
comparison check to determine if the version is greater than 5.
This meant for the iPhone 11 it was comparing 1 > 5, returning an
incorrect result.

It now supports multi-digit version numbers (i.e. 11), including
support for a suffix in the version (i.e. 11S), just in case...