### PR TITLE
Add colon after "Payment method" on tooltip

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -429,7 +429,7 @@ class OfferBookViewModel extends ActivatableViewModel {
         String result = "";
         if (item != null) {
             Offer offer = item.getOffer();
-            result = Res.get("shared.paymentMethod") + " " + Res.get(offer.getPaymentMethod().getId());
+            result = Res.getWithCol("shared.paymentMethod") + " " + Res.get(offer.getPaymentMethod().getId());
             result += "\n" + Res.getWithCol("shared.currency") + " " + CurrencyUtil.getNameAndCode(offer.getCurrencyCode());
 
             String countryCode = offer.getCountryCode();


### PR DESCRIPTION
This is a cosmetic fix of the tooltip over the payment method in the offer view tab. Every item on the tooltip have colons, some added with Res.getWithCol() and some hardcoded on the string. This one doesn't have.

![image](https://user-images.githubusercontent.com/6444444/69014791-b968ea00-096c-11ea-873e-d6a1d6bbef38.png)

