### PR TITLE
Fixes remaining dark mode bugs (except chat bubbles)

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -838,6 +838,7 @@ textfield */
     -fx-border-width: 0px;
     -fx-underline: true;
     -fx-text-fill: -bs-rd-font-dark;
+    -fx-fill: -bs-rd-font-dark;
 }
 
 .hyperlink.no-underline {
@@ -846,6 +847,7 @@ textfield */
 
 .hyperlink:hover {
     -fx-text-fill: -bs-text-color;
+    -fx-fill: -bs-text-color;
 }
 
 .hyperlink:hover,

--- a/desktop/src/main/java/bisq/desktop/components/HyperlinkWithIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/HyperlinkWithIcon.java
@@ -81,9 +81,6 @@ public class HyperlinkWithIcon extends Hyperlink {
 
         setContentDisplay(ContentDisplay.RIGHT);
         setGraphicTextGap(7.0);
-
-        //TODO: replace workaround of setting the style this way
-        tooltipProperty().addListener((observable, oldValue, newValue) -> newValue.getStyleClass().add("tooltip-hyperlink-icon"));
     }
 
     public void clear() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -65,8 +65,8 @@ import bisq.common.util.Tuple3;
 
 import org.bitcoinj.core.Coin;
 
-import javax.inject.Named;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import de.jensd.fx.glyphs.GlyphIcons;
 import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
@@ -1002,13 +1002,11 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                         iconView.setId("image-remove");
                                         title = Res.get("shared.remove");
                                         button.setId("cancel-button");
-                                        button.setStyle("-fx-text-fill: #444;"); // does not take the font colors sometimes from the style
                                         button.setOnAction(e -> onRemoveOpenOffer(offer));
                                     } else {
                                         boolean isSellOffer = offer.getDirection() == OfferPayload.Direction.SELL;
                                         iconView.setId(isSellOffer ? "image-buy-white" : "image-sell-white");
                                         button.setId(isSellOffer ? "buy-button" : "sell-button");
-                                        button.setStyle("-fx-text-fill: white;"); // does not take the font colors sometimes from the style
                                         if (isSellOffer) {
                                             title = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ?
                                                     Res.get("offerbook.takeOfferToBuy", offer.getOfferPayload().getBaseCurrencyCode()) :


### PR DESCRIPTION
I think with this PR all bugs mentioned in #3185 except for the chat bubbles color tuning 
and adding of the dark mode image for the tip of the bubble afterwards should be fixed.

![Bildschirmfoto 2019-12-19 um 11 34 27](https://user-images.githubusercontent.com/170962/71167250-a5a6f100-2254-11ea-87a5-c1048782ce29.png)
 
![Bildschirmfoto 2019-12-19 um 11 42 42](https://user-images.githubusercontent.com/170962/71167294-bce5de80-2254-11ea-95dd-749076c64497.png)
