### PR TITLE
Fix dark mode slider switch not disabling dark mode on first try

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -343,8 +343,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         this.useAnimationsProperty.set(useAnimations);
     }
 
-    public void setCssTheme(boolean useDarkMode) {
-        this.cssThemeProperty.set(useDarkMode == true ? 1 : 0);
+    public void setCssTheme(int cssTheme) {
+        this.cssThemeProperty.set(cssTheme);
     }
 
     public void addFiatCurrency(FiatCurrency tradeCurrency) {

--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -224,9 +224,6 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
         addSceneKeyEventHandler(scene, injector);
 
         Preferences preferences = injector.getInstance(Preferences.class);
-        preferences.getCssThemeProperty().addListener((ov) -> {
-            CssTheme.loadSceneStyles(scene, preferences.getCssTheme());
-        });
         CssTheme.loadSceneStyles(scene, preferences.getCssTheme());
 
         return scene;

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -24,7 +24,9 @@ import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.InputTextField;
 import bisq.desktop.components.PasswordTextField;
 import bisq.desktop.components.TitledGroupBg;
+import bisq.desktop.main.MainView;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.CssTheme;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.ImageUtil;
 import bisq.desktop.util.Layout;
@@ -74,6 +76,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.scene.Scene;
 
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
@@ -794,8 +797,15 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         useAnimations.setSelected(preferences.isUseAnimations());
         useAnimations.setOnAction(e -> preferences.setUseAnimations(useAnimations.isSelected()));
 
-        useDarkMode.setSelected(preferences.getCssTheme() == 1);
-        useDarkMode.setOnAction(e -> preferences.setCssTheme(useDarkMode.isSelected()));
+        useDarkMode.setSelected(preferences.getCssTheme() == CssTheme.CSS_THEME_DARK);
+        useDarkMode.setOnAction(e ->
+        {
+            int theme = (useDarkMode.isSelected() ? CssTheme.CSS_THEME_DARK : CssTheme.CSS_THEME_LIGHT);
+            preferences.setCssTheme(theme);
+
+            Scene scene = MainView.getRootContainer().getScene();
+            CssTheme.loadSceneStyles(scene, theme);
+        });
 
         // useStickyMarketPriceCheckBox.setSelected(preferences.isUseStickyMarketPrice());
         // useStickyMarketPriceCheckBox.setOnAction(e -> preferences.setUseStickyMarketPrice(useStickyMarketPriceCheckBox.isSelected()));


### PR DESCRIPTION
Apparently the preferences property listener I was using doesn't call
the event handler on the first change for some reason. This is a
workaround to change the CSS theme directly from the slider switch.

Needs review and testing! Fixes #3447 