### PR TITLE
Redact DepositTxId when publishing TradeStatistics for user privacy

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/tasks/PublishTradeStatistics.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/PublishTradeStatistics.java
@@ -83,7 +83,7 @@ public class PublishTradeStatistics extends TradeTask {
                         trade.getTradePrice(),
                         trade.getTradeAmount(),
                         trade.getDate(),
-                        trade.getDepositTx().getHashAsString(),
+                        "0000000000000000000000000000000000000000000000000000000000000000", // don't publish TXID for privacy
                         extraDataMap);
                 processModel.getP2PService().addPersistableNetworkPayload(tradeStatistics, true);
             }


### PR DESCRIPTION
Fixes #3893 by redacting the Bitcoin TXID from TradeStatistics2 objects.

Before:
```
  { 
    "currency": "JPY",
    "direction": "SELL",
    "tradePrice": 8791986900,
    "tradeAmount": 10000,
    "tradeDate": 1578784489588,
    "paymentMethod": "F2F",
    "offerDate": 1578784398352,
    "useMarketBasedPrice": true,
    "marketPriceMargin": 0.0,
    "offerAmount": 10000,
    "offerMinAmount": 10000,
    "offerId": "12635-224f7143-3366-46e7-9e14-7fa6f39fcb2b-125",
    "depositTxId": "9c67453e57cfc80e2c121caf54f8f739cef6c5d7e9afdceec7843436a920f9d8",
    "currencyPair": "BTC/JPY",
    "primaryMarketDirection": "SELL",
    "primaryMarketTradePrice": 87919869000000,
    "primaryMarketTradeAmount": 10000,
    "primaryMarketTradeVolume": 8791980000
  },
```

After:
```
  {
    "currency": "JPY", 
    "direction": "SELL",
    "tradePrice": 8791986900,
    "tradeAmount": 10000, 
    "tradeDate": 1578784489149,
    "paymentMethod": "F2F", 
    "offerDate": 1578784398352,
    "useMarketBasedPrice": true,
    "marketPriceMargin": 0.0,
    "offerAmount": 10000, 
    "offerMinAmount": 10000, 
    "offerId": "12635-224f7143-3366-46e7-9e14-7fa6f39fcb2b-125",
    "depositTxId": "0000000000000000000000000000000000000000000000000000000000000000",
    "currencyPair": "BTC/JPY",
    "primaryMarketDirection": "SELL",
    "primaryMarketTradePrice": 87919869000000,
    "primaryMarketTradeAmount": 10000, 
    "primaryMarketTradeVolume": 8791980000
  },
```