### PR TITLE
Check existence of selected block explorer using name string comparison

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -254,14 +254,12 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
         // if no valid Bitcoin block explorer is set, select the 1st valid Bitcoin block explorer
         ArrayList<BlockChainExplorer> btcExplorers = getBlockChainExplorers();
-        BlockChainExplorer btcExplorer = getBlockChainExplorer();
-        if (btcExplorer == null || btcExplorers.contains(btcExplorer) == false)
+        if (!blockExplorerExists(btcExplorers, getBlockChainExplorer()))
             setBlockChainExplorer(btcExplorers.get(0));
 
         // if no valid BSQ block explorer is set, randomly select a valid BSQ block explorer
         ArrayList<BlockChainExplorer> bsqExplorers = getBsqBlockChainExplorers();
-        BlockChainExplorer bsqExplorer = getBsqBlockChainExplorer();
-        if (bsqExplorer == null || bsqExplorers.contains(bsqExplorer) == false)
+        if (!blockExplorerExists(bsqExplorers, getBsqBlockChainExplorer()))
             setBsqBlockChainExplorer(bsqExplorers.get((new Random()).nextInt(bsqExplorers.size())));
 
         tradeCurrenciesAsObservable.addAll(prefPayload.getFiatCurrencies());
@@ -824,6 +822,16 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             tradeCurrenciesAsObservable.add(change.getAddedSubList().get(0));
         else if (change.wasRemoved() && change.getRemovedSize() == 1 && initialReadDone)
             tradeCurrenciesAsObservable.remove(change.getRemoved().get(0));
+    }
+
+    private boolean blockExplorerExists(ArrayList<BlockChainExplorer> explorers,
+                                              BlockChainExplorer explorer)
+    {
+        if (explorer != null && explorers != null && explorers.size() > 0)
+            for (int i = 0; i < explorers.size(); i++)
+                if (explorers.get(i).name.equals(explorer.name))
+                    return true;
+        return false;
     }
 
     private interface ExcludesDelegateMethods {


### PR DESCRIPTION
After further testing, I realized I introduced a bug in commit 4f4b0f6 because apparently the　ArrayList.contains() method does not properly work for BlockChainExplorer object - to fix this I implemented a new contains() method that uses string comparison instead