### PR TITLE
Show the correct sign state icon for accounts that are able to sign

### DIFF
--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -726,9 +726,8 @@ public class AccountAgeWitnessService {
             final long accountSignAge = getWitnessSignAge(accountAgeWitness, new Date());
             switch (getAccountAgeCategory(accountSignAge)) {
                 case TWO_MONTHS_OR_MORE:
-                    return SignState.PEER_SIGNER;
                 case ONE_TO_TWO_MONTHS:
-                    return SignState.PEER_LIMIT_LIFTED;
+                    return SignState.PEER_SIGNER;
                 case LESS_ONE_MONTH:
                     return SignState.PEER_INITIAL;
                 case UNVERIFIED:


### PR DESCRIPTION
This behavior was different during development time and wasn't updated properly in the UI.

Before
![Bildschirmfoto 2020-01-03 um 11 58 41](https://user-images.githubusercontent.com/170962/71720108-c78d9f80-2e20-11ea-8210-abfac03a69c6.png)

Now
![Bildschirmfoto 2020-01-03 um 11 59 14](https://user-images.githubusercontent.com/170962/71720117-ceb4ad80-2e20-11ea-857e-ce9ad40ca071.png)
