### PR TITLE
Fixes #3601 #3537 and Add colon after paymentMethod on tooltip

### DIFF
--- a/core/src/main/java/bisq/core/payment/PaymentAccountUtil.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountUtil.java
@@ -65,7 +65,7 @@ public class PaymentAccountUtil {
                                                 AccountAgeWitnessService accountAgeWitnessService) {
         boolean hasChargebackRisk = PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode());
         boolean hasValidAccountAgeWitness = accountAgeWitnessService.getMyTradeLimit(paymentAccount,
-                offer.getCurrencyCode(), offer.getMirroredDirection()) >= offer.getAmount().value;
+                offer.getCurrencyCode(), offer.getMirroredDirection()) >= offer.getMinAmount().value;
         return !hasChargebackRisk || hasValidAccountAgeWitness;
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -429,7 +429,7 @@ class OfferBookViewModel extends ActivatableViewModel {
         String result = "";
         if (item != null) {
             Offer offer = item.getOffer();
-            result = Res.get("shared.paymentMethod") + " " + Res.get(offer.getPaymentMethod().getId());
+            result = Res.getWithCol("shared.paymentMethod") + " " + Res.get(offer.getPaymentMethod().getId());
             result += "\n" + Res.getWithCol("shared.currency") + " " + CurrencyUtil.getNameAndCode(offer.getCurrencyCode());
 
             String countryCode = offer.getCountryCode();


### PR DESCRIPTION
This is a silly fix of the tooltip. Every item on the tooltip have colons, some added with getWithCol and some hardcoded on the string. This one doesn't have.