### PR TITLE
Use min. refund at mediated payout

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
+++ b/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
@@ -31,6 +31,9 @@ public class Restrictions {
     // For the seller we use a fixed one as there is no way the seller can cancel the trade
     // To make it editable would just increase complexity.
     private static Coin SELLER_SECURITY_DEPOSIT;
+    // At mediation we require a min. payout to the losing party to keep incentive for the trader to accept the
+    // mediated payout. For Refund agent cases we do not have that restriction.
+    private static Coin MIN_REFUND_AT_MEDIATED_DISPUTE;
 
     public static Coin getMinNonDustOutput() {
         if (minNonDustOutput == null)
@@ -92,5 +95,11 @@ public class Restrictions {
         if (SELLER_SECURITY_DEPOSIT == null)
             SELLER_SECURITY_DEPOSIT = Coin.parseCoin("0.005"); // 0.005 BTC about 20 USD @ 4000 USD/BTC
         return SELLER_SECURITY_DEPOSIT;
+    }
+
+    public static Coin getMinRefundAtMediatedDispute() {
+        if (MIN_REFUND_AT_MEDIATED_DISPUTE == null)
+            MIN_REFUND_AT_MEDIATED_DISPUTE = Coin.parseCoin("0.003"); // 0.003 BTC about 21 USD @ 7000 USD/BTC
+        return MIN_REFUND_AT_MEDIATED_DISPUTE;
     }
 }

--- a/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
+++ b/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
@@ -97,6 +97,7 @@ public class Restrictions {
         return SELLER_SECURITY_DEPOSIT;
     }
 
+    // This value must not be lower than MIN_BUYER_SECURITY_DEPOSIT or SELLER_SECURITY_DEPOSIT
     public static Coin getMinRefundAtMediatedDispute() {
         if (MIN_REFUND_AT_MEDIATED_DISPUTE == null)
             MIN_REFUND_AT_MEDIATED_DISPUTE = Coin.parseCoin("0.003"); // 0.003 BTC about 21 USD @ 7000 USD/BTC

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -45,10 +45,10 @@ import bisq.core.support.dispute.DisputeResult;
 import bisq.core.support.dispute.mediation.MediationManager;
 import bisq.core.support.dispute.refund.RefundManager;
 import bisq.core.trade.Contract;
-import bisq.core.util.coin.CoinFormatter;
-import bisq.core.util.coin.CoinUtil;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
+import bisq.core.util.coin.CoinFormatter;
+import bisq.core.util.coin.CoinUtil;
 
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
@@ -122,7 +122,7 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
     private ChangeListener<Boolean> customRadioButtonSelectedListener;
     private ChangeListener<Toggle> reasonToggleSelectionListener;
     private InputTextField buyerPayoutAmountInputTextField, sellerPayoutAmountInputTextField;
-    private ChangeListener<String> buyerPayoutAmountListener, sellerPayoutAmountListener;
+    private ChangeListener<Boolean> buyerPayoutAmountListener, sellerPayoutAmountListener;
     private CheckBox isLoserPublisherCheckBox;
     private ChangeListener<Toggle> tradeAmountToggleGroupListener;
 
@@ -337,16 +337,16 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         tradeAmountToggleGroupListener = (observable, oldValue, newValue) -> applyPayoutAmounts(newValue);
         tradeAmountToggleGroup.selectedToggleProperty().addListener(tradeAmountToggleGroupListener);
 
-        buyerPayoutAmountListener = (observable1, oldValue1, newValue1) -> applyCustomAmounts(buyerPayoutAmountInputTextField);
-        sellerPayoutAmountListener = (observable1, oldValue1, newValue1) -> applyCustomAmounts(sellerPayoutAmountInputTextField);
+        buyerPayoutAmountListener = (observable, oldValue, newValue) -> applyCustomAmounts(buyerPayoutAmountInputTextField, oldValue, newValue);
+        sellerPayoutAmountListener = (observable, oldValue, newValue) -> applyCustomAmounts(sellerPayoutAmountInputTextField, oldValue, newValue);
 
         customRadioButtonSelectedListener = (observable, oldValue, newValue) -> {
             buyerPayoutAmountInputTextField.setEditable(newValue);
             sellerPayoutAmountInputTextField.setEditable(newValue);
 
             if (newValue) {
-                buyerPayoutAmountInputTextField.textProperty().addListener(buyerPayoutAmountListener);
-                sellerPayoutAmountInputTextField.textProperty().addListener(sellerPayoutAmountListener);
+                buyerPayoutAmountInputTextField.focusedProperty().addListener(buyerPayoutAmountListener);
+                sellerPayoutAmountInputTextField.focusedProperty().addListener(sellerPayoutAmountListener);
             } else {
                 removePayoutAmountListeners();
             }
@@ -356,10 +356,10 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
 
     private void removePayoutAmountListeners() {
         if (buyerPayoutAmountInputTextField != null && buyerPayoutAmountListener != null)
-            buyerPayoutAmountInputTextField.textProperty().removeListener(buyerPayoutAmountListener);
+            buyerPayoutAmountInputTextField.focusedProperty().removeListener(buyerPayoutAmountListener);
 
         if (sellerPayoutAmountInputTextField != null && sellerPayoutAmountListener != null)
-            sellerPayoutAmountInputTextField.textProperty().removeListener(sellerPayoutAmountListener);
+            sellerPayoutAmountInputTextField.focusedProperty().removeListener(sellerPayoutAmountListener);
 
     }
 
@@ -373,6 +373,11 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
                 .add(offer.getBuyerSecurityDeposit())
                 .add(offer.getSellerSecurityDeposit());
         Coin totalAmount = buyerAmount.add(sellerAmount);
+
+        if (!totalAmount.isPositive()) {
+            return false;
+        }
+
         if (getDisputeManager(dispute) instanceof RefundManager) {
             // We allow to spend less in case of RefundAgent
             return totalAmount.compareTo(available) <= 0;
@@ -381,60 +386,71 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         }
     }
 
-    private void applyCustomAmounts(InputTextField inputTextField) {
-        Contract contract = dispute.getContract();
-        Offer offer = new Offer(contract.getOfferPayload());
-        Coin available = contract.getTradeAmount()
-                .add(offer.getBuyerSecurityDeposit())
-                .add(offer.getSellerSecurityDeposit());
-        Coin enteredAmount = ParsingUtils.parseToCoin(inputTextField.getText(), formatter);
-        if (enteredAmount.isNegative()) {
-            enteredAmount = Coin.ZERO;
-            inputTextField.setText(formatter.formatCoin(enteredAmount));
-        }
-        if (enteredAmount.isPositive() && !Restrictions.isAboveDust(enteredAmount)) {
-            enteredAmount = Restrictions.getMinNonDustOutput();
-            inputTextField.setText(formatter.formatCoin(enteredAmount));
-        }
-        if (enteredAmount.compareTo(available) > 0) {
-            enteredAmount = available;
-            inputTextField.setText(formatter.formatCoin(enteredAmount));
-        }
-        Coin counterPartAsCoin = available.subtract(enteredAmount);
-        String formattedCounterPartAmount = formatter.formatCoin(counterPartAsCoin);
-        Coin buyerAmount;
-        Coin sellerAmount;
-        if (inputTextField == buyerPayoutAmountInputTextField) {
-            buyerAmount = enteredAmount;
-            sellerAmount = counterPartAsCoin;
-            Coin sellerAmountFromField = ParsingUtils.parseToCoin(sellerPayoutAmountInputTextField.getText(), formatter);
-            Coin totalAmountFromFields = enteredAmount.add(sellerAmountFromField);
-            // RefundAgent can enter less then available
-            if (getDisputeManager(dispute) instanceof MediationManager ||
-                    totalAmountFromFields.compareTo(available) > 0) {
-                sellerPayoutAmountInputTextField.setText(formattedCounterPartAmount);
-            } else {
-                sellerAmount = sellerAmountFromField;
-            }
-        } else {
-            sellerAmount = enteredAmount;
-            buyerAmount = counterPartAsCoin;
-            Coin buyerAmountFromField = ParsingUtils.parseToCoin(buyerPayoutAmountInputTextField.getText(), formatter);
-            Coin totalAmountFromFields = enteredAmount.add(buyerAmountFromField);
-            // RefundAgent can enter less then available
-            if (getDisputeManager(dispute) instanceof MediationManager ||
-                    totalAmountFromFields.compareTo(available) > 0) {
-                buyerPayoutAmountInputTextField.setText(formattedCounterPartAmount);
-            } else {
-                buyerAmount = buyerAmountFromField;
-            }
-        }
+    private void applyCustomAmounts(InputTextField inputTextField, boolean oldFocusValue, boolean newFocusValue) {
+        // We only apply adjustments at focus out, otherwise we cannot enter certain values if we update at each
+        // keystroke.
+        if (oldFocusValue && !newFocusValue) {
+            Contract contract = dispute.getContract();
+            boolean isMediationDispute = getDisputeManager(dispute) instanceof MediationManager;
+            // At mediation we require a min. payout to the losing party to keep incentive for the trader to accept the
+            // mediated payout. For Refund agent cases we do not have that restriction.
+            Coin minRefundAtDispute = isMediationDispute ? Restrictions.getMinRefundAtMediatedDispute() : Coin.ZERO;
 
-        disputeResult.setBuyerPayoutAmount(buyerAmount);
-        disputeResult.setSellerPayoutAmount(sellerAmount);
-        disputeResult.setWinner(buyerAmount.compareTo(sellerAmount) > 0 ?
-                DisputeResult.Winner.BUYER :
-                DisputeResult.Winner.SELLER);
+            Offer offer = new Offer(contract.getOfferPayload());
+            Coin totalAvailable = contract.getTradeAmount()
+                    .add(offer.getBuyerSecurityDeposit())
+                    .add(offer.getSellerSecurityDeposit());
+            Coin availableForPayout = totalAvailable.subtract(minRefundAtDispute);
+
+            Coin enteredAmount = ParsingUtils.parseToCoin(inputTextField.getText(), formatter);
+            if (enteredAmount.compareTo(minRefundAtDispute) < 0) {
+                enteredAmount = minRefundAtDispute;
+                inputTextField.setText(formatter.formatCoin(enteredAmount));
+            }
+            if (enteredAmount.isPositive() && !Restrictions.isAboveDust(enteredAmount)) {
+                enteredAmount = Restrictions.getMinNonDustOutput();
+                inputTextField.setText(formatter.formatCoin(enteredAmount));
+            }
+            if (enteredAmount.compareTo(availableForPayout) > 0) {
+                enteredAmount = availableForPayout;
+                inputTextField.setText(formatter.formatCoin(enteredAmount));
+            }
+            Coin counterPartAsCoin = totalAvailable.subtract(enteredAmount);
+            String formattedCounterPartAmount = formatter.formatCoin(counterPartAsCoin);
+            Coin buyerAmount;
+            Coin sellerAmount;
+            if (inputTextField == buyerPayoutAmountInputTextField) {
+                buyerAmount = enteredAmount;
+                sellerAmount = counterPartAsCoin;
+                Coin sellerAmountFromField = ParsingUtils.parseToCoin(sellerPayoutAmountInputTextField.getText(), formatter);
+                Coin totalAmountFromFields = enteredAmount.add(sellerAmountFromField);
+                // RefundAgent can enter less then available
+                if (isMediationDispute ||
+                        totalAmountFromFields.compareTo(totalAvailable) > 0) {
+                    sellerPayoutAmountInputTextField.setText(formattedCounterPartAmount);
+                } else {
+                    sellerAmount = sellerAmountFromField;
+                }
+            } else {
+                sellerAmount = enteredAmount;
+                buyerAmount = counterPartAsCoin;
+                Coin buyerAmountFromField = ParsingUtils.parseToCoin(buyerPayoutAmountInputTextField.getText(), formatter);
+                Coin totalAmountFromFields = enteredAmount.add(buyerAmountFromField);
+                // RefundAgent can enter less then available
+                if (isMediationDispute ||
+                        totalAmountFromFields.compareTo(totalAvailable) > 0) {
+                    buyerPayoutAmountInputTextField.setText(formattedCounterPartAmount);
+                } else {
+                    buyerAmount = buyerAmountFromField;
+                }
+            }
+
+            disputeResult.setBuyerPayoutAmount(buyerAmount);
+            disputeResult.setSellerPayoutAmount(sellerAmount);
+            disputeResult.setWinner(buyerAmount.compareTo(sellerAmount) > 0 ?
+                    DisputeResult.Winner.BUYER :
+                    DisputeResult.Winner.SELLER);
+        }
     }
 
     private void addPayoutAmountTextFields() {
@@ -735,25 +751,31 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         Coin buyerSecurityDeposit = offer.getBuyerSecurityDeposit();
         Coin sellerSecurityDeposit = offer.getSellerSecurityDeposit();
         Coin tradeAmount = contract.getTradeAmount();
+
+        boolean isMediationDispute = getDisputeManager(dispute) instanceof MediationManager;
+        // At mediation we require a min. payout to the losing party to keep incentive for the trader to accept the
+        // mediated payout. For Refund agent cases we do not have that restriction.
+        Coin minRefundAtDispute = isMediationDispute ? Restrictions.getMinRefundAtMediatedDispute() : Coin.ZERO;
+        Coin maxPayoutAmount = tradeAmount
+                .add(buyerSecurityDeposit)
+                .add(sellerSecurityDeposit)
+                .subtract(minRefundAtDispute);
+
         if (selectedTradeAmountToggle == buyerGetsTradeAmountRadioButton) {
             disputeResult.setBuyerPayoutAmount(tradeAmount.add(buyerSecurityDeposit));
             disputeResult.setSellerPayoutAmount(sellerSecurityDeposit);
             disputeResult.setWinner(DisputeResult.Winner.BUYER);
         } else if (selectedTradeAmountToggle == buyerGetsAllRadioButton) {
-            disputeResult.setBuyerPayoutAmount(tradeAmount
-                    .add(buyerSecurityDeposit)
-                    .add(sellerSecurityDeposit));
-            disputeResult.setSellerPayoutAmount(Coin.ZERO);
+            disputeResult.setBuyerPayoutAmount(maxPayoutAmount);
+            disputeResult.setSellerPayoutAmount(minRefundAtDispute);
             disputeResult.setWinner(DisputeResult.Winner.BUYER);
         } else if (selectedTradeAmountToggle == sellerGetsTradeAmountRadioButton) {
             disputeResult.setBuyerPayoutAmount(buyerSecurityDeposit);
             disputeResult.setSellerPayoutAmount(tradeAmount.add(sellerSecurityDeposit));
             disputeResult.setWinner(DisputeResult.Winner.SELLER);
         } else if (selectedTradeAmountToggle == sellerGetsAllRadioButton) {
-            disputeResult.setBuyerPayoutAmount(Coin.ZERO);
-            disputeResult.setSellerPayoutAmount(tradeAmount
-                    .add(sellerSecurityDeposit)
-                    .add(buyerSecurityDeposit));
+            disputeResult.setBuyerPayoutAmount(minRefundAtDispute);
+            disputeResult.setSellerPayoutAmount(maxPayoutAmount);
             disputeResult.setWinner(DisputeResult.Winner.SELLER);
         }
 
@@ -774,17 +796,26 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         buyerPayoutAmountInputTextField.setText(formatter.formatCoin(buyerPayoutAmount));
         sellerPayoutAmountInputTextField.setText(formatter.formatCoin(sellerPayoutAmount));
 
+        boolean isMediationDispute = getDisputeManager(dispute) instanceof MediationManager;
+        // At mediation we require a min. payout to the losing party to keep incentive for the trader to accept the
+        // mediated payout. For Refund agent cases we do not have that restriction.
+        Coin minRefundAtDispute = isMediationDispute ? Restrictions.getMinRefundAtMediatedDispute() : Coin.ZERO;
+        Coin maxPayoutAmount = tradeAmount
+                .add(buyerSecurityDeposit)
+                .add(sellerSecurityDeposit)
+                .subtract(minRefundAtDispute);
+
         if (buyerPayoutAmount.equals(tradeAmount.add(buyerSecurityDeposit)) &&
                 sellerPayoutAmount.equals(sellerSecurityDeposit)) {
             buyerGetsTradeAmountRadioButton.setSelected(true);
-        } else if (buyerPayoutAmount.equals(tradeAmount.add(buyerSecurityDeposit).add(sellerSecurityDeposit)) &&
-                sellerPayoutAmount.equals(Coin.ZERO)) {
+        } else if (buyerPayoutAmount.equals(maxPayoutAmount) &&
+                sellerPayoutAmount.equals(minRefundAtDispute)) {
             buyerGetsAllRadioButton.setSelected(true);
         } else if (sellerPayoutAmount.equals(tradeAmount.add(sellerSecurityDeposit))
                 && buyerPayoutAmount.equals(buyerSecurityDeposit)) {
             sellerGetsTradeAmountRadioButton.setSelected(true);
-        } else if (sellerPayoutAmount.equals(tradeAmount.add(buyerSecurityDeposit).add(sellerSecurityDeposit))
-                && buyerPayoutAmount.equals(Coin.ZERO)) {
+        } else if (sellerPayoutAmount.equals(maxPayoutAmount)
+                && buyerPayoutAmount.equals(minRefundAtDispute)) {
             sellerGetsAllRadioButton.setSelected(true);
         } else {
             customRadioButton.setSelected(true);


### PR DESCRIPTION
At mediation we require a min. payout to the losing party to keep
incentive for the trader to accept the mediated payout. For Refund
agent cases we do not have that restriction.

There is a change in the adjustment behaviour for custom payout. The previous adjustment at keystroken does not work anymore as when one enters 0.1 the first 0 key stroke would trigger already the min refund value. I changed the event type to focus out, so the adjustment is only done at focus out. Clicking on the background does not trigger a focus out, only if you click on a control (text field, button, toggle,...).

I also added a check to not allow that both outputs are 0 at refund agent case. That was previously possible but caused an exception in the wallet class. Not the button will stay deactivated if both are 0 BTC.

Testing:
Run test case with mediation and refund agent and toggle between the 4 predefined payout distributions as well as a custom payout. Use diff. values including 0, negative and too high to see if it auto-adjusts after focus out. Note that mediation and refund agent have differnet policy here.