### PR TITLE
Translate name of Japan Bank Transfer for non-Japanese users

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2877,7 +2877,7 @@ CASH_DEPOSIT=Cash Deposit
 MONEY_GRAM=MoneyGram
 WESTERN_UNION=Western Union
 F2F=Face to face (in person)
-JAPAN_BANK=Japan Zengin Furikomi
+JAPAN_BANK=Japan Bank Furikomi
 
 # suppress inspection "UnusedProperty"
 NATIONAL_BANK_SHORT=National banks


### PR DESCRIPTION
For foreigners in Japan, let's use translation instead of romanization