### PR TITLE
Update seednode config to increase resource limits for v1.2

### DIFF
--- a/seednode/README.md
+++ b/seednode/README.md
@@ -1,6 +1,9 @@
 # Bisq Seed Node
 
-The distribution ships with a systemd .desktop file. Validate/change the executable/config paths within the shipped `bisq-seednode.service` file and copy/move the file to your systemd directory (something along `/usr/lib/systemd/system/`). Now you can control your *Seed Node* via the usual systemd start/stop commands
+* Install bisq-seednode.service in /etc/systemd/system
+* Install bisq-seednode in /etc/default
+* Modify the executable paths and configuration as necessary
+* Then you can do:
 
 ```
 systemctl start bisq-seednode.service

--- a/seednode/bisq-seednode
+++ b/seednode/bisq-seednode
@@ -1,0 +1,24 @@
+# env for bisq-seednode service
+# install in /etc/default/bisq-seednode
+
+# java home, set to openjdk 10
+JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
+
+# java memory and remote management options
+JAVA_OPTS="-Xms8192M -Xmx8192M -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=127.0.0.1 -Dcom.sun.management.jmxremote.port=6969 -Dcom.sun.management.jmxremote.rmi.port=6969 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+
+# bitcoin rpc credentials
+BITCOIN_RPC_USERNAME=foo
+BITCOIN_RPC_PASSWORD=bar
+
+# bitcoind rpc ports
+BITCOIN_RPC_PORT=8332
+BITCOIN_RPC_BLOCKNOTIFY_PORT=5120
+
+# bisq seednode settings
+BISQ_APP_NAME=bisq-seednode
+BISQ_DATA_DIR=/home/bisq/
+BISQ_NODE_PORT=8000
+BISQ_MAX_CONNECTIONS=50
+BISQ_MAX_MEMORY=8000
+BISQ_BASE_CURRENCY=BTC_MAINNET

--- a/seednode/bisq-seednode.service
+++ b/seednode/bisq-seednode.service
@@ -1,14 +1,23 @@
+# install in /etc/systemd/system/bisq-seednode.service
+
 [Unit]
 Description=Bisq Seed Node
 After=network.target
 
 [Service]
-Environment="JAVA_OPTS=-Xms800M -Xmx800M"
-ExecStart=/home/bisq/bisq/bisq-seednode --appName=seed_BTC_MAINNET --nodePort=8000 --userDataDir=/home/bisq/ --maxConnections=50 --baseCurrencyNetwork=BTC_MAINNET
+EnvironmentFile=/etc/default/bisq-seednode
+ExecStart=/home/bisq/bisq/bisq-seednode --appName=${BISQ_APP_NAME} --nodePort=${BISQ_NODE_PORT} --userDataDir=${BISQ_DATA_DIR} --maxConnections=${BISQ_MAX_CONNECTIONS} --maxMemory=${BISQ_MAX_MEMORY} --fullDaoNode=true --rpcUser=${BITCOIN_RPC_USERNAME} --rpcPassword=${BITCOIN_RPC_PASSWORD} --rpcPort=${BITCOIN_RPC_PORT} --rpcBlockNotificationPort=${BITCOIN_RPC_BLOCKNOTIFY_PORT} --baseCurrencyNetwork=${BISQ_BASE_CURRENCY}
+ExecStop=/bin/kill -TERM ${MAINPID}
 Restart=on-failure
 
 User=bisq
 Group=bisq
+
+PrivateTmp=true
+ProtectSystem=full
+NoNewPrivileges=true
+PrivateDevices=true
+MemoryDenyWriteExecute=false
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Seednodes required more RAM after v1.2 upgrade:
<img width="811" alt="Screen Shot 2019-11-02 at 21 18 48" src="https://user-images.githubusercontent.com/232186/68070800-6ad91e80-fdb6-11e9-90a4-1fec54d1f9a6.png">
