### PR TITLE
Speed up trades charts view load

### DIFF
--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -23,14 +23,12 @@ import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import org.bitcoinj.core.VersionMessage;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.ChainFileLockedException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.fxmisc.easybind.EasyBind;
@@ -60,7 +58,6 @@ public class WalletAppSetup {
     private final WalletsSetup walletsSetup;
     private final BisqEnvironment bisqEnvironment;
     private final Preferences preferences;
-    private final CoinFormatter formatter;
 
     @SuppressWarnings("FieldCanBeLocal")
     private MonadicBinding<String> btcInfoBinding;
@@ -84,13 +81,11 @@ public class WalletAppSetup {
     public WalletAppSetup(WalletsManager walletsManager,
                           WalletsSetup walletsSetup,
                           BisqEnvironment bisqEnvironment,
-                          Preferences preferences,
-                          @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+                          Preferences preferences) {
         this.walletsManager = walletsManager;
         this.walletsSetup = walletsSetup;
         this.bisqEnvironment = bisqEnvironment;
         this.preferences = preferences;
-        this.formatter = formatter;
         this.useTorForBTC.set(preferences.getUseTorForBitcoinJ());
     }
 
@@ -156,9 +151,7 @@ public class WalletAppSetup {
                     return result;
 
                 });
-        btcInfoBinding.subscribe((observable, oldValue, newValue) -> {
-            getBtcInfo().set(newValue);
-        });
+        btcInfoBinding.subscribe((observable, oldValue, newValue) -> getBtcInfo().set(newValue));
 
         walletsSetup.initialize(null,
                 () -> {

--- a/core/src/main/java/bisq/core/dao/governance/votereveal/VoteRevealService.java
+++ b/core/src/main/java/bisq/core/dao/governance/votereveal/VoteRevealService.java
@@ -38,8 +38,6 @@ import bisq.core.dao.state.model.blockchain.TxOutput;
 import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.dao.state.model.governance.DaoPhase;
 
-import bisq.network.p2p.P2PService;
-
 import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.InsufficientMoneyException;
@@ -81,7 +79,6 @@ public class VoteRevealService implements DaoStateListener, DaoSetupService {
     private final MyVoteListService myVoteListService;
     private final BsqWalletService bsqWalletService;
     private final BtcWalletService btcWalletService;
-    private final P2PService p2PService;
     private final WalletsManager walletsManager;
 
     @Getter
@@ -99,7 +96,6 @@ public class VoteRevealService implements DaoStateListener, DaoSetupService {
                              MyVoteListService myVoteListService,
                              BsqWalletService bsqWalletService,
                              BtcWalletService btcWalletService,
-                             P2PService p2PService,
                              WalletsManager walletsManager) {
         this.daoStateService = daoStateService;
         this.blindVoteListService = blindVoteListService;
@@ -107,7 +103,6 @@ public class VoteRevealService implements DaoStateListener, DaoSetupService {
         this.myVoteListService = myVoteListService;
         this.bsqWalletService = bsqWalletService;
         this.btcWalletService = btcWalletService;
-        this.p2PService = p2PService;
         this.walletsManager = walletsManager;
     }
 
@@ -243,7 +238,7 @@ public class VoteRevealService implements DaoStateListener, DaoSetupService {
             publishTx(voteRevealTx);
 
             // We don't want to wait for a successful broadcast to avoid issues if the broadcast succeeds delayed or at
-            // next startup but the tx was actually broadcasted.
+            // next startup but the tx was actually broadcast.
             myVoteListService.applyRevealTxId(myVote, voteRevealTx.getHashAsString());
         } catch (IOException | WalletException | TransactionVerificationException
                 | InsufficientMoneyException e) {
@@ -258,7 +253,7 @@ public class VoteRevealService implements DaoStateListener, DaoSetupService {
         walletsManager.publishAndCommitBsqTx(voteRevealTx, TxType.VOTE_REVEAL, new TxBroadcaster.Callback() {
             @Override
             public void onSuccess(Transaction transaction) {
-                log.info("voteRevealTx successfully broadcasted.");
+                log.info("voteRevealTx successfully broadcast.");
                 voteRevealTxPublishedListeners.forEach(l -> l.onVoteRevealTxPublished(transaction.getHashAsString()));
             }
 

--- a/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
+++ b/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
@@ -31,7 +31,6 @@ import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.crypto.KeyRing;
 import bisq.common.util.MathUtils;
@@ -39,7 +38,6 @@ import bisq.common.util.MathUtils;
 import org.bitcoinj.utils.Fiat;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.List;
@@ -55,17 +53,15 @@ public class MarketAlerts {
     private final User user;
     private final PriceFeedService priceFeedService;
     private final KeyRing keyRing;
-    private final CoinFormatter formatter;
 
     @Inject
-    public MarketAlerts(OfferBookService offerBookService, MobileNotificationService mobileNotificationService,
-                        User user, PriceFeedService priceFeedService, KeyRing keyRing, @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+    private MarketAlerts(OfferBookService offerBookService, MobileNotificationService mobileNotificationService,
+                         User user, PriceFeedService priceFeedService, KeyRing keyRing) {
         this.offerBookService = offerBookService;
         this.mobileNotificationService = mobileNotificationService;
         this.user = user;
         this.priceFeedService = priceFeedService;
         this.keyRing = keyRing;
-        this.formatter = formatter;
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
@@ -35,7 +35,6 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.AssetsAccountPayload;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.validation.AltCoinAddressValidator;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.InputValidator;
 
@@ -65,7 +64,6 @@ public class AssetsForm extends PaymentMethodForm {
     private final AltCoinAddressValidator altCoinAddressValidator;
     private final AssetService assetService;
     private final FilterManager filterManager;
-    private final Preferences preferences;
 
     private InputTextField addressInputTextField;
     private CheckBox tradeInstantCheckBox;
@@ -88,14 +86,12 @@ public class AssetsForm extends PaymentMethodForm {
                       int gridRow,
                       CoinFormatter formatter,
                       AssetService assetService,
-                      FilterManager filterManager,
-                      Preferences preferences) {
+                      FilterManager filterManager) {
         super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
         this.assetAccount = (AssetAccount) paymentAccount;
         this.altCoinAddressValidator = altCoinAddressValidator;
         this.assetService = assetService;
         this.filterManager = filterManager;
-        this.preferences = preferences;
 
         tradeInstant = paymentAccount instanceof InstantCryptoCurrencyAccount;
     }
@@ -207,9 +203,8 @@ public class AssetsForm extends PaymentMethodForm {
         currencyComboBox.setPromptText(Res.get("payment.select.altcoin"));
         currencyComboBox.setButtonCell(getComboBoxButtonCell(Res.get("payment.select.altcoin"), currencyComboBox));
 
-        currencyComboBox.getEditor().focusedProperty().addListener(observable -> {
-            currencyComboBox.setPromptText("");
-        });
+        currencyComboBox.getEditor().focusedProperty().addListener(observable ->
+                currencyComboBox.setPromptText(""));
 
         ((AutocompleteComboBox<TradeCurrency>) currencyComboBox).setAutocompleteItems(
                 CurrencyUtil.getActiveSortedCryptoCurrencies(assetService, filterManager));

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -176,7 +176,7 @@ public abstract class PaymentMethodForm {
             tradeCurrency = paymentAccount.getTradeCurrencies().get(0);
         else
             tradeCurrency = paymentAccount instanceof AssetAccount ?
-                    CurrencyUtil.getAllSortedCryptoCurrencies().get(0) :
+                    CurrencyUtil.getAllSortedCryptoCurrencies().iterator().next() :
                     CurrencyUtil.getDefaultTradeCurrency();
 
 

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -47,8 +47,6 @@ import bisq.core.exceptions.BisqException;
 import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.LanguageUtil;
 import bisq.core.locale.Res;
-import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
@@ -57,7 +55,6 @@ import bisq.common.util.Tuple2;
 import bisq.common.util.Utilities;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import com.jfoenix.controls.JFXBadge;
 import com.jfoenix.controls.JFXComboBox;
@@ -146,7 +143,6 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
 
     private final ViewLoader viewLoader;
     private final Navigation navigation;
-    private final CoinFormatter formatter;
 
     private final ToggleGroup navButtons = new ToggleGroup();
     private ChangeListener<String> walletServiceErrorMsgListener;
@@ -166,12 +162,10 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
                     CachingViewLoader viewLoader,
                     Navigation navigation,
                     Transitions transitions,
-                    @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                     DaoStateMonitoringService daoStateMonitoringService) {
         super(model);
         this.viewLoader = viewLoader;
         this.navigation = navigation;
-        this.formatter = formatter;
         MainView.transitions = transitions;
         this.daoStateMonitoringService = daoStateMonitoringService;
     }
@@ -405,9 +399,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
 
                 navigation.navigateToPreviousVisitedView();
 
-                transitions.fadeOutAndRemove(splashScreen, 1500, actionEvent -> {
-                    disposeSplashScreen();
-                });
+                transitions.fadeOutAndRemove(splashScreen, 1500, actionEvent -> disposeSplashScreen());
             }
         });
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
@@ -241,7 +241,7 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
 
     private PaymentMethodForm getPaymentMethodForm(PaymentAccount paymentAccount) {
         return new AssetsForm(paymentAccount, accountAgeWitnessService, altCoinAddressValidator,
-                inputValidator, root, gridRow, formatter, assetService, filterManager, preferences);
+                inputValidator, root, gridRow, formatter, assetService, filterManager);
     }
 
     private void removeNewAccountForm() {

--- a/desktop/src/main/java/bisq/desktop/main/account/content/notifications/ManageMarketAlertsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/notifications/ManageMarketAlertsWindow.java
@@ -27,7 +27,6 @@ import bisq.core.locale.Res;
 import bisq.core.notifications.alerts.market.MarketAlertFilter;
 import bisq.core.notifications.alerts.market.MarketAlerts;
 import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.UserThread;
 
@@ -54,11 +53,9 @@ import lombok.extern.slf4j.Slf4j;
 public class ManageMarketAlertsWindow extends Overlay<ManageMarketAlertsWindow> {
 
     private final MarketAlerts marketAlerts;
-    private final CoinFormatter formatter;
 
-    ManageMarketAlertsWindow(MarketAlerts marketAlerts, CoinFormatter formatter) {
+    ManageMarketAlertsWindow(MarketAlerts marketAlerts) {
         this.marketAlerts = marketAlerts;
-        this.formatter = formatter;
         type = Type.Attention;
     }
 
@@ -109,11 +106,10 @@ public class ManageMarketAlertsWindow extends Overlay<ManageMarketAlertsWindow> 
         column = new AutoTooltipTableColumn<>(Res.get("account.notifications.marketAlert.manageAlerts.header.paymentAccount"));
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<MarketAlertFilter, MarketAlertFilter>, TableCell<MarketAlertFilter, MarketAlertFilter>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<MarketAlertFilter, MarketAlertFilter> call(TableColumn<MarketAlertFilter, MarketAlertFilter> column) {
-                        return new TableCell<MarketAlertFilter, MarketAlertFilter>() {
-
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final MarketAlertFilter item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -132,11 +128,10 @@ public class ManageMarketAlertsWindow extends Overlay<ManageMarketAlertsWindow> 
         column = new AutoTooltipTableColumn<>(Res.get("account.notifications.marketAlert.manageAlerts.header.trigger"));
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<MarketAlertFilter, MarketAlertFilter>, TableCell<MarketAlertFilter, MarketAlertFilter>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<MarketAlertFilter, MarketAlertFilter> call(TableColumn<MarketAlertFilter, MarketAlertFilter> column) {
-                        return new TableCell<MarketAlertFilter, MarketAlertFilter>() {
-
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final MarketAlertFilter item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -155,11 +150,10 @@ public class ManageMarketAlertsWindow extends Overlay<ManageMarketAlertsWindow> 
         column = new AutoTooltipTableColumn<>(Res.get("account.notifications.marketAlert.manageAlerts.header.offerType"));
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<MarketAlertFilter, MarketAlertFilter>, TableCell<MarketAlertFilter, MarketAlertFilter>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<MarketAlertFilter, MarketAlertFilter> call(TableColumn<MarketAlertFilter, MarketAlertFilter> column) {
-                        return new TableCell<MarketAlertFilter, MarketAlertFilter>() {
-
+                        return new TableCell<>() {
                             @Override
                             public void updateItem(final MarketAlertFilter item, boolean empty) {
                                 super.updateItem(item, empty);
@@ -179,10 +173,10 @@ public class ManageMarketAlertsWindow extends Overlay<ManageMarketAlertsWindow> 
         column.setMaxWidth(column.getMinWidth());
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(
-                new Callback<TableColumn<MarketAlertFilter, MarketAlertFilter>, TableCell<MarketAlertFilter, MarketAlertFilter>>() {
+                new Callback<>() {
                     @Override
                     public TableCell<MarketAlertFilter, MarketAlertFilter> call(TableColumn<MarketAlertFilter, MarketAlertFilter> column) {
-                        return new TableCell<MarketAlertFilter, MarketAlertFilter>() {
+                        return new TableCell<>() {
                             final ImageView icon = ImageUtil.getImageViewById(ImageUtil.REMOVE_ICON);
                             final Button removeButton = new AutoTooltipButton("", icon);
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/notifications/MobileNotificationsView.java
@@ -49,7 +49,6 @@ import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
-import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.InputValidator;
 
 import bisq.common.UserThread;
@@ -57,7 +56,6 @@ import bisq.common.util.Tuple2;
 import bisq.common.util.Tuple3;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
@@ -91,7 +89,6 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
     private final PriceFeedService priceFeedService;
     private final MarketAlerts marketAlerts;
     private final MobileNotificationService mobileNotificationService;
-    private final CoinFormatter formatter;
 
     private WebCamWindow webCamWindow;
     private QrCodeReader qrCodeReader;
@@ -127,15 +124,13 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
                                     User user,
                                     PriceFeedService priceFeedService,
                                     MarketAlerts marketAlerts,
-                                    MobileNotificationService mobileNotificationService,
-                                    @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+                                    MobileNotificationService mobileNotificationService) {
         super();
         this.preferences = preferences;
         this.user = user;
         this.priceFeedService = priceFeedService;
         this.marketAlerts = marketAlerts;
         this.mobileNotificationService = mobileNotificationService;
-        this.formatter = formatter;
     }
 
     @Override
@@ -325,7 +320,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
         try {
             if (message != null) {
                 mobileNotificationService.sendMessage(message, useSoundToggleButton.isSelected());
-            } else if (messages != null) {
+            } else {
                 messages.forEach(msg -> {
                     try {
                         mobileNotificationService.sendMessage(msg, useSoundToggleButton.isSelected());
@@ -359,7 +354,7 @@ public class MobileNotificationsView extends ActivatableView<GridPane, Void> {
     }
 
     private void onManageMarketAlerts() {
-        new ManageMarketAlertsWindow(marketAlerts, formatter)
+        new ManageMarketAlertsWindow(marketAlerts)
                 .onClose(this::updateMarketAlertFields)
                 .show();
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/news/NewsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/news/NewsView.java
@@ -9,7 +9,6 @@ import bisq.desktop.util.Layout;
 
 import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
 
 import bisq.common.util.Tuple3;
@@ -35,15 +34,12 @@ import static bisq.desktop.util.FormBuilder.*;
 @FxmlView
 public class NewsView extends ActivatableView<HBox, Void> {
 
-    private final Preferences preferences;
     private final BsqWalletService bsqWalletService;
     private final BsqFormatter bsqFormatter;
     private BsqAddressTextField addressTextField;
 
     @Inject
-    private NewsView(Preferences preferences, BsqWalletService bsqWalletService,
-                     BsqFormatter bsqFormatter) {
-        this.preferences = preferences;
+    private NewsView(BsqWalletService bsqWalletService, BsqFormatter bsqFormatter) {
         this.bsqWalletService = bsqWalletService;
         this.bsqFormatter = bsqFormatter;
     }

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -36,8 +36,6 @@ import bisq.core.offer.OpenOffer;
 import bisq.core.trade.Tradable;
 import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
-import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.P2PService;
 
@@ -54,7 +52,6 @@ import org.bitcoinj.wallet.listeners.WalletEventListener;
 import com.googlecode.jcsv.writer.CSVEntryConverter;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import de.jensd.fx.fontawesome.AwesomeIcon;
 
@@ -102,7 +99,6 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     private final BtcWalletService btcWalletService;
     private final P2PService p2PService;
     private final WalletsSetup walletsSetup;
-    private final CoinFormatter formatter;
     private final Preferences preferences;
     private final TradeDetailsWindow tradeDetailsWindow;
     private final OfferDetailsWindow offerDetailsWindow;
@@ -119,7 +115,6 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     private TransactionsView(BtcWalletService btcWalletService,
                              P2PService p2PService,
                              WalletsSetup walletsSetup,
-                             @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                              Preferences preferences,
                              TradeDetailsWindow tradeDetailsWindow,
                              OfferDetailsWindow offerDetailsWindow,
@@ -127,7 +122,6 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         this.btcWalletService = btcWalletService;
         this.p2PService = p2PService;
         this.walletsSetup = walletsSetup;
-        this.formatter = formatter;
         this.preferences = preferences;
         this.tradeDetailsWindow = tradeDetailsWindow;
         this.offerDetailsWindow = offerDetailsWindow;

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -38,12 +38,8 @@ import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
-import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import com.google.inject.Inject;
-
-import javax.inject.Named;
 
 import com.google.common.math.LongMath;
 
@@ -85,7 +81,6 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     private final ObservableList<OfferListItem> topBuyOfferList = FXCollections.observableArrayList();
     private final ObservableList<OfferListItem> topSellOfferList = FXCollections.observableArrayList();
     private final ChangeListener<Number> currenciesUpdatedListener;
-    private final CoinFormatter formatter;
     private int selectedTabIndex;
     public final IntegerProperty maxPlacesForBuyPrice = new SimpleIntegerProperty();
     public final IntegerProperty maxPlacesForBuyVolume = new SimpleIntegerProperty();
@@ -96,15 +91,13 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     // Constructor, lifecycle
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    @SuppressWarnings("WeakerAccess")
     @Inject
-    public OfferBookChartViewModel(OfferBook offerBook, Preferences preferences, PriceFeedService priceFeedService,
-                                   AccountAgeWitnessService accountAgeWitnessService, Navigation navigation, @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+    OfferBookChartViewModel(OfferBook offerBook, Preferences preferences, PriceFeedService priceFeedService,
+                            AccountAgeWitnessService accountAgeWitnessService, Navigation navigation) {
         this.offerBook = offerBook;
         this.preferences = preferences;
         this.priceFeedService = priceFeedService;
         this.navigation = navigation;
-        this.formatter = formatter;
         this.accountAgeWitnessService = accountAgeWitnessService;
 
         String code = preferences.getOfferBookChartScreenCurrencyCode();

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -45,7 +45,6 @@ import bisq.desktop.main.portfolio.PortfolioView;
 import bisq.desktop.main.portfolio.openoffer.OpenOffersView;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
-import bisq.desktop.util.Transitions;
 
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
@@ -125,7 +124,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     public static final String BUYER_SECURITY_DEPOSIT_NEWS = "buyerSecurityDepositNews0.9.5";
     protected final Navigation navigation;
     private final Preferences preferences;
-    private final Transitions transitions;
     private final OfferDetailsWindow offerDetailsWindow;
     private final CoinFormatter btcFormatter;
     private final BsqFormatter bsqFormatter;
@@ -183,7 +181,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     public MutableOfferView(M model,
                             Navigation navigation,
                             Preferences preferences,
-                            Transitions transitions,
                             OfferDetailsWindow offerDetailsWindow,
                             CoinFormatter btcFormatter,
                             BsqFormatter bsqFormatter) {
@@ -191,7 +188,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         this.navigation = navigation;
         this.preferences = preferences;
-        this.transitions = transitions;
         this.offerDetailsWindow = offerDetailsWindow;
         this.btcFormatter = btcFormatter;
         this.bsqFormatter = bsqFormatter;

--- a/desktop/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferView.java
@@ -21,7 +21,6 @@ import bisq.desktop.Navigation;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.main.offer.MutableOfferView;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
-import bisq.desktop.util.Transitions;
 
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
@@ -36,8 +35,12 @@ import javax.inject.Named;
 public class CreateOfferView extends MutableOfferView<CreateOfferViewModel> {
 
     @Inject
-    public CreateOfferView(CreateOfferViewModel model, Navigation navigation, Preferences preferences, Transitions transitions, OfferDetailsWindow offerDetailsWindow, @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter, BsqFormatter bsqFormatter) {
-        super(model, navigation, preferences, transitions, offerDetailsWindow, btcFormatter, bsqFormatter);
+    private CreateOfferView(CreateOfferViewModel model,
+                            Navigation navigation,
+                            Preferences preferences,
+                            OfferDetailsWindow offerDetailsWindow,
+                            @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter,
+                            BsqFormatter bsqFormatter) {
+        super(model, navigation, preferences, offerDetailsWindow, btcFormatter, bsqFormatter);
     }
 }
-

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -29,7 +29,6 @@ import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.validation.BtcValidator;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
-import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Price;
@@ -43,8 +42,8 @@ import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
-import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.InputValidator;
 
@@ -87,7 +86,6 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     final TakeOfferDataModel dataModel;
     private final BtcValidator btcValidator;
     private final P2PService p2PService;
-    private final WalletsSetup walletsSetup;
     private final Preferences preferences;
     private final PriceFeedService priceFeedService;
     private AccountAgeWitnessService accountAgeWitnessService;
@@ -148,7 +146,6 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     public TakeOfferViewModel(TakeOfferDataModel dataModel,
                               BtcValidator btcValidator,
                               P2PService p2PService,
-                              WalletsSetup walletsSetup,
                               Preferences preferences,
                               PriceFeedService priceFeedService,
                               AccountAgeWitnessService accountAgeWitnessService,
@@ -160,7 +157,6 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
 
         this.btcValidator = btcValidator;
         this.p2PService = p2PService;
-        this.walletsSetup = walletsSetup;
         this.preferences = preferences;
         this.priceFeedService = priceFeedService;
         this.accountAgeWitnessService = accountAgeWitnessService;
@@ -283,7 +279,6 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
                     .show();
             return false;
         }
-
     }
 
     public void setIsCurrencyForTakerFeeBtc(boolean isCurrencyForTakerFeeBtc) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
@@ -38,16 +38,13 @@ import bisq.core.trade.Contract;
 import bisq.core.trade.Tradable;
 import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
-import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
 
 import com.googlecode.jcsv.writer.CSVEntryConverter;
 
-import javax.inject.Named;
-
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import javafx.fxml.FXML;
 
@@ -99,7 +96,6 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
 
     private final OfferDetailsWindow offerDetailsWindow;
     private Preferences preferences;
-    private final CoinFormatter formatter;
     private final TradeDetailsWindow tradeDetailsWindow;
     private final PrivateNotificationManager privateNotificationManager;
     private SortedList<ClosedTradableListItem> sortedList;
@@ -112,14 +108,12 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
                             Preferences preferences,
                             TradeDetailsWindow tradeDetailsWindow,
                             PrivateNotificationManager privateNotificationManager,
-                            @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                             @Named(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
         super(model);
         this.offerDetailsWindow = offerDetailsWindow;
         this.preferences = preferences;
         this.tradeDetailsWindow = tradeDetailsWindow;
         this.privateNotificationManager = privateNotificationManager;
-        this.formatter = formatter;
         this.useDevPrivilegeKeys = useDevPrivilegeKeys;
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferView.java
@@ -24,7 +24,6 @@ import bisq.desktop.components.BusyAnimation;
 import bisq.desktop.main.offer.MutableOfferView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.OfferDetailsWindow;
-import bisq.desktop.util.Transitions;
 
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
@@ -64,8 +63,13 @@ public class EditOfferView extends MutableOfferView<EditOfferViewModel> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    private EditOfferView(EditOfferViewModel model, Navigation navigation, Preferences preferences, Transitions transitions, OfferDetailsWindow offerDetailsWindow, @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter, BsqFormatter bsqFormatter) {
-        super(model, navigation, preferences, transitions, offerDetailsWindow, btcFormatter, bsqFormatter);
+    private EditOfferView(EditOfferViewModel model,
+                          Navigation navigation,
+                          Preferences preferences,
+                          OfferDetailsWindow offerDetailsWindow,
+                          @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter,
+                          BsqFormatter bsqFormatter) {
+        super(model, navigation, preferences, offerDetailsWindow, btcFormatter, bsqFormatter);
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
@@ -31,12 +31,10 @@ import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.UserThread;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.fxmisc.easybind.EasyBind;
@@ -66,7 +64,6 @@ import lombok.Getter;
 @Singleton
 public class MarketPricePresentation {
     private final Preferences preferences;
-    private final CoinFormatter formatter;
     private final PriceFeedService priceFeedService;
     @Getter
     private final ObservableList<PriceFeedComboBoxItem> priceFeedComboBoxItems = FXCollections.observableArrayList();
@@ -93,11 +90,9 @@ public class MarketPricePresentation {
     public MarketPricePresentation(BtcWalletService btcWalletService,
                                    PriceFeedService priceFeedService,
                                    Preferences preferences,
-                                   FeeService feeService,
-                                   @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+                                   FeeService feeService) {
         this.priceFeedService = priceFeedService;
         this.preferences = preferences;
-        this.formatter = formatter;
 
         TxIdTextField.setPreferences(preferences);
 
@@ -247,10 +242,10 @@ public class MarketPricePresentation {
 
     public StringProperty getMarketPrice(String currencyCode) {
         SimpleStringProperty marketPrice = new SimpleStringProperty(Res.get("shared.na"));
-        try {
-            marketPrice.set(String.valueOf(priceFeedService.getMarketPrice(currencyCode).getPrice()));
-        } catch (NullPointerException e) {
-            // Market price is not available yet
+        MarketPrice marketPriceValue = priceFeedService.getMarketPrice(currencyCode);
+        // Market price might not be available yet:
+        if (marketPriceValue != null) {
+            marketPrice.set(String.valueOf(marketPriceValue.getPrice()));
         }
         return marketPrice;
     }

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -36,7 +36,6 @@ import bisq.core.filter.FilterManager;
 import bisq.core.locale.Res;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.network.Statistic;
@@ -45,7 +44,6 @@ import bisq.common.ClockWatcher;
 import bisq.common.UserThread;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import javafx.fxml.FXML;
 
@@ -112,7 +110,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
     private final BisqEnvironment bisqEnvironment;
     private final TorNetworkSettingsWindow torNetworkSettingsWindow;
     private final ClockWatcher clockWatcher;
-    private final CoinFormatter formatter;
     private final WalletsSetup walletsSetup;
     private final P2PService p2PService;
 
@@ -142,8 +139,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                                FilterManager filterManager,
                                BisqEnvironment bisqEnvironment,
                                TorNetworkSettingsWindow torNetworkSettingsWindow,
-                               ClockWatcher clockWatcher,
-                               @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+                               ClockWatcher clockWatcher) {
         super();
         this.walletsSetup = walletsSetup;
         this.p2PService = p2PService;
@@ -153,7 +149,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         this.bisqEnvironment = bisqEnvironment;
         this.torNetworkSettingsWindow = torNetworkSettingsWindow;
         this.clockWatcher = clockWatcher;
-        this.formatter = formatter;
     }
 
     public void initialize() {
@@ -279,7 +274,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                         .actionButtonText(Res.get("shared.applyAndShutDown"))
                         .onAction(() -> {
                             preferences.setUseTorForBitcoinJ(selected);
-                            UserThread.runAfter(BisqApp.getShutDownHandler()::run, 500, TimeUnit.MILLISECONDS);
+                            UserThread.runAfter(BisqApp.getShutDownHandler(), 500, TimeUnit.MILLISECONDS);
                         })
                         .closeButtonText(Res.get("shared.cancel"))
                         .onClose(() -> useTorForBtcJCheckBox.setSelected(!selected))
@@ -464,7 +459,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         p2pPeersTableView.getItems().forEach(P2pNetworkListItem::cleanup);
         p2pNetworkListItems.clear();
         p2pNetworkListItems.setAll(p2PService.getNetworkNode().getAllConnections().stream()
-                .map(connection -> new P2pNetworkListItem(connection, clockWatcher, formatter))
+                .map(connection -> new P2pNetworkListItem(connection, clockWatcher))
                 .collect(Collectors.toList()));
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/P2pNetworkListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/P2pNetworkListItem.java
@@ -21,7 +21,6 @@ import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.Res;
 import bisq.core.util.FormattingUtils;
-import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.network.Connection;
 import bisq.network.p2p.network.OutboundConnection;
@@ -47,7 +46,6 @@ public class P2pNetworkListItem {
     private final Connection connection;
     private final Subscription sentBytesSubscription, receivedBytesSubscription, onionAddressSubscription, roundTripTimeSubscription;
     private final ClockWatcher clockWatcher;
-    private final CoinFormatter formatter;
 
     private final StringProperty lastActivity = new SimpleStringProperty();
     private final StringProperty sentBytes = new SimpleStringProperty();
@@ -58,10 +56,9 @@ public class P2pNetworkListItem {
     private final StringProperty onionAddress = new SimpleStringProperty();
     private final ClockWatcher.Listener listener;
 
-    public P2pNetworkListItem(Connection connection, ClockWatcher clockWatcher, CoinFormatter formatter) {
+    P2pNetworkListItem(Connection connection, ClockWatcher clockWatcher) {
         this.connection = connection;
         this.clockWatcher = clockWatcher;
-        this.formatter = formatter;
         this.statistic = connection.getStatistic();
 
         sentBytesSubscription = EasyBind.subscribe(statistic.sentBytesProperty(),

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -48,7 +48,6 @@ import bisq.core.user.BlockChainExplorer;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
-import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.IntegerValidator;
 
 import bisq.common.UserThread;
@@ -124,7 +123,6 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     private final AssetService assetService;
     private final FilterManager filterManager;
     private final DaoFacade daoFacade;
-    private final CoinFormatter formatter;
 
     private ListView<FiatCurrency> fiatCurrenciesListView;
     private ComboBox<FiatCurrency> fiatCurrenciesComboBox;
@@ -161,7 +159,6 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                            AssetService assetService,
                            FilterManager filterManager,
                            DaoFacade daoFacade,
-                           @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                            @Named(DaoOptionKeys.FULL_DAO_NODE) String fullDaoNode,
                            @Named(DaoOptionKeys.RPC_USER) String rpcUser,
                            @Named(DaoOptionKeys.RPC_PASSWORD) String rpcPassword,
@@ -172,7 +169,6 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         this.assetService = assetService;
         this.filterManager = filterManager;
         this.daoFacade = daoFacade;
-        this.formatter = formatter;
         daoOptionsSet = fullDaoNode != null && !fullDaoNode.isEmpty() &&
                 rpcUser != null && !rpcUser.isEmpty() &&
                 rpcPassword != null && !rpcPassword.isEmpty() &&

--- a/desktop/src/test/java/bisq/desktop/MarketsPrintTool.java
+++ b/desktop/src/test/java/bisq/desktop/MarketsPrintTool.java
@@ -21,8 +21,8 @@ import bisq.core.locale.CryptoCurrency;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.FiatCurrency;
 
+import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
 
@@ -37,14 +37,14 @@ public class MarketsPrintTool {
         // <option value="onion_btc">DeepOnion (ONION)</option>
         // <option value="btc_bhd">Bahraini Dinar (BHD)</option>
 
-        final List<FiatCurrency> allSortedFiatCurrencies = CurrencyUtil.getAllSortedFiatCurrencies();
+        final Collection<FiatCurrency> allSortedFiatCurrencies = CurrencyUtil.getAllSortedFiatCurrencies();
         final Stream<MarketCurrency> fiatStream = allSortedFiatCurrencies.stream()
                 .filter(e -> !e.getCurrency().getCurrencyCode().equals("BSQ"))
                 .filter(e -> !e.getCurrency().getCurrencyCode().equals("BTC"))
                 .map(e -> new MarketCurrency("btc_" + e.getCode().toLowerCase(), e.getName(), e.getCode()))
                 .distinct();
 
-        final List<CryptoCurrency> allSortedCryptoCurrencies = CurrencyUtil.getAllSortedCryptoCurrencies();
+        final Collection<CryptoCurrency> allSortedCryptoCurrencies = CurrencyUtil.getAllSortedCryptoCurrencies();
         final Stream<MarketCurrency> cryptoStream = allSortedCryptoCurrencies.stream()
                 .filter(e -> !e.getCode().equals("BTC"))
                 .map(e -> new MarketCurrency(e.getCode().toLowerCase() + "_btc", e.getName(), e.getCode()))

--- a/desktop/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModelTest.java
@@ -62,7 +62,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null);
         assertEquals(0, model.maxPlacesForBuyPrice.intValue());
     }
 
@@ -81,7 +81,7 @@ public class OfferBookChartViewModelTest {
         when(priceFeedService.updateCounterProperty()).thenReturn(new SimpleIntegerProperty());
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, priceFeedService, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, priceFeedService, null, null);
         model.activate();
         assertEquals(0, model.maxPlacesForBuyPrice.intValue());
     }
@@ -95,7 +95,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null);
         model.activate();
         assertEquals(7, model.maxPlacesForBuyPrice.intValue());
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.price, 94016475L))));
@@ -111,7 +111,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null);
         assertEquals(0, model.maxPlacesForBuyVolume.intValue());
     }
 
@@ -124,7 +124,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null);
         model.activate();
         assertEquals(4, model.maxPlacesForBuyVolume.intValue()); //0.01
         offerBookListItems.addAll(make(btcBuyItem.but(with(OfferBookListItemMaker.amount, 100000000L))));
@@ -140,7 +140,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null);
         assertEquals(0, model.maxPlacesForSellPrice.intValue());
     }
 
@@ -159,7 +159,7 @@ public class OfferBookChartViewModelTest {
         when(priceFeedService.updateCounterProperty()).thenReturn(new SimpleIntegerProperty());
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, priceFeedService, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, priceFeedService, null, null);
         model.activate();
         assertEquals(0, model.maxPlacesForSellPrice.intValue());
     }
@@ -173,7 +173,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null);
         model.activate();
         assertEquals(7, model.maxPlacesForSellPrice.intValue()); // 10.0000 default price
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.price, 94016475L))));
@@ -189,7 +189,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, null, null, null);
         assertEquals(0, model.maxPlacesForSellVolume.intValue());
     }
 
@@ -202,7 +202,7 @@ public class OfferBookChartViewModelTest {
 
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
-        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null, coinFormatter);
+        final OfferBookChartViewModel model = new OfferBookChartViewModel(offerBook, empty, service, null, null);
         model.activate();
         assertEquals(4, model.maxPlacesForSellVolume.intValue()); //0.01
         offerBookListItems.addAll(make(btcSellItem.but(with(OfferBookListItemMaker.amount, 100000000L))));

--- a/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
@@ -27,7 +27,6 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.statistics.TradeStatistics2;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
-import bisq.core.util.coin.ImmutableCoinFormatter;
 
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.KeyStorage;
@@ -111,7 +110,7 @@ public class TradesChartsViewModelTest {
     public void setup() throws IOException {
         tradeStatisticsManager = mock(TradeStatisticsManager.class);
         model = new TradesChartsViewModel(tradeStatisticsManager, mock(Preferences.class), mock(PriceFeedService.class),
-                mock(Navigation.class), mock(ImmutableCoinFormatter.class));
+                mock(Navigation.class));
         dir = File.createTempFile("temp_tests1", "");
         //noinspection ResultOfMethodCallIgnored
         dir.delete();
@@ -181,7 +180,7 @@ public class TradesChartsViewModelTest {
         // Trade EUR
         model.selectedTradeCurrencyProperty.setValue(new FiatCurrency("EUR"));
 
-        ArrayList<Trade> trades = new ArrayList<Trade>();
+        ArrayList<Trade> trades = new ArrayList<>();
 
         // Set predetermined time to use as "now" during test
         Date test_time = dateFormat.parse("2018-01-01T00:00:05");  // Monday
@@ -197,9 +196,7 @@ public class TradesChartsViewModelTest {
         trades.add(new Trade("2018-01-01T00:00:02", "1", "110", "EUR"));
         Set<TradeStatistics2> set = new HashSet<>();
         trades.forEach(t ->
-                {
-                    set.add(new TradeStatistics2(offer, Price.parse(t.cc, t.price), Coin.parseCoin(t.size), t.date, null, null));
-                }
+                set.add(new TradeStatistics2(offer, Price.parse(t.cc, t.price), Coin.parseCoin(t.size), t.date, null, null))
         );
         ObservableSet<TradeStatistics2> tradeStats = FXCollections.observableSet(set);
 


### PR DESCRIPTION
Use a `LinkedHashMap` in place of a `List`, for the caching `CurrencyUtil` fields `allSortedFiatCurrencies` & `allSortedCryptoCurrencies`, using the same iteration order as before. In this way, we can avoid a linear search in the lookup methods `getFiatCurrency` & `getCryptoCurrency`.

In particular, this speeds up the activation of `TradesChartsView` (and to a lesser extent `OfferBookChartView`), which make a lot of calls to `CurrencyUtil.getTradeCurrency` in the `fillTradeCurrencies`/`updateChartData` methods respectively.

Additionally, do some tiding of `TradeChartsViewModel` and remove some unused constructor-injected fields from that class and others.

To reproduce the hotspot, one can select the _Trades_ tab under _Market_ at least once, then flipping repeatedly between (say) the _Market_ and _Buy BTC_ panels, the following hotspots are revealed by JProfiler:

![Screenshot from 2019-12-23 23-01-07](https://user-images.githubusercontent.com/54855381/71384295-64a63800-25d8-11ea-808b-a7522077f490.png)

(The also very significant `com.sun.javafx.collections.VetoableListDecorator.setAll` hotspot seen at the bottom of the screenshot occurs during the initialisation of many views, but I haven't been able to find the cause or a fix for that yet.)