### PR TITLE
Sync dev docs with source code

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -72,8 +72,8 @@ For localhost/regtest mode run the `BisqAppMain` class or `./bisq-desktop` scrip
 
     --baseCurrencyNetwork=BTC_REGTEST --useLocalhostForP2P=true --useDevPrivilegeKeys=true --nodePort=4444 --appName=bisq-BTC_REGTEST_arbitrator
 
-Once it has started up go to `Account` and click `CMD +n`. This will open a new tab for `Arbitration registration`. Select the tab and you will see a popup with a pre-filled private key. That is the developer private key (which is only valid if `--useDevPrivilegeKeys` is set) which allows you to register a new arbitrator. Follow the next screen and complete registration.
-Next you have to register a mediator as well. Click `CMD + d`. This will open a new tab for `Mediator registration`. Follow the same steps as for the arbitrator registration before. Registration of legacy arbitrators was done with `CMD +n`. It is not needed anymore so we refer with the term arbitrator to the new arbitrator (or refund agent).
+Once it has started up go to `Account` and press `Alt-r`. This will open a new tab for `Arbitration registration`. Select the tab and you will see a popup with a pre-filled private key. That is the developer private key (which is only valid if `--useDevPrivilegeKeys` is set) which allows you to register a new arbitrator. Follow the next screen and complete registration.
+Next you have to register a mediator as well. Press `Cmd-d`. This will open a new tab for `Mediator registration`. Follow the same steps as for the arbitrator registration before. Registration of legacy arbitrators was done with `CMD +n`. It is not needed anymore so we refer with the term arbitrator to the new arbitrator (or refund agent).
 
 _Note: You need only register once but if you have shut down all nodes (including seed node) you need to start up the arbitrator again after you start the seed node so the arbitrator re-publishes his data to the P2P network. After it has started up you can close it again. You cannot trade without having an arbitrator available._
 


### PR DESCRIPTION
Dev docs say to use `Cmd-n` to bring up the arbitrator registration popup but in the [source code](https://github.com/bisq-network/bisq/blob/master/common/src/main/java/bisq/common/app/DevEnv.java#L35) it says to use `Alt-r` (which actually works).