### PR TITLE
Fix bank account number label for Swedish language

### DIFF
--- a/core/src/main/java/bisq/core/locale/BankUtil.java
+++ b/core/src/main/java/bisq/core/locale/BankUtil.java
@@ -157,9 +157,9 @@ public class BankUtil {
             case "HK":
                 return Res.get("payment.accountNr");
             case "NO":
-                return "Kontonummer"; // do not translate as it is used in Norwegian only
+                return "Kontonummer"; // do not translate as it is used in Norwegian and Swedish only
             case "SE":
-                return "Bankgiro number"; // do not translate as it is used in Swedish only
+                return "Kontonummer"; // do not translate as it is used in Norwegian and Swedish only
             case "MX":
                 return "CLABE"; // do not translate as it is used in Spanish only
             case "CL":


### PR DESCRIPTION
According to issue #3641, the label "Bankgiro number", as it was
hardcoded in BankUtil.java, should not be used in Sweden.
The label "Kontonummer" is the correct one to be used in Sweden and
Norway.

Account number validation is implemented to Norwegian accounts in
AccountNrValidator.java.
There is no validation implemented to Swedish accounts, so nothing
to change there.
If account validation for Sweden is needed, a different method would
be needed.

![image](https://user-images.githubusercontent.com/6444444/71691325-d3785380-2d85-11ea-850f-72f512cf8eef.png)

Fixes #3641