### PR TITLE
(4/8) Update behavior of add/remove/refresh on duplicate sequence numbers

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -700,12 +700,12 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                     };
                     boolean result = p2PDataStorage.addProtectedStorageEntry(protectedMailboxStorageEntry, networkNode.getNodeAddress(), listener, true);
                     if (!result) {
-                        //TODO remove and add again with a delay to ensure the data will be broadcasted
-                        // The p2PDataStorage.remove makes probably sense but need to be analysed more.
-                        // Don't change that if it is not 100% clear.
                         sendMailboxMessageListener.onFault("Data already exists in our local database");
-                        boolean removeResult = p2PDataStorage.remove(protectedMailboxStorageEntry, networkNode.getNodeAddress(), true);
-                        log.debug("remove result=" + removeResult);
+
+                        // This should only fail if there are concurrent calls to addProtectedStorageEntry with the
+                        // same ProtectedMailboxStorageEntry. This is an unexpected use case so if it happens we
+                        // want to see it, but it is not worth throwing an exception.
+                        log.error("Unexpected state: adding mailbox message that already exists.");
                     }
                 } catch (CryptoException e) {
                     log.error("Signing at getDataWithSignedSeqNr failed. That should never happen.");

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -447,17 +447,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         int sequenceNumber = refreshTTLMessage.getSequenceNumber();
 
-        // If we have seen a more recent operation for this payload, we ignore the current one
-        // TODO: I think we can return false here. All callers use the Client API (refreshTTL(getRefreshTTLMessage()) which increments the sequence number
-        //  leaving only the onMessage() handler which doesn't look at the return value. It makes more intuitive sense that operations that don't
-        //  change state return false.
-        if (sequenceNumberMap.containsKey(hashOfPayload) && sequenceNumberMap.get(hashOfPayload).sequenceNr == sequenceNumber) {
-            log.trace("We got that message with that seq nr already from another peer. We ignore that message.");
-
-            return true;
-        }
-
-        // TODO: Combine with above in future work, but preserve existing behavior for now
         if(!hasSequenceNrIncreased(sequenceNumber, hashOfPayload))
             return false;
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -497,7 +497,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         }
 
         // If we have seen a more recent operation for this payload, ignore this one
-        if (!isSequenceNrValid(protectedStorageEntry.getSequenceNumber(), hashOfPayload))
+        if (!hasSequenceNrIncreased(protectedStorageEntry.getSequenceNumber(), hashOfPayload))
             return false;
 
         // Verify the ProtectedStorageEntry is well formed and valid for the remove operation
@@ -585,7 +585,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         int sequenceNumber = protectedMailboxStorageEntry.getSequenceNumber();
 
-        if (!isSequenceNrValid(sequenceNumber, hashOfPayload))
+        if (!hasSequenceNrIncreased(sequenceNumber, hashOfPayload))
             return false;
 
         PublicKey receiversPubKey = protectedMailboxStorageEntry.getReceiversPubKey();
@@ -708,24 +708,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         map.remove(hashOfPayload);
         log.trace("Data removed from our map. We broadcast the message to our peers.");
         hashMapChangedListeners.forEach(e -> e.onRemoved(protectedStorageEntry));
-    }
-
-    private boolean isSequenceNrValid(int newSequenceNumber, ByteArray hashOfData) {
-        if (sequenceNumberMap.containsKey(hashOfData)) {
-            int storedSequenceNumber = sequenceNumberMap.get(hashOfData).sequenceNr;
-            if (newSequenceNumber >= storedSequenceNumber) {
-                log.trace("Sequence number is valid (>=). sequenceNumber = "
-                        + newSequenceNumber + " / storedSequenceNumber=" + storedSequenceNumber);
-                return true;
-            } else {
-                log.debug("Sequence number is invalid. sequenceNumber = "
-                        + newSequenceNumber + " / storedSequenceNumber=" + storedSequenceNumber + "\n" +
-                        "That can happen if the data owner gets an old delayed data storage message.");
-                return false;
-            }
-        } else {
-            return true;
-        }
     }
 
     private boolean hasSequenceNrIncreased(int newSequenceNumber, ByteArray hashOfData) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -93,6 +93,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Slf4j
 public class P2PDataStorage implements MessageListener, ConnectionListener, PersistedDataHost {
     /**
@@ -475,6 +477,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     public boolean remove(ProtectedStorageEntry protectedStorageEntry,
                           @Nullable NodeAddress sender,
                           boolean isDataOwner) {
+        checkArgument(!(protectedStorageEntry instanceof ProtectedMailboxStorageEntry), "Use removeMailboxData for ProtectedMailboxStorageEntry");
+
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
         boolean containsKey = map.containsKey(hashOfPayload);

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -976,7 +976,7 @@ public class P2PDataStorageTest {
             ProtectedStorageEntry entry = this.getProtectedStorageEntryForAdd(1);
             doProtectedStorageAddAndVerify(entry, true, true);
 
-            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys,1), true, false);
+            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys,1), false, false);
         }
 
         // TESTCASE: Duplicate refresh message (same seq #)
@@ -986,7 +986,7 @@ public class P2PDataStorageTest {
             doProtectedStorageAddAndVerify(entry, true, true);
 
             doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), true, true);
-            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), true, false);
+            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), false, false);
         }
 
         // TESTCASE: Duplicate refresh message (greater seq #)

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -737,12 +737,11 @@ public class P2PDataStorageTest {
         }
 
         // TESTCASE: Adding duplicate payload w/ same sequence number
-        // TODO: Should adds() of existing sequence #s return false since they don't update state?
         @Test
         public void addProtectedStorageEntry_duplicateSeqNrGt0() throws CryptoException {
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
-            doProtectedStorageAddAndVerify(entryForAdd, true, false);
+            doProtectedStorageAddAndVerify(entryForAdd, false, false);
         }
 
         // TESTCASE: Adding duplicate payload w/ 0 sequence number (special branch in code for logging)
@@ -750,7 +749,7 @@ public class P2PDataStorageTest {
         public void addProtectedStorageEntry_duplicateSeqNrEq0() throws CryptoException {
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(0);
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
-            doProtectedStorageAddAndVerify(entryForAdd, true, false);
+            doProtectedStorageAddAndVerify(entryForAdd, false, false);
         }
 
         // TESTCASE: Adding duplicate payload for w/ lower sequence number

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -1162,12 +1162,7 @@ public class P2PDataStorageTest {
         }
 
 
-        // XXXBUGXXX: The P2PService calls remove() instead of removeFromMailbox() in the addMailboxData() path.
-        // This test shows it will always fail even with a valid remove entry. Future work should be able to
-        // combine the remove paths in the same way the add() paths are combined. This will require deprecating
-        // the receiversPubKey field which is a duplicate of the ownerPubKey in the MailboxStoragePayload.
-        // More investigation is needed.
-        @Test
+        @Test(expected = IllegalArgumentException.class)
         public void remove_canCallWrongRemoveAndFail() throws CryptoException {
 
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
@@ -1175,38 +1170,9 @@ public class P2PDataStorageTest {
 
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
 
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForRemove);
-
             // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails
-            boolean addResult = super.doRemove(entryForRemove);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            // should succeed with expectedStatechange==true when remove paths are combined
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForRemove, false, this.expectIsDataOwner());
-        }
-
-        // TESTCASE: Verify misuse of the API (calling remove() instead of removeFromMailbox correctly errors with
-        // a payload that is valid for remove of a non-mailbox entry.
-        @Test
-        public void remove_canCallWrongRemoveAndFailInvalidPayload() throws CryptoException {
-
-            ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
-
-            doProtectedStorageAddAndVerify(entryForAdd, true, true);
-
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForAdd);
-
-            // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails with a payload that isn't signed by payload.ownerPubKey
-            boolean addResult = super.doRemove(entryForAdd);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForAdd, false, this.expectIsDataOwner());
+            // it fails spectacularly
+            super.doRemove(entryForRemove);
         }
 
         // TESTCASE: Add after removed when add-once required (greater seq #)


### PR DESCRIPTION
These patches changs some unexpected behavior when handling operations that have duplicate sequence numbers.

Now, if no internal state is changed the entry points will always return false.

It also fixes a subtle behavior of remove() where the code would allow duplicate add() operations if a
remove was processed with an equivalent sequence number.

Now, all operations require an increasing sequence number to update any internal state. I think this is a much easier way to think about the system, but I have no historical context for if/when these operations required equivalent sequence numbers between add() and remove().

I think it also closes a hole where a malicious node could rebroadcast an add() as a remove() and have it succeed. There are still other holes, but it moves it in the right direction.

This is the highest risk change in this stack.