### PR TITLE
Remove redundant interfaces from SendPrivateNotificationWindow

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/editor/PeerInfoWithTagEditor.java
@@ -245,10 +245,12 @@ public class PeerInfoWithTagEditor extends Overlay<PeerInfoWithTagEditor> {
                 doClose();
                 UserThread.runAfter(() -> {
                     //TODO only taker could send msg as maker would use its own key from offer....
-                    PubKeyRing pubKeyRing = offer.getPubKeyRing();
-                    new SendPrivateNotificationWindow(pubKeyRing, offer.getMakerNodeAddress(), useDevPrivilegeKeys)
-                            .onAddAlertMessage(privateNotificationManager::sendPrivateNotificationMessageIfKeyIsValid)
-                            .show();
+                    new SendPrivateNotificationWindow(
+                            privateNotificationManager,
+                            offer.getPubKeyRing(),
+                            offer.getMakerNodeAddress(),
+                            useDevPrivilegeKeys
+                    ).show();
                 }, 100, TimeUnit.MILLISECONDS);
             }
         };

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendPrivateNotificationWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SendPrivateNotificationWindow.java
@@ -22,6 +22,7 @@ import bisq.desktop.components.InputTextField;
 import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.popups.Popup;
 
+import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.alert.PrivateNotificationPayload;
 import bisq.core.locale.Res;
 
@@ -51,29 +52,13 @@ import static bisq.desktop.util.FormBuilder.addTopLabelTextArea;
 public class SendPrivateNotificationWindow extends Overlay<SendPrivateNotificationWindow> {
     private static final Logger log = LoggerFactory.getLogger(SendPrivateNotificationWindow.class);
 
+    private final PrivateNotificationManager privateNotificationManager;
     private final PubKeyRing pubKeyRing;
     private final NodeAddress nodeAddress;
     private final boolean useDevPrivilegeKeys;
-    private SendPrivateNotificationHandler sendPrivateNotificationHandler;
 
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Interface
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-    public interface SendPrivateNotificationHandler {
-        @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-        boolean handle(PrivateNotificationPayload privateNotification, PubKeyRing pubKeyRing,
-                       NodeAddress nodeAddress, String privKey, SendMailboxMessageListener sendMailboxMessageListener);
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Public API
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-
-    public SendPrivateNotificationWindow(PubKeyRing pubKeyRing, NodeAddress nodeAddress, boolean useDevPrivilegeKeys) {
+    public SendPrivateNotificationWindow(PrivateNotificationManager privateNotificationManager, PubKeyRing pubKeyRing, NodeAddress nodeAddress, boolean useDevPrivilegeKeys) {
+        this.privateNotificationManager = privateNotificationManager;
         this.pubKeyRing = pubKeyRing;
         this.nodeAddress = nodeAddress;
         this.useDevPrivilegeKeys = useDevPrivilegeKeys;
@@ -92,16 +77,6 @@ public class SendPrivateNotificationWindow extends Overlay<SendPrivateNotificati
         display();
     }
 
-    public SendPrivateNotificationWindow onAddAlertMessage(SendPrivateNotificationHandler sendPrivateNotificationHandler) {
-        this.sendPrivateNotificationHandler = sendPrivateNotificationHandler;
-        return this;
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Protected
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
     @Override
     protected void setupKeyHandler(Scene scene) {
         if (!hideCloseButton) {
@@ -115,8 +90,7 @@ public class SendPrivateNotificationWindow extends Overlay<SendPrivateNotificati
     }
 
     private void addContent() {
-        InputTextField keyInputTextField = addInputTextField(gridPane, ++rowIndex,
-                Res.get("shared.unlock"), 10);
+        InputTextField keyInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("shared.unlock"), 10);
         if (useDevPrivilegeKeys)
             keyInputTextField.setText(DevEnv.DEV_PRIVILEGE_PRIV_KEY);
 
@@ -131,7 +105,7 @@ public class SendPrivateNotificationWindow extends Overlay<SendPrivateNotificati
         sendButton.setOnAction(e -> {
             if (alertMessageTextArea.getText().length() > 0 && keyInputTextField.getText().length() > 0) {
                 PrivateNotificationPayload privateNotification = new PrivateNotificationPayload(alertMessageTextArea.getText());
-                if (!sendPrivateNotificationHandler.handle(
+                if (!privateNotificationManager.sendPrivateNotificationMessageIfKeyIsValid(
                         privateNotification,
                         pubKeyRing,
                         nodeAddress,
@@ -177,6 +151,4 @@ public class SendPrivateNotificationWindow extends Overlay<SendPrivateNotificati
         gridPane.getChildren().add(hBox);
         GridPane.setMargin(hBox, new Insets(10, 0, 0, 0));
     }
-
-
 }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -302,9 +302,12 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                     else
                         nodeAddress = selectedDispute.getContract().getSellerNodeAddress();
 
-                    new SendPrivateNotificationWindow(pubKeyRing, nodeAddress, useDevPrivilegeKeys)
-                            .onAddAlertMessage(privateNotificationManager::sendPrivateNotificationMessageIfKeyIsValid)
-                            .show();
+                    new SendPrivateNotificationWindow(
+                            privateNotificationManager,
+                            pubKeyRing,
+                            nodeAddress,
+                            useDevPrivilegeKeys
+                    ).show();
                 }
             } else {
                 handleKeyPressed(event);


### PR DESCRIPTION
It's continuation of changes from [my previous pull request](https://github.com/bisq-network/bisq/pull/3617)