### PR TITLE
Not show payment account details for blocked offers

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -882,10 +882,15 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
-                                    field = new HyperlinkWithIcon(model.getPaymentMethod(item));
-                                    field.setOnAction(event -> offerDetailsWindow.show(item.getOffer()));
-                                    field.setTooltip(new Tooltip(model.getPaymentMethodToolTip(item)));
-                                    setGraphic(field);
+
+                                    if (model.isOfferBanned(item.getOffer())) {
+                                        setGraphic(new AutoTooltipLabel(model.getPaymentMethod(item)));
+                                    } else {
+                                        field = new HyperlinkWithIcon(model.getPaymentMethod(item));
+                                        field.setOnAction(event -> offerDetailsWindow.show(item.getOffer()));
+                                        field.setTooltip(new Tooltip(model.getPaymentMethodToolTip(item)));
+                                        setGraphic(field);
+                                    }
                                 } else {
                                     setGraphic(null);
                                     if (field != null)


### PR DESCRIPTION
Atm blocking offers that abuse the general information section of the payment method is useless,
as it does exactly what the offer maker wants. Show the information and prevent the offer from being taken.