### PR TITLE
Show only active roles in "Bonded Roles" table

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
@@ -27,6 +27,7 @@ import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.dao.DaoFacade;
+import bisq.core.dao.governance.bond.Bond;
 import bisq.core.dao.governance.bond.BondState;
 import bisq.core.dao.governance.bond.role.BondedRole;
 import bisq.core.dao.state.model.governance.BondedRoleType;
@@ -122,6 +123,7 @@ public class RolesView extends ActivatableView<GridPane, Void> {
 
     private void updateList() {
         observableList.setAll(daoFacade.getBondedRoles().stream()
+                .filter(Bond::isActive)
                 .map(bond -> new RolesListItem(bond, daoFacade))
                 .sorted(Comparator.comparing(RolesListItem::getLockupDate).reversed())
                 .collect(Collectors.toList()));


### PR DESCRIPTION
Fix #3271.
Filter the bonded roles list to contain only active bonds in the RolesView table.