### PR TITLE
List uPlexa (UPX)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/uPlexa.java
+++ b/assets/src/main/java/bisq/asset/coins/uPlexa.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AltCoinAccountDisclaimer;
+import bisq.asset.Coin;
+import bisq.asset.RegexAddressValidator;
+
+@AltCoinAccountDisclaimer("account.altcoin.popup.upx.msg")
+public class uPlexa extends Coin {
+
+    public uPlexa() {
+        super("uPlexa", "UPX", new RegexAddressValidator("^((UPX)[1-9A-Za-z^OIl]{95}|(UPi)[1-9A-Za-z^OIl]{106}|(UmV|UmW)[1-9A-Za-z^OIl]{94})$"));
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -100,6 +100,7 @@ bisq.asset.coins.TEO
 bisq.asset.coins.TurtleCoin
 bisq.asset.coins.UnitedCommunityCoin
 bisq.asset.coins.Unobtanium
+bisq.asset.coins.uPlexa
 bisq.asset.coins.VARIUS
 bisq.asset.coins.Veil
 bisq.asset.coins.Vertcoin

--- a/assets/src/test/java/bisq/asset/coins/uPlexaTest.java
+++ b/assets/src/test/java/bisq/asset/coins/uPlexaTest.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+import org.junit.Test;
+
+public class uPlexaTest extends AbstractAssetTest {
+
+    public uPlexaTest() {
+        super(new uPlexa());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("UPX1dz81hmfWc7AUhn16JATXJJgZeQZ4zLKA4tnHJHcdS5zoSaKQUoaGqDUQnTXecPL4mjJF1vkwRF3EEq5UJdSw8A84sXDjFP");
+        assertValidAddress("UPi1S1uqRRNSgC26PjasZP8FwTBRwnAEmBnx5mAYsbGqRvsU46aficYEA3FAT621EuPeChyKQumS7j6jpF74zW9tLJMve8kUJLP5zUgR5ts8W");
+        assertValidAddress("UmV7QTQs5Q47wMPggtuQSMTvuqNie1MRmbD4AG1xJXykZmxBG4P18p4CHqkV5sKDRXauXWbs76835PZoemQmPGJC1Dv2zdF43");
+        assertValidAddress("UmWh1MthnAiRP4GuN3DEQxPt6kgeAZfJLUuX1krtufAj2XvUJxDYnuYTAQzEp25V2W8BAJQkfXj8yFNUqQphxddN35nRLnZeE");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("");
+        assertInvalidAddress("UPXLsinT9duNEtHGqAUicJKD2cmGiB9gB6sqHqWvV6suB4TtPSR8ynyh2vVVvNyDE6g7WEaBxCG8GD1KM2ffWPx7FLXgeJbNYrp");
+        assertInvalidAddress("UPXsjCoYrxag2pPoDDTB4cRriKCNn8WjhY99kqjYuNdTfE4MU2Yo1CPdpyK7PXpxDcAd5YDNerE6WCc4cVQvEbxLaHk4UcvbRp2");
+        assertInvalidAddress("UPXsinT9duNEtHGqAUicJKD2cmGiB9gB6sqHqWvV6suBx4TtPSR8ynyh2vVVvNyDE6g7W!!!xCG8GD1KM2ffWP7FLXgeJbNYrp2");
+        assertInvalidAddress("UmVSrJ7ES1IIIIIGHFm69SU6dTTKt8Vi6V7BoC3wsLccd1Y2CXgQkW7vHSe5uArGU9TjUC5RtvzhCycVDnPPbThTmZA8VqDzTP");
+        assertInvalidAddress("UmWrJ7ES1wGsikGHFm69SU6dTTKt8Vi6V7BoC3wsLcc1xY2CXgQkW7vHSe5uArGU9TjUC5RtvzhCycVDnPPbThTmZA8VqDzTPe");
+        assertInvalidAddress("UPi12rJ7ES1wGsikGHFm69SU6dTTKt8Vi6V7BoC36sqHqWvwsLcc1Y2CXgQkW7vHSe5uArGU9TjUC5RtvzhCycVDnPPbThTmZA8VqDzTPeM1");
+        assertInvalidAddress("UPisBB18NdcSywKDshsywbjc5uCi8ybSUtWgvM3LfzaYe93vd6DEu3PcSywKDshsywbjc5uCi8ybSUtWgvM3LfzaYe93d96NjjvBCYU2SZD2of");
+    }
+}

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1142,6 +1142,24 @@ described on the {1} web page.\nUsing wallets from centralized exchanges where (
 (b) which don''t use compatible wallet software is risky: it can lead to loss of the traded funds!\nThe mediator or arbitrator is \
 not a {2} specialist and cannot help in such cases.
 account.altcoin.popup.wallet.confirm=I understand and confirm that I know which wallet I need to use.
+account.altcoin.popup.upx.msg=Trading UPX on Bisq requires that you understand and fulfill \
+the following requirements:\n\n\
+For sending UPX, you need to use either the official uPlexa GUI wallet or uPlexa CLI wallet with the \
+store-tx-info flag enabled (default in new versions). Please be sure you can access the tx key as \
+that would be required in case of a dispute.\n\
+uplexa-wallet-cli (use the command get_tx_key)\n\
+uplexa-wallet-gui (go to history tab and click on the (P) button for payment proof)\n\n\
+At normal block explorers the transfer is not verifiable.\n\n\
+You need to provide the arbitrator the following data in case of a dispute:\n\
+- The tx private key\n\
+- The transaction hash\n\
+- The recipient's public address\n\n\
+Failure to provide the above data, or if you used an incompatible wallet, will result in losing the \
+dispute case. The UPX sender is responsible for providing verification of the UPX transfer to the \
+arbitrator in case of a dispute.\n\n\
+There is no payment ID required, just the normal public address.\n\
+If you are not sure about that process visit uPlexa discord channel (https://discord.gg/vhdNSrV) \
+or the uPlexa Telegram Chat (https://t.me/uplexaOfficial) to find more information.
 account.altcoin.popup.arq.msg=Trading ARQ on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 For sending ARQ, you need to use either the official ArQmA GUI wallet or ArQmA CLI wallet with the \


### PR DESCRIPTION
- Official project URL: https://uplexa.com
- Official block explorer URL: https://explorer.uplexa.com

Additional: UPX wallets support transaction keys that enable 3rd party audits in case of a dispute similar to Monero

Included: Support for standard addresses (UPX), sub-addresses (UmV & UmW), and integrated address (UPi)