### PR TITLE
Improve link to developer docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,5 +87,4 @@ See the issues in the [bisq-network/style](https://github.com/bisq-network/style
 ## See also
 
  - [contributor checklist](https://docs.bisq.network/contributor-checklist.html)
- - [developer docs](docs#readme) including build and dev environment setup instructions
-
+ - [developer docs](docs/README.md) including build and dev environment setup instructions


### PR DESCRIPTION
The previous link format works fine while in the GitHub web interface,
but is not useful when trying to navigate from the filesystem. This
format works well in both contexts.

This minor issue was discovered in the course of documentation updates
for PR #3718.