### PR TITLE
Fix tradestat hash issue

### DIFF
--- a/common/src/main/java/bisq/common/app/Capability.java
+++ b/common/src/main/java/bisq/common/app/Capability.java
@@ -39,6 +39,6 @@ public enum Capability {
 
     SIGNED_ACCOUNT_AGE_WITNESS,         // Supports the signed account age witness feature
     MEDIATION,                          // Supports mediation feature
-    REFUND_AGENT                        // Supports refund agents
-    ;
+    REFUND_AGENT,                       // Supports refund agents
+    TRADE_STATISTICS_HASH_UPDATE        // We changed the hash method in 1.2.0 and that requires update to 1.2.2 for handling it correctly, otherwise the seed nodes have to process too much data.
 }

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -250,4 +250,26 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
 
         ownerPubKeyBytes = Sig.getPublicKeyBytes(this.ownerPubKey);
     }
+
+    @Override
+    public String toString() {
+        return "Filter{" +
+                "\n     bannedOfferIds=" + bannedOfferIds +
+                ",\n     bannedNodeAddress=" + bannedNodeAddress +
+                ",\n     bannedPaymentAccounts=" + bannedPaymentAccounts +
+                ",\n     bannedCurrencies=" + bannedCurrencies +
+                ",\n     bannedPaymentMethods=" + bannedPaymentMethods +
+                ",\n     arbitrators=" + arbitrators +
+                ",\n     seedNodes=" + seedNodes +
+                ",\n     priceRelayNodes=" + priceRelayNodes +
+                ",\n     preventPublicBtcNetwork=" + preventPublicBtcNetwork +
+                ",\n     btcNodes=" + btcNodes +
+                ",\n     extraDataMap=" + extraDataMap +
+                ",\n     disableDao=" + disableDao +
+                ",\n     disableDaoBelowVersion='" + disableDaoBelowVersion + '\'' +
+                ",\n     disableTradeBelowVersion='" + disableTradeBelowVersion + '\'' +
+                ",\n     mediators=" + mediators +
+                ",\n     refundAgents=" + refundAgents +
+                "\n}";
+    }
 }

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -297,7 +297,7 @@ public class FilterManager {
             ECKey.fromPublicOnly(HEX.decode(pubKeyAsHex)).verifyMessage(getHexFromData(filter), filter.getSignatureAsBase64());
             return true;
         } catch (SignatureException e) {
-            log.warn("verifySignature failed");
+            log.warn("verifySignature failed. filter={}", filter);
             return false;
         }
     }

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -214,7 +214,7 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
                 proto.getTradeAmount(),
                 proto.getTradeDate(),
                 proto.getDepositTxId(),
-                proto.getHash().toByteArray(),
+                null,   // We want to clean up the hashes with the changed hash method in v.1.2.0 so we don't use the value from the proto
                 CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
     }
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -235,12 +235,13 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
     }
 
     // With v1.2.0 we changed the way how the hash is created. To not create too heavy load for seed nodes from
-    // requests from old nodes we use the SIGNED_ACCOUNT_AGE_WITNESS capability to send trade statistics only to new
+    // requests from old nodes we use the TRADE_STATISTICS_HASH_UPDATE capability to send trade statistics only to new
     // nodes. As trade statistics are only used for informational purpose it will not have any critical issue for the
-    // old nodes beside that they don't see the latest trades.
+    // old nodes beside that they don't see the latest trades. We added TRADE_STATISTICS_HASH_UPDATE in v1.2.2 to fix a
+    // problem of not handling the hashes correctly.
     @Override
     public Capabilities getRequiredCapabilities() {
-        return new Capabilities(Capability.SIGNED_ACCOUNT_AGE_WITNESS);
+        return new Capabilities(Capability.TRADE_STATISTICS_HASH_UPDATE);
     }
 
 
@@ -281,7 +282,6 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
         boolean excludedFailedTrade = offerId.equals("6E5KOI6O-3a06a037-6f03-4bfa-98c2-59f49f73466a-112");
         return tradeAmount > 0 && tradePrice > 0 && !excludedFailedTrade;
     }
-
 
     @Override
     public String toString() {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -280,7 +280,7 @@ public final class TradeStatistics2 implements LazyProcessedPayload, Persistable
         // Since the trade wasn't executed it's better to filter it out to avoid it having an undue influence on the
         // BSQ trade stats.
         boolean excludedFailedTrade = offerId.equals("6E5KOI6O-3a06a037-6f03-4bfa-98c2-59f49f73466a-112");
-        return tradeAmount > 0 && tradePrice > 0 && !excludedFailedTrade;
+        return tradeAmount > 0 && tradePrice > 0 && !excludedFailedTrade && !depositTxId.isEmpty();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2StorageService.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2StorageService.java
@@ -29,8 +29,6 @@ import javax.inject.Inject;
 
 import java.io.File;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
@@ -68,19 +66,6 @@ public class TradeStatistics2StorageService extends MapStoreService<TradeStatist
     @Override
     public boolean canHandle(PersistableNetworkPayload payload) {
         return payload instanceof TradeStatistics2;
-    }
-
-    Collection<TradeStatistics2> cleanupMap(Collection<TradeStatistics2> collection) {
-        Map<P2PDataStorage.ByteArray, TradeStatistics2> tempMap = new HashMap<>();
-        // We recreate the hash as there have been duplicates from diff. extraMap entries introduced at software updates
-        collection.forEach(item -> tempMap.putIfAbsent(new P2PDataStorage.ByteArray(item.createHash()), item));
-
-        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> map = getMap();
-        map.clear();
-        map.putAll(tempMap);
-        persist();
-
-        return tempMap.values();
     }
 
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -76,19 +76,6 @@ public class TradeStatisticsManager {
     }
 
     public void onAllServicesInitialized() {
-        if (dumpStatistics) {
-            ArrayList<CurrencyTuple> fiatCurrencyList = CurrencyUtil.getAllSortedFiatCurrencies().stream()
-                    .map(e -> new CurrencyTuple(e.getCode(), e.getName(), 8))
-                    .collect(Collectors.toCollection(ArrayList::new));
-            jsonFileManager.writeToDisc(Utilities.objectToJson(fiatCurrencyList), "fiat_currency_list");
-
-            ArrayList<CurrencyTuple> cryptoCurrencyList = CurrencyUtil.getAllSortedCryptoCurrencies().stream()
-                    .map(e -> new CurrencyTuple(e.getCode(), e.getName(), 8))
-                    .collect(Collectors.toCollection(ArrayList::new));
-            cryptoCurrencyList.add(0, new CurrencyTuple(Res.getBaseCurrencyCode(), Res.getBaseCurrencyName(), 8));
-            jsonFileManager.writeToDisc(Utilities.objectToJson(cryptoCurrencyList), "crypto_currency_list");
-        }
-
         p2PService.getP2PDataStorage().addAppendOnlyDataStoreListener(payload -> {
             if (payload instanceof TradeStatistics2)
                 addToSet((TradeStatistics2) payload);
@@ -149,6 +136,17 @@ public class TradeStatisticsManager {
 
     private void dump() {
         if (dumpStatistics) {
+            ArrayList<CurrencyTuple> fiatCurrencyList = CurrencyUtil.getAllSortedFiatCurrencies().stream()
+                    .map(e -> new CurrencyTuple(e.getCode(), e.getName(), 8))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            jsonFileManager.writeToDisc(Utilities.objectToJson(fiatCurrencyList), "fiat_currency_list");
+
+            ArrayList<CurrencyTuple> cryptoCurrencyList = CurrencyUtil.getAllSortedCryptoCurrencies().stream()
+                    .map(e -> new CurrencyTuple(e.getCode(), e.getName(), 8))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            cryptoCurrencyList.add(0, new CurrencyTuple(Res.getBaseCurrencyCode(), Res.getBaseCurrencyName(), 8));
+            jsonFileManager.writeToDisc(Utilities.objectToJson(cryptoCurrencyList), "crypto_currency_list");
+
             // We store the statistics as json so it is easy for further processing (e.g. for web based services)
             // TODO This is just a quick solution for storing to one file.
             // 1 statistic entry has 500 bytes as json.

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -803,7 +803,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                                     String senderNodeAddress = networkEnvelope instanceof SendersNodeAddressMessage ?
                                             ((SendersNodeAddressMessage) networkEnvelope).getSenderNodeAddress().getFullAddress() :
                                             "[unknown address]";
-                                    log.warn("We close a connection to old node {}. " +
+                                    log.info("We close a connection to old node {}. " +
                                                     "Capabilities of old node: {}, networkEnvelope class name={}",
                                             senderNodeAddress, capabilities.prettyPrint(), networkEnvelope.getClass().getSimpleName());
                                     shutDown(CloseConnectionReason.MANDATORY_CAPABILITIES_NOT_SUPPORTED);

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -800,8 +800,12 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
                                 // Capabilities can be empty. We only check for mandatory if we get some capabilities.
                                 if (!capabilities.isEmpty() && !Capabilities.hasMandatoryCapability(capabilities)) {
-                                    log.warn("We close a connection to an old node. Capabilities of old node: {}",
-                                            capabilities.prettyPrint());
+                                    String senderNodeAddress = networkEnvelope instanceof SendersNodeAddressMessage ?
+                                            ((SendersNodeAddressMessage) networkEnvelope).getSenderNodeAddress().getFullAddress() :
+                                            "[unknown address]";
+                                    log.warn("We close a connection to old node {}. " +
+                                                    "Capabilities of old node: {}, networkEnvelope class name={}",
+                                            senderNodeAddress, capabilities.prettyPrint(), networkEnvelope.getClass().getSimpleName());
                                     shutDown(CloseConnectionReason.MANDATORY_CAPABILITIES_NOT_SUPPORTED);
                                     return;
                                 }

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -358,7 +358,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                     data = ((AddDataMessage) msg).getProtectedStorageEntry().getProtectedStoragePayload();
                 }
                 // Monitoring nodes have only one capability set, we don't want to log those
-                log.info("We did not send the message because the peer does not support our required capabilities. " +
+                log.debug("We did not send the message because the peer does not support our required capabilities. " +
                                 "messageClass={}, peer={}, peers supportedCapabilities={}",
                         data.getClass().getSimpleName(), peersNodeAddressOptional, capabilities);
             }
@@ -800,6 +800,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
                                 // Capabilities can be empty. We only check for mandatory if we get some capabilities.
                                 if (!capabilities.isEmpty() && !Capabilities.hasMandatoryCapability(capabilities)) {
+                                    log.warn("We close a connection to an old node. Capabilities of old node: {}",
+                                            capabilities.prettyPrint());
                                     shutDown(CloseConnectionReason.MANDATORY_CAPABILITIES_NOT_SUPPORTED);
                                     return;
                                 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -353,8 +353,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
                     connection.shutDown(CloseConnectionReason.TOO_MANY_CONNECTIONS_OPEN, () -> UserThread.runAfter(this::checkMaxConnections, 100, TimeUnit.MILLISECONDS));
                 return true;
             } else {
-                log.warn("No candidates found to remove (That case should not be possible as we use in the " +
-                        "last case all connections).\n\t" +
+                log.debug("No candidates found to remove.\n\t" +
                         "size={}, allConnections={}", size, allConnections);
                 return false;
             }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
@@ -90,6 +90,7 @@ public class GetDataRequestHandler {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void handle(GetDataRequest getDataRequest, final Connection connection) {
+        long ts = System.currentTimeMillis();
         GetDataResponse getDataResponse = new GetDataResponse(getFilteredProtectedStorageEntries(getDataRequest, connection),
                 getFilteredPersistableNetworkPayload(getDataRequest, connection),
                 getDataRequest.getNonce(),
@@ -105,7 +106,7 @@ public class GetDataRequestHandler {
         }
 
         SettableFuture<Connection> future = networkNode.sendMessage(connection, getDataResponse);
-        Futures.addCallback(future, new FutureCallback<Connection>() {
+        Futures.addCallback(future, new FutureCallback<>() {
             @Override
             public void onSuccess(Connection connection) {
                 if (!stopped) {
@@ -130,9 +131,11 @@ public class GetDataRequestHandler {
                 }
             }
         });
+        log.info("handle GetDataRequest took {} ms", System.currentTimeMillis() - ts);
     }
 
-    private Set<PersistableNetworkPayload> getFilteredPersistableNetworkPayload(GetDataRequest getDataRequest, Connection connection) {
+    private Set<PersistableNetworkPayload> getFilteredPersistableNetworkPayload(GetDataRequest getDataRequest,
+                                                                                Connection connection) {
         final Set<P2PDataStorage.ByteArray> tempLookupSet = new HashSet<>();
         Set<P2PDataStorage.ByteArray> excludedKeysAsByteArray = P2PDataStorage.ByteArray.convertBytesSetToByteArraySet(getDataRequest.getExcludedKeys());
 
@@ -144,7 +147,8 @@ public class GetDataRequestHandler {
                 .collect(Collectors.toSet());
     }
 
-    private Set<ProtectedStorageEntry> getFilteredProtectedStorageEntries(GetDataRequest getDataRequest, Connection connection) {
+    private Set<ProtectedStorageEntry> getFilteredProtectedStorageEntries(GetDataRequest getDataRequest,
+                                                                          Connection connection) {
         final Set<ProtectedStorageEntry> filteredDataSet = new HashSet<>();
         final Set<Integer> lookupSet = new HashSet<>();
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -203,6 +203,7 @@ class RequestDataHandler implements MessageListener {
         if (networkEnvelope instanceof GetDataResponse) {
             if (connection.getPeersNodeAddressOptional().isPresent() && connection.getPeersNodeAddressOptional().get().equals(peersNodeAddress)) {
                 if (!stopped) {
+                    long ts1 = System.currentTimeMillis();
                     GetDataResponse getDataResponse = (GetDataResponse) networkEnvelope;
                     final Set<ProtectedStorageEntry> dataSet = getDataResponse.getDataSet();
                     Set<PersistableNetworkPayload> persistableNetworkPayloadSet = getDataResponse.getPersistableNetworkPayloadSet();
@@ -219,7 +220,7 @@ class RequestDataHandler implements MessageListener {
 
                         final NodeAddress sender = connection.getPeersNodeAddressOptional().get();
 
-                        long ts = System.currentTimeMillis();
+                        long ts2 = System.currentTimeMillis();
                         AtomicInteger counter = new AtomicInteger();
                         dataSet.forEach(e -> {
                             // We don't broadcast here (last param) as we are only connected to the seed node and would be pointless
@@ -227,14 +228,14 @@ class RequestDataHandler implements MessageListener {
                             counter.getAndIncrement();
 
                         });
-                        log.info("Processing {} protectedStorageEntries took {} ms.", counter.get(), System.currentTimeMillis() - ts);
+                        log.info("Processing {} protectedStorageEntries took {} ms.", counter.get(), System.currentTimeMillis() - ts2);
 
                         /* // engage the firstRequest logic only if we are a seed node. Normal clients get here twice at most.
                         if (!Capabilities.app.containsAll(Capability.SEED_NODE))
                             firstRequest = true;*/
 
                         if (persistableNetworkPayloadSet != null /*&& firstRequest*/) {
-                            ts = System.currentTimeMillis();
+                            ts2 = System.currentTimeMillis();
                             persistableNetworkPayloadSet.forEach(e -> {
                                 if (e instanceof LazyProcessedPayload) {
                                     // We use an optimized method as many checks are not required in that case to avoid
@@ -259,7 +260,7 @@ class RequestDataHandler implements MessageListener {
                             initialRequestApplied = true;
 
                             log.info("Processing {} persistableNetworkPayloads took {} ms.",
-                                    persistableNetworkPayloadSet.size(), System.currentTimeMillis() - ts);
+                                    persistableNetworkPayloadSet.size(), System.currentTimeMillis() - ts2);
                         }
 
                         cleanup();
@@ -272,6 +273,7 @@ class RequestDataHandler implements MessageListener {
                                         "We drop that message. nonce={} / requestNonce={}",
                                 nonce, getDataResponse.getRequestNonce());
                     }
+                    log.info("Processing GetDataResponse took {} ms", System.currentTimeMillis() - ts1);
                 } else {
                     log.warn("We have stopped already. We ignore that onDataRequest call.");
                 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -108,12 +108,17 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
                 .map(PersistableNetworkPayload::toProtoMessage)
                 .collect(Collectors.toList())));
 
-        return getNetworkEnvelopeBuilder()
+        protobuf.NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetDataResponse(builder)
                 .build();
+        log.info("Sending a GetDataResponse with size = {}", proto.toByteArray().length);
+        return proto;
     }
 
-    public static GetDataResponse fromProto(protobuf.GetDataResponse proto, NetworkProtoResolver resolver, int messageVersion) {
+    public static GetDataResponse fromProto(protobuf.GetDataResponse proto,
+                                            NetworkProtoResolver resolver,
+                                            int messageVersion) {
+        log.info("Received a GetDataResponse with size = {}", proto.toByteArray().length);
         Set<ProtectedStorageEntry> dataSet = new HashSet<>(
                 proto.getDataSetList().stream()
                         .map(entry -> (ProtectedStorageEntry) resolver.fromProto(entry))

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -111,14 +111,14 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
         protobuf.NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetDataResponse(builder)
                 .build();
-        log.info("Sending a GetDataResponse with size = {}", proto.toByteArray().length);
+        log.info("Sending a GetDataResponse with size = {} bytes", proto.toByteArray().length);
         return proto;
     }
 
     public static GetDataResponse fromProto(protobuf.GetDataResponse proto,
                                             NetworkProtoResolver resolver,
                                             int messageVersion) {
-        log.info("Received a GetDataResponse with size = {}", proto.toByteArray().length);
+        log.info("Received a GetDataResponse with size = {} bytes", proto.toByteArray().length);
         Set<ProtectedStorageEntry> dataSet = new HashSet<>(
                 proto.getDataSetList().stream()
                         .map(entry -> (ProtectedStorageEntry) resolver.fromProto(entry))

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
@@ -30,9 +30,15 @@ import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+
+
+import protobuf.NetworkEnvelope;
+
+@Slf4j
 @EqualsAndHashCode(callSuper = true)
 @Value
 public final class GetUpdatedDataRequest extends GetDataRequest implements SendersNodeAddressMessage {
@@ -72,12 +78,15 @@ public final class GetUpdatedDataRequest extends GetDataRequest implements Sende
                         .map(ByteString::copyFrom)
                         .collect(Collectors.toList()));
 
-        return getNetworkEnvelopeBuilder()
+        NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetUpdatedDataRequest(builder)
                 .build();
+        log.info("Sending a GetUpdatedDataRequest with size = {}", proto.toByteArray().length);
+        return proto;
     }
 
     public static GetUpdatedDataRequest fromProto(protobuf.GetUpdatedDataRequest proto, int messageVersion) {
+        log.info("Received a GetUpdatedDataRequest with size = {}", proto.toByteArray().length);
         return new GetUpdatedDataRequest(NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getNonce(),
                 ProtoUtil.byteSetFromProtoByteStringList(proto.getExcludedKeysList()),

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
@@ -81,12 +81,12 @@ public final class GetUpdatedDataRequest extends GetDataRequest implements Sende
         NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetUpdatedDataRequest(builder)
                 .build();
-        log.info("Sending a GetUpdatedDataRequest with size = {}", proto.toByteArray().length);
+        log.info("Sending a GetUpdatedDataRequest with size = {} bytes", proto.toByteArray().length);
         return proto;
     }
 
     public static GetUpdatedDataRequest fromProto(protobuf.GetUpdatedDataRequest proto, int messageVersion) {
-        log.info("Received a GetUpdatedDataRequest with size = {}", proto.toByteArray().length);
+        log.info("Received a GetUpdatedDataRequest with size = {} bytes", proto.toByteArray().length);
         return new GetUpdatedDataRequest(NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getNonce(),
                 ProtoUtil.byteSetFromProtoByteStringList(proto.getExcludedKeysList()),

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
@@ -36,6 +36,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+
+
+import protobuf.NetworkEnvelope;
+
 @Slf4j
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -72,12 +76,15 @@ public final class PreliminaryGetDataRequest extends GetDataRequest implements A
 
         Optional.ofNullable(supportedCapabilities).ifPresent(e -> builder.addAllSupportedCapabilities(Capabilities.toIntList(supportedCapabilities)));
 
-        return getNetworkEnvelopeBuilder()
+        NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setPreliminaryGetDataRequest(builder)
                 .build();
+        log.info("Sending a PreliminaryGetDataRequest with size = {}", proto.toByteArray().length);
+        return proto;
     }
 
     public static PreliminaryGetDataRequest fromProto(protobuf.PreliminaryGetDataRequest proto, int messageVersion) {
+        log.info("Received a PreliminaryGetDataRequest with size = {}", proto.toByteArray().length);
         Capabilities supportedCapabilities = proto.getSupportedCapabilitiesList().isEmpty() ?
                 null :
                 Capabilities.fromIntList(proto.getSupportedCapabilitiesList());

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
@@ -79,12 +79,12 @@ public final class PreliminaryGetDataRequest extends GetDataRequest implements A
         NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setPreliminaryGetDataRequest(builder)
                 .build();
-        log.info("Sending a PreliminaryGetDataRequest with size = {}", proto.toByteArray().length);
+        log.info("Sending a PreliminaryGetDataRequest with size = {} bytes", proto.toByteArray().length);
         return proto;
     }
 
     public static PreliminaryGetDataRequest fromProto(protobuf.PreliminaryGetDataRequest proto, int messageVersion) {
-        log.info("Received a PreliminaryGetDataRequest with size = {}", proto.toByteArray().length);
+        log.info("Received a PreliminaryGetDataRequest with size = {} bytes", proto.toByteArray().length);
         Capabilities supportedCapabilities = proto.getSupportedCapabilitiesList().isEmpty() ?
                 null :
                 Capabilities.fromIntList(proto.getSupportedCapabilitiesList());


### PR DESCRIPTION
We used the hash from the protobuf file of the trade statistics and that can be a hash which was created with an older version where we used a different hash method (extra map included). This causes that the excludedKeys at GetDataRequest are not matching the seed nodes keys so our deltat handling fails which results in too much data transmitted (7 MB instead of 3MB). To fix that we force the tradestat to update its hash by passing a null to the constructor which causes a call of the new hash method. Further we need to add a new capability so that seed nodes only deliver trade stat objects in case the node has updated.