### PR TITLE
Use macOS app Info.plist setting for automatic light/dark title bar

### DIFF
--- a/desktop/package/macosx/Info.plist
+++ b/desktop/package/macosx/Info.plist
@@ -55,7 +55,7 @@
         <key>CFBundlePackageType</key>
         <string>APPL</string>
 
-        <!-- macos will manage light/dark title bar automatically -->
+        <!-- macOS will manage light/dark title bar automatically -->
         <key>NSRequiresAquaSystemAppearance</key>
         <false/>
     </dict>

--- a/desktop/package/macosx/Info.plist
+++ b/desktop/package/macosx/Info.plist
@@ -54,5 +54,9 @@
 
         <key>CFBundlePackageType</key>
         <string>APPL</string>
+
+        <!-- macos will manage light/dark title bar automatically -->
+        <key>NSRequiresAquaSystemAppearance</key>
+        <false/>
     </dict>
 </plist>


### PR DESCRIPTION
macOS set to light theme:
<img width="1202" alt="Screen Shot 2020-01-10 at 8 07 35" src="https://user-images.githubusercontent.com/232186/72112208-484c1e80-3380-11ea-8a65-e13ce8ba756e.png">

macOS set to dark theme:
<img width="1199" alt="Screen Shot 2020-01-10 at 8 07 19" src="https://user-images.githubusercontent.com/232186/72112209-484c1e80-3380-11ea-86ff-0045b11f30a5.png">
