### PR TITLE
Refactor OfferView constructor

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/BuyOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/BuyOfferView.java
@@ -21,6 +21,7 @@ import bisq.desktop.Navigation;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.ViewLoader;
 
+import bisq.core.offer.OfferPayload;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
@@ -44,7 +45,7 @@ public class BuyOfferView extends OfferView {
                 preferences,
                 arbitratorManager,
                 user,
-                p2PService);
+                p2PService,
+                OfferPayload.Direction.BUY);
     }
 }
-

--- a/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
@@ -83,13 +83,14 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
                         Preferences preferences,
                         ArbitratorManager arbitratorManager,
                         User user,
-                        P2PService p2PService) {
+                        P2PService p2PService,
+                        OfferPayload.Direction direction) {
         this.viewLoader = viewLoader;
         this.navigation = navigation;
         this.preferences = preferences;
         this.user = user;
         this.p2PService = p2PService;
-        this.direction = (this instanceof BuyOfferView) ? OfferPayload.Direction.BUY : OfferPayload.Direction.SELL;
+        this.direction = direction;
         this.arbitratorManager = arbitratorManager;
     }
 
@@ -133,7 +134,7 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
 
     @Override
     protected void activate() {
-        Optional<TradeCurrency> tradeCurrencyOptional = (this instanceof SellOfferView) ?
+        Optional<TradeCurrency> tradeCurrencyOptional = (this.direction == OfferPayload.Direction.SELL) ?
                 CurrencyUtil.getTradeCurrency(preferences.getSellScreenCurrencyCode()) :
                 CurrencyUtil.getTradeCurrency(preferences.getBuyScreenCurrencyCode());
         tradeCurrency = tradeCurrencyOptional.orElseGet(GlobalSettings::getDefaultTradeCurrency);

--- a/desktop/src/main/java/bisq/desktop/main/offer/SellOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/SellOfferView.java
@@ -21,6 +21,7 @@ import bisq.desktop.Navigation;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.common.view.ViewLoader;
 
+import bisq.core.offer.OfferPayload;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
@@ -44,7 +45,7 @@ public class SellOfferView extends OfferView {
                 preferences,
                 arbitratorManager,
                 user,
-                p2PService);
+                p2PService,
+                OfferPayload.Direction.SELL);
     }
 }
-


### PR DESCRIPTION
`direction` is now passed directly to `OfferView` constructor, instead of doing `(this instanceof BuyOfferView)` checks in superclass.

Before that is was hard to check what is difference between `SellOfferView` and `BuyOfferView` classes.