### PR TITLE
Display appropriate account age info header

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2655,7 +2655,8 @@ peerInfo.title=Peer info
 peerInfo.nrOfTrades=Number of completed trades
 peerInfo.notTradedYet=You have not traded with that user so far.
 peerInfo.setTag=Set tag for that peer
-peerInfo.age=Payment account age
+peerInfo.age.noRisk=Payment account age
+peerInfo.age.chargeBackRisk=Time since signing
 peerInfo.unknownAge=Age not known
 
 addressTextField.openWallet=Open your default Bitcoin wallet

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -32,6 +32,8 @@ import bisq.core.util.BSFormatter;
 
 import bisq.network.p2p.NodeAddress;
 
+import bisq.common.util.Tuple2;
+
 import com.google.common.base.Charsets;
 
 import org.apache.commons.lang3.StringUtils;
@@ -134,7 +136,7 @@ public class PeerInfoIcon extends Group {
         peerTagMap = preferences.getPeerTagMap();
 
         boolean hasTraded = numTrades > 0;
-        long peersAccountAge = getPeersAccountAge(trade, offer);
+        Tuple2<Long, String> peersAccount = getPeersAccountAge(trade, offer);
         if (offer == null) {
             checkNotNull(trade, "Trade must not be null if offer is null.");
             offer = trade.getOffer();
@@ -145,7 +147,7 @@ public class PeerInfoIcon extends Group {
         boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode());
 
         String accountAge = isFiatCurrency ?
-                peersAccountAge > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(peersAccountAge)) :
+                peersAccount.first  > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(peersAccount.first)) :
                         Res.get("peerInfoIcon.tooltip.unknownAge") :
                 "";
         tooltipText = hasTraded ?
@@ -156,7 +158,7 @@ public class PeerInfoIcon extends Group {
         Color ringColor;
         if (isFiatCurrency) {
 
-            switch (accountAgeWitnessService.getPeersAccountAgeCategory(peersAccountAge)) {
+            switch (accountAgeWitnessService.getPeersAccountAgeCategory(peersAccount.first)) {
                 case TWO_MONTHS_OR_MORE:
                     ringColor = Color.rgb(0, 225, 0); // > 2 months green
                     break;
@@ -253,22 +255,24 @@ public class PeerInfoIcon extends Group {
             accountSigningState = StringUtils.capitalize(accountAgeWitnessService.getSignState(offer).getPresentation());
         }
 
-        addMouseListener(numTrades, privateNotificationManager, offer, preferences, formatter, useDevPrivilegeKeys, isFiatCurrency, peersAccountAge, accountSigningState);
+        addMouseListener(numTrades, privateNotificationManager, offer, preferences, formatter, useDevPrivilegeKeys,
+                isFiatCurrency, peersAccount.first, peersAccount.second, accountSigningState);
     }
 
-    private long getPeersAccountAge(@Nullable Trade trade, @Nullable Offer offer) {
+    private Tuple2<Long, String> getPeersAccountAge(@Nullable Trade trade, @Nullable Offer offer) {
         if (trade != null) {
             offer = trade.getOffer();
             if (offer == null) {
                 // unexpected
-                return -1;
+                return new Tuple2<>(-1L, Res.get("peerInfo.age.noRisk"));
             }
         }
         checkNotNull(offer, "Offer must not be null if trade is null.");
         if (PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode())) {
-            return accountAgeWitnessService.getWitnessSignAge(offer, new Date());
+            return new Tuple2<>(accountAgeWitnessService.getWitnessSignAge(offer, new Date()),
+                    Res.get("peerInfo.age.chargeBackRisk"));
         }
-        return accountAgeWitnessService.getAccountAge(offer);
+        return new Tuple2<>(accountAgeWitnessService.getAccountAge(offer), Res.get("peerInfo.age.noRisk"));
     }
 
     protected void addMouseListener(int numTrades,
@@ -279,6 +283,7 @@ public class PeerInfoIcon extends Group {
                                     boolean useDevPrivilegeKeys,
                                     boolean isFiatCurrency,
                                     long makersAccountAge,
+                                    String makersAccountAgeInfo,
                                     String accountSigningState) {
         final String accountAgeTagEditor = isFiatCurrency ?
                 makersAccountAge > -1 ?
@@ -290,6 +295,7 @@ public class PeerInfoIcon extends Group {
                 .fullAddress(fullAddress)
                 .numTrades(numTrades)
                 .accountAge(accountAgeTagEditor)
+                .accountAgeInfo(makersAccountAgeInfo)
                 .accountSigningState(accountSigningState)
                 .position(localToScene(new Point2D(0, 0)))
                 .onSave(newTag -> {

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
@@ -35,10 +35,14 @@ public class PeerInfoIconSmall extends PeerInfoIcon {
     @Override
     protected void addMouseListener(int numTrades,
                                     PrivateNotificationManager privateNotificationManager,
-                                    Offer offer, Preferences preferences,
+                                    Offer offer,
+                                    Preferences preferences,
                                     BSFormatter formatter,
                                     boolean useDevPrivilegeKeys,
-                                    boolean isFiatCurrency, long makersAccountAge, String accountSigningState) {
+                                    boolean isFiatCurrency,
+                                    long makersAccountAge,
+                                    String makersAccountAgeInfo,
+                                    String accountSigningState) {
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
@@ -90,6 +90,7 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
     private EventHandler<KeyEvent> keyEventEventHandler;
     @Nullable
     private String accountAge;
+    private String accountAgeInfo;
     @Nullable
     private String accountSigningState;
 
@@ -125,6 +126,11 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
 
     public PeerInfoWithTagEditor accountAge(@Nullable String accountAge) {
         this.accountAge = accountAge;
+        return this;
+    }
+
+    public PeerInfoWithTagEditor accountAgeInfo(String accountAgeInfo) {
+        this.accountAgeInfo = accountAgeInfo;
         return this;
     }
 
@@ -198,8 +204,9 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
         GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex,
                 Res.get("peerInfo.nrOfTrades"),
                 numTrades > 0 ? String.valueOf(numTrades) : Res.get("peerInfo.notTradedYet")).third, 2);
-        if (accountAge != null)
-            GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex, Res.get("peerInfo.age"), accountAge).third, 2);
+        if (accountAge != null) {
+            GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex, accountAgeInfo, accountAge).third, 2);
+        }
 
         if (accountSigningState != null) {
             GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex, Res.get("shared.accountSigningState"), accountSigningState).third, 2);


### PR DESCRIPTION
Depending on charge back risk type, accounts should show
accountAgeWitness age or time since signing

Screenshots of popups with this fix for #3482 
Accounts:
![image](https://user-images.githubusercontent.com/23560607/67637144-c8153180-f8d7-11e9-8268-1a541f5f178c.png)

First account popup:
![image](https://user-images.githubusercontent.com/23560607/67637150-d400f380-f8d7-11e9-8b9f-d7bc204aa990.png)


Second account popup:
![image](https://user-images.githubusercontent.com/23560607/67637154-dd8a5b80-f8d7-11e9-9dd7-4e9fe4abd1aa.png)

Third account popup:
![image](https://user-images.githubusercontent.com/23560607/67637160-f135c200-f8d7-11e9-8860-912cc4f3f0de.png)

Fourth account popup:
![image](https://user-images.githubusercontent.com/23560607/67637180-1296ae00-f8d8-11e9-82d6-d44487a5692a.png)



