### PR TITLE
Do not use 0 btc outputs

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -1135,8 +1135,13 @@ public class TradeWalletService {
         TransactionOutput p2SHMultiSigOutput = depositTx.getOutput(0);
         Transaction transaction = new Transaction(params);
         transaction.addInput(p2SHMultiSigOutput);
-        transaction.addOutput(buyerPayoutAmount, Address.fromBase58(params, buyerAddressString));
-        transaction.addOutput(sellerPayoutAmount, Address.fromBase58(params, sellerAddressString));
+        if (buyerPayoutAmount.isPositive()) {
+            transaction.addOutput(buyerPayoutAmount, Address.fromBase58(params, buyerAddressString));
+        }
+        if (sellerPayoutAmount.isPositive()) {
+            transaction.addOutput(sellerPayoutAmount, Address.fromBase58(params, sellerAddressString));
+        }
+        checkArgument(transaction.getOutputs().size() >= 1, "We need at least one output.");
         return transaction;
     }
 

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -926,10 +926,10 @@ public class TradeWalletService {
         TransactionOutput p2SHMultiSigOutput = depositTx.getOutput(0);
         Transaction payoutTx = new Transaction(params);
         payoutTx.addInput(p2SHMultiSigOutput);
-        if (buyerPayoutAmount.isGreaterThan(Coin.ZERO)) {
+        if (buyerPayoutAmount.isPositive()) {
             payoutTx.addOutput(buyerPayoutAmount, Address.fromBase58(params, buyerAddressString));
         }
-        if (sellerPayoutAmount.isGreaterThan(Coin.ZERO)) {
+        if (sellerPayoutAmount.isPositive()) {
             payoutTx.addOutput(sellerPayoutAmount, Address.fromBase58(params, sellerAddressString));
         }
 
@@ -989,10 +989,10 @@ public class TradeWalletService {
         Sha256Hash spendTxHash = Sha256Hash.wrap(depositTxHex);
         payoutTx.addInput(new TransactionInput(params, depositTx, p2SHMultiSigOutputScript.getProgram(), new TransactionOutPoint(params, 0, spendTxHash), msOutput));
 
-        if (buyerPayoutAmount.isGreaterThan(Coin.ZERO)) {
+        if (buyerPayoutAmount.isPositive()) {
             payoutTx.addOutput(buyerPayoutAmount, Address.fromBase58(params, buyerAddressString));
         }
-        if (sellerPayoutAmount.isGreaterThan(Coin.ZERO)) {
+        if (sellerPayoutAmount.isPositive()) {
             payoutTx.addOutput(sellerPayoutAmount, Address.fromBase58(params, sellerAddressString));
         }
 

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -223,6 +223,10 @@ class TransactionsListItem {
                     } else if (trade.getPayoutTx() != null &&
                             trade.getPayoutTx().getHashAsString().equals(txId)) {
                         details = Res.get("funds.tx.multiSigPayout", tradeId);
+
+                        if (amountAsCoin.isZero()) {
+                            txConfidenceIndicator.setVisible(false);
+                        }
                     } else {
                         Trade.DisputeState disputeState = trade.getDisputeState();
                         if (disputeState == Trade.DisputeState.DISPUTE_CLOSED) {


### PR DESCRIPTION
@ripcurlx Please cherry pick that to the release branch. 

Fixes https://github.com/bisq-network/bisq/issues/3721  and https://github.com/bisq-network/bisq/issues/3722 but there are more issues open as a payout with only 1 receiver still cause a trade to end up in failed trades.