### PR TITLE
[1.2.0] Set delayedPayoutTxBytes when setting delayedPayoutTx

### DIFF
--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -666,6 +666,7 @@ public abstract class Trade implements Tradable, Model {
 
     public void applyDelayedPayoutTx(Transaction delayedPayoutTx) {
         this.delayedPayoutTx = delayedPayoutTx;
+        this.delayedPayoutTxBytes = delayedPayoutTx.bitcoinSerialize();
         persist();
     }
 


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/3473

The delayedPayoutTx is not committed to the wallet as long it is not
published. The seller who creates the delayedPayoutTx has not stored the
delayedPayoutTxBytes which caused a nullpointer after restart.