### PR TITLE
Hide avoid standby mode feature on *nux OS

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -53,6 +53,7 @@ import bisq.core.util.validation.IntegerValidator;
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
 import bisq.common.util.Tuple3;
+import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Coin;
 
@@ -144,7 +145,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     private ChangeListener<Boolean> useCustomFeeCheckboxListener;
     private ChangeListener<Number> transactionFeeChangeListener;
     private final boolean daoOptionsSet;
-
+    private final boolean displayStandbyModeFeature;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor, initialisation
@@ -173,6 +174,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                 rpcUser != null && !rpcUser.isEmpty() &&
                 rpcPassword != null && !rpcPassword.isEmpty() &&
                 rpcBlockNotificationPort != null && !rpcBlockNotificationPort.isEmpty();
+        this.displayStandbyModeFeature = Utilities.isOSX() || Utilities.isWindows();
     }
 
     @Override
@@ -224,7 +226,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void initializeGeneralOptions() {
-        TitledGroupBg titledGroupBg = addTitledGroupBg(root, gridRow, 8, Res.get("setting.preferences.general"));
+        int titledGroupBgRowSpan = displayStandbyModeFeature ? 8 : 7;
+        TitledGroupBg titledGroupBg = addTitledGroupBg(root, gridRow, titledGroupBgRowSpan, Res.get("setting.preferences.general"));
         GridPane.setColumnSpan(titledGroupBg, 1);
 
         userLanguageComboBox = addComboBox(root, gridRow,
@@ -346,9 +349,11 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             }
         };
 
-        // AvoidStandbyModeService
-        avoidStandbyMode = addSlideToggleButton(root, ++gridRow,
-                Res.get("setting.preferences.avoidStandbyMode"));
+        if (displayStandbyModeFeature) {
+            // AvoidStandbyModeService feature works only on OSX & Windows
+            avoidStandbyMode = addSlideToggleButton(root, ++gridRow,
+                    Res.get("setting.preferences.avoidStandbyMode"));
+        }
     }
 
     private void initializeSeparator() {
@@ -806,8 +811,10 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
         // We use opposite property (useStandbyMode) in preferences to have the default value (false) set as we want it,
         // so users who update gets set avoidStandbyMode=true (useStandbyMode=false)
-        avoidStandbyMode.setSelected(!preferences.isUseStandbyMode());
-        avoidStandbyMode.setOnAction(e -> preferences.setUseStandbyMode(!avoidStandbyMode.isSelected()));
+        if (displayStandbyModeFeature) {
+            avoidStandbyMode.setSelected(!preferences.isUseStandbyMode());
+            avoidStandbyMode.setOnAction(e -> preferences.setUseStandbyMode(!avoidStandbyMode.isSelected()));
+        }
     }
 
     private void activateDaoPreferences() {
@@ -929,7 +936,9 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         sortMarketCurrenciesNumerically.setOnAction(null);
         showOwnOffersInOfferBook.setOnAction(null);
         resetDontShowAgainButton.setOnAction(null);
-        avoidStandbyMode.setOnAction(null);
+        if (displayStandbyModeFeature) {
+            avoidStandbyMode.setOnAction(null);
+        }
     }
 
     private void deactivateDaoPreferences() {

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -814,6 +814,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         if (displayStandbyModeFeature) {
             avoidStandbyMode.setSelected(!preferences.isUseStandbyMode());
             avoidStandbyMode.setOnAction(e -> preferences.setUseStandbyMode(!avoidStandbyMode.isSelected()));
+        } else {
+            preferences.setUseStandbyMode(false);
         }
     }
 


### PR DESCRIPTION
Displays standby mode button on only on Windows and OSX,
and hides it on Linux and Unix distributions.

TitledGroupBg num rows reduced to 7 when standby mode button
is not displayed.

Fixes #3223

Replaces PR #3322 -- rejected because source file reformat
rearanged class level field declarations, making review
more difficult.