### PR TITLE
(4/6) Implement proper remove-before-add behavior in P2PDataStorage

### DIFF
--- a/core/src/main/java/bisq/core/alert/AlertManager.java
+++ b/core/src/main/java/bisq/core/alert/AlertManager.java
@@ -44,6 +44,8 @@ import java.security.SignatureException;
 
 import java.math.BigInteger;
 
+import java.util.Collection;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,22 +81,26 @@ public class AlertManager {
         if (!ignoreDevMsg) {
             p2PService.addHashSetChangedListener(new HashMapChangedListener() {
                 @Override
-                public void onAdded(ProtectedStorageEntry data) {
-                    final ProtectedStoragePayload protectedStoragePayload = data.getProtectedStoragePayload();
-                    if (protectedStoragePayload instanceof Alert) {
-                        Alert alert = (Alert) protectedStoragePayload;
-                        if (verifySignature(alert))
-                            alertMessageProperty.set(alert);
-                    }
+                public void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+                    protectedStorageEntries.forEach(protectedStorageEntry -> {
+                        final ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
+                        if (protectedStoragePayload instanceof Alert) {
+                            Alert alert = (Alert) protectedStoragePayload;
+                            if (verifySignature(alert))
+                                alertMessageProperty.set(alert);
+                        }
+                    });
                 }
 
                 @Override
-                public void onRemoved(ProtectedStorageEntry data) {
-                    final ProtectedStoragePayload protectedStoragePayload = data.getProtectedStoragePayload();
-                    if (protectedStoragePayload instanceof Alert) {
-                        if (verifySignature((Alert) protectedStoragePayload))
-                            alertMessageProperty.set(null);
-                    }
+                public void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+                    protectedStorageEntries.forEach(protectedStorageEntry -> {
+                        final ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
+                        if (protectedStoragePayload instanceof Alert) {
+                            if (verifySignature((Alert) protectedStoragePayload))
+                                alertMessageProperty.set(null);
+                        }
+                    });
                 }
             });
         }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/ProposalListPresentation.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/ProposalListPresentation.java
@@ -41,6 +41,7 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -130,17 +131,21 @@ public class ProposalListPresentation implements DaoStateListener, HashMapChange
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void onAdded(ProtectedStorageEntry entry) {
-        if (entry.getProtectedStoragePayload() instanceof TempProposalPayload) {
-            tempProposalsChanged = true;
-        }
+    public void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+        protectedStorageEntries.forEach(protectedStorageEntry -> {
+            if (protectedStorageEntry.getProtectedStoragePayload() instanceof TempProposalPayload) {
+                tempProposalsChanged = true;
+            }
+        });
     }
 
     @Override
-    public void onRemoved(ProtectedStorageEntry entry) {
-        if (entry.getProtectedStoragePayload() instanceof TempProposalPayload) {
-            tempProposalsChanged = true;
-        }
+    public void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+        protectedStorageEntries.forEach(protectedStorageEntry -> {
+            if (protectedStorageEntry.getProtectedStoragePayload() instanceof TempProposalPayload) {
+                tempProposalsChanged = true;
+            }
+        });
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/governance/proposal/ProposalService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/ProposalService.java
@@ -50,6 +50,7 @@ import javax.inject.Named;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -133,13 +134,17 @@ public class ProposalService implements HashMapChangedListener, AppendOnlyDataSt
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void onAdded(ProtectedStorageEntry entry) {
-        onProtectedDataAdded(entry, true);
+    public void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+        protectedStorageEntries.forEach(protectedStorageEntry -> {
+            onProtectedDataAdded(protectedStorageEntry, true);
+        });
     }
 
     @Override
-    public void onRemoved(ProtectedStorageEntry entry) {
-        onProtectedDataRemoved(entry);
+    public void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+        protectedStorageEntries.forEach(protectedStorageEntry -> {
+            onProtectedDataRemoved(protectedStorageEntry);
+        });
     }
 
 

--- a/core/src/main/java/bisq/core/dao/governance/proposal/ProposalService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/ProposalService.java
@@ -50,6 +50,7 @@ import javax.inject.Named;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -142,9 +143,7 @@ public class ProposalService implements HashMapChangedListener, AppendOnlyDataSt
 
     @Override
     public void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
-        protectedStorageEntries.forEach(protectedStorageEntry -> {
-            onProtectedDataRemoved(protectedStorageEntry);
-        });
+        onProtectedDataRemoved(protectedStorageEntries);
     }
 
 
@@ -271,30 +270,39 @@ public class ProposalService implements HashMapChangedListener, AppendOnlyDataSt
         }
     }
 
-    private void onProtectedDataRemoved(ProtectedStorageEntry entry) {
-        ProtectedStoragePayload protectedStoragePayload = entry.getProtectedStoragePayload();
-        if (protectedStoragePayload instanceof TempProposalPayload) {
-            Proposal proposal = ((TempProposalPayload) protectedStoragePayload).getProposal();
-            // We allow removal only if we are in the proposal phase.
-            boolean inPhase = periodService.isInPhase(daoStateService.getChainHeight(), DaoPhase.Phase.PROPOSAL);
-            boolean txInPastCycle = periodService.isTxInPastCycle(proposal.getTxId(), daoStateService.getChainHeight());
-            Optional<Tx> tx = daoStateService.getTx(proposal.getTxId());
-            boolean unconfirmedOrNonBsqTx = !tx.isPresent();
-            // if the tx is unconfirmed we need to be in the PROPOSAL phase, otherwise the tx must be confirmed.
-            if (inPhase || txInPastCycle || unconfirmedOrNonBsqTx) {
-                if (tempProposals.contains(proposal)) {
-                    tempProposals.remove(proposal);
-                    log.debug("We received a remove request for a TempProposalPayload and have removed the proposal " +
-                                    "from our list. proposal creation date={}, proposalTxId={}, inPhase={}, " +
-                                    "txInPastCycle={}, unconfirmedOrNonBsqTx={}",
-                            proposal.getCreationDateAsDate(), proposal.getTxId(), inPhase, txInPastCycle, unconfirmedOrNonBsqTx);
+    private void onProtectedDataRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+
+        // The listeners of tmpProposals can do large amounts of work that cause performance issues. Apply all of the
+        // updates at once using retainAll which will cause all listeners to be updated only once.
+        ArrayList<Proposal> tempProposalsWithUpdates = new ArrayList<>(tempProposals);
+
+        protectedStorageEntries.forEach(protectedStorageEntry -> {
+            ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
+            if (protectedStoragePayload instanceof TempProposalPayload) {
+                Proposal proposal = ((TempProposalPayload) protectedStoragePayload).getProposal();
+                // We allow removal only if we are in the proposal phase.
+                boolean inPhase = periodService.isInPhase(daoStateService.getChainHeight(), DaoPhase.Phase.PROPOSAL);
+                boolean txInPastCycle = periodService.isTxInPastCycle(proposal.getTxId(), daoStateService.getChainHeight());
+                Optional<Tx> tx = daoStateService.getTx(proposal.getTxId());
+                boolean unconfirmedOrNonBsqTx = !tx.isPresent();
+                // if the tx is unconfirmed we need to be in the PROPOSAL phase, otherwise the tx must be confirmed.
+                if (inPhase || txInPastCycle || unconfirmedOrNonBsqTx) {
+                    if (tempProposalsWithUpdates.contains(proposal)) {
+                        tempProposalsWithUpdates.remove(proposal);
+                        log.debug("We received a remove request for a TempProposalPayload and have removed the proposal " +
+                                        "from our list. proposal creation date={}, proposalTxId={}, inPhase={}, " +
+                                        "txInPastCycle={}, unconfirmedOrNonBsqTx={}",
+                                proposal.getCreationDateAsDate(), proposal.getTxId(), inPhase, txInPastCycle, unconfirmedOrNonBsqTx);
+                    }
+                } else {
+                    log.warn("We received a remove request outside the PROPOSAL phase. " +
+                                    "Proposal creation date={}, proposal.txId={}, current blockHeight={}",
+                            proposal.getCreationDateAsDate(), proposal.getTxId(), daoStateService.getChainHeight());
                 }
-            } else {
-                log.warn("We received a remove request outside the PROPOSAL phase. " +
-                                "Proposal creation date={}, proposal.txId={}, current blockHeight={}",
-                        proposal.getCreationDateAsDate(), proposal.getTxId(), daoStateService.getChainHeight());
             }
-        }
+        });
+
+        tempProposals.retainAll(tempProposalsWithUpdates);
     }
 
     private void onAppendOnlyDataAdded(PersistableNetworkPayload persistableNetworkPayload, boolean fromBroadcastMessage) {

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalStore.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalStore.java
@@ -56,7 +56,7 @@ public class TempProposalStore implements PersistableEnvelope {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private TempProposalStore(List<ProtectedStorageEntry> list) {
-        list.forEach(entry -> map.put(P2PDataStorage.getCompactHashAsByteArray(entry.getProtectedStoragePayload()), entry));
+        list.forEach(entry -> map.put(P2PDataStorage.get32ByteHashAsByteArray(entry.getProtectedStoragePayload()), entry));
     }
 
     public Message toProtoMessage() {

--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -40,6 +40,7 @@ import javax.inject.Inject;
 
 import java.io.File;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -87,26 +88,30 @@ public class OfferBookService {
 
         p2PService.addHashSetChangedListener(new HashMapChangedListener() {
             @Override
-            public void onAdded(ProtectedStorageEntry data) {
-                offerBookChangedListeners.stream().forEach(listener -> {
-                    if (data.getProtectedStoragePayload() instanceof OfferPayload) {
-                        OfferPayload offerPayload = (OfferPayload) data.getProtectedStoragePayload();
-                        Offer offer = new Offer(offerPayload);
-                        offer.setPriceFeedService(priceFeedService);
-                        listener.onAdded(offer);
-                    }
+            public void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+                protectedStorageEntries.forEach(protectedStorageEntry -> {
+                    offerBookChangedListeners.stream().forEach(listener -> {
+                        if (protectedStorageEntry.getProtectedStoragePayload() instanceof OfferPayload) {
+                            OfferPayload offerPayload = (OfferPayload) protectedStorageEntry.getProtectedStoragePayload();
+                            Offer offer = new Offer(offerPayload);
+                            offer.setPriceFeedService(priceFeedService);
+                            listener.onAdded(offer);
+                        }
+                    });
                 });
             }
 
             @Override
-            public void onRemoved(ProtectedStorageEntry data) {
-                offerBookChangedListeners.stream().forEach(listener -> {
-                    if (data.getProtectedStoragePayload() instanceof OfferPayload) {
-                        OfferPayload offerPayload = (OfferPayload) data.getProtectedStoragePayload();
-                        Offer offer = new Offer(offerPayload);
-                        offer.setPriceFeedService(priceFeedService);
-                        listener.onRemoved(offer);
-                    }
+            public void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+                protectedStorageEntries.forEach(protectedStorageEntry -> {
+                    offerBookChangedListeners.stream().forEach(listener -> {
+                        if (protectedStorageEntry.getProtectedStoragePayload() instanceof OfferPayload) {
+                            OfferPayload offerPayload = (OfferPayload) protectedStorageEntry.getProtectedStoragePayload();
+                            Offer offer = new Offer(offerPayload);
+                            offer.setPriceFeedService(priceFeedService);
+                            listener.onRemoved(offer);
+                        }
+                    });
                 });
             }
         });

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentManager.java
@@ -46,6 +46,7 @@ import java.security.SignatureException;
 import java.math.BigInteger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -131,18 +132,22 @@ public abstract class DisputeAgentManager<T extends DisputeAgent> {
     public void onAllServicesInitialized() {
         disputeAgentService.addHashSetChangedListener(new HashMapChangedListener() {
             @Override
-            public void onAdded(ProtectedStorageEntry data) {
-                if (isExpectedInstance(data)) {
-                    updateMap();
-                }
+            public void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+                protectedStorageEntries.forEach(protectedStorageEntry -> {
+                    if (isExpectedInstance(protectedStorageEntry)) {
+                        updateMap();
+                    }
+                });
             }
 
             @Override
-            public void onRemoved(ProtectedStorageEntry data) {
-                if (isExpectedInstance(data)) {
-                    updateMap();
-                    removeAcceptedDisputeAgentFromUser(data);
-                }
+            public void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+                protectedStorageEntries.forEach(protectedStorageEntry -> {
+                    if (isExpectedInstance(protectedStorageEntry)) {
+                        updateMap();
+                        removeAcceptedDisputeAgentFromUser(protectedStorageEntry);
+                    }
+                });
             }
         });
 

--- a/core/src/test/java/bisq/core/dao/governance/proposal/ProposalServiceP2PDataStorageListenerTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/proposal/ProposalServiceP2PDataStorageListenerTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.governance.proposal;
+
+import bisq.core.dao.governance.period.PeriodService;
+import bisq.core.dao.governance.proposal.storage.appendonly.ProposalStorageService;
+import bisq.core.dao.governance.proposal.storage.temp.TempProposalPayload;
+import bisq.core.dao.governance.proposal.storage.temp.TempProposalStorageService;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.governance.DaoPhase;
+import bisq.core.dao.state.model.governance.Proposal;
+
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
+import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
+import bisq.network.p2p.storage.persistence.ProtectedDataStoreService;
+
+import javafx.collections.ListChangeListener;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+/**
+ * Tests of the P2PDataStorage::onRemoved callback behavior to ensure that the proper number of signal events occur.
+ */
+public class ProposalServiceP2PDataStorageListenerTest {
+    private ProposalService proposalService;
+
+    @Mock
+    private PeriodService periodService;
+
+    @Mock
+    private DaoStateService daoStateService;
+
+    @Mock
+    private ListChangeListener<Proposal> tempProposalListener;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        this.proposalService = new ProposalService(
+                mock(P2PService.class),
+                this.periodService,
+                mock(ProposalStorageService.class),
+                mock(TempProposalStorageService.class),
+                mock(AppendOnlyDataStoreService.class),
+                mock(ProtectedDataStoreService.class),
+                this.daoStateService,
+                mock(ProposalValidatorProvider.class),
+                true);
+
+        // Create a state so that all added/removed Proposals will actually update the tempProposals list.
+        when(this.periodService.isInPhase(anyInt(), any(DaoPhase.Phase.class))).thenReturn(true);
+        when(this.daoStateService.isParseBlockChainComplete()).thenReturn(false);
+    }
+
+    private static ProtectedStorageEntry buildProtectedStorageEntry() {
+        ProtectedStorageEntry protectedStorageEntry = mock(ProtectedStorageEntry.class);
+        TempProposalPayload tempProposalPayload = mock(TempProposalPayload.class);
+        Proposal tempProposal = mock(Proposal.class);
+        when(protectedStorageEntry.getProtectedStoragePayload()).thenReturn(tempProposalPayload);
+        when(tempProposalPayload.getProposal()).thenReturn(tempProposal);
+
+        return protectedStorageEntry;
+    }
+
+    // TESTCASE: If an onRemoved callback is called which does not remove anything the tempProposals listeners
+    // are not signaled.
+    @Test
+    public void onRemoved_noSignalIfNoChange() {
+        this.proposalService.onRemoved(Collections.singletonList(mock(ProtectedStorageEntry.class)));
+
+        verify(this.tempProposalListener, never()).onChanged(any());
+    }
+
+    // TESTCASE: If an onRemoved callback is called with 1 element AND it creates a remove of 1 element, the tempProposal
+    // listeners are signaled once.
+    @Test
+    public void onRemoved_signalOnceOnOneChange() {
+        ProtectedStorageEntry one = buildProtectedStorageEntry();
+        this.proposalService.onAdded(Collections.singletonList(one));
+        this.proposalService.getTempProposals().addListener(this.tempProposalListener);
+
+        this.proposalService.onRemoved(Collections.singletonList(one));
+
+        verify(this.tempProposalListener).onChanged(any());
+    }
+
+    // TESTCASE: If an onRemoved callback is called with 2 elements AND it creates a remove of 2 elements, the
+    // tempProposal listeners are signaled once.
+    @Test
+    public void onRemoved_signalOnceOnMultipleChanges() {
+        ProtectedStorageEntry one = buildProtectedStorageEntry();
+        ProtectedStorageEntry two = buildProtectedStorageEntry();
+        this.proposalService.onAdded(Arrays.asList(one, two));
+        this.proposalService.getTempProposals().addListener(this.tempProposalListener);
+
+        this.proposalService.onRemoved(Arrays.asList(one, two));
+
+        verify(this.tempProposalListener).onChanged(any());
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/P2PModule.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PModule.java
@@ -105,5 +105,6 @@ public class P2PModule extends AppModule {
         bindConstant().annotatedWith(named(NetworkOptionKeys.MSG_THROTTLE_PER_10_SEC)).to(environment.getRequiredProperty(NetworkOptionKeys.MSG_THROTTLE_PER_10_SEC));
         bindConstant().annotatedWith(named(NetworkOptionKeys.SEND_MSG_THROTTLE_TRIGGER)).to(environment.getRequiredProperty(NetworkOptionKeys.SEND_MSG_THROTTLE_TRIGGER));
         bindConstant().annotatedWith(named(NetworkOptionKeys.SEND_MSG_THROTTLE_SLEEP)).to(environment.getRequiredProperty(NetworkOptionKeys.SEND_MSG_THROTTLE_SLEEP));
+        bindConstant().annotatedWith(named("MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE")).to(1000);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -75,6 +75,7 @@ import javafx.beans.property.SimpleIntegerProperty;
 import java.security.PublicKey;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -432,15 +433,15 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void onAdded(ProtectedStorageEntry protectedStorageEntry) {
-        if (protectedStorageEntry instanceof ProtectedMailboxStorageEntry)
-            processMailboxEntry((ProtectedMailboxStorageEntry) protectedStorageEntry);
+    public void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+        protectedStorageEntries.forEach(protectedStorageEntry -> {
+            if (protectedStorageEntry instanceof ProtectedMailboxStorageEntry)
+                processMailboxEntry((ProtectedMailboxStorageEntry) protectedStorageEntry);
+        });
     }
 
     @Override
-    public void onRemoved(ProtectedStorageEntry data) {
-    }
-
+    public void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) { }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // DirectMessages

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -132,7 +132,7 @@ class RequestDataHandler implements MessageListener {
                     .map(e -> e.bytes)
                     .collect(Collectors.toSet());
 
-            Set<byte[]> excludedKeysFromPersistedEntryMap = dataStorage.getProtectedDataStoreMap().keySet()
+            Set<byte[]> excludedKeysFromPersistedEntryMap = dataStorage.getMap().keySet()
                     .stream()
                     .map(e -> e.bytes)
                     .collect(Collectors.toSet());

--- a/p2p/src/main/java/bisq/network/p2p/storage/HashMapChangedListener.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/HashMapChangedListener.java
@@ -26,12 +26,4 @@ public interface HashMapChangedListener {
 
     @SuppressWarnings("UnusedParameters")
     void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries);
-
-    // We process all expired entries after a delay (60 s) after onBootstrapComplete.
-    // We notify listeners of start and completion so they can optimize to only update after batch processing is done.
-    default void onBatchRemoveExpiredDataStarted() {
-    }
-
-    default void onBatchRemoveExpiredDataCompleted() {
-    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/HashMapChangedListener.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/HashMapChangedListener.java
@@ -19,11 +19,13 @@ package bisq.network.p2p.storage;
 
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 
+import java.util.Collection;
+
 public interface HashMapChangedListener {
-    void onAdded(ProtectedStorageEntry data);
+    void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries);
 
     @SuppressWarnings("UnusedParameters")
-    void onRemoved(ProtectedStorageEntry data);
+    void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries);
 
     // We process all expired entries after a delay (60 s) after onBootstrapComplete.
     // We notify listeners of start and completion so they can optimize to only update after batch processing is done.

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -423,8 +423,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         // Persist ProtectedStorageEntrys carrying PersistablePayload payloads and signal listeners on changes
         if (protectedStoragePayload instanceof PersistablePayload) {
-            ByteArray compactHash = P2PDataStorage.getCompactHashAsByteArray(protectedStoragePayload);
-            ProtectedStorageEntry previous = protectedDataStoreService.putIfAbsent(compactHash, protectedStorageEntry);
+            ProtectedStorageEntry previous = protectedDataStoreService.putIfAbsent(hashOfPayload, protectedStorageEntry);
             if (previous == null)
                 protectedDataStoreListeners.forEach(e -> e.onAdded(protectedStorageEntry));
         }
@@ -663,8 +662,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
             ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
             if (protectedStoragePayload instanceof PersistablePayload) {
-                ByteArray compactHash = getCompactHashAsByteArray(protectedStoragePayload);
-                ProtectedStorageEntry previous = protectedDataStoreService.remove(compactHash, protectedStorageEntry);
+                ProtectedStorageEntry previous = protectedDataStoreService.remove(hashOfPayload, protectedStorageEntry);
                 if (previous != null) {
                     protectedDataStoreListeners.forEach(e -> e.onRemoved(protectedStorageEntry));
                 } else {
@@ -712,14 +710,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
     public static ByteArray get32ByteHashAsByteArray(NetworkPayload data) {
         return new ByteArray(P2PDataStorage.get32ByteHash(data));
-    }
-
-    public static ByteArray getCompactHashAsByteArray(ProtectedStoragePayload protectedStoragePayload) {
-        return new ByteArray(getCompactHash(protectedStoragePayload));
-    }
-
-    private static byte[] getCompactHash(ProtectedStoragePayload protectedStoragePayload) {
-        return Hash.getSha256Ripemd160hash(protectedStoragePayload.toProtoMessage().toByteArray());
     }
 
     // Get a new map with entries older than PURGE_AGE_DAYS purged from the given map.

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -222,11 +222,6 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         return appendOnlyDataStoreService.getMap();
     }
 
-    public Map<P2PDataStorage.ByteArray, ProtectedStorageEntry> getProtectedDataStoreMap() {
-        return protectedDataStoreService.getMap();
-    }
-
-
     ///////////////////////////////////////////////////////////////////////////////////////////
     // MessageListener implementation
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -651,12 +651,17 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
     private void removeFromMapAndDataStore(
             Collection<Map.Entry<ByteArray, ProtectedStorageEntry>> entriesToRemoveWithPayloadHash) {
+
+        if (entriesToRemoveWithPayloadHash.isEmpty())
+            return;
+
+        ArrayList<ProtectedStorageEntry> entriesForSignal = new ArrayList<>(entriesToRemoveWithPayloadHash.size());
         entriesToRemoveWithPayloadHash.forEach(entryToRemoveWithPayloadHash -> {
             ByteArray hashOfPayload = entryToRemoveWithPayloadHash.getKey();
             ProtectedStorageEntry protectedStorageEntry = entryToRemoveWithPayloadHash.getValue();
 
             map.remove(hashOfPayload);
-            hashMapChangedListeners.forEach(e -> e.onRemoved(Collections.singletonList(protectedStorageEntry)));
+            entriesForSignal.add(protectedStorageEntry);
 
             ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
             if (protectedStoragePayload instanceof PersistablePayload) {
@@ -669,6 +674,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
                 }
             }
         });
+
+        hashMapChangedListeners.forEach(e -> e.onRemoved(entriesForSignal));
     }
 
     private boolean hasSequenceNrIncreased(int newSequenceNumber, ByteArray hashOfData) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -203,13 +203,11 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         // Batch processing can cause performance issues, so we give listeners a chance to deal with it by notifying
         // about start and end of iteration.
         hashMapChangedListeners.forEach(HashMapChangedListener::onBatchRemoveExpiredDataStarted);
-        toRemoveList.forEach(mapEntry -> {
-            ProtectedStorageEntry protectedStorageEntry = mapEntry.getValue();
-            ByteArray payloadHash = mapEntry.getKey();
-
-            log.debug("We found an expired data entry. We remove the protectedData:\n\t" + Utilities.toTruncatedString(protectedStorageEntry));
-            removeFromMapAndDataStore(protectedStorageEntry, payloadHash);
+        toRemoveList.forEach(toRemoveItem -> {
+            log.debug("We found an expired data entry. We remove the protectedData:\n\t" +
+                    Utilities.toTruncatedString(toRemoveItem.getValue()));
         });
+        removeFromMapAndDataStore(toRemoveList);
         hashMapChangedListeners.forEach(HashMapChangedListener::onBatchRemoveExpiredDataCompleted);
 
         if (sequenceNumberMap.size() > this.maxSequenceNumberMapSizeBeforePurge)

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -200,15 +200,13 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
                 .filter(entry -> entry.getValue().isExpired(this.clock))
                 .collect(Collectors.toCollection(ArrayList::new));
 
-        // Batch processing can cause performance issues, so we give listeners a chance to deal with it by notifying
-        // about start and end of iteration.
-        hashMapChangedListeners.forEach(HashMapChangedListener::onBatchRemoveExpiredDataStarted);
+        // Batch processing can cause performance issues, so do all of the removes first, then update the listeners
+        // to let them know about the removes.
         toRemoveList.forEach(toRemoveItem -> {
             log.debug("We found an expired data entry. We remove the protectedData:\n\t" +
                     Utilities.toTruncatedString(toRemoveItem.getValue()));
         });
         removeFromMapAndDataStore(toRemoveList);
-        hashMapChangedListeners.forEach(HashMapChangedListener::onBatchRemoveExpiredDataCompleted);
 
         if (sequenceNumberMap.size() > this.maxSequenceNumberMapSizeBeforePurge)
             sequenceNumberMap.setMap(getPurgedSequenceNumberMap(sequenceNumberMap.getMap()));

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -75,6 +75,7 @@ import java.security.PublicKey;
 import java.time.Clock;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -409,7 +410,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         // This is an updated entry. Record it and signal listeners.
         map.put(hashOfPayload, protectedStorageEntry);
-        hashMapChangedListeners.forEach(e -> e.onAdded(protectedStorageEntry));
+        hashMapChangedListeners.forEach(e -> e.onAdded(Collections.singletonList(protectedStorageEntry)));
 
         // Record the updated sequence number and persist it. Higher delay so we can batch more items.
         sequenceNumberMap.put(hashOfPayload, new MapValue(protectedStorageEntry.getSequenceNumber(), this.clock.millis()));
@@ -643,7 +644,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
     private void removeFromMapAndDataStore(ProtectedStorageEntry protectedStorageEntry, ByteArray hashOfPayload) {
         map.remove(hashOfPayload);
-        hashMapChangedListeners.forEach(e -> e.onRemoved(protectedStorageEntry));
+        hashMapChangedListeners.forEach(e -> e.onRemoved(Collections.singletonList(protectedStorageEntry)));
 
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         if (protectedStoragePayload instanceof PersistablePayload) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -121,7 +121,9 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     private Timer removeExpiredEntriesTimer;
 
     private final Storage<SequenceNumberMap> sequenceNumberMapStorage;
-    private final SequenceNumberMap sequenceNumberMap = new SequenceNumberMap();
+
+    @VisibleForTesting
+    final SequenceNumberMap sequenceNumberMap = new SequenceNumberMap();
 
     private final Set<AppendOnlyDataStoreListener> appendOnlyDataStoreListeners = new CopyOnWriteArraySet<>();
     private final Set<ProtectedDataStoreListener> protectedDataStoreListeners = new CopyOnWriteArraySet<>();

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageClientAPITest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageClientAPITest.java
@@ -188,7 +188,7 @@ public class P2PDataStorageClientAPITest {
         SavedTestState beforeState = this.testState.saveTestState(protectedMailboxStorageEntry);
         Assert.assertFalse(this.testState.mockedStorage.remove(protectedMailboxStorageEntry, TestState.getTestNodeAddress(), true));
 
-        this.testState.verifyProtectedStorageRemove(beforeState, protectedMailboxStorageEntry, false, true, false, true);
+        this.testState.verifyProtectedStorageRemove(beforeState, protectedMailboxStorageEntry, false, true, true, true);
     }
 
     // TESTCASE: Adding, then removing a mailbox message from the getMailboxDataWithSignedSeqNr API

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageClientAPITest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageClientAPITest.java
@@ -188,7 +188,7 @@ public class P2PDataStorageClientAPITest {
         SavedTestState beforeState = this.testState.saveTestState(protectedMailboxStorageEntry);
         Assert.assertFalse(this.testState.mockedStorage.remove(protectedMailboxStorageEntry, TestState.getTestNodeAddress(), true));
 
-        this.testState.verifyProtectedStorageRemove(beforeState, protectedMailboxStorageEntry, false, true, true, true);
+        this.testState.verifyProtectedStorageRemove(beforeState, protectedMailboxStorageEntry, false, true, false, true);
     }
 
     // TESTCASE: Adding, then removing a mailbox message from the getMailboxDataWithSignedSeqNr API

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStoragePersistableNetworkPayloadTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStoragePersistableNetworkPayloadTest.java
@@ -55,6 +55,7 @@ import static bisq.network.p2p.storage.TestState.*;
  * 2 & 3 Client API [addPersistableNetworkPayload(reBroadcast=(true && false))]
  * 4.    onMessage() [onMessage(AddPersistableNetworkPayloadMessage)]
  */
+@SuppressWarnings("unused")
 public class P2PDataStoragePersistableNetworkPayloadTest {
 
     @RunWith(Parameterized.class)

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
@@ -38,6 +38,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.Assert;
@@ -571,6 +572,23 @@ public class P2PDataStorageProtectedStorageEntryTest {
             return ProtectedStorageEntry.class;
         }
 
+
+        // Tests that just apply to PersistablePayload objects
+
+        // XXXBUG_3629XXX: Persisted ProtectedStorageEntries are saved to disk via their 20-byte hash. This causes
+        // the internal hash map to be reloaded with the 20-byte key instead of the 32-byte key.
+        @Test
+        public void addProtectedStorageEntry_afterReadFromResourcesWithDuplicate_3629RegressionTest() {
+            ProtectedStorageEntry protectedStorageEntry = this.getProtectedStorageEntryForAdd(1);
+            doProtectedStorageAddAndVerify(protectedStorageEntry, true, true);
+
+            Map<P2PDataStorage.ByteArray, ProtectedStorageEntry> beforeRestart = this.testState.mockedStorage.getMap();
+
+            this.testState.simulateRestart();
+
+            // Should be equal
+            Assert.assertNotEquals(beforeRestart, this.testState.mockedStorage.getMap());
+        }
     }
 
     /**

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
@@ -575,8 +575,7 @@ public class P2PDataStorageProtectedStorageEntryTest {
 
         // Tests that just apply to PersistablePayload objects
 
-        // XXXBUG_3629XXX: Persisted ProtectedStorageEntries are saved to disk via their 20-byte hash. This causes
-        // the internal hash map to be reloaded with the 20-byte key instead of the 32-byte key.
+        // TESTCASE: Ensure the HashMap is the same before and after a restart
         @Test
         public void addProtectedStorageEntry_afterReadFromResourcesWithDuplicate_3629RegressionTest() {
             ProtectedStorageEntry protectedStorageEntry = this.getProtectedStorageEntryForAdd(1);
@@ -585,9 +584,8 @@ public class P2PDataStorageProtectedStorageEntryTest {
             Map<P2PDataStorage.ByteArray, ProtectedStorageEntry> beforeRestart = this.testState.mockedStorage.getMap();
 
             this.testState.simulateRestart();
-
-            // Should be equal
-            Assert.assertNotEquals(beforeRestart, this.testState.mockedStorage.getMap());
+            
+            Assert.assertEquals(beforeRestart, this.testState.mockedStorage.getMap());
         }
     }
 

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
@@ -65,6 +65,7 @@ import static bisq.network.p2p.storage.TestState.*;
  * 1. Client API [addProtectedStorageEntry(), refreshTTL(), remove()]
  * 2. onMessage() [AddDataMessage, RefreshOfferMessage, RemoveDataMessage]
  */
+@SuppressWarnings("unused")
 public class P2PDataStorageProtectedStorageEntryTest {
     @RunWith(Parameterized.class)
     abstract public static class ProtectedStorageEntryTestBase {

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProtectedStorageEntryTest.java
@@ -211,7 +211,7 @@ public class P2PDataStorageProtectedStorageEntryTest {
             if (!this.useMessageHandler)
                 Assert.assertEquals(expectedReturnValue, addResult);
 
-            this.testState.verifyProtectedStorageRemove(beforeState, entry, expectInternalStateChange, true, true, this.expectIsDataOwner());
+            this.testState.verifyProtectedStorageRemove(beforeState, entry, expectInternalStateChange, true, expectInternalStateChange, this.expectIsDataOwner());
         }
 
         /// Valid Add Tests (isValidForAdd() and matchesRelevantPubKey() return true)

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRemoveExpiredTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRemoveExpiredTest.java
@@ -156,7 +156,7 @@ public class P2PDataStorageRemoveExpiredTest {
 
         Assert.assertTrue(testState.mockedStorage.addProtectedStorageEntry(purgedProtectedStorageEntry, TestState.getTestNodeAddress(), null, true));
 
-        for (int i = 0; i < 4; ++i) {
+        for (int i = 0; i < MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE - 1; ++i) {
             KeyPair ownerKeys = TestUtils.generateKeyPair();
             ProtectedStoragePayload protectedStoragePayload = new PersistableExpirableProtectedStoragePayloadStub(ownerKeys.getPublic(), 0);
             ProtectedStorageEntry tmpEntry = testState.mockedStorage.getProtectedStorageEntry(protectedStoragePayload, ownerKeys);

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStoreDisconnectTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStoreDisconnectTest.java
@@ -39,10 +39,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static bisq.network.p2p.storage.TestState.*;
@@ -173,7 +170,7 @@ public class P2PDataStoreDisconnectTest {
         class ExpirablePersistentProtectedStoragePayloadStub
                                          extends ExpirableProtectedStoragePayloadStub implements PersistablePayload {
 
-            public ExpirablePersistentProtectedStoragePayloadStub(PublicKey ownerPubKey) {
+            private ExpirablePersistentProtectedStoragePayloadStub(PublicKey ownerPubKey) {
                 super(ownerPubKey, 0);
             }
         }

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -215,7 +215,6 @@ public class TestState {
                                    boolean expectedStateChange,
                                    boolean expectedIsDataOwner) {
         P2PDataStorage.ByteArray hashMapHash = P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload());
-        P2PDataStorage.ByteArray storageHash = P2PDataStorage.getCompactHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload());
 
         if (expectedStateChange) {
             Assert.assertEquals(protectedStorageEntry, this.mockedStorage.getMap().get(hashMapHash));
@@ -225,10 +224,10 @@ public class TestState {
             // TODO: Should the behavior be identical between this and the HashMap listeners?
             // TODO: Do we want ot overwrite stale values in order to persist updated sequence numbers and timestamps?
             if (protectedStorageEntry.getProtectedStoragePayload() instanceof PersistablePayload && beforeState.protectedStorageEntryBeforeOpDataStoreMap == null) {
-                Assert.assertEquals(protectedStorageEntry, this.mockedStorage.getProtectedDataStoreMap().get(storageHash));
+                Assert.assertEquals(protectedStorageEntry, this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
                 verify(this.protectedDataStoreListener).onAdded(protectedStorageEntry);
             } else {
-                Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.mockedStorage.getProtectedDataStoreMap().get(storageHash));
+                Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
                 verify(this.protectedDataStoreListener, never()).onAdded(protectedStorageEntry);
             }
 
@@ -245,7 +244,7 @@ public class TestState {
             this.verifySequenceNumberMapWriteContains(P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload()), protectedStorageEntry.getSequenceNumber());
         } else {
             Assert.assertEquals(beforeState.protectedStorageEntryBeforeOp, this.mockedStorage.getMap().get(hashMapHash));
-            Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.mockedStorage.getProtectedDataStoreMap().get(storageHash));
+            Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
 
             verify(this.mockBroadcaster, never()).broadcast(any(BroadcastMessage.class), any(NodeAddress.class), any(BroadcastHandler.Listener.class), anyBoolean());
 
@@ -294,13 +293,12 @@ public class TestState {
 
         protectedStorageEntries.forEach(protectedStorageEntry -> {
             P2PDataStorage.ByteArray hashMapHash = P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload());
-            P2PDataStorage.ByteArray storageHash = P2PDataStorage.getCompactHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload());
 
             if (expectedStateChange) {
                 Assert.assertNull(this.mockedStorage.getMap().get(hashMapHash));
 
                 if (protectedStorageEntry.getProtectedStoragePayload() instanceof PersistablePayload) {
-                    Assert.assertNull(this.mockedStorage.getProtectedDataStoreMap().get(storageHash));
+                    Assert.assertNull(this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
 
                     verify(this.protectedDataStoreListener).onRemoved(protectedStorageEntry);
                 }
@@ -420,11 +418,10 @@ public class TestState {
         private SavedTestState(TestState testState, ProtectedStorageEntry protectedStorageEntry) {
             this(testState);
 
-            P2PDataStorage.ByteArray storageHash = P2PDataStorage.getCompactHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload());
-            this.protectedStorageEntryBeforeOpDataStoreMap = testState.mockedStorage.getProtectedDataStoreMap().get(storageHash);
-
             P2PDataStorage.ByteArray hashMapHash = P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload());
             this.protectedStorageEntryBeforeOp = testState.mockedStorage.getMap().get(hashMapHash);
+            this.protectedStorageEntryBeforeOpDataStoreMap = testState.mockedStorage.getProtectedDataStoreMap().get(hashMapHash);
+
 
             this.creationTimestampBeforeUpdate = (this.protectedStorageEntryBeforeOp != null) ? this.protectedStorageEntryBeforeOp.getCreationTimeStamp() : 0;
         }

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -45,6 +45,7 @@ import bisq.common.storage.Storage;
 
 import java.security.PublicKey;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
@@ -174,7 +175,7 @@ public class TestState {
                 verify(this.protectedDataStoreListener, never()).onAdded(protectedStorageEntry);
             }
 
-            verify(this.hashMapChangedListener).onAdded(protectedStorageEntry);
+            verify(this.hashMapChangedListener).onAdded(Collections.singletonList(protectedStorageEntry));
 
             final ArgumentCaptor<BroadcastMessage> captor = ArgumentCaptor.forClass(BroadcastMessage.class);
             verify(this.mockBroadcaster).broadcast(captor.capture(), any(NodeAddress.class),
@@ -192,7 +193,7 @@ public class TestState {
             verify(this.mockBroadcaster, never()).broadcast(any(BroadcastMessage.class), any(NodeAddress.class), any(BroadcastHandler.Listener.class), anyBoolean());
 
             // Internal state didn't change... nothing should be notified
-            verify(this.hashMapChangedListener, never()).onAdded(protectedStorageEntry);
+            verify(this.hashMapChangedListener, never()).onAdded(Collections.singletonList(protectedStorageEntry));
             verify(this.protectedDataStoreListener, never()).onAdded(protectedStorageEntry);
             verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class), anyLong());
         }
@@ -216,7 +217,7 @@ public class TestState {
                 verify(this.protectedDataStoreListener).onRemoved(protectedStorageEntry);
             }
 
-            verify(this.hashMapChangedListener).onRemoved(protectedStorageEntry);
+            verify(this.hashMapChangedListener).onRemoved(Collections.singletonList(protectedStorageEntry));
 
             if (expectedSeqNrWriteOnStateChange)
                 this.verifySequenceNumberMapWriteContains(P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload()), protectedStorageEntry.getSequenceNumber());
@@ -232,7 +233,7 @@ public class TestState {
             Assert.assertEquals(beforeState.protectedStorageEntryBeforeOp, this.mockedStorage.getMap().get(hashMapHash));
 
             verify(this.mockBroadcaster, never()).broadcast(any(BroadcastMessage.class), any(NodeAddress.class), any(BroadcastHandler.Listener.class), anyBoolean());
-            verify(this.hashMapChangedListener, never()).onAdded(protectedStorageEntry);
+            verify(this.hashMapChangedListener, never()).onAdded(Collections.singletonList(protectedStorageEntry));
             verify(this.protectedDataStoreListener, never()).onAdded(protectedStorageEntry);
             verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class), anyLong());
         }

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -63,6 +63,8 @@ import static org.mockito.Mockito.*;
  * Used in the P2PDataStorage*Test(s) in order to leverage common test set up and validation.
  */
 public class TestState {
+    static final int MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE = 5;
+
     final P2PDataStorage mockedStorage;
     final Broadcaster mockBroadcaster;
 
@@ -72,34 +74,16 @@ public class TestState {
     private final Storage<SequenceNumberMap> mockSeqNrStorage;
     final ClockFake clockFake;
 
-    /**
-     * Subclass of P2PDataStorage that allows for easier testing, but keeps all functionality
-     */
-    static class P2PDataStorageForTest extends P2PDataStorage {
-
-        P2PDataStorageForTest(NetworkNode networkNode,
-                              Broadcaster broadcaster,
-                              AppendOnlyDataStoreService appendOnlyDataStoreService,
-                              ProtectedDataStoreService protectedDataStoreService,
-                              ResourceDataStoreService resourceDataStoreService,
-                              Storage<SequenceNumberMap> sequenceNumberMapStorage,
-                              Clock clock) {
-            super(networkNode, broadcaster, appendOnlyDataStoreService, protectedDataStoreService, resourceDataStoreService, sequenceNumberMapStorage, clock);
-
-            this.maxSequenceNumberMapSizeBeforePurge = 5;
-        }
-    }
-
     TestState() {
         this.mockBroadcaster = mock(Broadcaster.class);
         this.mockSeqNrStorage = mock(Storage.class);
         this.clockFake = new ClockFake();
 
-        this.mockedStorage = new P2PDataStorageForTest(mock(NetworkNode.class),
+        this.mockedStorage = new P2PDataStorage(mock(NetworkNode.class),
                 this.mockBroadcaster,
                 new AppendOnlyDataStoreServiceFake(),
                 new ProtectedDataStoreServiceFake(), mock(ResourceDataStoreService.class),
-                this.mockSeqNrStorage, this.clockFake);
+                this.mockSeqNrStorage, this.clockFake, MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE);
 
         this.appendOnlyDataStoreListener = mock(AppendOnlyDataStoreListener.class);
         this.protectedDataStoreListener = mock(ProtectedDataStoreListener.class);

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -224,10 +224,10 @@ public class TestState {
             // TODO: Should the behavior be identical between this and the HashMap listeners?
             // TODO: Do we want ot overwrite stale values in order to persist updated sequence numbers and timestamps?
             if (protectedStorageEntry.getProtectedStoragePayload() instanceof PersistablePayload && beforeState.protectedStorageEntryBeforeOpDataStoreMap == null) {
-                Assert.assertEquals(protectedStorageEntry, this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
+                Assert.assertEquals(protectedStorageEntry, this.protectedDataStoreService.getMap().get(hashMapHash));
                 verify(this.protectedDataStoreListener).onAdded(protectedStorageEntry);
             } else {
-                Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
+                Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.protectedDataStoreService.getMap().get(hashMapHash));
                 verify(this.protectedDataStoreListener, never()).onAdded(protectedStorageEntry);
             }
 
@@ -244,7 +244,7 @@ public class TestState {
             this.verifySequenceNumberMapWriteContains(P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload()), protectedStorageEntry.getSequenceNumber());
         } else {
             Assert.assertEquals(beforeState.protectedStorageEntryBeforeOp, this.mockedStorage.getMap().get(hashMapHash));
-            Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
+            Assert.assertEquals(beforeState.protectedStorageEntryBeforeOpDataStoreMap, this.protectedDataStoreService.getMap().get(hashMapHash));
 
             verify(this.mockBroadcaster, never()).broadcast(any(BroadcastMessage.class), any(NodeAddress.class), any(BroadcastHandler.Listener.class), anyBoolean());
 
@@ -298,7 +298,7 @@ public class TestState {
                 Assert.assertNull(this.mockedStorage.getMap().get(hashMapHash));
 
                 if (protectedStorageEntry.getProtectedStoragePayload() instanceof PersistablePayload) {
-                    Assert.assertNull(this.mockedStorage.getProtectedDataStoreMap().get(hashMapHash));
+                    Assert.assertNull(this.protectedDataStoreService.getMap().get(hashMapHash));
 
                     verify(this.protectedDataStoreListener).onRemoved(protectedStorageEntry);
                 }
@@ -420,7 +420,7 @@ public class TestState {
 
             P2PDataStorage.ByteArray hashMapHash = P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload());
             this.protectedStorageEntryBeforeOp = testState.mockedStorage.getMap().get(hashMapHash);
-            this.protectedStorageEntryBeforeOpDataStoreMap = testState.mockedStorage.getProtectedDataStoreMap().get(hashMapHash);
+            this.protectedStorageEntryBeforeOpDataStoreMap = testState.protectedDataStoreService.getMap().get(hashMapHash);
 
 
             this.creationTimestampBeforeUpdate = (this.protectedStorageEntryBeforeOp != null) ? this.protectedStorageEntryBeforeOp.getCreationTimeStamp() : 0;

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -35,9 +35,7 @@ import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreListener;
-import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
 import bisq.network.p2p.storage.persistence.ProtectedDataStoreListener;
-import bisq.network.p2p.storage.persistence.ProtectedDataStoreService;
 import bisq.network.p2p.storage.persistence.ResourceDataStoreService;
 import bisq.network.p2p.storage.persistence.SequenceNumberMap;
 
@@ -46,8 +44,6 @@ import bisq.common.proto.persistable.PersistablePayload;
 import bisq.common.storage.Storage;
 
 import java.security.PublicKey;
-
-import java.time.Clock;
 
 import java.util.concurrent.TimeUnit;
 
@@ -70,7 +66,7 @@ public class TestState {
 
     final AppendOnlyDataStoreListener appendOnlyDataStoreListener;
     private final ProtectedDataStoreListener protectedDataStoreListener;
-    final HashMapChangedListener hashMapChangedListener;
+    private final HashMapChangedListener hashMapChangedListener;
     private final Storage<SequenceNumberMap> mockSeqNrStorage;
     final ClockFake clockFake;
 

--- a/p2p/src/test/java/bisq/network/p2p/storage/mocks/ProtectedStoragePayloadStub.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/mocks/ProtectedStoragePayloadStub.java
@@ -45,7 +45,7 @@ public class ProtectedStoragePayloadStub implements ProtectedStoragePayload {
     @Getter
     private PublicKey ownerPubKey;
 
-    protected Message messageMock;
+    protected final Message messageMock;
 
     public ProtectedStoragePayloadStub(PublicKey ownerPubKey) {
         this.ownerPubKey = ownerPubKey;


### PR DESCRIPTION
New commits are at 526aee5

According to the original [design doc](https://docs.google.com/document/d/1kdZf1ZaPuj8MmtueBhv0f8ztvnfd8hDJwNO1_TWH4MM/edit#), removes-before-adds were expected and should have the behavior that a remove with a larger sequence number will block a future add with a lower sequence number.

The idea is that you don't want out of order remove messages to get lost otherwise you may do more work then necessary by adding a stale `ProtectedStorageEntry` when you could have ignored it entirely. I'm not sure of any existing cases, but this may have been the cause of 'flapping' or 'undeleted' messages as nodes were starting.

I've left the existing behavior w.r.t. broadcasting. Even if this `remove()` is the first message we have seen for a payload, we don't rebroadcast it to our peers.  I'm not exactly sure what we want here, but rebroadcasting, in this case, could help network propagation and we may want to adopt the invariant that **_ANY_** state updates caused by a message are worth of rebroadcasting because the same state updates may be relevant to our peers.