### PR TITLE
Apply rule to not allow BSQ outputs after BTC output for regular txs

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -573,16 +573,21 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
-    // Burn fee tx
+    // Burn fee txs
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     // We create a tx with Bsq inputs for the fee and optional BSQ change output.
     // As the fee amount will be missing in the output those BSQ fees are burned.
-    public Transaction getPreparedProposalTx(Coin fee, boolean requireChangeOutput) throws InsufficientBsqException {
-        return getPreparedBurnFeeTx(fee, requireChangeOutput);
+    public Transaction getPreparedProposalTx(Coin fee) throws InsufficientBsqException {
+        return getPreparedBurnBsqFeeTx(fee);
     }
 
-    public Transaction getPreparedBurnFeeTx(Coin fee) throws InsufficientBsqException {
+    //todo
+    public Transaction getPreparedIssuanceTx(Coin fee) throws InsufficientBsqException {
+        return getPreparedBurnBsqFeeTx(fee);
+    }
+
+    public Transaction getPreparedTradeFeeTx(Coin fee) throws InsufficientBsqException {
         return getPreparedBurnFeeTx(fee, false);
     }
 
@@ -633,7 +638,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
                 log.warn("We increased required input as change output was zero or dust: New change value={}", change);
                 String info = "Available BSQ balance=" + coinSelection.valueGathered.value / 100 + " BSQ. " +
                         "Intended fee to burn=" + fee.value / 100 + " BSQ. " +
-                        "Please reduce the fee to burn to " + (coinSelection.valueGathered.value - minDustThreshold.value) / 100 + " BSQ.";
+                        "Please increase your balance to at least " + (coinSelection.valueGathered.value + minDustThreshold.value) / 100 + " BSQ.";
                 checkArgument(coinSelection.valueGathered.compareTo(fee) > 0,
                         "This transaction require a change output of at least " + minDustThreshold.value / 100 + " BSQ (dust limit). " +
                                 info);
@@ -655,6 +660,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
         }
     }
 
+    //todo
     private Transaction getPreparedBurnFeeTx(Coin fee, boolean requireChangeOutput) throws InsufficientBsqException {
         daoKillSwitch.assertDaoIsNotDisabled();
         final Transaction tx = new Transaction(params);

--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -595,15 +595,15 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
         // Instead we derive the asset listing fee from the parser.
 
         // Case 1: 10 BSQ asset listing fee
-        // In: 15 BSQ
-        // Out: BSQ change 5 BSQ -> valid BSQ
+        // In: 17 BSQ
+        // Out: BSQ change 7 BSQ -> valid BSQ
         // Out: OpReturn
         // Miner fee: 1000 sat  (10 BSQ burned)
 
 
-        // Case 2: 15 BSQ asset listing fee
-        // In: 15 BSQ
-        // Out: burned BSQ change 5 BSQ -> BTC (5 BSQ burned)
+        // Case 2: 17 BSQ asset listing fee
+        // In: 17 BSQ
+        // Out: burned BSQ change 7 BSQ -> BTC (7 BSQ burned)
         // Out: OpReturn
         // Miner fee: 1000 sat  (10 BSQ burned)
 

--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -613,7 +613,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
 
     // We need to require one BSQ change output as we could otherwise not be able to distinguish between 2
     // structurally same transactions where only the BSQ fee is different. In case of asset listing fee and proof of
-    // burn it  is a user input, so it is not know to the parser, instead we derive the burned fee from the parser.
+    // burn it is a user input, so it is not know to the parser, instead we derive the burned fee from the parser.
 
     // In case of proposal fee we could derive it from the params.
 

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -408,13 +408,13 @@ public class BtcWalletService extends WalletService {
             TransactionVerificationException, WalletException, InsufficientMoneyException {
         // preparedBsqTx has following structure:
         // inputs [1-n] BSQ inputs
-        // outputs [0-1] BSQ receivers output
+        // outputs [1] BSQ receivers output
         // outputs [0-1] BSQ change output
 
         // We add BTC mining fee. Result tx looks like:
         // inputs [1-n] BSQ inputs
         // inputs [1-n] BTC inputs
-        // outputs [0-1] BSQ receivers output
+        // outputs [1] BSQ receivers output
         // outputs [0-1] BSQ change output
         // outputs [0-1] BTC change output
         // mining fee: BTC mining fee
@@ -426,7 +426,7 @@ public class BtcWalletService extends WalletService {
 
         // preparedBsqTx has following structure:
         // inputs [1-n] BSQ inputs
-        // outputs [0-1] BSQ receivers output
+        // outputs [1] BSQ receivers output
         // outputs [0-1] BSQ change output
         // mining fee: optional burned BSQ fee (only if opReturnData != null)
 

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -220,6 +220,10 @@ public class TradeWalletService {
         // wait for 1 confirmation)
         // In case of double spend we will detect later in the trade process and use a ban score to penalize bad behaviour (not impl. yet)
 
+        // If BSQ trade fee > reservedFundsForOffer we would create a BSQ output instead of a BTC output.
+        // As the min. reservedFundsForOffer is 0.001 BTC which is 1000 BSQ this is an unrealistic scenario and not
+        // handled atm (if BTC price is 1M USD and BSQ price is 0.1 USD, then fee would be 10% which still is unrealistic).
+
         // WalletService.printTx("preparedBsqTx", preparedBsqTx);
         SendRequest sendRequest = SendRequest.forTx(preparedBsqTx);
         sendRequest.shuffleOutputs = false;

--- a/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
+++ b/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
@@ -322,11 +322,11 @@ public class AssetService implements DaoSetupService, DaoStateListener {
         checkArgument(listingFee % 100 == 0, "Fee must be a multiple of 1 BSQ (100 satoshi).");
         try {
             // We create a prepared Bsq Tx for the listing fee.
-            final Transaction preparedBurnFeeTx = bsqWalletService.getPreparedBurnFeeTx(Coin.valueOf(listingFee));
+            Transaction preparedBurnFeeTx = bsqWalletService.getPreparedBurnFeeTxForAssetListing(Coin.valueOf(listingFee));
             byte[] hash = AssetConsensus.getHash(statefulAsset);
             byte[] opReturnData = AssetConsensus.getOpReturnData(hash);
             // We add the BTC inputs for the miner fee.
-            final Transaction txWithBtcFee = btcWalletService.completePreparedBurnBsqTx(preparedBurnFeeTx, opReturnData);
+            Transaction txWithBtcFee = btcWalletService.completePreparedBurnBsqTx(preparedBurnFeeTx, opReturnData);
             // We sign the BSQ inputs of the final tx.
             Transaction transaction = bsqWalletService.signTx(txWithBtcFee);
             log.info("Asset listing fee tx: " + transaction);

--- a/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
@@ -134,11 +134,11 @@ public class ProofOfBurnService implements DaoSetupService, DaoStateListener {
     public Transaction burn(String preImageAsString, long amount) throws InsufficientMoneyException, TxException {
         try {
             // We create a prepared Bsq Tx for the burn amount
-            final Transaction preparedBurnFeeTx = bsqWalletService.getPreparedBurnFeeTx(Coin.valueOf(amount));
+            Transaction preparedBurnFeeTx = bsqWalletService.getPreparedProofOfBurnTx(Coin.valueOf(amount));
             byte[] hash = getHashFromPreImage(preImageAsString);
             byte[] opReturnData = ProofOfBurnConsensus.getOpReturnData(hash);
             // We add the BTC inputs for the miner fee.
-            final Transaction txWithBtcFee = btcWalletService.completePreparedBurnBsqTx(preparedBurnFeeTx, opReturnData);
+            Transaction txWithBtcFee = btcWalletService.completePreparedBurnBsqTx(preparedBurnFeeTx, opReturnData);
             // We sign the BSQ inputs of the final tx.
             Transaction transaction = bsqWalletService.signTx(txWithBtcFee);
             log.info("Proof of burn tx: " + transaction);

--- a/core/src/main/java/bisq/core/dao/governance/proposal/BaseProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/BaseProposalFactory.java
@@ -87,8 +87,9 @@ public abstract class BaseProposalFactory<R extends Proposal> {
         try {
             Coin fee = ProposalConsensus.getFee(daoStateService, daoStateService.getChainHeight());
             // We create a prepared Bsq Tx for the proposal fee.
-            boolean requireChangeOutput = proposal instanceof IssuanceProposal;
-            Transaction preparedBurnFeeTx = bsqWalletService.getPreparedProposalTx(fee, requireChangeOutput);
+            Transaction preparedBurnFeeTx = proposal instanceof IssuanceProposal ?
+                    bsqWalletService.getPreparedIssuanceTx(fee) :
+                    bsqWalletService.getPreparedProposalTx(fee);
 
             // payload does not have txId at that moment
             byte[] hashOfPayload = ProposalConsensus.getHashOfPayload(proposal);

--- a/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -172,16 +172,17 @@ class TxOutputParser {
                 handleBtcOutput(tempTxOutput, index);
             } else if (isHardForkActivated(tempTxOutput) && isIssuanceCandidateTxOutput(tempTxOutput)) {
                 // After the hard fork activation we fix a bug with a transaction which would have interpreted the
-                // vote fee output as BSQ if the vote fee was >= miner fee.
-                // Such a tx was never created but as we don't know if it will happen before activation date we cannot
-                // enforce the bug fix which represents a rule change before the activation date.
-                handleIssuanceCandidateOutput(tempTxOutput);
-            } else if (isHardForkActivated(tempTxOutput) && isBlindVoteFeeOutput(tempTxOutput)) {
-                // After the hard fork activation we fix a bug with a transaction which would have interpreted the
                 // issuance output as BSQ if the availableInputValue was >= issuance amount.
                 // Such a tx was never created but as we don't know if it will happen before activation date we cannot
                 // enforce the bug fix which represents a rule change before the activation date.
-                handleBlindVoteFeeOutput(tempTxOutput);
+                handleIssuanceCandidateOutput(tempTxOutput);
+            } else if (isHardForkActivated(tempTxOutput) && isBlindVoteBurnedFeeOutput(tempTxOutput)) {
+                // After the hard fork activation we fix a bug with a transaction which would have interpreted the
+                // vote fee output as BSQ if the vote fee was >= miner fee.
+                // Such a tx was never created but as we don't know if it will happen before activation date we cannot
+                // enforce the bug fix which represents a rule change before the activation date.
+
+                handleBlindVoteBurnedFeeOutput(tempTxOutput);
             } else if (availableInputValue > 0 && availableInputValue >= txOutputValue) {
                 if (isHardForkActivated(tempTxOutput) && prohibitMoreBsqOutputs) {
                     handleBtcOutput(tempTxOutput, index);
@@ -319,12 +320,12 @@ class TxOutputParser {
         optionalIssuanceCandidate = Optional.of(tempTxOutput);
     }
 
-    private void handleBlindVoteFeeOutput(TempTxOutput tempTxOutput) {
+    private void handleBlindVoteBurnedFeeOutput(TempTxOutput tempTxOutput) {
         tempTxOutput.setTxOutputType(TxOutputType.BTC_OUTPUT);
         prohibitMoreBsqOutputs = true;
     }
 
-    private boolean isBlindVoteFeeOutput(TempTxOutput tempTxOutput) {
+    private boolean isBlindVoteBurnedFeeOutput(TempTxOutput tempTxOutput) {
         if (!optionalOpReturnType.isPresent()) {
             return false;
         }

--- a/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -258,15 +258,15 @@ class TxOutputParser {
                     // Instead we derive the asset listing fee from the parser.
 
                     // Case 1: 10 BSQ asset listing fee
-                    // In: 15 BSQ
-                    // Out: BSQ change 5 BSQ -> valid BSQ
+                    // In: 17 BSQ
+                    // Out: BSQ change 7 BSQ -> valid BSQ
                     // Out: OpReturn
                     // Miner fee: 1000 sat  (10 BSQ burned)
 
 
-                    // Case 2: 15 BSQ asset listing fee
-                    // In: 15 BSQ
-                    // Out: burned BSQ change 5 BSQ -> BTC (5 BSQ burned)
+                    // Case 2: 17 BSQ asset listing fee
+                    // In: 17 BSQ
+                    // Out: burned BSQ change 7 BSQ -> BTC (7 BSQ burned)
                     // Out: OpReturn
                     // Miner fee: 1000 sat  (10 BSQ burned)
                     return tempTxOutput.getIndex() >= 1;

--- a/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -152,14 +152,14 @@ class TxOutputParser {
     }
 
     void processTxOutput(TempTxOutput tempTxOutput) {
-        if (!daoStateService.isConfiscatedOutput(tempTxOutput.getKey())) {
-            // We don not expect here an opReturn output as we do not get called on the last output. Any opReturn at
-            // another output index is invalid.
-            if (tempTxOutput.isOpReturnOutput()) {
-                tempTxOutput.setTxOutputType(TxOutputType.INVALID_OUTPUT);
-                return;
-            }
+        // We don not expect here an opReturn output as we do not get called on the last output. Any opReturn at
+        // another output index is invalid.
+        if (tempTxOutput.isOpReturnOutput()) {
+            tempTxOutput.setTxOutputType(TxOutputType.INVALID_OUTPUT);
+            return;
+        }
 
+        if (!daoStateService.isConfiscatedOutput(tempTxOutput.getKey())) {
             long txOutputValue = tempTxOutput.getValue();
             int index = tempTxOutput.getIndex();
             if (isUnlockBondTx(tempTxOutput.getValue(), index)) {

--- a/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -233,14 +233,49 @@ class TxOutputParser {
     }
 
     private boolean isBtcOutputOfBurnFeeTx(TempTxOutput tempTxOutput) {
-        // If we get a asset listing or proof of burn tx we have only 1 BSQ output and if the
-        // burned amount is larger than the miner fee we might have a BTC output for receiving the burned funds.
-        // If the burned funds are less than the miner fee a BTC input is used for miner fee and a BTC change output for
-        // the remaining funds. In any case only the first output is BSQ all the others are BTC.
-        return optionalOpReturnType.isPresent() &&
-                (optionalOpReturnType.get() == OpReturnType.ASSET_LISTING_FEE ||
-                        optionalOpReturnType.get() == OpReturnType.PROOF_OF_BURN) &&
-                tempTxOutput.getIndex() >= 1;
+        if (optionalOpReturnType.isPresent()) {
+            switch (optionalOpReturnType.get()) {
+                case UNDEFINED:
+                    break;
+                case PROPOSAL:
+                    // TODO
+                    break;
+                case COMPENSATION_REQUEST:
+                    break;
+                case REIMBURSEMENT_REQUEST:
+                    break;
+                case BLIND_VOTE:
+                    // TODO
+                    break;
+                case VOTE_REVEAL:
+                    break;
+                case LOCKUP:
+                    break;
+                case ASSET_LISTING_FEE:
+                    // We need to require one BSQ change output as we could otherwise not be able to distinguish between 2
+                    // structurally same transactions where only the BSQ fee is different and the asset listing fee is
+                    // a user input when creating the asset listing, so it is not know to the parser.
+                    // Instead we derive the asset listing fee from the parser.
+
+                    // Case 1: 10 BSQ asset listing fee
+                    // In: 15 BSQ
+                    // Out: BSQ change 5 BSQ -> valid BSQ
+                    // Out: OpReturn
+                    // Miner fee: 1000 sat  (10 BSQ burned)
+
+
+                    // Case 2: 15 BSQ asset listing fee
+                    // In: 15 BSQ
+                    // Out: burned BSQ change 5 BSQ -> BTC (5 BSQ burned)
+                    // Out: OpReturn
+                    // Miner fee: 1000 sat  (10 BSQ burned)
+                    return tempTxOutput.getIndex() >= 1;
+                case PROOF_OF_BURN:
+                    // TODO
+                    return tempTxOutput.getIndex() >= 1;
+            }
+        }
+        return false;
     }
 
     private void handleBsqOutput(TempTxOutput txOutput, int index, long txOutputValue) {

--- a/core/src/main/java/bisq/core/offer/placeoffer/tasks/CreateMakerFeeTx.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/tasks/CreateMakerFeeTx.java
@@ -109,7 +109,7 @@ public class CreateMakerFeeTx extends Task<PlaceOfferModel> {
                         });
             } else {
                 final BsqWalletService bsqWalletService = model.getBsqWalletService();
-                Transaction preparedBurnFeeTx = model.getBsqWalletService().getPreparedBurnFeeTx(offer.getMakerFee());
+                Transaction preparedBurnFeeTx = model.getBsqWalletService().getPreparedTradeFeeTx(offer.getMakerFee());
                 Transaction txWithBsqFee = tradeWalletService.completeBsqTradingFeeTx(preparedBurnFeeTx,
                         fundingAddress,
                         reservedForTradeAddress,

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
@@ -79,7 +79,7 @@ public class CreateTakerFeeTx extends TradeTask {
                         false,
                         null);
             } else {
-                Transaction preparedBurnFeeTx = processModel.getBsqWalletService().getPreparedBurnFeeTx(trade.getTakerFee());
+                Transaction preparedBurnFeeTx = processModel.getBsqWalletService().getPreparedTradeFeeTx(trade.getTakerFee());
                 Transaction txWithBsqFee = tradeWalletService.completeBsqTradingFeeTx(preparedBurnFeeTx,
                         fundingAddress,
                         reservedForTradeAddress,

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
@@ -162,6 +162,7 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
 
         assetService.getUpdateFlag().addListener(updateListener);
         bsqWalletService.addBsqBalanceListener(this);
+        onUpdateAvailableConfirmedBalance(bsqWalletService.getAvailableConfirmedBalance());
 
         payFeeButton.setOnAction((event) -> {
             Coin listingFee = getListingFee();
@@ -225,7 +226,8 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
                                  Coin lockedForVotingBalance,
                                  Coin lockupBondsBalance,
                                  Coin unlockingBondsBalance) {
-        bsqValidator.setAvailableBalance(availableConfirmedBalance);
+
+        onUpdateAvailableConfirmedBalance(availableConfirmedBalance);
     }
 
 
@@ -246,6 +248,11 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
         };
 
         updateListener = observable -> updateList();
+    }
+
+    private void onUpdateAvailableConfirmedBalance(Coin availableConfirmedBalance) {
+        bsqValidator.setAvailableBalance(availableConfirmedBalance);
+        updateButtonState();
     }
 
     private long getDays() {

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
@@ -163,6 +163,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
 
         proofOfBurnService.getUpdateFlag().addListener(updateListener);
         bsqWalletService.addBsqBalanceListener(this);
+        onUpdateAvailableConfirmedBalance(bsqWalletService.getAvailableConfirmedBalance());
 
         burnButton.setOnAction((event) -> {
             Coin amount = getAmountFee();
@@ -221,7 +222,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                                  Coin lockedForVotingBalance,
                                  Coin lockupBondsBalance,
                                  Coin unlockingBondsBalance) {
-        bsqValidator.setAvailableBalance(availableConfirmedBalance);
+        onUpdateAvailableConfirmedBalance(availableConfirmedBalance);
     }
 
 
@@ -251,6 +252,11 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
         };
 
         updateListener = observable -> updateList();
+    }
+
+    private void onUpdateAvailableConfirmedBalance(Coin availableConfirmedBalance) {
+        bsqValidator.setAvailableBalance(availableConfirmedBalance);
+        updateButtonState();
     }
 
     private void updateList() {


### PR DESCRIPTION
With block 602500 (about 2 weeks after v1.2.0 release) we enforce a new rule which represents a
hard fork. Not updated nodes would see an out of sync dao state hash if a relevant transaction would
happen again.
Further (highly unlikely) consequences could be:
If the BSQ output would be sent to a BSQ address the old client would accept that even it is
invalid according to the new rules. But sending such a output would require a manually crafted tx
(not possible in the UI). Worst case a not updated user would buy invalid BSQ but that is not possible as we
enforce update to 1.2.0 for trading a few days after release as that release introduced the new trade protocol
and protection tool. Only of both both traders would have deactivated filter messages they could trade.

Problem description:
We did not apply the check to not allow BSQ outputs after we had detected a BTC output.
The supported BSQ transactions did not support such cases anyway but we missed an edge case:
A trade fee tx in case when the BTC input matches exactly the BTC output
(or BTC change was <= the miner fee) and the BSQ fee was > the miner fee. Then we
create a change output after the BTC output (using an address from the BTC wallet) and as
available BSQ was >= as spent BSQ it was considered a valid BSQ output.
There have been observed 5 such transactions where 4 got spent later to a BTC address and by that burned
the pending BSQ (spending amount was higher than sending amount). One was still unspent.
The BSQ was sitting in the BTC wallet so not even visible as BSQ to the user.
If the user would have crafted a custom BSQ tx he could have avoided that the full trade fee was burned.

Not an universal rule:
We cannot enforce the rule that no BSQ output is permitted to all possible transactions because there can be cases
where we need to permit this case.
For instance in case we confiscate a lockupTx we have usually 2 BSQ outputs: The first one is the bond which
should be confiscated and the second one is the BSQ change output.
At confiscating we set the first to TxOutputType.BTC_OUTPUT but we do not want to confiscate
the second BSQ change output as well. So we do not apply the rule that no BSQ is allowed once a BTC output is
found. Theoretically other transactions could be confiscated as well and all BSQ tx which allow > 1 BSQ outputs
would have the same issue as well if the first output gets confiscated.
We also don't enforce the rule for irregular or invalid txs which are usually set and detected at the end of
the tx parsing which is done in the TxParser. Blind vote and LockupTx with invalid OpReturn would be such cases
where we don't want to invalidate the change output (See comments in TxParser).