### PR TITLE
Revolut account should accept only phone number

### DIFF
--- a/core/src/main/java/bisq/core/locale/CountryUtil.java
+++ b/core/src/main/java/bisq/core/locale/CountryUtil.java
@@ -44,6 +44,18 @@ public class CountryUtil {
         return list;
     }
 
+    public static List<Country> getAllRevolutCountries() {
+        List<Country> list = new ArrayList<>();
+        String[] codes = {"AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR",
+                "DE", "GR", "HU", "IS", "IE", "IT", "LV", "LI", "LT", "LU", "MT", "NL",
+                "NO", "PL", "PT", "RO", "SK", "SI", "ES", "SE", "GB",
+                "AU", "CA", "SG", "CH", "US"};
+        populateCountryListByCodes(list, codes);
+        list.sort((a, b) -> a.name.compareTo(b.name));
+
+        return list;
+    }
+
     public static List<Country> getAllSepaInstantEuroCountries() {
         return getAllSepaEuroCountries();
     }

--- a/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
@@ -17,13 +17,11 @@
 
 package bisq.desktop.util.validation;
 
-import bisq.core.util.validation.InputValidator;
+public final class RevolutValidator extends PhoneNumberValidator {
 
-public final class RevolutValidator extends InputValidator {
-
-    @Override
-    public ValidationResult validate(String input) {
-        // TODO
+    public ValidationResult validate(String input, String code) {
+        super.setIsoCountryCode(code);
         return super.validate(input);
     }
+
 }


### PR DESCRIPTION
Fixes #3728
Till now we used to accept email or phone number
Now we are accepting only phone number in input though
for display we will provide backward compatibility.

Based on the country selected, we will validate the given phone number input.


Added list of countries accepted from official revolut website
https://www.revolut.com/en-US/help/getting-started/verifying-identity/what-countries-are-supported

	
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

