### PR TITLE
Fix temp file path memory leak

### DIFF
--- a/common/src/main/java/bisq/common/storage/FileUtil.java
+++ b/common/src/main/java/bisq/common/storage/FileUtil.java
@@ -23,6 +23,7 @@ import com.google.common.io.Files;
 
 import org.apache.commons.io.FileUtils;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import java.io.File;
@@ -184,5 +185,13 @@ public class FileUtil {
 
     public static void copyDirectory(File source, File destination) throws IOException {
         FileUtils.copyDirectory(source, destination);
+    }
+
+    static File createNewFile(Path path) throws IOException {
+        File file = path.toFile();
+        if (!file.createNewFile()) {
+            throw new IOException("There already exists a file with path: " + path);
+        }
+        return file;
     }
 }


### PR DESCRIPTION
The internal `java.io.DeleteOnExitHook` uses a `LinkedHashSet` of paths to delete files at when the JVM exits. However, since there is no way to remove entries from the set, it leaks memory when calling `deleteOnExit()` for every new temp file created by `FileManager.saveToFile`. To avoid this, try to reuse temp file names (using one per `FileManager` instance).

`FileManager.saveToFile` appears to be called on average around every 2s, and this probably leaks around 36 + _length_ * 2 bytes for the String object, 36 bytes for the hashtable node and maybe around 10 bytes for the table entry, or 82 + _length_ * 2 ~= 236 bytes for a typical temp file path length on Windows - about 10MB per day.