### PR TITLE
Updating instructions for trading XMR (Monero)

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1226,25 +1226,24 @@ If you are not sure about that process visit ArQmA discord channel (https://disc
 or the ArQmA forum (https://labs.arqma.com) to find more information.
 account.altcoin.popup.xmr.msg=Trading XMR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
-For sending XMR, you need to use either the official Monero GUI wallet or Monero CLI wallet with the \
-store-tx-info flag enabled (default in new versions). Please be sure you can access the tx key as \
-that would be required in case of a dispute.\n\
-monero-wallet-cli (use the command get_tx_key)\n\
-monero-wallet-gui (go to history tab and click on the (P) button for payment proof)\n\n\
-In addition to XMR checktx tool (https://xmr.llcoins.net/checktx.html) verification can also be accomplished in-wallet.\n\
-monero-wallet-cli : using command (check_tx_key).\n\
-monero-wallet-gui : on the Advanced > Prove/Check page.\n\
-At normal block explorers the transfer is not verifiable.\n\n\
+For sending XMR, you need to use either the official Monero GUI wallet or the Monero CLI wallet with the \
+store-tx-info flag enabled (enabled by default in new versions). Please be sure you can access the transaction key (tx_key) as \
+that would be required in case of a dispute:\n\
+Monero GUI: go to History tab and click on the (P) button for payment proof\n\n\
+Monero CLI: use the command get_tx_key\n\
+Verification can be accomplished with XMR checktx tool (https://xmr.llcoins.net/checktx.html), Explore Monero website (https://www.exploremonero.com/receipt) or in-wallet:\n\
+Monero GUI: on the Advanced > Prove/Check page.\n\
+Monero CLI: use the command check_tx_key.\n\
+In some block explorers the transfer is not verifiable.\n\n\
 You need to provide the mediator or arbitrator the following data in case of a dispute:\n\
-- The tx private key\n\
-- The transaction hash\n\
-- The recipient's public address\n\n\
+- The transaction key\n\
+- The transaction ID\n\
+- The recipient's address\n\n\
 Failure to provide the above data, or if you used an incompatible wallet, will result in losing the \
 dispute case. The XMR sender is responsible for providing verification of the XMR transfer to the \
 mediator or arbitrator in case of a dispute.\n\n\
-There is no payment ID required, just the normal public address.\n\
-If you are not sure about that process visit (https://www.getmonero.org/resources/user-guides/prove-payment.html) \
-or the Monero forum (https://forum.getmonero.org) to find more information.
+If you are not sure about that process, visit (https://www.getmonero.org/resources/user-guides/prove-payment.html) \
+or the Monero support (https://www.reddit.com/r/monerosupport/) to find more information.
 # suppress inspection "TrailingSpacesInProperty"
 account.altcoin.popup.msr.msg=Trading MSR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1233,8 +1233,8 @@ Monero GUI: go to History tab and click on the (P) button for payment proof\n\n\
 Monero CLI: use the command get_tx_key\n\
 Other wallets: go to transaction history and search for Tx Key or Transaction key in a sent transaction
 Verification can be accomplished in the following way:\n\
-Monero GUI: on the Advanced > Prove/Check page.\n\
-Monero CLI: use the command check_tx_key.\n\
+Monero GUI: on the Advanced > Prove/Check page\n\
+Monero CLI: use the command check_tx_key\n\
 Other wallets: use XMR checktx tool (https://xmr.llcoins.net/checktx.html), Explore Monero website (https://www.exploremonero.com/receipt)
 You need to provide the mediator or arbitrator the following data in case of a dispute:\n\
 - The transaction key\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1228,8 +1228,8 @@ account.altcoin.popup.xmr.msg=Trading XMR on Bisq requires that you understand a
 the following requirements:\n\n\
 For sending XMR, you need to use a wallet that provides the transaction key (Tx key), the transaction ID and the destination address of previously sent transactions, like the official Monero GUI wallet or the Monero CLI wallet. Please be sure you can access the transaction key (Tx key) in your wallet, as \
 that would be required in case of a dispute:\n\
-Monero GUI: go to Transactions tab\n\n\
-Monero CLI: use the command get_tx_key\n\
+Monero GUI: go to Transactions tab\n\
+Monero CLI: use the command get_tx_key. The flag store-tx-info must be enabled (enabled by default in new versions)\n\
 Other wallets: go to Transactions history and search for Tx Key or Transaction key in a sent transaction
 Verification can be accomplished in the following way:\n\
 Monero GUI: change wallet to Advanced mode and go to the Advanced > Prove/Check page\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1235,7 +1235,7 @@ Other wallets: go to transaction history and search for Tx Key or Transaction ke
 Verification can be accomplished in the following way:\n\
 Monero GUI: on the Advanced > Prove/Check page\n\
 Monero CLI: use the command check_tx_key\n\
-Other wallets: use XMR checktx tool (https://xmr.llcoins.net/checktx.html), Explore Monero website (https://www.exploremonero.com/receipt)
+Other wallets: use XMR checktx tool (https://xmr.llcoins.net/checktx.html) or Explore Monero website (https://www.exploremonero.com/receipt)
 You need to provide the mediator or arbitrator the following data in case of a dispute:\n\
 - The transaction key\n\
 - The transaction ID\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1226,15 +1226,16 @@ If you are not sure about that process visit ArQmA discord channel (https://disc
 or the ArQmA forum (https://labs.arqma.com) to find more information.
 account.altcoin.popup.xmr.msg=Trading XMR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
-For sending XMR, you need to use either the official Monero GUI wallet or the Monero CLI wallet with the \
-store-tx-info flag enabled (enabled by default in new versions). Please be sure you can access the transaction key (tx_key) as \
+For sending XMR, you need to use a wallet that provides the transaction key (Tx key) and the transaction ID, like the official Monero GUI wallet or the Monero CLI wallet with the \
+store-tx-info flag enabled (enabled by default in new versions). Please be sure you can access the transaction key (Tx key) in your wallet, as \
 that would be required in case of a dispute:\n\
 Monero GUI: go to History tab and click on the (P) button for payment proof\n\n\
 Monero CLI: use the command get_tx_key\n\
-Verification can be accomplished with XMR checktx tool (https://xmr.llcoins.net/checktx.html), Explore Monero website (https://www.exploremonero.com/receipt) or in-wallet:\n\
+Other wallets: go to transaction history and search for Tx Key or Transaction key in a sent transaction
+Verification can be accomplished in the following way:\n\
 Monero GUI: on the Advanced > Prove/Check page.\n\
 Monero CLI: use the command check_tx_key.\n\
-In some block explorers the transfer is not verifiable.\n\n\
+Other wallets: use XMR checktx tool (https://xmr.llcoins.net/checktx.html), Explore Monero website (https://www.exploremonero.com/receipt)
 You need to provide the mediator or arbitrator the following data in case of a dispute:\n\
 - The transaction key\n\
 - The transaction ID\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1243,7 +1243,7 @@ Failure to provide the above data, or if you used an incompatible wallet, will r
 dispute case. The XMR sender is responsible for providing verification of the XMR transfer to the \
 mediator or arbitrator in case of a dispute.\n\n\
 If you are not sure about that process, visit (https://www.getmonero.org/resources/user-guides/prove-payment.html) \
-or the Monero support (https://www.reddit.com/r/monerosupport/) to find more information.
+or the Monero support subreddit (https://www.reddit.com/r/monerosupport/) to find more information.
 # suppress inspection "TrailingSpacesInProperty"
 account.altcoin.popup.msr.msg=Trading MSR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1226,14 +1226,13 @@ If you are not sure about that process visit ArQmA discord channel (https://disc
 or the ArQmA forum (https://labs.arqma.com) to find more information.
 account.altcoin.popup.xmr.msg=Trading XMR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
-For sending XMR, you need to use a wallet that provides the transaction key (Tx key) and the transaction ID, like the official Monero GUI wallet or the Monero CLI wallet with the \
-store-tx-info flag enabled (enabled by default in new versions). Please be sure you can access the transaction key (Tx key) in your wallet, as \
+For sending XMR, you need to use a wallet that provides the transaction key (Tx key), the transaction ID and the destination address of previously sent transactions, like the official Monero GUI wallet or the Monero CLI wallet. Please be sure you can access the transaction key (Tx key) in your wallet, as \
 that would be required in case of a dispute:\n\
-Monero GUI: go to History tab and click on the (P) button for payment proof\n\n\
+Monero GUI: go to Transactions tab\n\n\
 Monero CLI: use the command get_tx_key\n\
-Other wallets: go to transaction history and search for Tx Key or Transaction key in a sent transaction
+Other wallets: go to Transactions history and search for Tx Key or Transaction key in a sent transaction
 Verification can be accomplished in the following way:\n\
-Monero GUI: on the Advanced > Prove/Check page\n\
+Monero GUI: change wallet to Advanced mode and go to the Advanced > Prove/Check page\n\
 Monero CLI: use the command check_tx_key\n\
 Other wallets: use XMR checktx tool (https://xmr.llcoins.net/checktx.html) or Explore Monero website (https://www.exploremonero.com/receipt)
 You need to provide the mediator or arbitrator the following data in case of a dispute:\n\


### PR DESCRIPTION
- clarifying that official Monero wallets (GUI or CLI) are NOT required to send XMR, since user can use alternative wallets that provide the transaction key, transaction ID and destination address (like desktop wallets Exodus and MyMonero, or mobile wallets like Cake Wallet) and do the verification outside the wallet (Explore Monero website or XMR checktx tool).
- listing Monero GUI as first option (for common users), and Monero CLI as second option (for advanced users)
- to get transaction key in Monero GUI, user must go to Transactions tab (P button is only used to generate payment proof)
- adding Explore Monero website (https://www.exploremonero.com/receipt) as alternative to proof/verify payments
- using _transaction key_ and _transaction ID_, instead of _tx private key_ and _transaction hash_, which are the terms used in the official Monero wallets
- removing payment ID instructions, since it is being deprecated at the end of November (v0.15)
- directing to subreddit Monero support (https://www.reddit.com/r/monerosupport/), which is actively maintained, instead of Monero forum (https://forum.getmonero.org).
