### PR TITLE
Temporarily disable z33nukt7ngik3cpe btcnode due to failing service c…

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -70,8 +70,8 @@ public class BtcNodes {
                         // Devin Bileck
                         new BtcNode("btc1.dnsalias.net", "lva54pnbq2nsmjyr.onion", "165.227.34.198", BtcNode.DEFAULT_PORT, "@devinbileck"),
 
-                        // sgeisler
-                        new BtcNode("bcwat.ch", "z33nukt7ngik3cpe.onion", "5.189.166.193", BtcNode.DEFAULT_PORT, "@sgeisler"),
+                        // sgeisler - temporarily disabled due to recent uptime falling below acceptable threshold
+                        // new BtcNode("bcwat.ch", "z33nukt7ngik3cpe.onion", "5.189.166.193", BtcNode.DEFAULT_PORT, "@sgeisler"),
 
                         // wiz
                         new BtcNode("node100.hnl.wiz.biz", "22tg6ufbwz6o3l2u.onion", "103.99.168.100", BtcNode.DEFAULT_PORT, "@wiz"),


### PR DESCRIPTION
During the past cycle this btcnode has failed to respond to 42% of service checks, for example here is last 2 hours of monitoring graph

<img width="1559" alt="Screen Shot 2020-01-08 at 7 56 09" src="https://user-images.githubusercontent.com/232186/71936427-b233bf00-31ec-11ea-80a3-024e07d16fac.png">
