### PR TITLE
Add Makefile for automating localnet setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[Makefile]
+indent_style = tab
+
 [*.bat]
 end_of_line = crlf
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ deploy
 /monitor/TorHiddenServiceStartupTimeTests/*
 /monitor/monitor-tor/*
 .java-version
-localnet
+.localnet

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ deploy
 /monitor/TorHiddenServiceStartupTimeTests/*
 /monitor/monitor-tor/*
 .java-version
+localnet

--- a/Makefile
+++ b/Makefile
@@ -153,10 +153,15 @@ deploy: setup
 	# create a new screen session named 'localnet'
 	screen -dmS localnet
 	# deploy each node in its own named screen window
-	targets=('bitcoind' 'seednode' 'seednode2' 'alice' 'bob' 'mediator'); \
-	for t in "$${targets[@]}"; do \
-		screen -S localnet -X screen -t $$t; \
-		screen -S localnet -p $$t -X stuff "make $$t\n"; \
+	for target in \
+			bitcoind \
+			seednode \
+			seednode2 \
+			alice \
+			bob \
+			mediator; do \
+		screen -S localnet -X screen -t $$target; \
+		screen -S localnet -p $$target -X stuff "make $$target\n"; \
 	done;
 	# give bitcoind rpc server time to start
 	sleep 5

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@
 #     bisq-seednode
 #     bisq-statsnode
 #
-#  - You will see a new 'localnet' directory containing the data dirs
+#  - You will see a new '.localnet' directory containing the data dirs
 #  for your regtest Bitcoin and Bisq nodes. Once you've deployed
 #  them in the step below, the directory will look as follows:
 #
-#     $ tree -d -L 1 localnet
-#     localnet
+#     $ tree -d -L 1 .localnet
+#     .localnet
 #     ├── alice
 #     ├── bitcoind
 #     ├── bob
@@ -101,6 +101,7 @@
 # cases.
 #
 
+STATE_DIR := .localnet
 
 # Set up everything necessary for deploying your localnet. This is the
 # default target.
@@ -112,7 +113,7 @@ clean-build:
 	./gradlew clean
 
 clean-localnet:
-	rm -rf localnet
+	rm -rf $(STATE_DIR)
 
 # Build all Bisq binaries and generate the shell scripts used to run
 # them in the targets below
@@ -127,16 +128,16 @@ localnet:
 	# and intuitive naming. This is a temporary measure until we clean these
 	# resources up more thoroughly.
 	unzip docs/dao-setup.zip
-	mv dao-setup localnet
-	mv localnet/Bitcoin-regtest localnet/bitcoind
-	mv localnet/bisq-BTC_REGTEST_Alice_dao localnet/alice
-	mv localnet/bisq-BTC_REGTEST_Bob_dao localnet/bob
+	mv dao-setup $(STATE_DIR)
+	mv $(STATE_DIR)/Bitcoin-regtest $(STATE_DIR)/bitcoind
+	mv $(STATE_DIR)/bisq-BTC_REGTEST_Alice_dao $(STATE_DIR)/alice
+	mv $(STATE_DIR)/bisq-BTC_REGTEST_Bob_dao $(STATE_DIR)/bob
 	# Remove the preconfigured bitcoin.conf in favor of explicitly
 	# parameterizing the invocation of bitcoind in the target below
-	rm -v localnet/bitcoind/bitcoin.conf
+	rm -v $(STATE_DIR)/bitcoind/bitcoin.conf
 	# Avoid spurious 'runCommand' errors in the bitcoind log when nc
 	# fails to bind to one of the listed block notification ports
-	echo exit 0 >> localnet/bitcoind/blocknotify
+	echo exit 0 >> $(STATE_DIR)/bitcoind/blocknotify
 
 # Deploy a complete localnet by running all required Bitcoin and Bisq
 # nodes, each in their own named screen window. If you are not a screen
@@ -163,8 +164,8 @@ bitcoind: localnet
 		-server \
 		-rpcuser=bisqdao \
 		-rpcpassword=bsq \
-		-datadir=localnet/bitcoind \
-		-blocknotify='localnet/bitcoind/blocknotify %s'
+		-datadir=$(STATE_DIR)/bitcoind \
+		-blocknotify='$(STATE_DIR)/bitcoind/blocknotify %s'
 
 seednode: build
 	./bisq-seednode \
@@ -176,7 +177,7 @@ seednode: build
 		--rpcPassword=bsq \
 		--rpcBlockNotificationPort=5120 \
 		--nodePort=2002 \
-		--userDataDir=localnet \
+		--userDataDir=$(STATE_DIR) \
 		--appName=seednode
 
 seednode2: build
@@ -189,7 +190,7 @@ seednode2: build
 		--rpcPassword=bsq \
 		--rpcBlockNotificationPort=5121 \
 		--nodePort=3002 \
-		--userDataDir=localnet \
+		--userDataDir=$(STATE_DIR) \
 		--appName=seednode2
 
 mediator: build
@@ -198,7 +199,7 @@ mediator: build
 		--useLocalhostForP2P=true \
 		--useDevPrivilegeKeys=true \
 		--nodePort=4444 \
-		--appDataDir=localnet/mediator \
+		--appDataDir=$(STATE_DIR)/mediator \
 		--appName=Mediator
 
 alice: setup
@@ -213,7 +214,7 @@ alice: setup
 		--rpcBlockNotificationPort=5122 \
 		--genesisBlockHeight=111 \
 		--genesisTxId=30af0050040befd8af25068cc697e418e09c2d8ebd8d411d2240591b9ec203cf \
-		--appDataDir=localnet/alice \
+		--appDataDir=$(STATE_DIR)/alice \
 		--appName=Alice
 
 bob: setup
@@ -222,7 +223,7 @@ bob: setup
 		--useLocalhostForP2P=true \
 		--useDevPrivilegeKeys=true \
 		--nodePort=6666 \
-		--appDataDir=localnet/bob \
+		--appDataDir=$(STATE_DIR)/bob \
 		--appName=Bob
 
 # Generate a new block on your Bitcoin regtest network. Requires that

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ build:
 # Unpack and customize a Bitcoin regtest node and Alice and Bob Bisq
 # nodes that have been preconfigured with a blockchain containing the
 # BSQ genesis transaction
-localnet: clean-localnet
+localnet:
 	# Unpack the old dao-setup.zip and move things around for more concise
 	# and intuitive naming. This is a temporary measure until we clean these
 	# resources up more thoroughly.

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,14 @@ deploy: setup
 	# generate a block to ensure Bisq nodes get dao-synced
 	make block
 
+# Undeploy a running localnet by killing all Bitcoin and Bisq
+# node processes, then killing the localnet screen session altogether
+undeploy:
+	# kill all Bitcoind and Bisq nodes running in screen windows
+	screen -S localnet -X at "#" stuff "^C"
+	# quit all screen windows which results in killing the session
+	screen -S localnet -X at "#" kill
+
 bitcoind: .localnet
 	bitcoind \
 		-regtest \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,242 @@
+#
+# INTRODUCTION
+#
+# This makefile is designed to help Bisq contributors get up and running
+# as quickly as possible with a local regtest Bisq network deployment,
+# or 'localnet' for short. A localnet is a complete and self-contained
+# "mini Bisq network" suitable for development and end-to-end testing
+# efforts.
+#
+#
+# REQUIREMENTS
+#
+# You'll need the following to proceed:
+#
+#  - Linux, macOS or similar *nix with standard tools like `make`
+#  - bitcoind and bitcoin-cli (`brew install bitcoin` on macOS)
+#  - JDK 10 to build and run Bisq binaries; see
+#    https://www.oracle.com/java/technologies/java-archive-javase10-downloads.html
+#
+#
+# USAGE
+#
+# The following commands (and a couple manual instructions) will get your
+# localnet up and running quickly.
+#
+# STEP 1: Build all Bisq binaries and set up localnet resources. This will
+# take a few minutes the first time through.
+#
+#     $ make
+#
+# Notes:
+#
+#  - When complete, you'll have a number of scripts available in the
+#  root directory. They will be used in the make targets below to start
+#  the various Bisq seed and desktop nodes that will make up your
+#  localnet:
+#
+#     $ ls -1 bisq-*
+#     bisq-desktop
+#     bisq-monitor
+#     bisq-pricenode
+#     bisq-relay
+#     bisq-seednode
+#     bisq-statsnode
+#
+#  - You will see a new 'localnet' directory containing the data dirs
+#  for your regtest Bitcoin and Bisq nodes. Once you've deployed
+#  them in the step below, the directory will look as follows:
+#
+#     $ tree -d -L 1 localnet
+#     localnet
+#     ├── alice
+#     ├── bitcoind
+#     ├── bob
+#     ├── mediator
+#     ├── seednode
+#     └── seednode2
+#
+# STEP 2: Deploy the Bitcoin and Bisq nodes that make up the localnet.
+# Run each of the following in a SEPARATE TERMINAL WINDOW, as they are
+# long-running processes.
+#
+#     $ make bitcoind
+#     $ make seednode
+#     $ make seednode2
+#     $ make mediator
+#     $ make alice
+#     $ make bob
+#
+#  Tip: Those familiar with the `screen` terminal multiplexer can
+#  automate the above by running the `deploy` target found below.
+#
+#  Notes:
+#
+#    - The 'seednode' targets launch headless Bisq nodes that help
+#    desktop nodes discover other peers, as well as storing and
+#    forwarding p2p network messages for nodes as they go on and
+#    offline.
+#
+#    - As you run the 'mediator', 'alice' and 'bob' targets above,
+#    you'll see a Bisq desktop node window appear for each. The Alice
+#    and Bob instances represent two traders who can make and take
+#    offers with one another. The Mediator instance represents a Bisq
+#    contributor who can help resolve any technical problems or disputes
+#    that come up between the two traders.
+#
+# STEP 3: Configure the mediator Bisq node. In order to make and take
+# offers, Alice and Bob will need to have a mediator and a refund agent
+# registered on the network. Follow the instructions below to complete
+# that process:
+#
+#  a) Go to the Account screen in the Mediator instance and press CMD+N
+#  and a popup will appear. Click 'Unlock' and then click 'Register' to
+#  register the instance as a mediator.
+#
+#  b) While still in the Account screen, press CMD+D and follow the same
+#  steps as above to register the instance as a refund agent.
+#
+# When the steps above are complete, your localnet should be up and
+# ready to use. You can now test in isolation all Bisq features and use
+# cases.
+#
+
+
+# Set up everything necessary for deploying your localnet. This is the
+# default target.
+setup: build localnet
+
+clean: clean-build clean-localnet
+
+clean-build:
+	./gradlew clean
+
+clean-localnet:
+	rm -rf localnet
+
+# Build all Bisq binaries and generate the shell scripts used to run
+# them in the targets below
+build:
+	./gradlew build
+
+# Unpack and customize a Bitcoin regtest node and Alice and Bob Bisq
+# nodes that have been preconfigured with a blockchain containing the
+# BSQ genesis transaction
+localnet:
+	# Unpack the old dao-setup.zip and move things around for more concise
+	# and intuitive naming. This is a temporary measure until we clean these
+	# resources up more thoroughly.
+	unzip docs/dao-setup.zip
+	mv dao-setup localnet
+	mv localnet/Bitcoin-regtest localnet/bitcoind
+	mv localnet/bisq-BTC_REGTEST_Alice_dao localnet/alice
+	mv localnet/bisq-BTC_REGTEST_Bob_dao localnet/bob
+	# Remove the preconfigured bitcoin.conf in favor of explicitly
+	# parameterizing the invocation of bitcoind in the target below
+	rm -v localnet/bitcoind/bitcoin.conf
+	# Avoid spurious 'runCommand' errors in the bitcoind log when nc
+	# fails to bind to one of the listed block notification ports
+	echo exit 0 >> localnet/bitcoind/blocknotify
+
+# Deploy a complete localnet by running all required Bitcoin and Bisq
+# nodes, each in their own named screen window. If you are not a screen
+# user, you'll need to run each of the make commands manually in a
+# separate terminal or as a background job.
+#
+# NOTE: You MUST already be attached to a screen session for the
+# following commands to work properly.
+deploy: setup
+	screen -t bitcoin make bitcoind
+	sleep 2    # wait for bitcoind rpc server to start
+	make block # generate a block to ensure Bisq nodes get dao-synced
+	screen -t seednode make seednode
+	screen -t seednode2 make seednode2
+	screen -t alice make alice
+	screen -t bob make bob
+	screen -t mediator make mediator
+
+bitcoind: localnet
+	bitcoind \
+		-regtest \
+		-prune=0 \
+		-txindex=1 \
+		-server \
+		-rpcuser=bisqdao \
+		-rpcpassword=bsq \
+		-datadir=localnet/bitcoind \
+		-blocknotify='localnet/bitcoind/blocknotify %s'
+
+seednode: build
+	./bisq-seednode \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--fullDaoNode=true \
+		--rpcUser=bisqdao \
+		--rpcPassword=bsq \
+		--rpcBlockNotificationPort=5120 \
+		--nodePort=2002 \
+		--userDataDir=localnet \
+		--appName=seednode
+
+seednode2: build
+	./bisq-seednode \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--fullDaoNode=true \
+		--rpcUser=bisqdao \
+		--rpcPassword=bsq \
+		--rpcBlockNotificationPort=5121 \
+		--nodePort=3002 \
+		--userDataDir=localnet \
+		--appName=seednode2
+
+mediator: build
+	./bisq-desktop \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--nodePort=4444 \
+		--appDataDir=localnet/mediator \
+		--appName=Mediator
+
+alice: setup
+	./bisq-desktop \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--nodePort=5555 \
+		--fullDaoNode=true \
+		--rpcUser=bisqdao \
+		--rpcPassword=bsq \
+		--rpcBlockNotificationPort=5122 \
+		--genesisBlockHeight=111 \
+		--genesisTxId=30af0050040befd8af25068cc697e418e09c2d8ebd8d411d2240591b9ec203cf \
+		--appDataDir=localnet/alice \
+		--appName=Alice
+
+bob: setup
+	./bisq-desktop \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--nodePort=6666 \
+		--appDataDir=localnet/bob \
+		--appName=Bob
+
+# Generate a new block on your Bitcoin regtest network. Requires that
+# bitcoind is already running. See the `bitcoind` target above.
+block:
+	bitcoin-cli \
+		-regtest \
+		-rpcuser=bisqdao \
+		-rpcpassword=bsq \
+		getnewaddress \
+		| xargs bitcoin-cli \
+				-regtest \
+				-rpcuser=bisqdao \
+				-rpcpassword=bsq \
+				generatetoaddress 1
+
+.PHONY: seednode

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ clean-build:
 
 clean-localnet:
 	rm -rf $(STATE_DIR)
+	rm -rf ./dao-setup
 
 # Build all Bisq binaries and generate the shell scripts used to run
 # them in the targets below
@@ -123,7 +124,7 @@ build:
 # Unpack and customize a Bitcoin regtest node and Alice and Bob Bisq
 # nodes that have been preconfigured with a blockchain containing the
 # BSQ genesis transaction
-localnet:
+localnet: clean-localnet
 	# Unpack the old dao-setup.zip and move things around for more concise
 	# and intuitive naming. This is a temporary measure until we clean these
 	# resources up more thoroughly.

--- a/Makefile
+++ b/Makefile
@@ -241,4 +241,4 @@ block:
 				-rpcpassword=bsq \
 				generatetoaddress 1
 
-.PHONY: seednode
+.PHONY: build seednode

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@
 #
 # USAGE
 #
-# The following commands (and a couple manual instructions) will get your
-# localnet up and running quickly.
+# The following commands (and a couple manual instructions) will get
+# your localnet up and running quickly.
 #
-# STEP 1: Build all Bisq binaries and set up localnet resources. This will
-# take a few minutes the first time through.
+# STEP 1: Build all Bisq binaries and set up localnet resources. This
+# will take a few minutes the first time through.
 #
 #     $ make
 #
@@ -44,8 +44,8 @@
 #     bisq-statsnode
 #
 #  - You will see a new '.localnet' directory containing the data dirs
-#  for your regtest Bitcoin and Bisq nodes. Once you've deployed
-#  them in the step below, the directory will look as follows:
+#  for your regtest Bitcoin and Bisq nodes. Once you've deployed them in
+#  the step below, the directory will look as follows:
 #
 #     $ tree -d -L 1 .localnet
 #     .localnet
@@ -122,9 +122,9 @@ build:
 # nodes that have been preconfigured with a blockchain containing the
 # BSQ genesis transaction
 .localnet:
-	# Unpack the old dao-setup.zip and move things around for more concise
-	# and intuitive naming. This is a temporary measure until we clean these
-	# resources up more thoroughly.
+	# Unpack the old dao-setup.zip and move things around for more
+	# concise and intuitive naming. This is a temporary measure until we
+	# clean these resources up more thoroughly.
 	unzip docs/dao-setup.zip
 	mv dao-setup .localnet
 	mv .localnet/Bitcoin-regtest .localnet/bitcoind

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ bitcoind: .localnet
 		-regtest \
 		-prune=0 \
 		-txindex=1 \
+		-peerbloomfilters=1 \
 		-server \
 		-rpcuser=bisqdao \
 		-rpcpassword=bsq \

--- a/Makefile
+++ b/Makefile
@@ -108,15 +108,19 @@ setup: build .localnet
 clean: clean-build clean-localnet
 
 clean-build:
-	rm -rf build
+	./gradlew clean
 
 clean-localnet:
 	rm -rf .localnet ./dao-setup
 
-# Build all Bisq binaries and generate the shell scripts used to run
-# them in the targets below
-build:
-	./gradlew build
+# Build Bisq binaries and shell scripts used in the targets below
+build: seednode/build desktop/build
+
+seednode/build:
+	./gradlew :seednode:build
+
+desktop/build:
+	./gradlew :desktop:build
 
 # Unpack and customize a Bitcoin regtest node and Alice and Bob Bisq
 # nodes that have been preconfigured with a blockchain containing the
@@ -171,7 +175,7 @@ bitcoind: .localnet
 		-datadir=.localnet/bitcoind \
 		-blocknotify='.localnet/bitcoind/blocknotify %s'
 
-seednode: build
+seednode: seednode/build
 	./bisq-seednode \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
@@ -184,7 +188,7 @@ seednode: build
 		--userDataDir=.localnet \
 		--appName=seednode
 
-seednode2: build
+seednode2: seednode/build
 	./bisq-seednode \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
@@ -197,7 +201,7 @@ seednode2: build
 		--userDataDir=.localnet \
 		--appName=seednode2
 
-mediator: build
+mediator: desktop/build
 	./bisq-desktop \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
@@ -244,4 +248,4 @@ block:
 				-rpcpassword=bsq \
 				generatetoaddress 1
 
-.PHONY: seednode
+.PHONY: build seednode

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,9 @@
  - [CONTRIBUTING.md](../CONTRIBUTING.md): Understand Bisq's contribution and compensation guidelines
  - [build.md](build.md): Build and run Bisq at the command line
  - [idea-import.md](idea-import.md): Import Bisq sources into IntelliJ IDEA
- - [dev-setup.md](dev-setup.md): Set up a self-contained local Bisq network on Bitcoin regtest
- - [dao-setup.md](dao-setup.md): Set up a complete Bisq DAO development environment
+ - [Makefile](../Makefile): (new) Set up a self-contained local Bisq network on Bitcoin regtest
+ - [dev-setup.md](dev-setup.md): (deprecated) Set up a self-contained local Bisq network on Bitcoin regtest
+ - [dao-setup.md](dao-setup.md): (deprecated) Set up a complete Bisq DAO development environment
  - [testing.md](testing.md): Learn about the Bisq testing process and how you can contribute.
 
 Looking for user-facing documentation? See https://docs.bisq.network.


### PR DESCRIPTION
Problem: contributors old and new must read and follow many manual steps
spread across three documents (docs/{build,dev-setup,dao-setup}.md) in
order to get up and running with a local regtest Bisq network deployment
suitable for isolated development and end-to-end testing. This process
is not only manual, but requires considerable trial and error for most
contributors, and can amount to hours of effort. Perhaps most
detrimental is that this friction makes it much less likely that we get
"all hands on deck" to cover test scenarios at release time. Getting up
and running with what this change refers to as a "localnet" should be
among the very first things a new contributor does. It should be fast
and easy, maximizing the contributor's ability to get productive right
away.

Solution: this commit introduces a simple and well-documented makefile
to the root of the source tree. It instructs the user to issue a series
of simple `make` commands, at the end of which they'll have a fully
functional localnet deployment.

Caveats:

 - No support for Windows unless the user is running Git Bash, Cygwin or
   similar. In any case, the makefile serves as clear documentation
   about what a Windows user would need to do manually, i.e. without the
   benefit of `make` automating it all.

 - The aforementioned setup documents should be updated to point to this
   makefile instead of explaining everything in prose. The dev-setup.md
   and dao-setup.md documents may actually be candidates for deletion if
   this new approach proves successful.

 - These changes do not include passing the new -peerbloomfilters=1
   option to bitcoin versions 0.19 and above. Those who have already
   upgraded should take care to add that option.

Notes:

 - The introduction of this makefile has no impact on Bisq's use of
   Gradle as a build system. Everything there is as it has been. This
   makefile is a completely optional convenience being added into the
   mix. It has the added benefit of being a "friendly face" to those not
   familiar with the Java / JVM ecosystem. Developers from many
   different backgrounds are familiar with make and makefiles, and they
   may find this one a pleasant and inviting surprise.

----

Special thanks to @bodymindarts for the inspiration to take this makefile-based approach. The [makefile in his bisq-workspace repo](https://github.com/bodymindarts/bisq-workspace/blob/master/Makefile) plus the pain I was experiencing trying to help out with v1.2.4 testing was what got this ball rolling.

For those interested in putting this to use in your current testing efforts, this PR is branched from the last common commit between the `master` and `release/v1.2.4` branches, so you can merge it into your own local `release/v1.2.4 branch` or just cherry-pick the single commit. Both should work cleanly.