### PR TITLE
Do not commit delayedPayoutTx to avoid publishing at restart

### DIFF
--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -1375,7 +1375,7 @@ message Trade {
     repeated ChatMessage chat_message = 29;
     MediationResultState mediation_result_state = 30;
     int64 lock_time = 31;
-    string delayed_payout_tx_id = 32;
+    bytes delayed_payout_tx_bytes = 32;
     NodeAddress refund_agent_node_address = 33;
     PubKeyRing refund_agent_pub_key_ring = 34;
     RefundResultState refund_result_state = 35;

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -58,11 +58,9 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             BtcWalletService.printTx("depositTx received from peer", committedDepositTx);
 
             // To access tx confidence we need to add that tx into our wallet.
-            Transaction delayedPayoutTx = processModel.getBtcWalletService().getTxFromSerializedTx(message.getDelayedPayoutTx());
-            trade.applyDelayedPayoutTx(delayedPayoutTx);
-            BtcWalletService.printTx("delayedPayoutTx received from peer", delayedPayoutTx);
-
-            WalletService.maybeAddSelfTxToWallet(delayedPayoutTx, processModel.getBtcWalletService().getWallet());
+            byte[] delayedPayoutTxBytes = message.getDelayedPayoutTx();
+            trade.applyDelayedPayoutTxBytes(delayedPayoutTxBytes);
+            BtcWalletService.printTx("delayedPayoutTx received from peer", trade.getDelayedPayoutTx());
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
@@ -19,7 +19,6 @@ package bisq.core.trade.protocol.tasks.seller;
 
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
-import bisq.core.btc.wallet.WalletService;
 import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.tasks.TradeTask;
 
@@ -66,7 +65,6 @@ public class SellerFinalizesDelayedPayoutTx extends TradeTask {
                     sellerSignature);
 
             trade.applyDelayedPayoutTx(signedDelayedPayoutTx);
-            WalletService.maybeAddSelfTxToWallet(signedDelayedPayoutTx, processModel.getBtcWalletService().getWallet());
 
             complete();
         } catch (Throwable t) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/3463

BitcoinJ publishes automatically committed transactions.
We committed it to the wallet to be able to access it later after a
restart. We stored the txId in Trade and used that to request the tx
from the wallet (as it was committed). Now we store the
bitcoin serialized bytes of the tx and do not commit the tx before
broadcasting it (if a trader opens refund agent ticket).