### PR TITLE
Add command for signing windows executables with the default code signing certificate

### DIFF
--- a/desktop/package/windows/package.bat
+++ b/desktop/package/windows/package.bat
@@ -2,6 +2,9 @@
 ::   - Inno Setup unicode installed (http://www.jrsoftware.org/isdl.php)
 ::   - OracleJDK 10 installed
 ::     Note: OpenJDK 10 does not have the javapackager util, so must use OracleJDK
+::   - Sign Tool installed (https://docs.microsoft.com/en-us/windows/win32/seccrypto/signtool)
+::     Note: Sign Tool is part of Windows 10 SDK (https://go.microsoft.com/fwlink/?LinkID=698771)
+::   - Code signing certificate installed
 :: Prior to running this script:
 ::   - Update version below
 ::   - Ensure JAVA_HOME below is pointing to OracleJDK 10 directory
@@ -114,6 +117,9 @@ if not exist "%package_dir%\windows\Bisq-%version%.exe" (
     echo No exe file found at %package_dir%\windows\Bisq-%version%.exe
     exit /B 3
 )
+
+echo Signing executable with default Code Signing Certificate
+call "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" sign /v /fd SHA256 /a "Bisq-%version%.exe"
 
 echo SHA256 of %package_dir%\windows\Bisq-%version%.exe:
 for /F "delims=" %%h in ('certutil -hashfile "%package_dir%\windows\Bisq-%version%.exe" SHA256 ^| findstr -i -v "SHA256" ^| findstr -i -v "certutil"') do (set hash=%%h)


### PR DESCRIPTION
Fixes #1952.

In my role as Bisq desktop maintainer and release manager I applied for a personal code signing certificate for `DI(FH) Christoph Johann Atteneder` (yes they wanted all academic titles and names included) at Sectigo (former Comodo). I applied for a code signing certificate which will expire on December 10th 2020.

### Verification steps
To test the behavior of a signed Windows executable you'll actually need a Windows machine to do so.
For testing purpose I've created a signed version of our Windows installer for v1.2.4.
Executable: https://www.dropbox.com/s/ukrotb5neajgwwu/Bisq-1.2.4.exe?dl=0
Signature: https://www.dropbox.com/s/hasuwvch0lag7wx/Bisq-1.2.4.exe.asc?dl=0