### PR TITLE
Limit max. nr. of PersistableNetworkPayload and ProtectedStorageEntries

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/messages/GetBlocksResponse.java
+++ b/core/src/main/java/bisq/core/dao/node/messages/GetBlocksResponse.java
@@ -57,13 +57,15 @@ public final class GetBlocksResponse extends NetworkEnvelope implements DirectMe
 
     @Override
     public protobuf.NetworkEnvelope toProtoNetworkEnvelope() {
-        return getNetworkEnvelopeBuilder()
+        protobuf.NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetBlocksResponse(protobuf.GetBlocksResponse.newBuilder()
                         .addAllRawBlocks(blocks.stream()
                                 .map(RawBlock::toProtoMessage)
                                 .collect(Collectors.toList()))
                         .setRequestNonce(requestNonce))
                 .build();
+        log.info("Sending a GetBlocksResponse with {} kB", proto.getSerializedSize() / 1000d);
+        return proto;
     }
 
     public static NetworkEnvelope fromProto(protobuf.GetBlocksResponse proto, int messageVersion) {

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +51,7 @@ import org.jetbrains.annotations.NotNull;
 @Slf4j
 public class GetDataRequestHandler {
     private static final long TIMEOUT = 90;
+    private static final int MAX_ENTRIES = 10000;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -138,13 +140,22 @@ public class GetDataRequestHandler {
                                                                                 Connection connection) {
         final Set<P2PDataStorage.ByteArray> tempLookupSet = new HashSet<>();
         Set<P2PDataStorage.ByteArray> excludedKeysAsByteArray = P2PDataStorage.ByteArray.convertBytesSetToByteArraySet(getDataRequest.getExcludedKeys());
-
-        return dataStorage.getAppendOnlyDataStoreMap().entrySet().stream()
+        AtomicInteger maxSize = new AtomicInteger(MAX_ENTRIES);
+        Set<PersistableNetworkPayload> result = dataStorage.getAppendOnlyDataStoreMap().entrySet().stream()
                 .filter(e -> !excludedKeysAsByteArray.contains(e.getKey()))
+                .filter(e -> maxSize.decrementAndGet() >= 0)
                 .map(Map.Entry::getValue)
-                .filter(payload -> (connection.noCapabilityRequiredOrCapabilityIsSupported(payload)))
-                .filter(payload -> tempLookupSet.add(new P2PDataStorage.ByteArray(payload.getHash())))
+                .filter(connection::noCapabilityRequiredOrCapabilityIsSupported)
+                .filter(payload -> {
+                    boolean notContained = tempLookupSet.add(new P2PDataStorage.ByteArray(payload.getHash()));
+                    return notContained;
+                })
                 .collect(Collectors.toSet());
+        if (maxSize.get() <= 0) {
+            log.warn("The peer request caused too much PersistableNetworkPayload entries to get delivered. We limited the entries for the response to {} entries", MAX_ENTRIES);
+        }
+        log.info("PersistableNetworkPayload set contains {} entries ", result.size());
+        return result;
     }
 
     private Set<ProtectedStorageEntry> getFilteredProtectedStorageEntries(GetDataRequest getDataRequest,
@@ -152,11 +163,17 @@ public class GetDataRequestHandler {
         final Set<ProtectedStorageEntry> filteredDataSet = new HashSet<>();
         final Set<Integer> lookupSet = new HashSet<>();
 
+        AtomicInteger maxSize = new AtomicInteger(MAX_ENTRIES);
         Set<P2PDataStorage.ByteArray> excludedKeysAsByteArray = P2PDataStorage.ByteArray.convertBytesSetToByteArraySet(getDataRequest.getExcludedKeys());
         Set<ProtectedStorageEntry> filteredSet = dataStorage.getMap().entrySet().stream()
                 .filter(e -> !excludedKeysAsByteArray.contains(e.getKey()))
+                .filter(e -> maxSize.decrementAndGet() >= 0)
                 .map(Map.Entry::getValue)
                 .collect(Collectors.toSet());
+        if (maxSize.get() <= 0) {
+            log.warn("The peer request caused too much ProtectedStorageEntry entries to get delivered. We limited the entries for the response to {} entries", MAX_ENTRIES);
+        }
+        log.info("getFilteredProtectedStorageEntries " + filteredSet.size());
 
         for (ProtectedStorageEntry protectedStorageEntry : filteredSet) {
             final ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
@@ -171,11 +188,13 @@ public class GetDataRequestHandler {
                 doAdd = true;
             }
             if (doAdd) {
-                if (lookupSet.add(protectedStoragePayload.hashCode()))
+                boolean notContained = lookupSet.add(protectedStoragePayload.hashCode());
+                if (notContained)
                     filteredDataSet.add(protectedStorageEntry);
             }
         }
 
+        log.info("ProtectedStorageEntry set contains {} entries ", filteredDataSet.size());
         return filteredDataSet;
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -111,14 +111,14 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
         protobuf.NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetDataResponse(builder)
                 .build();
-        log.info("Sending a GetDataResponse with size = {} bytes", proto.toByteArray().length);
+        log.info("Sending a GetDataResponse with {} kB", proto.getSerializedSize() / 1000d);
         return proto;
     }
 
     public static GetDataResponse fromProto(protobuf.GetDataResponse proto,
                                             NetworkProtoResolver resolver,
                                             int messageVersion) {
-        log.info("Received a GetDataResponse with size = {} bytes", proto.toByteArray().length);
+        log.info("Received a GetDataResponse with {} kB", proto.getSerializedSize() / 1000d);
         Set<ProtectedStorageEntry> dataSet = new HashSet<>(
                 proto.getDataSetList().stream()
                         .map(entry -> (ProtectedStorageEntry) resolver.fromProto(entry))

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
@@ -81,12 +81,12 @@ public final class GetUpdatedDataRequest extends GetDataRequest implements Sende
         NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetUpdatedDataRequest(builder)
                 .build();
-        log.info("Sending a GetUpdatedDataRequest with size = {} bytes", proto.toByteArray().length);
+        log.info("Sending a GetUpdatedDataRequest with {} kB", proto.getSerializedSize() / 1000d);
         return proto;
     }
 
     public static GetUpdatedDataRequest fromProto(protobuf.GetUpdatedDataRequest proto, int messageVersion) {
-        log.info("Received a GetUpdatedDataRequest with size = {} bytes", proto.toByteArray().length);
+        log.info("Received a GetUpdatedDataRequest with {} kB", proto.getSerializedSize() / 1000d);
         return new GetUpdatedDataRequest(NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getNonce(),
                 ProtoUtil.byteSetFromProtoByteStringList(proto.getExcludedKeysList()),

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
@@ -79,12 +79,12 @@ public final class PreliminaryGetDataRequest extends GetDataRequest implements A
         NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setPreliminaryGetDataRequest(builder)
                 .build();
-        log.info("Sending a PreliminaryGetDataRequest with size = {} bytes", proto.toByteArray().length);
+        log.info("Sending a PreliminaryGetDataRequest with {} kB", proto.getSerializedSize() / 1000d);
         return proto;
     }
 
     public static PreliminaryGetDataRequest fromProto(protobuf.PreliminaryGetDataRequest proto, int messageVersion) {
-        log.info("Received a PreliminaryGetDataRequest with size = {} bytes", proto.toByteArray().length);
+        log.info("Received a PreliminaryGetDataRequest with {} kB", proto.getSerializedSize() / 1000d);
         Capabilities supportedCapabilities = proto.getSupportedCapabilitiesList().isEmpty() ?
                 null :
                 Capabilities.fromIntList(proto.getSupportedCapabilitiesList());

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -504,6 +504,37 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         return result;
     }
 
+
+    /**
+     * This method must be called only from client code not from network messages! We omit the ownership checks
+     * so we must apply it only if it comes from our trusted application code. It is used from client code which detects
+     * that the domain object violates specific domain rules.
+     * We could make it more generic by adding an Interface with a generic validation method.
+     *
+     * @param protectedStorageEntry     The entry to be removed
+     */
+    public void removeInvalidProtectedStorageEntry(ProtectedStorageEntry protectedStorageEntry) {
+        ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
+        ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
+
+        if (!map.containsKey(hashOfPayload)) {
+            return;
+        }
+
+        doRemoveProtectedExpirableData(protectedStorageEntry, hashOfPayload);
+        removeFromProtectedDataStore(protectedStorageEntry);
+
+        // We do not update the sequence number as that method is only called if we have received an invalid
+        // protectedStorageEntry from a previous add operation.
+
+        // We do not call maybeAddToRemoveAddOncePayloads to avoid that an invalid object might block a valid object
+        // which we might receive in future (could be potential attack).
+
+        // We do not broadcast as this is a local operation only to avoid our maps get polluted with invalid objects
+        // and as we do not check for ownership a node would not accept such a procedure if it would come from untrusted
+        // source (network).
+    }
+
     private void removeFromProtectedDataStore(ProtectedStorageEntry protectedStorageEntry) {
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         if (protectedStoragePayload instanceof PersistablePayload) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -514,6 +514,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
      * @param protectedStorageEntry     The entry to be removed
      */
     public void removeInvalidProtectedStorageEntry(ProtectedStorageEntry protectedStorageEntry) {
+        log.warn("We remove an invalid protectedStorageEntry: {}", protectedStorageEntry);
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
 


### PR DESCRIPTION


To avoid that seed nodes get overloaded with requests for too many
PersistableNetworkPayload and ProtectedStorageEntry data we limit nr. of
entries to max 10000.