### PR TITLE
Fix proposal table hide when switching to another screen and back

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -207,6 +207,9 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         });
         if (proposalsTableView != null) {
             GUIUtil.setFitToRowsForTableView(proposalsTableView, 25, 28, 6, 6);
+
+            selectedProposalSubscription = EasyBind.subscribe(proposalsTableView.getSelectionModel().selectedItemProperty(),
+                    this::onSelectProposalResultListItem);
         }
         GUIUtil.setFitToRowsForTableView(cyclesTableView, 25, 28, 6, 6);
     }
@@ -214,8 +217,6 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
     @Override
     protected void deactivate() {
         super.deactivate();
-
-        onResultsListItemSelected(null);
 
         phasesView.deactivate();
 
@@ -296,7 +297,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
 
                         });
                     });
-            if (!sb.toString().isEmpty()) {
+            if (sb.length() != 0) {
                 new Popup<>().information(Res.get("dao.results.invalidVotes", sb.toString())).show();
             }
         }
@@ -326,10 +327,6 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
 
     private void onSelectProposalResultListItem(ProposalListItem item) {
         selectedProposalListItem = item;
-
-        GUIUtil.removeChildrenFromGridPaneRows(root, 5, gridRow);
-        gridRow = 3;
-
 
         if (selectedProposalListItem != null) {
             EvaluatedProposal evaluatedProposal = selectedProposalListItem.getEvaluatedProposal();
@@ -465,8 +462,8 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         proposalsTableView.setItems(sortedProposalList);
         sortedProposalList.comparatorProperty().bind(proposalsTableView.comparatorProperty());
 
-        proposalList.clear();
         proposalList.forEach(ProposalListItem::resetTableRow);
+        proposalList.clear();
 
         Map<String, Ballot> ballotByProposalTxIdMap = daoFacade.getAllValidBallots().stream()
                 .collect(Collectors.toMap(Ballot::getTxId, ballot -> ballot));


### PR DESCRIPTION
Do not remove the proposals table when VoteResultView is deactivated, as the cycle selection which triggered its display is still active upon switching to another screen and back again. This fixes #3269.

Also remove a spurious _GUIUtil.removeChildrenFromGridPaneRows_ call when a proposal result is selected, as it is no longer needed since switching from an inline votes table to a popup.