### PR TITLE
Use correct monetary format in BsqFormatter

### DIFF
--- a/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
@@ -72,22 +72,12 @@ public class BsqFormatter implements CoinFormatter {
 
     @Inject
     public BsqFormatter() {
-        this.monetaryFormat = BisqEnvironment.getParameters().getMonetaryFormat();
-        this.immutableCoinFormatter = new ImmutableCoinFormatter(BisqEnvironment.getParameters().getMonetaryFormat());
+        this.btcCoinFormat = BisqEnvironment.getParameters().getMonetaryFormat();
+        this.monetaryFormat = new MonetaryFormat().shift(6).code(6, "BSQ").minDecimals(2);
+        this.immutableCoinFormatter = new ImmutableCoinFormatter(monetaryFormat);
 
         GlobalSettings.localeProperty().addListener((observable, oldValue, newValue) -> switchLocale(newValue));
         switchLocale(GlobalSettings.getLocale());
-
-        btcCoinFormat = monetaryFormat;
-
-        final String baseCurrencyCode = BisqEnvironment.getBaseCurrencyNetwork().getCurrencyCode();
-        switch (baseCurrencyCode) {
-            case "BTC":
-                monetaryFormat = new MonetaryFormat().shift(6).code(6, "BSQ").minDecimals(2);
-                break;
-            default:
-                throw new RuntimeException("baseCurrencyCode not defined. baseCurrencyCode=" + baseCurrencyCode);
-        }
 
         amountFormat.setMinimumFractionDigits(2);
     }


### PR DESCRIPTION
Also remove logic regarding base currency. Only BTC is currently
supported so there is no need to keep the logic around.

Fixes https://github.com/bisq-network/bisq/issues/3672