### PR TITLE
[BUGFIX] Account validation comparing user trade limit with MAX amount of offer

### DIFF
--- a/core/src/main/java/bisq/core/payment/PaymentAccountUtil.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountUtil.java
@@ -65,7 +65,7 @@ public class PaymentAccountUtil {
                                                 AccountAgeWitnessService accountAgeWitnessService) {
         boolean hasChargebackRisk = PaymentMethod.hasChargebackRisk(offer.getPaymentMethod(), offer.getCurrencyCode());
         boolean hasValidAccountAgeWitness = accountAgeWitnessService.getMyTradeLimit(paymentAccount,
-                offer.getCurrencyCode(), offer.getMirroredDirection()) >= offer.getAmount().value;
+                offer.getCurrencyCode(), offer.getMirroredDirection()) >= offer.getMinAmount().value;
         return !hasChargebackRisk || hasValidAccountAgeWitness;
     }
 


### PR DESCRIPTION
Fixes #3601 and fixes #3537.
The bug only happens when the offer has MIN-MAX value range.
The new `isAmountValidForOffer` in `PaymentAccountUtil.java` considers the MAX amount of the offer, but the button to take it is ungrayed considering the MIN amount, which causes the bug.
For example, if a user has a trade limit of 0.01BTC and an offer has a range of 0.005BTC to 0.1BTC, this user might want to accept it up to his limit, and the button will be available to him.
But the bug will kick in, which freezes any other offer taking until Bisq is restarted.
After getting to next screen, other methods of preventing the user to go above his limit are already implemented in `TakeOfferDataModel.java`, like:

```
void initWithData(Offer offer) {
        [...]
        this.amount.set(Coin.valueOf(Math.min(offer.getAmount().value, getMaxTradeLimit())));
```

```
public void onPaymentAccountSelected(PaymentAccount paymentAccount) {
        [...]
        this.amount.set(Coin.valueOf(Math.max(offer.getMinAmount().value, Math.min(amount.get().value, myLimit))));
```


```
void applyAmount(Coin amount) {
        this.amount.set(Coin.valueOf(Math.min(amount.value, getMaxTradeLimit())));
```