### PR TITLE
Updating trading instructions for XMR (Monero)

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1227,25 +1227,28 @@ If you are not sure about that process visit ArQmA discord channel (https://disc
 or the ArQmA forum (https://labs.arqma.com) to find more information.
 account.altcoin.popup.xmr.msg=Trading XMR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
-For sending XMR, you need to use either the official Monero GUI wallet or Monero CLI wallet with the \
-store-tx-info flag enabled (default in new versions). Please be sure you can access the tx key as \
-that would be required in case of a dispute.\n\
-monero-wallet-cli (use the command get_tx_key)\n\
-monero-wallet-gui (go to history tab and click on the (P) button for payment proof)\n\n\
-In addition to XMR checktx tool (https://xmr.llcoins.net/checktx.html) verification can also be accomplished in-wallet.\n\
-monero-wallet-cli : using command (check_tx_key).\n\
-monero-wallet-gui : on the Advanced > Prove/Check page.\n\
-At normal block explorers the transfer is not verifiable.\n\n\
-You need to provide the mediator or arbitrator the following data in case of a dispute:\n\
-- The tx private key\n\
-- The transaction hash\n\
-- The recipient's public address\n\n\
-Failure to provide the above data, or if you used an incompatible wallet, will result in losing the \
-dispute case. The XMR sender is responsible for providing verification of the XMR transfer to the \
-mediator or arbitrator in case of a dispute.\n\n\
-There is no payment ID required, just the normal public address.\n\
-If you are not sure about that process visit (https://www.getmonero.org/resources/user-guides/prove-payment.html) \
-or the Monero forum (https://forum.getmonero.org) to find more information.
+Prove payments: if you are sending XMR, you are the one responsible for providing verification of the \
+XMR transfer to the mediator or arbitrator in case of a dispute. Therefore, you must use a Monero wallet \
+that provides the information required to prove the payment was made. This information includes:\n\n\
+- the transaction key (Tx Key or Tx Secret Key)\n\
+- the transaction ID (Tx ID)\n\
+- the destination address (recipient's address)\n\n\
+Wallets known to provide this information are the official Monero GUI & CLI wallets, MyMonero, and \
+Exodus (desktop) as well as Cake Wallet, MyMonero, and Monerujo (mobile). You can find it here:\n\n\
+- Monero GUI: go to Transactions tab\n\
+- Monero CLI: use the command get_tx_key TXID. The flag store-tx-info must be enabled (enabled by default in new versions)\n\
+- Other wallets: go to Transactions history and search for Transaction key (Tx key or Secret key) and the destination address in a sent\
+transaction. Saving of recipient address must be enabled in Cake Wallet.\n\n\
+If you are using a wallet different from the mentioned above, please be sure you can access those \
+three pieces of information. Failure to provide the above data will result in losing the dispute case.\n\n\
+Check payments: with those three pieces of information, the verification that a quantity of Monero was sent \
+to a specific address can be accomplished the following way:\n\n\
+- Monero GUI: change wallet to Advanced mode and go to Advanced > Prove/check > Check Transaction\n\
+- Monero CLI: use the command check_tx_key TXID TXKEY ADDRESS\n\
+- XMR checktx tool (https://xmr.llcoins.net/checktx.html)\n\
+- Explore Monero website (https://www.exploremonero.com/receipt)\n\n\
+If you are still not sure about this process, visit (https://www.getmonero.org/resources/user-guides/prove-payment.html) \
+to find more information or ask a question on the Monero support subreddit (https://www.reddit.com/r/monerosupport/).
 # suppress inspection "TrailingSpacesInProperty"
 account.altcoin.popup.msr.msg=Trading MSR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\


### PR DESCRIPTION
Prove payments:
- clarifying that the official wallets (Monero GUI or CLI) are NOT required to send XMR, since user can use some alternative wallets (desktop: MyMonero, Exodus / mobile: Cake Wallet, MyMonero, Monerujo) that provide the information required to prove a payment (transaction key, transaction ID and destination address). This information is not provided by the remaining desktop and mobile wallets that currently support Monero, but since they could provide it in the future, I kept the warning about using other wallets different from the previously mentioned.
- listing Monero GUI as first option (for most users), and CLI as second option (for advanced users)
- renaming "transaction hash" to "transaction ID", which is used in official wallets
- renaming "tx private key" to "transaction key", which is used in official wallets
- adding "Secret key" as synonymous for "transaction key" (used in MyMonero wallet)
- adding "destination address" and keeping  "recipient's address" as synonymous
- renaming History tab to Transactions tab in Monero GUI
- adding "save recipient address" option must be enabled in Cake Wallet settings

Check payments:
- adding Monero GUI must be in Advanced mode
- adding Monero GUI verification must be done in Check Transaction section of Prove/check page
- adding parameters TXID TXKEY ADDRESS to the command check_tx_key in Monero CLI, as instructions in (https://www.getmonero.org/resources/user-guides/prove-payment.html)
- adding Explore Monero website (https://www.exploremonero.com/receipt) as alternative to verify payments
- removing payment ID instructions (it is being deprecated at the end of November in v0.15)

More info:
- directing to subreddit Monero support (https://www.reddit.com/r/monerosupport/), which is actively maintained, instead of Monero forum (https://forum.getmonero.org).