### PR TITLE
Price dynamics fix

### DIFF
--- a/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
+++ b/pricenode/src/main/java/bisq/price/spot/providers/BitcoinAverage.java
@@ -105,10 +105,20 @@ public abstract class BitcoinAverage extends ExchangeRateProvider {
     }
 
     private Map<String, BitcoinAverageTicker> getTickersKeyedByCurrencyPair() {
+        String uriString = "https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC";
+        
+        /**
+         * Target fiat currencies in the local symbol set: "USD", "EUR"
+         */       
+        if (symbolSet.equals("local")) {
+            String fiat = "USD,EUR";
+            uriString.concat("&fiat=" + fiat);
+        }
+    
         return restTemplate.exchange(
             RequestEntity
                 .get(UriComponentsBuilder
-                    .fromUriString("https://apiv2.bitcoinaverage.com/indices/{symbol-set}/ticker/all?crypto=BTC")
+                    .fromUriString(uriString)
                     .buildAndExpand(symbolSet)
                     .toUri())
                 .header("X-signature", getAuthSignature())


### PR DESCRIPTION
Fixes #3527 

Price dynamics altering in fiat currency markets. Fixes low volume impairing.

Uses USD and EUR in local symbol set, everything else from global symbol set.
