### PR TITLE
Monitor fixes

### DIFF
--- a/monitor/src/main/java/bisq/monitor/Monitor.java
+++ b/monitor/src/main/java/bisq/monitor/Monitor.java
@@ -29,6 +29,9 @@ import bisq.monitor.metric.P2PSeedNodeSnapshot;
 import bisq.monitor.reporter.ConsoleReporter;
 import bisq.monitor.reporter.GraphiteReporter;
 
+import bisq.common.app.Capabilities;
+import bisq.common.app.Capability;
+
 import org.berndpruenster.netlayer.tor.NativeTor;
 import org.berndpruenster.netlayer.tor.Tor;
 
@@ -77,6 +80,16 @@ public class Monitor {
 
         // start Tor
         Tor.setDefault(new NativeTor(TOR_WORKING_DIR, null, null, false));
+
+        Capabilities.app.addAll(Capability.TRADE_STATISTICS,
+                Capability.TRADE_STATISTICS_2,
+                Capability.ACCOUNT_AGE_WITNESS,
+                Capability.ACK_MSG,
+                Capability.PROPOSAL,
+                Capability.BLIND_VOTE,
+                Capability.DAO_STATE,
+                Capability.BUNDLE_OF_ENVELOPES,
+                Capability.MEDIATION);
 
         // assemble Metrics
         // - create reporters

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -42,8 +42,6 @@ import bisq.network.p2p.peers.peerexchange.PeerList;
 import bisq.network.p2p.storage.messages.BroadcastMessage;
 
 import bisq.common.ClockWatcher;
-import bisq.common.app.Capabilities;
-import bisq.common.app.Capability;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.storage.CorruptedDatabaseFilesHandler;
@@ -202,8 +200,6 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
         super.configure(properties);
 
         history = Collections.synchronizedMap(new FixedSizeHistoryTracker<>(Integer.parseInt(configuration.getProperty(HISTORY_SIZE, "200"))));
-
-        Capabilities.app.addAll(Capability.DAO_STATE);
     }
 
     /**

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -203,7 +203,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
 
         history = Collections.synchronizedMap(new FixedSizeHistoryTracker<>(Integer.parseInt(configuration.getProperty(HISTORY_SIZE, "200"))));
 
-        Capabilities.app.addAll(Capability.DAO_FULL_NODE);
+        Capabilities.app.addAll(Capability.DAO_STATE);
     }
 
     /**

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
@@ -20,11 +20,15 @@ package bisq.monitor.metric;
 import bisq.monitor.OnionParser;
 import bisq.monitor.Reporter;
 
+import bisq.core.account.witness.AccountAgeWitnessStore;
+import bisq.core.btc.BaseCurrencyNetwork;
 import bisq.core.dao.monitoring.model.StateHash;
 import bisq.core.dao.monitoring.network.messages.GetBlindVoteStateHashesRequest;
 import bisq.core.dao.monitoring.network.messages.GetDaoStateHashesRequest;
 import bisq.core.dao.monitoring.network.messages.GetProposalStateHashesRequest;
 import bisq.core.dao.monitoring.network.messages.GetStateHashesResponse;
+import bisq.core.proto.persistable.CorePersistenceProtoResolver;
+import bisq.core.trade.statistics.TradeStatistics2Store;
 
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.Connection;
@@ -34,20 +38,25 @@ import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
+import bisq.common.app.Version;
 import bisq.common.proto.network.NetworkEnvelope;
+import bisq.common.proto.persistable.PersistableEnvelope;
+import bisq.common.storage.Storage;
 
 import java.net.MalformedURLException;
 
 import java.nio.ByteBuffer;
 
+import java.io.File;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
@@ -72,6 +81,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @Slf4j
 public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
+    private static final String DATABASE_DIR = "run.dbDir";
 
     Statistics statistics;
     final Map<NodeAddress, Statistics> bucketsPerHost = new ConcurrentHashMap<>();
@@ -131,22 +141,28 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
     public P2PSeedNodeSnapshot(Reporter reporter) {
         super(reporter);
 
-
-//        AppendOnlyDataStoreService appendOnlyDataStoreService,
-//        ProtectedDataStoreService protectedDataStoreService,
-//        ResourceDataStoreService resourceDataStoreService,
-//        Storage<SequenceNumberMap> sequenceNumberMapStorage) {
-//
-//        Set<byte[]> excludedKeys = dataStorage.getAppendOnlyDataStoreMap().keySet().stream()
-//                .map(e -> e.bytes)
-//                .collect(Collectors.toSet());
-//
-//        Set<byte[]> excludedKeysFromPersistedEntryMap = dataStorage.getProtectedDataStoreMap().keySet()
-//                .stream()
-//                .map(e -> e.bytes)
-//                .collect(Collectors.toSet());
-
         statistics = new MyStatistics();
+    }
+
+    @Override
+    public void configure(Properties properties) {
+        super.configure(properties);
+
+        if (hashes.isEmpty() && configuration.getProperty(DATABASE_DIR) != null) {
+            File dir = new File(configuration.getProperty(DATABASE_DIR));
+            String networkPostfix = "_" + BaseCurrencyNetwork.values()[Version.getBaseCurrencyNetwork()].toString();
+            try {
+                Storage<PersistableEnvelope> storage = new Storage<>(dir, new CorePersistenceProtoResolver(null, null, null, null), null);
+                TradeStatistics2Store tradeStatistics2Store = (TradeStatistics2Store) storage.initAndGetPersistedWithFileName(TradeStatistics2Store.class.getSimpleName() + networkPostfix, 0);
+                hashes.addAll(tradeStatistics2Store.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
+
+                AccountAgeWitnessStore accountAgeWitnessStore = (AccountAgeWitnessStore) storage.initAndGetPersistedWithFileName(AccountAgeWitnessStore.class.getSimpleName() + networkPostfix, 0);
+                hashes.addAll(accountAgeWitnessStore.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
+            } catch (NullPointerException e) {
+                // in case there is no store file
+                log.error("There is no storage file where there should be one: {}", dir.getAbsolutePath());
+            }
+        }
     }
 
     protected List<NetworkEnvelope> getRequests() {

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
@@ -86,7 +86,7 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
     Statistics statistics;
     final Map<NodeAddress, Statistics> bucketsPerHost = new ConcurrentHashMap<>();
     protected final Set<byte[]> hashes = new TreeSet<>(Arrays::compare);
-    private int daostateheight = 550000;
+    private int daostateheight = 594000;
     private int proposalheight = daostateheight;
     private int blindvoteheight = daostateheight;
 

--- a/monitor/src/main/resources/metrics.properties
+++ b/monitor/src/main/resources/metrics.properties
@@ -55,6 +55,7 @@ P2PSeedNodeSnapshot.run.torProxyPort=9062
 #P2PMarketStats Metric
 P2PMarketStats.enabled=false
 P2PMarketStats.run.interval=37
+P2PMarketStats.run.dbDir=bisq/p2p/build/resources/main/
 P2PMarketStats.run.hosts=ef5qnzx6znifo3df.onion:8000
 P2PMarketStats.run.torProxyPort=9063
 

--- a/monitor/src/main/resources/metrics.properties
+++ b/monitor/src/main/resources/metrics.properties
@@ -47,6 +47,7 @@ P2PNetworkLoad.run.historySize=200
 
 #P2PSeedNodeSnapshotBase Metric
 P2PSeedNodeSnapshot.enabled=true
+P2PSeedNodeSnapshot.run.dbDir=bisq/p2p/build/resources/main/
 P2PSeedNodeSnapshot.run.interval=24
 P2PSeedNodeSnapshot.run.hosts=3f3cu2yw7u457ztq.onion:8000, 723ljisnynbtdohi.onion:8000, fl3mmribyxgrv63c.onion:8000
 P2PSeedNodeSnapshot.run.torProxyPort=9062


### PR DESCRIPTION
The monitor has been offline for a couple of hours because:
- the Capability stuff changed
- data responses finally got too big

This PR fixes all of that and adds a few tweaks as well:
- Refer Seednode diffs to the global unique number of messages instead of a random seed node
- add a new metric that lets us get an idea on how the bisq software version landscape looks like
- make the DAO monitoring more deterministic
