### PR TITLE
Added padding for flowpane to resolve moneygram save issue.

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/MoneyGramForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/MoneyGramForm.java
@@ -146,7 +146,8 @@ public class MoneyGramForm extends PaymentMethodForm {
     }
 
     private void addCurrenciesGrid(boolean isEditable) {
-        final Tuple2<Label, FlowPane> labelFlowPaneTuple2 = addTopLabelFlowPane(gridPane, ++gridRow, Res.get("payment.supportedCurrencies"), 0);
+        final Tuple2<Label, FlowPane> labelFlowPaneTuple2 = addTopLabelFlowPane(gridPane, ++gridRow, Res.get("payment.supportedCurrencies"),
+                Layout.FLOATING_LABEL_DISTANCE * 3, Layout.FLOATING_LABEL_DISTANCE * 3);
 
         FlowPane flowPane = labelFlowPaneTuple2.second;
 


### PR DESCRIPTION
For https://github.com/bisq-network/bisq/issues/3598

Basically flowpane is hiding email label, hence we could not save. so 
@ripcurlx suggested this workaround fix for immeidate push.  