### PR TITLE
Show connected Bitcoin network peer info

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1060,6 +1060,10 @@ settings.net.receivedBytesColumn=Received
 settings.net.peerTypeColumn=Peer type
 settings.net.openTorSettingsButton=Open Tor settings
 
+settings.net.versionColumn=Version
+settings.net.subVersionColumn=Subversion
+settings.net.heightColumn=Height
+
 settings.net.needRestart=You need to restart the application to apply that change.\nDo you want to do that now?
 settings.net.notKnownYet=Not known yet...
 settings.net.sentReceived=Sent: {0}, received: {1}

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/BitcoinNetworkListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/BitcoinNetworkListItem.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.settings.network;
+
+import org.bitcoinj.core.Peer;
+
+public class BitcoinNetworkListItem {
+    private final Peer peer;
+
+    public BitcoinNetworkListItem(Peer peer) {
+        this.peer = peer;
+    }
+
+    public String getOnionAddress() {
+        return peer.getAddress().toString();
+    }
+
+    public String getVersion() {
+        return String.valueOf(peer.getPeerVersionMessage().clientVersion);
+    }
+
+    public String getSubVersion() {
+        return peer.getPeerVersionMessage().subVer;
+    }
+
+    public String getHeight() {
+        return String.valueOf(peer.getBestHeight());
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.fxml
@@ -21,7 +21,6 @@
 <?import bisq.desktop.components.AutoTooltipCheckBox?>
 <?import bisq.desktop.components.AutoTooltipLabel?>
 <?import bisq.desktop.components.AutoTooltipRadioButton?>
-<?import bisq.desktop.components.BisqTextArea?>
 <?import bisq.desktop.components.BisqTextField?>
 <?import bisq.desktop.components.InputTextField?>
 <?import bisq.desktop.components.TitledGroupBg?>
@@ -45,12 +44,34 @@
     </padding>
 
     <TitledGroupBg fx:id="btcHeader" GridPane.rowSpan="5"/>
-    <BisqTextArea fx:id="bitcoinPeersTextArea" GridPane.rowIndex="0" GridPane.hgrow="ALWAYS"
-                  GridPane.vgrow="SOMETIMES" editable="false" focusTraversable="false" labelFloat="true">
-        <GridPane.margin>
-            <Insets top="25"/>
-        </GridPane.margin>
-    </BisqTextArea>
+    <VBox GridPane.rowIndex="0" GridPane.hgrow="ALWAYS" GridPane.vgrow="SOMETIMES">
+        <AutoTooltipLabel fx:id="bitcoinPeersLabel" styleClass="small-text"/>
+        <TableView fx:id="bitcoinPeersTableView">
+            <columns>
+                <TableColumn fx:id="bitcoinPeerAddressColumn" minWidth="220">
+                    <cellValueFactory>
+                        <PropertyValueFactory property="onionAddress"/>
+                    </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="bitcoinPeerVersionColumn" minWidth="80" maxWidth="90">
+                    <cellValueFactory>
+                        <PropertyValueFactory property="version"/>
+                    </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="bitcoinPeerSubVersionColumn" minWidth="180" maxWidth="180">
+                    <cellValueFactory>
+                        <PropertyValueFactory property="subVersion"/>
+                    </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="bitcoinPeerHeightColumn" minWidth="80" maxWidth="80">
+                    <cellValueFactory>
+                        <PropertyValueFactory property="height"/>
+                    </cellValueFactory>
+                </TableColumn>
+            </columns>
+        </TableView>
+        <AutoTooltipLabel fx:id="localhostBtcNodeInfoLabel" styleClass="small-text"/>
+    </VBox>
 
     <AutoTooltipCheckBox fx:id="useTorForBtcJCheckBox" GridPane.rowIndex="1"/>
 
@@ -91,7 +112,7 @@
 
     <VBox GridPane.rowIndex="6" GridPane.hgrow="ALWAYS" GridPane.vgrow="SOMETIMES">
         <AutoTooltipLabel fx:id="p2PPeersLabel" styleClass="small-text"/>
-        <TableView fx:id="tableView">
+        <TableView fx:id="p2pPeersTableView">
             <columns>
                 <TableColumn fx:id="onionAddressColumn" minWidth="220">
                     <cellValueFactory>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/603793/66967119-b066bf00-f034-11e9-969f-ab110c816af3.png)

After:
![image](https://user-images.githubusercontent.com/603793/66967133-b9f02700-f034-11e9-95dd-7f691f85e178.png)

This partially addresses #2457, perhaps we can add additional P2P network peer details in the future.