### PR TITLE
Fix account age format when ended in 1

### DIFF
--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -70,8 +70,8 @@ public class DisplayUtils {
         durationMillis = Math.max(0, durationMillis);
         String day = Res.get("time.day").toLowerCase();
         String days = Res.get("time.days");
-        String format = "d\' " + days + "\'";
-        return StringUtils.replaceOnce(DurationFormatUtils.formatDuration(durationMillis, format), "1 " + days, "1 " + day);
+        String format = " d\' " + days + "\'";
+        return StringUtils.strip(StringUtils.replaceOnce(DurationFormatUtils.formatDuration(durationMillis, format), " 1 " + days, " 1 " + day));
     }
 
     public static String booleanToYesNo(boolean value) {


### PR DESCRIPTION
The method formatAccountAge is replacing the string "1 days" for "1 day".
This is done to fix the plural for that case.
But it is also changing strings like "21 days" into "21 day".

![image](https://user-images.githubusercontent.com/6444444/71776447-9cb26100-2f70-11ea-8c3d-062870f8e601.png)

![image](https://user-images.githubusercontent.com/6444444/71776441-78ef1b00-2f70-11ea-9f2a-14a760f838f4.png)
