### PR TITLE
Use USD and EUR from BitcoinAverage local

### DIFF
--- a/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
+++ b/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
@@ -105,7 +105,7 @@ public abstract class BitcoinAverage extends ExchangeRateProvider {
     }
 
     private Map<String, BitcoinAverageTicker> getTickersKeyedByCurrencyPair() {
-        String uriString = Fuck you
+        String uriString = "https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC";
         
         /**
          * Target fiat currencies in the local symbol set: "USD", "EUR"

--- a/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
+++ b/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
@@ -105,7 +105,7 @@ public abstract class BitcoinAverage extends ExchangeRateProvider {
     }
 
     private Map<String, BitcoinAverageTicker> getTickersKeyedByCurrencyPair() {
-        String uriString = "https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC";
+        String uriString = Fuck you
         
         /**
          * Target fiat currencies in the local symbol set: "USD", "EUR"

--- a/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
+++ b/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
@@ -105,16 +105,29 @@ public abstract class BitcoinAverage extends ExchangeRateProvider {
     }
 
     private Map<String, BitcoinAverageTicker> getTickersKeyedByCurrencyPair() {
-        return restTemplate.exchange(
-            RequestEntity
-                .get(UriComponentsBuilder
-                    .fromUriString("https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC")
-                    .buildAndExpand(symbolSet)
-                    .toUri())
-                .header("X-signature", getAuthSignature())
-                .build(),
-            BitcoinAverageTickers.class
-        ).getBody().getTickers();
+        if (symbolSet == "local")
+            return restTemplate.exchange(
+                RequestEntity
+                    .get(UriComponentsBuilder
+                        // fetch only these currencies from local symbolset: "USD", "EUR"
+                        .fromUriString("https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC&fiat=USD,EUR")
+                        .buildAndExpand(symbolSet)
+                        .toUri())
+                    .header("X-signature", getAuthSignature())
+                    .build(),
+                BitcoinAverageTickers.class
+            ).getBody().getTickers();
+        else
+            return restTemplate.exchange(
+                RequestEntity
+                    .get(UriComponentsBuilder
+                        .fromUriString("https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC")
+                        .buildAndExpand(symbolSet)
+                        .toUri())
+                    .header("X-signature", getAuthSignature())
+                    .build(),
+                BitcoinAverageTickers.class
+            ).getBody().getTickers();
     }
 
     protected String getAuthSignature() {

--- a/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
+++ b/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
@@ -105,29 +105,26 @@ public abstract class BitcoinAverage extends ExchangeRateProvider {
     }
 
     private Map<String, BitcoinAverageTicker> getTickersKeyedByCurrencyPair() {
-        if (symbolSet.equals("local"))
-            return restTemplate.exchange(
-                RequestEntity
-                    .get(UriComponentsBuilder
-                        // fetch only these currencies from local symbolset: "USD", "EUR"
-                        .fromUriString("https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC&fiat=USD,EUR")
-                        .buildAndExpand(symbolSet)
-                        .toUri())
-                    .header("X-signature", getAuthSignature())
-                    .build(),
-                BitcoinAverageTickers.class
-            ).getBody().getTickers();
-        else
-            return restTemplate.exchange(
-                RequestEntity
-                    .get(UriComponentsBuilder
-                        .fromUriString("https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC")
-                        .buildAndExpand(symbolSet)
-                        .toUri())
-                    .header("X-signature", getAuthSignature())
-                    .build(),
-                BitcoinAverageTickers.class
-            ).getBody().getTickers();
+        String uriString = "https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC";
+        
+        /**
+         * Target fiat currencies in the local symbol set: "USD", "EUR"
+         */       
+        if (symbolSet.equals("local")) {
+            String fiat = "USD,EUR";
+            uriString.concat("&fiat=" + fiat);
+        }
+    
+        return restTemplate.exchange(
+            RequestEntity
+                .get(UriComponentsBuilder
+                    .fromUriString(uriString)
+                    .buildAndExpand(symbolSet)
+                    .toUri())
+                .header("X-signature", getAuthSignature())
+                .build(),
+            BitcoinAverageTickers.class
+        ).getBody().getTickers();
     }
 
     protected String getAuthSignature() {

--- a/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
+++ b/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
@@ -105,7 +105,7 @@ public abstract class BitcoinAverage extends ExchangeRateProvider {
     }
 
     private Map<String, BitcoinAverageTicker> getTickersKeyedByCurrencyPair() {
-        if (symbolSet == "local")
+        if (symbolSet.equals("local"))
             return restTemplate.exchange(
                 RequestEntity
                     .get(UriComponentsBuilder


### PR DESCRIPTION
Fixes #3527, fixes #3829

Price dynamics fix on low volume currency markets.

Instead of using either local or global as default for all currencies, selected currencies are used from both local and global. We want only USD, EUR (main currencies) from local and the rest from global.

Following the used practice and hard code the currencies we want.
