### PR TITLE
Remove listener before setting a new one

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -892,6 +892,10 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                             public void updateItem(final Dispute item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null && !empty) {
+                                    if (closedProperty != null) {
+                                        closedProperty.removeListener(listener);
+                                    }
+
                                     listener = (observable, oldValue, newValue) -> {
                                         setText(newValue ? Res.get("support.closed") : Res.get("support.open"));
                                         if (getTableRow() != null)


### PR DESCRIPTION
Fixes #3731.

Experienced it nearly every time when testing https://github.com/bisq-network/bisq/pull/3790. After this fix I didn't saw this issue again.

### Testing
**Using master:**
- Create 3+ mediation cases
- Close a single mediation entry
- You will see another mediation entry to be deactivated as well (opacity: 0.4)

**Using this PR:**
- Create 3+ mediation cases
- Close a single mediation entry
- Only this one entry should be deactivated

