### PR TITLE
Use /usr/bin/caffeinate to disable power management on macOS

### DIFF
--- a/core/src/main/java/bisq/core/app/OSXStandbyModeDisabler.java
+++ b/core/src/main/java/bisq/core/app/OSXStandbyModeDisabler.java
@@ -15,6 +15,8 @@ public class OSXStandbyModeDisabler {
         long pid = ProcessHandle.current().pid();
         try {
             String[] params = {"/usr/bin/caffeinate", "-w", "" + pid};
+
+            // we only start the process. caffeinate blocks until we exit.
             new ProcessBuilder(params).start();
             log.info("disabled power management via " + String.join(" ", params));
         } catch (IOException e) {

--- a/core/src/main/java/bisq/core/app/OSXStandbyModeDisabler.java
+++ b/core/src/main/java/bisq/core/app/OSXStandbyModeDisabler.java
@@ -1,0 +1,25 @@
+package bisq.core.app;
+
+import bisq.common.util.Utilities;
+
+import java.io.IOException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OSXStandbyModeDisabler {
+    public void doIt() {
+        if (!Utilities.isOSX()) {
+            return;
+        }
+        long pid = ProcessHandle.current().pid();
+        try {
+            String[] params = {"/usr/bin/caffeinate", "-w", "" + pid};
+            new ProcessBuilder(params).start();
+            log.info("disabled power management via " + String.join(" ", params));
+        } catch (IOException e) {
+            log.error("could not disable standby mode on osx", e);
+        }
+
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -29,13 +29,14 @@ import bisq.desktop.main.overlays.windows.FilterWindow;
 import bisq.desktop.main.overlays.windows.ManualPayoutTxWindow;
 import bisq.desktop.main.overlays.windows.SendAlertMessageWindow;
 import bisq.desktop.main.overlays.windows.ShowWalletDataWindow;
-import bisq.desktop.util.ImageUtil;
 import bisq.desktop.util.CssTheme;
+import bisq.desktop.util.ImageUtil;
 
 import bisq.core.alert.AlertManager;
 import bisq.core.app.AppOptionKeys;
 import bisq.core.app.AvoidStandbyModeService;
 import bisq.core.app.BisqEnvironment;
+import bisq.core.app.OSXStandbyModeDisabler;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.dao.governance.voteresult.MissingDataRequestService;
@@ -139,6 +140,7 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
             scene = createAndConfigScene(mainView, injector);
             setupStage(scene);
 
+            injector.getInstance(OSXStandbyModeDisabler.class).doIt();
             injector.getInstance(AvoidStandbyModeService.class).init();
 
             UserThread.runPeriodically(() -> Profiler.printSystemLoad(log), LOG_MEMORY_PERIOD_MIN, TimeUnit.MINUTES);


### PR DESCRIPTION
a possible fix for #3276 

I verified that caffeinate is correctly called and that it keeps running until bisq exits. the other standby mode service is still running, not sure if we want to disable it on macOS