### PR TITLE
Rename "Spread" tab to a more general "Details"

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -287,7 +287,7 @@ mainView.version.update=(Update available)
 ####################################################################
 
 market.tabs.offerBook=Offer book
-market.tabs.spread=Spread
+market.tabs.spread=Details
 market.tabs.trades=Trades
 
 # OfferBookChartView


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #3376 

Because spread is one of many columns in the table in the "Spread" tab, calling the whole tab "Spread" is not general enough. Calling the table "Details" is more general and is meant to signify that it offers more information than the "offer book" view.

A counter-argument would be that 1) the table does not actually offer new information, just new aggregates on the same information displayed under "Offer book"; and 2), "Details" is somewhat vague.

Currently, it is unclear what a more accurate title could be, and in the meantime "Details" is an improvement on "Spread".
