### PR TITLE
Add missing network capability for trade statistics hash update

### DIFF
--- a/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
+++ b/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
@@ -39,7 +39,8 @@ public class CoreNetworkCapabilities {
                 Capability.BUNDLE_OF_ENVELOPES,
                 Capability.MEDIATION,
                 Capability.SIGNED_ACCOUNT_AGE_WITNESS,
-                Capability.REFUND_AGENT
+                Capability.REFUND_AGENT,
+                Capability.TRADE_STATISTICS_HASH_UPDATE
         );
 
         if (BisqEnvironment.isDaoActivated(bisqEnvironment)) {


### PR DESCRIPTION
I think we missed to add the new statistics hash capability to the core network capabilities.
At least this worked for me in my local nodes when I recognized some missing trade statistics.