### PR TITLE
Account number label in Swedish fix

### DIFF
--- a/core/src/main/java/bisq/core/locale/BankUtil.java
+++ b/core/src/main/java/bisq/core/locale/BankUtil.java
@@ -156,10 +156,8 @@ public class BankUtil {
             case "CA":
             case "HK":
                 return Res.get("payment.accountNr");
-            case "NO":
-                return "Kontonummer"; // do not translate as it is used in norwegian only
-            case "SE":
-                return "Bankgiro number"; // do not translate as it is used in swedish only
+            case "NO" || "SE":
+                return "Kontonummer"; // do not translate as it is used in norwegian and swedish only
             case "MX":
                 return "CLABE"; // do not translate as it is used in spanish only
             case "CL":

--- a/core/src/main/java/bisq/core/locale/BankUtil.java
+++ b/core/src/main/java/bisq/core/locale/BankUtil.java
@@ -156,7 +156,9 @@ public class BankUtil {
             case "CA":
             case "HK":
                 return Res.get("payment.accountNr");
-            case "NO" || "SE":
+            case "NO":
+                return "Kontonummer"; // do not translate as it is used in norwegian and swedish only
+            case "SE":
                 return "Kontonummer"; // do not translate as it is used in norwegian and swedish only
             case "MX":
                 return "CLABE"; // do not translate as it is used in spanish only


### PR DESCRIPTION
Fixes #3641
According to this issue, the label "Bankgiro number", as it was hardcoded in BankUtil.java, should not be used in Sweden.
The label "Kontonummer" is the correct one to be used in Sweden and Norway.

Account number validation is implemented to Norwegian accounts in AccountNrValidator.java.
There is no validation implemented to Swedish accounts, so nothing to change there.
If account validation for Sweden is needed, a different method would be needed (see Wikipedia reference below):

![image](https://user-images.githubusercontent.com/6444444/69269777-8151e900-0bb0-11ea-9f9b-80e0212a873c.png)
