### PR TITLE
Update .gitignore and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.diff]
+trim_trailing_whitespace = false
+
 [Makefile]
 indent_style = tab
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build
 .project
 .settings
 *.java.hsp
+*.java.hsw
 *.~ava
 /bundles
 /bisq-*


### PR DESCRIPTION
This PR introduces two non-code related changes:

    368f0ad7f (Chris Beams, 5 weeks ago)
       Ignore Structure101 Workspace files

       In the refactorings that will follow, Structure101 Studio and the
       Structure101 Workspace IDEA plugin will be used to visualize and help
       resolve tangles in the codebase. We were already ignore Studio
       configuration files which end in .java.hsb, and this commit ignores the
       newer Workspace product's .java.hsw files as well.

    b4ee9d33e (Chris Beams, 3 weeks ago)
       Do not strip trailing whitespace in Git diffs

       Problem: Editorconfig was configured to strip trailing whitespace in all
       file types. This is generally a good thing, but when interactive rebasing
       with Git and editing the contents of a commit, trailing whitespace is
       significant on blank lines and must be preserved in order for edits to be
       applied cleanly.

       Solution: Update Editorconfig to exclude *.diff from the strip whitespace
       rule, as interactive rebasing edits are done in a temporary file with a
       '.diff' suffix.

Note that this is the first in a series of PRs that lead up to a larger refactoring effort. As each subsequent PR is submitted it will reference the PR that comes before it, creating a chain.