### PR TITLE
Un-generify Popup class

### DIFF
--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -65,7 +65,6 @@ import javafx.stage.StageStyle;
 
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
@@ -149,7 +148,7 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
     @Override
     public void stop() {
         if (!shutDownRequested) {
-            new Popup<>().headLine(Res.get("popup.shutDownInProgress.headline"))
+            new Popup().headLine(Res.get("popup.shutDownInProgress.headline"))
                     .backgroundInfo(Res.get("popup.shutDownInProgress.msg"))
                     .hideCloseButton()
                     .useAnimation(false)
@@ -182,7 +181,7 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
                 try {
                     if (!popupOpened) {
                         popupOpened = true;
-                        new Popup<>().error(Objects.requireNonNullElse(throwable.getMessage(), throwable.toString()))
+                        new Popup().error(Objects.requireNonNullElse(throwable.getMessage(), throwable.toString()))
                                 .onClose(() -> popupOpened = false)
                                 .show();
                     }
@@ -296,12 +295,12 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
                     if (walletsManager.areWalletsAvailable())
                         new ShowWalletDataWindow(walletsManager).show();
                     else
-                        new Popup<>().warning(Res.get("popup.warning.walletNotInitialized")).show();
+                        new Popup().warning(Res.get("popup.warning.walletNotInitialized")).show();
                 } else if (Utilities.isAltOrCtrlPressed(KeyCode.G, keyEvent)) {
                     if (injector.getInstance(BtcWalletService.class).isWalletReady())
                         injector.getInstance(ManualPayoutTxWindow.class).show();
                     else
-                        new Popup<>().warning(Res.get("popup.warning.walletNotInitialized")).show();
+                        new Popup().warning(Res.get("popup.warning.walletNotInitialized")).show();
                 } else if (DevEnv.isDevMode()) {
                     if (Utilities.isAltOrCtrlPressed(KeyCode.Z, keyEvent))
                         showDebugWindow(scene, injector);
@@ -327,7 +326,7 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
         // We show a popup to inform user that open offers will be removed if Bisq is not running.
         String key = "showOpenOfferWarnPopupAtShutDown";
         if (injector.getInstance(Preferences.class).showAgain(key) && !DevEnv.isDevMode()) {
-            new Popup<>().information(Res.get("popup.info.shutDownWithOpenOffers"))
+            new Popup().information(Res.get("popup.info.shutDownWithOpenOffers"))
                     .dontShowAgainId(key)
                     .useShutDownButton()
                     .closeButtonText(Res.get("shared.cancel"))

--- a/desktop/src/main/java/bisq/desktop/components/AddressTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/AddressTextField.java
@@ -111,7 +111,7 @@ public class AddressTextField extends AnchorPane {
             Utilities.openURI(URI.create(getBitcoinURI()));
         } catch (Exception e) {
             log.warn(e.getMessage());
-            new Popup<>().warning(Res.get("addressTextField.openWallet.failed")).show();
+            new Popup().warning(Res.get("addressTextField.openWallet.failed")).show();
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
@@ -113,7 +113,7 @@ public class AssetsForm extends PaymentMethodForm {
         tradeInstantCheckBox.setOnAction(e -> {
             tradeInstant = tradeInstantCheckBox.isSelected();
             if (tradeInstant)
-                new Popup<>().information(Res.get("payment.altcoin.tradeInstant.popup")).show();
+                new Popup().information(Res.get("payment.altcoin.tradeInstant.popup")).show();
         });
 
         gridPane.getChildren().remove(tradeInstantCheckBox);

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -264,7 +264,7 @@ public abstract class PaymentMethodForm {
 
     void applyTradeCurrency(TradeCurrency tradeCurrency, FiatCurrency defaultCurrency) {
         if (!defaultCurrency.equals(tradeCurrency)) {
-            new Popup<>().warning(Res.get("payment.foreign.currency"))
+            new Popup().warning(Res.get("payment.foreign.currency"))
                     .actionButtonText(Res.get("shared.yes"))
                     .onAction(() -> {
                         paymentAccount.setSingleTradeCurrency(tradeCurrency);

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -158,7 +158,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
     private Label splashP2PNetworkLabel;
     private ProgressBar btcSyncIndicator, p2pNetworkProgressBar;
     private Label btcSplashInfo;
-    private Popup<?> p2PNetworkWarnMsgPopup, btcNetworkWarnMsgPopup;
+    private Popup p2PNetworkWarnMsgPopup, btcNetworkWarnMsgPopup;
     private final DaoStateMonitoringService daoStateMonitoringService;
 
     @Inject
@@ -427,7 +427,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
 
     @Override
     public void onCheckpointFail() {
-        new Popup<>().attention(Res.get("dao.monitor.daoState.checkpoint.popup"))
+        new Popup().attention(Res.get("dao.monitor.daoState.checkpoint.popup"))
                 .useShutDownButton()
                 .show();
     }
@@ -715,7 +715,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
                 btcInfoLabel.setId("splash-error-state-msg");
                 btcInfoLabel.getStyleClass().add("error-text");
                 if (btcNetworkWarnMsgPopup == null) {
-                    btcNetworkWarnMsgPopup = new Popup<>().warning(newValue);
+                    btcNetworkWarnMsgPopup = new Popup().warning(newValue);
                     btcNetworkWarnMsgPopup.show();
                 }
             } else {
@@ -774,7 +774,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
         p2PNetworkLabel.idProperty().bind(model.getP2pNetworkLabelId());
         model.getP2pNetworkWarnMsg().addListener((ov, oldValue, newValue) -> {
             if (newValue != null) {
-                p2PNetworkWarnMsgPopup = new Popup<>().warning(newValue);
+                p2PNetworkWarnMsgPopup = new Popup().warning(newValue);
                 p2PNetworkWarnMsgPopup.show();
             } else if (p2PNetworkWarnMsgPopup != null) {
                 p2PNetworkWarnMsgPopup.hide();

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -219,7 +219,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                             key = "displayHalfTradePeriodOver" + trade.getId();
                             if (DontShowAgainLookup.showAgain(key)) {
                                 DontShowAgainLookup.dontShowAgain(key, true);
-                                new Popup<>().warning(Res.get("popup.warning.tradePeriod.halfReached",
+                                new Popup().warning(Res.get("popup.warning.tradePeriod.halfReached",
                                         trade.getShortId(),
                                         DisplayUtils.formatDateTime(maxTradePeriodDate)))
                                         .show();
@@ -229,7 +229,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                             key = "displayTradePeriodOver" + trade.getId();
                             if (DontShowAgainLookup.showAgain(key)) {
                                 DontShowAgainLookup.dontShowAgain(key, true);
-                                new Popup<>().warning(Res.get("popup.warning.tradePeriod.ended",
+                                new Popup().warning(Res.get("popup.warning.tradePeriod.ended",
                                         trade.getShortId(),
                                         DisplayUtils.formatDateTime(maxTradePeriodDate)))
                                         .show();
@@ -292,7 +292,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         }, 1));
 
         bisqSetup.setCryptoSetupFailedHandler(msg -> UserThread.execute(() ->
-                new Popup<>().warning(msg)
+                new Popup().warning(msg)
                         .useShutDownButton()
                         .useReportBugButton()
                         .show()));
@@ -302,16 +302,16 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
             else
                 torNetworkSettingsWindow.hide();
         });
-        bisqSetup.setSpvFileCorruptedHandler(msg -> new Popup<>().warning(msg)
+        bisqSetup.setSpvFileCorruptedHandler(msg -> new Popup().warning(msg)
                 .actionButtonText(Res.get("settings.net.reSyncSPVChainButton"))
                 .onAction(() -> GUIUtil.reSyncSPVChain(preferences))
                 .show());
         bisqSetup.setVoteResultExceptionHandler(voteResultException -> log.warn(voteResultException.toString()));
 
-        bisqSetup.setChainFileLockedExceptionHandler(msg -> new Popup<>().warning(msg)
+        bisqSetup.setChainFileLockedExceptionHandler(msg -> new Popup().warning(msg)
                 .useShutDownButton()
                 .show());
-        bisqSetup.setLockedUpFundsHandler(msg -> new Popup<>().width(850).warning(msg).show());
+        bisqSetup.setLockedUpFundsHandler(msg -> new Popup().width(850).warning(msg).show());
         bisqSetup.setShowFirstPopupIfResyncSPVRequestedHandler(this::showFirstPopupIfResyncSPVRequested);
         bisqSetup.setRequestWalletPasswordHandler(aesKeyHandler -> walletPasswordWindow
                 .onAesKey(aesKeyHandler::accept)
@@ -334,22 +334,22 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                 .onClose(() -> user.setDisplayedAlert(alert))
                 .show());
         bisqSetup.setDisplayPrivateNotificationHandler(privateNotification ->
-                new Popup<>().headLine(Res.get("popup.privateNotification.headline"))
+                new Popup().headLine(Res.get("popup.privateNotification.headline"))
                         .attention(privateNotification.getMessage())
                         .setHeadlineStyle("-fx-text-fill: -bs-error-red;  -fx-font-weight: bold;  -fx-font-size: 16;")
                         .onClose(privateNotificationManager::removePrivateNotification)
                         .useIUnderstandButton()
                         .show());
-        bisqSetup.setDaoErrorMessageHandler(errorMessage -> new Popup<>().error(errorMessage).show());
-        bisqSetup.setDaoWarnMessageHandler(warnMessage -> new Popup<>().warning(warnMessage).show());
+        bisqSetup.setDaoErrorMessageHandler(errorMessage -> new Popup().error(errorMessage).show());
+        bisqSetup.setDaoWarnMessageHandler(warnMessage -> new Popup().warning(warnMessage).show());
         bisqSetup.setDisplaySecurityRecommendationHandler(key ->
-                new Popup<>().headLine(Res.get("popup.securityRecommendation.headline"))
+                new Popup().headLine(Res.get("popup.securityRecommendation.headline"))
                         .information(Res.get("popup.securityRecommendation.msg"))
                         .dontShowAgainId(key)
                         .show());
         bisqSetup.setDisplayLocalhostHandler(key -> {
             if (!DevEnv.isDevMode()) {
-                Overlay popup = new Popup<>().backgroundInfo(Res.get("popup.bitcoinLocalhostNode.msg"))
+                Overlay popup = new Popup().backgroundInfo(Res.get("popup.bitcoinLocalhostNode.msg"))
                         .dontShowAgainId(key);
                 popup.setDisplayOrderPriority(5);
                 popupQueue.add(popup);
@@ -364,17 +364,17 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         bisqSetup.setDisplayPeerSignerHandler(key -> accountPresentation.showOneTimeAccountSigningPopup(
                 key, "popup.accountSigning.peerSigner"));
 
-        bisqSetup.setWrongOSArchitectureHandler(msg -> new Popup<>().warning(msg).show());
+        bisqSetup.setWrongOSArchitectureHandler(msg -> new Popup().warning(msg).show());
 
-        bisqSetup.setRejectedTxErrorMessageHandler(msg -> new Popup<>().width(850).warning(msg).show());
+        bisqSetup.setRejectedTxErrorMessageHandler(msg -> new Popup().width(850).warning(msg).show());
 
-        corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> new Popup<>()
+        corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> new Popup()
                 .warning(Res.get("popup.warning.incompatibleDB", files.toString(),
                         bisqEnvironment.getProperty(AppOptionKeys.APP_DATA_DIR_KEY)))
                 .useShutDownButton()
                 .show());
 
-        tradeManager.setTakeOfferRequestErrorMessageHandler(errorMessage -> new Popup<>()
+        tradeManager.setTakeOfferRequestErrorMessageHandler(errorMessage -> new Popup()
                 .warning(Res.get("popup.error.takeOfferRequestFailed", errorMessage))
                 .show());
 
@@ -382,7 +382,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
             c.next();
             if (c.wasAdded()) {
                 c.getAddedSubList().forEach(trade -> {
-                    new Popup<>().warning(Res.get("popup.warning.trade.depositTxNull", trade.getShortId()))
+                    new Popup().warning(Res.get("popup.warning.trade.depositTxNull", trade.getShortId()))
                             .actionButtonText(Res.get("popup.warning.trade.depositTxNull.moveToFailedTrades"))
                             .onAction(() -> tradeManager.addTradeToFailedTrades(trade))
                             .show();
@@ -393,7 +393,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         bisqSetup.getBtcSyncProgress().addListener((observable, oldValue, newValue) -> updateBtcSyncProgress());
         daoPresentation.getBsqSyncProgress().addListener((observable, oldValue, newValue) -> updateBtcSyncProgress());
 
-        bisqSetup.setFilterWarningHandler(warning -> new Popup<>().warning(warning).show());
+        bisqSetup.setFilterWarningHandler(warning -> new Popup().warning(warning).show());
     }
 
     private void setupP2PNumPeersWatcher() {
@@ -451,7 +451,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
     }
 
     private void showFirstPopupIfResyncSPVRequested() {
-        Popup firstPopup = new Popup<>();
+        Popup firstPopup = new Popup();
         firstPopup.information(Res.get("settings.net.reSyncSPVAfterRestart")).show();
         if (bisqSetup.getBtcSyncProgress().get() == 1) {
             showSecondPopupIfResyncSPVRequested(firstPopup);
@@ -466,7 +466,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
     private void showSecondPopupIfResyncSPVRequested(Popup firstPopup) {
         firstPopup.hide();
         preferences.setResyncSpvRequested(false);
-        new Popup<>().information(Res.get("settings.net.reSyncSPVAfterRestartCompleted"))
+        new Popup().information(Res.get("settings.net.reSyncSPVAfterRestartCompleted"))
                 .hideCloseButton()
                 .useShutDownButton()
                 .show();

--- a/desktop/src/main/java/bisq/desktop/main/account/AccountView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/AccountView.java
@@ -245,7 +245,7 @@ public class AccountView extends ActivatableView<TabPane, Void> {
 
         String key = "accountPrivacyInfo";
         if (!DevEnv.isDevMode())
-            new Popup<>()
+            new Popup()
                     .headLine(Res.get("account.info.headline"))
                     .backgroundInfo(Res.get("account.info.msg"))
                     .dontShowAgainId(key)

--- a/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
@@ -79,14 +79,14 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
     }
 
     protected void onDeleteAccount(PaymentAccount paymentAccount) {
-        new Popup<>().warning(Res.get("shared.askConfirmDeleteAccount"))
+        new Popup().warning(Res.get("shared.askConfirmDeleteAccount"))
                 .actionButtonText(Res.get("shared.yes"))
                 .onAction(() -> {
                     boolean isPaymentAccountUsed = deleteAccountFromModel(paymentAccount);
                     if (!isPaymentAccountUsed)
                         removeSelectAccountForm();
                     else
-                        UserThread.runAfter(() -> new Popup<>().warning(
+                        UserThread.runAfter(() -> new Popup().warning(
                                 Res.get("shared.cannotDeleteAccount"))
                                 .show(), 100, TimeUnit.MILLISECONDS);
                 })

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
@@ -129,7 +129,7 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
         if (selectedTradeCurrency != null) {
             if (selectedTradeCurrency instanceof CryptoCurrency && ((CryptoCurrency) selectedTradeCurrency).isAsset()) {
                 String name = selectedTradeCurrency.getName();
-                new Popup<>().information(Res.get("account.altcoin.popup.wallet.msg",
+                new Popup().information(Res.get("account.altcoin.popup.wallet.msg",
                         selectedTradeCurrency.getCodeAndName(),
                         name,
                         name))
@@ -141,7 +141,7 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
             if (asset.isPresent()) {
                 final AltCoinAccountDisclaimer disclaimerAnnotation = asset.get().getClass().getAnnotation(AltCoinAccountDisclaimer.class);
                 if (disclaimerAnnotation != null) {
-                    new Popup<>()
+                    new Popup()
                             .width(asset.get() instanceof Monero ? 1000 : 669)
                             .maxMessageLength(2500)
                             .information(Res.get(disclaimerAnnotation.value()))
@@ -155,7 +155,7 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
                 model.onSaveNewAccount(paymentAccount);
                 removeNewAccountForm();
             } else {
-                new Popup<>().warning(Res.get("shared.accountNameAlreadyUsed")).show();
+                new Popup().warning(Res.get("shared.accountNameAlreadyUsed")).show();
             }
 
             preferences.dontShowAgain(INSTANT_TRADE_NEWS, true);

--- a/desktop/src/main/java/bisq/desktop/main/account/content/backup/BackupView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/backup/BackupView.java
@@ -141,7 +141,7 @@ public class BackupView extends ActivatableView<GridPane, Void> {
                     String dateString = new SimpleDateFormat("yyyy-MM-dd-HHmmss").format(new Date());
                     String destination = Paths.get(backupDirectory, "bisq_backup_" + dateString).toString();
                     FileUtil.copyDirectory(dataDir, new File(destination));
-                    new Popup<>().feedback(Res.get("account.backup.success", destination)).show();
+                    new Popup().feedback(Res.get("account.backup.success", destination)).show();
                 } catch (IOException e) {
                     e.printStackTrace();
                     log.error(e.getMessage());
@@ -181,7 +181,7 @@ public class BackupView extends ActivatableView<GridPane, Void> {
 
     private void showWrongPathWarningAndReset(@Nullable Throwable t) {
         String error = t != null ? Res.get("shared.errorMessageInline", t.getMessage()) : "";
-        new Popup<>().warning(Res.get("account.backup.directoryNotAccessible", error)).show();
+        new Popup().warning(Res.get("account.backup.directoryNotAccessible", error)).show();
         applyBackupDirectory(Utilities.getSystemHomeDirectory());
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -223,7 +223,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
         Coin maxTradeLimitSecondMonth = maxTradeLimitAsCoin.divide(2L);
         Coin maxTradeLimitFirstMonth = maxTradeLimitAsCoin.divide(4L);
         if (paymentAccount instanceof F2FAccount) {
-            new Popup<>().information(Res.get("payment.f2f.info"))
+            new Popup().information(Res.get("payment.f2f.info"))
                     .width(700)
                     .closeButtonText(Res.get("payment.f2f.info.openURL"))
                     .onClose(() -> GUIUtil.openWebPage("https://docs.bisq.network/trading-rules.html#f2f-trading"))
@@ -232,7 +232,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                     .show();
         } else if (paymentAccount instanceof HalCashAccount) {
             // HalCash has no chargeback risk so we don't show the text from payment.limits.info.
-            new Popup<>().information(Res.get("payment.halCash.info"))
+            new Popup().information(Res.get("payment.halCash.info"))
                     .width(700)
                     .closeButtonText(Res.get("shared.cancel"))
                     .actionButtonText(Res.get("shared.iUnderstand"))
@@ -248,7 +248,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                 initialLimit = formatter.formatCoinWithCode(OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT);
             }
 
-            new Popup<>().information(Res.get(limitsInfoKey,
+            new Popup().information(Res.get(limitsInfoKey,
                     initialLimit,
                     formatter.formatCoinWithCode(maxTradeLimitSecondMonth),
                     formatter.formatCoinWithCode(maxTradeLimitAsCoin)))
@@ -258,42 +258,42 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                     .onAction(() -> {
                         final String currencyName = BisqEnvironment.getBaseCurrencyNetwork().getCurrencyName();
                         if (paymentAccount instanceof ClearXchangeAccount) {
-                            new Popup<>().information(Res.get("payment.clearXchange.info", currencyName, currencyName))
+                            new Popup().information(Res.get("payment.clearXchange.info", currencyName, currencyName))
                                     .width(900)
                                     .closeButtonText(Res.get("shared.cancel"))
                                     .actionButtonText(Res.get("shared.iConfirm"))
                                     .onAction(() -> doSaveNewAccount(paymentAccount))
                                     .show();
                         } else if (paymentAccount instanceof WesternUnionAccount) {
-                            new Popup<>().information(Res.get("payment.westernUnion.info"))
+                            new Popup().information(Res.get("payment.westernUnion.info"))
                                     .width(700)
                                     .closeButtonText(Res.get("shared.cancel"))
                                     .actionButtonText(Res.get("shared.iUnderstand"))
                                     .onAction(() -> doSaveNewAccount(paymentAccount))
                                     .show();
                         } else if (paymentAccount instanceof MoneyGramAccount) {
-                            new Popup<>().information(Res.get("payment.moneyGram.info"))
+                            new Popup().information(Res.get("payment.moneyGram.info"))
                                     .width(700)
                                     .closeButtonText(Res.get("shared.cancel"))
                                     .actionButtonText(Res.get("shared.iUnderstand"))
                                     .onAction(() -> doSaveNewAccount(paymentAccount))
                                     .show();
                         } else if (paymentAccount instanceof CashDepositAccount) {
-                            new Popup<>().information(Res.get("payment.cashDeposit.info"))
+                            new Popup().information(Res.get("payment.cashDeposit.info"))
                                     .width(700)
                                     .closeButtonText(Res.get("shared.cancel"))
                                     .actionButtonText(Res.get("shared.iConfirm"))
                                     .onAction(() -> doSaveNewAccount(paymentAccount))
                                     .show();
                         } else if (paymentAccount instanceof RevolutAccount) {
-                            new Popup<>().information(Res.get("payment.revolut.info"))
+                            new Popup().information(Res.get("payment.revolut.info"))
                                     .width(700)
                                     .closeButtonText(Res.get("shared.cancel"))
                                     .actionButtonText(Res.get("shared.iConfirm"))
                                     .onAction(() -> doSaveNewAccount(paymentAccount))
                                     .show();
                         } else if (paymentAccount instanceof USPostalMoneyOrderAccount) {
-                            new Popup<>().information(Res.get("payment.usPostalMoneyOrder.info"))
+                            new Popup().information(Res.get("payment.usPostalMoneyOrder.info"))
                                     .width(700)
                                     .closeButtonText(Res.get("shared.cancel"))
                                     .actionButtonText(Res.get("shared.iUnderstand"))
@@ -313,7 +313,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
             model.onSaveNewAccount(paymentAccount);
             removeNewAccountForm();
         } else {
-            new Popup<>().warning(Res.get("shared.accountNameAlreadyUsed")).show();
+            new Popup().warning(Res.get("shared.accountNameAlreadyUsed")).show();
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
@@ -271,12 +271,12 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
             });
         }, throwable -> {
             if (throwable instanceof NoWebCamFoundException) {
-                new Popup<>().warning(Res.get("account.notifications.noWebCamFound.warning")).show();
+                new Popup().warning(Res.get("account.notifications.noWebCamFound.warning")).show();
                 webCamButton.setDisable(false);
                 onNoWebCam();
             } else {
                 log.error(throwable.toString());
-                new Popup<>().error(throwable.toString()).show();
+                new Popup().error(throwable.toString()).show();
             }
         });
     }
@@ -292,7 +292,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
             mobileNotificationService.sendEraseMessage();
             reset();
         } catch (Exception e) {
-            new Popup<>().error(e.toString()).show();
+            new Popup().error(e.toString()).show();
         }
     }
 
@@ -335,7 +335,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
                 });
             }
         } catch (Exception e) {
-            new Popup<>().error(e.toString()).show();
+            new Popup().error(e.toString()).show();
         }
     }
 
@@ -564,7 +564,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
                 long priceAlertLowTextFieldValue = getPriceAsLong(priceAlertLowInputTextField);
                 if (priceAlertLowTextFieldValue != 0 && priceAlertHighTextFieldValue != 0) {
                     if (priceAlertHighTextFieldValue <= priceAlertLowTextFieldValue) {
-                        new Popup<>().warning(Res.get("account.notifications.priceAlert.warning.highPriceTooLow")).show();
+                        new Popup().warning(Res.get("account.notifications.priceAlert.warning.highPriceTooLow")).show();
                         UserThread.execute(() -> {
                             priceAlertHighInputTextField.clear();
                             updatePriceAlertFields();
@@ -589,7 +589,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
             long priceAlertLowTextFieldValue = getPriceAsLong(priceAlertLowInputTextField);
             if (priceAlertLowTextFieldValue != 0 && priceAlertHighTextFieldValue != 0) {
                 if (priceAlertLowTextFieldValue >= priceAlertHighTextFieldValue) {
-                    new Popup<>().warning(Res.get("account.notifications.priceAlert.warning.lowerPriceTooHigh")).show();
+                    new Popup().warning(Res.get("account.notifications.priceAlert.warning.lowerPriceTooHigh")).show();
                     UserThread.execute(() -> {
                         priceAlertLowInputTextField.clear();
                         updatePriceAlertFields();

--- a/desktop/src/main/java/bisq/desktop/main/account/content/password/PasswordView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/password/PasswordView.java
@@ -115,7 +115,7 @@ public class PasswordView extends ActivatableView<GridPane, Void> {
 
         pwButton.setOnAction(e -> {
             if (!walletsManager.areWalletsEncrypted()) {
-                new Popup<>().backgroundInfo(Res.get("password.backupReminder"))
+                new Popup().backgroundInfo(Res.get("password.backupReminder"))
                         .secondaryActionButtonText(Res.get("password.backupWasDone"))
                         .onSecondaryAction(() -> onApplyPassword(busyAnimation, deriveStatusLabel))
                         .actionButtonTextWithGoTo("navigation.account.walletSeed")
@@ -150,26 +150,26 @@ public class PasswordView extends ActivatableView<GridPane, Void> {
             if (walletsManager.areWalletsEncrypted()) {
                 if (walletsManager.checkAESKey(aesKey)) {
                     walletsManager.decryptWallets(aesKey);
-                    new Popup<>()
+                    new Popup()
                             .feedback(Res.get("password.walletDecrypted"))
                             .show();
                     backupWalletAndResetFields();
                 } else {
                     pwButton.setDisable(false);
-                    new Popup<>()
+                    new Popup()
                             .warning(Res.get("password.wrongPw"))
                             .show();
                 }
             } else {
                 try {
                     walletsManager.encryptWallets(keyCrypterScrypt, aesKey);
-                    new Popup<>()
+                    new Popup()
                             .feedback(Res.get("password.walletEncrypted"))
                             .show();
                     backupWalletAndResetFields();
                     walletsManager.clearBackup();
                 } catch (Throwable t) {
-                    new Popup<>()
+                    new Popup()
                             .warning(Res.get("password.walletEncryptionFailed"))
                             .show();
                 }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
@@ -153,7 +153,7 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
                 seedWordsValid, seedWordsEdited));
 
         restoreButton.setOnAction(e -> {
-            new Popup<>().information(Res.get("account.seed.restore.info"))
+            new Popup().information(Res.get("account.seed.restore.info"))
                     .closeButtonText(Res.get("shared.cancel"))
                     .actionButtonText(Res.get("account.seed.restore.ok"))
                     .onAction(this::onRestore)
@@ -172,7 +172,7 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
         } else {
             String key = "showSeedWordsWarning";
             if (DontShowAgainLookup.showAgain(key)) {
-                new Popup<>().warning(Res.get("account.seed.warn.noPw.msg"))
+                new Popup().warning(Res.get("account.seed.warn.noPw.msg"))
                         .actionButtonText(Res.get("account.seed.warn.noPw.yes"))
                         .onAction(() -> {
                             DontShowAgainLookup.dontShowAgain(key, true);
@@ -226,7 +226,7 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
 
     private void onRestore() {
         if (walletsManager.hasPositiveBalance()) {
-            new Popup<>().warning(Res.get("seed.warn.walletNotEmpty.msg"))
+            new Popup().warning(Res.get("seed.warn.walletNotEmpty.msg"))
                     .actionButtonText(Res.get("seed.warn.walletNotEmpty.restore"))
                     .onAction(this::checkIfEncrypted)
                     .closeButtonText(Res.get("seed.warn.walletNotEmpty.emptyWallet"))
@@ -238,7 +238,7 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
 
     private void checkIfEncrypted() {
         if (walletsManager.areWalletsEncrypted()) {
-            new Popup<>().information(Res.get("seed.warn.notEncryptedAnymore"))
+            new Popup().information(Res.get("seed.warn.notEncryptedAnymore"))
                     .closeButtonText(Res.get("shared.no"))
                     .actionButtonText(Res.get("shared.yes"))
                     .onAction(this::doRestore)

--- a/desktop/src/main/java/bisq/desktop/main/account/register/AgentRegistrationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/AgentRegistrationView.java
@@ -244,7 +244,7 @@ public abstract class AgentRegistrationView<R extends DisputeAgent, T extends Ag
         model.onRemoveLanguage(locale);
 
         if (languagesListView.getItems().size() == 0) {
-            new Popup<>().warning(Res.get("account.arbitratorRegistration.warn.min1Language")).show();
+            new Popup().warning(Res.get("account.arbitratorRegistration.warn.min1Language")).show();
             model.onAddLanguage(LanguageUtil.getDefaultLanguageLocaleAsCode());
         }
     }
@@ -252,8 +252,8 @@ public abstract class AgentRegistrationView<R extends DisputeAgent, T extends Ag
     private void onRevoke() {
         if (model.isBootstrappedOrShowPopup()) {
             model.onRevoke(
-                    () -> new Popup<>().feedback(Res.get("account.arbitratorRegistration.removedSuccess")).show(),
-                    (errorMessage) -> new Popup<>().error(Res.get("account.arbitratorRegistration.removedFailed",
+                    () -> new Popup().feedback(Res.get("account.arbitratorRegistration.removedSuccess")).show(),
+                    (errorMessage) -> new Popup().error(Res.get("account.arbitratorRegistration.removedFailed",
                             Res.get("shared.errorMessageInline", errorMessage))).show());
         }
     }
@@ -261,8 +261,8 @@ public abstract class AgentRegistrationView<R extends DisputeAgent, T extends Ag
     private void onRegister() {
         if (model.isBootstrappedOrShowPopup()) {
             model.onRegister(
-                    () -> new Popup<>().feedback(Res.get("account.arbitratorRegistration.registerSuccess")).show(),
-                    (errorMessage) -> new Popup<>().error(Res.get("account.arbitratorRegistration.registerFailed",
+                    () -> new Popup().feedback(Res.get("account.arbitratorRegistration.registerSuccess")).show(),
+                    (errorMessage) -> new Popup().error(Res.get("account.arbitratorRegistration.registerFailed",
                             Res.get("shared.errorMessageInline", errorMessage))).show());
         }
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/DaoView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/DaoView.java
@@ -74,7 +74,7 @@ public class DaoView extends ActivatableView<TabPane, Void> {
         this.preferences = preferences;
 
         voteRevealService.addVoteRevealTxPublishedListener(txId -> {
-            new Popup<>().headLine(Res.get("dao.voteReveal.txPublished.headLine"))
+            new Popup().headLine(Res.get("dao.voteReveal.txPublished.headLine"))
                     .feedback(Res.get("dao.voteReveal.txPublished", txId))
                     .show();
         });

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
@@ -115,7 +115,7 @@ public class BondingViewUtils {
                     Coin miningFee = miningFeeAndTxSize.first;
                     int txSize = miningFeeAndTxSize.second;
                     String duration = FormattingUtils.formatDurationAsWords(lockupTime * 10 * 60 * 1000L, false, false);
-                    new Popup<>().headLine(Res.get("dao.bond.reputation.lockup.headline"))
+                    new Popup().headLine(Res.get("dao.bond.reputation.lockup.headline"))
                             .confirmation(Res.get("dao.bond.reputation.lockup.details",
                                     bsqFormatter.formatCoinWithCode(lockupAmount),
                                     lockupTime,
@@ -131,7 +131,7 @@ public class BondingViewUtils {
                 } catch (Throwable e) {
                     log.error(e.toString());
                     e.printStackTrace();
-                    new Popup<>().warning(e.getMessage()).show();
+                    new Popup().warning(e.getMessage()).show();
                 }
             } else {
                 publishLockupTx(lockupAmount, lockupTime, lockupReason, hash, resultHandler);
@@ -146,7 +146,7 @@ public class BondingViewUtils {
                 hash,
                 txId -> {
                     if (!DevEnv.isDevMode())
-                        new Popup<>().feedback(Res.get("dao.tx.published.success")).show();
+                        new Popup().feedback(Res.get("dao.tx.published.success")).show();
 
                     if (resultHandler != null)
                         resultHandler.accept(txId);
@@ -173,7 +173,7 @@ public class BondingViewUtils {
                     Coin miningFee = miningFeeAndTxSize.first;
                     int txSize = miningFeeAndTxSize.second;
                     String duration = FormattingUtils.formatDurationAsWords(lockTime * 10 * 60 * 1000L, false, false);
-                    new Popup<>().headLine(Res.get("dao.bond.reputation.unlock.headline"))
+                    new Popup().headLine(Res.get("dao.bond.reputation.unlock.headline"))
                             .confirmation(Res.get("dao.bond.reputation.unlock.details",
                                     bsqFormatter.formatCoinWithCode(unlockAmount),
                                     lockTime,
@@ -192,7 +192,7 @@ public class BondingViewUtils {
             } catch (Throwable t) {
                 log.error(t.toString());
                 t.printStackTrace();
-                new Popup<>().warning(t.getMessage()).show();
+                new Popup().warning(t.getMessage()).show();
             }
         }
         log.info("unlock tx: {}", lockupTxId);
@@ -202,12 +202,12 @@ public class BondingViewUtils {
         daoFacade.publishUnlockTx(lockupTxId,
                 txId -> {
                     if (!DevEnv.isDevMode())
-                        new Popup<>().confirmation(Res.get("dao.tx.published.success")).show();
+                        new Popup().confirmation(Res.get("dao.tx.published.success")).show();
 
                     if (resultHandler != null)
                         resultHandler.accept(txId);
                 },
-                errorMessage -> new Popup<>().warning(errorMessage.toString()).show()
+                errorMessage -> new Popup().warning(errorMessage.toString()).show()
         );
     }
 
@@ -215,14 +215,14 @@ public class BondingViewUtils {
         if (throwable instanceof InsufficientMoneyException) {
             final Coin missingCoin = ((InsufficientMoneyException) throwable).missing;
             final String missing = missingCoin != null ? missingCoin.toFriendlyString() : "null";
-            new Popup<>().warning(Res.get("popup.warning.insufficientBtcFundsForBsqTx", missing))
+            new Popup().warning(Res.get("popup.warning.insufficientBtcFundsForBsqTx", missing))
                     .actionButtonTextWithGoTo("navigation.funds.depositFunds")
                     .onAction(() -> navigation.navigateTo(MainView.class, FundsView.class, DepositView.class))
                     .show();
         } else {
             log.error(throwable.toString());
             throwable.printStackTrace();
-            new Popup<>().warning(throwable.toString()).show();
+            new Popup().warning(throwable.toString()).show();
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
@@ -187,10 +187,10 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
                     }
                 } catch (InsufficientMoneyException | TxException e) {
                     e.printStackTrace();
-                    new Popup<>().error(e.toString()).show();
+                    new Popup().error(e.toString()).show();
                 }
             } else {
-                new Popup<>().warning(Res.get("dao.burnBsq.assets.toFewDays", minDays)).show();
+                new Popup().warning(Res.get("dao.burnBsq.assets.toFewDays", minDays)).show();
             }
         });
 
@@ -291,9 +291,9 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
                 () -> {
                     assetComboBox.getSelectionModel().clearSelection();
                     if (!DevEnv.isDevMode())
-                        new Popup<>().confirmation(Res.get("dao.tx.published.success")).show();
+                        new Popup().confirmation(Res.get("dao.tx.published.success")).show();
                 },
-                errorMessage -> new Popup<>().warning(errorMessage).show());
+                errorMessage -> new Popup().warning(errorMessage).show());
 
         feeAmountInputTextField.clear();
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
@@ -182,7 +182,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                 }
             } catch (InsufficientMoneyException | TxException e) {
                 e.printStackTrace();
-                new Popup<>().error(e.toString()).show();
+                new Popup().error(e.toString()).show();
             }
         });
 
@@ -288,9 +288,9 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
         proofOfBurnService.publishTransaction(transaction, preImageAsString,
                 () -> {
                     if (!DevEnv.isDevMode())
-                        new Popup<>().confirmation(Res.get("dao.tx.published.success")).show();
+                        new Popup().confirmation(Res.get("dao.tx.published.success")).show();
                 },
-                errorMessage -> new Popup<>().warning(errorMessage).show());
+                errorMessage -> new Popup().warning(errorMessage).show());
 
         amountInputTextField.clear();
         preImageTextField.clear();

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -295,7 +295,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
 
                 if (requiredBond > availableBalance) {
                     long missing = requiredBond - availableBalance;
-                    new Popup<>().warning(Res.get("dao.proposal.create.missingBsqFundsForBond",
+                    new Popup().warning(Res.get("dao.proposal.create.missingBsqFundsForBond",
                             bsqFormatter.formatCoinWithCode(missing)))
                             .actionButtonText(Res.get("dao.proposal.create.publish"))
                             .onAction(() -> {
@@ -310,15 +310,15 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
             }
         } catch (InsufficientMoneyException e) {
             if (e instanceof InsufficientBsqException) {
-                new Popup<>().warning(Res.get("dao.proposal.create.missingBsqFunds",
+                new Popup().warning(Res.get("dao.proposal.create.missingBsqFunds",
                         bsqFormatter.formatCoinWithCode(e.missing))).show();
             } else {
                 if (type.equals(ProposalType.COMPENSATION_REQUEST) || type.equals(ProposalType.REIMBURSEMENT_REQUEST)) {
-                    new Popup<>().warning(Res.get("dao.proposal.create.missingIssuanceFunds",
+                    new Popup().warning(Res.get("dao.proposal.create.missingIssuanceFunds",
                             100,
                             btcFormatter.formatCoinWithCode(e.missing))).show();
                 } else {
-                    new Popup<>().warning(Res.get("dao.proposal.create.missingMinerFeeFunds",
+                    new Popup().warning(Res.get("dao.proposal.create.missingMinerFeeFunds",
                             btcFormatter.formatCoinWithCode(e.missing))).show();
                 }
             }
@@ -330,15 +330,15 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
             } else {
                 message = e.getMessage();
             }
-            new Popup<>().warning(message).show();
+            new Popup().warning(message).show();
         } catch (IllegalArgumentException e) {
             log.error(e.toString());
             e.printStackTrace();
-            new Popup<>().warning(e.getMessage()).show();
+            new Popup().warning(e.getMessage()).show();
         } catch (Throwable e) {
             log.error(e.toString());
             e.printStackTrace();
-            new Popup<>().warning(e.toString()).show();
+            new Popup().warning(e.toString()).show();
         }
     }
 
@@ -366,7 +366,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
                 transaction,
                 () -> {
                     if (!DevEnv.isDevMode())
-                        new Popup<>().feedback(Res.get("dao.tx.published.success")).show();
+                        new Popup().feedback(Res.get("dao.tx.published.success")).show();
 
                     if (proposalDisplay != null)
                         proposalDisplay.clearForm();
@@ -376,7 +376,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
                     makeProposalButton.setDisable(false);
                 },
                 errorMessage -> {
-                    new Popup<>().warning(errorMessage).show();
+                    new Popup().warning(errorMessage).show();
                     busyAnimation.stop();
                     busyLabel.setVisible(false);
                     makeProposalButton.setDisable(false);
@@ -428,7 +428,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
                             selectedParam,
                             paramValue);
                 } catch (Throwable e) {
-                    new Popup<>().warning(e.getMessage()).show();
+                    new Popup().warning(e.getMessage()).show();
                     return null;
                 }
             case BONDED_ROLE:

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -386,11 +386,11 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
     private void onRemoveProposal() {
         if (daoFacade.phaseProperty().get() == DaoPhase.Phase.PROPOSAL) {
             Proposal proposal = selectedItem.getProposal();
-            new Popup<>().warning(Res.get("dao.proposal.active.remove.confirm"))
+            new Popup().warning(Res.get("dao.proposal.active.remove.confirm"))
                     .actionButtonText(Res.get("dao.proposal.active.remove.doRemove"))
                     .onAction(() -> {
                         if (!daoFacade.removeMyProposal(proposal)) {
-                            new Popup<>().warning(Res.get("dao.proposal.active.remove.failed")).show();
+                            new Popup().warning(Res.get("dao.proposal.active.remove.failed")).show();
                         }
                         tableView.getSelectionModel().clearSelection();
                     })
@@ -461,7 +461,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
     private void showHowToSetStakeForVotingPopup() {
         String id = "explainHowToSetStakeForVoting";
         if (preferences.showAgain(id))
-            new Popup<>().information(Res.get("dao.proposal.myVote.setStake.description"))
+            new Popup().information(Res.get("dao.proposal.myVote.setStake.description"))
                     .dontShowAgainId(id).show();
     }
 
@@ -480,7 +480,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                 publishBlindVote(stake);
             }
         } catch (InsufficientMoneyException | WalletException | TransactionVerificationException exception) {
-            new Popup<>().warning(exception.toString()).show();
+            new Popup().warning(exception.toString()).show();
         }
     }
 
@@ -493,12 +493,12 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
         daoFacade.publishBlindVote(stake,
                 () -> {
                     if (!DevEnv.isDevMode())
-                        new Popup<>().feedback(Res.get("dao.blindVote.success")).show();
+                        new Popup().feedback(Res.get("dao.blindVote.success")).show();
                 }, exception -> {
                     voteButtonBusyAnimation.stop();
                     voteButtonInfoLabel.setText("");
                     updateViews();
-                    new Popup<>().warning(exception.toString()).show();
+                    new Popup().warning(exception.toString()).show();
                 });
 
         // We reset UI without waiting for callback as callback might be slow and then the user could click
@@ -575,7 +575,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                 log.warn(msg);
                 String id = "multipleVotes";
                 if (preferences.showAgain(id))
-                    new Popup<>().warning(msg).dontShowAgainId(id).show();
+                    new Popup().warning(msg).dontShowAgainId(id).show();
             }
             voteButton.setVisible(false);
             voteButton.setManaged(false);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -326,7 +326,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
                         });
                     });
             if (sb.length() != 0) {
-                new Popup<>().information(Res.get("dao.results.invalidVotes", sb.toString())).show();
+                new Popup().information(Res.get("dao.results.invalidVotes", sb.toString())).show();
             }
         }
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
@@ -158,14 +158,14 @@ public abstract class StateMonitorView<StH extends StateHash,
                 newFileName = "BallotList_" + currentTime;
                 FileManager.removeAndBackupFile(storageDir, new File(storageDir, "BallotList"), newFileName, backupDirName);
 
-                daoFacade.resyncDao(() -> new Popup<>().attention(Res.get("setting.preferences.dao.resync.popup"))
+                daoFacade.resyncDao(() -> new Popup().attention(Res.get("setting.preferences.dao.resync.popup"))
                         .useShutDownButton()
                         .hideCloseButton()
                         .show());
             } catch (Throwable t) {
                 t.printStackTrace();
                 log.error(t.toString());
-                new Popup<>().error(t.toString()).show();
+                new Popup().error(t.toString()).show();
             }
         });
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateMonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateMonitorView.java
@@ -215,7 +215,7 @@ public class DaoStateMonitorView extends StateMonitorView<DaoStateHash, DaoState
             });
 
             if (warningPopup == null) {
-                warningPopup = new Popup<>().headLine(Res.get("dao.monitor.daoState.utxoConflicts"))
+                warningPopup = new Popup().headLine(Res.get("dao.monitor.daoState.utxoConflicts"))
                         .warning(Utilities.toTruncatedString(sb.toString(), 500, false)).onClose(() -> {
                             warningPopup = null;
                         });

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -258,7 +258,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                             });
                 } catch (BsqChangeBelowDustException e) {
                     String msg = Res.get("popup.warning.bsqChangeBelowDustException", bsqFormatter.formatCoinWithCode(e.getOutputValue()));
-                    new Popup<>().warning(msg).show();
+                    new Popup().warning(msg).show();
                 } catch (Throwable t) {
                     handleError(t);
                 }
@@ -321,7 +321,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                     }
                 } catch (BsqChangeBelowDustException e) {
                     String msg = Res.get("popup.warning.btcChangeBelowDustException", btcFormatter.formatCoinWithCode(e.getOutputValue()));
-                    new Popup<>().warning(msg).show();
+                    new Popup().warning(msg).show();
                 } catch (Throwable t) {
                     handleError(t);
                 }
@@ -333,14 +333,14 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
         if (t instanceof InsufficientMoneyException) {
             final Coin missingCoin = ((InsufficientMoneyException) t).missing;
             final String missing = missingCoin != null ? missingCoin.toFriendlyString() : "null";
-            new Popup<>().warning(Res.get("popup.warning.insufficientBtcFundsForBsqTx", missing))
+            new Popup().warning(Res.get("popup.warning.insufficientBtcFundsForBsqTx", missing))
                     .actionButtonTextWithGoTo("navigation.funds.depositFunds")
                     .onAction(() -> navigation.navigateTo(MainView.class, FundsView.class, DepositView.class))
                     .show();
         } else {
             log.error(t.toString());
             t.printStackTrace();
-            new Popup<>().warning(t.getMessage()).show();
+            new Popup().warning(t.getMessage()).show();
         }
     }
 
@@ -352,7 +352,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                                     CoinFormatter amountFormatter, // can be BSQ or BTC formatter
                                     CoinFormatter feeFormatter,
                                     ResultHandler resultHandler) {
-        new Popup<>().headLine(Res.get("dao.wallet.send.sendFunds.headline"))
+        new Popup().headLine(Res.get("dao.wallet.send.sendFunds.headline"))
                 .confirmation(Res.get("dao.wallet.send.sendFunds.details",
                         amountFormatter.formatCoinWithCode(receiverAmount),
                         address,
@@ -370,7 +370,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
 
                         @Override
                         public void onFailure(TxBroadcastException exception) {
-                            new Popup<>().warning(exception.toString());
+                            new Popup().warning(exception.toString());
                         }
                     });
                     resultHandler.handleResult();

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
@@ -204,7 +204,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
         generateNewAddressButton.setOnAction(event -> {
             boolean hasUnUsedAddress = observableList.stream().anyMatch(e -> e.getNumTxOutputs() == 0);
             if (hasUnUsedAddress) {
-                new Popup<>().warning(Res.get("funds.deposit.selectUnused")).show();
+                new Popup().warning(Res.get("funds.deposit.selectUnused")).show();
             } else {
                 AddressEntry newSavingsAddressEntry = walletService.getFreshAddressEntry();
                 updateList();

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -356,7 +356,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                                     } else {
                                         if (item.isDustAttackTx()) {
                                             hyperlinkWithIcon = new HyperlinkWithIcon(item.getDetails(), AwesomeIcon.WARNING_SIGN);
-                                            hyperlinkWithIcon.setOnAction(event -> new Popup<>().warning(Res.get("funds.tx.dustAttackTx.popup")).show());
+                                            hyperlinkWithIcon.setOnAction(event -> new Popup().warning(Res.get("funds.tx.dustAttackTx.popup")).show());
                                             setGraphic(hyperlinkWithIcon);
                                         } else {
                                             setGraphic(new AutoTooltipLabel(item.getDetails()));
@@ -547,10 +547,10 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                     if (tradable != null)
                         btcWalletService.swapAnyTradeEntryContextToAvailableEntry(tradable.getId());
 
-                    new Popup<>().information(Res.get("funds.tx.txSent")).show();
-                }, errorMessage -> new Popup<>().warning(errorMessage).show());
+                    new Popup().information(Res.get("funds.tx.txSent")).show();
+                }, errorMessage -> new Popup().warning(errorMessage).show());
             } catch (Throwable e) {
-                new Popup<>().warning(e.getMessage()).show();
+                new Popup().warning(e.getMessage()).show();
             }
         }
     }
@@ -640,7 +640,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         });
         // This is not intended for the public so we don't translate here
         String message = stringBuilder.toString() + "\nNo. of transactions by day:" + transactionsByDayStringBuilder.toString();
-        new Popup<>().headLine("Statistical info")
+        new Popup().headLine("Statistical info")
                 .information(message)
                 .actionButtonText("Copy")
                 .onAction(() -> Utilities.copyToClipboard(message +

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -340,7 +340,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                     if (receiverAmount.isPositive()) {
                         double feePerByte = CoinUtil.getFeePerByte(fee, txSize);
                         double kb = txSize / 1000d;
-                        new Popup<>().headLine(Res.get("funds.withdrawal.confirmWithdrawalRequest"))
+                        new Popup().headLine(Res.get("funds.withdrawal.confirmWithdrawalRequest"))
                                 .confirmation(Res.get("shared.sendFundsDetailsWithFee",
                                         formatter.formatCoinWithCode(sendersAmount),
                                         withdrawFromTextField.getText(),
@@ -377,15 +377,15 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                                 .closeButtonText(Res.get("shared.cancel"))
                                 .show();
                     } else {
-                        new Popup<>().warning(Res.get("portfolio.pending.step5_buyer.amountTooLow")).show();
+                        new Popup().warning(Res.get("portfolio.pending.step5_buyer.amountTooLow")).show();
                     }
                 }
             } catch (InsufficientFundsException e) {
-                new Popup<>().warning(Res.get("funds.withdrawal.warn.amountExceeds") + "\n\nError message:\n" + e.getMessage()).show();
+                new Popup().warning(Res.get("funds.withdrawal.warn.amountExceeds") + "\n\nError message:\n" + e.getMessage()).show();
             } catch (Throwable e) {
                 e.printStackTrace();
                 log.error(e.toString());
-                new Popup<>().warning(e.toString()).show();
+                new Popup().warning(e.toString()).show();
             }
         }
     }
@@ -469,18 +469,18 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
             reset();
             updateList();
         } catch (AddressFormatException e) {
-            new Popup<>().warning(Res.get("validation.btc.invalidAddress")).show();
+            new Popup().warning(Res.get("validation.btc.invalidAddress")).show();
         } catch (Wallet.DustySendRequested e) {
-            new Popup<>().warning(Res.get("validation.amountBelowDust",
+            new Popup().warning(Res.get("validation.amountBelowDust",
                     formatter.formatCoinWithCode(Restrictions.getMinNonDustOutput()))).show();
         } catch (AddressEntryException e) {
-            new Popup<>().error(e.getMessage()).show();
+            new Popup().error(e.getMessage()).show();
         } catch (InsufficientMoneyException e) {
             log.warn(e.getMessage());
-            new Popup<>().warning(Res.get("funds.withdrawal.notEnoughFunds") + "\n\nError message:\n" + e.getMessage()).show();
+            new Popup().warning(Res.get("funds.withdrawal.notEnoughFunds") + "\n\nError message:\n" + e.getMessage()).show();
         } catch (Throwable e) {
             log.warn(e.toString());
-            new Popup<>().warning(e.toString()).show();
+            new Popup().warning(e.toString()).show();
         }
     }
 
@@ -504,21 +504,21 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
 
     private boolean areInputsValid() {
         if (!sendersAmount.isPositive()) {
-            new Popup<>().warning(Res.get("validation.negative")).show();
+            new Popup().warning(Res.get("validation.negative")).show();
             return false;
         }
 
         if (!btcAddressValidator.validate(withdrawToTextField.getText()).isValid) {
-            new Popup<>().warning(Res.get("validation.btc.invalidAddress")).show();
+            new Popup().warning(Res.get("validation.btc.invalidAddress")).show();
             return false;
         }
         if (!totalAvailableAmountOfSelectedItems.isPositive()) {
-            new Popup<>().warning(Res.get("funds.withdrawal.warn.noSourceAddressSelected")).show();
+            new Popup().warning(Res.get("funds.withdrawal.warn.noSourceAddressSelected")).show();
             return false;
         }
 
         if (sendersAmount.compareTo(totalAvailableAmountOfSelectedItems) > 0) {
-            new Popup<>().warning(Res.get("funds.withdrawal.warn.amountExceeds")).show();
+            new Popup().warning(Res.get("funds.withdrawal.warn.amountExceeds")).show();
             return false;
         }
 

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -114,13 +114,13 @@ public class MarketView extends ActivatableView<TabPane, Void> {
         keyEventEventHandler = keyEvent -> {
             if (Utilities.isCtrlPressed(KeyCode.T, keyEvent)) {
                 String allTradesWithReferralId = getAllTradesWithReferralId();
-                new Popup<>().message(StringUtils.abbreviate(allTradesWithReferralId, 600))
+                new Popup().message(StringUtils.abbreviate(allTradesWithReferralId, 600))
                         .actionButtonText(Res.get("shared.copyToClipboard"))
                         .onAction(() -> Utilities.copyToClipboard(allTradesWithReferralId))
                         .show();
             } else if (Utilities.isCtrlPressed(KeyCode.O, keyEvent)) {
                 String allOffersWithReferralId = getAllOffersWithReferralId();
-                new Popup<>().message(StringUtils.abbreviate(allOffersWithReferralId, 600))
+                new Popup().message(StringUtils.abbreviate(allOffersWithReferralId, 600))
                         .actionButtonText(Res.get("shared.copyToClipboard"))
                         .onAction(() -> Utilities.copyToClipboard(allOffersWithReferralId))
                         .show();

--- a/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadViewModel.java
@@ -202,7 +202,7 @@ class SpreadViewModel extends ActivatableViewModel {
                                 "sellOffer getCurrencyCode: " + sellOffers.get(0).getCurrencyCode() + "\n" +
                                 "buyOffer getCurrencyCode: " + buyOffers.get(0).getCurrencyCode() + "\n\n" +
                                 "Please copy and paste this data and send it to the developers so they can investigate the issue.";
-                        new Popup<>().error(msg).show();
+                        new Popup().error(msg).show();
                         log.error(t.toString());
                         t.printStackTrace();
                     } catch (Throwable t2) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -299,7 +299,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         boolean result = model.initWithData(direction, tradeCurrency);
 
         if (!result) {
-            new Popup<>().headLine(Res.get("popup.warning.noTradingAccountSetup.headline"))
+            new Popup().headLine(Res.get("popup.warning.noTradingAccountSetup.headline"))
                     .instruction(Res.get("popup.warning.noTradingAccountSetup.msg"))
                     .actionButtonTextWithGoTo("navigation.account")
                     .onAction(() -> {
@@ -332,7 +332,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             model.getDataModel().swapTradeToSavings();
             String key = "CreateOfferCancelAndFunded";
             if (preferences.showAgain(key)) {
-                new Popup<>().information(Res.get("createOffer.alreadyFunded"))
+                new Popup().information(Res.get("createOffer.alreadyFunded"))
                         .actionButtonTextWithGoTo("navigation.funds.availableForWithdrawal")
                         .onAction(() -> navigation.navigateTo(MainView.class, FundsView.class, WithdrawalView.class))
                         .dontShowAgainId(key)
@@ -379,7 +379,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             message = Res.get("popup.warning.noBsqFundsForBtcFeePayment");
 
         if (message != null)
-            new Popup<>().warning(message)
+            new Popup().warning(message)
                     .actionButtonTextWithGoTo("navigation.dao.wallet.receive")
                     .onAction(() -> navigation.navigateTo(MainView.class, DaoView.class, BsqWalletView.class, BsqReceiveView.class))
                     .show();
@@ -417,7 +417,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                         model.getTradeFee(),
                         model.getTxFee()
                 );
-                new Popup<>().headLine(Res.get("createOffer.createOfferFundWalletInfo.headline"))
+                new Popup().headLine(Res.get("createOffer.createOfferFundWalletInfo.headline"))
                         .instruction(message)
                         .dontShowAgainId(key)
                         .show();
@@ -440,7 +440,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         if (!DevEnv.isDevMode()) {
             String key = "securityDepositInfo";
-            new Popup<>().backgroundInfo(Res.get("popup.info.securityDepositInfo"))
+            new Popup().backgroundInfo(Res.get("popup.info.securityDepositInfo"))
                     .actionButtonText(Res.get("shared.faq"))
                     .onAction(() -> GUIUtil.openWebPage("https://bisq.network/faq#6"))
                     .useIUnderstandButton()
@@ -704,7 +704,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         errorMessageListener = (o, oldValue, newValue) -> {
             if (newValue != null)
-                UserThread.runAfter(() -> new Popup<>().error(Res.get("createOffer.amountPriceBox.error.message", model.errorMessage.get()))
+                UserThread.runAfter(() -> new Popup().error(Res.get("createOffer.amountPriceBox.error.message", model.errorMessage.get()))
                         .show(), 100, TimeUnit.MILLISECONDS);
         };
 
@@ -724,7 +724,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 // We need a bit of delay to avoid issues with fade out/fade in of 2 popups
                 String key = "createOfferSuccessInfo";
                 if (DontShowAgainLookup.showAgain(key)) {
-                    UserThread.runAfter(() -> new Popup<>().headLine(Res.get("createOffer.success.headline"))
+                    UserThread.runAfter(() -> new Popup().headLine(Res.get("createOffer.success.headline"))
                                     .feedback(Res.get("createOffer.success.info"))
                                     .dontShowAgainId(key)
                                     .actionButtonTextWithGoTo("navigation.portfolio.myOpenOffers")
@@ -1218,7 +1218,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         cancelButton2.setOnAction(e -> {
             if (model.getDataModel().getIsBtcWalletFunded().get()) {
-                new Popup<>().warning(Res.get("createOffer.warnCancelOffer"))
+                new Popup().warning(Res.get("createOffer.warnCancelOffer"))
                         .closeButtonText(Res.get("shared.no"))
                         .actionButtonText(Res.get("shared.yesCancel"))
                         .onAction(() -> {
@@ -1240,7 +1240,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             Utilities.openURI(URI.create(getBitcoinURI()));
         } catch (Exception ex) {
             log.warn(ex.getMessage());
-            new Popup<>().warning(Res.get("shared.openDefaultWalletFailed")).show();
+            new Popup().warning(Res.get("shared.openDefaultWalletFailed")).show();
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -332,7 +332,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                                 applyMakerFee();
                             } catch (NumberFormatException t) {
                                 marketPriceMargin.set("");
-                                new Popup<>().warning(Res.get("validation.NaN")).show();
+                                new Popup().warning(Res.get("validation.NaN")).show();
                             }
                         } else {
                             log.debug("We don't have a market price. We use the static price instead.");
@@ -348,7 +348,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                     if (!newValue.isEmpty() && !newValue.equals("-")) {
                         double percentage = ParsingUtils.parsePercentStringToDouble(newValue);
                         if (percentage >= 1 || percentage <= -1) {
-                            new Popup<>().warning(Res.get("popup.warning.tooLargePercentageValue") + "\n" +
+                            new Popup().warning(Res.get("popup.warning.tooLargePercentageValue") + "\n" +
                                     Res.get("popup.warning.examplePercentageValue"))
                                     .show();
                         } else {
@@ -381,7 +381,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                                 marketPriceMargin.set("");
                                 String id = "showNoPriceFeedAvailablePopup";
                                 if (preferences.showAgain(id)) {
-                                    new Popup<>().warning(Res.get("popup.warning.noPriceFeedAvailable"))
+                                    new Popup().warning(Res.get("popup.warning.noPriceFeedAvailable"))
                                             .dontShowAgainId(id)
                                             .show();
                                 }
@@ -391,11 +391,11 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 } catch (NumberFormatException t) {
                     log.error(t.toString());
                     t.printStackTrace();
-                    new Popup<>().warning(Res.get("validation.NaN")).show();
+                    new Popup().warning(Res.get("validation.NaN")).show();
                 } catch (Throwable t) {
                     log.error(t.toString());
                     t.printStackTrace();
-                    new Popup<>().warning(Res.get("validation.inputError", t.toString())).show();
+                    new Popup().warning(Res.get("validation.inputError", t.toString())).show();
                 }
             }
         };
@@ -695,7 +695,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             updateButtonDisableState();
             return true;
         } else {
-            new Popup<>().warning(Res.get("shared.notEnoughFunds",
+            new Popup().warning(Res.get("shared.notEnoughFunds",
                     btcFormatter.formatCoinWithCode(dataModel.totalToPayAsCoinProperty().get()),
                     btcFormatter.formatCoinWithCode(dataModel.getTotalAvailableBalance())))
                     .actionButtonTextWithGoTo("navigation.funds.depositFunds")
@@ -736,7 +736,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                     minAmountValidationResult.set(isBtcInputValid(minAmount.get()));
             } else if (amount.get() != null && btcValidator.getMaxTradeLimit() != null && btcValidator.getMaxTradeLimit().value == OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.value) {
                 amount.set(btcFormatter.formatCoin(btcValidator.getMaxTradeLimit()));
-                new Popup<>().information(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.buyer",
+                new Popup().information(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.buyer",
                         btcFormatter.formatCoinWithCode(OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT),
                         Res.get("offerbook.warning.newVersionAnnouncement")))
                         .width(900)
@@ -885,7 +885,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                     String postfix = dataModel.isBuyOffer() ?
                             Res.get("createOffer.tooLowSecDeposit.makerIsBuyer") :
                             Res.get("createOffer.tooLowSecDeposit.makerIsSeller");
-                    new Popup<>()
+                    new Popup()
                             .warning(Res.get("createOffer.tooLowSecDeposit.warning",
                                     FormattingUtils.formatToPercentWithSymbol(defaultSecurityDeposit)) + "\n\n" + postfix)
                             .width(800)
@@ -932,7 +932,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     }
 
     private void displayPriceOutOfRangePopup() {
-        Popup popup = new Popup<>();
+        Popup popup = new Popup();
         popup.warning(Res.get("createOffer.priceOutSideOfDeviation",
                 FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())))
                 .actionButtonText(Res.get("createOffer.changePrice"))
@@ -1237,7 +1237,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             marketPriceMargin.set("");
             String id = "showNoPriceFeedAvailablePopup";
             if (preferences.showAgain(id)) {
-                new Popup<>().warning(Res.get("popup.warning.noPriceFeedAvailable"))
+                new Popup().warning(Res.get("popup.warning.noPriceFeedAvailable"))
                         .dontShowAgainId(id)
                         .show();
             }

--- a/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
@@ -238,7 +238,7 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
 
     private void showNoArbitratorForUserLocaleWarning() {
         String key = "NoArbitratorForUserLocaleWarning";
-        new Popup<>().information(Res.get("offerbook.info.noArbitrationInUserLanguage",
+        new Popup().information(Res.get("offerbook.info.noArbitrationInUserLanguage",
                 getArbitrationLanguages(), LanguageUtil.getDisplayName(preferences.getUserLanguage())))
                 .closeButtonText(Res.get("shared.ok"))
                 .dontShowAgainId(key)

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -520,7 +520,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
     private void onCreateOffer() {
         if (model.canCreateOrTakeOffer()) {
             if (!model.hasPaymentAccountForCurrency()) {
-                new Popup<>().headLine(Res.get("offerbook.warning.noTradingAccountForCurrency.headline"))
+                new Popup().headLine(Res.get("offerbook.warning.noTradingAccountForCurrency.headline"))
                         .instruction(Res.get("offerbook.warning.noTradingAccountForCurrency.msg"))
                         .actionButtonText(Res.get("offerbook.yesCreateOffer"))
                         .onAction(() -> {
@@ -559,27 +559,27 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                     FiatAccountsView.class,
                     "navigation.account");
         } else if (isInsufficientCounterpartyTradeLimit) {
-            new Popup<>().warning(Res.get("offerbook.warning.counterpartyTradeRestrictions")).show();
+            new Popup().warning(Res.get("offerbook.warning.counterpartyTradeRestrictions")).show();
         } else if (!hasSameProtocolVersion) {
-            new Popup<>().warning(Res.get("offerbook.warning.wrongTradeProtocol")).show();
+            new Popup().warning(Res.get("offerbook.warning.wrongTradeProtocol")).show();
         } else if (isIgnored) {
-            new Popup<>().warning(Res.get("offerbook.warning.userIgnored")).show();
+            new Popup().warning(Res.get("offerbook.warning.userIgnored")).show();
         } else if (isOfferBanned) {
-            new Popup<>().warning(Res.get("offerbook.warning.offerBlocked")).show();
+            new Popup().warning(Res.get("offerbook.warning.offerBlocked")).show();
         } else if (isCurrencyBanned) {
-            new Popup<>().warning(Res.get("offerbook.warning.currencyBanned")).show();
+            new Popup().warning(Res.get("offerbook.warning.currencyBanned")).show();
         } else if (isPaymentMethodBanned) {
-            new Popup<>().warning(Res.get("offerbook.warning.paymentMethodBanned")).show();
+            new Popup().warning(Res.get("offerbook.warning.paymentMethodBanned")).show();
         } else if (isNodeAddressBanned) {
-            new Popup<>().warning(Res.get("offerbook.warning.nodeBlocked")).show();
+            new Popup().warning(Res.get("offerbook.warning.nodeBlocked")).show();
         } else if (requireUpdateToNewVersion) {
-            new Popup<>().warning(Res.get("offerbook.warning.requireUpdateToNewVersion")).show();
+            new Popup().warning(Res.get("offerbook.warning.requireUpdateToNewVersion")).show();
         } else if (isInsufficientTradeLimit) {
             final Optional<PaymentAccount> account = model.getMostMaturePaymentAccountForOffer(offer);
             if (account.isPresent()) {
                 final long tradeLimit = model.accountAgeWitnessService.getMyTradeLimit(account.get(),
                         offer.getCurrencyCode(), offer.getMirroredDirection());
-                new Popup<>()
+                new Popup()
                         .warning(Res.get("offerbook.warning.tradeLimitNotMatching",
                                 DisplayUtils.formatAccountAge(model.accountAgeWitnessService.getMyAccountAge(account.get().getPaymentAccountPayload())),
                                 formatter.formatCoinWithCode(Coin.valueOf(tradeLimit)),
@@ -595,7 +595,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         if (model.canCreateOrTakeOffer()) {
             if (offer.getDirection() == OfferPayload.Direction.SELL &&
                     offer.getPaymentMethod().getId().equals(PaymentMethod.CASH_DEPOSIT.getId())) {
-                new Popup<>().confirmation(Res.get("popup.info.cashDepositInfo", offer.getBankId()))
+                new Popup().confirmation(Res.get("popup.info.cashDepositInfo", offer.getBankId()))
                         .actionButtonText(Res.get("popup.info.cashDepositInfo.confirm"))
                         .onAction(() -> offerActionHandler.onTakeOffer(offer))
                         .show();
@@ -609,7 +609,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         if (model.isBootstrappedOrShowPopup()) {
             String key = "RemoveOfferWarning";
             if (DontShowAgainLookup.showAgain(key)) {
-                new Popup<>().warning(Res.get("popup.warning.removeOffer", model.getMakerFeeAsString(offer)))
+                new Popup().warning(Res.get("popup.warning.removeOffer", model.getMakerFeeAsString(offer)))
                         .actionButtonText(Res.get("shared.removeOffer"))
                         .onAction(() -> doRemoveOffer(offer))
                         .closeButtonText(Res.get("shared.dontRemoveOffer"))
@@ -627,7 +627,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 () -> {
                     log.debug(Res.get("offerbook.removeOffer.success"));
                     if (DontShowAgainLookup.showAgain(key))
-                        new Popup<>().instruction(Res.get("offerbook.withdrawFundsHint", Res.get("navigation.funds.availableForWithdrawal")))
+                        new Popup().instruction(Res.get("offerbook.withdrawFundsHint", Res.get("navigation.funds.availableForWithdrawal")))
                                 .actionButtonTextWithGoTo("navigation.funds.availableForWithdrawal")
                                 .onAction(() -> navigation.navigateTo(MainView.class, FundsView.class, WithdrawalView.class))
                                 .dontShowAgainId(key)
@@ -635,12 +635,12 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 },
                 (message) -> {
                     log.error(message);
-                    new Popup<>().warning(Res.get("offerbook.removeOffer.failed", message)).show();
+                    new Popup().warning(Res.get("offerbook.removeOffer.failed", message)).show();
                 });
     }
 
     private void openPopupForMissingAccountSetup(String headLine, String message, Class target, String targetAsString) {
-        new Popup<>().headLine(headLine)
+        new Popup().headLine(headLine)
                 .instruction(message)
                 .actionButtonTextWithGoTo(targetAsString)
                 .onAction(() -> {

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
@@ -168,7 +168,7 @@ class TakeOfferDataModel extends OfferDataModel {
             tradeManager.checkOfferAvailability(offer,
                     () -> {
                     },
-                    errorMessage -> new Popup<>().warning(errorMessage).show());
+                    errorMessage -> new Popup().warning(errorMessage).show());
         }
     }
 
@@ -306,15 +306,15 @@ class TakeOfferDataModel extends OfferDataModel {
             fundsNeededForTrade = fundsNeededForTrade.add(amount.get());
 
         if (filterManager.isCurrencyBanned(offer.getCurrencyCode())) {
-            new Popup<>().warning(Res.get("offerbook.warning.currencyBanned")).show();
+            new Popup().warning(Res.get("offerbook.warning.currencyBanned")).show();
         } else if (filterManager.isPaymentMethodBanned(offer.getPaymentMethod())) {
-            new Popup<>().warning(Res.get("offerbook.warning.paymentMethodBanned")).show();
+            new Popup().warning(Res.get("offerbook.warning.paymentMethodBanned")).show();
         } else if (filterManager.isOfferIdBanned(offer.getId())) {
-            new Popup<>().warning(Res.get("offerbook.warning.offerBlocked")).show();
+            new Popup().warning(Res.get("offerbook.warning.offerBlocked")).show();
         } else if (filterManager.isNodeAddressBanned(offer.getMakerNodeAddress())) {
-            new Popup<>().warning(Res.get("offerbook.warning.nodeBlocked")).show();
+            new Popup().warning(Res.get("offerbook.warning.nodeBlocked")).show();
         } else if (filterManager.requireUpdateToNewVersionForTrading()) {
-            new Popup<>().warning(Res.get("offerbook.warning.requireUpdateToNewVersion")).show();
+            new Popup().warning(Res.get("offerbook.warning.requireUpdateToNewVersion")).show();
         } else {
             tradeManager.onTakeOffer(amount.get(),
                     txFeeFromFeeService,
@@ -328,7 +328,7 @@ class TakeOfferDataModel extends OfferDataModel {
                     tradeResultHandler,
                     errorMessage -> {
                         log.warn(errorMessage);
-                        new Popup<>().warning(errorMessage).show();
+                        new Popup().warning(errorMessage).show();
                     }
             );
         }

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -283,7 +283,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         if (model.getPossiblePaymentAccounts().size() > 1) {
 
-            new Popup<>().headLine(Res.get("popup.info.multiplePaymentAccounts.headline"))
+            new Popup().headLine(Res.get("popup.info.multiplePaymentAccounts.headline"))
                     .information(Res.get("popup.info.multiplePaymentAccounts.msg"))
                     .dontShowAgainId("MultiplePaymentAccountsAvailableWarning")
                     .show();
@@ -383,7 +383,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
             volumeInfoTextField.setContentForPrivacyPopOver(createPopoverLabel(Res.get("offerbook.info.roundedFiatVolume")));
 
         if (offer.getPrice() == null)
-            new Popup<>().warning(Res.get("takeOffer.noPriceFeedAvailable"))
+            new Popup().warning(Res.get("takeOffer.noPriceFeedAvailable"))
                     .onClose(this::close)
                     .show();
     }
@@ -397,7 +397,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         Coin balance = model.dataModel.getBalance().get();
         if (balance != null && balance.isPositive() && !model.takeOfferCompleted.get() && !DevEnv.isDevMode()) {
             model.dataModel.swapTradeToSavings();
-            new Popup<>().information(Res.get("takeOffer.alreadyFunded.movedFunds"))
+            new Popup().information(Res.get("takeOffer.alreadyFunded.movedFunds"))
                     .actionButtonTextWithGoTo("navigation.funds.availableForWithdrawal")
                     .onAction(() -> navigation.navigateTo(MainView.class, FundsView.class, WithdrawalView.class))
                     .show();
@@ -499,7 +499,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         if (!DevEnv.isDevMode()) {
             String key = "securityDepositInfo";
-            new Popup<>().backgroundInfo(Res.get("popup.info.securityDepositInfo"))
+            new Popup().backgroundInfo(Res.get("popup.info.securityDepositInfo"))
                     .actionButtonText(Res.get("shared.faq"))
                     .onAction(() -> GUIUtil.openWebPage("https://bisq.network/faq#6"))
                     .useIUnderstandButton()
@@ -516,7 +516,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
                     model.getTxFee()
             );
             key = "takeOfferFundWalletInfo";
-            new Popup<>().headLine(Res.get("takeOffer.takeOfferFundWalletInfo.headline"))
+            new Popup().headLine(Res.get("takeOffer.takeOfferFundWalletInfo.headline"))
                     .instruction(message)
                     .dontShowAgainId(key)
                     .show();
@@ -653,7 +653,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
                 if (offerDetailsWindowDisplayed)
                     offerDetailsWindow.hide();
 
-                UserThread.runAfter(() -> new Popup<>().warning(newValue + "\n\n" +
+                UserThread.runAfter(() -> new Popup().warning(newValue + "\n\n" +
                         Res.get("takeOffer.alreadyPaidInFunds"))
                         .actionButtonTextWithGoTo("navigation.funds.availableForWithdrawal")
                         .onAction(() -> {
@@ -673,7 +673,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         errorMessageSubscription = EasyBind.subscribe(model.errorMessage, newValue -> {
             if (newValue != null) {
-                new Popup<>().error(Res.get("takeOffer.error.message", model.errorMessage.get()) +
+                new Popup().error(Res.get("takeOffer.error.message", model.errorMessage.get()) +
                         Res.get("popup.error.tryRestart"))
                         .onClose(() -> {
                             errorPopupDisplayed.set(true);
@@ -704,7 +704,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         showWarningInvalidBtcDecimalPlacesSubscription = EasyBind.subscribe(model.showWarningInvalidBtcDecimalPlaces, newValue -> {
             if (newValue) {
-                new Popup<>().warning(Res.get("takeOffer.amountPriceBox.warning.invalidBtcDecimalPlaces")).show();
+                new Popup().warning(Res.get("takeOffer.amountPriceBox.warning.invalidBtcDecimalPlaces")).show();
                 model.showWarningInvalidBtcDecimalPlaces.set(false);
             }
         });
@@ -717,7 +717,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
                 if (newValue && model.getTrade() != null && !model.getTrade().hasFailed()) {
                     String key = "takeOfferSuccessInfo";
                     if (DontShowAgainLookup.showAgain(key)) {
-                        UserThread.runAfter(() -> new Popup<>().headLine(Res.get("takeOffer.success.headline"))
+                        UserThread.runAfter(() -> new Popup().headLine(Res.get("takeOffer.success.headline"))
                                 .feedback(Res.get("takeOffer.success.info"))
                                 .actionButtonTextWithGoTo("navigation.portfolio.pending")
                                 .dontShowAgainId(key)
@@ -1046,7 +1046,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         cancelButton2.setOnAction(e -> {
             if (model.dataModel.getIsBtcWalletFunded().get()) {
-                new Popup<>().warning(Res.get("takeOffer.alreadyFunded.askCancel"))
+                new Popup().warning(Res.get("takeOffer.alreadyFunded.askCancel"))
                         .closeButtonText(Res.get("shared.no"))
                         .actionButtonText(Res.get("shared.yesCancel"))
                         .onAction(() -> {
@@ -1068,7 +1068,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
             Utilities.openURI(URI.create(getBitcoinURI()));
         } catch (Exception ex) {
             log.warn(ex.getMessage());
-            new Popup<>().warning(Res.get("shared.openDefaultWalletFailed")).show();
+            new Popup().warning(Res.get("shared.openDefaultWalletFailed")).show();
         }
     }
 
@@ -1231,7 +1231,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
             message = Res.get("popup.warning.noBsqFundsForBtcFeePayment");
 
         if (message != null)
-            new Popup<>().warning(message)
+            new Popup().warning(message)
                     .actionButtonTextWithGoTo("navigation.dao.wallet.receive")
                     .onAction(() -> navigation.navigateTo(MainView.class, DaoView.class, BsqWalletView.class, BsqReceiveView.class))
                     .show();

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -275,7 +275,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
             updateButtonDisableState();
             return true;
         } else {
-            new Popup<>().warning(Res.get("shared.notEnoughFunds",
+            new Popup().warning(Res.get("shared.notEnoughFunds",
                     btcFormatter.formatCoinWithCode(dataModel.getTotalToPayAsCoin().get()),
                     btcFormatter.formatCoinWithCode(dataModel.getTotalAvailableBalance())))
                     .actionButtonTextWithGoTo("navigation.funds.depositFunds")
@@ -387,13 +387,13 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
                             Res.get("takeOffer.validation.amountLargerThanOfferAmountMinusFee")));
             } else if (btcValidator.getMaxTradeLimit() != null && btcValidator.getMaxTradeLimit().value == OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.value) {
                 if (dataModel.getDirection() == OfferPayload.Direction.BUY) {
-                    new Popup<>().information(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.seller",
+                    new Popup().information(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.seller",
                             btcFormatter.formatCoinWithCode(OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT),
                             Res.get("offerbook.warning.newVersionAnnouncement")))
                             .width(900)
                             .show();
                 } else {
-                    new Popup<>().information(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.buyer",
+                    new Popup().information(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.buyer",
                             btcFormatter.formatCoinWithCode(OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT),
                             Res.get("offerbook.warning.newVersionAnnouncement")))
                             .width(900)

--- a/desktop/src/main/java/bisq/desktop/main/overlays/popups/Popup.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/popups/Popup.java
@@ -22,8 +22,7 @@ import bisq.desktop.main.overlays.Overlay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO: Type parameter is unused - remove:
-public class Popup<T> extends Overlay<Popup<T>> {
+public class Popup extends Overlay<Popup> {
     protected final Logger log = LoggerFactory.getLogger(this.getClass());
 
     public Popup() {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -612,7 +612,7 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
                     formatter.formatCoinWithCode(sellerPayoutAmount),
                     sellerPayoutAddressString);
         }
-        new Popup<>().width(900)
+        new Popup().width(900)
                 .headLine(Res.get("disputeSummaryWindow.close.txDetails.headline"))
                 .confirmation(Res.get("disputeSummaryWindow.close.txDetails",
                         formatter.formatCoinWithCode(inputAmount),
@@ -658,13 +658,13 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
                 @Override
                 public void onFailure(TxBroadcastException exception) {
                     log.error("TxBroadcastException at doPayout", exception);
-                    new Popup<>().error(exception.toString()).show();
+                    new Popup().error(exception.toString()).show();
                     ;
                 }
             });
         } catch (InsufficientMoneyException | WalletException | TransactionVerificationException e) {
             log.error("Exception at doPayout", e);
-            new Popup<>().error(e.toString()).show();
+            new Popup().error(e.toString()).show();
         }
     }
 
@@ -688,7 +688,7 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         checkNotNull(getDisputeManager(dispute)).sendDisputeResultMessage(disputeResult, dispute, text);
 
         if (peersDisputeOptional.isPresent() && !peersDisputeOptional.get().isClosed() && !DevEnv.isDevMode()) {
-            UserThread.runAfter(() -> new Popup<>()
+            UserThread.runAfter(() -> new Popup()
                             .attention(Res.get("disputeSummaryWindow.close.closePeer"))
                             .show(),
                     200, TimeUnit.MILLISECONDS);

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/EmptyWalletWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/EmptyWalletWindow.java
@@ -210,7 +210,7 @@ public class EmptyWalletWindow extends Overlay<EmptyWalletWindow> {
         if (GUIUtil.isReadyForTxBroadcastOrShowPopup(p2PService, walletsSetup)) {
             if (!openOfferManager.getObservableList().isEmpty()) {
                 UserThread.runAfter(() ->
-                        new Popup<>().warning(Res.get("emptyWalletWindow.openOffers.warn"))
+                        new Popup().warning(Res.get("emptyWalletWindow.openOffers.warn"))
                                 .actionButtonText(Res.get("emptyWalletWindow.openOffers.yes"))
                                 .onAction(() -> doEmptyWallet2(aesKey))
                                 .show(), 300, TimeUnit.MILLISECONDS);
@@ -231,7 +231,7 @@ public class EmptyWalletWindow extends Overlay<EmptyWalletWindow> {
                             balanceTextField.setText(getFormatter().formatCoinWithCode(getWalletService().getAvailableConfirmedBalance()));
                             emptyWalletButton.setDisable(true);
                             log.debug("wallet empty successful");
-                            onClose(() -> UserThread.runAfter(() -> new Popup<>()
+                            onClose(() -> UserThread.runAfter(() -> new Popup()
                                     .feedback(Res.get("emptyWalletWindow.sent.success"))
                                     .show(), Transitions.DEFAULT_DURATION, TimeUnit.MILLISECONDS));
                             doClose();

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -188,7 +188,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
             )
                 hide();
             else
-                new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
+                new Popup().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
         });
 
         Button removeFilterMessageButton = new AutoTooltipButton(Res.get("filterWindow.remove"));
@@ -197,7 +197,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
                 if (removeFilterMessageHandler.handle(keyInputTextField.getText()))
                     hide();
                 else
-                    new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
+                    new Popup().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
             }
         });
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
@@ -153,14 +153,14 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
                 log.error("onSuccess");
                 UserThread.execute(() -> {
                     String txId = result != null ? result.getHashAsString() : "null";
-                    new Popup<>().information("Transaction successful published. Transaction ID: " + txId).show();
+                    new Popup().information("Transaction successful published. Transaction ID: " + txId).show();
                 });
             }
 
             @Override
             public void onFailure(TxBroadcastException exception) {
                 log.error(exception.toString());
-                UserThread.execute(() -> new Popup<>().warning(exception.toString()).show());
+                UserThread.execute(() -> new Popup().warning(exception.toString()).show());
             }
         };
         onAction(() -> {
@@ -184,7 +184,7 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
                 } catch (AddressFormatException | WalletException | TransactionVerificationException e) {
                     log.error(e.toString());
                     e.printStackTrace();
-                    UserThread.execute(() -> new Popup<>().warning(e.toString()).show());
+                    UserThread.execute(() -> new Popup().warning(e.toString()).show());
                 }
             }
         });

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendAlertMessageWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendAlertMessageWindow.java
@@ -145,7 +145,7 @@ public class SendAlertMessageWindow extends Overlay<SendAlertMessageWindow> {
                 final String[] split = version.split("\\.");
                 versionOK = split.length == 3;
                 if (!versionOK) // Do not translate as only used by devs
-                    new Popup<>().warning("Version number must be in semantic version format (contain 2 '.'). version=" + version)
+                    new Popup().warning("Version number must be in semantic version format (contain 2 '.'). version=" + version)
                             .onClose(this::blurAgain)
                             .show();
             }
@@ -158,7 +158,7 @@ public class SendAlertMessageWindow extends Overlay<SendAlertMessageWindow> {
                             keyInputTextField.getText()))
                         hide();
                     else
-                        new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
+                        new Popup().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
                 }
             }
         });
@@ -169,7 +169,7 @@ public class SendAlertMessageWindow extends Overlay<SendAlertMessageWindow> {
                 if (removeAlertMessageHandler.handle(keyInputTextField.getText()))
                     hide();
                 else
-                    new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
+                    new Popup().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
             }
         });
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendPrivateNotificationWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendPrivateNotificationWindow.java
@@ -140,14 +140,14 @@ public class SendPrivateNotificationWindow extends Overlay<SendPrivateNotificati
                             @Override
                             public void onArrived() {
                                 log.info("PrivateNotificationPayload arrived at peer {}.", nodeAddress);
-                                new Popup<>().feedback(Res.get("shared.messageArrived"))
+                                new Popup().feedback(Res.get("shared.messageArrived"))
                                         .onClose(SendPrivateNotificationWindow.this::hide).show();
                             }
 
                             @Override
                             public void onStoredInMailbox() {
                                 log.info("PrivateNotificationPayload stored in mailbox for peer {}.", nodeAddress);
-                                new Popup<>().feedback(Res.get("shared.messageStoredInMailbox"))
+                                new Popup().feedback(Res.get("shared.messageStoredInMailbox"))
                                         .onClose(SendPrivateNotificationWindow.this::hide).show();
                             }
 
@@ -155,11 +155,11 @@ public class SendPrivateNotificationWindow extends Overlay<SendPrivateNotificati
                             public void onFault(String errorMessage) {
                                 log.error("PrivateNotificationPayload failed: Peer {}, errorMessage={}", nodeAddress,
                                         errorMessage);
-                                new Popup<>().feedback(Res.get("shared.messageSendingFailed", errorMessage))
+                                new Popup().feedback(Res.get("shared.messageSendingFailed", errorMessage))
                                         .onClose(SendPrivateNotificationWindow.this::hide).show();
                             }
                         }))
-                    new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
+                    new Popup().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
             }
         });
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignPaymentAccountsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignPaymentAccountsWindow.java
@@ -286,7 +286,7 @@ public class SignPaymentAccountsWindow extends Overlay<SignPaymentAccountsWindow
                     addSuccessContent();
                 }
             } else {
-                new Popup<>().error(Res.get("popup.accountSigning.signAccounts.ECKey.error")).onClose(this::hide).show();
+                new Popup().error(Res.get("popup.accountSigning.signAccounts.ECKey.error")).onClose(this::hide).show();
             }
 
         });

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TorNetworkSettingsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TorNetworkSettingsWindow.java
@@ -221,7 +221,7 @@ public class TorNetworkSettingsWindow extends Overlay<TorNetworkSettingsWindow> 
             cleanTorDir(() -> {
                 tuple.second.stop();
                 tuple.third.setText("");
-                new Popup<>().feedback(Res.get("torNetworkSettingWindow.deleteFiles.success"))
+                new Popup().feedback(Res.get("torNetworkSettingWindow.deleteFiles.success"))
                         .useShutDownButton()
                         .hideCloseButton()
                         .show();
@@ -338,7 +338,7 @@ public class TorNetworkSettingsWindow extends Overlay<TorNetworkSettingsWindow> 
         networkNode.shutDown(() -> {
             // We give it a bit extra time to be sure that OS locks are removed
             UserThread.runAfter(() -> {
-                torSetup.cleanupTorFiles(resultHandler, errorMessage -> new Popup<>().error(errorMessage).show());
+                torSetup.cleanupTorFiles(resultHandler, errorMessage -> new Popup().error(errorMessage).show());
             }, 3);
         });
     }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/UnlockDisputeAgentRegistrationWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/UnlockDisputeAgentRegistrationWindow.java
@@ -135,7 +135,7 @@ public class UnlockDisputeAgentRegistrationWindow extends Overlay<UnlockDisputeA
             if (privKeyHandler.checkKey(keyInputTextField.getText()))
                 hide();
             else
-                new Popup<>().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
+                new Popup().warning(Res.get("shared.invalidKey")).width(300).onClose(this::blurAgain).show();
         });
 
         Button closeButton = buttonButtonTuple2.second;

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
@@ -223,7 +223,7 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
                         busyAnimation.stop();
                         deriveStatusLabel.setText("");
 
-                        UserThread.runAfter(() -> new Popup<>()
+                        UserThread.runAfter(() -> new Popup()
                                 .warning(Res.get("password.wrongPw"))
                                 .onClose(this::blurAgain).show(), Transitions.DEFAULT_DURATION, TimeUnit.MILLISECONDS);
                     }
@@ -329,7 +329,7 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
 
     private void onRestore() {
         if (walletsManager.hasPositiveBalance()) {
-            new Popup<>().warning(Res.get("seed.warn.walletNotEmpty.msg"))
+            new Popup().warning(Res.get("seed.warn.walletNotEmpty.msg"))
                     .actionButtonText(Res.get("seed.warn.walletNotEmpty.restore"))
                     .onAction(this::checkIfEncrypted)
                     .closeButtonText(Res.get("seed.warn.walletNotEmpty.emptyWallet"))
@@ -341,7 +341,7 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
 
     private void checkIfEncrypted() {
         if (walletsManager.areWalletsEncrypted()) {
-            new Popup<>().information(Res.get("seed.warn.notEncryptedAnymore"))
+            new Popup().information(Res.get("seed.warn.notEncryptedAnymore"))
                     .closeButtonText(Res.get("shared.no"))
                     .actionButtonText(Res.get("shared.yes"))
                     .onAction(this::doRestore)

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DisplayUpdateDownloadWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DisplayUpdateDownloadWindow.java
@@ -254,7 +254,7 @@ public class DisplayUpdateDownloadWindow extends Overlay<DisplayUpdateDownloadWi
                                     showErrorMessage(downloadButton, statusLabel, Res.get("displayUpdateDownloadWindow.verify.failed"));
                                 } else {
                                     verifiedSigLabel.getStyleClass().add("success-text");
-                                    new Popup<>().feedback(Res.get("displayUpdateDownloadWindow.success"))
+                                    new Popup().feedback(Res.get("displayUpdateDownloadWindow.success"))
                                             .actionButtonText(Res.get("displayUpdateDownloadWindow.download.openDir"))
                                             .onAction(() -> {
                                                 try {
@@ -369,7 +369,7 @@ public class DisplayUpdateDownloadWindow extends Overlay<DisplayUpdateDownloadWi
         statusLabel.setText("");
         stopAnimations();
         downloadButton.setDisable(false);
-        new Popup<>()
+        new Popup()
                 .headLine(Res.get("displayUpdateDownloadWindow.download.failed.headline"))
                 .feedback(errorMsg)
                 .onClose(this::doClose)

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
@@ -122,7 +122,7 @@ public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
     public void onClose() {
         model.onCancelEditOffer(errorMessage -> {
             log.error(errorMessage);
-            new Popup<>().warning(Res.get("editOffer.failed", errorMessage)).show();
+            new Popup().warning(Res.get("editOffer.failed", errorMessage)).show();
         });
     }
 
@@ -145,13 +145,13 @@ public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
 
         model.onStartEditOffer(errorMessage -> {
             log.error(errorMessage);
-            new Popup<>().warning(Res.get("editOffer.failed", errorMessage))
+            new Popup().warning(Res.get("editOffer.failed", errorMessage))
                     .onClose(this::close)
                     .show();
         });
 
         if (!model.isSecurityDepositValid()) {
-            new Popup<>().warning(Res.get("editOffer.invalidDeposit"))
+            new Popup().warning(Res.get("editOffer.invalidDeposit"))
                     .onClose(this::close)
                     .show();
         }
@@ -205,7 +205,7 @@ public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
                 //edit offer
                 model.onPublishOffer(() -> {
                     log.debug("Edit offer was successful");
-                    new Popup<>().feedback(Res.get("editOffer.success")).show();
+                    new Popup().feedback(Res.get("editOffer.success")).show();
                     spinnerInfoLabel.setText("");
                     busyAnimation.stop();
                     close();
@@ -215,7 +215,7 @@ public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
                     busyAnimation.stop();
                     model.isNextButtonDisabled.setValue(false);
                     cancelButton.setDisable(false);
-                    new Popup<>().warning(Res.get("editOffer.failed", message)).show();
+                    new Popup().warning(Res.get("editOffer.failed", message)).show();
                 });
             }
         });

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersView.java
@@ -139,7 +139,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
                     () -> log.debug("Deactivate offer was successful"),
                     (message) -> {
                         log.error(message);
-                        new Popup<>().warning(Res.get("offerbook.deactivateOffer.failed", message)).show();
+                        new Popup().warning(Res.get("offerbook.deactivateOffer.failed", message)).show();
                     });
         }
     }
@@ -150,7 +150,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
                     () -> log.debug("Activate offer was successful"),
                     (message) -> {
                         log.error(message);
-                        new Popup<>().warning(Res.get("offerbook.activateOffer.failed", message)).show();
+                        new Popup().warning(Res.get("offerbook.activateOffer.failed", message)).show();
                     });
         }
     }
@@ -159,7 +159,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
         if (model.isBootstrappedOrShowPopup()) {
             String key = "RemoveOfferWarning";
             if (DontShowAgainLookup.showAgain(key)) {
-                new Popup<>().warning(Res.get("popup.warning.removeOffer", model.getMakerFeeAsString(openOffer)))
+                new Popup().warning(Res.get("popup.warning.removeOffer", model.getMakerFeeAsString(openOffer)))
                         .actionButtonText(Res.get("shared.removeOffer"))
                         .onAction(() -> doRemoveOpenOffer(openOffer))
                         .closeButtonText(Res.get("shared.dontRemoveOffer"))
@@ -180,7 +180,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
 
                     String key = "WithdrawFundsAfterRemoveOfferInfo";
                     if (DontShowAgainLookup.showAgain(key)) {
-                        new Popup<>().instruction(Res.get("offerbook.withdrawFundsHint", Res.get("navigation.funds.availableForWithdrawal")))
+                        new Popup().instruction(Res.get("offerbook.withdrawFundsHint", Res.get("navigation.funds.availableForWithdrawal")))
                                 .actionButtonTextWithGoTo("navigation.funds.availableForWithdrawal")
                                 .onAction(() -> navigation.navigateTo(MainView.class, FundsView.class, WithdrawalView.class))
                                 .dontShowAgainId(key)
@@ -189,7 +189,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
                 },
                 (message) -> {
                     log.error(message);
-                    new Popup<>().warning(Res.get("offerbook.removeOffer.failed", message)).show();
+                    new Popup().warning(Res.get("offerbook.removeOffer.failed", message)).show();
                 });
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -455,7 +455,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
         // in such cases. The mediators or arbitrators could not help anyway with a payout in such cases.
         if (depositTx == null) {
             log.error("Deposit tx must not be null");
-            new Popup<>().instruction(Res.get("portfolio.pending.error.depositTxNull")).show();
+            new Popup().instruction(Res.get("portfolio.pending.error.depositTxNull")).show();
             return;
         }
         String depositTxId = depositTx.getHashAsString();
@@ -527,7 +527,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                     (errorMessage, throwable) -> {
                         if ((throwable instanceof DisputeAlreadyOpenException)) {
                             errorMessage += "\n\n" + Res.get("portfolio.pending.openAgainDispute.msg");
-                            new Popup<>().warning(errorMessage)
+                            new Popup().warning(errorMessage)
                                     .actionButtonText(Res.get("portfolio.pending.openAgainDispute.button"))
                                     .onAction(() -> disputeManager.sendOpenNewDisputeMessage(dispute,
                                             true,
@@ -538,7 +538,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                                     .closeButtonText(Res.get("shared.cancel"))
                                     .show();
                         } else {
-                            new Popup<>().warning(errorMessage).show();
+                            new Popup().warning(errorMessage).show();
                         }
                     });
         } else if (useRefundAgent) {
@@ -554,7 +554,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
             TransactionConfidence confidenceForTxId = btcWalletService.getConfidenceForTxId(depositTxId);
             if (confidenceForTxId == null || confidenceForTxId.getConfidenceType() != TransactionConfidence.ConfidenceType.BUILDING) {
                 log.error("Confidence for deposit tx must be BUILDING, confidenceForTxId={}", confidenceForTxId);
-                new Popup<>().instruction(Res.get("portfolio.pending.error.depositTxNotConfirmed")).show();
+                new Popup().instruction(Res.get("portfolio.pending.error.depositTxNotConfirmed")).show();
                 return;
             }
 
@@ -562,7 +562,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
             int bestChainHeight = btcWalletService.getBestChainHeight();
             long remaining = lockTime - bestChainHeight;
             if (remaining > 0) {
-                new Popup<>()
+                new Popup()
                         .instruction(Res.get("portfolio.pending.timeLockNotOver",
                                 FormattingUtils.getDateFromBlockHeight(remaining), remaining))
                         .show();
@@ -621,7 +621,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                                 (errorMessage, throwable) -> {
                                     if ((throwable instanceof DisputeAlreadyOpenException)) {
                                         errorMessage += "\n\n" + Res.get("portfolio.pending.openAgainDispute.msg");
-                                        new Popup<>().warning(errorMessage)
+                                        new Popup().warning(errorMessage)
                                                 .actionButtonText(Res.get("portfolio.pending.openAgainDispute.button"))
                                                 .onAction(() -> disputeManager.sendOpenNewDisputeMessage(dispute,
                                                         true,
@@ -632,12 +632,12 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                                                 .closeButtonText(Res.get("shared.cancel"))
                                                 .show();
                                     } else {
-                                        new Popup<>().warning(errorMessage).show();
+                                        new Popup().warning(errorMessage).show();
                                     }
                                 });
                     },
                     errorMessage -> {
-                        new Popup<>().error(errorMessage).show();
+                        new Popup().error(errorMessage).show();
                     });
 
         } else {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -202,7 +202,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         // we use a hidden emergency shortcut to open support ticket
         keyEventEventHandler = keyEvent -> {
             if (Utilities.isAltOrCtrlPressed(KeyCode.O, keyEvent)) {
-                Popup popup = new Popup<>();
+                Popup popup = new Popup();
                 popup.headLine(Res.get("portfolio.pending.openSupportTicket.headline"))
                         .message(Res.get("portfolio.pending.openSupportTicket.msg"))
                         .actionButtonText(Res.get("portfolio.pending.openSupportTicket.headline"))
@@ -211,7 +211,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                         .onClose(popup::hide)
                         .show();
             } else if (Utilities.isAltPressed(KeyCode.Y, keyEvent)) {
-                new Popup<>().warning(Res.get("portfolio.pending.removeFailedTrade"))
+                new Popup().warning(Res.get("portfolio.pending.removeFailedTrade"))
                         .onAction(model.dataModel::onMoveToFailedTrades)
                         .show();
             }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -143,7 +143,7 @@ public abstract class TradeStepView extends AnchorPane {
 
         errorMessageListener = (observable, oldValue, newValue) -> {
             if (newValue != null)
-                new Popup<>().error(newValue).show();
+                new Popup().error(newValue).show();
         };
 
         clockListener = new ClockWatcher.Listener() {
@@ -174,7 +174,7 @@ public abstract class TradeStepView extends AnchorPane {
 
         if (!isMediationClosedState()) {
             tradeStepInfo.setOnAction(e -> {
-                new Popup<>().attention(Res.get("portfolio.pending.support.popup.info"))
+                new Popup().attention(Res.get("portfolio.pending.support.popup.info"))
                         .actionButtonText(Res.get("portfolio.pending.support.popup.button"))
                         .onAction(this::openSupportTicket)
                         .closeButtonText(Res.get("shared.cancel"))
@@ -527,7 +527,7 @@ public abstract class TradeStepView extends AnchorPane {
             log.error("trade.getDepositTx() or trade.getDelayedPayoutTx() was null at openMediationResultPopup. " +
                     "We add the trade to failed trades. TradeId={}", trade.getId());
             model.dataModel.addTradeToFailedTrades();
-            new Popup<>().warning(Res.get("portfolio.pending.mediationResult.error.depositTxNull")).show();
+            new Popup().warning(Res.get("portfolio.pending.mediationResult.error.depositTxNull")).show();
             return;
         }
 
@@ -546,7 +546,7 @@ public abstract class TradeStepView extends AnchorPane {
         String actionButtonText = hasSelfAccepted() ?
                 Res.get("portfolio.pending.mediationResult.popup.alreadyAccepted") : Res.get("shared.accept");
 
-        acceptMediationResultPopup = new Popup<>().width(900)
+        acceptMediationResultPopup = new Popup().width(900)
                 .headLine(headLine)
                 .instruction(Res.get("portfolio.pending.mediationResult.popup.info",
                         myPayoutAmount,
@@ -562,7 +562,7 @@ public abstract class TradeStepView extends AnchorPane {
                             },
                             errorMessage -> {
                                 UserThread.execute(() -> {
-                                    new Popup<>().error(errorMessage).show();
+                                    new Popup().error(errorMessage).show();
                                     if (acceptMediationResultPopup != null) {
                                         acceptMediationResultPopup.hide();
                                         acceptMediationResultPopup = null;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -370,7 +370,7 @@ public class BuyerStep2View extends TradeStepView {
             if (model.dataModel.getSellersPaymentAccountPayload() instanceof CashDepositAccountPayload) {
                 String key = "confirmPaperReceiptSent";
                 if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
-                    Popup popup = new Popup<>();
+                    Popup popup = new Popup();
                     popup.headLine(Res.get("portfolio.pending.step2_buyer.paperReceipt.headline"))
                             .feedback(Res.get("portfolio.pending.step2_buyer.paperReceipt.msg"))
                             .onAction(this::showConfirmPaymentStartedPopup)
@@ -385,7 +385,7 @@ public class BuyerStep2View extends TradeStepView {
                 String key = "westernUnionMTCNSent";
                 if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
                     String email = ((WesternUnionAccountPayload) model.dataModel.getSellersPaymentAccountPayload()).getEmail();
-                    Popup popup = new Popup<>();
+                    Popup popup = new Popup();
                     popup.headLine(Res.get("portfolio.pending.step2_buyer.westernUnionMTCNInfo.headline"))
                             .feedback(Res.get("portfolio.pending.step2_buyer.westernUnionMTCNInfo.msg", email))
                             .onAction(this::showConfirmPaymentStartedPopup)
@@ -401,7 +401,7 @@ public class BuyerStep2View extends TradeStepView {
                 String key = "moneyGramMTCNSent";
                 if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
                     String email = ((MoneyGramAccountPayload) model.dataModel.getSellersPaymentAccountPayload()).getEmail();
-                    Popup popup = new Popup<>();
+                    Popup popup = new Popup();
                     popup.headLine(Res.get("portfolio.pending.step2_buyer.moneyGramMTCNInfo.headline"))
                             .feedback(Res.get("portfolio.pending.step2_buyer.moneyGramMTCNInfo.msg", email))
                             .onAction(this::showConfirmPaymentStartedPopup)
@@ -417,7 +417,7 @@ public class BuyerStep2View extends TradeStepView {
                 String key = "halCashCodeInfo";
                 if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
                     String mobileNr = ((HalCashAccountPayload) model.dataModel.getSellersPaymentAccountPayload()).getMobileNr();
-                    Popup popup = new Popup<>();
+                    Popup popup = new Popup();
                     popup.headLine(Res.get("portfolio.pending.step2_buyer.halCashInfo.headline"))
                             .feedback(Res.get("portfolio.pending.step2_buyer.halCashInfo.msg",
                                     model.dataModel.getTrade().getShortId(), mobileNr))
@@ -439,7 +439,7 @@ public class BuyerStep2View extends TradeStepView {
     private void showConfirmPaymentStartedPopup() {
         String key = "confirmPaymentStarted";
         if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
-            Popup popup = new Popup<>();
+            Popup popup = new Popup();
             popup.headLine(Res.get("portfolio.pending.step2_buyer.confirmStart.headline"))
                     .confirmation(Res.get("portfolio.pending.step2_buyer.confirmStart.msg",
                             CurrencyUtil.getNameByCode(trade.getOffer().getCurrencyCode())))
@@ -471,7 +471,7 @@ public class BuyerStep2View extends TradeStepView {
         }, errorMessage -> {
             // confirmButton.setDisable(false);
             busyAnimation.stop();
-            new Popup<>().warning(Res.get("popup.warning.sendMsgFailed")).show();
+            new Popup().warning(Res.get("popup.warning.sendMsgFailed")).show();
         });
     }
 
@@ -566,7 +566,7 @@ public class BuyerStep2View extends TradeStepView {
             String key = "startPayment" + trade.getId();
             if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
                 DontShowAgainLookup.dontShowAgain(key, true);
-                new Popup<>().headLine(Res.get("popup.attention.forTradeWithId", id))
+                new Popup().headLine(Res.get("popup.attention.forTradeWithId", id))
                         .attention(message)
                         .show();
             }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep4View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep4View.java
@@ -191,7 +191,7 @@ public class BuyerStep4View extends TradeStepView {
                 Coin fee = feeEstimationTransaction.getFee();
                 Coin receiverAmount = amount.subtract(fee);
                 if (balance.isZero()) {
-                    new Popup<>().warning(Res.get("portfolio.pending.step5_buyer.alreadyWithdrawn")).show();
+                    new Popup().warning(Res.get("portfolio.pending.step5_buyer.alreadyWithdrawn")).show();
                     model.dataModel.tradeManager.addTradeToClosedTrades(trade);
                 } else {
                     if (toAddresses.isEmpty()) {
@@ -202,7 +202,7 @@ public class BuyerStep4View extends TradeStepView {
                         double feePerByte = CoinUtil.getFeePerByte(fee, txSize);
                         double kb = txSize / 1000d;
                         String recAmount = formatter.formatCoinWithCode(receiverAmount);
-                        new Popup<>().headLine(Res.get("portfolio.pending.step5_buyer.confirmWithdrawal"))
+                        new Popup().headLine(Res.get("portfolio.pending.step5_buyer.confirmWithdrawal"))
                                 .confirmation(Res.get("shared.sendFundsDetailsWithFee",
                                         formatter.formatCoinWithCode(amount),
                                         fromAddresses,
@@ -220,7 +220,7 @@ public class BuyerStep4View extends TradeStepView {
                                 })
                                 .show();
                     } else {
-                        new Popup<>().warning(Res.get("portfolio.pending.step5_buyer.amountTooLow")).show();
+                        new Popup().warning(Res.get("portfolio.pending.step5_buyer.amountTooLow")).show();
                     }
                 }
             } catch (AddressFormatException e) {
@@ -230,10 +230,10 @@ public class BuyerStep4View extends TradeStepView {
             } catch (InsufficientFundsException e) {
                 log.error(e.getMessage());
                 e.printStackTrace();
-                new Popup<>().warning(e.getMessage()).show();
+                new Popup().warning(e.getMessage()).show();
             }
         } else {
-            new Popup<>().warning(Res.get("validation.btc.invalidAddress")).show();
+            new Popup().warning(Res.get("validation.btc.invalidAddress")).show();
         }
     }
 
@@ -244,9 +244,9 @@ public class BuyerStep4View extends TradeStepView {
             useSavingsWalletButton.setDisable(false);
             withdrawToExternalWalletButton.setDisable(false);
             if (throwable != null && throwable.getMessage() != null)
-                new Popup<>().error(errorMessage + "\n\n" + throwable.getMessage()).show();
+                new Popup().error(errorMessage + "\n\n" + throwable.getMessage()).show();
             else
-                new Popup<>().error(errorMessage).show();
+                new Popup().error(errorMessage).show();
         };
         if (model.dataModel.btcWalletService.isEncrypted()) {
             UserThread.runAfter(() -> model.dataModel.walletPasswordWindow.onAesKey(aesKey ->
@@ -297,7 +297,7 @@ public class BuyerStep4View extends TradeStepView {
     private void showNavigateToClosedTradesViewPopup() {
         if (!DevEnv.isDevMode()) {
             UserThread.runAfter(() -> {
-                new Popup<>().headLine(Res.get("portfolio.pending.step5_buyer.withdrawalCompleted.headline"))
+                new Popup().headLine(Res.get("portfolio.pending.step5_buyer.withdrawalCompleted.headline"))
                         .feedback(Res.get("portfolio.pending.step5_buyer.withdrawalCompleted.msg"))
                         .actionButtonTextWithGoTo("navigation.portfolio.closedTrades")
                         .onAction(() -> model.dataModel.navigation.navigateTo(MainView.class, PortfolioView.class, ClosedTradesView.class))

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -297,7 +297,7 @@ public class SellerStep3View extends TradeStepView {
                 if (model.isSignWitnessTrade(true)) {
                     message += Res.get("portfolio.pending.step3_seller.onPaymentReceived.signer");
                 }
-                new Popup<>()
+                new Popup()
                         .headLine(Res.get("portfolio.pending.step3_seller.onPaymentReceived.confirm.headline"))
                         .confirmation(message)
                         .width(700)
@@ -357,7 +357,7 @@ public class SellerStep3View extends TradeStepView {
         }
         if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
             DontShowAgainLookup.dontShowAgain(key, true);
-            new Popup<>().headLine(Res.get("popup.attention.forTradeWithId", id))
+            new Popup().headLine(Res.get("popup.attention.forTradeWithId", id))
                     .attention(message)
                     .show();
         }
@@ -381,7 +381,7 @@ public class SellerStep3View extends TradeStepView {
         }, errorMessage -> {
             // confirmButton.setDisable(false);
             busyAnimation.stop();
-            new Popup<>().warning(Res.get("popup.warning.sendMsgFailed")).show();
+            new Popup().warning(Res.get("popup.warning.sendMsgFailed")).show();
         });
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/presentation/AccountPresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/AccountPresentation.java
@@ -82,7 +82,7 @@ public class AccountPresentation {
                     Res.get(s, optionalParam, Res.get("popup.accountSigning.generalInformation")) :
                     Res.get(s, Res.get("popup.accountSigning.generalInformation"));
 
-            new Popup<>().information(message)
+            new Popup().information(message)
                     .show();
         }
     }

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -275,7 +275,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         useTorForBtcJCheckBox.setOnAction(event -> {
             boolean selected = useTorForBtcJCheckBox.isSelected();
             if (selected != preferences.getUseTorForBitcoinJ()) {
-                new Popup<>().information(Res.get("settings.net.needRestart"))
+                new Popup().information(Res.get("settings.net.needRestart"))
                         .actionButtonText(Res.get("shared.applyAndShutDown"))
                         .onAction(() -> {
                             preferences.setUseTorForBitcoinJ(selected);
@@ -378,7 +378,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
     }
 
     private void showShutDownPopup() {
-        new Popup<>()
+        new Popup()
                 .information(Res.get("settings.net.needRestart"))
                 .closeButtonText(Res.get("shared.cancel"))
                 .useShutDownButton()
@@ -401,7 +401,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                 btcNodesLabel.setDisable(false);
                 if (calledFromUser && !btcNodesInputTextField.getText().isEmpty()) {
                     if (isPreventPublicBtcNetwork()) {
-                        new Popup<>().warning(Res.get("settings.net.warn.useCustomNodes.B2XWarning"))
+                        new Popup().warning(Res.get("settings.net.warn.useCustomNodes.B2XWarning"))
                                 .onAction(() -> {
                                     UserThread.runAfter(this::showShutDownPopup, 300, TimeUnit.MILLISECONDS);
                                 }).show();
@@ -414,7 +414,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                 btcNodesInputTextField.setDisable(true);
                 btcNodesLabel.setDisable(true);
                 if (calledFromUser)
-                    new Popup<>()
+                    new Popup()
                             .warning(Res.get("settings.net.warn.usePublicNodes"))
                             .actionButtonText(Res.get("settings.net.warn.usePublicNodes.useProvided"))
                             .onAction(() -> {

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -266,10 +266,10 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                     int withdrawalTxFeePerByte = Integer.parseInt(transactionFeeInputTextField.getText());
                     final long minFeePerByte = BisqEnvironment.getBaseCurrencyNetwork().getDefaultMinFeePerByte();
                     if (withdrawalTxFeePerByte < minFeePerByte) {
-                        new Popup<>().warning(Res.get("setting.preferences.txFeeMin", minFeePerByte)).show();
+                        new Popup().warning(Res.get("setting.preferences.txFeeMin", minFeePerByte)).show();
                         transactionFeeInputTextField.setText(estimatedFee);
                     } else if (withdrawalTxFeePerByte > 5000) {
-                        new Popup<>().warning(Res.get("setting.preferences.txFeeTooLarge")).show();
+                        new Popup().warning(Res.get("setting.preferences.txFeeTooLarge")).show();
                         transactionFeeInputTextField.setText(estimatedFee);
                     } else {
                         preferences.setWithdrawalTxFeeInBytes(withdrawalTxFeePerByte);
@@ -277,12 +277,12 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                 } catch (NumberFormatException t) {
                     log.error(t.toString());
                     t.printStackTrace();
-                    new Popup<>().warning(Res.get("validation.integerOnly")).show();
+                    new Popup().warning(Res.get("validation.integerOnly")).show();
                     transactionFeeInputTextField.setText(estimatedFee);
                 } catch (Throwable t) {
                     log.error(t.toString());
                     t.printStackTrace();
-                    new Popup<>().warning(Res.get("validation.inputError", t.getMessage())).show();
+                    new Popup().warning(Res.get("validation.inputError", t.getMessage())).show();
                     transactionFeeInputTextField.setText(estimatedFee);
                 }
             }
@@ -300,7 +300,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                 if (value <= maxDeviation) {
                     preferences.setMaxPriceDistanceInPercent(value);
                 } else {
-                    new Popup<>().warning(Res.get("setting.preferences.deviationToLarge", maxDeviation * 100)).show();
+                    new Popup().warning(Res.get("setting.preferences.deviationToLarge", maxDeviation * 100)).show();
                     UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatPercentagePrice(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
                 }
             } catch (NumberFormatException t) {
@@ -430,7 +430,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                             label.setText(item.getNameAndCode());
                             removeButton.setOnAction(e -> {
                                 if (item.equals(preferences.getPreferredTradeCurrency())) {
-                                    new Popup<>().warning(Res.get("setting.preferences.cannotRemovePrefCurrency")).show();
+                                    new Popup().warning(Res.get("setting.preferences.cannotRemovePrefCurrency")).show();
                                 } else {
                                     preferences.removeFiatCurrency(item);
                                     if (!allFiatCurrencies.contains(item)) {
@@ -485,7 +485,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                             label.setText(item.getNameAndCode());
                             removeButton.setOnAction(e -> {
                                 if (item.equals(preferences.getPreferredTradeCurrency())) {
-                                    new Popup<>().warning(Res.get("setting.preferences.cannotRemovePrefCurrency")).show();
+                                    new Popup().warning(Res.get("setting.preferences.cannotRemovePrefCurrency")).show();
                                 } else {
                                     preferences.removeCryptoCurrency(item);
                                     if (!allCryptoCurrencies.contains(item)) {
@@ -667,12 +667,12 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             String selectedItem = userLanguageComboBox.getSelectionModel().getSelectedItem();
             if (selectedItem != null) {
                 preferences.setUserLanguage(selectedItem);
-                new Popup<>().information(Res.get("settings.preferences.languageChange"))
+                new Popup().information(Res.get("settings.preferences.languageChange"))
                         .closeButtonText(Res.get("shared.ok"))
                         .show();
 
                 if (model.needsArbitrationLanguageWarning()) {
-                    new Popup<>().warning(Res.get("settings.preferences.arbitrationLanguageWarning",
+                    new Popup().warning(Res.get("settings.preferences.arbitrationLanguageWarning",
                             model.getArbitrationLanguages()))
                             .closeButtonText(Res.get("shared.ok"))
                             .show();
@@ -830,7 +830,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         updateDaoFields();
 
         resyncDaoButton.setOnAction(e -> daoFacade.resyncDao(() ->
-                new Popup<>().attention(Res.get("setting.preferences.dao.resync.popup"))
+                new Popup().attention(Res.get("setting.preferences.dao.resync.popup"))
                         .useShutDownButton()
                         .hideCloseButton()
                         .show()));
@@ -839,7 +839,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             String key = "daoFullModeInfoShown";
             if (isDaoFullNodeToggleButton.isSelected() && preferences.showAgain(key)) {
                 String url = "https://bisq.network/docs/dao-full-node";
-                new Popup<>().backgroundInfo(Res.get("setting.preferences.dao.fullNodeInfo", url))
+                new Popup().backgroundInfo(Res.get("setting.preferences.dao.fullNodeInfo", url))
                         .onAction(() -> GUIUtil.openWebPage(url))
                         .actionButtonText(Res.get("setting.preferences.dao.fullNodeInfo.ok"))
                         .closeButtonText(Res.get("setting.preferences.dao.fullNodeInfo.cancel"))

--- a/desktop/src/main/java/bisq/desktop/main/shared/ChatView.java
+++ b/desktop/src/main/java/bisq/desktop/main/shared/ChatView.java
@@ -528,11 +528,11 @@ public class ChatView extends AnchorPane {
                 if (text.length() < 5_000) {
                     onSendMessage(text);
                 } else {
-                    new Popup<>().information(Res.get("popup.warning.messageTooLong")).show();
+                    new Popup().information(Res.get("popup.warning.messageTooLong")).show();
                 }
             }
         } else {
-            new Popup<>().information(Res.get("popup.warning.notFullyConnected")).show();
+            new Popup().information(Res.get("popup.warning.notFullyConnected")).show();
         }
     }
 
@@ -556,9 +556,9 @@ public class ChatView extends AnchorPane {
                         int size = filesAsBytes.length;
                         int newSize = totalSize + size;
                         if (newSize > maxMsgSize) {
-                            new Popup<>().warning(Res.get("support.attachmentTooLarge", (newSize / 1024), maxSizeInKB)).show();
+                            new Popup().warning(Res.get("support.attachmentTooLarge", (newSize / 1024), maxSizeInKB)).show();
                         } else if (size > maxMsgSize) {
-                            new Popup<>().warning(Res.get("support.maxSize", maxSizeInKB)).show();
+                            new Popup().warning(Res.get("support.maxSize", maxSizeInKB)).show();
                         } else {
                             tempAttachments.add(new Attachment(result.getName(), filesAsBytes));
                             inputTextArea.setText(inputTextArea.getText() + "\n[" + Res.get("support.attachment") + " " + result.getName() + "]");
@@ -573,7 +573,7 @@ public class ChatView extends AnchorPane {
                 }
             }
         } else {
-            new Popup<>().warning(Res.get("support.tooManyAttachments")).show();
+            new Popup().warning(Res.get("support.tooManyAttachments")).show();
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
@@ -225,7 +225,7 @@ public class SupportView extends ActivatableView<TabPane, Void> {
 
         String key = "supportInfo";
         if (!DevEnv.isDevMode())
-            new Popup<>().backgroundInfo(Res.get("support.backgroundInfo"))
+            new Popup().backgroundInfo(Res.get("support.backgroundInfo"))
                     .width(900)
                     .dontShowAgainId(key)
                     .show();

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -280,7 +280,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                 });
                 String message = stringBuilder.toString();
                 // We don't translate that as it is not intended for the public
-                new Popup<>().headLine("All disputes (" + disputeGroups.size() + ")")
+                new Popup().headLine("All disputes (" + disputeGroups.size() + ")")
                         .information(message)
                         .width(1000)
                         .actionButtonText("Copy")
@@ -467,7 +467,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
             disputeSummaryWindow.onFinalizeDispute(() -> chatView.removeInputBox())
                     .show(dispute);
         } else {
-            new Popup<>()
+            new Popup()
                     .warning(Res.get("support.wrongVersion", protocolVersion))
                     .show();
         }

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -192,7 +192,7 @@ public class GUIUtil {
     public static void showFeeInfoBeforeExecute(Runnable runnable) {
         String key = "miningFeeInfo";
         if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
-            new Popup<>().attention(Res.get("guiUtil.miningFeeInfo", String.valueOf(GUIUtil.feeService.getTxFeePerByte().value)))
+            new Popup().attention(Res.get("guiUtil.miningFeeInfo", String.valueOf(GUIUtil.feeService.getTxFeePerByte().value)))
                     .onClose(runnable)
                     .useIUnderstandButton()
                     .show();
@@ -214,10 +214,10 @@ public class GUIUtil {
                 Storage<PersistableList<PaymentAccount>> paymentAccountsStorage = new Storage<>(new File(directory), persistenceProtoResolver, corruptedDatabaseFilesHandler);
                 paymentAccountsStorage.initAndGetPersisted(new PaymentAccountList(accounts), fileName, 100);
                 paymentAccountsStorage.queueUpForSave();
-                new Popup<>().feedback(Res.get("guiUtil.accountExport.savedToPath", Paths.get(directory, fileName).toAbsolutePath())).show();
+                new Popup().feedback(Res.get("guiUtil.accountExport.savedToPath", Paths.get(directory, fileName).toAbsolutePath())).show();
             }
         } else {
-            new Popup<>().warning(Res.get("guiUtil.accountExport.noAccountSetup")).show();
+            new Popup().warning(Res.get("guiUtil.accountExport.noAccountSetup")).show();
         }
     }
 
@@ -254,10 +254,10 @@ public class GUIUtil {
                         }
                     });
                     user.addImportedPaymentAccounts(paymentAccounts);
-                    new Popup<>().feedback(Res.get("guiUtil.accountImport.imported", path, msg)).show();
+                    new Popup().feedback(Res.get("guiUtil.accountImport.imported", path, msg)).show();
 
                 } else {
-                    new Popup<>().warning(Res.get("guiUtil.accountImport.noAccountsFound", path, fileName)).show();
+                    new Popup().warning(Res.get("guiUtil.accountImport.noAccountsFound", path, fileName)).show();
                 }
             } else {
                 log.error("The selected file is not the expected file for import. The expected file name is: " + fileName + ".");
@@ -289,7 +289,7 @@ public class GUIUtil {
             } catch (RuntimeException | IOException e) {
                 e.printStackTrace();
                 log.error(e.getMessage());
-                new Popup<>().error(Res.get("guiUtil.accountExport.exportFailed", e.getMessage()));
+                new Popup().error(Res.get("guiUtil.accountExport.exportFailed", e.getMessage()));
             }
         }
     }
@@ -305,7 +305,7 @@ public class GUIUtil {
             } catch (RuntimeException | IOException e) {
                 e.printStackTrace();
                 log.error(e.getMessage());
-                new Popup<>().error(Res.get("guiUtil.accountExport.exportFailed", e.getMessage()));
+                new Popup().error(Res.get("guiUtil.accountExport.exportFailed", e.getMessage()));
             }
         }
     }
@@ -606,7 +606,7 @@ public class GUIUtil {
 
         if (DontShowAgainLookup.showAgain(OPEN_WEB_PAGE_KEY)) {
             final String finalTarget = target;
-            new Popup<>().information(Res.get("guiUtil.openWebBrowser.warning", target))
+            new Popup().information(Res.get("guiUtil.openWebBrowser.warning", target))
                     .actionButtonText(Res.get("guiUtil.openWebBrowser.doOpen"))
                     .onAction(() -> {
                         DontShowAgainLookup.dontShowAgain(OPEN_WEB_PAGE_KEY, true);
@@ -686,7 +686,7 @@ public class GUIUtil {
     public static void showClearXchangeWarning() {
         String key = "confirmClearXchangeRequirements";
         final String currencyName = BisqEnvironment.getBaseCurrencyNetwork().getCurrencyName();
-        new Popup<>().information(Res.get("payment.clearXchange.info", currencyName, currencyName))
+        new Popup().information(Res.get("payment.clearXchange.info", currencyName, currencyName))
                 .width(900)
                 .closeButtonText(Res.get("shared.iConfirm"))
                 .dontShowAgainId(key)
@@ -702,7 +702,7 @@ public class GUIUtil {
 
     public static boolean isBootstrappedOrShowPopup(P2PService p2PService) {
         if (!p2PService.isBootstrapped()) {
-            new Popup<>().information(Res.get("popup.warning.notFullyConnected")).show();
+            new Popup().information(Res.get("popup.warning.notFullyConnected")).show();
             return false;
         }
 
@@ -715,12 +715,12 @@ public class GUIUtil {
         }
 
         if (!walletsSetup.hasSufficientPeersForBroadcast()) {
-            new Popup<>().information(Res.get("popup.warning.notSufficientConnectionsToBtcNetwork", walletsSetup.getMinBroadcastConnections())).show();
+            new Popup().information(Res.get("popup.warning.notSufficientConnectionsToBtcNetwork", walletsSetup.getMinBroadcastConnections())).show();
             return false;
         }
 
         if (!walletsSetup.isDownloadComplete()) {
-            new Popup<>().information(Res.get("popup.warning.downloadNotComplete")).show();
+            new Popup().information(Res.get("popup.warning.downloadNotComplete")).show();
             return false;
         }
 
@@ -729,17 +729,17 @@ public class GUIUtil {
 
     public static boolean canCreateOrTakeOfferOrShowPopup(User user, Navigation navigation) {
         if (!user.hasAcceptedRefundAgents()) {
-            new Popup<>().warning(Res.get("popup.warning.noArbitratorsAvailable")).show();
+            new Popup().warning(Res.get("popup.warning.noArbitratorsAvailable")).show();
             return false;
         }
 
         if (!user.hasAcceptedMediators()) {
-            new Popup<>().warning(Res.get("popup.warning.noMediatorsAvailable")).show();
+            new Popup().warning(Res.get("popup.warning.noMediatorsAvailable")).show();
             return false;
         }
 
         if (user.currentPaymentAccountProperty().get() == null) {
-            new Popup<>().headLine(Res.get("popup.warning.noTradingAccountSetup.headline"))
+            new Popup().headLine(Res.get("popup.warning.noTradingAccountSetup.headline"))
                     .instruction(Res.get("popup.warning.noTradingAccountSetup.msg"))
                     .actionButtonTextWithGoTo("navigation.account")
                     .onAction(() -> {
@@ -753,7 +753,7 @@ public class GUIUtil {
     }
 
     public static void showWantToBurnBTCPopup(Coin miningFee, Coin amount, CoinFormatter btcFormatter) {
-        new Popup<>().warning(Res.get("popup.warning.burnBTC", btcFormatter.formatCoinWithCode(miningFee),
+        new Popup().warning(Res.get("popup.warning.burnBTC", btcFormatter.formatCoinWithCode(miningFee),
                 btcFormatter.formatCoinWithCode(amount))).show();
     }
 
@@ -763,7 +763,7 @@ public class GUIUtil {
 
     public static void reSyncSPVChain(Preferences preferences) {
         try {
-            new Popup<>().feedback(Res.get("settings.net.reSyncSPVSuccess"))
+            new Popup().feedback(Res.get("settings.net.reSyncSPVSuccess"))
                     .useShutDownButton()
                     .actionButtonText(Res.get("shared.shutDown"))
                     .onAction(() -> {
@@ -773,7 +773,7 @@ public class GUIUtil {
                     .hideCloseButton()
                     .show();
         } catch (Throwable t) {
-            new Popup<>().error(Res.get("settings.net.reSyncSPVFailed", t)).show();
+            new Popup().error(Res.get("settings.net.reSyncSPVFailed", t)).show();
         }
     }
 
@@ -781,18 +781,18 @@ public class GUIUtil {
         try {
             FileUtil.renameFile(new File(storageDir, "AddressEntryList"), new File(storageDir, "AddressEntryList_wallet_restore_" + System.currentTimeMillis()));
         } catch (Throwable t) {
-            new Popup<>().error(Res.get("error.deleteAddressEntryListFailed", t)).show();
+            new Popup().error(Res.get("error.deleteAddressEntryListFailed", t)).show();
         }
         walletsManager.restoreSeedWords(
                 seed,
                 () -> UserThread.execute(() -> {
                     log.info("Wallets restored with seed words");
-                    new Popup<>().feedback(Res.get("seed.restore.success")).hideCloseButton().show();
+                    new Popup().feedback(Res.get("seed.restore.success")).hideCloseButton().show();
                     BisqApp.getShutDownHandler().run();
                 }),
                 throwable -> UserThread.execute(() -> {
                     log.error(throwable.toString());
-                    new Popup<>().error(Res.get("seed.restore.error", Res.get("shared.errorMessageInline", throwable)))
+                    new Popup().error(Res.get("seed.restore.error", Res.get("shared.errorMessageInline", throwable)))
                             .show();
                 }));
     }
@@ -928,7 +928,7 @@ public class GUIUtil {
                     txSize / 1000d,
                     type);
         }
-        new Popup<>().headLine(Res.get("dao.feeTx.confirm", type))
+        new Popup().headLine(Res.get("dao.feeTx.confirm", type))
                 .confirmation(confirmationMessage)
                 .actionButtonText(Res.get("shared.yes"))
                 .onAction(actionHandler)


### PR DESCRIPTION
Remove the type parameter `T` from `Popup<T> extends Overlay<Popup>`, as it appears to have never been used or set anywhere in the code. (This mainly involves replacing a lot of `new Popup<>` occurrences, which was done entirely automatically by the IDE.)

I guess the original purpose of the type parameter was to allow different kinds of popup, all extending the same class, e.g. `Foo extends Popup<Foo> extends Overlay<Foo>`. However, due to the fluent interface of `Overlay`, this wouldn't be entirely type safe as long as `Popup` has a public constructor and standalone instances of it can be created. For example,

> `Foo foo = new Popup<Foo>().headline("foo");`

would typecheck fine but throw a `ClassCastException` at runtime, when it tries to assign the underived `Popup` instance to `foo`. (In more complex cases this could cause heap pollution.)

If different popup subclasses are later required, it would probably be better to define an abstract base class but keep all the concrete subclasses non-generic, e.g. `BasePopup<T extends BasePopup<T>> extends Overlay<T>`, similar to the `TabbedOverlay` class.