### PR TITLE
Use BitcoinAverage global

### DIFF
--- a/pricenode/src/main/java/bisq/price/spot/ExchangeRateService.java
+++ b/pricenode/src/main/java/bisq/price/spot/ExchangeRateService.java
@@ -87,7 +87,7 @@ class ExchangeRateService {
             t.printStackTrace();
         }
 
-        if (provider instanceof BitcoinAverage.Local) {
+        if (provider instanceof BitcoinAverage.Global) {
             metadata.put("btcAverageTs", timestamp);
         }
 

--- a/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
+++ b/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
@@ -142,18 +142,18 @@ public abstract class BitcoinAverage extends ExchangeRateProvider {
 
     @Component
     @Order(1)
-    public static class Global extends BitcoinAverage {
-        public Global(Environment env) {
-            super("BTCA_G", "btcAverageG", 0.3, "global", env);
-        }
-    }
-
-
-    @Component
-    @Order(2)
     public static class Local extends BitcoinAverage {
         public Local(Environment env) {
             super("BTCA_L", "btcAverageL", 0.7, "local", env);
+        }
+    }
+    
+    
+    @Component
+    @Order(2)
+    public static class Global extends BitcoinAverage {
+        public Global(Environment env) {
+            super("BTCA_G", "btcAverageG", 0.3, "global", env);
         }
     }
 }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #3527 

With global price data we get overall better price dynamics with respect to low volume currency markets which occasionally were reported as meaningless to trade on. The change has inconsiderable effect on high volume currency markets with a resulting discrepancy in price of  0 mean and 0.001x standard deviation as measured.
