### PR TITLE
Vote Reveal - Silent Fail

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1619,6 +1619,9 @@ dao.cycle.phaseDurationWithoutBlocks=Block {0} - {1} (≈{2} - ≈{3})
 dao.voteReveal.txPublished.headLine=Vote reveal transaction published
 dao.voteReveal.txPublished=Your vote reveal transaction with transaction ID {0} was successfully published.\n\n\
   This happens automatically by the software if you have participated in the DAO voting.
+dao.voteReveal.txFailed.headLine=Vote reveal transaction failed
+dao.voteReveal.txFailed=Your vote reveal transaction with transaction ID {0} failed.\n\n\
+  Reason was: {1}.
 
 dao.results.cycles.header=Cycles
 dao.results.cycles.table.header.cycle=Cycle

--- a/desktop/src/main/java/bisq/desktop/main/dao/DaoView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/DaoView.java
@@ -78,6 +78,16 @@ public class DaoView extends ActivatableView<TabPane, Void> {
                     .feedback(Res.get("dao.voteReveal.txPublished", txId))
                     .show();
         });
+
+        voteRevealService.addVoteRevealTxFailedListener((exception) -> {
+            String key = "showVoteRevealFailedWarnPopupOnStartup" + exception.getBlindVoteTxId();
+            if (preferences.showAgain(key)) {
+                new Popup().headLine(Res.get("dao.voteReveal.txFailed.headLine"))
+                        .dontShowAgainId(key)
+                        .error(Res.get("dao.voteReveal.txFailed", exception.getBlindVoteTxId(), exception.getLocalizedMessage()))
+                        .show();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #3408

The log below shows where the vote reveal failed silently as a result of insufficient wallet balance.
```
Oct-15 06:43:21.835 [JavaFX Application Thread] INFO  org.bitcoinj.wallet.Wallet: Completing send tx with 1 outputs totalling 0.00000596 BTC and a fee of 0.00 BTC/kB 
Oct-15 06:43:21.837 [JavaFX Application Thread] WARN  org.bitcoinj.wallet.Wallet: Insufficient value in wallet for send: needed 0.00001606 BTC more 
Oct-15 06:43:21.845 [JavaFX Application Thread] ERROR b.c.d.g.v.VoteRevealService: VoteRevealException{
     voteRevealTx=null,
     blindVoteTxId='3cf435e275b8e1518ea969fe90e0504bbed1d68135310b3c24546244fca90b5d',
     myVote=null
} bisq.core.dao.governance.votereveal.VoteRevealException: Exception at calling revealVote. 
Oct-15 06:43:24.448 [JavaFX Application Thread] INFO  b.c.d.m.DaoStateMonitoringService: Passed checkpoint Checkpoint {
     height=586920,
     hash=523aaad4e760f6ac6196fec1b3ec9a2f42e5b272
} 
```
