### PR TITLE
Update dao-setup doc to include bloom filter for newer bitcoincore v0.19.0.1

### DIFF
--- a/docs/dao-setup.md
+++ b/docs/dao-setup.md
@@ -16,6 +16,8 @@ regtest=1
 # The default rpcPort for regtest from Bitcoin Core 0.16 and higher is: 18443
 # The default rpcPort for testnet is: 18332
 # For mainnet: 8332
+[regtest]
+peerbloomfilters=1
 rpcport=18443
 
 server=1
@@ -32,6 +34,8 @@ regtest=1
 # The default rpcPort for regtest from Bitcoin Core 0.16 and higher is: 18443
 # The default rpcPort for testnet is: 18332
 # For mainnet: 8332
+[regtest]
+peerbloomfilters=1
 rpcport=18443
 
 server=1
@@ -48,6 +52,8 @@ regtest=1
 # The default rpcPort for regtest from Bitcoin Core 0.16 and higher is: 18443
 # The default rpcPort for testnet is: 18332
 # For mainnet: 8332
+[regtest]
+peerbloomfilters=1
 rpcport=18443
 
 server=1


### PR DESCRIPTION
My dao setup was not synchronizing due to latest bitcoin core updation. 
using @ripcurlx's hint, i have added bloom filter then it worked. so proposed doc changes according to it.