### PR TITLE
Remove redundant interfaces from FilterWindow and SendAlertMessageWindow

### DIFF
--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -349,10 +349,7 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
     private void showFilterPopup(Injector injector) {
         FilterManager filterManager = injector.getInstance(FilterManager.class);
         boolean useDevPrivilegeKeys = injector.getInstance(Key.get(Boolean.class, Names.named(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS)));
-        new FilterWindow(filterManager, useDevPrivilegeKeys)
-                .onAddFilter(filterManager::addFilterMessageIfKeyIsValid)
-                .onRemoveFilter(filterManager::removeFilterMessageIfKeyIsValid)
-                .show();
+        new FilterWindow(filterManager, useDevPrivilegeKeys).show();
     }
 
     private void showBtcEmergencyWalletPopup(Injector injector) {

--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -340,10 +340,7 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
     private void showSendAlertMessagePopup(Injector injector) {
         AlertManager alertManager = injector.getInstance(AlertManager.class);
         boolean useDevPrivilegeKeys = injector.getInstance(Key.get(Boolean.class, Names.named(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS)));
-        new SendAlertMessageWindow(useDevPrivilegeKeys)
-                .onAddAlertMessage(alertManager::addAlertMessageIfKeyIsValid)
-                .onRemoveAlertMessage(alertManager::removeAlertMessageIfKeyIsValid)
-                .show();
+        new SendAlertMessageWindow(alertManager, useDevPrivilegeKeys).show();
     }
 
     private void showFilterPopup(Injector injector) {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -51,23 +51,8 @@ import static bisq.desktop.util.FormBuilder.addLabelCheckBox;
 import static bisq.desktop.util.FormBuilder.addTopLabelInputTextField;
 
 public class FilterWindow extends Overlay<FilterWindow> {
-    private SendFilterMessageHandler sendFilterMessageHandler;
-    private RemoveFilterMessageHandler removeFilterMessageHandler;
     private final FilterManager filterManager;
     private final boolean useDevPrivilegeKeys;
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Interface
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    public interface SendFilterMessageHandler {
-        boolean handle(Filter filter, String privKey);
-    }
-
-    public interface RemoveFilterMessageHandler {
-        boolean handle(String privKey);
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Public API
@@ -89,16 +74,6 @@ public class FilterWindow extends Overlay<FilterWindow> {
         addContent();
         applyStyles();
         display();
-    }
-
-    public FilterWindow onAddFilter(SendFilterMessageHandler sendFilterMessageHandler) {
-        this.sendFilterMessageHandler = sendFilterMessageHandler;
-        return this;
-    }
-
-    public FilterWindow onRemoveFilter(RemoveFilterMessageHandler removeFilterMessageHandler) {
-        this.removeFilterMessageHandler = removeFilterMessageHandler;
-        return this;
     }
 
 
@@ -166,7 +141,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
         }
         Button sendButton = new AutoTooltipButton(Res.get("filterWindow.add"));
         sendButton.setOnAction(e -> {
-            if (sendFilterMessageHandler.handle(
+            if (filterManager.addFilterMessageIfKeyIsValid(
                     new Filter(
                             readAsList(offerIdsInputTextField),
                             readAsList(nodesInputTextField),
@@ -194,7 +169,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
         Button removeFilterMessageButton = new AutoTooltipButton(Res.get("filterWindow.remove"));
         removeFilterMessageButton.setOnAction(e -> {
             if (keyInputTextField.getText().length() > 0) {
-                if (removeFilterMessageHandler.handle(keyInputTextField.getText()))
+                if (filterManager.removeFilterMessageIfKeyIsValid(keyInputTextField.getText()))
                     hide();
                 else
                     new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendAlertMessageWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendAlertMessageWindow.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.overlays.windows;
 
+import bisq.core.alert.AlertManager;
 import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.InputTextField;
 import bisq.desktop.main.overlays.Overlay;
@@ -46,28 +47,15 @@ import static bisq.desktop.util.FormBuilder.addLabelCheckBox;
 import static bisq.desktop.util.FormBuilder.addTopLabelTextArea;
 
 public class SendAlertMessageWindow extends Overlay<SendAlertMessageWindow> {
+    private final AlertManager alertManager;
     private final boolean useDevPrivilegeKeys;
-    private SendAlertMessageHandler sendAlertMessageHandler;
-    private RemoveAlertMessageHandler removeAlertMessageHandler;
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Interface
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    public interface SendAlertMessageHandler {
-        boolean handle(Alert alert, String privKey);
-    }
-
-    public interface RemoveAlertMessageHandler {
-        boolean handle(String privKey);
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Public API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public SendAlertMessageWindow(boolean useDevPrivilegeKeys) {
+    public SendAlertMessageWindow(AlertManager alertManager, boolean useDevPrivilegeKeys) {
+        this.alertManager = alertManager;
         this.useDevPrivilegeKeys = useDevPrivilegeKeys;
         type = Type.Attention;
     }
@@ -82,16 +70,6 @@ public class SendAlertMessageWindow extends Overlay<SendAlertMessageWindow> {
         addContent();
         applyStyles();
         display();
-    }
-
-    public SendAlertMessageWindow onAddAlertMessage(SendAlertMessageHandler sendAlertMessageHandler) {
-        this.sendAlertMessageHandler = sendAlertMessageHandler;
-        return this;
-    }
-
-    public SendAlertMessageWindow onRemoveAlertMessage(RemoveAlertMessageHandler removeAlertMessageHandler) {
-        this.removeAlertMessageHandler = removeAlertMessageHandler;
-        return this;
     }
 
 
@@ -151,11 +129,10 @@ public class SendAlertMessageWindow extends Overlay<SendAlertMessageWindow> {
             }
             if (!isUpdate || versionOK) {
                 if (alertMessageTextArea.getText().length() > 0 && keyInputTextField.getText().length() > 0) {
-                    if (sendAlertMessageHandler.handle(
-                            new Alert(alertMessageTextArea.getText(),
-                                    isUpdate,
-                                    version),
-                            keyInputTextField.getText()))
+                    if (alertManager.addAlertMessageIfKeyIsValid(
+                            new Alert(alertMessageTextArea.getText(), isUpdate, version),
+                            keyInputTextField.getText())
+                    )
                         hide();
                     else
                         new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
@@ -166,7 +143,7 @@ public class SendAlertMessageWindow extends Overlay<SendAlertMessageWindow> {
         Button removeAlertMessageButton = new AutoTooltipButton(Res.get("sendAlertMessageWindow.remove"));
         removeAlertMessageButton.setOnAction(e -> {
             if (keyInputTextField.getText().length() > 0) {
-                if (removeAlertMessageHandler.handle(keyInputTextField.getText()))
+                if (alertManager.removeAlertMessageIfKeyIsValid(keyInputTextField.getText()))
                     hide();
                 else
                     new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();


### PR DESCRIPTION
Interfaces like [these](https://github.com/bisq-network/bisq/blob/d55114e019fda469266dab50f63916289b2e71cb/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java#L60-L69) are redundant, and unnecessarily increase the complexity of the code. In this pull request I remove them and use appropriate methods like `filterManager.addFilterMessageIfKeyIsValid` directly. It's separated into 2 commits:
- [first one](https://github.com/bisq-network/bisq/commit/4dfc69e02cf2ba56634868257863b74e68cd9522) for FilterWindow
- [second one](https://github.com/bisq-network/bisq/commit/5cdb65d19e9702edafa3be0be7297ecae113ca07) for SendAlertMessageWindow