### PR TITLE
PaymentAccount object removal from ObservableSet issue

### DIFF
--- a/core/src/main/java/bisq/core/payment/PaymentAccount.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccount.java
@@ -43,15 +43,17 @@ import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString
 @Getter
 @Slf4j
 public abstract class PaymentAccount implements PersistablePayload {
     protected final PaymentMethod paymentMethod;
     @Setter
+    @EqualsAndHashCode.Include
     protected String id;
     @Setter
+    @EqualsAndHashCode.Include
     protected long creationDate;
     @Setter
     public PaymentAccountPayload paymentAccountPayload;

--- a/core/src/test/java/bisq/core/payment/PaymentAccountsTest.java
+++ b/core/src/test/java/bisq/core/payment/PaymentAccountsTest.java
@@ -21,12 +21,17 @@ import bisq.core.account.witness.AccountAgeWitness;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.offer.Offer;
 import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.user.UserPayload;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableSet;
 
 import java.util.Collections;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -70,5 +75,22 @@ public class PaymentAccountsTest {
         when(service.getMyWitness(payload)).thenReturn(witness);
 
         return account;
+    }
+
+    @Test
+    public void testRemoveAccount() {
+        PaymentAccount account = new RevolutAccount();
+        account.setAccountName("account name");
+
+        ObservableSet<PaymentAccount> paymentAccountsAsObservable;
+        paymentAccountsAsObservable = FXCollections.observableSet(new UserPayload().getPaymentAccounts());
+
+        //add element
+        paymentAccountsAsObservable.add(account);
+
+        //remove element with some state change
+        account.setAccountName("new account name for new hash code");
+
+        assertTrue(paymentAccountsAsObservable.remove(account));
     }
 }


### PR DESCRIPTION
Issue:
https://github.com/bisq-network/bisq/issues/3461

Addresses issue by adding equals/hashcode override.
Also added one unit test.

fixes #3461 