### PR TITLE
(7/8) Develop APIs for ProtectedStorageEntry to enable testing and code refactoring

### DIFF
--- a/common/src/main/java/bisq/common/proto/network/NetworkProtoResolver.java
+++ b/common/src/main/java/bisq/common/proto/network/NetworkProtoResolver.java
@@ -20,6 +20,8 @@ package bisq.common.proto.network;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.ProtobufferException;
 
+import java.time.Clock;
+
 
 public interface NetworkProtoResolver extends ProtoResolver {
     NetworkEnvelope fromProto(protobuf.NetworkEnvelope proto) throws ProtobufferException;
@@ -27,4 +29,6 @@ public interface NetworkProtoResolver extends ProtoResolver {
     NetworkPayload fromProto(protobuf.StoragePayload proto);
 
     NetworkPayload fromProto(protobuf.StorageEntryWrapper proto);
+
+    Clock getClock();
 }

--- a/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -59,10 +59,16 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.persistable.PersistableEnvelope;
 
+import java.time.Clock;
+
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CoreProtoResolver implements ProtoResolver {
+    @Getter
+    protected Clock clock;
+
     @Override
     public PaymentAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
         if (proto != null) {

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -88,6 +88,8 @@ import bisq.common.proto.network.NetworkProtoResolver;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import java.time.Clock;
+
 import lombok.extern.slf4j.Slf4j;
 
 // TODO Use ProtobufferException instead of ProtobufferRuntimeException
@@ -95,7 +97,8 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class CoreNetworkProtoResolver extends CoreProtoResolver implements NetworkProtoResolver {
     @Inject
-    public CoreNetworkProtoResolver() {
+    public CoreNetworkProtoResolver(Clock clock) {
+        this.clock = clock;
     }
 
     @Override

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -49,6 +49,8 @@ import bisq.common.storage.Storage;
 
 import org.springframework.core.env.PropertySource;
 
+import java.time.Clock;
+
 import java.io.File;
 
 import java.util.Collections;
@@ -118,7 +120,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
 
             // start the network node
             networkNode = new TorNetworkNode(Integer.parseInt(configuration.getProperty(TOR_PROXY_PORT, "9053")),
-                    new CoreNetworkProtoResolver(), false,
+                    new CoreNetworkProtoResolver(Clock.systemDefaultZone()), false,
                     new AvailableTor(Monitor.TOR_WORKING_DIR, torHiddenServiceDir.getName()));
             networkNode.start(this);
 
@@ -139,7 +141,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
                 });
                 CorruptedDatabaseFilesHandler corruptedDatabaseFilesHandler = new CorruptedDatabaseFilesHandler();
                 int maxConnections = Integer.parseInt(configuration.getProperty(MAX_CONNECTIONS, "12"));
-                NetworkProtoResolver networkProtoResolver = new CoreNetworkProtoResolver();
+                NetworkProtoResolver networkProtoResolver = new CoreNetworkProtoResolver(Clock.systemDefaultZone());
                 CorePersistenceProtoResolver persistenceProtoResolver = new CorePersistenceProtoResolver(null,
                         networkProtoResolver, storageDir, corruptedDatabaseFilesHandler);
                 DefaultSeedNodeRepository seedNodeRepository = new DefaultSeedNodeRepository(environment, null);

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
@@ -39,6 +39,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
 
+import java.time.Clock;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +92,7 @@ public abstract class P2PSeedNodeSnapshotBase extends Metric implements MessageL
     protected void execute() {
         // start the network node
         final NetworkNode networkNode = new TorNetworkNode(Integer.parseInt(configuration.getProperty(TOR_PROXY_PORT, "9054")),
-                new CoreNetworkProtoResolver(), false,
+                new CoreNetworkProtoResolver(Clock.systemDefaultZone()), false,
                 new AvailableTor(Monitor.TOR_WORKING_DIR, "unused"));
         // we do not need to start the networkNode, as we do not need the HS
         //networkNode.start(this);

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -759,7 +759,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                             expirableMailboxStoragePayload,
                             keyRing.getSignatureKeyPair(),
                             receiversPubKey);
-                    p2PDataStorage.removeMailboxData(protectedMailboxStorageEntry, networkNode.getNodeAddress(), true);
+                    p2PDataStorage.remove(protectedMailboxStorageEntry, networkNode.getNodeAddress(), true);
                 } catch (CryptoException e) {
                     log.error("Signing at getDataWithSignedSeqNr failed. That should never happen.");
                 }

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -700,12 +700,12 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                     };
                     boolean result = p2PDataStorage.addProtectedStorageEntry(protectedMailboxStorageEntry, networkNode.getNodeAddress(), listener, true);
                     if (!result) {
-                        //TODO remove and add again with a delay to ensure the data will be broadcasted
-                        // The p2PDataStorage.remove makes probably sense but need to be analysed more.
-                        // Don't change that if it is not 100% clear.
                         sendMailboxMessageListener.onFault("Data already exists in our local database");
-                        boolean removeResult = p2PDataStorage.remove(protectedMailboxStorageEntry, networkNode.getNodeAddress(), true);
-                        log.debug("remove result=" + removeResult);
+
+                        // This should only fail if there are concurrent calls to addProtectedStorageEntry with the
+                        // same ProtectedMailboxStorageEntry. This is an unexpected use case so if it happens we
+                        // want to see it, but it is not worth throwing an exception.
+                        log.error("Unexpected state: adding mailbox message that already exists.");
                     }
                 } catch (CryptoException e) {
                     log.error("Signing at getDataWithSignedSeqNr failed. That should never happen.");

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -400,7 +400,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             return false;
 
         // Verify the ProtectedStorageEntry is well formed and valid for the add operation
-        if (!protectedStorageEntry.isValidForAddOperation() || !checkSignature(protectedStorageEntry))
+        if (!protectedStorageEntry.isValidForAddOperation())
             return false;
 
         // In a hash collision between two well formed ProtectedStorageEntry, the first item wins and will not be overwritten

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -465,12 +465,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             return false;
 
         // Verify the updated ProtectedStorageEntry is well formed and valid for update
-        if (!checkSignature(updatedEntry))
-            return false;
-
-        // Verify the Payload owner and the Entry owner for the stored Entry are the same
-        // TODO: This is also checked in the validation for the original add(), investigate if this can be removed
-        if (!checkIfStoredDataPubKeyMatchesNewDataPubKey(updatedEntry.getOwnerPubKey(), hashOfPayload))
+        if (!updatedEntry.isValidForAddOperation())
             return false;
 
         // Update the hash map with the updated entry

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -124,6 +124,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     private final Set<ProtectedDataStoreListener> protectedDataStoreListeners = new CopyOnWriteArraySet<>();
     private final Clock clock;
 
+    protected int maxSequenceNumberMapSizeBeforePurge;
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -148,6 +150,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         this.sequenceNumberMapStorage = sequenceNumberMapStorage;
         sequenceNumberMapStorage.setNumMaxBackupFiles(5);
+        this.maxSequenceNumberMapSizeBeforePurge = 1000;
     }
 
     @Override
@@ -209,7 +212,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         });
         hashMapChangedListeners.forEach(HashMapChangedListener::onBatchRemoveExpiredDataCompleted);
 
-        if (sequenceNumberMap.size() > 1000)
+        if (sequenceNumberMap.size() > this.maxSequenceNumberMapSizeBeforePurge)
             sequenceNumberMap.setMap(getPurgedSequenceNumberMap(sequenceNumberMap.getMap()));
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -447,17 +447,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         int sequenceNumber = refreshTTLMessage.getSequenceNumber();
 
-        // If we have seen a more recent operation for this payload, we ignore the current one
-        // TODO: I think we can return false here. All callers use the Client API (refreshTTL(getRefreshTTLMessage()) which increments the sequence number
-        //  leaving only the onMessage() handler which doesn't look at the return value. It makes more intuitive sense that operations that don't
-        //  change state return false.
-        if (sequenceNumberMap.containsKey(hashOfPayload) && sequenceNumberMap.get(hashOfPayload).sequenceNr == sequenceNumber) {
-            log.trace("We got that message with that seq nr already from another peer. We ignore that message.");
-
-            return true;
-        }
-
-        // TODO: Combine with above in future work, but preserve existing behavior for now
         if(!hasSequenceNrIncreased(sequenceNumber, hashOfPayload))
             return false;
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -505,7 +505,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             return false;
 
         // Verify the ProtectedStorageEntry is well formed and valid for the remove operation
-        if (!protectedStorageEntry.isValidForRemoveOperation() || !checkSignature(protectedStorageEntry))
+        if (!protectedStorageEntry.isValidForRemoveOperation())
             return false;
 
         // If we have already seen an Entry with the same hash, verify the new Entry has the same owner
@@ -594,7 +594,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         PublicKey receiversPubKey = protectedMailboxStorageEntry.getReceiversPubKey();
 
-        if (!protectedMailboxStorageEntry.isValidForRemoveOperation() || !checkSignature(protectedMailboxStorageEntry))
+        if (!protectedMailboxStorageEntry.isValidForRemoveOperation())
             return false;
 
         // Verify the Entry has the correct receiversPubKey for removal.

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -597,11 +597,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         if (!protectedMailboxStorageEntry.isValidForRemoveOperation())
             return false;
 
-        // Verify the Entry has the correct receiversPubKey for removal.
-        if (!protectedMailboxStorageEntry.getMailboxStoragePayload().getOwnerPubKey().equals(receiversPubKey)) {
-            log.debug("Entry receiversPubKey does not match payload owner which is a requirement for removing MailboxStoragePayloads");
-            return false;
-        }
 
         // If we have already seen an Entry with the same hash, verify the new Entry has the same owner
         if (!checkIfStoredMailboxDataMatchesNewMailboxData(receiversPubKey, hashOfPayload))
@@ -755,11 +750,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             log.error("Signature verification failed at checkSignature");
             return false;
         }
-    }
-
-    private boolean checkSignature(ProtectedStorageEntry protectedStorageEntry) {
-        byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new DataAndSeqNrPair(protectedStorageEntry.getProtectedStoragePayload(), protectedStorageEntry.getSequenceNumber()));
-        return checkSignature(protectedStorageEntry.getOwnerPubKey(), hashOfDataAndSeqNr, protectedStorageEntry.getSignature());
     }
 
     private boolean checkIfStoredDataPubKeyMatchesNewDataPubKey(PublicKey ownerPubKey, ByteArray hashOfData) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -406,7 +406,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         ProtectedStorageEntry storedEntry = map.get(hashOfPayload);
 
         // If we have already seen an Entry with the same hash, verify the metadata is equal
-        if (storedEntry != null && !protectedStorageEntry.isMetadataEquals(storedEntry))
+        if (storedEntry != null && !protectedStorageEntry.matchesRelevantPubKey(storedEntry))
             return false;
 
         // This is an updated entry. Record it and signal listeners.
@@ -504,7 +504,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             return false;
 
         // If we have already seen an Entry with the same hash, verify the metadata is the same
-        if (!protectedStorageEntry.isMetadataEquals(storedEntry))
+        if (!protectedStorageEntry.matchesRelevantPubKey(storedEntry))
             return false;
 
         // Valid remove entry, do the remove and signal listeners

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -770,15 +770,12 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         if (protectedStoragePayload instanceof MailboxStoragePayload) {
             MailboxStoragePayload payload = (MailboxStoragePayload) protectedStoragePayload;
             if (isAddOperation)
-                result = payload.getSenderPubKeyForAddOperation() != null &&
-                        payload.getSenderPubKeyForAddOperation().equals(protectedStorageEntry.getOwnerPubKey());
+                result = protectedStorageEntry.isValidForAddOperation();
             else
                 result = payload.getOwnerPubKey() != null &&
                         payload.getOwnerPubKey().equals(protectedStorageEntry.getOwnerPubKey());
         } else {
-            result = protectedStorageEntry.getOwnerPubKey() != null &&
-                    protectedStoragePayload != null &&
-                    protectedStorageEntry.getOwnerPubKey().equals(protectedStoragePayload.getOwnerPubKey());
+            result = protectedStorageEntry.isValidForAddOperation();
         }
 
         if (!result) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -497,7 +497,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         }
 
         // If we have seen a more recent operation for this payload, ignore this one
-        if (!isSequenceNrValid(protectedStorageEntry.getSequenceNumber(), hashOfPayload))
+        if (!hasSequenceNrIncreased(protectedStorageEntry.getSequenceNumber(), hashOfPayload))
             return false;
 
         // Verify the ProtectedStorageEntry is well formed and valid for the remove operation
@@ -585,7 +585,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         int sequenceNumber = protectedMailboxStorageEntry.getSequenceNumber();
 
-        if (!isSequenceNrValid(sequenceNumber, hashOfPayload))
+        if (!hasSequenceNrIncreased(sequenceNumber, hashOfPayload))
             return false;
 
         PublicKey receiversPubKey = protectedMailboxStorageEntry.getReceiversPubKey();
@@ -708,24 +708,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         map.remove(hashOfPayload);
         log.trace("Data removed from our map. We broadcast the message to our peers.");
         hashMapChangedListeners.forEach(e -> e.onRemoved(protectedStorageEntry));
-    }
-
-    private boolean isSequenceNrValid(int newSequenceNumber, ByteArray hashOfData) {
-        if (sequenceNumberMap.containsKey(hashOfData)) {
-            int storedSequenceNumber = sequenceNumberMap.get(hashOfData).sequenceNr;
-            if (newSequenceNumber >= storedSequenceNumber) {
-                log.trace("Sequence number is valid (>=). sequenceNumber = "
-                        + newSequenceNumber + " / storedSequenceNumber=" + storedSequenceNumber);
-                return true;
-            } else {
-                log.debug("Sequence number is invalid. sequenceNumber = "
-                        + newSequenceNumber + " / storedSequenceNumber=" + storedSequenceNumber + "\n" +
-                        "That can happen if the data owner gets an old delayed data storage message.");
-                return false;
-            }
-        } else {
-            return true;
-        }
     }
 
     private boolean hasSequenceNrIncreased(int newSequenceNumber, ByteArray hashOfData) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -93,6 +93,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Slf4j
 public class P2PDataStorage implements MessageListener, ConnectionListener, PersistedDataHost {
     /**
@@ -475,6 +477,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     public boolean remove(ProtectedStorageEntry protectedStorageEntry,
                           @Nullable NodeAddress sender,
                           boolean isDataOwner) {
+        checkArgument(!(protectedStorageEntry instanceof ProtectedMailboxStorageEntry), "Use removeMailboxData for ProtectedMailboxStorageEntry");
+
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
         boolean containsKey = map.containsKey(hashOfPayload);

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -772,8 +772,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             if (isAddOperation)
                 result = protectedStorageEntry.isValidForAddOperation();
             else
-                result = payload.getOwnerPubKey() != null &&
-                        payload.getOwnerPubKey().equals(protectedStorageEntry.getOwnerPubKey());
+                result = protectedStorageEntry.isValidForRemoveOperation();
         } else {
             result = protectedStorageEntry.isValidForAddOperation();
         }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -90,6 +90,9 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
      */
     @Override
     public boolean isValidForAddOperation() {
+        if (!this.isSignatureValid())
+            return false;
+
         MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
         boolean result = mailboxStoragePayload.getSenderPubKeyForAddOperation() != null &&
                 mailboxStoragePayload.getSenderPubKeyForAddOperation().equals(this.getOwnerPubKey());

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -91,8 +91,21 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
     @Override
     public boolean isValidForAddOperation() {
         MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
-        return mailboxStoragePayload.getSenderPubKeyForAddOperation() != null &&
+        boolean result = mailboxStoragePayload.getSenderPubKeyForAddOperation() != null &&
                 mailboxStoragePayload.getSenderPubKeyForAddOperation().equals(this.getOwnerPubKey());
+
+        if (!result) {
+            String res1 = this.toString();
+            String res2 = "null";
+            if (mailboxStoragePayload != null && mailboxStoragePayload.getOwnerPubKey() != null)
+                res2 = Utilities.encodeToHex(mailboxStoragePayload.getSenderPubKeyForAddOperation().getEncoded(),true);
+
+            log.warn(String.format("ProtectedMailboxStorageEntry::isValidForAddOperation() failed. " +
+                    "Entry owner does not match sender key in payload:\nProtectedStorageEntry=%s\n" +
+                    "SenderPubKeyForAddOperation=%s", res1, res2));
+        }
+
+        return result;
     }
 
     /*
@@ -102,8 +115,21 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
     @Override
     public boolean isValidForRemoveOperation() {
         MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
-        return mailboxStoragePayload.getOwnerPubKey() != null &&
+        boolean result = mailboxStoragePayload.getOwnerPubKey() != null &&
                 mailboxStoragePayload.getOwnerPubKey().equals(this.getOwnerPubKey());
+
+        if (!result) {
+            String res1 = this.toString();
+            String res2 = "null";
+            if (mailboxStoragePayload != null && mailboxStoragePayload.getOwnerPubKey() != null)
+                res2 = Utilities.encodeToHex(mailboxStoragePayload.getOwnerPubKey().getEncoded(), true);
+
+            log.warn(String.format("ProtectedMailboxStorageEntry::isValidForRemoveOperation() failed. " +
+                    "Entry owner does not match Payload owner:\nProtectedStorageEntry=%s\n" +
+                    "PayloadOwner=%s", res1, res2));
+        }
+
+        return result;
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -117,6 +117,9 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
      */
     @Override
     public boolean isValidForRemoveOperation() {
+        if (!this.isSignatureValid())
+            return false;
+
         MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
         boolean result = mailboxStoragePayload.getOwnerPubKey() != null &&
                 mailboxStoragePayload.getOwnerPubKey().equals(this.getOwnerPubKey());

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -41,10 +41,33 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                         int sequenceNumber,
                                         byte[] signature,
                                         PublicKey receiversPubKey) {
-        super(mailboxStoragePayload, ownerPubKey, sequenceNumber, signature);
+        this(mailboxStoragePayload,
+                Sig.getPublicKeyBytes(ownerPubKey),
+                ownerPubKey,
+                sequenceNumber,
+                signature,
+                Sig.getPublicKeyBytes(receiversPubKey),
+                receiversPubKey,
+                System.currentTimeMillis());
+    }
+
+    private ProtectedMailboxStorageEntry(MailboxStoragePayload mailboxStoragePayload,
+                                        byte[] ownerPubKeyBytes,
+                                        PublicKey ownerPubKey,
+                                        int sequenceNumber,
+                                        byte[] signature,
+                                        byte[] receiversPubKeyBytes,
+                                        PublicKey receiversPubKey,
+                                        long creationTimeStamp) {
+        super(mailboxStoragePayload,
+                ownerPubKeyBytes,
+                ownerPubKey,
+                sequenceNumber,
+                signature,
+                creationTimeStamp);
 
         this.receiversPubKey = receiversPubKey;
-        receiversPubKeyBytes = Sig.getPublicKeyBytes(receiversPubKey);
+        this.receiversPubKeyBytes = receiversPubKeyBytes;
     }
 
     public MailboxStoragePayload getMailboxStoragePayload() {
@@ -56,22 +79,20 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private ProtectedMailboxStorageEntry(long creationTimeStamp,
-                                         MailboxStoragePayload mailboxStoragePayload,
-                                         byte[] ownerPubKey,
+    private ProtectedMailboxStorageEntry(MailboxStoragePayload mailboxStoragePayload,
+                                         byte[] ownerPubKeyBytes,
                                          int sequenceNumber,
                                          byte[] signature,
-                                         byte[] receiversPubKeyBytes) {
-        super(creationTimeStamp,
-                mailboxStoragePayload,
-                ownerPubKey,
+                                         byte[] receiversPubKeyBytes,
+                                         long creationTimeStamp) {
+        this(mailboxStoragePayload,
+                ownerPubKeyBytes,
+                Sig.getPublicKeyFromBytes(ownerPubKeyBytes),
                 sequenceNumber,
-                signature);
-
-        this.receiversPubKeyBytes = receiversPubKeyBytes;
-        receiversPubKey = Sig.getPublicKeyFromBytes(receiversPubKeyBytes);
-
-        maybeAdjustCreationTimeStamp();
+                signature,
+                receiversPubKeyBytes,
+                Sig.getPublicKeyFromBytes(receiversPubKeyBytes),
+                creationTimeStamp);
     }
 
     public protobuf.ProtectedMailboxStorageEntry toProtoMessage() {
@@ -85,12 +106,12 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                                          NetworkProtoResolver resolver) {
         ProtectedStorageEntry entry = ProtectedStorageEntry.fromProto(proto.getEntry(), resolver);
         return new ProtectedMailboxStorageEntry(
-                entry.getCreationTimeStamp(),
                 (MailboxStoragePayload) entry.getProtectedStoragePayload(),
                 entry.getOwnerPubKey().getEncoded(),
                 entry.getSequenceNumber(),
                 entry.getSignature(),
-                proto.getReceiversPubKeyBytes().toByteArray());
+                proto.getReceiversPubKeyBytes().toByteArray(),
+                entry.getCreationTimeStamp());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -25,6 +25,8 @@ import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
+import java.time.Clock;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +42,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                         PublicKey ownerPubKey,
                                         int sequenceNumber,
                                         byte[] signature,
-                                        PublicKey receiversPubKey) {
+                                        PublicKey receiversPubKey,
+                                        Clock clock) {
         this(mailboxStoragePayload,
                 Sig.getPublicKeyBytes(ownerPubKey),
                 ownerPubKey,
@@ -48,7 +51,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                 signature,
                 Sig.getPublicKeyBytes(receiversPubKey),
                 receiversPubKey,
-                System.currentTimeMillis());
+                clock.millis(),
+                clock);
     }
 
     private ProtectedMailboxStorageEntry(MailboxStoragePayload mailboxStoragePayload,
@@ -58,13 +62,15 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                         byte[] signature,
                                         byte[] receiversPubKeyBytes,
                                         PublicKey receiversPubKey,
-                                        long creationTimeStamp) {
+                                        long creationTimeStamp,
+                                        Clock clock) {
         super(mailboxStoragePayload,
                 ownerPubKeyBytes,
                 ownerPubKey,
                 sequenceNumber,
                 signature,
-                creationTimeStamp);
+                creationTimeStamp,
+                clock);
 
         this.receiversPubKey = receiversPubKey;
         this.receiversPubKeyBytes = receiversPubKeyBytes;
@@ -84,7 +90,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                                          int sequenceNumber,
                                          byte[] signature,
                                          byte[] receiversPubKeyBytes,
-                                         long creationTimeStamp) {
+                                         long creationTimeStamp,
+                                         Clock clock) {
         this(mailboxStoragePayload,
                 ownerPubKeyBytes,
                 Sig.getPublicKeyFromBytes(ownerPubKeyBytes),
@@ -92,7 +99,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                 signature,
                 receiversPubKeyBytes,
                 Sig.getPublicKeyFromBytes(receiversPubKeyBytes),
-                creationTimeStamp);
+                creationTimeStamp,
+                clock);
     }
 
     public protobuf.ProtectedMailboxStorageEntry toProtoMessage() {
@@ -111,7 +119,8 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
                 entry.getSequenceNumber(),
                 entry.getSignature(),
                 proto.getReceiversPubKeyBytes().toByteArray(),
-                entry.getCreationTimeStamp());
+                entry.getCreationTimeStamp(),
+                resolver.getClock());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -103,9 +103,9 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
             if (mailboxStoragePayload != null && mailboxStoragePayload.getOwnerPubKey() != null)
                 res2 = Utilities.encodeToHex(mailboxStoragePayload.getSenderPubKeyForAddOperation().getEncoded(),true);
 
-            log.warn(String.format("ProtectedMailboxStorageEntry::isValidForAddOperation() failed. " +
-                    "Entry owner does not match sender key in payload:\nProtectedStorageEntry=%s\n" +
-                    "SenderPubKeyForAddOperation=%s", res1, res2));
+            log.warn("ProtectedMailboxStorageEntry::isValidForAddOperation() failed. " +
+                    "Entry owner does not match sender key in payload:\nProtectedStorageEntry=%{}\n" +
+                    "SenderPubKeyForAddOperation=%{}", res1, res2);
         }
 
         return result;
@@ -137,9 +137,9 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
             if (mailboxStoragePayload != null && mailboxStoragePayload.getOwnerPubKey() != null)
                 res2 = Utilities.encodeToHex(mailboxStoragePayload.getOwnerPubKey().getEncoded(), true);
 
-            log.warn(String.format("ProtectedMailboxStorageEntry::isValidForRemoveOperation() failed. " +
-                    "Entry owner does not match Payload owner:\nProtectedStorageEntry=%s\n" +
-                    "PayloadOwner=%s", res1, res2));
+            log.warn("ProtectedMailboxStorageEntry::isValidForRemoveOperation() failed. " +
+                    "Entry owner does not match Payload owner:\nProtectedStorageEntry={}\n" +
+                    "PayloadOwner={}", res1, res2);
         }
 
         return result;
@@ -150,7 +150,7 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
      * Returns true if the Entry metadata that is expected to stay constant between different versions of the same object
      * matches. For ProtectedMailboxStorageEntry, the receiversPubKey must stay the same.
      */
-    public boolean isMetadataEquals(ProtectedStorageEntry protectedStorageEntry) {
+    public boolean matchesRelevantPubKey(ProtectedStorageEntry protectedStorageEntry) {
         if (!(protectedStorageEntry instanceof ProtectedMailboxStorageEntry)) {
             log.error("ProtectedMailboxStorageEntry::isMetadataEquals() failed due to object type mismatch. " +
                     "ProtectedMailboxStorageEntry required, but got\n" + protectedStorageEntry);

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -179,8 +179,7 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
     @Override
     public String toString() {
         return "ProtectedMailboxStorageEntry{" +
-                "\n     receiversPubKeyBytes=" + Utilities.bytesAsHexString(receiversPubKeyBytes) +
-                ",\n     receiversPubKey=" + receiversPubKey +
-                "\n} " + super.toString();
+                "\n\tReceivers Public Key:    " + Utilities.bytesAsHexString(receiversPubKeyBytes) +
+                "\n" + super.toString();
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -86,13 +86,24 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
 
     /*
      * Returns true if this Entry is valid for an add operation. For mailbox Entrys, the entry owner must
-     * match the valid sender Public Key specified in the payload.
+     * match the valid sender Public Key specified in the payload. (Only sender can add)
      */
     @Override
     public boolean isValidForAddOperation() {
         MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
         return mailboxStoragePayload.getSenderPubKeyForAddOperation() != null &&
                 mailboxStoragePayload.getSenderPubKeyForAddOperation().equals(this.getOwnerPubKey());
+    }
+
+    /*
+     * Returns true if the Entry is valid for a remove operation. For mailbox Entrys, the entry owner must
+     * match the payload owner. (Only receiver can remove)
+     */
+    @Override
+    public boolean isValidForRemoveOperation() {
+        MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
+        return mailboxStoragePayload.getOwnerPubKey() != null &&
+                mailboxStoragePayload.getOwnerPubKey().equals(this.getOwnerPubKey());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -76,8 +76,23 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
         this.receiversPubKeyBytes = receiversPubKeyBytes;
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
     public MailboxStoragePayload getMailboxStoragePayload() {
         return (MailboxStoragePayload) getProtectedStoragePayload();
+    }
+
+    /*
+     * Returns true if this Entry is valid for an add operation. For mailbox Entrys, the entry owner must
+     * match the valid sender Public Key specified in the payload.
+     */
+    @Override
+    public boolean isValidForAddOperation() {
+        MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
+        return mailboxStoragePayload.getSenderPubKeyForAddOperation() != null &&
+                mailboxStoragePayload.getSenderPubKeyForAddOperation().equals(this.getOwnerPubKey());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -121,6 +121,13 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
             return false;
 
         MailboxStoragePayload mailboxStoragePayload = this.getMailboxStoragePayload();
+
+        // Verify the Entry has the correct receiversPubKey for removal
+        if (!mailboxStoragePayload.getOwnerPubKey().equals(this.receiversPubKey)) {
+            log.debug("Entry receiversPubKey does not match payload owner which is a requirement for removing MailboxStoragePayloads");
+            return false;
+        }
+
         boolean result = mailboxStoragePayload.getOwnerPubKey() != null &&
                 mailboxStoragePayload.getOwnerPubKey().equals(this.getOwnerPubKey());
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntry.java
@@ -145,6 +145,31 @@ public class ProtectedMailboxStorageEntry extends ProtectedStorageEntry {
         return result;
     }
 
+    @Override
+    /*
+     * Returns true if the Entry metadata that is expected to stay constant between different versions of the same object
+     * matches. For ProtectedMailboxStorageEntry, the receiversPubKey must stay the same.
+     */
+    public boolean isMetadataEquals(ProtectedStorageEntry protectedStorageEntry) {
+        if (!(protectedStorageEntry instanceof ProtectedMailboxStorageEntry)) {
+            log.error("ProtectedMailboxStorageEntry::isMetadataEquals() failed due to object type mismatch. " +
+                    "ProtectedMailboxStorageEntry required, but got\n" + protectedStorageEntry);
+
+            return false;
+        }
+
+        ProtectedMailboxStorageEntry protectedMailboxStorageEntry = (ProtectedMailboxStorageEntry) protectedStorageEntry;
+
+        boolean result = protectedMailboxStorageEntry.getReceiversPubKey().equals(this.receiversPubKey);
+        if (!result) {
+            log.warn("ProtectedMailboxStorageEntry::isMetadataEquals() failed due to metadata mismatch. " +
+                    "new.receiversPubKey=" + Utilities.bytesAsHexString(protectedMailboxStorageEntry.getReceiversPubKeyBytes()) +
+                    "stored.receiversPubKey=" + Utilities.bytesAsHexString(this.getReceiversPubKeyBytes()));
+        }
+
+        return result;
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -43,37 +43,50 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
     private long creationTimeStamp;
 
     public ProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
-                                 PublicKey ownerPubKey,
-                                 int sequenceNumber,
-                                 byte[] signature) {
-        this.protectedStoragePayload = protectedStoragePayload;
-        ownerPubKeyBytes = Sig.getPublicKeyBytes(ownerPubKey);
-        this.ownerPubKey = ownerPubKey;
-
-        this.sequenceNumber = sequenceNumber;
-        this.signature = signature;
-        this.creationTimeStamp = System.currentTimeMillis();
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // PROTO BUFFER
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-    protected ProtectedStorageEntry(long creationTimeStamp,
-                                    ProtectedStoragePayload protectedStoragePayload,
-                                    byte[] ownerPubKeyBytes,
+                                    PublicKey ownerPubKey,
                                     int sequenceNumber,
                                     byte[] signature) {
+        this(protectedStoragePayload,
+                Sig.getPublicKeyBytes(ownerPubKey),
+                ownerPubKey,
+                sequenceNumber,
+                signature,
+                System.currentTimeMillis());
+    }
+
+    protected ProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
+                                 byte[] ownerPubKeyBytes,
+                                 PublicKey ownerPubKey,
+                                 int sequenceNumber,
+                                 byte[] signature,
+                                 long creationTimeStamp) {
+
         this.protectedStoragePayload = protectedStoragePayload;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
-        ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyBytes);
+        this.ownerPubKey = ownerPubKey;
 
         this.sequenceNumber = sequenceNumber;
         this.signature = signature;
         this.creationTimeStamp = creationTimeStamp;
 
         maybeAdjustCreationTimeStamp();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private ProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
+                                    byte[] ownerPubKeyBytes,
+                                    int sequenceNumber,
+                                    byte[] signature,
+                                    long creationTimeStamp) {
+        this(protectedStoragePayload,
+                ownerPubKeyBytes,
+                Sig.getPublicKeyFromBytes(ownerPubKeyBytes),
+                sequenceNumber,
+                signature,
+                creationTimeStamp);
     }
 
     public Message toProtoMessage() {
@@ -93,11 +106,12 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
 
     public static ProtectedStorageEntry fromProto(protobuf.ProtectedStorageEntry proto,
                                                   NetworkProtoResolver resolver) {
-        return new ProtectedStorageEntry(proto.getCreationTimeStamp(),
+        return new ProtectedStorageEntry(
                 ProtectedStoragePayload.fromProto(proto.getStoragePayload(), resolver),
                 proto.getOwnerPubKeyBytes().toByteArray(),
                 proto.getSequenceNumber(),
-                proto.getSignature().toByteArray());
+                proto.getSignature().toByteArray(),
+                proto.getCreationTimeStamp());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -165,4 +165,14 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
                     this.ownerPubKey.equals(protectedStoragePayload.getOwnerPubKey());
         }
     }
+
+    /*
+     * Returns true if the Entry is valid for a remove operation. For non-mailbox Entrys, the entry owner must
+     * match the payload owner.
+     */
+    public boolean isValidForRemoveOperation() {
+
+        // Same requirements as add()
+        return this.isValidForAddOperation();
+    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -21,6 +21,7 @@ import bisq.common.crypto.Sig;
 import bisq.common.proto.network.NetworkPayload;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.proto.persistable.PersistablePayload;
+import bisq.common.util.Utilities;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
@@ -160,9 +161,21 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
                     mailboxStoragePayload.getSenderPubKeyForAddOperation().equals(this.getOwnerPubKey());
 
         } else {
-            return this.ownerPubKey != null &&
+            boolean result = this.ownerPubKey != null &&
                     this.protectedStoragePayload != null &&
                     this.ownerPubKey.equals(protectedStoragePayload.getOwnerPubKey());
+
+            if (!result) {
+                String res1 = this.toString();
+                String res2 = "null";
+                if (protectedStoragePayload != null && protectedStoragePayload.getOwnerPubKey() != null)
+                    res2 = Utilities.encodeToHex(protectedStoragePayload.getOwnerPubKey().getEncoded(), true);
+
+                log.warn(String.format("ProtectedStorageEntry::isValidForAddOperation() failed. Entry owner does not match Payload owner:\n" +
+                        "ProtectedStorageEntry=%s\nPayloadOwner=%s", res1, res2));
+            }
+
+            return result;
         }
     }
 
@@ -173,6 +186,18 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
     public boolean isValidForRemoveOperation() {
 
         // Same requirements as add()
-        return this.isValidForAddOperation();
+        boolean result = this.isValidForAddOperation();
+
+        if (!result) {
+            String res1 = this.toString();
+            String res2 = "null";
+            if (protectedStoragePayload != null && protectedStoragePayload.getOwnerPubKey() != null)
+                res2 = Utilities.encodeToHex(protectedStoragePayload.getOwnerPubKey().getEncoded(), true);
+
+            log.warn(String.format("ProtectedStorageEntry::isValidForRemoveOperation() failed. Entry owner does not match Payload owner:\n" +
+                    "ProtectedStorageEntry=%s\nPayloadOwner=%s", res1, res2));
+        }
+
+        return result;
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -200,4 +200,15 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
 
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "ProtectedStorageEntry {" +
+                "\n\tPayload:                 " + protectedStoragePayload +
+                "\n\tOwner Public Key:        " + Utilities.bytesAsHexString(this.ownerPubKeyBytes) +
+                "\n\tSequence Number:         " + this.sequenceNumber +
+                "\n\tSignature:               " + Utilities.bytesAsHexString(this.signature) +
+                "\n\tTimestamp:               " + this.creationTimeStamp +
+                "\n} ";
+    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -147,4 +147,22 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
         return protectedStoragePayload instanceof ExpirablePayload &&
                 (clock.millis() - creationTimeStamp) > ((ExpirablePayload) protectedStoragePayload).getTTL();
     }
+
+    /*
+     * Returns true if the Entry is valid for an add operation. For non-mailbox Entrys, the entry owner must
+     * match the payload owner.
+     */
+    public boolean isValidForAddOperation() {
+        // TODO: The code currently supports MailboxStoragePayload objects inside ProtectedStorageEntry. Fix this.
+        if (protectedStoragePayload instanceof MailboxStoragePayload) {
+            MailboxStoragePayload mailboxStoragePayload = (MailboxStoragePayload) this.getProtectedStoragePayload();
+            return mailboxStoragePayload.getSenderPubKeyForAddOperation() != null &&
+                    mailboxStoragePayload.getSenderPubKeyForAddOperation().equals(this.getOwnerPubKey());
+
+        } else {
+            return this.ownerPubKey != null &&
+                    this.protectedStoragePayload != null &&
+                    this.ownerPubKey.equals(protectedStoragePayload.getOwnerPubKey());
+        }
+    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -177,8 +177,8 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
                 if (protectedStoragePayload != null && protectedStoragePayload.getOwnerPubKey() != null)
                     res2 = Utilities.encodeToHex(protectedStoragePayload.getOwnerPubKey().getEncoded(), true);
 
-                log.warn(String.format("ProtectedStorageEntry::isValidForAddOperation() failed. Entry owner does not match Payload owner:\n" +
-                        "ProtectedStorageEntry=%s\nPayloadOwner=%s", res1, res2));
+                log.warn("ProtectedStorageEntry::isValidForAddOperation() failed. Entry owner does not match Payload owner:\n" +
+                        "ProtectedStorageEntry={}\nPayloadOwner={}", res1, res2);
             }
 
             return result;
@@ -200,8 +200,8 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
             if (protectedStoragePayload != null && protectedStoragePayload.getOwnerPubKey() != null)
                 res2 = Utilities.encodeToHex(protectedStoragePayload.getOwnerPubKey().getEncoded(), true);
 
-            log.warn(String.format("ProtectedStorageEntry::isValidForRemoveOperation() failed. Entry owner does not match Payload owner:\n" +
-                    "ProtectedStorageEntry=%s\nPayloadOwner=%s", res1, res2));
+            log.warn("ProtectedStorageEntry::isValidForRemoveOperation() failed. Entry owner does not match Payload owner:\n" +
+                    "ProtectedStorageEntry={}\nPayloadOwner={}", res1, res2);
         }
 
         return result;
@@ -218,11 +218,11 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
             boolean result = Sig.verify(this.ownerPubKey, hashOfDataAndSeqNr, this.signature);
 
             if (!result)
-                log.warn(String.format("ProtectedStorageEntry::isSignatureValid() failed.\n%s", this));
+                log.warn("ProtectedStorageEntry::isSignatureValid() failed.\n{}}", this);
 
             return result;
         } catch (CryptoException e) {
-            log.error(String.format("ProtectedStorageEntry::isSignatureValid() exception %s", e.toString()));
+            log.error("ProtectedStorageEntry::isSignatureValid() exception {}", e.toString());
             return false;
         }
     }
@@ -231,7 +231,7 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
      * Returns true if the Entry metadata that is expected to stay constant between different versions of the same object
      * matches.
      */
-    public boolean isMetadataEquals(ProtectedStorageEntry protectedStorageEntry) {
+    public boolean matchesRelevantPubKey(ProtectedStorageEntry protectedStorageEntry) {
         boolean result = protectedStorageEntry.getOwnerPubKey().equals(this.ownerPubKey);
 
         if (!result) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -227,6 +227,22 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
         }
     }
 
+    /*
+     * Returns true if the Entry metadata that is expected to stay constant between different versions of the same object
+     * matches.
+     */
+    public boolean isMetadataEquals(ProtectedStorageEntry protectedStorageEntry) {
+        boolean result = protectedStorageEntry.getOwnerPubKey().equals(this.ownerPubKey);
+
+        if (!result) {
+            log.warn("New data entry does not match our stored data. storedData.ownerPubKey=" +
+                    (protectedStorageEntry.getOwnerPubKey() != null ? protectedStorageEntry.getOwnerPubKey().toString() : "null") +
+                    ", ownerPubKey=" + this.ownerPubKey);
+        }
+
+        return result;
+    }
+
     @Override
     public String toString() {
         return "ProtectedStorageEntry {" +

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStorageEntry.java
@@ -40,7 +40,7 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
     private final ProtectedStoragePayload protectedStoragePayload;
     private final byte[] ownerPubKeyBytes;
     transient private final PublicKey ownerPubKey;
-    private int sequenceNumber;
+    private final int sequenceNumber;
     private byte[] signature;
     private long creationTimeStamp;
 
@@ -133,19 +133,12 @@ public class ProtectedStorageEntry implements NetworkPayload, PersistablePayload
             creationTimeStamp = clock.millis();
     }
 
-    public void refreshTTL(Clock clock) {
-        creationTimeStamp = clock.millis();
-    }
-
     public void backDate() {
         if (protectedStoragePayload instanceof ExpirablePayload)
             creationTimeStamp -= ((ExpirablePayload) protectedStoragePayload).getTTL() / 2;
     }
 
-    public void updateSequenceNumber(int sequenceNumber) {
-        this.sequenceNumber = sequenceNumber;
-    }
-
+    // TODO: only used in tests so find a better way to test and delete public API
     public void updateSignature(byte[] signature) {
         this.signature = signature;
     }

--- a/p2p/src/test/java/bisq/network/p2p/TestUtils.java
+++ b/p2p/src/test/java/bisq/network/p2p/TestUtils.java
@@ -27,6 +27,8 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 
+import java.time.Clock;
+
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
@@ -184,6 +186,9 @@ public class TestUtils {
             public NetworkPayload fromProto(protobuf.StorageEntryWrapper proto) {
                 return null;
             }
+
+            @Override
+            public Clock getClock() { return null; }
         };
     }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -1130,7 +1130,7 @@ public class P2PDataStorageTest {
                 return true;
             } else {
                 // XXX: All external callers just pass in true, a future patch can remove the argument.
-                return testState.mockedStorage.removeMailboxData((ProtectedMailboxStorageEntry) entry, getTestNodeAddress(), true);
+                return testState.mockedStorage.remove(entry, getTestNodeAddress(), true);
             }
         }
 
@@ -1278,20 +1278,6 @@ public class P2PDataStorageTest {
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
 
             doProtectedStorageRemoveAndVerify(this.getProtectedStorageEntryForRemove(2), false, false);
-        }
-
-
-        @Test(expected = IllegalArgumentException.class)
-        public void remove_canCallWrongRemoveAndFail() throws CryptoException {
-
-            ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
-            ProtectedStorageEntry entryForRemove = this.getProtectedStorageEntryForRemove(1);
-
-            doProtectedStorageAddAndVerify(entryForAdd, true, true);
-
-            // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails spectacularly
-            super.doRemove(entryForRemove);
         }
 
         // TESTCASE: Add after removed when add-once required (greater seq #)
@@ -1445,7 +1431,7 @@ public class P2PDataStorageTest {
                     this.testState.mockedStorage.getMailboxDataWithSignedSeqNr(mailboxStoragePayload, receiverKeys, receiverKeys.getPublic());
 
             SavedTestState beforeState = new SavedTestState(this.testState, protectedMailboxStorageEntry);
-            Assert.assertFalse(this.testState.mockedStorage.removeMailboxData(protectedMailboxStorageEntry, getTestNodeAddress(), true));
+            Assert.assertFalse(this.testState.mockedStorage.remove(protectedMailboxStorageEntry, getTestNodeAddress(), true));
 
             verifyProtectedStorageRemove(this.testState, beforeState, protectedMailboxStorageEntry, false, true, true, true);
         }
@@ -1467,7 +1453,7 @@ public class P2PDataStorageTest {
                     this.testState.mockedStorage.getMailboxDataWithSignedSeqNr(mailboxStoragePayload, receiverKeys, receiverKeys.getPublic());
 
             SavedTestState beforeState = new SavedTestState(this.testState, protectedMailboxStorageEntry);
-            Assert.assertTrue(this.testState.mockedStorage.removeMailboxData(protectedMailboxStorageEntry, getTestNodeAddress(), true));
+            Assert.assertTrue(this.testState.mockedStorage.remove(protectedMailboxStorageEntry, getTestNodeAddress(), true));
 
             verifyProtectedStorageRemove(this.testState, beforeState, protectedMailboxStorageEntry, true, true, true,true);
         }
@@ -1493,7 +1479,7 @@ public class P2PDataStorageTest {
                     this.testState.mockedStorage.getMailboxDataWithSignedSeqNr(mailboxStoragePayload, receiverKeys, receiverKeys.getPublic());
 
             SavedTestState beforeState = new SavedTestState(this.testState, protectedMailboxStorageEntry);
-            Assert.assertTrue(this.testState.mockedStorage.removeMailboxData(protectedMailboxStorageEntry, getTestNodeAddress(), true));
+            Assert.assertTrue(this.testState.mockedStorage.remove(protectedMailboxStorageEntry, getTestNodeAddress(), true));
 
             verifyProtectedStorageRemove(this.testState, beforeState, protectedMailboxStorageEntry, true, true, true,true);
         }

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -976,7 +976,7 @@ public class P2PDataStorageTest {
             ProtectedStorageEntry entry = this.getProtectedStorageEntryForAdd(1);
             doProtectedStorageAddAndVerify(entry, true, true);
 
-            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys,1), true, false);
+            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys,1), false, false);
         }
 
         // TESTCASE: Duplicate refresh message (same seq #)
@@ -986,7 +986,7 @@ public class P2PDataStorageTest {
             doProtectedStorageAddAndVerify(entry, true, true);
 
             doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), true, true);
-            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), true, false);
+            doRefreshTTLAndVerify(buildRefreshOfferMessage(entry, this.payloadOwnerKeys, 2), false, false);
         }
 
         // TESTCASE: Duplicate refresh message (greater seq #)

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -392,8 +392,12 @@ public class P2PDataStorageTest {
             if (expectedSeqNrWriteOnStateChange)
                 verifySequenceNumberMapWriteContains(currentState, P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload()), protectedStorageEntry.getSequenceNumber());
 
-            if (expectedBroadcastOnStateChange)
-                verify(currentState.mockBroadcaster).broadcast(any(BroadcastMessage.class), any(NodeAddress.class), eq(null), eq(expectedIsDataOwner));
+            if (expectedBroadcastOnStateChange) {
+                if (protectedStorageEntry instanceof ProtectedMailboxStorageEntry)
+                    verify(currentState.mockBroadcaster).broadcast(any(RemoveMailboxDataMessage.class), any(NodeAddress.class), eq(null), eq(expectedIsDataOwner));
+                else
+                    verify(currentState.mockBroadcaster).broadcast(any(RemoveDataMessage.class), any(NodeAddress.class), eq(null), eq(expectedIsDataOwner));
+            }
 
         } else {
             Assert.assertEquals(beforeState.protectedStorageEntryBeforeOp, currentState.mockedStorage.getMap().get(hashMapHash));

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -191,7 +191,7 @@ public class P2PDataStorageTest {
         byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new P2PDataStorage.DataAndSeqNrPair(protectedStoragePayload, sequenceNumber));
         byte[] signature = Sig.sign(entrySignerKeys.getPrivate(), hashOfDataAndSeqNr);
 
-        return new ProtectedStorageEntry(protectedStoragePayload, entryOwnerKeys.getPublic(), sequenceNumber, signature);
+        return new ProtectedStorageEntry(protectedStoragePayload, entryOwnerKeys.getPublic(), sequenceNumber, signature, Clock.systemDefaultZone());
     }
 
     private static MailboxStoragePayload buildMailboxStoragePayload(PublicKey payloadSenderPubKeyForAddOperation,
@@ -220,7 +220,7 @@ public class P2PDataStorageTest {
         byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new P2PDataStorage.DataAndSeqNrPair(payload, sequenceNumber));
         byte[] signature = Sig.sign(entrySigner, hashOfDataAndSeqNr);
         return new ProtectedMailboxStorageEntry(payload,
-                entryOwnerPubKey, sequenceNumber, signature, entryReceiversPubKey);
+                entryOwnerPubKey, sequenceNumber, signature, entryReceiversPubKey, Clock.systemDefaultZone());
     }
 
     private static RefreshOfferMessage buildRefreshOfferMessage(ProtectedStoragePayload protectedStoragePayload,

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -737,12 +737,11 @@ public class P2PDataStorageTest {
         }
 
         // TESTCASE: Adding duplicate payload w/ same sequence number
-        // TODO: Should adds() of existing sequence #s return false since they don't update state?
         @Test
         public void addProtectedStorageEntry_duplicateSeqNrGt0() throws CryptoException {
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
-            doProtectedStorageAddAndVerify(entryForAdd, true, false);
+            doProtectedStorageAddAndVerify(entryForAdd, false, false);
         }
 
         // TESTCASE: Adding duplicate payload w/ 0 sequence number (special branch in code for logging)
@@ -750,7 +749,7 @@ public class P2PDataStorageTest {
         public void addProtectedStorageEntry_duplicateSeqNrEq0() throws CryptoException {
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(0);
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
-            doProtectedStorageAddAndVerify(entryForAdd, true, false);
+            doProtectedStorageAddAndVerify(entryForAdd, false, false);
         }
 
         // TESTCASE: Adding duplicate payload for w/ lower sequence number

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -1162,12 +1162,7 @@ public class P2PDataStorageTest {
         }
 
 
-        // XXXBUGXXX: The P2PService calls remove() instead of removeFromMailbox() in the addMailboxData() path.
-        // This test shows it will always fail even with a valid remove entry. Future work should be able to
-        // combine the remove paths in the same way the add() paths are combined. This will require deprecating
-        // the receiversPubKey field which is a duplicate of the ownerPubKey in the MailboxStoragePayload.
-        // More investigation is needed.
-        @Test
+        @Test(expected = IllegalArgumentException.class)
         public void remove_canCallWrongRemoveAndFail() throws CryptoException {
 
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
@@ -1175,38 +1170,9 @@ public class P2PDataStorageTest {
 
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
 
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForRemove);
-
             // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails
-            boolean addResult = super.doRemove(entryForRemove);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            // should succeed with expectedStatechange==true when remove paths are combined
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForRemove, false, this.expectIsDataOwner());
-        }
-
-        // TESTCASE: Verify misuse of the API (calling remove() instead of removeFromMailbox correctly errors with
-        // a payload that is valid for remove of a non-mailbox entry.
-        @Test
-        public void remove_canCallWrongRemoveAndFailInvalidPayload() throws CryptoException {
-
-            ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
-
-            doProtectedStorageAddAndVerify(entryForAdd, true, true);
-
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForAdd);
-
-            // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails with a payload that isn't signed by payload.ownerPubKey
-            boolean addResult = super.doRemove(entryForAdd);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForAdd, false, this.expectIsDataOwner());
+            // it fails spectacularly
+            super.doRemove(entryForRemove);
         }
 
         // TESTCASE: Add after removed when add-once required (greater seq #)

--- a/p2p/src/test/java/bisq/network/p2p/storage/ProtectedDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/ProtectedDataStorageTest.java
@@ -42,6 +42,8 @@ import java.security.NoSuchProviderException;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 
+import java.time.Clock;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -142,7 +144,7 @@ public class ProtectedDataStorageTest {
         int newSequenceNumber = data.getSequenceNumber() + 1;
         byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new P2PDataStorage.DataAndSeqNrPair(data.getProtectedStoragePayload(), newSequenceNumber));
         byte[] signature = Sig.sign(storageSignatureKeyPair1.getPrivate(), hashOfDataAndSeqNr);
-        ProtectedStorageEntry dataToRemove = new ProtectedStorageEntry(data.getProtectedStoragePayload(), data.getOwnerPubKey(), newSequenceNumber, signature);
+        ProtectedStorageEntry dataToRemove = new ProtectedStorageEntry(data.getProtectedStoragePayload(), data.getOwnerPubKey(), newSequenceNumber, signature, Clock.systemDefaultZone());
         Assert.assertTrue(dataStorage1.remove(dataToRemove, null, true));
         Assert.assertEquals(0, dataStorage1.getMap().size());
     }

--- a/p2p/src/test/java/bisq/network/p2p/storage/messages/AddDataMessageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/messages/AddDataMessageTest.java
@@ -36,6 +36,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 
+import java.time.Clock;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -72,7 +74,7 @@ public class AddDataMessageTest {
         MailboxStoragePayload mailboxStoragePayload = new MailboxStoragePayload(prefixedSealedAndSignedMessage,
                 keyRing1.getPubKeyRing().getSignaturePubKey(), keyRing1.getPubKeyRing().getSignaturePubKey());
         ProtectedStorageEntry protectedStorageEntry = new ProtectedMailboxStorageEntry(mailboxStoragePayload,
-                keyRing1.getSignatureKeyPair().getPublic(), 1, RandomUtils.nextBytes(10), keyRing1.getPubKeyRing().getSignaturePubKey());
+                keyRing1.getSignatureKeyPair().getPublic(), 1, RandomUtils.nextBytes(10), keyRing1.getPubKeyRing().getSignaturePubKey(), Clock.systemDefaultZone());
         AddDataMessage dataMessage1 = new AddDataMessage(protectedStorageEntry);
         protobuf.NetworkEnvelope envelope = dataMessage1.toProtoNetworkEnvelope();
 

--- a/p2p/src/test/java/bisq/network/p2p/storage/mocks/ClockFake.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/mocks/ClockFake.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.mocks;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class ClockFake extends Clock {
+    private Instant currentInstant;
+
+    public ClockFake() {
+        this.currentInstant = Instant.now();
+    }
+
+    @Override
+    public ZoneId getZone() {
+        throw new UnsupportedOperationException("ClockFake does not support getZone");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zoneId) {
+        throw new UnsupportedOperationException("ClockFake does not support withZone");
+    }
+
+    @Override
+    public Instant instant() {
+        return this.currentInstant;
+    }
+
+    public void increment(long milliseconds) {
+        this.currentInstant = this.currentInstant.plusMillis(milliseconds);
+    }
+}

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
@@ -146,4 +146,18 @@ public class ProtectedMailboxStorageEntryTest {
 
         Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
     }
+
+    // TESTCASE: isValidForRemoveOperation() should fail if the signature is bad
+    @Test
+    public void isValidForRemoveOperation_BadSignature() throws NoSuchAlgorithmException, CryptoException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic());
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedMailboxStorageEntry(mailboxStoragePayload, receiverKeys, receiverKeys.getPublic());
+
+        protectedStorageEntry.updateSignature(new byte[] { 0 });
+
+        Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
+    }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
@@ -81,4 +81,28 @@ public class ProtectedMailboxStorageEntryTest {
         // should be assertFalse
         Assert.assertTrue(protectedStorageEntry.isValidForAddOperation());
     }
+
+    // TESTCASE: validForRemoveOperation() should return true if the Entry owner and payload owner match
+    @Test
+    public void validForRemove() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic());
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedMailboxStorageEntry(mailboxStoragePayload, receiverKeys.getPublic(), receiverKeys.getPublic());
+
+        Assert.assertTrue(protectedStorageEntry.isValidForRemoveOperation());
+    }
+
+    // TESTCASE: validForRemoveOperation() should return false if the Entry owner and payload owner don't match
+    @Test
+    public void validForRemoveEntryOwnerPayloadOwnerMismatch() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic());
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedMailboxStorageEntry(mailboxStoragePayload, senderKeys.getPublic(), receiverKeys.getPublic());
+
+        Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
+    }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.payload;
+
+import bisq.network.p2p.PrefixedSealedAndSignedMessage;
+import bisq.network.p2p.TestUtils;
+
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+
+import java.time.Clock;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class ProtectedMailboxStorageEntryTest {
+
+    private static MailboxStoragePayload buildMailboxStoragePayload(PublicKey payloadSenderPubKeyForAddOperation,
+                                                                    PublicKey payloadOwnerPubKey) {
+        return new MailboxStoragePayload(
+                mock(PrefixedSealedAndSignedMessage.class), payloadSenderPubKeyForAddOperation, payloadOwnerPubKey);
+    }
+
+    private static ProtectedMailboxStorageEntry buildProtectedMailboxStorageEntry(MailboxStoragePayload mailboxStoragePayload, PublicKey ownerKey, PublicKey receiverKey) {
+        return new ProtectedMailboxStorageEntry(mailboxStoragePayload, ownerKey, 1, new byte[] { 0 }, receiverKey, Clock.systemDefaultZone());
+    }
+
+    // TESTCASE: validForAddOperation() should return true if the Entry owner and sender key specified in payload match
+    @Test
+    public void isValidForAddOperation() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic());
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedMailboxStorageEntry(mailboxStoragePayload, senderKeys.getPublic(), receiverKeys.getPublic());
+
+        Assert.assertTrue(protectedStorageEntry.isValidForAddOperation());
+    }
+
+    // TESTCASE: validForAddOperation() should return false if the Entry owner and sender key specified in payload don't match
+    @Test
+    public void isValidForAddOperation_EntryOwnerPayloadReceiverMismatch() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic());
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedMailboxStorageEntry(mailboxStoragePayload, receiverKeys.getPublic(), receiverKeys.getPublic());
+
+        Assert.assertFalse(protectedStorageEntry.isValidForAddOperation());
+    }
+
+    // TESTCASE: validForAddOperation() should fail if Entry.receiversPubKey and Payload.ownerPubKey don't match
+    // XXXBUGXXX: The current code doesn't validate this mismatch, but it would create an added payload that could never
+    // be removed since the remove code requires Entry.receiversPubKey == Payload.ownerPubKey
+    @Test
+    public void isValidForAddOperation_EntryReceiverPayloadReceiverMismatch() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic());
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedMailboxStorageEntry(mailboxStoragePayload, senderKeys.getPublic(), senderKeys.getPublic());
+
+        // should be assertFalse
+        Assert.assertTrue(protectedStorageEntry.isValidForAddOperation());
+    }
+}

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
@@ -160,4 +160,16 @@ public class ProtectedMailboxStorageEntryTest {
 
         Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
     }
+
+    // TESTCASE: isValidForRemoveOperation() should fail if the receiversPubKey does not match the Entry owner
+    @Test
+    public void isValidForRemoveOperation_ReceiversPubKeyMismatch() throws NoSuchAlgorithmException, CryptoException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic());
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedMailboxStorageEntry(mailboxStoragePayload, receiverKeys, senderKeys.getPublic());
+
+        Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
+    }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedMailboxStorageEntryTest.java
@@ -183,7 +183,7 @@ public class ProtectedMailboxStorageEntryTest {
 
         ProtectedStorageEntry seqNrTwo = buildProtectedMailboxStorageEntry(mailboxStoragePayload, senderKeys, receiverKeys.getPublic(), 2);
 
-        Assert.assertTrue(seqNrOne.isMetadataEquals(seqNrTwo));
+        Assert.assertTrue(seqNrOne.matchesRelevantPubKey(seqNrTwo));
     }
 
     // TESTCASE: isMetadataEquals() should fail if the receiversPubKey changes
@@ -197,6 +197,6 @@ public class ProtectedMailboxStorageEntryTest {
 
         ProtectedStorageEntry seqNrTwo = buildProtectedMailboxStorageEntry(mailboxStoragePayload, senderKeys, senderKeys.getPublic(), 1);
 
-        Assert.assertFalse(seqNrOne.isMetadataEquals(seqNrTwo));
+        Assert.assertFalse(seqNrOne.matchesRelevantPubKey(seqNrTwo));
     }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
@@ -40,14 +40,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ProtectedStorageEntryTest {
-    private static ProtectedStorageEntry buildProtectedStorageEntry(KeyPair payloadOwner, KeyPair entryOwner) throws CryptoException {
-        return buildProtectedStorageEntry(new ProtectedStoragePayloadStub(payloadOwner.getPublic()), entryOwner);
+    private static ProtectedStorageEntry buildProtectedStorageEntry(KeyPair payloadOwner, KeyPair entryOwner, int sequenceNumber) throws CryptoException {
+        return buildProtectedStorageEntry(new ProtectedStoragePayloadStub(payloadOwner.getPublic()), entryOwner, sequenceNumber);
     }
 
     private static ProtectedStorageEntry buildProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
-                                                                    KeyPair entryOwner) throws CryptoException {
-
-        int sequenceNumber = 1;
+                                                                    KeyPair entryOwner, int sequenceNumber) throws CryptoException {
 
         byte[] hashOfDataAndSeqNr = P2PDataStorage.get32ByteHash(new P2PDataStorage.DataAndSeqNrPair(protectedStoragePayload, sequenceNumber));
         byte[] signature = Sig.sign(entryOwner.getPrivate(), hashOfDataAndSeqNr);
@@ -82,7 +80,7 @@ public class ProtectedStorageEntryTest {
     @Test
     public void isValidForAddOperation() throws NoSuchAlgorithmException, CryptoException {
         KeyPair ownerKeys = TestUtils.generateKeyPair();
-        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys);
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys, 1);
 
         Assert.assertTrue(protectedStorageEntry.isValidForAddOperation());
     }
@@ -92,7 +90,7 @@ public class ProtectedStorageEntryTest {
     public void isValidForAddOperation_Mismatch() throws NoSuchAlgorithmException, CryptoException {
         KeyPair ownerKeys = TestUtils.generateKeyPair();
         KeyPair notOwnerKeys = TestUtils.generateKeyPair();
-        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, notOwnerKeys);
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, notOwnerKeys, 1);
 
         Assert.assertFalse(protectedStorageEntry.isValidForAddOperation());
     }
@@ -106,7 +104,7 @@ public class ProtectedStorageEntryTest {
         KeyPair receiverKeys = TestUtils.generateKeyPair();
 
         ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(
-                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), senderKeys);
+                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), senderKeys, 1);
 
         // should be assertFalse
         Assert.assertTrue(protectedStorageEntry.isValidForAddOperation());
@@ -120,7 +118,7 @@ public class ProtectedStorageEntryTest {
         KeyPair receiverKeys = TestUtils.generateKeyPair();
 
         ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(
-                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), receiverKeys);
+                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), receiverKeys, 1);
 
         Assert.assertFalse(protectedStorageEntry.isValidForAddOperation());
     }
@@ -129,7 +127,7 @@ public class ProtectedStorageEntryTest {
     @Test
     public void isValidForAddOperation_BadSignature() throws NoSuchAlgorithmException, CryptoException {
         KeyPair ownerKeys = TestUtils.generateKeyPair();
-        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys);
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys, 1);
 
         protectedStorageEntry.updateSignature( new byte[] { 0 });
 
@@ -140,7 +138,7 @@ public class ProtectedStorageEntryTest {
     @Test
     public void isValidForRemoveOperation() throws NoSuchAlgorithmException, CryptoException {
         KeyPair ownerKeys = TestUtils.generateKeyPair();
-        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys);
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys, 1);
 
         Assert.assertTrue(protectedStorageEntry.isValidForRemoveOperation());
     }
@@ -150,7 +148,7 @@ public class ProtectedStorageEntryTest {
     public void isValidForRemoveOperation_Mismatch() throws NoSuchAlgorithmException, CryptoException {
         KeyPair ownerKeys = TestUtils.generateKeyPair();
         KeyPair notOwnerKeys = TestUtils.generateKeyPair();
-        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, notOwnerKeys);
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, notOwnerKeys, 1);
 
         Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
     }
@@ -164,7 +162,7 @@ public class ProtectedStorageEntryTest {
         KeyPair receiverKeys = TestUtils.generateKeyPair();
 
         ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(
-                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), senderKeys);
+                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), senderKeys, 1);
 
         // should be assertFalse
         Assert.assertTrue(protectedStorageEntry.isValidForRemoveOperation());
@@ -176,7 +174,7 @@ public class ProtectedStorageEntryTest {
         KeyPair receiverKeys = TestUtils.generateKeyPair();
 
         ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(
-                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), receiverKeys);
+                buildMailboxStoragePayload(senderKeys.getPublic(), receiverKeys.getPublic()), receiverKeys, 1);
 
         Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
     }
@@ -185,10 +183,34 @@ public class ProtectedStorageEntryTest {
     @Test
     public void isValidForRemoveOperation_BadSignature() throws NoSuchAlgorithmException, CryptoException {
         KeyPair ownerKeys = TestUtils.generateKeyPair();
-        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys);
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys, 1);
 
         protectedStorageEntry.updateSignature(new byte[] { 0 });
 
         Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
+    }
+
+    // TESTCASE: isMetadataEquals() should succeed if the sequence number changes
+    @Test
+    public void isMetadataEquals() throws NoSuchAlgorithmException, CryptoException {
+        KeyPair ownerKeys = TestUtils.generateKeyPair();
+        ProtectedStorageEntry seqNrOne = buildProtectedStorageEntry(ownerKeys, ownerKeys, 1);
+
+        ProtectedStorageEntry seqNrTwo = buildProtectedStorageEntry(ownerKeys, ownerKeys, 2);
+
+        Assert.assertTrue(seqNrOne.isMetadataEquals(seqNrTwo));
+    }
+
+    // TESTCASE: isMetadataEquals() should fail if the OwnerPubKey changes
+    @Test
+    public void isMetadataEquals_OwnerPubKeyChanged() throws NoSuchAlgorithmException, CryptoException {
+        KeyPair ownerKeys = TestUtils.generateKeyPair();
+        KeyPair notOwner = TestUtils.generateKeyPair();
+
+        ProtectedStorageEntry protectedStorageEntryOne = buildProtectedStorageEntry(ownerKeys, ownerKeys, 1);
+
+        ProtectedStorageEntry protectedStorageEntryTwo = buildProtectedStorageEntry(ownerKeys, notOwner, 1);
+
+        Assert.assertFalse(protectedStorageEntryOne.isMetadataEquals(protectedStorageEntryTwo));
     }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
@@ -180,4 +180,15 @@ public class ProtectedStorageEntryTest {
 
         Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
     }
+
+    // TESTCASE: isValidForRemoveOperation() should fail if the signature is bad
+    @Test
+    public void isValidForRemoveOperation_BadSignature() throws NoSuchAlgorithmException, CryptoException {
+        KeyPair ownerKeys = TestUtils.generateKeyPair();
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys);
+
+        protectedStorageEntry.updateSignature(new byte[] { 0 });
+
+        Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
+    }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.payload;
+
+import bisq.network.p2p.PrefixedSealedAndSignedMessage;
+import bisq.network.p2p.TestUtils;
+import bisq.network.p2p.storage.mocks.ProtectedStoragePayloadStub;
+
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+
+import java.time.Clock;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class ProtectedStorageEntryTest {
+
+    private static ProtectedStorageEntry buildProtectedStorageEntry(KeyPair payloadOwner, KeyPair entryOwner) {
+        return buildProtectedStorageEntry(new ProtectedStoragePayloadStub(payloadOwner.getPublic()), entryOwner);
+    }
+
+    private static ProtectedStorageEntry buildProtectedStorageEntry(ProtectedStoragePayload protectedStoragePayload,
+                                                                    KeyPair entryOwner) {
+        return new ProtectedStorageEntry(protectedStoragePayload, entryOwner.getPublic(), 1,
+                new byte[] { 0 }, Clock.systemDefaultZone());
+    }
+
+    // TESTCASE: validForAddOperation() should return true if the Entry owner and payload owner match
+    @Test
+    public void isValidForAddOperation() throws NoSuchAlgorithmException {
+        KeyPair ownerKeys = TestUtils.generateKeyPair();
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys);
+
+        Assert.assertTrue(protectedStorageEntry.isValidForAddOperation());
+    }
+
+    // TESTCASE: validForAddOperation() should return false if the Entry owner and payload owner don't match
+    @Test
+    public void isValidForAddOperation_Mismatch() throws NoSuchAlgorithmException {
+        KeyPair ownerKeys = TestUtils.generateKeyPair();
+        KeyPair notOwnerKeys = TestUtils.generateKeyPair();
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, notOwnerKeys);
+
+        Assert.assertFalse(protectedStorageEntry.isValidForAddOperation());
+    }
+
+    // TESTCASE: validForAddOperation() should fail if the entry is a MailboxStoragePayload wrapped in a
+    // ProtectedStorageEntry and the Entry is owned by the sender
+    // XXXBUGXXX: Currently, a mis-wrapped MailboxStorageEntry will circumvent the senderPubKeyForAddOperation checks
+    @Test
+    public void isValidForAddOperation_invalidMailboxPayloadSender() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = new MailboxStoragePayload(
+                mock(PrefixedSealedAndSignedMessage.class), senderKeys.getPublic(), receiverKeys.getPublic());
+
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(mailboxStoragePayload, senderKeys);
+
+        // should be assertFalse
+        Assert.assertTrue(protectedStorageEntry.isValidForAddOperation());
+    }
+
+    // TESTCASE: validForAddOperation() should fail if the entry is a MailboxStoragePayload wrapped in a
+    // ProtectedStorageEntry and the Entry is owned by the receiver
+    @Test
+    public void isValidForAddOperation_invalidMailboxPayloadReceiver() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = new MailboxStoragePayload(
+                mock(PrefixedSealedAndSignedMessage.class), senderKeys.getPublic(), receiverKeys.getPublic());
+
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(mailboxStoragePayload, receiverKeys);
+
+        Assert.assertFalse(protectedStorageEntry.isValidForAddOperation());
+    }
+
+}

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
@@ -94,4 +94,52 @@ public class ProtectedStorageEntryTest {
         Assert.assertFalse(protectedStorageEntry.isValidForAddOperation());
     }
 
+    // TESTCASE: validForRemoveOperation() should return true if the Entry owner and payload owner match
+    @Test
+    public void isValidForRemoveOperation() throws NoSuchAlgorithmException {
+        KeyPair ownerKeys = TestUtils.generateKeyPair();
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, ownerKeys);
+
+        Assert.assertTrue(protectedStorageEntry.isValidForRemoveOperation());
+    }
+
+    // TESTCASE: validForRemoveOperation() should return false if the Entry owner and payload owner don't match
+    @Test
+    public void isValidForRemoveOperation_Mismatch() throws NoSuchAlgorithmException {
+        KeyPair ownerKeys = TestUtils.generateKeyPair();
+        KeyPair notOwnerKeys = TestUtils.generateKeyPair();
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(ownerKeys, notOwnerKeys);
+
+        Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
+    }
+
+    // TESTCASE: validForRemoveOperation() should fail if the entry is a MailboxStoragePayload wrapped in a
+    // ProtectedStorageEntry and the Entry is owned by the sender
+    // XXXBUGXXX: Currently, a mis-wrapped MailboxStoragePayload will succeed
+    @Test
+    public void isValidForRemoveOperation_invalidMailboxPayloadSender() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = new MailboxStoragePayload(
+                mock(PrefixedSealedAndSignedMessage.class), senderKeys.getPublic(), receiverKeys.getPublic());
+
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(mailboxStoragePayload, senderKeys);
+
+        // should be assertFalse
+        Assert.assertTrue(protectedStorageEntry.isValidForRemoveOperation());
+    }
+
+    @Test
+    public void isValidForRemoveOperation_invalidMailboxPayloadReceiver() throws NoSuchAlgorithmException {
+        KeyPair senderKeys = TestUtils.generateKeyPair();
+        KeyPair receiverKeys = TestUtils.generateKeyPair();
+
+        MailboxStoragePayload mailboxStoragePayload = new MailboxStoragePayload(
+                mock(PrefixedSealedAndSignedMessage.class), senderKeys.getPublic(), receiverKeys.getPublic());
+
+        ProtectedStorageEntry protectedStorageEntry = buildProtectedStorageEntry(mailboxStoragePayload, receiverKeys);
+
+        Assert.assertFalse(protectedStorageEntry.isValidForRemoveOperation());
+    }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/ProtectedStorageEntryTest.java
@@ -198,7 +198,7 @@ public class ProtectedStorageEntryTest {
 
         ProtectedStorageEntry seqNrTwo = buildProtectedStorageEntry(ownerKeys, ownerKeys, 2);
 
-        Assert.assertTrue(seqNrOne.isMetadataEquals(seqNrTwo));
+        Assert.assertTrue(seqNrOne.matchesRelevantPubKey(seqNrTwo));
     }
 
     // TESTCASE: isMetadataEquals() should fail if the OwnerPubKey changes
@@ -211,6 +211,6 @@ public class ProtectedStorageEntryTest {
 
         ProtectedStorageEntry protectedStorageEntryTwo = buildProtectedStorageEntry(ownerKeys, notOwner, 1);
 
-        Assert.assertFalse(protectedStorageEntryOne.isMetadataEquals(protectedStorageEntryTwo));
+        Assert.assertFalse(protectedStorageEntryOne.matchesRelevantPubKey(protectedStorageEntryTwo));
     }
 }


### PR DESCRIPTION
New commits start 54b4b4d

I expect a bit of discussion on this one based on my previous feedback, so I wanted to outline my thoughts here so that the best path forward can be taken with regards to testing, maintainability, and clean programming practices.

This entire stack was based on testing the P2PDataStore and refactoring it so it is more maintainable and easier to add new features in the future.

The module was almost impossible to test when starting out. I decided to write very heavy-handed integration tests while looking at the implementation to verify I covered all the branches and edge cases. The end result #3554 allowed refactoring to be done while ensuring the various combinations of ProtectedStorageEntrys and Payloads still worked correctly.

But in order to do that, the tests needed to create REAL ProtectedStorageEntry & ProtectedMailboxStorageEntry objects from scratch and manipulate them into the various valid and invalid configurations to exercise the code. Real keys, real hashes, a lot of overhead for testing that should be pretty straight forward.

The issue is that too much of the code exists in private helper functions inside the P2PDataStore itself. The only testing that can be done is front door integration testing where the tests know way too much about the implementation.

My solution to the complexity that I present in the next 2 pull requests is to turn ProtectedStorageEntry into a real object with a real API that can be unit tested. Determining whether or not an Entry is valid for an add operation shouldn't depend on the P2PDataStore internal state, or have to be run through the Client API to verify correctness.

If you are at all interested, I urge you to look at the unit tests in the following pull request (ProtectedStorageEntryTest & ProtectedMailboxStorageEntryTest) and see how easy it is to verify the correctness of an add or remove operation versus the path the integration test had to take in the beginning.

In addition to adding the ability to unit test the Entrys, real unit tests can now exist for the P2PDataStore. Instead of constructing a real object, they now just build a mock Entry (something that wasn't possible with the old object relationship). The result is that the unit tests for P2PDatastore can test only the code they need to (what data structures to update, who to signal, etc) and not worry about the implementation specifics of Mailbox vs. Normal Entrys.

The end result is code that has unit tests, has integration tests, is easy to navigate, and has line and branch coverage over 80%. More important than the numbers is that a developer can go in and change the code and get feedback on whether or not it worked. Something that wasn't possible before.

In summary, I would request that anyone who is interested look through the testing and weigh in on the maintainability and testing strategy of this refactor. The reality is that this code wasn't tested, has plenty of bugs, and was hard to maintain and develop against. It is only one of many that likely have the same problem and starting to have a discussion on the practices that everyone wants in Bisq should happen sooner than later.

Pull Request (7/8)

This pull request will introduce the API, test it, and use the new benefits to combine the remove() and removeMailboxData() paths. 

Pull Request(8/8)

This pull request will make use of the new objects to create clean mocks that clean up the integration tests and remove a lot of the heavy-handed object creation.

If you got this far, thanks again for taking the time to look.
