### PR TITLE
[1.2.0] Fix style issues with dark mode

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -783,11 +783,15 @@ tree-table-view:focused {
 }
 
 .close-icon {
-    -fx-text-fill: -bs-text-color;
+    -fx-fill: -bs-text-color;
 }
 
 .close-icon:hover {
-    -fx-text-fill: -fx-accent;
+    -fx-fill: -fx-accent;
+}
+
+.tooltip-icon {
+    -fx-fill: -bs-text-color;
 }
 
 /*******************************************************************************
@@ -2040,3 +2044,9 @@ textfield */
 .popover > .content {
     -fx-padding: 10;
 }
+
+.popover > .content .default-text {
+    -fx-text-fill: -bs-text-color;
+}
+
+

--- a/desktop/src/main/java/bisq/desktop/components/InfoAutoTooltipLabel.java
+++ b/desktop/src/main/java/bisq/desktop/components/InfoAutoTooltipLabel.java
@@ -81,6 +81,7 @@ public class InfoAutoTooltipLabel extends AutoTooltipLabel {
 
     private void positionAndActivateIcon(ContentDisplay contentDisplay, String info, double width) {
         textIcon.setOpacity(0.4);
+        textIcon.getStyleClass().add("tooltip-icon");
 
         textIcon.setOnMouseEntered(e -> {
             hidePopover = false;

--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -2107,14 +2107,14 @@ public class FormBuilder {
 
     public static Button getIconButton(GlyphIcons icon, String styleClass, String iconSize) {
         if (icon.fontFamily().equals(MATERIAL_DESIGN_ICONS)) {
-            Button textIcon = MaterialDesignIconFactory.get().createIconButton(icon,
+            Button iconButton = MaterialDesignIconFactory.get().createIconButton(icon,
                     "", iconSize, null, ContentDisplay.CENTER);
-            textIcon.setId("icon-button");
-            textIcon.getGraphic().getStyleClass().add(styleClass);
-            textIcon.setPrefWidth(20);
-            textIcon.setPrefHeight(20);
-            textIcon.setPadding(new Insets(0));
-            return textIcon;
+            iconButton.setId("icon-button");
+            iconButton.getGraphic().getStyleClass().add(styleClass);
+            iconButton.setPrefWidth(20);
+            iconButton.setPrefHeight(20);
+            iconButton.setPadding(new Insets(0));
+            return iconButton;
         } else {
             throw new IllegalArgumentException("Not supported icon type");
         }


### PR DESCRIPTION
Fixes #3472.

![Bildschirmfoto 2019-10-28 um 10 43 06](https://user-images.githubusercontent.com/170962/67668722-c9df0380-f970-11e9-9fa6-187e05a14946.png)
Also now the icons are visible in dark mode
<img width="1312" alt="Bildschirmfoto 2019-10-28 um 10 48 25" src="https://user-images.githubusercontent.com/170962/67668723-c9df0380-f970-11e9-9bd5-603cdb4d1bf9.png">
Still this issue is still open as I wasn't able to fix this quickly (nothing new - already existed in v1.1.7)
<img width="1312" alt="Bildschirmfoto 2019-10-28 um 10 48 43" src="https://user-images.githubusercontent.com/170962/67668798-eda24980-f970-11e9-9458-5396ca7d3958.png">

Maybe @wiz could have a more detailed look at it.
