### PR TITLE
(5/8) Test P2PDataStore expiration code and make testing time sensitive code easier.

### DIFF
--- a/common/src/main/java/bisq/common/proto/network/NetworkProtoResolver.java
+++ b/common/src/main/java/bisq/common/proto/network/NetworkProtoResolver.java
@@ -20,6 +20,8 @@ package bisq.common.proto.network;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.ProtobufferException;
 
+import java.time.Clock;
+
 
 public interface NetworkProtoResolver extends ProtoResolver {
     NetworkEnvelope fromProto(protobuf.NetworkEnvelope proto) throws ProtobufferException;
@@ -27,4 +29,6 @@ public interface NetworkProtoResolver extends ProtoResolver {
     NetworkPayload fromProto(protobuf.StoragePayload proto);
 
     NetworkPayload fromProto(protobuf.StorageEntryWrapper proto);
+
+    Clock getClock();
 }

--- a/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -59,10 +59,16 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.persistable.PersistableEnvelope;
 
+import java.time.Clock;
+
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CoreProtoResolver implements ProtoResolver {
+    @Getter
+    protected Clock clock;
+
     @Override
     public PaymentAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
         if (proto != null) {

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -88,6 +88,8 @@ import bisq.common.proto.network.NetworkProtoResolver;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import java.time.Clock;
+
 import lombok.extern.slf4j.Slf4j;
 
 // TODO Use ProtobufferException instead of ProtobufferRuntimeException
@@ -95,7 +97,8 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class CoreNetworkProtoResolver extends CoreProtoResolver implements NetworkProtoResolver {
     @Inject
-    public CoreNetworkProtoResolver() {
+    public CoreNetworkProtoResolver(Clock clock) {
+        this.clock = clock;
     }
 
     @Override

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -49,6 +49,8 @@ import bisq.common.storage.Storage;
 
 import org.springframework.core.env.PropertySource;
 
+import java.time.Clock;
+
 import java.io.File;
 
 import java.util.Collections;
@@ -118,7 +120,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
 
             // start the network node
             networkNode = new TorNetworkNode(Integer.parseInt(configuration.getProperty(TOR_PROXY_PORT, "9053")),
-                    new CoreNetworkProtoResolver(), false,
+                    new CoreNetworkProtoResolver(Clock.systemDefaultZone()), false,
                     new AvailableTor(Monitor.TOR_WORKING_DIR, torHiddenServiceDir.getName()));
             networkNode.start(this);
 
@@ -139,7 +141,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
                 });
                 CorruptedDatabaseFilesHandler corruptedDatabaseFilesHandler = new CorruptedDatabaseFilesHandler();
                 int maxConnections = Integer.parseInt(configuration.getProperty(MAX_CONNECTIONS, "12"));
-                NetworkProtoResolver networkProtoResolver = new CoreNetworkProtoResolver();
+                NetworkProtoResolver networkProtoResolver = new CoreNetworkProtoResolver(Clock.systemDefaultZone());
                 CorePersistenceProtoResolver persistenceProtoResolver = new CorePersistenceProtoResolver(null,
                         networkProtoResolver, storageDir, corruptedDatabaseFilesHandler);
                 DefaultSeedNodeRepository seedNodeRepository = new DefaultSeedNodeRepository(environment, null);

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
@@ -39,6 +39,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
 
+import java.time.Clock;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +92,7 @@ public abstract class P2PSeedNodeSnapshotBase extends Metric implements MessageL
     protected void execute() {
         // start the network node
         final NetworkNode networkNode = new TorNetworkNode(Integer.parseInt(configuration.getProperty(TOR_PROXY_PORT, "9054")),
-                new CoreNetworkProtoResolver(), false,
+                new CoreNetworkProtoResolver(Clock.systemDefaultZone()), false,
                 new AvailableTor(Monitor.TOR_WORKING_DIR, "unused"));
         // we do not need to start the networkNode, as we do not need the HS
         //networkNode.start(this);

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -700,12 +700,12 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                     };
                     boolean result = p2PDataStorage.addProtectedStorageEntry(protectedMailboxStorageEntry, networkNode.getNodeAddress(), listener, true);
                     if (!result) {
-                        //TODO remove and add again with a delay to ensure the data will be broadcasted
-                        // The p2PDataStorage.remove makes probably sense but need to be analysed more.
-                        // Don't change that if it is not 100% clear.
                         sendMailboxMessageListener.onFault("Data already exists in our local database");
-                        boolean removeResult = p2PDataStorage.remove(protectedMailboxStorageEntry, networkNode.getNodeAddress(), true);
-                        log.debug("remove result=" + removeResult);
+
+                        // This should only fail if there are concurrent calls to addProtectedStorageEntry with the
+                        // same ProtectedMailboxStorageEntry. This is an unexpected use case so if it happens we
+                        // want to see it, but it is not worth throwing an exception.
+                        log.error("Unexpected state: adding mailbox message that already exists.");
                     }
                 } catch (CryptoException e) {
                     log.error("Signing at getDataWithSignedSeqNr failed. That should never happen.");

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -124,6 +124,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     private final Set<ProtectedDataStoreListener> protectedDataStoreListeners = new CopyOnWriteArraySet<>();
     private final Clock clock;
 
+    protected int maxSequenceNumberMapSizeBeforePurge;
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -148,6 +150,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         this.sequenceNumberMapStorage = sequenceNumberMapStorage;
         sequenceNumberMapStorage.setNumMaxBackupFiles(5);
+        this.maxSequenceNumberMapSizeBeforePurge = 1000;
     }
 
     @Override
@@ -209,7 +212,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         });
         hashMapChangedListeners.forEach(HashMapChangedListener::onBatchRemoveExpiredDataCompleted);
 
-        if (sequenceNumberMap.size() > 1000)
+        if (sequenceNumberMap.size() > this.maxSequenceNumberMapSizeBeforePurge)
             sequenceNumberMap.setMap(getPurgedSequenceNumberMap(sequenceNumberMap.getMap()));
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -447,17 +447,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         int sequenceNumber = refreshTTLMessage.getSequenceNumber();
 
-        // If we have seen a more recent operation for this payload, we ignore the current one
-        // TODO: I think we can return false here. All callers use the Client API (refreshTTL(getRefreshTTLMessage()) which increments the sequence number
-        //  leaving only the onMessage() handler which doesn't look at the return value. It makes more intuitive sense that operations that don't
-        //  change state return false.
-        if (sequenceNumberMap.containsKey(hashOfPayload) && sequenceNumberMap.get(hashOfPayload).sequenceNr == sequenceNumber) {
-            log.trace("We got that message with that seq nr already from another peer. We ignore that message.");
-
-            return true;
-        }
-
-        // TODO: Combine with above in future work, but preserve existing behavior for now
         if(!hasSequenceNrIncreased(sequenceNumber, hashOfPayload))
             return false;
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -497,7 +497,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         }
 
         // If we have seen a more recent operation for this payload, ignore this one
-        if (!isSequenceNrValid(protectedStorageEntry.getSequenceNumber(), hashOfPayload))
+        if (!hasSequenceNrIncreased(protectedStorageEntry.getSequenceNumber(), hashOfPayload))
             return false;
 
         // Verify the ProtectedStorageEntry is well formed and valid for the remove operation
@@ -585,7 +585,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         int sequenceNumber = protectedMailboxStorageEntry.getSequenceNumber();
 
-        if (!isSequenceNrValid(sequenceNumber, hashOfPayload))
+        if (!hasSequenceNrIncreased(sequenceNumber, hashOfPayload))
             return false;
 
         PublicKey receiversPubKey = protectedMailboxStorageEntry.getReceiversPubKey();
@@ -708,24 +708,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         map.remove(hashOfPayload);
         log.trace("Data removed from our map. We broadcast the message to our peers.");
         hashMapChangedListeners.forEach(e -> e.onRemoved(protectedStorageEntry));
-    }
-
-    private boolean isSequenceNrValid(int newSequenceNumber, ByteArray hashOfData) {
-        if (sequenceNumberMap.containsKey(hashOfData)) {
-            int storedSequenceNumber = sequenceNumberMap.get(hashOfData).sequenceNr;
-            if (newSequenceNumber >= storedSequenceNumber) {
-                log.trace("Sequence number is valid (>=). sequenceNumber = "
-                        + newSequenceNumber + " / storedSequenceNumber=" + storedSequenceNumber);
-                return true;
-            } else {
-                log.debug("Sequence number is invalid. sequenceNumber = "
-                        + newSequenceNumber + " / storedSequenceNumber=" + storedSequenceNumber + "\n" +
-                        "That can happen if the data owner gets an old delayed data storage message.");
-                return false;
-            }
-        } else {
-            return true;
-        }
     }
 
     private boolean hasSequenceNrIncreased(int newSequenceNumber, ByteArray hashOfData) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -93,6 +93,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Slf4j
 public class P2PDataStorage implements MessageListener, ConnectionListener, PersistedDataHost {
     /**
@@ -475,6 +477,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     public boolean remove(ProtectedStorageEntry protectedStorageEntry,
                           @Nullable NodeAddress sender,
                           boolean isDataOwner) {
+        checkArgument(!(protectedStorageEntry instanceof ProtectedMailboxStorageEntry), "Use removeMailboxData for ProtectedMailboxStorageEntry");
+
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
         boolean containsKey = map.containsKey(hashOfPayload);

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -41,10 +41,33 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                         int sequenceNumber,
                                         byte[] signature,
                                         PublicKey receiversPubKey) {
-        super(mailboxStoragePayload, ownerPubKey, sequenceNumber, signature);
+        this(mailboxStoragePayload,
+                Sig.getPublicKeyBytes(ownerPubKey),
+                ownerPubKey,
+                sequenceNumber,
+                signature,
+                Sig.getPublicKeyBytes(receiversPubKey),
+                receiversPubKey,
+                System.currentTimeMillis());
+    }
+
+    private ProtectedMailboxStorageEntry(MailboxStoragePayload mailboxStoragePayload,
+                                        byte[] ownerPubKeyBytes,
+                                        PublicKey ownerPubKey,
+                                        int sequenceNumber,
+                                        byte[] signature,
+                                        byte[] receiversPubKeyBytes,
+                                        PublicKey receiversPubKey,
+                                        long creationTimeStamp) {
+        super(mailboxStoragePayload,
+                ownerPubKeyBytes,
+                ownerPubKey,
+                sequenceNumber,
+                signature,
+                creationTimeStamp);
 
         this.receiversPubKey = receiversPubKey;
-        receiversPubKeyBytes = Sig.getPublicKeyBytes(receiversPubKey);
+        this.receiversPubKeyBytes = receiversPubKeyBytes;
     }
 
     public MailboxStoragePayload getMailboxStoragePayload() {
@@ -56,22 +79,20 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private ProtectedMailboxStorageEntry(long creationTimeStamp,
-                                         MailboxStoragePayload mailboxStoragePayload,
-                                         byte[] ownerPubKey,
+    private ProtectedMailboxStorageEntry(MailboxStoragePayload mailboxStoragePayload,
+                                         byte[] ownerPubKeyBytes,
                                          int sequenceNumber,
                                          byte[] signature,
-                                         byte[] receiversPubKeyBytes) {
-        super(creationTimeStamp,
-                mailboxStoragePayload,
-                ownerPubKey,
+                                         byte[] receiversPubKeyBytes,
+                                         long creationTimeStamp) {
+        this(mailboxStoragePayload,
+                ownerPubKeyBytes,
+                Sig.getPublicKeyFromBytes(ownerPubKeyBytes),
                 sequenceNumber,
-                signature);
-
-        this.receiversPubKeyBytes = receiversPubKeyBytes;
-        receiversPubKey = Sig.getPublicKeyFromBytes(receiversPubKeyBytes);
-
-        maybeAdjustCreationTimeStamp();
+                signature,
+                receiversPubKeyBytes,
+                Sig.getPublicKeyFromBytes(receiversPubKeyBytes),
+                creationTimeStamp);
     }
 
     public protobuf.ProtectedMailboxStorageEntry toProtoMessage() {
@@ -85,12 +106,12 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                                          NetworkProtoResolver resolver) {
         ProtectedStorageEntry entry = ProtectedStorageEntry.fromProto(proto.getEntry(), resolver);
         return new ProtectedMailboxStorageEntry(
-                entry.getCreationTimeStamp(),
                 (MailboxStoragePayload) entry.getProtectedStoragePayload(),
                 entry.getOwnerPubKey().getEncoded(),
                 entry.getSequenceNumber(),
                 entry.getSignature(),
-                proto.getReceiversPubKeyBytes().toByteArray());
+                proto.getReceiversPubKeyBytes().toByteArray(),
+                entry.getCreationTimeStamp());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -25,6 +25,8 @@ import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
+import java.time.Clock;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +42,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                         PublicKey ownerPubKey,
                                         int sequenceNumber,
                                         byte[] signature,
-                                        PublicKey receiversPubKey) {
+                                        PublicKey receiversPubKey,
+                                        Clock clock) {
         this(mailboxStoragePayload,
                 Sig.getPublicKeyBytes(ownerPubKey),
                 ownerPubKey,
@@ -48,7 +51,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                 signature,
                 Sig.getPublicKeyBytes(receiversPubKey),
                 receiversPubKey,
-                System.currentTimeMillis());
+                clock.millis(),
+                clock);
     }
 
     private ProtectedMailboxStorageEntry(MailboxStoragePayload mailboxStoragePayload,
@@ -58,13 +62,15 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                         byte[] signature,
                                         byte[] receiversPubKeyBytes,
                                         PublicKey receiversPubKey,
-                                        long creationTimeStamp) {
+                                        long creationTimeStamp,
+                                        Clock clock) {
         super(mailboxStoragePayload,
                 ownerPubKeyBytes,
                 ownerPubKey,
                 sequenceNumber,
                 signature,
-                creationTimeStamp);
+                creationTimeStamp,
+                clock);
 
         this.receiversPubKey = receiversPubKey;
         this.receiversPubKeyBytes = receiversPubKeyBytes;
@@ -84,7 +90,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                          int sequenceNumber,
                                          byte[] signature,
                                          byte[] receiversPubKeyBytes,
-                                         long creationTimeStamp) {
+                                         long creationTimeStamp,
+                                         Clock clock) {
         this(mailboxStoragePayload,
                 ownerPubKeyBytes,
                 Sig.getPublicKeyFromBytes(ownerPubKeyBytes),
@@ -92,7 +99,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                 signature,
                 receiversPubKeyBytes,
                 Sig.getPublicKeyFromBytes(receiversPubKeyBytes),
-                creationTimeStamp);
+                creationTimeStamp,
+                clock);
     }
 
     public protobuf.ProtectedMailboxStorageEntry toProtoMessage() {
@@ -111,7 +119,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                 entry.getSequenceNumber(),
                 entry.getSignature(),
                 proto.getReceiversPubKeyBytes().toByteArray(),
-                entry.getCreationTimeStamp());
+                entry.getCreationTimeStamp(),
+                resolver.getClock());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -43,37 +43,50 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
     private long creationTimeStamp;
 
     public ProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
-                                 PublicKey ownerPubKey,
-                                 int sequenceNumber,
-                                 byte[] signature) {
-        this.protectedStoragePayload = protectedStoragePayload;
-        ownerPubKeyBytes = Sig.getPublicKeyBytes(ownerPubKey);
-        this.ownerPubKey = ownerPubKey;
-
-        this.sequenceNumber = sequenceNumber;
-        this.signature = signature;
-        this.creationTimeStamp = System.currentTimeMillis();
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // PROTO BUFFER
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-    protected ProtectedStorageEntry(long creationTimeStamp,
-                                    ProtectedStoragePayload protectedStoragePayload,
-                                    byte[] ownerPubKeyBytes,
+                                    PublicKey ownerPubKey,
                                     int sequenceNumber,
                                     byte[] signature) {
+        this(protectedStoragePayload,
+                Sig.getPublicKeyBytes(ownerPubKey),
+                ownerPubKey,
+                sequenceNumber,
+                signature,
+                System.currentTimeMillis());
+    }
+
+    protected ProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
+                                 byte[] ownerPubKeyBytes,
+                                 PublicKey ownerPubKey,
+                                 int sequenceNumber,
+                                 byte[] signature,
+                                 long creationTimeStamp) {
+
         this.protectedStoragePayload = protectedStoragePayload;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
-        ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyBytes);
+        this.ownerPubKey = ownerPubKey;
 
         this.sequenceNumber = sequenceNumber;
         this.signature = signature;
         this.creationTimeStamp = creationTimeStamp;
 
         maybeAdjustCreationTimeStamp();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private ProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
+                                    byte[] ownerPubKeyBytes,
+                                    int sequenceNumber,
+                                    byte[] signature,
+                                    long creationTimeStamp) {
+        this(protectedStoragePayload,
+                ownerPubKeyBytes,
+                Sig.getPublicKeyFromBytes(ownerPubKeyBytes),
+                sequenceNumber,
+                signature,
+                creationTimeStamp);
     }
 
     public Message toProtoMessage() {
@@ -93,11 +106,12 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
 
     public static ProtectedStorageEntry fromProto(protobuf.ProtectedStorageEntry proto,
                                                   NetworkProtoResolver resolver) {
-        return new ProtectedStorageEntry(proto.getCreationTimeStamp(),
+        return new ProtectedStorageEntry(
                 ProtectedStoragePayload.fromProto(proto.getStoragePayload(), resolver),
                 proto.getOwnerPubKeyBytes().toByteArray(),
                 proto.getSequenceNumber(),
-                proto.getSignature().toByteArray());
+                proto.getSignature().toByteArray(),
+                proto.getCreationTimeStamp());
     }
 
 

--- a/p2p/src/test/java/bisq/network/p2p/TestUtils.java
+++ b/p2p/src/test/java/bisq/network/p2p/TestUtils.java
@@ -27,6 +27,8 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 
+import java.time.Clock;
+
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
@@ -184,6 +186,9 @@ public class TestUtils {
             public NetworkPayload fromProto(protobuf.StorageEntryWrapper proto) {
                 return null;
             }
+
+            @Override
+            public Clock getClock() { return null; }
         };
     }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -976,7 +976,7 @@ public class P2PDataStorageTest {
             ProtectedStorageEntry entry = this.getProtectedStorageEntryForAdd(1);
             doProtectedStorageAddAndVerify(entry, true, true);
 
-            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys,1), true, false);
+            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys,1), false, false);
         }
 
         // TESTCASE: Duplicate refresh message (same seq #)
@@ -986,7 +986,7 @@ public class P2PDataStorageTest {
             doProtectedStorageAddAndVerify(entry, true, true);
 
             doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), true, true);
-            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), true, false);
+            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), false, false);
         }
 
         // TESTCASE: Duplicate refresh message (greater seq #)

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -191,7 +191,7 @@ public class P2PDataStorageTest {
         byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new P2PDataStorage.DataAndSeqNrPair(protectedStoragePayload, sequenceNumber));
         byte[] signature = Sig.sign(entrySignerKeys.getPrivate(), hashOfDataAndSeqNr);
 
-        return new ProtectedStorageEntry(protectedStoragePayload, entryOwnerKeys.getPublic(), sequenceNumber, signature);
+        return new ProtectedStorageEntry(protectedStoragePayload, entryOwnerKeys.getPublic(), sequenceNumber, signature, Clock.systemDefaultZone());
     }
 
     private static MailboxStoragePayload buildMailboxStoragePayload(PublicKey payloadSenderPubKeyForAddOperation,
@@ -220,7 +220,7 @@ public class P2PDataStorageTest {
         byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new P2PDataStorage.DataAndSeqNrPair(payload, sequenceNumber));
         byte[] signature = Sig.sign(entrySigner, hashOfDataAndSeqNr);
         return new ProtectedMailboxStorageEntry(payload,
-                entryOwnerPubKey, sequenceNumber, signature, entryReceiversPubKey);
+                entryOwnerPubKey, sequenceNumber, signature, entryReceiversPubKey, Clock.systemDefaultZone());
     }
 
     private static RefreshOfferMessage buildRefreshOfferMessage(ProtectedStoragePayload protectedStoragePayload,

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -737,12 +737,11 @@ public class P2PDataStorageTest {
         }
 
         // TESTCASE: Adding duplicate payload w/ same sequence number
-        // TODO: Should adds() of existing sequence #s return false since they don't update state?
         @Test
         public void addProtectedStorageEntry_duplicateSeqNrGt0() throws CryptoException {
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
-            doProtectedStorageAddAndVerify(entryForAdd, true, false);
+            doProtectedStorageAddAndVerify(entryForAdd, false, false);
         }
 
         // TESTCASE: Adding duplicate payload w/ 0 sequence number (special branch in code for logging)
@@ -750,7 +749,7 @@ public class P2PDataStorageTest {
         public void addProtectedStorageEntry_duplicateSeqNrEq0() throws CryptoException {
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(0);
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
-            doProtectedStorageAddAndVerify(entryForAdd, true, false);
+            doProtectedStorageAddAndVerify(entryForAdd, false, false);
         }
 
         // TESTCASE: Adding duplicate payload for w/ lower sequence number

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -1162,12 +1162,7 @@ public class P2PDataStorageTest {
         }
 
 
-        // XXXBUGXXX: The P2PService calls remove() instead of removeFromMailbox() in the addMailboxData() path.
-        // This test shows it will always fail even with a valid remove entry. Future work should be able to
-        // combine the remove paths in the same way the add() paths are combined. This will require deprecating
-        // the receiversPubKey field which is a duplicate of the ownerPubKey in the MailboxStoragePayload.
-        // More investigation is needed.
-        @Test
+        @Test(expected = IllegalArgumentException.class)
         public void remove_canCallWrongRemoveAndFail() throws CryptoException {
 
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
@@ -1175,38 +1170,9 @@ public class P2PDataStorageTest {
 
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
 
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForRemove);
-
             // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails
-            boolean addResult = super.doRemove(entryForRemove);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            // should succeed with expectedStatechange==true when remove paths are combined
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForRemove, false, this.expectIsDataOwner());
-        }
-
-        // TESTCASE: Verify misuse of the API (calling remove() instead of removeFromMailbox correctly errors with
-        // a payload that is valid for remove of a non-mailbox entry.
-        @Test
-        public void remove_canCallWrongRemoveAndFailInvalidPayload() throws CryptoException {
-
-            ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
-
-            doProtectedStorageAddAndVerify(entryForAdd, true, true);
-
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForAdd);
-
-            // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails with a payload that isn't signed by payload.ownerPubKey
-            boolean addResult = super.doRemove(entryForAdd);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForAdd, false, this.expectIsDataOwner());
+            // it fails spectacularly
+            super.doRemove(entryForRemove);
         }
 
         // TESTCASE: Add after removed when add-once required (greater seq #)

--- a/p2p/src/test/java/bisq/network/p2p/storage/ProtectedDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/ProtectedDataStorageTest.java
@@ -42,6 +42,8 @@ import java.security.NoSuchProviderException;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 
+import java.time.Clock;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -142,7 +144,7 @@ public class ProtectedDataStorageTest {
         int newSequenceNumber = data.getSequenceNumber() + 1;
         byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new P2PDataStorage.DataAndSeqNrPair(data.getProtectedStoragePayload(), newSequenceNumber));
         byte[] signature = Sig.sign(storageSignatureKeyPair1.getPrivate(), hashOfDataAndSeqNr);
-        ProtectedStorageEntry dataToRemove = new ProtectedStorageEntry(data.getProtectedStoragePayload(), data.getOwnerPubKey(), newSequenceNumber, signature);
+        ProtectedStorageEntry dataToRemove = new ProtectedStorageEntry(data.getProtectedStoragePayload(), data.getOwnerPubKey(), newSequenceNumber, signature, Clock.systemDefaultZone());
         Assert.assertTrue(dataStorage1.remove(dataToRemove, null, true));
         Assert.assertEquals(0, dataStorage1.getMap().size());
     }

--- a/p2p/src/test/java/bisq/network/p2p/storage/messages/AddDataMessageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/messages/AddDataMessageTest.java
@@ -36,6 +36,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 
+import java.time.Clock;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -72,7 +74,7 @@ public class AddDataMessageTest {
         MailboxStoragePayload mailboxStoragePayload = new MailboxStoragePayload(prefixedSealedAndSignedMessage,
                 keyRing1.getPubKeyRing().getSignaturePubKey(), keyRing1.getPubKeyRing().getSignaturePubKey());
         ProtectedStorageEntry protectedStorageEntry = new ProtectedMailboxStorageEntry(mailboxStoragePayload,
-                keyRing1.getSignatureKeyPair().getPublic(), 1, RandomUtils.nextBytes(10), keyRing1.getPubKeyRing().getSignaturePubKey());
+                keyRing1.getSignatureKeyPair().getPublic(), 1, RandomUtils.nextBytes(10), keyRing1.getPubKeyRing().getSignaturePubKey(), Clock.systemDefaultZone());
         AddDataMessage dataMessage1 = new AddDataMessage(protectedStorageEntry);
         protobuf.NetworkEnvelope envelope = dataMessage1.toProtoNetworkEnvelope();
 

--- a/p2p/src/test/java/bisq/network/p2p/storage/mocks/ClockFake.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/mocks/ClockFake.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.mocks;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class ClockFake extends Clock {
+    private Instant currentInstant;
+
+    public ClockFake() {
+        this.currentInstant = Instant.now();
+    }
+
+    @Override
+    public ZoneId getZone() {
+        throw new UnsupportedOperationException("ClockFake does not support getZone");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zoneId) {
+        throw new UnsupportedOperationException("ClockFake does not support withZone");
+    }
+
+    @Override
+    public Instant instant() {
+        return this.currentInstant;
+    }
+
+    public void increment(long milliseconds) {
+        this.currentInstant = this.currentInstant.plusMillis(milliseconds);
+    }
+}


### PR DESCRIPTION
This new set of patches starts at de72d39 (The rest are just merges of my previous pull requests).

The end goal of this stack is to test the expiration code that runs periodically in P2PDataStore. Since the tests require modification of time and the current objects made use of System.currentTimeMillis() (an unmockable static function) a detour of plumbing and dependency injection was required to get the objects in a state where they could be tested. #3037 looks to have started the pattern in other modules.

The end result is that all tests in P2PDataStore now have fine-grained control of the clock and can easily test the various expiration and purge functions. The periodic expiration code is now fully tested.

With the addition of these tests, the code coverage now stands at 81% line and 70% branch coverage.
