### PR TITLE
Add transient tx map to DaoState to speed up getTx queries

### DIFF
--- a/core/src/main/java/bisq/core/dao/DaoFacade.java
+++ b/core/src/main/java/bisq/core/dao/DaoFacade.java
@@ -94,7 +94,6 @@ import javafx.collections.transformation.FilteredList;
 import java.io.IOException;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -625,9 +624,8 @@ public class DaoFacade implements DaoSetupService {
         return daoStateService.getUnspentTxOutputs();
     }
 
-    // Returns a view rather than a copy of all the txs.
-    public Collection<Tx> getTxs() {
-        return daoStateService.getTxs();
+    public int getNumTxs() {
+        return daoStateService.getNumTxs();
     }
 
     public Optional<TxOutput> getLockupTxOutput(String txId) {

--- a/core/src/main/java/bisq/core/dao/DaoFacade.java
+++ b/core/src/main/java/bisq/core/dao/DaoFacade.java
@@ -94,6 +94,7 @@ import javafx.collections.transformation.FilteredList;
 import java.io.IOException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -624,7 +625,8 @@ public class DaoFacade implements DaoSetupService {
         return daoStateService.getUnspentTxOutputs();
     }
 
-    public Set<Tx> getTxs() {
+    // Returns a view rather than a copy of all the txs.
+    public Collection<Tx> getTxs() {
         return daoStateService.getTxs();
     }
 

--- a/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
+++ b/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
@@ -140,7 +140,7 @@ public class ExportJsonFilesService implements DaoSetupService {
             // Access to daoStateService is single threaded, we must not access daoStateService from the thread.
             List<JsonTxOutput> allJsonTxOutputs = new ArrayList<>();
 
-            List<JsonTx> jsonTxs = daoStateService.getTxStream()
+            List<JsonTx> jsonTxs = daoStateService.getUnorderedTxStream()
                     .map(tx -> {
                         JsonTx jsonTx = getJsonTx(tx);
                         allJsonTxOutputs.addAll(jsonTx.getOutputs());

--- a/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
@@ -53,7 +53,6 @@ public class BlockParser {
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    @SuppressWarnings("WeakerAccess")
     @Inject
     public BlockParser(TxParser txParser,
                        DaoStateService daoStateService) {

--- a/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
@@ -22,7 +22,6 @@ import bisq.core.dao.node.parser.exceptions.BlockHashNotConnectingException;
 import bisq.core.dao.node.parser.exceptions.BlockHeightNotConnectingException;
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.dao.state.model.blockchain.Block;
-import bisq.core.dao.state.model.blockchain.Tx;
 
 import bisq.common.app.DevEnv;
 
@@ -31,7 +30,6 @@ import org.bitcoinj.core.Coin;
 import javax.inject.Inject;
 
 import java.util.LinkedList;
-import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -106,14 +104,13 @@ public class BlockParser {
         // one get resolved.
         // Lately there is a patter with 24 iterations observed
         long startTs = System.currentTimeMillis();
-        List<Tx> txList = block.getTxs();
 
         rawBlock.getRawTxs().forEach(rawTx ->
                 txParser.findTx(rawTx,
                         genesisTxId,
                         genesisBlockHeight,
                         genesisTotalSupply)
-                        .ifPresent(txList::add));
+                        .ifPresent(tx -> daoStateService.onNewTxForLastBlock(block, tx)));
 
         log.info("Parsing {} transactions at block height {} took {} ms", rawBlock.getRawTxs().size(),
                 blockHeight, System.currentTimeMillis() - startTs);

--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -36,6 +36,7 @@ import com.google.protobuf.Message;
 import javax.inject.Inject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -46,7 +47,6 @@ import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
 
 /**
  * Root class for mutable state of the DAO.
@@ -103,9 +103,8 @@ public class DaoState implements PersistablePayload {
     private final List<DecryptedBallotsWithMerits> decryptedBallotsWithMeritsList;
 
     // Transient data used only as an index - must be kept in sync with the block list
-    @Getter
     @JsonExclude
-    private transient final Map<String, Tx> txMap; // key is txId
+    private transient final Map<String, Tx> txCache; // key is txId
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -155,9 +154,9 @@ public class DaoState implements PersistablePayload {
         this.evaluatedProposalList = evaluatedProposalList;
         this.decryptedBallotsWithMeritsList = decryptedBallotsWithMeritsList;
 
-        txMap = blocks.stream()
+        txCache = blocks.stream()
                 .flatMap(block -> block.getTxs().stream())
-                .collect(Collectors.toMap(Tx::getId, Function.identity(), (x, y) -> y, HashMap::new));
+                .collect(Collectors.toMap(Tx::getId, Function.identity(), (x, y) -> x, HashMap::new));
     }
 
     @Override
@@ -237,6 +236,21 @@ public class DaoState implements PersistablePayload {
         return getBsqStateBuilderExcludingBlocks().addBlocks(getBlocks().getLast().toProtoMessage()).build().toByteArray();
     }
 
+    public void addToTxCache(Tx tx) {
+        // We shouldn't get duplicate txIds, but use putIfAbsent instead of put for consistency with the map merge
+        // function used in the constructor to initialise txCache (and to exactly match the pre-caching behaviour).
+        txCache.putIfAbsent(tx.getId(), tx);
+    }
+
+    public void setTxCache(Map<String, Tx> txCache) {
+        this.txCache.clear();
+        this.txCache.putAll(txCache);
+    }
+
+    public Map<String, Tx> getTxCache() {
+        return Collections.unmodifiableMap(txCache);
+    }
+
     @Override
     public String toString() {
         return "DaoState{" +
@@ -250,7 +264,7 @@ public class DaoState implements PersistablePayload {
                 ",\n     paramChangeList=" + paramChangeList +
                 ",\n     evaluatedProposalList=" + evaluatedProposalList +
                 ",\n     decryptedBallotsWithMeritsList=" + decryptedBallotsWithMeritsList +
-                ",\n     txMap=" + txMap +
+                ",\n     txCache=" + txCache +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/Block.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/Block.java
@@ -24,11 +24,11 @@ import bisq.common.proto.persistable.PersistablePayload;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
-import lombok.Value;
 
 /**
  * The Block which gets persisted in the DaoState. During parsing transactions can be
@@ -44,8 +44,8 @@ import lombok.Value;
  *
  */
 @EqualsAndHashCode(callSuper = true)
-@Value
 public final class Block extends BaseBlock implements PersistablePayload, ImmutableDaoStateModel {
+    // We do not expose txs with a Lombok getter. We cannot make it immutable as we add transactions during parsing.
     private final List<Tx> txs;
 
     public Block(int height, long time, String hash, String previousBlockHash) {
@@ -91,6 +91,17 @@ public final class Block extends BaseBlock implements PersistablePayload, Immuta
                 proto.getHash(),
                 proto.getPreviousBlockHash(),
                 txs);
+    }
+
+    public void addTx(Tx tx) {
+        txs.add(tx);
+    }
+
+    // We want to guarantee that no client can modify the list. We use unmodifiableList and not ImmutableList as
+    // we want that clients reflect any change to the source list. Also ImmutableList is more expensive as it
+    // creates a copy.
+    public List<Tx> getTxs() {
+        return Collections.unmodifiableList(txs);
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/transactions/BSQTransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/transactions/BSQTransactionsView.java
@@ -143,7 +143,7 @@ public class BSQTransactionsView extends ActivatableView<GridPane, Void> impleme
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void updateWithBsqBlockChainData() {
-        allTxTextField.setText(String.valueOf(daoFacade.getTxs().size()));
+        allTxTextField.setText(String.valueOf(daoFacade.getNumTxs()));
         utxoTextField.setText(String.valueOf(daoFacade.getUnspentTxOutputs().size()));
         compensationIssuanceTxTextField.setText(String.valueOf(daoFacade.getNumIssuanceTransactions(IssuanceType.COMPENSATION)));
         reimbursementIssuanceTxTextField.setText(String.valueOf(daoFacade.getNumIssuanceTransactions(IssuanceType.REIMBURSEMENT)));


### PR DESCRIPTION
Build a `HashMap` of all BSQ transactions found, when loading the `DaoState` from disc, and store it in a transient field which is always kept in sync with the associated list of blocks. (The latter is only modified in a couple of places in `DaoStateService`, making this straightforward.)

This is to speed up `daoStateService.getTx(id)`, which is called from many places and appears to be a significant bottleneck. In particular, the initial load of the results in `VoteResultView.doFillCycleList` was very slow (taking nearly a minute on a Core i3 machine) and likely to suffer a quadratic slowdown (#cycles * #tx's) over time.