### PR TITLE
Increase security deposits

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
+++ b/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
@@ -19,7 +19,6 @@ package bisq.core.btc.wallet;
 
 import bisq.core.app.BisqEnvironment;
 import bisq.core.payment.PaymentAccount;
-import bisq.core.payment.PaymentAccountUtil;
 
 import org.bitcoinj.core.Coin;
 
@@ -50,47 +49,38 @@ public class Restrictions {
 
     public static Coin getMinTradeAmount() {
         if (MIN_TRADE_AMOUNT == null)
-            MIN_TRADE_AMOUNT = Coin.valueOf(10_000); // 0,4 USD @ 4000 USD/BTC
+            MIN_TRADE_AMOUNT = Coin.valueOf(10_000); // 0,7 USD @ 7000 USD/BTC
         return MIN_TRADE_AMOUNT;
     }
 
     public static double getDefaultBuyerSecurityDepositAsPercent(@Nullable PaymentAccount paymentAccount) {
-        if (PaymentAccountUtil.isCryptoCurrencyAccount(paymentAccount))
-            return 0.02; // 2% of trade amount.
-        else
-            return 0.1; // 10% of trade amount.
+        return 0.15; // 15% of trade amount.
     }
 
     public static double getMinBuyerSecurityDepositAsPercent(@Nullable PaymentAccount paymentAccount) {
-        if (PaymentAccountUtil.isCryptoCurrencyAccount(paymentAccount))
-            return 0.005; // 0.5% of trade amount.
-        else
-            return 0.05; // 5% of trade amount.
+        return 0.15; // 15% of trade amount.
     }
 
     public static double getMaxBuyerSecurityDepositAsPercent(@Nullable PaymentAccount paymentAccount) {
-        if (PaymentAccountUtil.isCryptoCurrencyAccount(paymentAccount))
-            return 0.2; // 20% of trade amount. For a 1 BTC trade it is about 800 USD @ 4000 USD/BTC
-        else
-            return 0.5; // 50% of trade amount. For a 1 BTC trade it is about 2000 USD @ 4000 USD/BTC
+        return 0.5; // 50% of trade amount. For a 1 BTC trade it is about 3500 USD @ 7000 USD/BTC
     }
 
     // We use MIN_BUYER_SECURITY_DEPOSIT as well as lower bound in case of small trade amounts.
     // So 0.0005 BTC is the min. buyer security deposit even with amount of 0.0001 BTC and 0.05% percentage value.
     public static Coin getMinBuyerSecurityDepositAsCoin() {
         if (MIN_BUYER_SECURITY_DEPOSIT == null)
-            MIN_BUYER_SECURITY_DEPOSIT = Coin.parseCoin("0.001"); // 0.001 BTC about 4 USD @ 4000 USD/BTC
+            MIN_BUYER_SECURITY_DEPOSIT = Coin.parseCoin("0.006"); // 0.006 BTC about 42 USD @ 7000 USD/BTC
         return MIN_BUYER_SECURITY_DEPOSIT;
     }
 
 
     public static double getSellerSecurityDepositAsPercent() {
-        return 0.05; // 5% of trade amount.
+        return 0.15; // 15% of trade amount.
     }
 
     public static Coin getMinSellerSecurityDepositAsCoin() {
         if (SELLER_SECURITY_DEPOSIT == null)
-            SELLER_SECURITY_DEPOSIT = Coin.parseCoin("0.005"); // 0.005 BTC about 20 USD @ 4000 USD/BTC
+            SELLER_SECURITY_DEPOSIT = Coin.parseCoin("0.006"); // 0.006 BTC about 42 USD @ 7000 USD/BTC
         return SELLER_SECURITY_DEPOSIT;
     }
 }

--- a/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
+++ b/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
@@ -18,11 +18,8 @@
 package bisq.core.btc.wallet;
 
 import bisq.core.app.BisqEnvironment;
-import bisq.core.payment.PaymentAccount;
 
 import org.bitcoinj.core.Coin;
-
-import javax.annotation.Nullable;
 
 public class Restrictions {
     private static Coin MIN_TRADE_AMOUNT;
@@ -53,15 +50,15 @@ public class Restrictions {
         return MIN_TRADE_AMOUNT;
     }
 
-    public static double getDefaultBuyerSecurityDepositAsPercent(@Nullable PaymentAccount paymentAccount) {
+    public static double getDefaultBuyerSecurityDepositAsPercent() {
         return 0.15; // 15% of trade amount.
     }
 
-    public static double getMinBuyerSecurityDepositAsPercent(@Nullable PaymentAccount paymentAccount) {
+    public static double getMinBuyerSecurityDepositAsPercent() {
         return 0.15; // 15% of trade amount.
     }
 
-    public static double getMaxBuyerSecurityDepositAsPercent(@Nullable PaymentAccount paymentAccount) {
+    public static double getMaxBuyerSecurityDepositAsPercent() {
         return 0.5; // 50% of trade amount. For a 1 BTC trade it is about 3500 USD @ 7000 USD/BTC
     }
 

--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -354,12 +354,12 @@ public class OfferUtil {
                                          Coin makerFeeAsCoin) {
         checkNotNull(makerFeeAsCoin, "makerFee must not be null");
         checkNotNull(p2PService.getAddress(), "Address must not be null");
-        checkArgument(buyerSecurityDeposit <= Restrictions.getMaxBuyerSecurityDepositAsPercent(paymentAccount),
+        checkArgument(buyerSecurityDeposit <= Restrictions.getMaxBuyerSecurityDepositAsPercent(),
                 "securityDeposit must not exceed " +
-                        Restrictions.getMaxBuyerSecurityDepositAsPercent(paymentAccount));
-        checkArgument(buyerSecurityDeposit >= Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount),
+                        Restrictions.getMaxBuyerSecurityDepositAsPercent());
+        checkArgument(buyerSecurityDeposit >= Restrictions.getMinBuyerSecurityDepositAsPercent(),
                 "securityDeposit must not be less than " +
-                        Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount));
+                        Restrictions.getMinBuyerSecurityDepositAsPercent());
         checkArgument(!filterManager.isCurrencyBanned(currencyCode),
                 Res.get("offerbook.warning.currencyBanned"));
         checkArgument(!filterManager.isPaymentMethodBanned(paymentAccount.getPaymentMethod()),

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -500,8 +500,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     }
 
     public void setBuyerSecurityDepositAsPercent(double buyerSecurityDepositAsPercent, PaymentAccount paymentAccount) {
-        double max = Restrictions.getMaxBuyerSecurityDepositAsPercent(paymentAccount);
-        double min = Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount);
+        double max = Restrictions.getMaxBuyerSecurityDepositAsPercent();
+        double min = Restrictions.getMinBuyerSecurityDepositAsPercent();
 
         if (PaymentAccountUtil.isCryptoCurrencyAccount(paymentAccount))
             prefPayload.setBuyerSecurityDepositAsPercentForCrypto(Math.min(max, Math.max(min, buyerSecurityDepositAsPercent)));
@@ -746,12 +746,12 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         double value = PaymentAccountUtil.isCryptoCurrencyAccount(paymentAccount) ?
                 prefPayload.getBuyerSecurityDepositAsPercentForCrypto() : prefPayload.getBuyerSecurityDepositAsPercent();
 
-        if (value < Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount)) {
-            value = Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount);
+        if (value < Restrictions.getMinBuyerSecurityDepositAsPercent()) {
+            value = Restrictions.getMinBuyerSecurityDepositAsPercent();
             setBuyerSecurityDepositAsPercent(value, paymentAccount);
         }
 
-        return value == 0 ? Restrictions.getDefaultBuyerSecurityDepositAsPercent(paymentAccount) : value;
+        return value == 0 ? Restrictions.getDefaultBuyerSecurityDepositAsPercent() : value;
     }
 
     //TODO remove and use isPayFeeInBtc instead

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -21,7 +21,6 @@ import bisq.core.locale.Country;
 import bisq.core.locale.CryptoCurrency;
 import bisq.core.locale.FiatCurrency;
 import bisq.core.locale.TradeCurrency;
-import bisq.core.payment.CryptoCurrencyAccount;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.proto.CoreProtoResolver;
 
@@ -122,9 +121,9 @@ public final class PreferencesPayload implements PersistableEnvelope {
     private String rpcPw;
     @Nullable
     private String takeOfferSelectedPaymentAccountId;
-    private double buyerSecurityDepositAsPercent = getDefaultBuyerSecurityDepositAsPercent(null);
+    private double buyerSecurityDepositAsPercent = getDefaultBuyerSecurityDepositAsPercent();
     private int ignoreDustThreshold = 600;
-    private double buyerSecurityDepositAsPercentForCrypto = getDefaultBuyerSecurityDepositAsPercent(new CryptoCurrencyAccount());
+    private double buyerSecurityDepositAsPercentForCrypto = getDefaultBuyerSecurityDepositAsPercent();
     private int blockNotifyPort;
     private boolean tacAcceptedV120;
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -51,9 +51,9 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
-import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
+import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.InputValidator;
 
@@ -878,7 +878,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             InputValidator.ValidationResult result = securityDepositValidator.validate(buyerSecurityDeposit.get());
             buyerSecurityDepositValidationResult.set(result);
             if (result.isValid) {
-                double defaultSecurityDeposit = Restrictions.getDefaultBuyerSecurityDepositAsPercent(getPaymentAccount());
+                double defaultSecurityDeposit = Restrictions.getDefaultBuyerSecurityDepositAsPercent();
                 String key = "buyerSecurityDepositIsLowerAsDefault";
                 double depositAsDouble = ParsingUtils.parsePercentStringToDouble(buyerSecurityDeposit.get());
                 if (preferences.showAgain(key) && depositAsDouble < defaultSecurityDeposit) {
@@ -1139,7 +1139,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         if (buyerSecurityDeposit.get() != null && !buyerSecurityDeposit.get().isEmpty()) {
             dataModel.setBuyerSecurityDeposit(ParsingUtils.parsePercentStringToDouble(buyerSecurityDeposit.get()));
         } else {
-            dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent(getPaymentAccount()));
+            dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent());
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
@@ -132,9 +132,9 @@ class EditOfferDataModel extends MutableOfferDataModel {
         // by percentage than the restriction. We can't determine the percentage originally entered at offer
         // creation, so just use the default value as it doesn't matter anyway.
         double buyerSecurityDepositPercent = CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount());
-        if (buyerSecurityDepositPercent > Restrictions.getMaxBuyerSecurityDepositAsPercent(this.paymentAccount)
+        if (buyerSecurityDepositPercent > Restrictions.getMaxBuyerSecurityDepositAsPercent()
                 && offer.getBuyerSecurityDeposit().value == Restrictions.getMinBuyerSecurityDepositAsCoin().value)
-            buyerSecurityDeposit.set(Restrictions.getDefaultBuyerSecurityDepositAsPercent(this.paymentAccount));
+            buyerSecurityDeposit.set(Restrictions.getDefaultBuyerSecurityDepositAsPercent());
         else
             buyerSecurityDeposit.set(buyerSecurityDepositPercent);
 

--- a/desktop/src/main/java/bisq/desktop/util/validation/SecurityDepositValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/SecurityDepositValidator.java
@@ -58,7 +58,7 @@ public class SecurityDepositValidator extends NumberValidator {
     private ValidationResult validateIfNotTooLowPercentageValue(String input) {
         try {
             double percentage = ParsingUtils.parsePercentStringToDouble(input);
-            double minPercentage = Restrictions.getMinBuyerSecurityDepositAsPercent(paymentAccount);
+            double minPercentage = Restrictions.getMinBuyerSecurityDepositAsPercent();
             if (percentage < minPercentage)
                 return new ValidationResult(false,
                         Res.get("validation.inputTooSmall", FormattingUtils.formatToPercentWithSymbol(minPercentage)));
@@ -72,7 +72,7 @@ public class SecurityDepositValidator extends NumberValidator {
     private ValidationResult validateIfNotTooHighPercentageValue(String input) {
         try {
             double percentage = ParsingUtils.parsePercentStringToDouble(input);
-            double maxPercentage = Restrictions.getMaxBuyerSecurityDepositAsPercent(paymentAccount);
+            double maxPercentage = Restrictions.getMaxBuyerSecurityDepositAsPercent();
             if (percentage > maxPercentage)
                 return new ValidationResult(false,
                         Res.get("validation.inputTooLarge", FormattingUtils.formatToPercentWithSymbol(maxPercentage)));


### PR DESCRIPTION
Implement adjustment according to: bisq-network/proposals#155

For buyer:
Default: 15%
Min. 15% for Altcoin, 15% for Fiat
Max. 50% for Altcoin, 50% for Fiat
Absolute min. deposit in BTC: 0.006 BTC (currently 40 USD)

For Seller:
Fixed: 15%
Absolute min. deposit in BTC: 0.006 BTC (currently 40 USD)

Testing:
Create all offer types with min. sec. deposit, max. sec. deposit, min. trade amount, max. trade amount for both buy and sell side and fiat and altcoins. Take all offers and exectute trade if all works. 
Also test backward compatibility with one node on PR version and one on master with all above combinations.