### PR TITLE
Add an extra byte to TX size when calculating Bitcoin TX fees

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -896,7 +896,7 @@ public class BtcWalletService extends WalletService {
                 SendRequest sendRequest = getSendRequest(fromAddress, toAddress, amount, fee, aesKey, context);
                 wallet.completeTx(sendRequest);
                 tx = sendRequest.tx;
-                txSize = tx.bitcoinSerialize().length;
+                txSize = tx.bitcoinSerialize().length + 1; // add extra byte to prevent rounding down causing invalid TX
                 printTx("FeeEstimationTransaction", tx);
             }
             while (feeEstimationNotSatisfied(counter, tx));
@@ -945,7 +945,7 @@ public class BtcWalletService extends WalletService {
                 SendRequest sendRequest = getSendRequestForMultipleAddresses(fromAddresses, dummyReceiver, amount, fee, null, aesKey);
                 wallet.completeTx(sendRequest);
                 tx = sendRequest.tx;
-                txSize = tx.bitcoinSerialize().length;
+                txSize = tx.bitcoinSerialize().length + 1; // add extra byte to prevent rounding down causing invalid TX
                 printTx("FeeEstimationTransactionForMultipleAddresses", tx);
             }
             while (feeEstimationNotSatisfied(counter, tx));
@@ -983,7 +983,7 @@ public class BtcWalletService extends WalletService {
         sendRequest.ensureMinRequiredFee = false;
         sendRequest.changeAddress = dummyAddress;
         wallet.completeTx(sendRequest);
-        return transaction.bitcoinSerialize().length;
+        return transaction.bitcoinSerialize().length + 1; // add extra byte to prevent rounding down causing invalid TX
     }
 
 


### PR DESCRIPTION
After investigating, it seems Bisq will sometimes create Bitcoin transactions with less than 1 sat/byte fee for TX, caused by:

1) User has set 1 sat/byte fee in settings
2) TX size gets rounded down when converting from bytes to vbytes (25% chance)

For example:
2080/4 = 520 (good)
2081/4 = 520.25 (bad, gets rounded down to 520)
2082/4 = 520.5 (good, gets rounded up to 521)
2083/4 = 520.75 (good, gets rounded up to 521)

In the case TX is 2081 bytes, 520 sats of fee gets used, for what should be considered a 521 vbyte TX. This results in a net fee of 0.998 sats/vbyte, which won't get relayed through Bitcoin network with the latest Bitcoin Core default settings.

This PR fixes the above issue by adding a workaround to add 1 byte to the TX size when calculating the fee, so it always "rounds up"