### PR TITLE
Disable @KanoczTomas btcnode on both clearnet and onion

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -69,7 +69,7 @@ public class BtcNodes {
                         new BtcNode("btc2.sqrrm.net", "i3a5xtzfm4xwtybd.onion", "81.171.22.143", BtcNode.DEFAULT_PORT, "@sqrrm"),
 
                         // KanoczTomas
-                        new BtcNode("btc.ispol.sk", null, "193.58.196.212", BtcNode.DEFAULT_PORT, "@KanoczTomas"),
+                        new BtcNode("btc.ispol.sk", "mbm6ffx6j5ygi2ck.onion", "193.58.196.212", BtcNode.DEFAULT_PORT, "@KanoczTomas"),
 
                         // Devin Bileck
                         new BtcNode("btc1.dnsalias.net", "lva54pnbq2nsmjyr.onion", "165.227.34.198", BtcNode.DEFAULT_PORT, "@devinbileck"),

--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -68,8 +68,8 @@ public class BtcNodes {
                         new BtcNode("btc1.sqrrm.net", "3r44ddzjitznyahw.onion", "185.25.48.184", BtcNode.DEFAULT_PORT, "@sqrrm"),
                         new BtcNode("btc2.sqrrm.net", "i3a5xtzfm4xwtybd.onion", "81.171.22.143", BtcNode.DEFAULT_PORT, "@sqrrm"),
 
-                        // KanoczTomas
-                        new BtcNode("btc.ispol.sk", "mbm6ffx6j5ygi2ck.onion", "193.58.196.212", BtcNode.DEFAULT_PORT, "@KanoczTomas"),
+                        // KanoczTomas - temp disabled until he returns
+                        // new BtcNode("btc.ispol.sk", "mbm6ffx6j5ygi2ck.onion", "193.58.196.212", BtcNode.DEFAULT_PORT, "@KanoczTomas"),
 
                         // Devin Bileck
                         new BtcNode("btc1.dnsalias.net", "lva54pnbq2nsmjyr.onion", "165.227.34.198", BtcNode.DEFAULT_PORT, "@devinbileck"),


### PR DESCRIPTION
In PR #3263 we temporarily disabled @KanoczTomas btcnode's onion host, as it was having issues and it seems that @KanoczTomas is unavailable to maintain his btcnode. Unfortunately now it is generating monitoring system alerts on both clearnet and onion. This PR disables both clearnet and onion hosts, until @KanoczTomas returns and fixes his node. Hope he is okay.

<img width="647" alt="Screen Shot 2019-10-09 at 1 07 50" src="https://user-images.githubusercontent.com/232186/66412837-409f7580-ea31-11e9-9d9d-3df25e771f45.png">
