### PR TITLE
Fix failing test when there are spaces in the project path

### DIFF
--- a/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
@@ -42,20 +42,20 @@ public class BisqInstallerTest {
     @Test
     public void verifySignature() throws Exception {
         URL url = this.getClass().getResource("/downloadUpdate/test.txt");
-        File dataFile = new File(url.getFile());
+        File dataFile = new File(url.toURI().getPath());
         url = this.getClass().getResource("/downloadUpdate/test.txt.asc");
-        File sigFile = new File(url.getFile());
+        File sigFile = new File(url.toURI().getPath());
         url = this.getClass().getResource("/downloadUpdate/F379A1C6.asc");
-        File pubKeyFile = new File(url.getFile());
+        File pubKeyFile = new File(url.toURI().getPath());
 
         assertEquals(BisqInstaller.VerifyStatusEnum.OK, BisqInstaller.verifySignature(pubKeyFile, sigFile, dataFile));
 
         url = this.getClass().getResource("/downloadUpdate/test_bad.txt");
-        dataFile = new File(url.getFile());
+        dataFile = new File(url.toURI().getPath());
         url = this.getClass().getResource("/downloadUpdate/test_bad.txt.asc");
-        sigFile = new File(url.getFile());
+        sigFile = new File(url.toURI().getPath());
         url = this.getClass().getResource("/downloadUpdate/F379A1C6.asc");
-        pubKeyFile = new File(url.getFile());
+        pubKeyFile = new File(url.toURI().getPath());
 
         BisqInstaller.verifySignature(pubKeyFile, sigFile, dataFile);
         assertEquals(BisqInstaller.VerifyStatusEnum.FAIL, BisqInstaller.verifySignature(pubKeyFile, sigFile, dataFile));


### PR DESCRIPTION
Use URI.getPath() rather than URL.getFile() to get the absolute path of a test resource, since the latter fails to perform URL decoding. This breaks the tests when the project root contain chars needing %-encoding.

This fixes errors of the following form in _(BisqInstallerTest)_ _verifySignature_:

>java.io.FileNotFoundException: /home/steven/Documents/Java%20Projects/bisq/desktop/build/resources/test/downloadUpdate/F379A1C6.asc (No such file or directory)