### PR TITLE
Remove unused method parameters

### DIFF
--- a/core/src/main/java/bisq/core/account/sign/SignedWitness.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitness.java
@@ -20,8 +20,8 @@ package bisq.core.account.sign;
 import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
 import bisq.network.p2p.storage.payload.DateTolerantPayload;
-import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
+import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
 
 import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
@@ -35,8 +35,8 @@ import com.google.protobuf.ByteString;
 import org.bitcoinj.core.Coin;
 
 import java.time.Clock;
+import java.time.Instant;
 
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import lombok.Value;
@@ -142,7 +142,7 @@ public class SignedWitness implements ProcessOncePersistableNetworkPayload, Pers
     public boolean isDateInTolerance(Clock clock) {
         // We don't allow older or newer than 1 day.
         // Preventing forward dating is also important to protect against a sophisticated attack
-        return Math.abs(new Date().getTime() - date) <= TOLERANCE;
+        return Math.abs(clock.millis() - date) <= TOLERANCE;
     }
 
     @Override
@@ -176,12 +176,12 @@ public class SignedWitness implements ProcessOncePersistableNetworkPayload, Pers
     @Override
     public String toString() {
         return "SignedWitness{" +
-                ",\n     verificationMethod=" + verificationMethod +
+                "\n     verificationMethod=" + verificationMethod +
                 ",\n     witnessHash=" + Utilities.bytesAsHexString(accountAgeWitnessHash) +
                 ",\n     signature=" + Utilities.bytesAsHexString(signature) +
                 ",\n     signerPubKey=" + Utilities.bytesAsHexString(signerPubKey) +
                 ",\n     witnessOwnerPubKey=" + Utilities.bytesAsHexString(witnessOwnerPubKey) +
-                ",\n     date=" + date +
+                ",\n     date=" + Instant.ofEpochMilli(date) +
                 ",\n     tradeAmount=" + Coin.valueOf(tradeAmount).toFriendlyString() +
                 ",\n     hash=" + Utilities.bytesAsHexString(hash) +
                 "\n}";

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitness.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitness.java
@@ -19,8 +19,8 @@ package bisq.core.account.witness;
 
 import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.network.p2p.storage.payload.DateTolerantPayload;
-import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
+import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
 
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.util.Utilities;
@@ -28,8 +28,8 @@ import bisq.common.util.Utilities;
 import com.google.protobuf.ByteString;
 
 import java.time.Clock;
+import java.time.Instant;
 
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import lombok.Value;
@@ -65,7 +65,7 @@ public class AccountAgeWitness implements ProcessOncePersistableNetworkPayload, 
         return protobuf.PersistableNetworkPayload.newBuilder().setAccountAgeWitness(builder).build();
     }
 
-    public protobuf.AccountAgeWitness toProtoAccountAgeWitness() {
+    protobuf.AccountAgeWitness toProtoAccountAgeWitness() {
         return toProtoMessage().getAccountAgeWitness();
     }
 
@@ -89,7 +89,7 @@ public class AccountAgeWitness implements ProcessOncePersistableNetworkPayload, 
     public boolean isDateInTolerance(Clock clock) {
         // We don't allow older or newer than 1 day.
         // Preventing forward dating is also important to protect against a sophisticated attack
-        return Math.abs(new Date().getTime() - date) <= TOLERANCE;
+        return Math.abs(clock.millis() - date) <= TOLERANCE;
     }
 
     @Override
@@ -107,7 +107,7 @@ public class AccountAgeWitness implements ProcessOncePersistableNetworkPayload, 
     // Getters
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public P2PDataStorage.ByteArray getHashAsByteArray() {
+    P2PDataStorage.ByteArray getHashAsByteArray() {
         return new P2PDataStorage.ByteArray(hash);
     }
 
@@ -115,7 +115,7 @@ public class AccountAgeWitness implements ProcessOncePersistableNetworkPayload, 
     public String toString() {
         return "AccountAgeWitness{" +
                 "\n     hash=" + Utilities.bytesAsHexString(hash) +
-                ",\n     date=" + new Date(date) +
+                ",\n     date=" + Instant.ofEpochMilli(date) +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -707,7 +707,7 @@ public class TradeWalletService {
         return delayedPayoutTx;
     }
 
-    public boolean verifiesDepositTxAndDelayedPayoutTx(Transaction depositTx,
+    public boolean verifiesDepositTxAndDelayedPayoutTx(@SuppressWarnings("unused") Transaction depositTx,
                                                        Transaction delayedPayoutTx) {
         // todo add more checks
         if (delayedPayoutTx.getLockTime() == 0) {
@@ -963,17 +963,17 @@ public class TradeWalletService {
     // Emergency payoutTx
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public Transaction emergencySignAndPublishPayoutTxFrom2of2MultiSig(String depositTxHex,
-                                                                       Coin buyerPayoutAmount,
-                                                                       Coin sellerPayoutAmount,
-                                                                       Coin txFee,
-                                                                       String buyerAddressString,
-                                                                       String sellerAddressString,
-                                                                       String buyerPrivateKeyAsHex,
-                                                                       String sellerPrivateKeyAsHex,
-                                                                       String buyerPubKeyAsHex,
-                                                                       String sellerPubKeyAsHex,
-                                                                       TxBroadcaster.Callback callback)
+    public void emergencySignAndPublishPayoutTxFrom2of2MultiSig(String depositTxHex,
+                                                                Coin buyerPayoutAmount,
+                                                                Coin sellerPayoutAmount,
+                                                                Coin txFee,
+                                                                String buyerAddressString,
+                                                                String sellerAddressString,
+                                                                String buyerPrivateKeyAsHex,
+                                                                String sellerPrivateKeyAsHex,
+                                                                String buyerPubKeyAsHex,
+                                                                String sellerPubKeyAsHex,
+                                                                TxBroadcaster.Callback callback)
             throws AddressFormatException, TransactionVerificationException, WalletException {
         byte[] buyerPubKey = ECKey.fromPublicOnly(Utils.HEX.decode(buyerPubKeyAsHex)).getPubKey();
         byte[] sellerPubKey = ECKey.fromPublicOnly(Utils.HEX.decode(sellerPubKeyAsHex)).getPubKey();
@@ -1018,7 +1018,6 @@ public class TradeWalletService {
         WalletService.verifyTransaction(payoutTx);
         WalletService.checkWalletConsistency(wallet);
         broadcastTx(payoutTx, callback, 20);
-        return payoutTx;
     }
 
 

--- a/core/src/main/java/bisq/core/dao/presentation/DaoUtil.java
+++ b/core/src/main/java/bisq/core/dao/presentation/DaoUtil.java
@@ -21,7 +21,6 @@ import bisq.core.dao.DaoFacade;
 import bisq.core.dao.state.model.governance.DaoPhase;
 import bisq.core.locale.Res;
 import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import java.text.SimpleDateFormat;
 
@@ -33,7 +32,7 @@ import java.util.Locale;
  */
 public class DaoUtil {
 
-    public static String getNextPhaseDuration(int height, DaoPhase.Phase phase, DaoFacade daoFacade, CoinFormatter formatter) {
+    public static String getNextPhaseDuration(int height, DaoPhase.Phase phase, DaoFacade daoFacade) {
         final int currentCycleDuration = daoFacade.getCurrentCycleDuration();
         long start = daoFacade.getFirstBlockOfPhaseForDisplay(height, phase) + currentCycleDuration;
         long end = daoFacade.getLastBlockOfPhaseForDisplay(height, phase) + currentCycleDuration;
@@ -47,7 +46,7 @@ public class DaoUtil {
         return Res.get("dao.cycle.phaseDurationWithoutBlocks", start, end, startDateTime, endDateTime);
     }
 
-    public static String getPhaseDuration(int height, DaoPhase.Phase phase, DaoFacade daoFacade, CoinFormatter formatter) {
+    public static String getPhaseDuration(int height, DaoPhase.Phase phase, DaoFacade daoFacade) {
         long start = daoFacade.getFirstBlockOfPhaseForDisplay(height, phase);
         long end = daoFacade.getLastBlockOfPhaseForDisplay(height, phase);
         long duration = daoFacade.getDurationForPhaseForDisplay(phase);

--- a/core/src/main/java/bisq/core/locale/BankUtil.java
+++ b/core/src/main/java/bisq/core/locale/BankUtil.java
@@ -30,8 +30,8 @@ public class BankUtil {
 
     // BankName
     @SuppressWarnings("SameReturnValue")
-    public static boolean isBankNameRequired(String countryCode) {
-        // Currently we always return true but let's keep that method to be more flexible in case we what to not show
+    public static boolean isBankNameRequired(@SuppressWarnings("unused") String countryCode) {
+        // Currently we always return true but let's keep that method to be more flexible in case we want to not show
         // it at some new payment method.
         return true;
          /*

--- a/core/src/main/java/bisq/core/offer/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/CreateOfferService.java
@@ -201,8 +201,7 @@ public class CreateOfferService {
         Map<String, String> extraDataMap = OfferUtil.getExtraDataMap(accountAgeWitnessService,
                 referralIdService,
                 paymentAccount,
-                currencyCode,
-                preferences);
+                currencyCode);
 
         OfferUtil.validateOfferData(filterManager,
                 p2PService,

--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -291,9 +291,9 @@ public class OfferUtil {
                 bsqFormatter);
     }
 
-    public static Optional<Volume> getFeeInUserFiatCurrency(Coin makerFee, boolean isCurrencyForMakerFeeBtc,
-                                                            String userCurrencyCode, PriceFeedService priceFeedService,
-                                                            CoinFormatter bsqFormatter) {
+    private static Optional<Volume> getFeeInUserFiatCurrency(Coin makerFee, boolean isCurrencyForMakerFeeBtc,
+                                                             String userCurrencyCode, PriceFeedService priceFeedService,
+                                                             CoinFormatter bsqFormatter) {
         // We use the users currency derived from his selected country.
         // We don't use the preferredTradeCurrency from preferences as that can be also set to an altcoin.
 
@@ -325,8 +325,7 @@ public class OfferUtil {
     public static Map<String, String> getExtraDataMap(AccountAgeWitnessService accountAgeWitnessService,
                                                       ReferralIdService referralIdService,
                                                       PaymentAccount paymentAccount,
-                                                      String currencyCode,
-                                                      Preferences preferences) {
+                                                      String currencyCode) {
         Map<String, String> extraDataMap = new HashMap<>();
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String myWitnessHashAsHex = accountAgeWitnessService.getMyWitnessHashAsHex(paymentAccount.getPaymentAccountPayload());

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -152,8 +152,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
                        @Named(DaoOptionKeys.FULL_DAO_NODE) String fullDaoNode,
                        @Named(DaoOptionKeys.RPC_USER) String rpcUser,
                        @Named(DaoOptionKeys.RPC_PASSWORD) String rpcPassword,
-                       @Named(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT) String rpcBlockNotificationPort,
-                       @Named(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_HOST) String rpcBlockNotificationHost) {
+                       @Named(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT) String rpcBlockNotificationPort) {
 
 
         this.storage = storage;
@@ -329,7 +328,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     }
 
     public void setCssTheme(boolean useDarkMode) {
-        this.cssThemeProperty.set(useDarkMode == true ? 1 : 0);
+        this.cssThemeProperty.set(useDarkMode ? 1 : 0);
     }
 
     public void addFiatCurrency(FiatCurrency tradeCurrency) {
@@ -339,8 +338,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     public void removeFiatCurrency(FiatCurrency tradeCurrency) {
         if (tradeCurrenciesAsObservable.size() > 1) {
-            if (fiatCurrenciesAsObservable.contains(tradeCurrency))
-                fiatCurrenciesAsObservable.remove(tradeCurrency);
+            fiatCurrenciesAsObservable.remove(tradeCurrency);
 
             if (prefPayload.getPreferredTradeCurrency() != null &&
                     prefPayload.getPreferredTradeCurrency().equals(tradeCurrency))
@@ -357,8 +355,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     public void removeCryptoCurrency(CryptoCurrency tradeCurrency) {
         if (tradeCurrenciesAsObservable.size() > 1) {
-            if (cryptoCurrenciesAsObservable.contains(tradeCurrency))
-                cryptoCurrenciesAsObservable.remove(tradeCurrency);
+            cryptoCurrenciesAsObservable.remove(tradeCurrency);
 
             if (prefPayload.getPreferredTradeCurrency() != null &&
                     prefPayload.getPreferredTradeCurrency().equals(tradeCurrency))
@@ -538,12 +535,12 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         persist();
     }
 
-    public void setBlockChainExplorerTestNet(BlockChainExplorer blockChainExplorerTestNet) {
+    private void setBlockChainExplorerTestNet(BlockChainExplorer blockChainExplorerTestNet) {
         prefPayload.setBlockChainExplorerTestNet(blockChainExplorerTestNet);
         persist();
     }
 
-    public void setBlockChainExplorerMainNet(BlockChainExplorer blockChainExplorerMainNet) {
+    private void setBlockChainExplorerMainNet(BlockChainExplorer blockChainExplorerMainNet) {
         prefPayload.setBlockChainExplorerMainNet(blockChainExplorerMainNet);
         persist();
     }

--- a/core/src/main/java/bisq/core/util/FormattingUtils.java
+++ b/core/src/main/java/bisq/core/util/FormattingUtils.java
@@ -157,7 +157,7 @@ public class FormattingUtils {
     }
 
     public static String formatPrice(Price price, boolean appendCurrencyCode) {
-        return formatPrice(price, fiatPriceFormat, true);
+        return formatPrice(price, fiatPriceFormat, appendCurrencyCode);
     }
 
     public static String formatPrice(Price price) {
@@ -279,7 +279,7 @@ public class FormattingUtils {
     }
 
     @NotNull
-    public static String fillUpPlacesWithEmptyStrings(String formattedNumber, int maxNumberOfDigits) {
+    public static String fillUpPlacesWithEmptyStrings(String formattedNumber, @SuppressWarnings("unused") int maxNumberOfDigits) {
         //FIXME: temporary deactivate adding spaces in front of numbers as we don't use a monospace font right now.
         /*int numberOfPlacesToFill = maxNumberOfDigits - formattedNumber.length();
         for (int i = 0; i < numberOfPlacesToFill; i++) {

--- a/core/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/core/src/test/java/bisq/core/user/PreferencesTest.java
@@ -61,7 +61,7 @@ public class PreferencesTest {
         storage = mock(Storage.class);
         bisqEnvironment = mock(BisqEnvironment.class);
 
-        preferences = new Preferences(storage, bisqEnvironment, null, null, null, null, null, null, null, null);
+        preferences = new Preferences(storage, bisqEnvironment, null, null, null, null, null, null, null);
     }
 
     @Test

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
@@ -4,7 +4,6 @@ import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.offer.Offer;
 import bisq.core.user.Preferences;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
 
@@ -13,7 +12,6 @@ public class PeerInfoIconSmall extends PeerInfoIcon {
                              String role, Offer offer,
                              Preferences preferences,
                              AccountAgeWitnessService accountAgeWitnessService,
-                             CoinFormatter formatter,
                              boolean useDevPrivilegeKeys) {
         // We don't want to show number of trades in that case as it would be unreadable.
         // Also we don't need the privateNotificationManager as no interaction will take place with this icon.

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/dashboard/GovernanceDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/dashboard/GovernanceDashboardView.java
@@ -30,11 +30,8 @@ import bisq.core.dao.state.DaoStateListener;
 import bisq.core.dao.state.model.blockchain.Block;
 import bisq.core.dao.state.model.governance.DaoPhase;
 import bisq.core.locale.Res;
-import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
@@ -50,7 +47,6 @@ public class GovernanceDashboardView extends ActivatableView<GridPane, Void> imp
     private final DaoFacade daoFacade;
     private final PeriodService periodService;
     private final PhasesView phasesView;
-    private final CoinFormatter formatter;
 
     private int gridRow = 0;
     private TextField currentPhaseTextField, currentBlockHeightTextField, proposalTextField, blindVoteTextField, voteRevealTextField, voteResultTextField;
@@ -61,11 +57,10 @@ public class GovernanceDashboardView extends ActivatableView<GridPane, Void> imp
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    public GovernanceDashboardView(DaoFacade daoFacade, PeriodService periodService, PhasesView phasesView, @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+    public GovernanceDashboardView(DaoFacade daoFacade, PeriodService periodService, PhasesView phasesView) {
         this.daoFacade = daoFacade;
         this.periodService = periodService;
         this.phasesView = phasesView;
-        this.formatter = formatter;
     }
 
     @Override
@@ -127,9 +122,9 @@ public class GovernanceDashboardView extends ActivatableView<GridPane, Void> imp
             phase = periodService.getPhaseForHeight(height + 1);
         }
         currentPhaseTextField.setText(Res.get("dao.phase." + phase.name()));
-        proposalTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.PROPOSAL, daoFacade, formatter));
-        blindVoteTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.BLIND_VOTE, daoFacade, formatter));
-        voteRevealTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.VOTE_REVEAL, daoFacade, formatter));
-        voteResultTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.RESULT, daoFacade, formatter));
+        proposalTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.PROPOSAL, daoFacade));
+        blindVoteTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.BLIND_VOTE, daoFacade));
+        voteRevealTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.VOTE_REVEAL, daoFacade));
+        voteResultTextField.setText(DaoUtil.getPhaseDuration(height, DaoPhase.Phase.RESULT, daoFacade));
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -271,7 +271,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void updateTimeUntilNextProposalPhase(int height) {
-        nextProposalTextField.setText(DaoUtil.getNextPhaseDuration(height, DaoPhase.Phase.PROPOSAL, daoFacade, btcFormatter));
+        nextProposalTextField.setText(DaoUtil.getNextPhaseDuration(height, DaoPhase.Phase.PROPOSAL, daoFacade));
     }
 
     private void publishMyProposal(ProposalType type) {
@@ -298,9 +298,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
                     new Popup().warning(Res.get("dao.proposal.create.missingBsqFundsForBond",
                             bsqFormatter.formatCoinWithCode(missing)))
                             .actionButtonText(Res.get("dao.proposal.create.publish"))
-                            .onAction(() -> {
-                                showFeeInfoAndPublishMyProposal(proposal, transaction, miningFee, txSize, fee);
-                            })
+                            .onAction(() -> showFeeInfoAndPublishMyProposal(proposal, transaction, miningFee, txSize, fee))
                             .show();
                 } else {
                     showFeeInfoAndPublishMyProposal(proposal, transaction, miningFee, txSize, fee);

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
@@ -34,7 +34,6 @@ import bisq.core.btc.listeners.BalanceListener;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.locale.Res;
-import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
@@ -123,7 +122,6 @@ public class DepositView extends ActivatableView<VBox, Void> {
 
     @Inject
     private DepositView(BtcWalletService walletService,
-                        FeeService feeService,
                         Preferences preferences,
                         @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
         this.walletService = walletService;

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionListItemFactory.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionListItemFactory.java
@@ -24,8 +24,6 @@ import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
-import bisq.common.crypto.PubKeyRing;
-
 import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
@@ -40,7 +38,6 @@ public class TransactionListItemFactory {
     private final BtcWalletService btcWalletService;
     private final BsqWalletService bsqWalletService;
     private final DaoFacade daoFacade;
-    private final PubKeyRing pubKeyRing;
     private final CoinFormatter formatter;
     private final Preferences preferences;
 
@@ -48,13 +45,11 @@ public class TransactionListItemFactory {
     TransactionListItemFactory(BtcWalletService btcWalletService,
                                BsqWalletService bsqWalletService,
                                DaoFacade daoFacade,
-                               PubKeyRing pubKeyRing,
                                @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                                Preferences preferences) {
         this.btcWalletService = btcWalletService;
         this.bsqWalletService = bsqWalletService;
         this.daoFacade = daoFacade;
-        this.pubKeyRing = pubKeyRing;
         this.formatter = formatter;
         this.preferences = preferences;
     }
@@ -65,7 +60,6 @@ public class TransactionListItemFactory {
                 bsqWalletService,
                 tradable,
                 daoFacade,
-                pubKeyRing,
                 formatter,
                 preferences.getIgnoreDustThreshold());
     }

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -34,8 +34,6 @@ import bisq.core.trade.Tradable;
 import bisq.core.trade.Trade;
 import bisq.core.util.coin.CoinFormatter;
 
-import bisq.common.crypto.PubKeyRing;
-
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
@@ -89,7 +87,6 @@ class TransactionsListItem {
                          BsqWalletService bsqWalletService,
                          TransactionAwareTradable transactionAwareTradable,
                          DaoFacade daoFacade,
-                         PubKeyRing pubKeyRing,
                          CoinFormatter formatter,
                          long ignoreDustThreshold) {
         this.btcWalletService = btcWalletService;

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -592,7 +592,6 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                                             offer,
                                             model.preferences,
                                             model.accountAgeWitnessService,
-                                            formatter,
                                             useDevPrivilegeKeys);
 //                                    setAlignment(Pos.CENTER);
                                     setGraphic(peerInfoIcon);

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -247,7 +247,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
         dataModel.onTakeOffer(trade -> {
             this.trade = trade;
             trade.stateProperty().addListener(tradeStateListener);
-            applyTradeState(trade.getState());
+            applyTradeState();
             trade.errorMessageProperty().addListener(tradeErrorListener);
             applyTradeErrorMessage(trade.getErrorMessage());
             takeOfferCompleted.set(true);
@@ -486,7 +486,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
         }
     }
 
-    private void applyTradeState(Trade.State tradeState) {
+    private void applyTradeState() {
         if (trade.isDepositPublished()) {
             if (trade.getDepositTx() != null) {
                 if (takeOfferSucceededHandler != null)
@@ -551,7 +551,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
         };
         isWalletFundedListener = (ov, oldValue, newValue) -> updateButtonDisableState();
 
-        tradeStateListener = (ov, oldValue, newValue) -> applyTradeState(newValue);
+        tradeStateListener = (ov, oldValue, newValue) -> applyTradeState();
         tradeErrorListener = (ov, oldValue, newValue) -> applyTradeErrorMessage(newValue);
         offerStateListener = (ov, oldValue, newValue) -> applyOfferState(newValue);
         connectionListener = new ConnectionListener() {

--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -504,9 +504,9 @@ public class FormBuilder {
 
     public static TextArea addTextArea(GridPane gridPane, int rowIndex, String prompt, double top) {
 
-        TextArea textArea = new BisqTextArea();
+        JFXTextArea textArea = new BisqTextArea();
         textArea.setPromptText(prompt);
-        ((JFXTextArea) textArea).setLabelFloat(true);
+        textArea.setLabelFloat(true);
         textArea.setWrapText(true);
 
         GridPane.setRowIndex(textArea, rowIndex);
@@ -901,7 +901,7 @@ public class FormBuilder {
     }
 
     public static CheckBox addCheckBox(GridPane gridPane, int rowIndex, String checkBoxTitle, double top) {
-        return addCheckBox(gridPane, rowIndex, 0, checkBoxTitle, 0);
+        return addCheckBox(gridPane, rowIndex, 0, checkBoxTitle, top);
     }
 
     public static CheckBox addCheckBox(GridPane gridPane,
@@ -1221,7 +1221,7 @@ public class FormBuilder {
         final Label topLabel2 = getTopLabel(titleCombobox);
         AutocompleteComboBox<T> comboBox = new AutocompleteComboBox<>();
         comboBox.setPromptText(titleCombobox);
-        ((JFXComboBox<T>) comboBox).setLabelFloat(true);
+        comboBox.setLabelFloat(true);
         topLabelVBox2.getChildren().addAll(topLabel2, comboBox);
 
         hBox.getChildren().addAll(topLabelVBox1, topLabelVBox2);
@@ -1278,9 +1278,9 @@ public class FormBuilder {
         HBox hBox = new HBox();
         hBox.setSpacing(10);
 
-        ComboBox<T> comboBox = new JFXComboBox<>();
+        JFXComboBox<T> comboBox = new JFXComboBox<>();
         comboBox.setPromptText(titleCombobox);
-        ((JFXComboBox<T>) comboBox).setLabelFloat(true);
+        comboBox.setLabelFloat(true);
 
         TextField textField = new BisqTextField();
 

--- a/desktop/src/test/java/bisq/desktop/maker/PreferenceMakers.java
+++ b/desktop/src/test/java/bisq/desktop/maker/PreferenceMakers.java
@@ -43,7 +43,7 @@ public class PreferenceMakers {
             lookup.valueOf(btcNodesFromOptions, new SameValueDonor<String>(null)),
             lookup.valueOf(useTorFlagFromOptions, new SameValueDonor<String>(null)),
             lookup.valueOf(referralID, new SameValueDonor<String>(null)),
-            null, null, null, null, null);
+            null, null, null, null);
 
     public static final Preferences empty = make(a(Preferences));
 


### PR DESCRIPTION
Remove unused parameters from assorted methods (as found by the IDE), excluding abstract or default methods, as well as cases where the parameter is currently unused but is probably intended to be used later.

For most other such methods, either suppress the warning (where the parameter looks like it will be needed later) or actually use the parameter where it probably should have been. The latter applies to a couple of forwarded telescoping method parameters and an injected clock parameter added a few months ago to `[Signed|AccountAge]Witness.isDateInTolerance`.