### PR TITLE
Clean up trade statistics from duplicate entries

### DIFF
--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -82,7 +82,8 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
     private final long tradeDate;
     private final String depositTxId;
 
-    // hash get set in constructor from json of all the other data fields (with hash = null).
+    // Hash get set in constructor from json of all the other data fields (with hash = null).
+    @JsonExclude
     private final byte[] hash;
     // PB field signature_pub_key_bytes not used anymore from v0.6 on
 
@@ -90,6 +91,7 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
     // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
     // field in a class would break that hash and therefore break the storage mechanism.
     @Nullable
+    @JsonExclude
     private Map<String, String> extraDataMap;
 
     public TradeStatistics2(OfferPayload offerPayload,
@@ -152,12 +154,14 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
         this.depositTxId = depositTxId;
         this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
 
-        if (hash == null)
-            // We create hash from all fields excluding hash itself. We use json as simple data serialisation.
-            // tradeDate is different for both peers so we ignore it for hash.
-            this.hash = Hash.getSha256Ripemd160hash(Utilities.objectToJson(this).getBytes(Charsets.UTF_8));
-        else
-            this.hash = hash;
+        this.hash = hash == null ? createHash() : hash;
+    }
+
+    public byte[] createHash() {
+        // We create hash from all fields excluding hash itself. We use json as simple data serialisation.
+        // TradeDate is different for both peers so we ignore it for hash. ExtraDataMap is ignored as well as at
+        // software updates we might have different entries which would cause a different hash.
+        return Hash.getSha256Ripemd160hash(Utilities.objectToJson(this).getBytes(Charsets.UTF_8));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -43,11 +43,13 @@ import javafx.collections.ObservableSet;
 import java.io.File;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -60,9 +62,11 @@ public class TradeStatisticsManager {
     private final JsonFileManager jsonFileManager;
     private final P2PService p2PService;
     private final PriceFeedService priceFeedService;
+    private final TradeStatistics2StorageService tradeStatistics2StorageService;
     private final ReferralIdService referralIdService;
     private final boolean dumpStatistics;
     private final ObservableSet<TradeStatistics2> observableTradeStatisticsSet = FXCollections.observableSet();
+    private int duplicates = 0;
 
     @Inject
     public TradeStatisticsManager(P2PService p2PService,
@@ -74,6 +78,7 @@ public class TradeStatisticsManager {
                                   @Named(AppOptionKeys.DUMP_STATISTICS) boolean dumpStatistics) {
         this.p2PService = p2PService;
         this.priceFeedService = priceFeedService;
+        this.tradeStatistics2StorageService = tradeStatistics2StorageService;
         this.referralIdService = referralIdService;
         this.dumpStatistics = dumpStatistics;
         jsonFileManager = new JsonFileManager(storageDir);
@@ -101,12 +106,29 @@ public class TradeStatisticsManager {
         });
 
         Map<String, TradeStatistics2> map = new HashMap<>();
+        AtomicInteger origSize = new AtomicInteger();
         p2PService.getP2PDataStorage().getAppendOnlyDataStoreMap().values().stream()
                 .filter(e -> e instanceof TradeStatistics2)
                 .map(e -> (TradeStatistics2) e)
                 .filter(TradeStatistics2::isValid)
-                .forEach(e -> addToMap(e, map));
-        observableTradeStatisticsSet.addAll(map.values());
+                .forEach(e -> {
+                    origSize.getAndIncrement();
+                    addToMap(e, map);
+                });
+
+        Collection<TradeStatistics2> items = map.values();
+        // At startup we check if we have duplicate entries. This might be the case from software updates when we
+        // introduced new entries to the extraMap. As that map is for flexibility in updates we keep it excluded from
+        // json so that it will not cause duplicates anymore. Until all users have updated we keep the cleanup code.
+        // Should not be needed later anymore, but will also not hurt if no duplicates exist.
+        if (duplicates > 0) {
+            long ts = System.currentTimeMillis();
+            items = tradeStatistics2StorageService.cleanupMap(items);
+            log.info("We found {} duplicate entries. Size of map entries before and after cleanup: {} / {}. Cleanup took {} ms.",
+                    duplicates, origSize, items.size(), System.currentTimeMillis() - ts);
+        }
+
+        observableTradeStatisticsSet.addAll(items);
 
         priceFeedService.applyLatestBisqMarketPrice(observableTradeStatisticsSet);
 
@@ -169,8 +191,9 @@ public class TradeStatisticsManager {
 
     private void addToMap(TradeStatistics2 tradeStatistics, Map<String, TradeStatistics2> map) {
         TradeStatistics2 prevValue = map.putIfAbsent(tradeStatistics.getOfferId(), tradeStatistics);
-        if (prevValue != null)
-            log.trace("We have already an item with the same offer ID. That might happen if both the maker and the taker published the tradeStatistics");
+        if (prevValue != null) {
+            duplicates++;
+        }
     }
 
     private void dump() {

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -58,6 +58,8 @@ import org.jetbrains.annotations.Nullable;
 @Slf4j
 class RequestDataHandler implements MessageListener {
     private static final long TIMEOUT = 90;
+    private static boolean initialRequestApplied = false;
+
     private NodeAddress peersNodeAddress;
     /*
      */
@@ -240,7 +242,12 @@ class RequestDataHandler implements MessageListener {
                                     // Processing 82645 items took now 61 ms compared to earlier version where it took ages (> 2min).
                                     // Usually we only get about a few hundred or max. a few 1000 items. 82645 is all
                                     // trade stats stats and all account age witness data.
-                                    dataStorage.addPersistableNetworkPayloadFromInitialRequest(e);
+
+                                    // We only apply it once from first response
+                                    if (!initialRequestApplied) {
+                                        dataStorage.addPersistableNetworkPayloadFromInitialRequest(e);
+                                        initialRequestApplied = true;
+                                    }
                                 } else {
                                     // We don't broadcast here as we are only connected to the seed node and would be pointless
                                     dataStorage.addPersistableNetworkPayload(e, sender, false,

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -348,7 +348,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     // Overwriting an entry would be also no issue. We also skip notifying listeners as we get called before the domain
     // is ready so no listeners are set anyway. We might get called twice from a redundant call later, so listeners
     // might be added then but as we have the data already added calling them would be irrelevant as well.
-    // TODO find a way to avoid the second call...
     public boolean addPersistableNetworkPayloadFromInitialRequest(PersistableNetworkPayload payload) {
         byte[] hash = payload.getHash();
         if (payload.verifyHashSize()) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/3470

At software updates we added new entries to the extraMap which caused
duplicate entries (if one if the traders was on the new and the other on
the old version or at republishing). We set it now json exclude so avoid
that in future and clean up the map.