### PR TITLE
Add shortcut to move failed trade to pending trades

### DIFF
--- a/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
+++ b/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
@@ -32,10 +32,13 @@ import com.google.inject.Inject;
 import javafx.collections.ObservableList;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import lombok.Setter;
 
 public class FailedTradesManager implements PersistedDataHost {
     private static final Logger log = LoggerFactory.getLogger(FailedTradesManager.class);
@@ -44,6 +47,8 @@ public class FailedTradesManager implements PersistedDataHost {
     private final PriceFeedService priceFeedService;
     private final BtcWalletService btcWalletService;
     private final Storage<TradableList<Trade>> tradableListStorage;
+    @Setter
+    private Consumer<Trade> unfailTradeCallback;
 
     @Inject
     public FailedTradesManager(KeyRing keyRing,
@@ -90,5 +95,11 @@ public class FailedTradesManager implements PersistedDataHost {
     public Stream<Trade> getTradesStreamWithFundsLockedIn() {
         return failedTrades.stream()
                 .filter(Trade::isFundsLockedIn);
+    }
+
+    public void unfailTrade(Trade trade) {
+        if (unfailTradeCallback == null) return;
+        unfailTradeCallback.accept(trade);
+        failedTrades.remove(trade);
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -848,6 +848,8 @@ portfolio.closed.ticketClosed=Arbitrated
 portfolio.closed.mediationTicketClosed=Mediated
 portfolio.closed.canceled=Canceled
 portfolio.failed.Failed=Failed
+portfolio.failed.unfail=Do you want to move this trade back to pending trades? \
+  Only do this if you need to open a support ticket.
 
 
 ####################################################################

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
@@ -74,4 +74,7 @@ class FailedTradesDataModel extends ActivatableDataModel {
         list.sort((o1, o2) -> o2.getTrade().getDate().compareTo(o1.getTrade().getDate()));
     }
 
+    public void unfailTrade(Trade trade) {
+        failedTradesManager.unfailTrade(trade);
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -21,21 +21,30 @@ import bisq.desktop.common.view.ActivatableViewAndModel;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.HyperlinkWithIcon;
+import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
 
 import bisq.core.locale.Res;
+import bisq.core.trade.Trade;
+
+import bisq.common.util.Utilities;
 
 import javax.inject.Inject;
 
 import javafx.fxml.FXML;
 
+import javafx.scene.Scene;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.VBox;
 
 import javafx.beans.property.ReadOnlyObjectWrapper;
+
+import javafx.event.EventHandler;
 
 import javafx.collections.transformation.SortedList;
 
@@ -53,6 +62,8 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
             marketColumn, directionColumn, dateColumn, tradeIdColumn, stateColumn;
     private final TradeDetailsWindow tradeDetailsWindow;
     private SortedList<FailedTradesListItem> sortedList;
+    private EventHandler<KeyEvent> keyEventEventHandler;
+    private Scene scene;
 
     @Inject
     public FailedTradesView(FailedTradesViewModel model, TradeDetailsWindow tradeDetailsWindow) {
@@ -95,10 +106,28 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
         dateColumn.setSortType(TableColumn.SortType.DESCENDING);
         tableView.getSortOrder().add(dateColumn);
 
+        keyEventEventHandler = keyEvent -> {
+            if (Utilities.isAltOrCtrlPressed(KeyCode.Y, keyEvent)) {
+                new Popup().warning(Res.get("portfolio.failed.unfail"))
+                        .onAction(this::onUnfail)
+                        .show();
+            }
+        };
+
+    }
+
+    private void onUnfail() {
+        Trade trade = sortedList.get(tableView.getSelectionModel().getFocusedIndex()).getTrade();
+        model.dataModel.unfailTrade(trade);
+
     }
 
     @Override
     protected void activate() {
+        scene = root.getScene();
+        if (scene != null) {
+            scene.addEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
+        }
         sortedList = new SortedList<>(model.getList());
         sortedList.comparatorProperty().bind(tableView.comparatorProperty());
         tableView.setItems(sortedList);
@@ -106,6 +135,9 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
 
     @Override
     protected void deactivate() {
+        if (scene != null) {
+            scene.removeEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
+        }
         sortedList.comparatorProperty().unbind();
     }
 


### PR DESCRIPTION
Looking at https://github.com/bisq-network/bisq/issues/3764 and https://github.com/bisq-network/bisq/issues/3794 to see how to unlock the funds and get to arbitration. This PR adds a shortcut (ctrl+y, same as moving it from pending to failed) to move back the trade from failed trades to pending trades.

## Testing
I have run this in regtest.
1. Old trades I had in failed (I don't know their history or how they got there), moved to pending and opening a dispute works. Nothing to pay out as they didn't have any locked funds.
1. Created a trade, took it to mediation, closed the popup and moved trade to failed (with ctrl+y). Moved it back to pending trades (ctrl+y). Waited until time locked tx could be broadcast and opened a dispute. Worked as a normal dispute with refund agent.
