### PR TITLE
Update account signing strings for v1.2 release

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -343,8 +343,8 @@ offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts
 offerbook.timeSinceSigning.daysSinceSigning={0} days
 offerbook.timeSinceSigning.daysSinceSigning.long={0} since signing
 
-offerbook.timeSinceSigning.help=By trading with a payment account that was verified by an arbitrator or a peer, your account gets signed as well.\n\
-   {0} days later the initial limit of {1} gets lifted and your account can sign other peers as well.
+offerbook.timeSinceSigning.help=When you successfully complete a trade with a peer who has a signed payment account, your payment account is signed.\n\
+   {0} days later, the initial limit of {1} is lifted and your account can sign other peers'' payment accounts.
 offerbook.timeSinceSigning.notSigned=Not signed yet
 offerbook.timeSinceSigning.notSigned.noNeed=Unsigned
 shared.notSigned=This account hasn't been signed yet
@@ -376,15 +376,17 @@ offerbook.warning.noMatchingAccount.msg=To take this offer, you will need to set
 
 offerbook.warning.counterpartyTradeRestrictions=This offer cannot be taken due to counterparty trade restrictions
 
-offerbook.warning.newVersionAnnouncement=With this version of the software trading peers can verify and sign each other to create a network of trusted accounts.\n\n\
- By trading with a peer that has already been verified your account will be signed after a successful trade as well and the limits will be lifted after a certain time frame based on the verification method.\n\n\
-  For more information on account signing, please visit our documentation section on docs.bisq.network/account-signing.
+offerbook.warning.newVersionAnnouncement=With this version of the software, trading peers can verify and sign each others' payment accounts to create a network of trusted payment accounts.\n\n\
+ After successfully trading with a peer with a verified payment account, your payment account will be signed and trading limits will be lifted after a certain time interval (length of this interval is based on the verification method).\n\n\
+  For more information on account signing, please see the documentation at https://docs.bisq.network/payment-methods#account-signing.
 
 popup.warning.tradeLimitDueAccountAgeRestriction.seller=The allowed trade amount is limited to {0} because of security restrictions based on the following criteria:\n\
- - The buyers account was created after March 1st 2019\n\
+ - The buyer''s account is not at least 60 days old
+ - The buyer''s account was not involved in a dispute in which BTC was received (proving that fiat payment from this account occurred) \n\
  - The payment method for this offer is considered risky for bank chargebacks\n\n{1}
 popup.warning.tradeLimitDueAccountAgeRestriction.buyer=The allowed trade amount is limited to {0} because of security restrictions based on the following criteria:\n\
- - Your payment account was created after March 1st 2019\n\
+ - Your payment account is not at least 60 days old\n\
+ - Your account was not involved in a dispute in which BTC was received (proving that fiat payment from this account occurred) \n\
  - The payment method for this offer is considered risky for bank chargebacks\n\n{1}
 
 offerbook.warning.wrongTradeProtocol=That offer requires a different protocol version as the one used in your version of the software.\n\nPlease check if you have the latest version installed, otherwise the user who created the offer has used an older version.\n\nUsers cannot trade with an incompatible trade protocol version.
@@ -693,9 +695,9 @@ portfolio.pending.step3_seller.westernUnion=The buyer has to send you the MTCN (
 portfolio.pending.step3_seller.halCash=The buyer has to send you the HalCash code as text message. Beside that you will receive a message from HalCash with the required information to withdraw the EUR from a HalCash supporting ATM.\n\n\
   After you have picked up the money from the ATM please confirm here the receipt of the payment!
 
-portfolio.pending.step3_seller.bankCheck=\n\nPlease also verify that the sender''s name in your bank statement matches that one from the trade contract:\nSender''s name: {0}\n\n\
-  If the name is not the same as the one displayed here, {1}
-portfolio.pending.step3_seller.openDispute=please don't confirm but open a dispute by entering \"alt + o\" or \"option + o\".\n\n
+portfolio.pending.step3_seller.bankCheck=\n\nPlease also verify that the name of the sender specified on the trade contract matches the name that appears on your bank statement:\nSender''s name, per trade contract: {0}\n\n\
+  If the names are not exactly the same, {1}
+portfolio.pending.step3_seller.openDispute=don't confirm payment receipt. Instead, open a dispute by pressing \"alt + o\" or \"option + o\".\n\n
 portfolio.pending.step3_seller.confirmPaymentReceipt=Confirm payment receipt
 portfolio.pending.step3_seller.amountToReceive=Amount to receive
 portfolio.pending.step3_seller.yourAddress=Your {0} address
@@ -717,13 +719,13 @@ portfolio.pending.step3_seller.onPaymentReceived.part1=Have you received the {0}
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.fiat=The trade ID (\"reason for payment\" text) of the transaction is: \"{0}\"\n\n
 # suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the sender''s name in your bank statement matches that one from the trade contract:\nSender''s name: {0}\n\nIf the name is not the same as the one displayed here, please don''t confirm but open a dispute by entering \"alt + o\" or \"option + o\".\n\n
+portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the name of the sender specified on the trade contract matches the name that appears on your bank statement:\nSender''s name, per trade contract: {0}\n\nIf the names are not exactly the same, don''t confirm payment receipt. Instead, open a dispute by pressing \"alt + o\" or \"option + o\".\n\n
 portfolio.pending.step3_seller.onPaymentReceived.note=Please note, that as soon you have confirmed the receipt, the locked trade amount will be released to the BTC buyer and the security deposit will be refunded.\n\n
 portfolio.pending.step3_seller.onPaymentReceived.confirm.headline=Confirm that you have received the payment
 portfolio.pending.step3_seller.onPaymentReceived.confirm.yes=Yes, I have received the payment
-portfolio.pending.step3_seller.onPaymentReceived.signer=IMPORTANT: By confirming the receipt of payment you'll also \
-  verify the account of the counterparty and sign it accordingly. As the account of the counterparty hasn't been signed yet \
-  it is advised to delay the confirmation of the received payment as long as possible to reduce the risk of a chargeback.
+portfolio.pending.step3_seller.onPaymentReceived.signer=IMPORTANT: By confirming receipt of payment, you are also \
+  verifying the account of the counterparty and signing it accordingly. Since the account of the counterparty hasn't been signed yet, \
+  you should delay confirmation of the payment as long as possible to reduce the risk of a chargeback.
 
 portfolio.pending.step5_buyer.groupTitle=Summary of completed trade
 portfolio.pending.step5_buyer.tradeFee=Trade fee
@@ -732,7 +734,7 @@ portfolio.pending.step5_buyer.takersMiningFee=Total mining fees
 portfolio.pending.step5_buyer.refunded=Refunded security deposit
 portfolio.pending.step5_buyer.withdrawBTC=Withdraw your bitcoin
 portfolio.pending.step5_buyer.amount=Amount to withdraw
-portfolio.pending.step5_buyer.signer=By withdrawing your bitcoins you verify that the \
+portfolio.pending.step5_buyer.signer=By withdrawing your bitcoins, you verify that the \
   counterparty has acted according to the trade protocol.
 portfolio.pending.step5_buyer.withdrawToAddress=Withdraw to address
 portfolio.pending.step5_buyer.moveToBisqWallet=Move funds to Bisq wallet
@@ -818,14 +820,14 @@ portfolio.pending.mediationResult.popup.headline=Mediation result for trade with
 portfolio.pending.mediationResult.popup.headline.peerAccepted=Your trade peer has accepted the mediator''s suggestion for trade {0}
 portfolio.pending.mediationResult.popup.info=The mediator has suggested the following payout:\n\
   You receive: {0}\n\
-  Your trade peer receives: {1}\n\n\
+  Your trading peer receives: {1}\n\n\
   You can accept or reject this suggested payout.\n\n\
   By accepting, you sign the proposed payout transaction. \
-  If your trade peer also accepts and signs, the payout will be completed, and the trade will be closed.\n\n\
+  If your trading peer also accepts and signs, the payout will be completed, and the trade will be closed.\n\n\
   If one or both of you reject the suggestion, you will have to wait until {2} (block {3}) to open a \
-  second dispute round with an arbitrator who will investigate the case again and do a payout based on their findings.\n\n\
-  The arbitrator may charge a small fee (max. the trader's security deposit) as compensation for their work. \
-  Both traders agreeing to the mediator's suggestion is the happy path — requesting arbitration is meant for \
+  second-round dispute with an arbitrator who will investigate the case again and do a payout based on their findings.\n\n\
+  The arbitrator may charge a small fee (fee maximum: the trader''s security deposit) as compensation for their work. \
+  Both traders agreeing to the mediator''s suggestion is the happy path—requesting arbitration is meant for \
   exceptional circumstances, such as if a trader is sure the mediator did not make a fair payout suggestion \
   (or if the other peer is unresponsive).\n\n\
   More details about the new arbitration model:\n\
@@ -994,10 +996,10 @@ You can read more about the dispute process at: {2}
 support.systemMsg=System message: {0}
 support.youOpenedTicket=You opened a request for support.\n\n{0}\n\nBisq version: {1}
 support.youOpenedDispute=You opened a request for a dispute.\n\n{0}\n\nBisq version: {1}
-support.youOpenedDisputeForMediation=You asked for mediation.\n\n{0}\n\nBisq version: {1}
+support.youOpenedDisputeForMediation=You requested mediation.\n\n{0}\n\nBisq version: {1}
 support.peerOpenedTicket=Your trading peer has requested support due to technical problems.\n\n{0}\n\nBisq version: {1}
 support.peerOpenedDispute=Your trading peer has requested a dispute.\n\n{0}\n\nBisq version: {1}
-support.peerOpenedDisputeForMediation=Your trading peer has asked for mediation.\n\n{0}\n\nBisq version: {1}
+support.peerOpenedDisputeForMediation=Your trading peer has requested mediation.\n\n{0}\n\nBisq version: {1}
 support.mediatorsDisputeSummary=System message:\nMediator''s dispute summary:\n{0}
 support.mediatorsAddress=Mediator''s node address: {0}
 
@@ -2263,7 +2265,7 @@ disputeSummaryWindow.close.txDetails=Spending: {0}\n\
   {1}{2}\
   Transaction fee: {3} ({4} satoshis/byte)\n\
   Transaction size: {5} Kb\n\n\
-  Are you sure you want to publish that transaction?
+  Are you sure you want to publish this transaction?
 
 emptyWalletWindow.headline={0} emergency wallet tool
 emptyWalletWindow.info=Please use that only in emergency case if you cannot access your fund from the UI.\n\n\
@@ -2555,9 +2557,9 @@ popup.accountSigning.signAccounts.ECKey.error=Bad arbitrator ECKey
 popup.accountSigning.success.headline=Congratulations
 popup.accountSigning.success.description=All {0} payment accounts were successfully signed!
 popup.accountSigning.generalInformation=You'll find the signing state of all your accounts in the account section.\n\n\
-  For further information please visit docs.bisq.network/account-signing.html.
+  For further information, please visit https://docs.bisq.network/payment-methods#account-signing.
 popup.accountSigning.signedByArbitrator=One of your payment accounts has been verified and signed by an arbitrator. Trading with this account will automatically sign your trading peer''s account after a successful trade.\n\n{0}
-popup.accountSigning.signedByPeer=One of your payment accounts has been verified and signed by a trading peer. Your initial limit will be lifted and you''ll be able to sign other accounts within {0} days from now.\n\n{1}
+popup.accountSigning.signedByPeer=One of your payment accounts has been verified and signed by a trading peer. Your initial trading limit will be lifted and you''ll be able to sign other accounts in {0} days from now.\n\n{1}
 popup.accountSigning.peerLimitLifted=The initial limit for one of your accounts has been lifted.\n\n{0}
 popup.accountSigning.peerSigner=One of your accounts is mature enough to sign other payment accounts \
   and the initial limit for one of your accounts has been lifted.\n\n{0}

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -339,7 +339,7 @@ offerbook.timeSinceSigning.info=This account was verified and {0}
 offerbook.timeSinceSigning.info.arbitrator=signed by an arbitrator and can sign peer accounts
 offerbook.timeSinceSigning.info.peer=signed by a peer, waiting for limits to be lifted
 offerbook.timeSinceSigning.info.peerLimitLifted=signed by a peer and limits were lifted
-offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts
+offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts (limits lifted)
 offerbook.timeSinceSigning.daysSinceSigning={0} days
 offerbook.timeSinceSigning.daysSinceSigning.long={0} since signing
 
@@ -381,7 +381,7 @@ offerbook.warning.newVersionAnnouncement=With this version of the software, trad
   For more information on account signing, please see the documentation at https://docs.bisq.network/payment-methods#account-signing.
 
 popup.warning.tradeLimitDueAccountAgeRestriction.seller=The allowed trade amount is limited to {0} because of security restrictions based on the following criteria:\n\
- - The buyer''s account is not at least 60 days old
+ - The buyer''s account is not at least 60 days old\n\
  - The buyer''s account was not involved in a dispute in which BTC was received (proving that fiat payment from this account occurred) \n\
  - The payment method for this offer is considered risky for bank chargebacks\n\n{1}
 popup.warning.tradeLimitDueAccountAgeRestriction.buyer=The allowed trade amount is limited to {0} because of security restrictions based on the following criteria:\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -381,12 +381,12 @@ offerbook.warning.newVersionAnnouncement=With this version of the software, trad
   For more information on account signing, please see the documentation at https://docs.bisq.network/payment-methods#account-signing.
 
 popup.warning.tradeLimitDueAccountAgeRestriction.seller=The allowed trade amount is limited to {0} because of security restrictions based on the following criteria:\n\
- - The buyer''s account is not at least 60 days old\n\
- - The buyer''s account was not involved in a dispute in which BTC was received (proving that fiat payment from this account occurred) \n\
+ - The buyer''s account has not been signed by an arbitrator or a peer\n\
+ - The time since signing of the buyer''s account is not at least 30 days\n\
  - The payment method for this offer is considered risky for bank chargebacks\n\n{1}
 popup.warning.tradeLimitDueAccountAgeRestriction.buyer=The allowed trade amount is limited to {0} because of security restrictions based on the following criteria:\n\
- - Your payment account is not at least 60 days old\n\
- - Your account was not involved in a dispute in which BTC was received (proving that fiat payment from this account occurred) \n\
+ - Your account has not been signed by an arbitrator or a peer\n\
+ - The time since signing of your account is not at least 30 days\n\
  - The payment method for this offer is considered risky for bank chargebacks\n\n{1}
 
 offerbook.warning.wrongTradeProtocol=That offer requires a different protocol version as the one used in your version of the software.\n\nPlease check if you have the latest version installed, otherwise the user who created the offer has used an older version.\n\nUsers cannot trade with an incompatible trade protocol version.


### PR DESCRIPTION
I'm making a couple of in-line comments -- please see them.

EDIT

Cannot comment on unchanged code...I'll just add comments here.

---

```
offerbook.timeSinceSigning.info.peerLimitLifted=signed by a peer and limits were lifted
offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts
```

Same thing now?

---

Changed `popup.warning.tradeLimitDueAccountAgeRestriction` to fit new rules (since March 1 2019 date is no longer the determining factor for signing).

---

Changed single quotes to double quotes in `portfolio.pending.mediationResult.popup.info`...seems like mistake since variable includes {n} insertions.