### PR TITLE
Not allow bitcoinj to auto connect to localhost when localhost was not detected by client

### DIFF
--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -216,8 +216,6 @@ public class WalletConfig extends AbstractIdleService {
         // no proxy case.
         if (socks5Proxy == null) {
             peerGroup = new PeerGroup(params, vChain);
-            // For dao testnet (server side regtest) we prevent to connect to a localhost node to avoid confusion
-            // if local btc node is not synced with our dao testnet master node.
         } else {
             // proxy case (tor).
             Proxy proxy = new Proxy(Proxy.Type.SOCKS,
@@ -238,7 +236,9 @@ public class WalletConfig extends AbstractIdleService {
 
         // For dao testnet (server side regtest) we prevent to connect to a localhost node to avoid confusion
         // if local btc node is not synced with our dao testnet master node.
-        if (BisqEnvironment.getBaseCurrencyNetwork().isDaoRegTest() || BisqEnvironment.getBaseCurrencyNetwork().isDaoTestNet())
+        if (BisqEnvironment.getBaseCurrencyNetwork().isDaoRegTest() ||
+                BisqEnvironment.getBaseCurrencyNetwork().isDaoTestNet() ||
+                !bisqEnvironment.isBitcoinLocalhostNodeRunning())
             peerGroup.setUseLocalhostPeerWhenPossible(false);
 
         return peerGroup;


### PR DESCRIPTION
This fixes the problem if the local bitcoin core node is not detected by our client,
but bitcoinj is able to connect to it because of the auto connect to localhost behavior.
In that case the minimum required nodes to broadcast a transaction will be 4 (provided nodes settings),
but bitcoinj will only connect to one node. The requirement of 4 nodes will be never fulfilled and
the transaction never broadcasted.

### Testing
As this is a bug based on the default localhost connect behavior of bitcoinj it is difficult to simulate on regtest.
To simulate this behavior on mainnet you could try following steps:
- Use current master
- Skip the initial check for a localhost node in BisqSetup `step 3`
- Go to network settings and you'll see only one node is connected but the minimum peers for broadcast is still set to `4`
- Checkout this PR and skip the initial check for localhost again
- Go to network settings and you'll see that the client connects to the provided nodes and will be able to broadcast transactions