### PR TITLE
Use 2of2 multisig deposit tx version for manual payout

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
 
 import static bisq.desktop.util.FormBuilder.addInputTextField;
 
-// We dont translate here as it is for dev only purpose
+// We don't translate here as it is for dev only purpose
 public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
     private static final Logger log = LoggerFactory.getLogger(ManualPayoutTxWindow.class);
     private final TradeWalletService tradeWalletService;
@@ -105,34 +105,28 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
 
         InputTextField buyerPayoutAmount = addInputTextField(gridPane, ++rowIndex, "buyerPayoutAmount");
         InputTextField sellerPayoutAmount = addInputTextField(gridPane, ++rowIndex, "sellerPayoutAmount");
-        InputTextField arbitratorPayoutAmount = addInputTextField(gridPane, ++rowIndex, "arbitratorPayoutAmount");
         InputTextField txFee = addInputTextField(gridPane, ++rowIndex, "Tx fee");
 
         InputTextField buyerAddressString = addInputTextField(gridPane, ++rowIndex, "buyerAddressString");
         InputTextField sellerAddressString = addInputTextField(gridPane, ++rowIndex, "sellerAddressString");
-        InputTextField arbitratorAddressString = addInputTextField(gridPane, ++rowIndex, "arbitratorAddressString");
 
         InputTextField buyerPrivateKeyAsHex = addInputTextField(gridPane, ++rowIndex, "buyerPrivateKeyAsHex");
         InputTextField sellerPrivateKeyAsHex = addInputTextField(gridPane, ++rowIndex, "sellerPrivateKeyAsHex");
-        InputTextField arbitratorPrivateKeyAsHex = addInputTextField(gridPane, ++rowIndex, "arbitratorPrivateKeyAsHex");
 
         InputTextField buyerPubKeyAsHex = addInputTextField(gridPane, ++rowIndex, "buyerPubKeyAsHex");
         InputTextField sellerPubKeyAsHex = addInputTextField(gridPane, ++rowIndex, "sellerPubKeyAsHex");
-        InputTextField arbitratorPubKeyAsHex = addInputTextField(gridPane, ++rowIndex, "arbitratorPubKeyAsHex");
 
         // Notes:
-        // Open with alt+g and enable DEV mode
+        // Open with alt+g
         // Priv key is only visible if pw protection is removed (wallet details data (alt+j))
         // Take missing buyerPubKeyAsHex and sellerPubKeyAsHex from contract data!
         // Lookup sellerPrivateKeyAsHex associated with sellerPubKeyAsHex (or buyers) in wallet details data
         // sellerPubKeys/buyerPubKeys are auto generated if used the fields below
-        // Never set the priv arbitr. key here!
 
         depositTxHex.setText("");
 
         buyerPayoutAmount.setText("");
         sellerPayoutAmount.setText("");
-        arbitratorPayoutAmount.setText("0");
 
         buyerAddressString.setText("");
         buyerPubKeyAsHex.setText("");
@@ -141,9 +135,6 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
         sellerAddressString.setText("");
         sellerPubKeyAsHex.setText("");
         sellerPrivateKeyAsHex.setText("");
-
-        arbitratorAddressString.setText("");
-        arbitratorPubKeyAsHex.setText("");
 
         actionButtonText("Sign and publish transaction");
 
@@ -166,20 +157,16 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
         onAction(() -> {
             if (GUIUtil.isReadyForTxBroadcastOrShowPopup(p2PService, walletsSetup)) {
                 try {
-                    tradeWalletService.emergencySignAndPublishPayoutTxFrom2of3MultiSig(depositTxHex.getText(),
+                    tradeWalletService.emergencySignAndPublishPayoutTxFrom2of2MultiSig(depositTxHex.getText(),
                             Coin.parseCoin(buyerPayoutAmount.getText()),
                             Coin.parseCoin(sellerPayoutAmount.getText()),
-                            Coin.parseCoin(arbitratorPayoutAmount.getText()),
                             Coin.parseCoin(txFee.getText()),
                             buyerAddressString.getText(),
                             sellerAddressString.getText(),
-                            arbitratorAddressString.getText(),
                             buyerPrivateKeyAsHex.getText(),
                             sellerPrivateKeyAsHex.getText(),
-                            arbitratorPrivateKeyAsHex.getText(),
                             buyerPubKeyAsHex.getText(),
                             sellerPubKeyAsHex.getText(),
-                            arbitratorPubKeyAsHex.getText(),
                             callback);
                 } catch (AddressFormatException | WalletException | TransactionVerificationException e) {
                     log.error(e.toString());


### PR DESCRIPTION
With v1.2 we use 2of2 multisig for deposit tx. This commit changes the
manual payout window to reflect that.

- Remove unused code from legacy arbitration
- Fix comments