### PR TITLE
Upgrade Gradle Shadow plugin from 4.0.2 => 5.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
         classpath files('gradle/witness/gradle-witness.jar')
         classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.10.RELEASE'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.41"


### PR DESCRIPTION
After the upgrade from Gradle 4.10.2 to 5.6.4 in commit 5fe71fa0a,
all of Bisq's shadowJar tasks started failing Gradle's incremental build
checks. This meant that repeated invocations of `gradle build` went from
a handful of seconds to more than a minute, because shadowJar tasks had
to be re-executed on every build.

For example, with --info enabled, one would see entries like this in the
build output:

    > Task :seednode:shadowJar
    Custom actions are attached to task ':seednode:shadowJar'.
    Caching disabled for task ':seednode:shadowJar' because:
      Caching has not been enabled for the task
    Task ':seednode:shadowJar' is not up-to-date because:
      Output property 'archiveFile' file [...]libs/seednode.jar has changed.

This problem was solved by in johnrengelman/shadow#524 and made
available in the project's recent 5.0.2 release. This patch simply bumps
the shadow plugin version to that value, and gets us back to snappy
incremental builds, e.g.:

    $ gradle build

    BUILD SUCCESSFUL in 7s