### PR TITLE
Increase minimum TX fee to 2 sats/vByte to fix #3106

### DIFF
--- a/core/src/main/java/bisq/core/btc/BaseCurrencyNetwork.java
+++ b/core/src/main/java/bisq/core/btc/BaseCurrencyNetwork.java
@@ -73,6 +73,6 @@ public enum BaseCurrencyNetwork {
     }
 
     public long getDefaultMinFeePerByte() {
-        return 1;
+        return 2;
     }
 }


### PR DESCRIPTION
Trigger k3tan and also Don't allow users to set less than 2 sats/vByte TX fee in settings to prevent invalid TX with too low of a fee from being created