### PR TITLE
Re-introduce account age to chargeback risk payment methods

### DIFF
--- a/common/src/main/java/bisq/common/util/Tuple2.java
+++ b/common/src/main/java/bisq/common/util/Tuple2.java
@@ -19,6 +19,8 @@ package bisq.common.util;
 
 import java.io.Serializable;
 
+import java.util.Objects;
+
 public class Tuple2<A, B> implements Serializable {
     private static final long serialVersionUID = 1;
 
@@ -38,8 +40,8 @@ public class Tuple2<A, B> implements Serializable {
 
         Tuple2<?, ?> tuple2 = (Tuple2<?, ?>) o;
 
-        if (first != null ? !first.equals(tuple2.first) : tuple2.first != null) return false;
-        return !(second != null ? !second.equals(tuple2.second) : tuple2.second != null);
+        if (!Objects.equals(first, tuple2.first)) return false;
+        return Objects.equals(second, tuple2.second);
 
     }
 

--- a/common/src/main/java/bisq/common/util/Tuple3.java
+++ b/common/src/main/java/bisq/common/util/Tuple3.java
@@ -17,6 +17,8 @@
 
 package bisq.common.util;
 
+import java.util.Objects;
+
 public class Tuple3<A, B, C> {
     final public A first;
     final public B second;
@@ -36,9 +38,9 @@ public class Tuple3<A, B, C> {
 
         Tuple3<?, ?, ?> tuple3 = (Tuple3<?, ?, ?>) o;
 
-        if (first != null ? !first.equals(tuple3.first) : tuple3.first != null) return false;
-        if (second != null ? !second.equals(tuple3.second) : tuple3.second != null) return false;
-        return !(third != null ? !third.equals(tuple3.third) : tuple3.third != null);
+        if (!Objects.equals(first, tuple3.first)) return false;
+        if (!Objects.equals(second, tuple3.second)) return false;
+        return Objects.equals(third, tuple3.third);
 
     }
 

--- a/common/src/main/java/bisq/common/util/Tuple4.java
+++ b/common/src/main/java/bisq/common/util/Tuple4.java
@@ -23,13 +23,13 @@ public class Tuple4<A, B, C, D> {
     final public A first;
     final public B second;
     final public C third;
-    final public D forth;
+    final public D fourth;
 
-    public Tuple4(A first, B second, C third, D forth) {
+    public Tuple4(A first, B second, C third, D fourth) {
         this.first = first;
         this.second = second;
         this.third = third;
-        this.forth = forth;
+        this.fourth = fourth;
     }
 
     @SuppressWarnings("SimplifiableIfStatement")
@@ -43,7 +43,7 @@ public class Tuple4<A, B, C, D> {
         if (!Objects.equals(first, tuple4.first)) return false;
         if (!Objects.equals(second, tuple4.second)) return false;
         if (!Objects.equals(third, tuple4.third)) return false;
-        return Objects.equals(forth, tuple4.forth);
+        return Objects.equals(fourth, tuple4.fourth);
 
     }
 
@@ -52,7 +52,7 @@ public class Tuple4<A, B, C, D> {
         int result = first != null ? first.hashCode() : 0;
         result = 31 * result + (second != null ? second.hashCode() : 0);
         result = 31 * result + (third != null ? third.hashCode() : 0);
-        result = 31 * result + (forth != null ? forth.hashCode() : 0);
+        result = 31 * result + (fourth != null ? fourth.hashCode() : 0);
         return result;
     }
 }

--- a/common/src/main/java/bisq/common/util/Tuple5.java
+++ b/common/src/main/java/bisq/common/util/Tuple5.java
@@ -19,31 +19,34 @@ package bisq.common.util;
 
 import java.util.Objects;
 
-public class Tuple4<A, B, C, D> {
+public class Tuple5<A, B, C, D, E> {
     final public A first;
     final public B second;
     final public C third;
     final public D forth;
+    final public E fifth;
 
-    public Tuple4(A first, B second, C third, D forth) {
+    public Tuple5(A first, B second, C third, D forth, E fifth) {
         this.first = first;
         this.second = second;
         this.third = third;
         this.forth = forth;
+        this.fifth = fifth;
     }
 
     @SuppressWarnings("SimplifiableIfStatement")
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Tuple4)) return false;
+        if (!(o instanceof Tuple5)) return false;
 
-        Tuple4<?, ?, ?, ?> tuple4 = (Tuple4<?, ?, ?, ?>) o;
+        Tuple5<?, ?, ?, ?, ?> tuple5 = (Tuple5<?, ?, ?, ?, ?>) o;
 
-        if (!Objects.equals(first, tuple4.first)) return false;
-        if (!Objects.equals(second, tuple4.second)) return false;
-        if (!Objects.equals(third, tuple4.third)) return false;
-        return Objects.equals(forth, tuple4.forth);
+        if (!Objects.equals(first, tuple5.first)) return false;
+        if (!Objects.equals(second, tuple5.second)) return false;
+        if (!Objects.equals(third, tuple5.third)) return false;
+        if (!Objects.equals(forth, tuple5.forth)) return false;
+        return Objects.equals(fifth, tuple5.fifth);
 
     }
 
@@ -53,6 +56,7 @@ public class Tuple4<A, B, C, D> {
         result = 31 * result + (second != null ? second.hashCode() : 0);
         result = 31 * result + (third != null ? third.hashCode() : 0);
         result = 31 * result + (forth != null ? forth.hashCode() : 0);
+        result = 31 * result + (fifth != null ? fifth.hashCode() : 0);
         return result;
     }
 }

--- a/common/src/main/java/bisq/common/util/Tuple5.java
+++ b/common/src/main/java/bisq/common/util/Tuple5.java
@@ -23,14 +23,14 @@ public class Tuple5<A, B, C, D, E> {
     final public A first;
     final public B second;
     final public C third;
-    final public D forth;
+    final public D fourth;
     final public E fifth;
 
-    public Tuple5(A first, B second, C third, D forth, E fifth) {
+    public Tuple5(A first, B second, C third, D fourth, E fifth) {
         this.first = first;
         this.second = second;
         this.third = third;
-        this.forth = forth;
+        this.fourth = fourth;
         this.fifth = fifth;
     }
 
@@ -45,9 +45,8 @@ public class Tuple5<A, B, C, D, E> {
         if (!Objects.equals(first, tuple5.first)) return false;
         if (!Objects.equals(second, tuple5.second)) return false;
         if (!Objects.equals(third, tuple5.third)) return false;
-        if (!Objects.equals(forth, tuple5.forth)) return false;
+        if (!Objects.equals(fourth, tuple5.fourth)) return false;
         return Objects.equals(fifth, tuple5.fifth);
-
     }
 
     @Override
@@ -55,7 +54,7 @@ public class Tuple5<A, B, C, D, E> {
         int result = first != null ? first.hashCode() : 0;
         result = 31 * result + (second != null ? second.hashCode() : 0);
         result = 31 * result + (third != null ? third.hashCode() : 0);
-        result = 31 * result + (forth != null ? forth.hashCode() : 0);
+        result = 31 * result + (fourth != null ? fourth.hashCode() : 0);
         result = 31 * result + (fifth != null ? fifth.hashCode() : 0);
         return result;
     }

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -247,7 +247,7 @@ public class PeerInfoIcon extends Group {
         getChildren().addAll(outerBackground, innerBackground, avatarImageView, tagPane, numTradesPane);
 
         addMouseListener(numTrades, privateNotificationManager, offer, preferences, useDevPrivilegeKeys,
-                isFiatCurrency, accountAge, signAge, peersAccount.third, peersAccount.forth, peersAccount.fifth);
+                isFiatCurrency, accountAge, signAge, peersAccount.third, peersAccount.fourth, peersAccount.fifth);
     }
 
     /**

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -155,7 +155,7 @@ public class PeerInfoIcon extends Group {
         Color ringColor;
         if (isFiatCurrency) {
 
-            switch (accountAgeWitnessService.getPeersAccountAgeCategory(accountAge)) {
+            switch (accountAgeWitnessService.getPeersAccountAgeCategory(hasChargebackRisk(trade, offer) ? signAge : accountAge)) {
                 case TWO_MONTHS_OR_MORE:
                     ringColor = Color.rgb(0, 225, 0); // > 2 months green
                     break;
@@ -277,7 +277,7 @@ public class PeerInfoIcon extends Group {
             accountAge = accountAgeWitnessService.getAccountAge(offer);
         }
 
-        if (PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode())) {
+        if (hasChargebackRisk(trade, offer)) {
             String signAgeInfo = Res.get("peerInfo.age.chargeBackRisk");
             String accountSigningState = StringUtils.capitalize(signState.getPresentation());
             if (signState.equals(AccountAgeWitnessService.SignState.UNSIGNED))
@@ -286,6 +286,13 @@ public class PeerInfoIcon extends Group {
             return new Tuple5<>(accountAge, signAge, Res.get("peerInfo.age.noRisk"), signAgeInfo, accountSigningState);
         }
         return new Tuple5<>(accountAge, signAge, Res.get("peerInfo.age.noRisk"), null, null);
+    }
+
+    private boolean hasChargebackRisk(@Nullable Trade trade, @Nullable Offer offer) {
+        Offer offerToCheck = trade != null ? trade.getOffer() : offer;
+
+        return offerToCheck != null &&
+                PaymentMethod.hasChargebackRisk(offerToCheck.getPaymentMethod(), offerToCheck.getCurrencyCode());
     }
 
     protected void addMouseListener(int numTrades,

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -28,11 +28,10 @@ import bisq.core.offer.Offer;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
-import bisq.core.util.BSFormatter;
 
 import bisq.network.p2p.NodeAddress;
 
-import bisq.common.util.Tuple3;
+import bisq.common.util.Tuple5;
 
 import com.google.common.base.Charsets;
 
@@ -69,10 +68,9 @@ public class PeerInfoIcon extends Group {
     private final Map<String, String> peerTagMap;
     private final Label numTradesLabel;
     private final Label tagLabel;
-    protected final Pane tagPane;
-    protected final Pane numTradesPane;
+    final Pane tagPane;
+    final Pane numTradesPane;
     private final String fullAddress;
-    private final double scaleFactor;
 
     public PeerInfoIcon(NodeAddress nodeAddress,
                         String role,
@@ -81,7 +79,6 @@ public class PeerInfoIcon extends Group {
                         Offer offer,
                         Preferences preferences,
                         AccountAgeWitnessService accountAgeWitnessService,
-                        BSFormatter formatter,
                         boolean useDevPrivilegeKeys) {
         this(nodeAddress,
                 role,
@@ -91,7 +88,6 @@ public class PeerInfoIcon extends Group {
                 null,
                 preferences,
                 accountAgeWitnessService,
-                formatter,
                 useDevPrivilegeKeys);
 
     }
@@ -103,7 +99,6 @@ public class PeerInfoIcon extends Group {
                         Trade trade,
                         Preferences preferences,
                         AccountAgeWitnessService accountAgeWitnessService,
-                        BSFormatter formatter,
                         boolean useDevPrivilegeKeys) {
         this(nodeAddress,
                 role,
@@ -113,7 +108,6 @@ public class PeerInfoIcon extends Group {
                 trade,
                 preferences,
                 accountAgeWitnessService,
-                formatter,
                 useDevPrivilegeKeys);
     }
 
@@ -125,18 +119,21 @@ public class PeerInfoIcon extends Group {
                          @Nullable Trade trade,
                          Preferences preferences,
                          AccountAgeWitnessService accountAgeWitnessService,
-                         BSFormatter formatter,
                          boolean useDevPrivilegeKeys) {
         this.numTrades = numTrades;
         this.accountAgeWitnessService = accountAgeWitnessService;
 
-        scaleFactor = getScaleFactor();
+        double scaleFactor = getScaleFactor();
         fullAddress = nodeAddress != null ? nodeAddress.getFullAddress() : "";
 
         peerTagMap = preferences.getPeerTagMap();
 
         boolean hasTraded = numTrades > 0;
-        Tuple3<Long, String, String> peersAccount = getPeersAccountAge(trade, offer);
+        Tuple5<Long, Long, String, String, String> peersAccount = getPeersAccountAge(trade, offer);
+
+        Long accountAge = peersAccount.first;
+        Long signAge = peersAccount.second;
+
         if (offer == null) {
             checkNotNull(trade, "Trade must not be null if offer is null.");
             offer = trade.getOffer();
@@ -146,19 +143,19 @@ public class PeerInfoIcon extends Group {
 
         boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode());
 
-        String accountAge = isFiatCurrency ?
-                peersAccount.first > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(peersAccount.first)) :
+        String accountAgeTooltip = isFiatCurrency ?
+                accountAge > -1 ? Res.get("peerInfoIcon.tooltip.age", DisplayUtils.formatAccountAge(accountAge)) :
                         Res.get("peerInfoIcon.tooltip.unknownAge") :
                 "";
         tooltipText = hasTraded ?
-                Res.get("peerInfoIcon.tooltip.trade.traded", role, fullAddress, numTrades, accountAge) :
-                Res.get("peerInfoIcon.tooltip.trade.notTraded", role, fullAddress, accountAge);
+                Res.get("peerInfoIcon.tooltip.trade.traded", role, fullAddress, numTrades, accountAgeTooltip) :
+                Res.get("peerInfoIcon.tooltip.trade.notTraded", role, fullAddress, accountAgeTooltip);
 
         // outer circle
         Color ringColor;
         if (isFiatCurrency) {
 
-            switch (accountAgeWitnessService.getPeersAccountAgeCategory(peersAccount.first)) {
+            switch (accountAgeWitnessService.getPeersAccountAgeCategory(accountAge)) {
                 case TWO_MONTHS_OR_MORE:
                     ringColor = Color.rgb(0, 225, 0); // > 2 months green
                     break;
@@ -249,20 +246,26 @@ public class PeerInfoIcon extends Group {
 
         getChildren().addAll(outerBackground, innerBackground, avatarImageView, tagPane, numTradesPane);
 
-        addMouseListener(numTrades, privateNotificationManager, offer, preferences, formatter, useDevPrivilegeKeys,
-                isFiatCurrency, peersAccount.first, peersAccount.second, peersAccount.third);
+        addMouseListener(numTrades, privateNotificationManager, offer, preferences, useDevPrivilegeKeys,
+                isFiatCurrency, accountAge, signAge, peersAccount.third, peersAccount.forth, peersAccount.fifth);
     }
 
-    // Return Sign age, account info, sign state
-    private Tuple3<Long, String, String> getPeersAccountAge(@Nullable Trade trade, @Nullable Offer offer) {
+    /**
+     * @param trade Open trade for trading peer info to be shown
+     * @param offer Open offer for trading peer info to be shown
+     * @return account age, sign age, account info, sign info, sign state
+     */
+    private Tuple5<Long, Long, String, String, String> getPeersAccountAge(@Nullable Trade trade,
+                                                                          @Nullable Offer offer) {
         AccountAgeWitnessService.SignState signState;
         long signAge = -1L;
         long accountAge = -1L;
+
         if (trade != null) {
             offer = trade.getOffer();
             if (offer == null) {
                 // unexpected
-                return new Tuple3<>(-1L, Res.get("peerInfo.age.noRisk"), null);
+                return new Tuple5<>(signAge, accountAge, Res.get("peerInfo.age.noRisk"), null, null);
             }
             signState = accountAgeWitnessService.getSignState(trade);
             signAge = accountAgeWitnessService.getWitnessSignAge(trade, new Date());
@@ -273,39 +276,49 @@ public class PeerInfoIcon extends Group {
             signAge = accountAgeWitnessService.getWitnessSignAge(offer, new Date());
             accountAge = accountAgeWitnessService.getAccountAge(offer);
         }
+
         if (PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode())) {
-            String accountAgeInfo = Res.get("peerInfo.age.chargeBackRisk");
+            String signAgeInfo = Res.get("peerInfo.age.chargeBackRisk");
             String accountSigningState = StringUtils.capitalize(signState.getPresentation());
             if (signState.equals(AccountAgeWitnessService.SignState.UNSIGNED))
-                accountAgeInfo = null;
+                signAgeInfo = null;
 
-            return new Tuple3<>(signAge, accountAgeInfo, accountSigningState);
+            return new Tuple5<>(accountAge, signAge, Res.get("peerInfo.age.noRisk"), signAgeInfo, accountSigningState);
         }
-        return new Tuple3<>(accountAge, Res.get("peerInfo.age.noRisk"), null);
+        return new Tuple5<>(accountAge, signAge, Res.get("peerInfo.age.noRisk"), null, null);
     }
 
     protected void addMouseListener(int numTrades,
                                     PrivateNotificationManager privateNotificationManager,
                                     Offer offer,
                                     Preferences preferences,
-                                    BSFormatter formatter,
                                     boolean useDevPrivilegeKeys,
                                     boolean isFiatCurrency,
                                     long peersAccountAge,
+                                    long peersSignAge,
                                     String peersAccountAgeInfo,
+                                    String peersSignAgeInfo,
                                     String accountSigningState) {
 
-        final String accountAgeTagEditor = isFiatCurrency && peersAccountAgeInfo != null ?
+        final String accountAgeFormatted = isFiatCurrency ?
                 peersAccountAge > -1 ?
                         DisplayUtils.formatAccountAge(peersAccountAge) :
+                        Res.get("peerInfo.unknownAge") :
+                null;
+
+        final String signAgeFormatted = isFiatCurrency && peersSignAgeInfo != null ?
+                peersSignAge > -1 ?
+                        DisplayUtils.formatAccountAge(peersSignAge) :
                         Res.get("peerInfo.unknownAge") :
                 null;
 
         setOnMouseClicked(e -> new PeerInfoWithTagEditor(privateNotificationManager, offer, preferences, useDevPrivilegeKeys)
                 .fullAddress(fullAddress)
                 .numTrades(numTrades)
-                .accountAge(accountAgeTagEditor)
+                .accountAge(accountAgeFormatted)
+                .signAge(signAgeFormatted)
                 .accountAgeInfo(peersAccountAgeInfo)
+                .signAgeInfo(peersSignAgeInfo)
                 .accountSigningState(accountSigningState)
                 .position(localToScene(new Point2D(0, 0)))
                 .onSave(newTag -> {

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
@@ -23,7 +23,6 @@ public class PeerInfoIconSmall extends PeerInfoIcon {
                 offer,
                 preferences,
                 accountAgeWitnessService,
-                formatter,
                 useDevPrivilegeKeys);
     }
 
@@ -37,11 +36,12 @@ public class PeerInfoIconSmall extends PeerInfoIcon {
                                     PrivateNotificationManager privateNotificationManager,
                                     Offer offer,
                                     Preferences preferences,
-                                    BSFormatter formatter,
                                     boolean useDevPrivilegeKeys,
                                     boolean isFiatCurrency,
                                     long peersAccountAge,
+                                    long peersSignAge,
                                     String peersAccountAgeInfo,
+                                    String peersSignAgeInfo,
                                     String accountSigningState) {
     }
 

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/BankForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/BankForm.java
@@ -430,7 +430,7 @@ abstract class BankForm extends GeneralBankForm {
             TextField holderNameTextField = tuple.second;
             holderNameTextField.setText(bankAccountPayload.getHolderName());
             holderNameTextField.setMinWidth(250);
-            tuple.forth.setText(bankAccountPayload.getHolderTaxId());
+            tuple.fourth.setText(bankAccountPayload.getHolderTaxId());
         } else {
             addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"), bankAccountPayload.getHolderName());
         }

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/CashDepositForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/CashDepositForm.java
@@ -478,7 +478,7 @@ public class CashDepositForm extends GeneralBankForm {
             TextField holderNameTextField = tuple.second;
             holderNameTextField.setText(cashDepositAccountPayload.getHolderName());
             holderNameTextField.setMinWidth(300);
-            tuple.forth.setText(cashDepositAccountPayload.getHolderTaxId());
+            tuple.fourth.setText(cashDepositAccountPayload.getHolderTaxId());
         } else {
             addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
                     cashDepositAccountPayload.getHolderName());

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/JapanBankTransferForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/JapanBankTransferForm.java
@@ -182,7 +182,7 @@ public class JapanBankTransferForm extends PaymentMethodForm
         bankCodeField.setEditable(false);
 
         // Bank Selector
-        bankComboBox = tuple4.forth;
+        bankComboBox = tuple4.fourth;
         bankComboBox.setPromptText(JapanBankData.getString("bank.select"));
         bankComboBox.setButtonCell(getComboBoxButtonCell(JapanBankData.getString("bank.name"), bankComboBox));
         bankComboBox.getEditor().focusedProperty().addListener(observable -> {

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -692,7 +692,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                 Res.get("dao.proposal.myVote.button"));
         voteButton = voteButtonTuple.first;
         voteButtons.add(voteButton);
-        voteFields.add(voteButtonTuple.forth);
+        voteFields.add(voteButtonTuple.fourth);
         voteButtonBusyAnimation = voteButtonTuple.second;
         voteButtonInfoLabel = voteButtonTuple.third;
     }

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -592,7 +592,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                 Tuple4<Date, Integer, Integer, Integer> tuple = dataByDayMap.get(day);
                 int prev = tuple.second;
                 int numOffers = tuple.third;
-                int numTrades = tuple.forth;
+                int numTrades = tuple.fourth;
                 if (amountAsCoin.compareTo(createOfferFee.subtract(txFee)) == 0)
                     numOffers++;
                 else if (amountAsCoin.compareTo(takeOfferFee.subtract(txFee)) == 0)
@@ -615,7 +615,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         List<Tuple4<String, Date, Integer, Tuple2<Integer, Integer>>> sortedDataByDayList = dataByDayMap.entrySet().stream().
                 map(e -> {
                     Tuple4<Date, Integer, Integer, Integer> data = e.getValue();
-                    return new Tuple4<>(e.getKey(), data.first, data.second, new Tuple2<>(data.third, data.forth));
+                    return new Tuple4<>(e.getKey(), data.first, data.second, new Tuple2<>(data.third, data.fourth));
                 }).sorted((o1, o2) -> o2.second.compareTo(o1.second))
                 .collect(Collectors.toList());
         StringBuilder transactionsByDayStringBuilder = new StringBuilder();
@@ -625,17 +625,17 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         // This is not intended for the public so we don't translate here
         allStringBuilder.append(Res.get("shared.date")).append(";").append("Offers").append(";").append("Trades").append("\n");
         sortedDataByDayList.forEach(tuple4 -> {
-            offersStringBuilder.append(tuple4.forth.first).append(",");
-            tradesStringBuilder.append(tuple4.forth.second).append(",");
-            allStringBuilder.append(tuple4.first).append(";").append(tuple4.forth.first).append(";").append(tuple4.forth.second).append("\n");
+            offersStringBuilder.append(tuple4.fourth.first).append(",");
+            tradesStringBuilder.append(tuple4.fourth.second).append(",");
+            allStringBuilder.append(tuple4.first).append(";").append(tuple4.fourth.first).append(";").append(tuple4.fourth.second).append("\n");
             transactionsByDayStringBuilder.append("\n").
                     append(tuple4.first).
                     append(": ").
                     append(tuple4.third).
                     append(" (Offers: ").
-                    append(tuple4.forth.first).
+                    append(tuple4.fourth.first).
                     append(" / Trades: ").
-                    append(tuple4.forth.second).
+                    append(tuple4.fourth.second).
                     append(")");
         });
         // This is not intended for the public so we don't translate here

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -206,7 +206,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
         amountTextField = feeTuple3.second;
         amountTextField.setMinWidth(180);
         feeExcludedRadioButton = feeTuple3.third;
-        RadioButton feeIncludedRadioButton = feeTuple3.forth;
+        RadioButton feeIncludedRadioButton = feeTuple3.fourth;
 
         withdrawFromTextField = addTopLabelTextField(gridPane, ++rowIndex,
                 Res.get("funds.withdrawal.fromLabel", Res.getBaseCurrencyCode())).second;

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -23,9 +23,9 @@ import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.AutoTooltipTableColumn;
+import bisq.desktop.components.AutocompleteComboBox;
 import bisq.desktop.components.ColoredDecimalPlacesWithZerosText;
 import bisq.desktop.components.PeerInfoIconSmall;
-import bisq.desktop.components.AutocompleteComboBox;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.offer.BuyOfferView;
 import bisq.desktop.main.offer.SellOfferView;
@@ -164,8 +164,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         leftButton = (AutoTooltipButton) tupleBuy.third;
         rightButton = (AutoTooltipButton) tupleSell.third;
 
-        leftHeaderLabel = tupleBuy.forth;
-        rightHeaderLabel = tupleSell.forth;
+        leftHeaderLabel = tupleBuy.fourth;
+        rightHeaderLabel = tupleSell.fourth;
 
         bottomHBox = new HBox();
         bottomHBox.setSpacing(20); //30

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -1160,7 +1160,6 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                             offer,
                                             model.preferences,
                                             model.accountAgeWitnessService,
-                                            formatter,
                                             useDevPrivilegeKeys);
                                     setGraphic(peerInfoIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -858,7 +858,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         final Tuple2<Label, VBox> tradeCurrencyTuple = getTopLabelWithVBox(Res.get("shared.tradeCurrency"), currencyTextField);
         HBox.setMargin(tradeCurrencyTuple.second, new Insets(5, 0, 0, 0));
 
-        final HBox hBox = paymentAccountTuple.forth;
+        final HBox hBox = paymentAccountTuple.fourth;
         hBox.setSpacing(30);
         hBox.setAlignment(Pos.CENTER_LEFT);
         hBox.setPadding(new Insets(10, 0, 18, 0));

--- a/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
@@ -93,6 +93,10 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
     private String accountAgeInfo;
     @Nullable
     private String accountSigningState;
+    @Nullable
+    private String signAge;
+    @Nullable
+    private String signAgeInfo;
 
     public PeerInfoWithTagEditor(PrivateNotificationManager privateNotificationManager,
                                  Offer offer,
@@ -131,6 +135,16 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
 
     public PeerInfoWithTagEditor accountAgeInfo(String accountAgeInfo) {
         this.accountAgeInfo = accountAgeInfo;
+        return this;
+    }
+
+    public PeerInfoWithTagEditor signAge(@Nullable String signAge) {
+        this.signAge = signAge;
+        return this;
+    }
+
+    public PeerInfoWithTagEditor signAgeInfo(String signAgeInfo) {
+        this.signAgeInfo = signAgeInfo;
         return this;
     }
 
@@ -205,18 +219,23 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
                 Res.get("peerInfo.nrOfTrades"),
                 numTrades > 0 ? String.valueOf(numTrades) : Res.get("peerInfo.notTradedYet")).third, 2);
 
-        if (accountSigningState != null) {
-            GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex, Res.get("shared.accountSigningState"), accountSigningState).third, 2);
-        }
-
         if (accountAge != null) {
             GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex, accountAgeInfo, accountAge).third, 2);
         }
 
+        if (accountSigningState != null) {
+            GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex, Res.get("shared.accountSigningState"), accountSigningState).third, 2);
+        }
+
+        if (signAge != null) {
+            GridPane.setColumnSpan(addCompactTopLabelTextField(gridPane, ++rowIndex, signAgeInfo, signAge).third, 2);
+        }
+
+
         inputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("peerInfo.setTag"));
         GridPane.setColumnSpan(inputTextField, 2);
         Map<String, String> peerTagMap = preferences.getPeerTagMap();
-        String tag = peerTagMap.containsKey(hostName) ? peerTagMap.get(hostName) : "";
+        String tag = peerTagMap.getOrDefault(hostName, "");
         inputTextField.setText(tag);
 
         keyEventEventHandler = event -> {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
@@ -389,7 +389,7 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
             hide();
         });
 
-        placeOfferTuple.forth.getChildren().add(cancelButton);
+        placeOfferTuple.fourth.getChildren().add(cancelButton);
 
         button.setOnAction(e -> {
             if (GUIUtil.canCreateOrTakeOfferOrShowPopup(user, navigation)) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
@@ -416,7 +416,6 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
                                             trade,
                                             preferences,
                                             model.accountAgeWitnessService,
-                                            formatter,
                                             useDevPrivilegeKeys);
                                     setPadding(new Insets(1, 15, 0, 0));
                                     setGraphic(peerInfoIcon);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
@@ -175,7 +175,7 @@ public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
         int tmpGridRow = 4;
         final Tuple4<Button, BusyAnimation, Label, HBox> editOfferTuple = addButtonBusyAnimationLabelAfterGroup(gridPane, tmpGridRow++, Res.get("editOffer.confirmEdit"));
 
-        final HBox editOfferConfirmationBox = editOfferTuple.forth;
+        final HBox editOfferConfirmationBox = editOfferTuple.fourth;
         editOfferConfirmationBox.setAlignment(Pos.CENTER_LEFT);
         GridPane.setHalignment(editOfferConfirmationBox, HPos.LEFT);
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -664,7 +664,6 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                                             trade,
                                             preferences,
                                             model.accountAgeWitnessService,
-                                            formatter,
                                             useDevPrivilegeKeys);
                                     setPadding(new Insets(1, 0, 0, 0));
                                     setGraphic(peerInfoIcon);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -330,7 +330,7 @@ public class BuyerStep2View extends TradeStepView {
         Tuple4<Button, BusyAnimation, Label, HBox> tuple3 = addButtonBusyAnimationLabel(gridPane, ++gridRow, 0,
                 Res.get("portfolio.pending.step2_buyer.paymentStarted"), 10);
 
-        GridPane.setColumnSpan(tuple3.forth, 2);
+        GridPane.setColumnSpan(tuple3.fourth, 2);
         confirmButton = tuple3.first;
         confirmButton.setOnAction(e -> onPaymentStarted());
         busyAnimation = tuple3.second;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -220,7 +220,7 @@ public class SellerStep3View extends TradeStepView {
         Tuple4<Button, BusyAnimation, Label, HBox> tuple = addButtonBusyAnimationLabelAfterGroup(gridPane, ++gridRow,
                 Res.get("portfolio.pending.step3_seller.confirmReceipt"));
 
-        GridPane.setColumnSpan(tuple.forth, 2);
+        GridPane.setColumnSpan(tuple.fourth, 2);
         confirmButton = tuple.first;
         confirmButton.setOnAction(e -> onPaymentReceived());
         busyAnimation = tuple.second;


### PR DESCRIPTION
We are not showing the account age info for payment methods that
have a high chargeback risk. This PR adds them back again.

![Bildschirmfoto 2019-11-08 um 11 35 07](https://user-images.githubusercontent.com/170962/68470488-785e3080-021c-11ea-8f7a-132b4a951928.png)
![Bildschirmfoto 2019-11-08 um 11 35 20](https://user-images.githubusercontent.com/170962/68470490-785e3080-021c-11ea-9260-be785277ea55.png)
![Bildschirmfoto 2019-11-08 um 11 36 08](https://user-images.githubusercontent.com/170962/68470491-785e3080-021c-11ea-85c5-24deb6d0c0fc.png)
