### PR TITLE
Added a Pull Request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- 
+- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
+- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
+- pick a descriptive title
+- provide some meaningful PR description below
+- create the PR
+- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
+- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
+-->
+
+Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr
+
+Your PR description here.


### PR DESCRIPTION
In order to streamline our reviewing process and thus, get more PR reviewed and subsequently merged in less time, I added a simple pull request template.

Main points:
- highlight to re-request a review after you addressed the requested changes in order for us to not loose track of your PR
- prefill github keywords for closing issues, as these are not always used correctly