### PR TITLE
Prevent taking of offers with unequal bank account types (excl. SEPA)

### DIFF
--- a/core/src/main/java/bisq/core/payment/ReceiptValidator.java
+++ b/core/src/main/java/bisq/core/payment/ReceiptValidator.java
@@ -66,10 +66,15 @@ class ReceiptValidator {
             return true;
         }
 
+        // Aside from Sepa or Sepa Instant, payment methods need to match
+        if (!isEqualPaymentMethods) {
+            return false;
+        }
+
         if (predicates.isOfferRequireSameOrSpecificBank(offer, account)) {
             return predicates.isMatchingBankId(offer, account);
         }
 
-        return isEqualPaymentMethods;
+        return true;
     }
 }

--- a/core/src/test/java/bisq/core/payment/ReceiptValidatorTest.java
+++ b/core/src/test/java/bisq/core/payment/ReceiptValidatorTest.java
@@ -18,17 +18,18 @@
 package bisq.core.payment;
 
 import bisq.core.offer.Offer;
-import bisq.core.payment.payload.PaymentMethod;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ReceiptValidatorTest {
     private ReceiptValidator validator;
     private PaymentAccount account;
@@ -41,6 +42,11 @@ public class ReceiptValidatorTest {
         this.account = mock(CountryBasedPaymentAccount.class);
         this.offer = mock(Offer.class);
         this.validator = new ReceiptValidator(offer, account, predicates);
+    }
+
+    @After
+    public void tearDown() {
+        verifyZeroInteractions(offer);
     }
 
     @Test
@@ -172,10 +178,6 @@ public class ReceiptValidatorTest {
     public void testIsValidWhenWesternUnionAccount() {
         account = mock(WesternUnionAccount.class);
 
-        PaymentMethod.WESTERN_UNION = mock(PaymentMethod.class);
-
-        when(offer.getPaymentMethod()).thenReturn(PaymentMethod.WESTERN_UNION);
-
         when(predicates.isMatchingCurrency(offer, account)).thenReturn(true);
         when(predicates.isEqualPaymentMethods(offer, account)).thenReturn(true);
         when(predicates.isMatchingCountryCodes(offer, account)).thenReturn(true);
@@ -202,17 +204,14 @@ public class ReceiptValidatorTest {
     public void testIsValidWhenMoneyGramAccount() {
         account = mock(MoneyGramAccount.class);
 
-        PaymentMethod.MONEY_GRAM = mock(PaymentMethod.class);
-
-        when(offer.getPaymentMethod()).thenReturn(PaymentMethod.MONEY_GRAM);
-
         when(predicates.isMatchingCurrency(offer, account)).thenReturn(true);
         when(predicates.isEqualPaymentMethods(offer, account)).thenReturn(true);
-        when(predicates.isMatchingCountryCodes(offer, account)).thenReturn(false);
-        when(predicates.isMatchingSepaOffer(offer, account)).thenReturn(false);
-        when(predicates.isMatchingSepaInstant(offer, account)).thenReturn(false);
-        when(predicates.isOfferRequireSameOrSpecificBank(offer, account)).thenReturn(false);
 
         assertTrue(new ReceiptValidator(offer, account, predicates).isValid());
+
+        verify(predicates, never()).isMatchingCountryCodes(offer, account);
+        verify(predicates, never()).isMatchingSepaOffer(offer, account);
+        verify(predicates, never()).isMatchingSepaInstant(offer, account);
+        verify(predicates, never()).isOfferRequireSameOrSpecificBank(offer, account);
     }
 }

--- a/core/src/test/java/bisq/core/payment/ReceiptValidatorTest.java
+++ b/core/src/test/java/bisq/core/payment/ReceiptValidatorTest.java
@@ -175,6 +175,57 @@ public class ReceiptValidatorTest {
     }
 
     @Test
+    // Same or Specific Bank offers can't be taken by National Bank accounts. TODO: Consider partially relaxing to allow Specific Banks.
+    public void testIsValidWhenNationalBankAccountAndOfferIsNot() {
+        account = mock(NationalBankAccount.class);
+
+        when(predicates.isMatchingCurrency(offer, account)).thenReturn(true);
+        when(predicates.isEqualPaymentMethods(offer, account)).thenReturn(false);
+        when(predicates.isMatchingCountryCodes(offer, account)).thenReturn(true);
+        when(predicates.isMatchingSepaOffer(offer, account)).thenReturn(false);
+        when(predicates.isMatchingSepaInstant(offer, account)).thenReturn(false);
+
+        assertFalse(new ReceiptValidator(offer, account, predicates).isValid());
+
+        verify(predicates, never()).isOfferRequireSameOrSpecificBank(offer, account);
+        verify(predicates, never()).isMatchingBankId(offer, account);
+    }
+
+    @Test
+    // National or Same Bank offers can't be taken by Specific Banks accounts. TODO: Consider partially relaxing to allow National Bank.
+    public void testIsValidWhenSpecificBanksAccountAndOfferIsNot() {
+        account = mock(SpecificBanksAccount.class);
+
+        when(predicates.isMatchingCurrency(offer, account)).thenReturn(true);
+        when(predicates.isEqualPaymentMethods(offer, account)).thenReturn(false);
+        when(predicates.isMatchingCountryCodes(offer, account)).thenReturn(true);
+        when(predicates.isMatchingSepaOffer(offer, account)).thenReturn(false);
+        when(predicates.isMatchingSepaInstant(offer, account)).thenReturn(false);
+
+        assertFalse(new ReceiptValidator(offer, account, predicates).isValid());
+
+        verify(predicates, never()).isOfferRequireSameOrSpecificBank(offer, account);
+        verify(predicates, never()).isMatchingBankId(offer, account);
+    }
+
+    @Test
+    // National or Specific Bank offers can't be taken by Same Bank accounts.
+    public void testIsValidWhenSameBankAccountAndOfferIsNot() {
+        account = mock(SameBankAccount.class);
+
+        when(predicates.isMatchingCurrency(offer, account)).thenReturn(true);
+        when(predicates.isEqualPaymentMethods(offer, account)).thenReturn(false);
+        when(predicates.isMatchingCountryCodes(offer, account)).thenReturn(true);
+        when(predicates.isMatchingSepaOffer(offer, account)).thenReturn(false);
+        when(predicates.isMatchingSepaInstant(offer, account)).thenReturn(false);
+
+        assertFalse(new ReceiptValidator(offer, account, predicates).isValid());
+
+        verify(predicates, never()).isOfferRequireSameOrSpecificBank(offer, account);
+        verify(predicates, never()).isMatchingBankId(offer, account);
+    }
+
+    @Test
     public void testIsValidWhenWesternUnionAccount() {
         account = mock(WesternUnionAccount.class);
 


### PR DESCRIPTION
Use stricter criteria when deciding which of the taker's accounts (if any) are valid for a given offer. Specifically, prevent National Bank accounts from being used to take Same / Specific Bank(s) offers, so the three payment method types can never being mixed.

This prevents an error on the trading peer when the trade starts, due to enforcement of equal maker & taker payment method IDs (except for SEPA) in the Contract payload constructor.

This partially addresses #3602, where the erroneous peer response caused the taker to be presented with a confusing timeout, after they managed to take a _SAME_BANK_ offer using their _NATIONAL_BANK_ account. With this change, the taker would be directed to create a separate _SAME_BANK_ account if they don't have one already (which would then be automatically selected).

(Later, it might be worthwhile to make a more substantial change to allow National, Same or Specific Bank account types to be mixed under certain circumstances when trading, but that could be complicated by the peer running an older version.)