### PR TITLE
Refactor of FilterWindow - eliminate duplicates

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -148,8 +148,9 @@ public class FilterWindow extends Overlay<FilterWindow> {
 
         final Filter filter = filterManager.getDevelopersFilter();
         if (filter != null) {
-            offerIdsInputTextField.setText(filter.getBannedOfferIds().stream().collect(Collectors.joining(", ")));
-            nodesInputTextField.setText(filter.getBannedNodeAddress().stream().collect(Collectors.joining(", ")));
+            setupFieldFromList(offerIdsInputTextField, filter.getBannedOfferIds());
+            setupFieldFromList(nodesInputTextField, filter.getBannedNodeAddress());
+
             if (filter.getBannedPaymentAccounts() != null) {
                 StringBuilder sb = new StringBuilder();
                 filter.getBannedPaymentAccounts().stream().forEach(e -> {
@@ -165,29 +166,14 @@ public class FilterWindow extends Overlay<FilterWindow> {
                 paymentAccountFilterInputTextField.setText(sb.toString());
             }
 
-            if (filter.getBannedCurrencies() != null)
-                bannedCurrenciesInputTextField.setText(filter.getBannedCurrencies().stream().collect(Collectors.joining(", ")));
-
-            if (filter.getBannedPaymentMethods() != null)
-                bannedPaymentMethodsInputTextField.setText(filter.getBannedPaymentMethods().stream().collect(Collectors.joining(", ")));
-
-            if (filter.getArbitrators() != null)
-                arbitratorsInputTextField.setText(filter.getArbitrators().stream().collect(Collectors.joining(", ")));
-
-            if (filter.getMediators() != null)
-                mediatorsInputTextField.setText(filter.getMediators().stream().collect(Collectors.joining(", ")));
-
-            if (filter.getRefundAgents() != null)
-                refundAgentsInputTextField.setText(filter.getRefundAgents().stream().collect(Collectors.joining(", ")));
-
-            if (filter.getSeedNodes() != null)
-                seedNodesInputTextField.setText(filter.getSeedNodes().stream().collect(Collectors.joining(", ")));
-
-            if (filter.getPriceRelayNodes() != null)
-                priceRelayNodesInputTextField.setText(filter.getPriceRelayNodes().stream().collect(Collectors.joining(", ")));
-
-            if (filter.getBtcNodes() != null)
-                btcNodesInputTextField.setText(filter.getBtcNodes().stream().collect(Collectors.joining(", ")));
+            setupFieldFromList(bannedCurrenciesInputTextField, filter.getBannedCurrencies());
+            setupFieldFromList(bannedPaymentMethodsInputTextField, filter.getBannedPaymentMethods());
+            setupFieldFromList(arbitratorsInputTextField, filter.getArbitrators());
+            setupFieldFromList(mediatorsInputTextField, filter.getMediators());
+            setupFieldFromList(refundAgentsInputTextField, filter.getRefundAgents());
+            setupFieldFromList(seedNodesInputTextField, filter.getSeedNodes());
+            setupFieldFromList(priceRelayNodesInputTextField, filter.getPriceRelayNodes());
+            setupFieldFromList(btcNodesInputTextField, filter.getBtcNodes());
 
             preventPublicBtcNetworkCheckBox.setSelected(filter.isPreventPublicBtcNetwork());
 
@@ -252,6 +238,11 @@ public class FilterWindow extends Overlay<FilterWindow> {
         hBox.getChildren().addAll(sendButton, removeFilterMessageButton, closeButton);
         gridPane.getChildren().add(hBox);
         GridPane.setMargin(hBox, new Insets(10, 0, 0, 0));
+    }
+
+    private void setupFieldFromList(InputTextField field, List<String> values) {
+        if (values != null)
+            field.setText(values.stream().collect(Collectors.joining(", ")));
     }
 
     private List<String> readAsList(InputTextField field) {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -166,7 +166,8 @@ public class FilterWindow extends Overlay<FilterWindow> {
         }
         Button sendButton = new AutoTooltipButton(Res.get("filterWindow.add"));
         sendButton.setOnAction(e -> {
-            if (sendFilterMessageHandler.handle(new Filter(
+            if (sendFilterMessageHandler.handle(
+                    new Filter(
                             readAsList(offerIdsInputTextField),
                             readAsList(nodesInputTextField),
                             readAsPaymentAccountFiltersList(paymentAccountFilterInputTextField),
@@ -181,8 +182,10 @@ public class FilterWindow extends Overlay<FilterWindow> {
                             disableDaoBelowVersionInputTextField.getText(),
                             disableTradeBelowVersionInputTextField.getText(),
                             readAsList(mediatorsInputTextField),
-                            readAsList(refundAgentsInputTextField)),
-                    keyInputTextField.getText()))
+                            readAsList(refundAgentsInputTextField)
+                    ),
+                    keyInputTextField.getText())
+            )
                 hide();
             else
                 new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -183,21 +183,10 @@ public class FilterWindow extends Overlay<FilterWindow> {
         }
         Button sendButton = new AutoTooltipButton(Res.get("filterWindow.add"));
         sendButton.setOnAction(e -> {
-            List<PaymentAccountFilter> paymentAccountFilters = readAsList(paymentAccountFilterInputTextField)
-                    .stream().map(item -> {
-                        String[] list = item.split("\\|");
-                        if (list.length == 3)
-                            return new PaymentAccountFilter(list[0], list[1], list[2]);
-                        else
-                            return new PaymentAccountFilter("", "", "");
-                    })
-                    .collect(Collectors.toList());
-
-
             if (sendFilterMessageHandler.handle(new Filter(
                             readAsList(offerIdsInputTextField),
                             readAsList(nodesInputTextField),
-                            paymentAccountFilters,
+                            readAsPaymentAccountFiltersList(paymentAccountFilterInputTextField),
                             readAsList(bannedCurrenciesInputTextField),
                             readAsList(bannedPaymentMethodsInputTextField),
                             readAsList(arbitratorsInputTextField),
@@ -251,5 +240,17 @@ public class FilterWindow extends Overlay<FilterWindow> {
         } else {
             return Arrays.asList(StringUtils.deleteWhitespace(field.getText()).split(","));
         }
+    }
+
+    private List<PaymentAccountFilter> readAsPaymentAccountFiltersList(InputTextField field) {
+        return readAsList(field)
+                .stream().map(item -> {
+                    String[] list = item.split("\\|");
+                    if (list.length == 3)
+                        return new PaymentAccountFilter(list[0], list[1], list[2]);
+                    else
+                        return new PaymentAccountFilter("", "", "");
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -150,22 +150,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
         if (filter != null) {
             setupFieldFromList(offerIdsInputTextField, filter.getBannedOfferIds());
             setupFieldFromList(nodesInputTextField, filter.getBannedNodeAddress());
-
-            if (filter.getBannedPaymentAccounts() != null) {
-                StringBuilder sb = new StringBuilder();
-                filter.getBannedPaymentAccounts().stream().forEach(e -> {
-                    if (e != null && e.getPaymentMethodId() != null) {
-                        sb.append(e.getPaymentMethodId())
-                                .append("|")
-                                .append(e.getGetMethodName())
-                                .append("|")
-                                .append(e.getValue())
-                                .append(", ");
-                    }
-                });
-                paymentAccountFilterInputTextField.setText(sb.toString());
-            }
-
+            setupFieldFromPaymentAccountFiltersList(paymentAccountFilterInputTextField, filter.getBannedPaymentAccounts());
             setupFieldFromList(bannedCurrenciesInputTextField, filter.getBannedCurrencies());
             setupFieldFromList(bannedPaymentMethodsInputTextField, filter.getBannedPaymentMethods());
             setupFieldFromList(arbitratorsInputTextField, filter.getArbitrators());
@@ -174,9 +159,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
             setupFieldFromList(seedNodesInputTextField, filter.getSeedNodes());
             setupFieldFromList(priceRelayNodesInputTextField, filter.getPriceRelayNodes());
             setupFieldFromList(btcNodesInputTextField, filter.getBtcNodes());
-
             preventPublicBtcNetworkCheckBox.setSelected(filter.isPreventPublicBtcNetwork());
-
             disableDaoCheckBox.setSelected(filter.isDisableDao());
             disableDaoBelowVersionInputTextField.setText(filter.getDisableDaoBelowVersion());
             disableTradeBelowVersionInputTextField.setText(filter.getDisableTradeBelowVersion());
@@ -232,6 +215,24 @@ public class FilterWindow extends Overlay<FilterWindow> {
     private void setupFieldFromList(InputTextField field, List<String> values) {
         if (values != null)
             field.setText(values.stream().collect(Collectors.joining(", ")));
+    }
+
+    private void setupFieldFromPaymentAccountFiltersList(InputTextField field, List<PaymentAccountFilter> values) {
+        if (values != null) {
+            StringBuilder sb = new StringBuilder();
+            values.stream().forEach(e -> {
+                if (e != null && e.getPaymentMethodId() != null) {
+                    sb
+                            .append(e.getPaymentMethodId())
+                            .append("|")
+                            .append(e.getGetMethodName())
+                            .append("|")
+                            .append(e.getValue())
+                            .append(", ");
+                }
+            });
+            field.setText(sb.toString());
+        }
     }
 
     private List<String> readAsList(InputTextField field) {


### PR DESCRIPTION
Pull request includes 4 commits, it would be easier to review them one by one. Short description of them
- [in first one](https://github.com/bisq-network/bisq/commit/96046fa110028b5096e827a2238393b0d7fd837a) I moved repated code like:

        if (values != null)
            field.setText(values.stream().collect(Collectors.joining(", ")));

into `setupFieldFromList` method

- [second](https://github.com/bisq-network/bisq/commit/415648e257f4718eac931741deea46b8f3130cf2) and [third](https://github.com/bisq-network/bisq/commit/0c2639a87b2930cc0eff29d31cf31bf00987becb)  moves some code into private methods to make `addContent` method smaller and simpler

- [last one](https://github.com/bisq-network/bisq/commit/a6ee5d5c457601f3d1cecb31272461d0dc7854bc) is just small reformatting