### PR TITLE
Fix missing handling of mediator mailbox msg

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -240,11 +240,23 @@ public abstract class TradeProtocol {
     }
 
     public void applyMailboxMessage(DecryptedMessageWithPubKey decryptedMessageWithPubKey, Trade trade) {
-        log.debug("applyMailboxMessage {}", decryptedMessageWithPubKey.getNetworkEnvelope());
+        NetworkEnvelope networkEnvelope = decryptedMessageWithPubKey.getNetworkEnvelope();
+        log.debug("applyMailboxMessage {}", networkEnvelope);
         if (processModel.getTradingPeer().getPubKeyRing() != null &&
                 decryptedMessageWithPubKey.getSignaturePubKey().equals(processModel.getTradingPeer().getPubKeyRing().getSignaturePubKey())) {
             processModel.setDecryptedMessageWithPubKey(decryptedMessageWithPubKey);
-            doApplyMailboxMessage(decryptedMessageWithPubKey.getNetworkEnvelope(), trade);
+            doApplyMailboxMessage(networkEnvelope, trade);
+
+            // This is just a quick fix for the missing handling of the mediation MailboxMessages.
+            // With the new trade protocol that will be refactored further with using doApplyMailboxMessage...
+            if (networkEnvelope instanceof MailboxMessage && networkEnvelope instanceof TradeMessage) {
+                NodeAddress sender = ((MailboxMessage) networkEnvelope).getSenderNodeAddress();
+                if (networkEnvelope instanceof MediatedPayoutTxSignatureMessage) {
+                    handle((MediatedPayoutTxSignatureMessage) networkEnvelope, sender);
+                } else if (networkEnvelope instanceof MediatedPayoutTxPublishedMessage) {
+                    handle((MediatedPayoutTxPublishedMessage) networkEnvelope, sender);
+                }
+            }
         } else {
             log.error("SignaturePubKey in message does not match the SignaturePubKey we have stored to that trading peer.");
         }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
@@ -25,6 +25,7 @@ import bisq.core.trade.messages.MediatedPayoutTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.TradeTask;
 import bisq.core.util.Validator;
 
+import bisq.common.UserThread;
 import bisq.common.taskrunner.TaskRunner;
 
 import org.bitcoinj.core.Transaction;
@@ -61,7 +62,12 @@ public class ProcessMediatedPayoutTxPublishedMessage extends TradeTask {
                 trade.setMediationResultState(MediationResultState.RECEIVED_PAYOUT_TX_PUBLISHED_MSG);
 
                 if (trade.getPayoutTx() != null) {
-                    processModel.getTradeManager().closeDisputedTrade(trade.getId(), Trade.DisputeState.MEDIATION_CLOSED);
+                    // We need to delay that call as we might get executed at startup after mailbox messages are
+                    // applied where we iterate over out pending trades. The closeDisputedTrade method would remove
+                    // that trade from the list causing a ConcurrentModificationException.
+                    // To avoid that we delay for one render frame.
+                    UserThread.execute(() -> processModel.getTradeManager()
+                            .closeDisputedTrade(trade.getId(), Trade.DisputeState.MEDIATION_CLOSED));
                 }
 
                 processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(trade.getId(), AddressEntry.Context.MULTI_SIG);


### PR DESCRIPTION
We have a bug with the handling of missing mailbox messaged from mediation result and the peers accept message (carrying the signature). This PR fixes that.

For testing shut down the other trade peer at each step after mediation gets closed.
1. Mediation is opened 
2. Bob shutd down
3. Alice accept result
4. Alice shuts down
5. Bob starts and accepts result
6. Alice starts and sees the trade got closed