### PR TITLE
Avoid unchecked casts/assignments/calls

### DIFF
--- a/common/src/main/java/bisq/common/app/Log.java
+++ b/common/src/main/java/bisq/common/app/Log.java
@@ -23,6 +23,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
@@ -38,7 +39,7 @@ public class Log {
     public static void setup(String fileName) {
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
-        RollingFileAppender appender = new RollingFileAppender();
+        RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
         appender.setContext(loggerContext);
         appender.setFile(fileName + ".log");
 
@@ -50,7 +51,7 @@ public class Log {
         rollingPolicy.setMaxIndex(10);
         rollingPolicy.start();
 
-        SizeBasedTriggeringPolicy triggeringPolicy = new SizeBasedTriggeringPolicy();
+        SizeBasedTriggeringPolicy<ILoggingEvent> triggeringPolicy = new SizeBasedTriggeringPolicy<>();
         triggeringPolicy.setMaxFileSize(FileSize.valueOf("10MB"));
         triggeringPolicy.start();
 
@@ -59,15 +60,12 @@ public class Log {
         encoder.setPattern("%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{15}: %msg %xEx%n");
         encoder.start();
 
-        //noinspection unchecked
         appender.setEncoder(encoder);
         appender.setRollingPolicy(rollingPolicy);
-        //noinspection unchecked
         appender.setTriggeringPolicy(triggeringPolicy);
         appender.start();
 
         logbackLogger = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-        //noinspection unchecked
         logbackLogger.addAppender(appender);
         logbackLogger.setLevel(Level.INFO);
 

--- a/common/src/main/java/bisq/common/proto/ProtoUtil.java
+++ b/common/src/main/java/bisq/common/proto/ProtoUtil.java
@@ -77,15 +77,14 @@ public class ProtoUtil {
         return result;
     }
 
-    public static <T extends Message> Iterable<T> collectionToProto(Collection<? extends Proto> collection) {
+    public static <T extends Message> Iterable<T> collectionToProto(Collection<? extends Proto> collection, Class<T> messageType) {
         return collection.stream()
                 .map(e -> {
                     final Message message = e.toProtoMessage();
                     try {
-                        //noinspection unchecked
-                        return (T) message;
-                    } catch (Throwable t) {
-                        log.error("message could not be casted. message=" + message);
+                        return messageType.cast(message);
+                    } catch (ClassCastException t) {
+                        log.error("Message could not be cast. message={}, messageType={}", message, messageType);
                         return null;
                     }
                 })

--- a/core/src/main/java/bisq/core/app/BisqEnvironment.java
+++ b/core/src/main/java/bisq/core/app/BisqEnvironment.java
@@ -361,11 +361,11 @@ public class BisqEnvironment extends StandardEnvironment {
         return new ResourcePropertySource(BISQ_APP_DIR_PROPERTY_SOURCE_NAME, resource);
     }
 
-    private String getProperty (PropertySource properties, String propertyKey, String defaultValue) {
+    private String getProperty(PropertySource properties, String propertyKey, String defaultValue) {
         return properties.containsProperty(propertyKey) ? (String) properties.getProperty(propertyKey) : defaultValue;
     }
 
-    private List<String> getListProperty (String key, List defaultValue) {
+    private List<String> getListProperty(String key, List<String> defaultValue) {
         final String value = getProperty(key, "");
         return value.isEmpty() ? defaultValue : Arrays.asList(StringUtils.deleteWhitespace(value).split(","));
     }

--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -55,6 +55,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -465,7 +466,7 @@ public class WalletConfig extends AbstractIdleService {
                 vPeerGroup.startBlockChainDownload(listener);
                 listener.await();
             } else {
-                Futures.addCallback(vPeerGroup.startAsync(), new FutureCallback() {
+                Futures.addCallback((ListenableFuture<?>) vPeerGroup.startAsync(), new FutureCallback<Object>() {
                     @Override
                     public void onSuccess(@Nullable Object result) {
                         final PeerDataEventListener listener = downloadListener == null ?
@@ -476,7 +477,6 @@ public class WalletConfig extends AbstractIdleService {
                     @Override
                     public void onFailure(@NotNull Throwable t) {
                         throw new RuntimeException(t);
-
                     }
                 });
             }

--- a/core/src/main/java/bisq/core/payment/PaymentAccount.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccount.java
@@ -91,7 +91,7 @@ public abstract class PaymentAccount implements PersistablePayload {
                 .setCreationDate(creationDate)
                 .setPaymentAccountPayload((protobuf.PaymentAccountPayload) paymentAccountPayload.toProtoMessage())
                 .setAccountName(accountName)
-                .addAllTradeCurrencies(ProtoUtil.<protobuf.TradeCurrency>collectionToProto(tradeCurrencies));
+                .addAllTradeCurrencies(ProtoUtil.collectionToProto(tradeCurrencies, protobuf.TradeCurrency.class));
         Optional.ofNullable(selectedTradeCurrency).ifPresent(selectedTradeCurrency -> builder.setSelectedTradeCurrency((protobuf.TradeCurrency) selectedTradeCurrency.toProtoMessage()));
         return builder.build();
     }

--- a/core/src/main/java/bisq/core/provider/fee/FeeProvider.java
+++ b/core/src/main/java/bisq/core/provider/fee/FeeProvider.java
@@ -47,16 +47,15 @@ public class FeeProvider extends HttpClientProvider {
     public Tuple2<Map<String, Long>, Map<String, Long>> getFees() throws IOException {
         String json = httpClient.requestWithGET("getFees", "User-Agent", "bisq/" + Version.VERSION + ", uid:" + httpClient.getUid());
 
-        LinkedTreeMap<String, Object> linkedTreeMap = new Gson().<LinkedTreeMap<String, Object>>fromJson(json, LinkedTreeMap.class);
+        LinkedTreeMap<?, ?> linkedTreeMap = new Gson().fromJson(json, LinkedTreeMap.class);
         Map<String, Long> tsMap = new HashMap<>();
         tsMap.put("bitcoinFeesTs", ((Double) linkedTreeMap.get("bitcoinFeesTs")).longValue());
 
         Map<String, Long> map = new HashMap<>();
 
         try {
-            //noinspection unchecked
-            LinkedTreeMap<String, Double> dataMap = (LinkedTreeMap<String, Double>) linkedTreeMap.get("dataMap");
-            Long btcTxFee = dataMap.get("btcTxFee").longValue();
+            LinkedTreeMap<?, ?> dataMap = (LinkedTreeMap<?, ?>) linkedTreeMap.get("dataMap");
+            Long btcTxFee = ((Double) dataMap.get("btcTxFee")).longValue();
 
             map.put("BTC", btcTxFee);
         } catch (Throwable t) {

--- a/core/src/main/java/bisq/core/provider/price/PriceProvider.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceProvider.java
@@ -50,20 +50,20 @@ public class PriceProvider extends HttpClientProvider {
         String json = httpClient.requestWithGET("getAllMarketPrices", "User-Agent", "bisq/"
                 + Version.VERSION + ", uid:" + httpClient.getUid());
 
-        LinkedTreeMap<String, Object> map = new Gson().<LinkedTreeMap<String, Object>>fromJson(json, LinkedTreeMap.class);
+        LinkedTreeMap<?, ?> map = new Gson().fromJson(json, LinkedTreeMap.class);
         Map<String, Long> tsMap = new HashMap<>();
         tsMap.put("btcAverageTs", ((Double) map.get("btcAverageTs")).longValue());
         tsMap.put("poloniexTs", ((Double) map.get("poloniexTs")).longValue());
         tsMap.put("coinmarketcapTs", ((Double) map.get("coinmarketcapTs")).longValue());
 
-        //noinspection unchecked
-        List<LinkedTreeMap<String, Object>> list = (ArrayList<LinkedTreeMap<String, Object>>) map.get("data");
-        list.forEach(treeMap -> {
+        List<?> list = (ArrayList<?>) map.get("data");
+        list.forEach(obj -> {
             try {
+                LinkedTreeMap<?, ?> treeMap = (LinkedTreeMap<?, ?>) obj;
                 final String currencyCode = (String) treeMap.get("currencyCode");
-                final double price = (double) treeMap.get("price");
+                final double price = (Double) treeMap.get("price");
                 // json uses double for our timestampSec long value...
-                final long timestampSec = MathUtils.doubleToLong((double) treeMap.get("timestampSec"));
+                final long timestampSec = MathUtils.doubleToLong((Double) treeMap.get("timestampSec"));
                 marketPriceMap.put(currencyCode, new MarketPrice(currencyCode, price, timestampSec, true));
             } catch (Throwable t) {
                 log.error(t.toString());

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationDisputeList.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationDisputeList.java
@@ -74,7 +74,7 @@ public final class ArbitrationDisputeList extends DisputeList<ArbitrationDispute
         list.forEach(dispute -> checkArgument(dispute.getSupportType().equals(SupportType.ARBITRATION), "Support type has to be ARBITRATION"));
 
         return protobuf.PersistableEnvelope.newBuilder().setArbitrationDisputeList(protobuf.ArbitrationDisputeList.newBuilder()
-                .addAllDispute(ProtoUtil.collectionToProto(new ArrayList<>(list)))).build();
+                .addAllDispute(ProtoUtil.collectionToProto(new ArrayList<>(list), protobuf.Dispute.class))).build();
     }
 
     public static ArbitrationDisputeList fromProto(protobuf.ArbitrationDisputeList proto,

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationDisputeList.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationDisputeList.java
@@ -67,7 +67,7 @@ public final class MediationDisputeList extends DisputeList<MediationDisputeList
     @Override
     public Message toProtoMessage() {
         return protobuf.PersistableEnvelope.newBuilder().setMediationDisputeList(protobuf.MediationDisputeList.newBuilder()
-                .addAllDispute(ProtoUtil.collectionToProto(new ArrayList<>(list)))).build();
+                .addAllDispute(ProtoUtil.collectionToProto(new ArrayList<>(list), protobuf.Dispute.class))).build();
     }
 
     public static MediationDisputeList fromProto(protobuf.MediationDisputeList proto,

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundDisputeList.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundDisputeList.java
@@ -74,7 +74,7 @@ public final class RefundDisputeList extends DisputeList<RefundDisputeList> {
         list.forEach(dispute -> checkArgument(dispute.getSupportType().equals(SupportType.REFUND), "Support type has to be REFUND"));
 
         return protobuf.PersistableEnvelope.newBuilder().setRefundDisputeList(protobuf.RefundDisputeList.newBuilder()
-                .addAllDispute(ProtoUtil.collectionToProto(new ArrayList<>(list)))).build();
+                .addAllDispute(ProtoUtil.collectionToProto(new ArrayList<>(list), protobuf.Dispute.class))).build();
     }
 
     public static RefundDisputeList fromProto(protobuf.RefundDisputeList proto,

--- a/core/src/main/java/bisq/core/trade/TradableList.java
+++ b/core/src/main/java/bisq/core/trade/TradableList.java
@@ -74,7 +74,7 @@ public final class TradableList<T extends Tradable> implements PersistableEnvelo
         ArrayList<T> clonedList = new ArrayList<>(this.list);
         return protobuf.PersistableEnvelope.newBuilder()
                 .setTradableList(protobuf.TradableList.newBuilder()
-                        .addAllTradable(ProtoUtil.collectionToProto(clonedList)))
+                        .addAllTradable(ProtoUtil.collectionToProto(clonedList, protobuf.Tradable.class)))
                 .build();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
@@ -188,7 +188,8 @@ public class ProcessModel implements Model, PersistablePayload {
         Optional.ofNullable(takeOfferFeeTxId).ifPresent(builder::setTakeOfferFeeTxId);
         Optional.ofNullable(payoutTxSignature).ifPresent(e -> builder.setPayoutTxSignature(ByteString.copyFrom(payoutTxSignature)));
         Optional.ofNullable(preparedDepositTx).ifPresent(e -> builder.setPreparedDepositTx(ByteString.copyFrom(preparedDepositTx)));
-        Optional.ofNullable(rawTransactionInputs).ifPresent(e -> builder.addAllRawTransactionInputs(ProtoUtil.collectionToProto(rawTransactionInputs)));
+        Optional.ofNullable(rawTransactionInputs).ifPresent(e -> builder.addAllRawTransactionInputs(
+                ProtoUtil.collectionToProto(rawTransactionInputs, protobuf.RawTransactionInput.class)));
         Optional.ofNullable(changeOutputAddress).ifPresent(builder::setChangeOutputAddress);
         Optional.ofNullable(myMultiSigPubKey).ifPresent(e -> builder.setMyMultiSigPubKey(ByteString.copyFrom(myMultiSigPubKey)));
         Optional.ofNullable(tempTradingPeerNodeAddress).ifPresent(e -> builder.setTempTradingPeerNodeAddress(tempTradingPeerNodeAddress.toProtoMessage()));

--- a/core/src/main/java/bisq/core/trade/protocol/TradingPeer.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradingPeer.java
@@ -104,7 +104,8 @@ public final class TradingPeer implements PersistablePayload {
         Optional.ofNullable(signature).ifPresent(e -> builder.setSignature(ByteString.copyFrom(e)));
         Optional.ofNullable(pubKeyRing).ifPresent(e -> builder.setPubKeyRing(e.toProtoMessage()));
         Optional.ofNullable(multiSigPubKey).ifPresent(e -> builder.setMultiSigPubKey(ByteString.copyFrom(e)));
-        Optional.ofNullable(rawTransactionInputs).ifPresent(e -> builder.addAllRawTransactionInputs(ProtoUtil.collectionToProto(e)));
+        Optional.ofNullable(rawTransactionInputs).ifPresent(e -> builder.addAllRawTransactionInputs(
+                ProtoUtil.collectionToProto(e, protobuf.RawTransactionInput.class)));
         Optional.ofNullable(changeOutputAddress).ifPresent(builder::setChangeOutputAddress);
         Optional.ofNullable(accountAgeWitnessNonce).ifPresent(e -> builder.setAccountAgeWitnessNonce(ByteString.copyFrom(e)));
         Optional.ofNullable(accountAgeWitnessSignature).ifPresent(e -> builder.setAccountAgeWitnessSignature(ByteString.copyFrom(e)));

--- a/core/src/main/java/bisq/core/user/UserPayload.java
+++ b/core/src/main/java/bisq/core/user/UserPayload.java
@@ -88,7 +88,7 @@ public class UserPayload implements PersistableEnvelope {
         protobuf.UserPayload.Builder builder = protobuf.UserPayload.newBuilder();
         Optional.ofNullable(accountId).ifPresent(e -> builder.setAccountId(accountId));
         Optional.ofNullable(paymentAccounts)
-                .ifPresent(e -> builder.addAllPaymentAccounts(ProtoUtil.collectionToProto(paymentAccounts)));
+                .ifPresent(e -> builder.addAllPaymentAccounts(ProtoUtil.collectionToProto(paymentAccounts, protobuf.PaymentAccount.class)));
         Optional.ofNullable(currentPaymentAccount)
                 .ifPresent(e -> builder.setCurrentPaymentAccount(currentPaymentAccount.toProtoMessage()));
         Optional.ofNullable(acceptedLanguageLocaleCodes)
@@ -111,7 +111,7 @@ public class UserPayload implements PersistableEnvelope {
                         message -> ((protobuf.StoragePayload) message).getMediator())));
         Optional.ofNullable(priceAlertFilter).ifPresent(priceAlertFilter -> builder.setPriceAlertFilter(priceAlertFilter.toProtoMessage()));
         Optional.ofNullable(marketAlertFilters)
-                .ifPresent(e -> builder.addAllMarketAlertFilters(ProtoUtil.collectionToProto(marketAlertFilters)));
+                .ifPresent(e -> builder.addAllMarketAlertFilters(ProtoUtil.collectionToProto(marketAlertFilters, protobuf.MarketAlertFilter.class)));
 
         Optional.ofNullable(registeredRefundAgent)
                 .ifPresent(registeredRefundAgent -> builder.setRegisteredRefundAgent(registeredRefundAgent.toProtoMessage().getRefundAgent()));

--- a/desktop/src/main/java/bisq/desktop/Navigation.java
+++ b/desktop/src/main/java/bisq/desktop/Navigation.java
@@ -84,8 +84,7 @@ public final class Navigation implements PersistedDataHost {
             List<Class<? extends View>> viewClasses = persisted.getPath().stream()
                     .map(className -> {
                         try {
-                            //noinspection unchecked
-                            return ((Class<? extends View>) Class.forName(className));
+                            return (Class<? extends View>) Class.forName(className).asSubclass(View.class);
                         } catch (ClassNotFoundException e) {
                             log.warn("Could not find the viewPath class {}; exception: {}", className, e);
                         }
@@ -118,13 +117,12 @@ public final class Navigation implements PersistedDataHost {
             Class<? extends View> viewClass = newPath.get(i);
             temp.add(viewClass);
             if (currentPath == null ||
-                    (currentPath != null &&
-                            currentPath.size() > i &&
+                    (currentPath.size() > i &&
                             viewClass != currentPath.get(i) &&
                             i != newPath.size() - 1)) {
                 ArrayList<Class<? extends View>> temp2 = new ArrayList<>(temp);
                 for (int n = i + 1; n < newPath.size(); n++) {
-                    //noinspection unchecked,unchecked,unchecked
+                    //noinspection unchecked
                     Class<? extends View>[] newTemp = new Class[i + 1];
                     currentPath = ViewPath.to(temp2.toArray(newTemp));
                     navigateTo(currentPath, data);

--- a/desktop/src/main/java/bisq/desktop/common/model/Activatable.java
+++ b/desktop/src/main/java/bisq/desktop/common/model/Activatable.java
@@ -22,16 +22,4 @@ public interface Activatable {
     void _activate();
 
     void _deactivate();
-
-
-    Activatable NO_OP_INSTANCE = new Activatable() {
-        @Override
-        public void _activate() {
-        }
-
-        @Override
-        public void _deactivate() {
-        }
-    };
-
 }

--- a/desktop/src/main/java/bisq/desktop/common/view/ActivatableViewAndModel.java
+++ b/desktop/src/main/java/bisq/desktop/common/view/ActivatableViewAndModel.java
@@ -29,11 +29,6 @@ public abstract class ActivatableViewAndModel<R extends Node, M extends Activata
         super(checkNotNull(model, "Model must not be null"));
     }
 
-    public ActivatableViewAndModel() {
-        //noinspection unchecked
-        this((M) Activatable.NO_OP_INSTANCE);
-    }
-
     @Override
     protected void prepareInitialize() {
         if (root != null) {

--- a/desktop/src/main/java/bisq/desktop/components/AutocompleteComboBox.java
+++ b/desktop/src/main/java/bisq/desktop/components/AutocompleteComboBox.java
@@ -46,7 +46,7 @@ import java.util.List;
 public class AutocompleteComboBox<T> extends JFXComboBox<T> {
     private ArrayList<T> completeList;
     private ArrayList<T> matchingList;
-    private JFXComboBoxListViewSkin comboBoxListViewSkin;
+    private JFXComboBoxListViewSkin<T> comboBoxListViewSkin;
 
     public AutocompleteComboBox() {
         this(FXCollections.observableArrayList());
@@ -65,7 +65,7 @@ public class AutocompleteComboBox<T> extends JFXComboBox<T> {
     /**
      * Set the complete list of ComboBox items. Use this instead of setItems().
      */
-    public void setAutocompleteItems(List<T> items) {
+    public void setAutocompleteItems(List<? extends T> items) {
         completeList = new ArrayList<>(items);
         matchingList = new ArrayList<>(completeList);
         setValue(null);

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
@@ -211,10 +211,11 @@ public class AssetsForm extends PaymentMethodForm {
             currencyComboBox.setPromptText("");
         });
 
-        ((AutocompleteComboBox) currencyComboBox).setAutocompleteItems(CurrencyUtil.getActiveSortedCryptoCurrencies(assetService, filterManager));
+        ((AutocompleteComboBox<TradeCurrency>) currencyComboBox).setAutocompleteItems(
+                CurrencyUtil.getActiveSortedCryptoCurrencies(assetService, filterManager));
         currencyComboBox.setVisibleRowCount(Math.min(currencyComboBox.getItems().size(), 10));
 
-        currencyComboBox.setConverter(new StringConverter<TradeCurrency>() {
+        currencyComboBox.setConverter(new StringConverter<>() {
             @Override
             public String toString(TradeCurrency tradeCurrency) {
                 return tradeCurrency != null ? tradeCurrency.getNameAndCode() : "";
@@ -223,12 +224,12 @@ public class AssetsForm extends PaymentMethodForm {
             @Override
             public TradeCurrency fromString(String s) {
                 return currencyComboBox.getItems().stream().
-                       filter(item -> item.getNameAndCode().equals(s)).
-                       findAny().orElse(null);
+                        filter(item -> item.getNameAndCode().equals(s)).
+                        findAny().orElse(null);
             }
         });
 
-        ((AutocompleteComboBox) currencyComboBox).setOnChangeConfirmed(e -> {
+        ((AutocompleteComboBox<?>) currencyComboBox).setOnChangeConfirmed(e -> {
             addressInputTextField.resetValidation();
             addressInputTextField.validate();
             paymentAccount.setSingleTradeCurrency(currencyComboBox.getSelectionModel().getSelectedItem());

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/JapanBankTransferForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/JapanBankTransferForm.java
@@ -197,12 +197,12 @@ public class JapanBankTransferForm extends PaymentMethodForm
                 return s != null ? s : "";
             }
         });
-        ((AutocompleteComboBox) bankComboBox).setAutocompleteItems(JapanBankData.prettyPrintBankList());
+        ((AutocompleteComboBox<String>) bankComboBox).setAutocompleteItems(JapanBankData.prettyPrintBankList());
 
         bankComboBox.setPrefWidth(430);
         bankComboBox.setVisibleRowCount(430);
 
-        ((AutocompleteComboBox) bankComboBox).setOnChangeConfirmed(e -> {
+        ((AutocompleteComboBox<?>) bankComboBox).setOnChangeConfirmed(e -> {
             // get selected value
             String bank = bankComboBox.getSelectionModel().getSelectedItem();
 

--- a/desktop/src/main/java/bisq/desktop/main/account/register/AgentRegistrationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/AgentRegistrationView.java
@@ -32,6 +32,7 @@ import bisq.desktop.util.Layout;
 import bisq.core.app.AppOptionKeys;
 import bisq.core.locale.LanguageUtil;
 import bisq.core.locale.Res;
+import bisq.core.support.dispute.agent.DisputeAgent;
 
 import bisq.common.UserThread;
 import bisq.common.util.Tuple2;
@@ -70,7 +71,8 @@ import static bisq.desktop.util.FormBuilder.addTopLabelTextField;
 // TODO translation string keys should renamed to be more generic.
 // Lets do it for 1.1.7 the translator have time to add new string.
 @FxmlView
-public abstract class AgentRegistrationView<R, T extends AgentRegistrationViewModel> extends ActivatableViewAndModel<VBox, T> {
+public abstract class AgentRegistrationView<R extends DisputeAgent, T extends AgentRegistrationViewModel<R, ?>>
+        extends ActivatableViewAndModel<VBox, T> {
 
     private final boolean useDevPrivilegeKeys;
     private ListView<String> languagesListView;

--- a/desktop/src/main/java/bisq/desktop/main/dao/DaoView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/DaoView.java
@@ -18,8 +18,7 @@
 package bisq.desktop.main.dao;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -53,7 +52,7 @@ import javafx.scene.control.TabPane;
 import javafx.beans.value.ChangeListener;
 
 @FxmlView
-public class DaoView extends ActivatableViewAndModel<TabPane, Activatable> {
+public class DaoView extends ActivatableView<TabPane, Void> {
 
     @FXML
     private Tab bsqWalletTab, proposalsTab, bondingTab, burnBsqTab, daoNewsTab, monitorTab, factsAndFiguresTab;

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.dao.bonding;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -49,7 +49,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 @FxmlView
-public class BondingView extends ActivatableViewAndModel {
+public class BondingView extends ActivatableView<AnchorPane, Void> {
 
     private final ViewLoader viewLoader;
     private final Navigation navigation;

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/BurnBsqView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/BurnBsqView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.dao.burnbsq;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -44,7 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @FxmlView
-public class BurnBsqView extends ActivatableViewAndModel {
+public class BurnBsqView extends ActivatableView<AnchorPane, Void> {
 
     private final ViewLoader viewLoader;
     private final Navigation navigation;

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/EconomyView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/EconomyView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.dao.economy;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -47,7 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @FxmlView
-public class EconomyView extends ActivatableViewAndModel {
+public class EconomyView extends ActivatableView<AnchorPane, Void> {
 
     private final ViewLoader viewLoader;
     private final Navigation navigation;

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
@@ -105,7 +105,7 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
 
     private ChangeListener<Number> priceChangeListener;
 
-    private AreaChart bsqPriceChart;
+    private AreaChart<Number, Number> bsqPriceChart;
     private XYChart.Series<Number, Number> seriesBSQPrice;
 
     private TextField avgPrice90TextField, marketCapTextField, availableAmountTextField;
@@ -254,7 +254,7 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
         bsqPriceChart.setPrefHeight(bsqPriceChart.getMinHeight());
         bsqPriceChart.setCreateSymbols(true);
         bsqPriceChart.setPadding(new Insets(0));
-        bsqPriceChart.getData().addAll(seriesBSQPrice);
+        bsqPriceChart.getData().add(seriesBSQPrice);
 
         AnchorPane chartPane = new AnchorPane();
         chartPane.getStyleClass().add("chart-pane");
@@ -368,7 +368,7 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
         long average = getAverage(bsqTradePast90Days);
         Coin oneBsq = Coin.valueOf(100);
         Price avgPrice = Price.valueOf("BSQ", average);
-        String avg = bsqFormatter.formatPrice(avgPrice);
+        String avg = BsqFormatter.formatPrice(avgPrice);
         String bsqInUsdAvg = average > 0 ? GUIUtil.getBsqInUsd(avgPrice, oneBsq, priceFeedService, bsqFormatter) : Res.get("shared.na");
         textField.setText(avg + " BSQ/BTC (" + "1 BSQ = " + bsqInUsdAvg + ")");
         return average;

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/SupplyView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/SupplyView.java
@@ -195,7 +195,6 @@ public class SupplyView extends ActivatableView<GridPane, Void> implements DaoSt
                 Res.get("dao.factsAndFigures.supply.totalConfiscatedAmount")).second;
     }
 
-    @SuppressWarnings("unchecked")
     private void createChart(XYChart.Series<Number, Number> series, String seriesLabel, String datePattern) {
         NumberAxis xAxis = new NumberAxis();
         xAxis.setForceZeroInRange(false);
@@ -246,7 +245,7 @@ public class SupplyView extends ActivatableView<GridPane, Void> implements DaoSt
         chart.setPrefHeight(250);
         chart.setCreateSymbols(true);
         chart.setPadding(new Insets(0));
-        chart.getData().addAll(series);
+        chart.getData().add(series);
 
         AnchorPane chartPane = new AnchorPane();
         chartPane.getStyleClass().add("chart-pane");

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/GovernanceView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/GovernanceView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.dao.governance;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -52,7 +52,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @FxmlView
-public class GovernanceView extends ActivatableViewAndModel implements DaoStateListener {
+public class GovernanceView extends ActivatableView<AnchorPane, Void> implements DaoStateListener {
     private final ViewLoader viewLoader;
     private final Navigation navigation;
     private final DaoFacade daoFacade;

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
@@ -136,7 +136,7 @@ public class ProposalDisplay {
     @Getter
     private List<TextInputControl> inputControls = new ArrayList<>();
     @Getter
-    private List<ComboBox> comboBoxes = new ArrayList<>();
+    private List<ComboBox<?>> comboBoxes = new ArrayList<>();
     private final ChangeListener<Boolean> focusOutListener;
     private final ChangeListener<Object> inputListener;
     private ChangeListener<Param> paramChangeListener;
@@ -602,10 +602,8 @@ public class ProposalDisplay {
             inputControl.focusedProperty().addListener(focusOutListener);
         });
         comboBoxes.stream()
-                .filter(Objects::nonNull).forEach(comboBox -> {
-            //noinspection unchecked
-            comboBox.getSelectionModel().selectedItemProperty().addListener(inputListener);
-        });
+                .filter(Objects::nonNull)
+                .forEach(comboBox -> comboBox.getSelectionModel().selectedItemProperty().addListener(inputListener));
     }
 
     public void removeListeners() {
@@ -615,10 +613,8 @@ public class ProposalDisplay {
             inputControl.focusedProperty().removeListener(focusOutListener);
         });
         comboBoxes.stream()
-                .filter(Objects::nonNull).forEach(comboBox -> {
-            //noinspection unchecked
-            comboBox.getSelectionModel().selectedItemProperty().removeListener(inputListener);
-        });
+                .filter(Objects::nonNull)
+                .forEach(comboBox -> comboBox.getSelectionModel().selectedItemProperty().removeListener(inputListener));
 
         if (paramComboBox != null && paramChangeListener != null)
             paramComboBox.getSelectionModel().selectedItemProperty().removeListener(paramChangeListener);

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/MonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/MonitorView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.dao.monitor;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -45,7 +45,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @FxmlView
-public class MonitorView extends ActivatableViewAndModel {
+public class MonitorView extends ActivatableView<AnchorPane, Void> {
     private final ViewLoader viewLoader;
     private final Navigation navigation;
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/BsqWalletView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/BsqWalletView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.dao.wallet;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -47,7 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @FxmlView
-public class BsqWalletView extends ActivatableViewAndModel {
+public class BsqWalletView extends ActivatableView<AnchorPane, Void> {
 
     private final ViewLoader viewLoader;
     private final Navigation navigation;

--- a/desktop/src/main/java/bisq/desktop/main/funds/FundsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/FundsView.java
@@ -18,8 +18,7 @@
 package bisq.desktop.main.funds;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -43,7 +42,7 @@ import javafx.scene.control.TabPane;
 import javafx.beans.value.ChangeListener;
 
 @FxmlView
-public class FundsView extends ActivatableViewAndModel<TabPane, Activatable> {
+public class FundsView extends ActivatableView<TabPane, Void> {
 
     @FXML
     Tab depositTab, withdrawalTab, reservedTab, lockedTab, transactionsTab;

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -18,8 +18,7 @@
 package bisq.desktop.main.market;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -65,7 +64,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @FxmlView
-public class MarketView extends ActivatableViewAndModel<TabPane, Activatable> {
+public class MarketView extends ActivatableView<TabPane, Void> {
     @FXML
     Tab offerBookTab, tradesTab, spreadTab;
     private final ViewLoader viewLoader;

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -74,8 +74,8 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     private final Navigation navigation;
 
     final ObjectProperty<TradeCurrency> selectedTradeCurrencyProperty = new SimpleObjectProperty<>();
-    private final List<XYChart.Data> buyData = new ArrayList<>();
-    private final List<XYChart.Data> sellData = new ArrayList<>();
+    private final List<XYChart.Data<Number, Number>> buyData = new ArrayList<>();
+    private final List<XYChart.Data<Number, Number>> sellData = new ArrayList<>();
     private final ObservableList<OfferBookListItem> offerBookListItems;
     private final ListChangeListener<OfferBookListItem> offerBookListItemsListener;
     final CurrencyList currencyListItems;
@@ -131,7 +131,7 @@ class OfferBookChartViewModel extends ActivatableViewModel {
             fillTradeCurrencies();
         };
 
-        currenciesUpdatedListener = new ChangeListener<Number>() {
+        currenciesUpdatedListener = new ChangeListener<>() {
             @Override
             public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
                 if (!isAnyPricePresent()) {
@@ -210,11 +210,11 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     // Getters
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public List<XYChart.Data> getBuyData() {
+    public List<XYChart.Data<Number, Number>> getBuyData() {
         return buyData;
     }
 
-    public List<XYChart.Data> getSellData() {
+    public List<XYChart.Data<Number, Number>> getSellData() {
         return sellData;
     }
 
@@ -359,7 +359,10 @@ class OfferBookChartViewModel extends ActivatableViewModel {
         buildChartAndTableEntries(allSellOffers, OfferPayload.Direction.SELL, sellData, topSellOfferList);
     }
 
-    private void buildChartAndTableEntries(List<Offer> sortedList, OfferPayload.Direction direction, List<XYChart.Data> data, ObservableList<OfferListItem> offerTableList) {
+    private void buildChartAndTableEntries(List<Offer> sortedList,
+                                           OfferPayload.Direction direction,
+                                           List<XYChart.Data<Number, Number>> data,
+                                           ObservableList<OfferListItem> offerTableList) {
         data.clear();
         double accumulatedAmount = 0;
         List<OfferListItem> offerTableListTemp = new ArrayList<>();

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -88,6 +88,7 @@ import javafx.util.StringConverter;
 
 import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -380,8 +381,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         priceChart.setMaxHeight(300);
         priceChart.setLegendVisible(false);
         priceChart.setPadding(new Insets(0));
-        //noinspection unchecked
-        priceChart.setData(FXCollections.observableArrayList(priceSeries));
+        priceChart.setData(FXCollections.observableArrayList(List.of(priceSeries)));
 
         priceChartPane = new AnchorPane();
         priceChartPane.getStyleClass().add("chart-pane");
@@ -428,9 +428,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 return null;
             }
         });
-        //noinspection unchecked
         volumeChart.setId("volume-chart");
-        volumeChart.setData(FXCollections.observableArrayList(volumeSeries));
+        volumeChart.setData(FXCollections.observableArrayList(List.of(volumeSeries)));
         volumeChart.setMinHeight(128);
         volumeChart.setPrefHeight(128);
         volumeChart.setMaxHeight(200);
@@ -457,8 +456,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         priceSeries = new XYChart.Series<>();
         priceSeries.getData().setAll(model.priceItems);
         priceChart.getData().clear();
-        //noinspection unchecked
-        priceChart.setData(FXCollections.observableArrayList(priceSeries));
+        priceChart.setData(FXCollections.observableArrayList(List.of(priceSeries)));
     }
 
     private void layoutChart() {

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -89,7 +89,6 @@ import javafx.util.StringConverter;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.jetbrains.annotations.NotNull;
@@ -185,7 +184,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     @Override
     protected void activate() {
         // root.getParent() is null at initialize
-        tabPaneSelectionModel = Objects.requireNonNull(GUIUtil.getParentOfType(root, JFXTabPane.class)).getSelectionModel();
+        tabPaneSelectionModel = GUIUtil.getParentOfType(root, JFXTabPane.class).getSelectionModel();
         selectedTabIndexListener = (observable, oldValue, newValue) -> model.setSelectedTabIndex((int) newValue);
         model.setSelectedTabIndex(tabPaneSelectionModel.getSelectedIndex());
         tabPaneSelectionModel.selectedIndexProperty().addListener(selectedTabIndexListener);

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -121,7 +121,7 @@ import org.jetbrains.annotations.NotNull;
 import static bisq.desktop.util.FormBuilder.*;
 import static javafx.beans.binding.Bindings.createStringBinding;
 
-public abstract class MutableOfferView<M extends MutableOfferViewModel> extends ActivatableViewAndModel<AnchorPane, M> {
+public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> extends ActivatableViewAndModel<AnchorPane, M> {
     public static final String BUYER_SECURITY_DEPOSIT_NEWS = "buyerSecurityDepositNews0.9.5";
     protected final Navigation navigation;
     private final Preferences preferences;
@@ -438,7 +438,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel> extends 
 
         balanceTextField.setTargetAmount(model.getDataModel().totalToPayAsCoinProperty().get());
 
-        //noinspection PointlessBooleanExpression
         if (!DevEnv.isDevMode()) {
             String key = "securityDepositInfo";
             new Popup<>().backgroundInfo(Res.get("popup.info.securityDepositInfo"))

--- a/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
@@ -29,13 +29,15 @@ import bisq.desktop.util.Transitions;
 
 import bisq.core.app.BisqEnvironment;
 import bisq.core.locale.GlobalSettings;
+import bisq.core.locale.LanguageUtil;
 import bisq.core.locale.Res;
 import bisq.core.user.DontShowAgainLookup;
-import bisq.core.locale.LanguageUtil;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.util.Utilities;
+
+import com.google.common.reflect.TypeToken;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -68,8 +70,8 @@ import javafx.scene.transform.Rotate;
 
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
-import javafx.geometry.Pos;
 import javafx.geometry.NodeOrientation;
+import javafx.geometry.Pos;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -93,7 +95,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public abstract class Overlay<T extends Overlay> {
+public abstract class Overlay<T extends Overlay<T>> {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Enum
@@ -185,12 +187,23 @@ public abstract class Overlay<T extends Overlay> {
 
     protected int maxChar = 1800;
 
+    private T cast() {
+        //noinspection unchecked
+        return (T) this;
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Public API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public Overlay() {
+        //noinspection UnstableApiUsage
+        TypeToken<T> typeToken = new TypeToken<>(getClass()) {
+        };
+        if (!typeToken.isSupertypeOf(getClass())) {
+            throw new RuntimeException("Subclass of Overlay<T> should be castable to T");
+        }
     }
 
     public void show(boolean showAgainChecked) {
@@ -266,26 +279,22 @@ public abstract class Overlay<T extends Overlay> {
 
     public T onClose(Runnable closeHandler) {
         this.closeHandlerOptional = Optional.of(closeHandler);
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T onAction(Runnable actionHandler) {
         this.actionHandlerOptional = Optional.of(actionHandler);
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T onSecondaryAction(Runnable secondaryActionHandlerOptional) {
         this.secondaryActionHandlerOptional = Optional.of(secondaryActionHandlerOptional);
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T headLine(String headLine) {
         this.headLine = headLine;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T notification(String message) {
@@ -294,8 +303,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.notification");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T instruction(String message) {
@@ -304,8 +312,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.instruction");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T attention(String message) {
@@ -314,8 +321,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.attention");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T backgroundInfo(String message) {
@@ -324,8 +330,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.backgroundInfo");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T feedback(String message) {
@@ -334,8 +339,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.feedback");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T confirmation(String message) {
@@ -344,8 +348,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.confirmation");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T information(String message) {
@@ -354,8 +357,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.information");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T warning(String message) {
@@ -365,8 +367,7 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.warning");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T error(String message) {
@@ -377,136 +378,116 @@ public abstract class Overlay<T extends Overlay> {
             this.headLine = Res.get("popup.headline.error");
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     @SuppressWarnings("UnusedReturnValue")
     public T showReportErrorButtons() {
         this.showReportErrorButtons = true;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T message(String message) {
         this.message = message;
         setTruncatedMessage();
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T closeButtonText(String closeButtonText) {
         this.closeButtonText = closeButtonText;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T useReportBugButton() {
         this.closeButtonText = Res.get("shared.reportBug");
         this.closeHandlerOptional = Optional.of(() -> GUIUtil.openWebPage("https://bisq.network/source/bisq/issues"));
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T useIUnderstandButton() {
         this.closeButtonText = Res.get("shared.iUnderstand");
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T actionButtonTextWithGoTo(String target) {
         this.actionButtonText = Res.get("shared.goTo", Res.get(target));
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T secondaryActionButtonTextWithGoTo(String target) {
         this.secondaryActionButtonText = Res.get("shared.goTo", Res.get(target));
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T closeButtonTextWithGoTo(String target) {
         this.closeButtonText = Res.get("shared.goTo", Res.get(target));
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T actionButtonText(String actionButtonText) {
         this.actionButtonText = actionButtonText;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T secondaryActionButtonText(String secondaryActionButtonText) {
         this.secondaryActionButtonText = secondaryActionButtonText;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T useShutDownButton() {
         this.actionButtonText = Res.get("shared.shutDown");
         this.actionHandlerOptional = Optional.ofNullable(BisqApp.getShutDownHandler());
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T buttonAlignment(HPos pos) {
         this.buttonAlignment = pos;
-        return (T) this;
+        return cast();
     }
 
     public T width(double width) {
         this.width = width;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T maxMessageLength(int maxChar) {
         this.maxChar = maxChar;
-        return (T) this;
+        return cast();
     }
 
     public T showBusyAnimation() {
         this.showBusyAnimation = true;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T dontShowAgainId(String key) {
         this.dontShowAgainId = key;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T dontShowAgainText(String dontShowAgainText) {
         this.dontShowAgainText = dontShowAgainText;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T hideCloseButton() {
         this.hideCloseButton = true;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T useAnimation(boolean useAnimation) {
         this.useAnimation = useAnimation;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T setHeadlineStyle(String headlineStyle) {
         this.headlineStyle = headlineStyle;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
     public T disableActionButton() {
         this.disableActionButton = true;
-        //noinspection unchecked
-        return (T) this;
+        return cast();
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/TabbedOverlay.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/TabbedOverlay.java
@@ -4,7 +4,7 @@ import com.jfoenix.controls.JFXTabPane;
 
 import javafx.scene.layout.Region;
 
-public abstract class TabbedOverlay<T extends TabbedOverlay> extends Overlay {
+public abstract class TabbedOverlay<T extends TabbedOverlay<T>> extends Overlay<T> {
 
     protected JFXTabPane tabPane;
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/PortfolioView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/PortfolioView.java
@@ -18,8 +18,7 @@
 package bisq.desktop.main.portfolio;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -50,7 +49,7 @@ import javafx.collections.ListChangeListener;
 import java.util.List;
 
 @FxmlView
-public class PortfolioView extends ActivatableViewAndModel<TabPane, Activatable> {
+public class PortfolioView extends ActivatableView<TabPane, Void> {
 
     @FXML
     Tab openOffersTab, pendingTradesTab, closedTradesTab;

--- a/desktop/src/main/java/bisq/desktop/main/settings/SettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/SettingsView.java
@@ -18,8 +18,7 @@
 package bisq.desktop.main.settings;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -42,7 +41,7 @@ import javafx.scene.control.TabPane;
 import javafx.beans.value.ChangeListener;
 
 @FxmlView
-public class SettingsView extends ActivatableViewAndModel<TabPane, Activatable> {
+public class SettingsView extends ActivatableView<TabPane, Void> {
     @FXML
     Tab preferencesTab, networkTab, aboutTab;
     private final ViewLoader viewLoader;

--- a/desktop/src/main/java/bisq/desktop/main/settings/about/AboutView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/about/AboutView.java
@@ -17,8 +17,7 @@
 
 package bisq.desktop.main.settings.about;
 
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.components.TitledGroupBg;
@@ -41,7 +40,7 @@ import static bisq.desktop.util.FormBuilder.addLabel;
 import static bisq.desktop.util.FormBuilder.addTitledGroupBg;
 
 @FxmlView
-public class AboutView extends ActivatableViewAndModel<GridPane, Activatable> {
+public class AboutView extends ActivatableView<GridPane, Void> {
 
     private int gridRow = 0;
 

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -18,8 +18,7 @@
 package bisq.desktop.main.settings.network;
 
 import bisq.desktop.app.BisqApp;
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
@@ -74,7 +73,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @FxmlView
-public class NetworkSettingsView extends ActivatableViewAndModel<GridPane, Activatable> {
+public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
 
     @FXML
     TitledGroupBg p2pHeader, btcHeader;

--- a/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
@@ -18,8 +18,7 @@
 package bisq.desktop.main.support;
 
 import bisq.desktop.Navigation;
-import bisq.desktop.common.model.Activatable;
-import bisq.desktop.common.view.ActivatableViewAndModel;
+import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.CachingViewLoader;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.View;
@@ -62,7 +61,7 @@ import javafx.beans.value.ChangeListener;
 import javafx.collections.MapChangeListener;
 
 @FxmlView
-public class SupportView extends ActivatableViewAndModel<TabPane, Activatable> {
+public class SupportView extends ActivatableView<TabPane, Void> {
 
     @FXML
     Tab tradersMediationDisputesTab, tradersRefundDisputesTab, tradersArbitrationDisputesTab;

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -188,11 +188,8 @@ public class GUIUtil {
         });
     }
 
-    @SuppressWarnings("PointlessBooleanExpression")
     public static void showFeeInfoBeforeExecute(Runnable runnable) {
-        //noinspection UnusedAssignment
         String key = "miningFeeInfo";
-        //noinspection ConstantConditions,ConstantConditions
         if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
             new Popup<>().attention(Res.get("guiUtil.miningFeeInfo", String.valueOf(GUIUtil.feeService.getTxFeePerByte().value)))
                     .onClose(runnable)
@@ -682,8 +679,7 @@ public class GUIUtil {
                 parent = parent.getParent();
             }
         }
-        //noinspection unchecked
-        return parent != null ? (T) parent : null;
+        return t.cast(parent);
     }
 
     public static void showClearXchangeWarning() {

--- a/desktop/src/test/java/bisq/desktop/main/overlays/OverlayTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/overlays/OverlayTest.java
@@ -15,31 +15,33 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.desktop.main.overlays.popups;
+package bisq.desktop.main.overlays;
 
-import bisq.desktop.main.overlays.Overlay;
+import org.junit.Test;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public class OverlayTest {
 
-// TODO: Type parameter is unused - remove:
-public class Popup<T> extends Overlay<Popup<T>> {
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
-
-    public Popup() {
+    @Test
+    public void typeSafeCreation() {
+        new A();
+        new C();
+        new D<>();
     }
 
-    public void onReadyForDisplay() {
-        super.display();
+    @Test(expected = RuntimeException.class)
+    public void typeUnsafeCreation() {
+        new B();
     }
 
-    @Override
-    protected void onShow() {
-        PopupManager.queueForDisplay(this);
+    private static class A extends Overlay<A> {
     }
 
-    @Override
-    protected void onHidden() {
-        PopupManager.onHidden(this);
+    private static class B extends Overlay<A> {
+    }
+
+    private static class C extends TabbedOverlay<C> {
+    }
+
+    private static class D<T> extends Overlay<D<T>> {
     }
 }

--- a/monitor/src/main/java/bisq/monitor/metric/P2PMarketStats.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PMarketStats.java
@@ -68,7 +68,7 @@ public class P2PMarketStats extends P2PSeedNodeSnapshotBase {
 
     private final Set<byte[]> hashes = new TreeSet<>(Arrays::compare);
 
-    final Map<NodeAddress, Statistics> versionBucketsPerHost = new ConcurrentHashMap<>();
+    final Map<NodeAddress, Statistics<Counter>> versionBucketsPerHost = new ConcurrentHashMap<>();
 
     /**
      * Efficient way to count occurrences.
@@ -189,13 +189,13 @@ public class P2PMarketStats extends P2PSeedNodeSnapshotBase {
     @Override
     protected void report() {
         Map<String, String> report = new HashMap<>();
-        bucketsPerHost.forEach((host, statistics) -> statistics.values().forEach((market, numberOfOffers) -> report.put(OnionParser.prettyPrint(host) + "." + market.toString(), String.valueOf(((Counter) numberOfOffers).value()))));
+        bucketsPerHost.forEach((host, statistics) -> statistics.values().forEach((market, numberOfOffers) -> report.put(OnionParser.prettyPrint(host) + "." + market, String.valueOf(((Counter) numberOfOffers).value()))));
 
         reporter.report(report, getName());
 
         // do version statistics
         report.clear();
-        versionBucketsPerHost.values().stream().findAny().get().values().forEach((version, numberOfOccurrences) -> report.put(version.toString(), String.valueOf(((Counter) numberOfOccurrences).value())));
+        versionBucketsPerHost.values().stream().findAny().get().values().forEach((version, numberOfOccurrences) -> report.put(version, String.valueOf(numberOfOccurrences.value())));
         reporter.report(report, "versions");
     }
 

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
@@ -63,7 +63,7 @@ public abstract class P2PSeedNodeSnapshotBase extends Metric implements MessageL
     private static final String HOSTS = "run.hosts";
     private static final String TOR_PROXY_PORT = "run.torProxyPort";
     Statistics statistics;
-    final Map<NodeAddress, Statistics> bucketsPerHost = new ConcurrentHashMap<>();
+    final Map<NodeAddress, Statistics<?>> bucketsPerHost = new ConcurrentHashMap<>();
     private final ThreadGate gate = new ThreadGate();
 
     /**


### PR DESCRIPTION
Improve type safety by avoiding most of the current unchecked operations, instead of simply suppressing the warnings (as is being done for almost all of them now). This mostly involves adding some missing arguments to raw types, using wildcards in a few extra places and making some minor changes to the logic (such as passing an explicit _Class\<T\>_ argument or replacing a generic vararg list with _List.of(..)_).

(In the case of _OfferBookChartView.updateChartData()_, I made a somewhat larger change to the method body. I also replaced some _ActivatableViewAndModel_ superclasses with _ActivatableView\<R, Void\>_ where this made sense.)

The test classes and some of the harder cases of potentially type-unsafe unchecked operations have been skipped for now, such as _bisq.common.storage.FileManager.read(File)_.