### PR TITLE
List BlacerCoin (BLCR)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/BlacerCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/BlacerCoin.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class BlacerCoin extends Coin {
+    public BlacerCoin() {
+        super("BlacerCoin", "BLCR", new Base58BitcoinAddressValidator(new BlacerCoinMainNetParams()));
+    }
+
+    public static class BlacerCoinMainNetParams extends NetworkParametersAdapter {
+        public BlacerCoinMainNetParams() {
+            this.addressHeader = 26;
+            this.p2shHeader = 13;
+            this.acceptableAddressCodes = new int[]{this.addressHeader, this.p2shHeader};
+        }
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -18,6 +18,7 @@ bisq.asset.coins.Bitcoin$Testnet
 bisq.asset.coins.BitDaric
 bisq.asset.coins.Bitmark
 bisq.asset.coins.Bitzec
+bisq.asset.coins.BlacerCoin
 bisq.asset.coins.Blur
 bisq.asset.coins.BSQ$Mainnet
 bisq.asset.coins.BSQ$Regtest

--- a/assets/src/test/java/bisq/asset/coins/BlacerCoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/BlacerCoinTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class BlacerCoinTest extends AbstractAssetTest {
+
+    public BlacerCoinTest() {
+        super(new BlacerCoin());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("BrCKPBWAkX9KBZhtLzFWJsnWmUeWkVzupw");
+        assertValidAddress("BrGSwkHJxKH5W91yu5d7s66psdp4Rw3YU8");
+        assertValidAddress("BWfMD5z95bk3x9PRstNxhK7BjguFtBHGRB");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("1BWfMD5z95bk3x9PRstNxhK7BjguFtBHGRB");
+        assertInvalidAddress("BWfMD5z95bk3x9PRstNxhK7BjguFtBHGRBd");
+        assertInvalidAddress("BWfMD5z95bk3x9PRstNxhK7BjguFtBHGRB#");
+    }
+}


### PR DESCRIPTION
Add BlacerCoin (BLCR) cryptocurrency to Bisq exchange.

- Official project URL: http://blacercoin.com/
- Official block explorer URL: http://explorer.blacercoin.com/