### PR TITLE
Fix BTC valuation popups

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -254,11 +254,12 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             protected Tooltip computeValue() {
                 String tooltipText = Res.get("mainView.balance.available");
                 try {
+                    String preferredTradeCurrency = model.getPreferences().getPreferredTradeCurrency().getCode();
                     double availableBalance = Double.parseDouble(
                             model.getAvailableBalance().getValue().replace("BTC", ""));
-                    double marketPrice = Double.parseDouble(model.getMarketPrice().getValue());
+                    double marketPrice = Double.parseDouble(model.getMarketPrice(preferredTradeCurrency).getValue());
                     tooltipText += "\n" + currencyFormat.format(availableBalance * marketPrice) +
-                            " " + model.getPreferences().getPreferredTradeCurrency().getCode();
+                            " " + preferredTradeCurrency;
                 } catch (NullPointerException | NumberFormatException e) {
                     // Either the balance or market price is not available yet
                 }
@@ -278,11 +279,12 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             protected Tooltip computeValue() {
                 String tooltipText = Res.get("mainView.balance.reserved");
                 try {
+                    String preferredTradeCurrency = model.getPreferences().getPreferredTradeCurrency().getCode();
                     double reservedBalance = Double.parseDouble(
                             model.getReservedBalance().getValue().replace("BTC", ""));
-                    double marketPrice = Double.parseDouble(model.getMarketPrice().getValue());
+                    double marketPrice = Double.parseDouble(model.getMarketPrice(preferredTradeCurrency).getValue());
                     tooltipText += "\n" + currencyFormat.format(reservedBalance * marketPrice) +
-                            " " + model.getPreferences().getPreferredTradeCurrency().getCode();
+                            " " + preferredTradeCurrency;
                 } catch (NullPointerException | NumberFormatException e) {
                     // Either the balance or market price is not available yet
                 }
@@ -302,11 +304,12 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             protected Tooltip computeValue() {
                 String tooltipText = Res.get("mainView.balance.locked");
                 try {
+                    String preferredTradeCurrency = model.getPreferences().getPreferredTradeCurrency().getCode();
                     double lockedBalance = Double.parseDouble(
                             model.getLockedBalance().getValue().replace("BTC", ""));
-                    double marketPrice = Double.parseDouble(model.getMarketPrice().getValue());
+                    double marketPrice = Double.parseDouble(model.getMarketPrice(preferredTradeCurrency).getValue());
                     tooltipText += "\n" + currencyFormat.format(lockedBalance * marketPrice) +
-                            " " + model.getPreferences().getPreferredTradeCurrency().getCode();
+                            " " + preferredTradeCurrency;
                 } catch (NullPointerException | NumberFormatException e) {
                     // Either the balance or market price is not available yet
                 }

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -613,6 +613,10 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         return marketPricePresentation.getMarketPrice();
     }
 
+    StringProperty getMarketPrice(String currencyCode) {
+        return marketPricePresentation.getMarketPrice(currencyCode);
+    }
+
     public ObservableList<PriceFeedComboBoxItem> getPriceFeedComboBoxItems() {
         return marketPricePresentation.getPriceFeedComboBoxItems();
     }

--- a/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
@@ -242,4 +242,14 @@ public class MarketPricePresentation {
     public StringProperty getMarketPrice() {
         return marketPrice;
     }
+
+    public StringProperty getMarketPrice(String currencyCode) {
+        SimpleStringProperty marketPrice = new SimpleStringProperty(Res.get("shared.na"));
+        try {
+            marketPrice.set(String.valueOf(priceFeedService.getMarketPrice(currencyCode).getPrice()));
+        } catch (NullPointerException e) {
+            // Market price is not available yet
+        }
+        return marketPrice;
+    }
 }


### PR DESCRIPTION
When hovering over the BTC balances, the popup was using the market
price based on the locale combined with the preferred currency as its
units. This lead to the situation where it could show a mismatch
between value and units.

Instead, use the market price based on the preferred currency.

Fixes #3515