### PR TITLE
Validate ignored peers and BTC nodes

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
@@ -95,6 +95,7 @@ public class BisqHeadlessApp implements HeadlessApp {
         bisqSetup.setWrongOSArchitectureHandler(msg -> log.error("onWrongOSArchitectureHandler. msg={}", msg));
         bisqSetup.setVoteResultExceptionHandler(voteResultException -> log.warn("voteResultException={}", voteResultException.toString()));
         bisqSetup.setRejectedTxErrorMessageHandler(errorMessage -> log.warn("setRejectedTxErrorMessageHandler. errorMessage={}", errorMessage));
+        bisqSetup.setShowPopupIfInvalidBtcConfigHandler(() -> log.error("onShowPopupIfInvalidBtcConfigHandler"));
 
         //TODO move to bisqSetup
         corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> log.warn("getCorruptedDatabaseFiles. files={}", files));

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -222,6 +222,9 @@ public class BisqSetup {
     @Setter
     @Nullable
     private Consumer<PrivateNotificationPayload> displayPrivateNotificationHandler;
+    @Setter
+    @Nullable
+    private Runnable showPopupIfInvalidBtcConfigHandler;
 
     @Getter
     final BooleanProperty newVersionAvailableProperty = new SimpleBooleanProperty(false);
@@ -545,9 +548,9 @@ public class BisqSetup {
         };
 
         Timer startupTimeout = UserThread.runAfter(() -> {
-            if (p2PNetworkSetup.p2pNetworkFailed.get()) {
-                // Skip this timeout action if the p2p network setup failed
-                // since a p2p network error prompt will be shown containing the error message
+            if (p2PNetworkSetup.p2pNetworkFailed.get() || walletsSetup.walletsSetupFailed.get()) {
+                // Skip this timeout action if the p2p network or wallet setup failed
+                // since an error prompt will be shown containing the error message
                 return;
             }
             log.warn("startupTimeout called");
@@ -614,6 +617,7 @@ public class BisqSetup {
         walletAppSetup.init(chainFileLockedExceptionHandler,
                 spvFileCorruptedHandler,
                 showFirstPopupIfResyncSPVRequestedHandler,
+                showPopupIfInvalidBtcConfigHandler,
                 walletPasswordHandler,
                 () -> {
                     if (allBasicServicesInitialized) {

--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -17,6 +17,7 @@
 
 package bisq.core.app;
 
+import bisq.core.btc.exceptions.InvalidHostException;
 import bisq.core.btc.exceptions.RejectedTxException;
 import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.btc.wallet.WalletsManager;
@@ -92,6 +93,7 @@ public class WalletAppSetup {
     void init(@Nullable Consumer<String> chainFileLockedExceptionHandler,
               @Nullable Consumer<String> spvFileCorruptedHandler,
               @Nullable Runnable showFirstPopupIfResyncSPVRequestedHandler,
+              @Nullable Runnable showPopupIfInvalidBtcConfigHandler,
               Runnable walletPasswordHandler,
               Runnable downloadCompleteHandler,
               Runnable walletInitializedHandler) {
@@ -169,7 +171,13 @@ public class WalletAppSetup {
                         }
                     }
                 },
-                walletServiceException::set);
+                exception -> {
+                    if (exception instanceof InvalidHostException && showPopupIfInvalidBtcConfigHandler != null) {
+                        showPopupIfInvalidBtcConfigHandler.run();
+                    } else {
+                        walletServiceException.set(exception);
+                    }
+                });
     }
 
     private String getBtcNetworkAsString() {

--- a/core/src/main/java/bisq/core/btc/exceptions/InvalidHostException.java
+++ b/core/src/main/java/bisq/core/btc/exceptions/InvalidHostException.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.btc.exceptions;
+
+public class InvalidHostException extends IllegalArgumentException {
+
+    public InvalidHostException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1090,6 +1090,7 @@ settings.net.warn.useCustomNodes.B2XWarning=Please be sure that your Bitcoin nod
   Users who connect to nodes that violate consensus rules are responsible for any resulting damage. \
   Any resulting disputes will be decided in favor of the other peer. No technical support will be given \
   to users who ignore this warning and protection mechanisms!
+settings.net.warn.invalidBtcConfig=Connection to the Bitcoin network failed because your configuration is invalid.\n\nYour configuration has been reset to use the provided Bitcoin nodes instead. You will need to restart the application.
 settings.net.localhostBtcNodeInfo=(Background information: If you are running a local Bitcoin node (localhost) you can connect exclusively to it.)
 settings.net.p2PPeersLabel=Connected peers
 settings.net.onionAddressColumn=Onion address

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3284,3 +3284,4 @@ validation.phone.insufficientDigits=Not enough digits in {0} for a valid phone n
 validation.phone.tooManyDigits=Too many digits in {0} to be a valid phone number
 validation.phone.invalidDialingCode=Country dialing code in number {0} is invalid for country {1}.  \
   The correct dialing code is {2}.
+validation.invalidAddressList=Must be comma separated list of valid addresses

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -256,7 +256,7 @@ mainView.footer.bsqInfo.synchronizing=/ Synchronizing DAO
 mainView.footer.btcInfo.synchronizingWith=Synchronizing with
 mainView.footer.btcInfo.synchronizedWith=Synchronized with
 mainView.footer.btcInfo.connectingTo=Connecting to
-mainView.footer.btcInfo.connectionFailed=connection failed
+mainView.footer.btcInfo.connectionFailed=Connection failed to
 mainView.footer.p2pInfo=Bisq network peers: {0}
 mainView.footer.daoFullNode=DAO full node
 

--- a/desktop/src/main/java/bisq/desktop/components/InputTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/InputTextField.java
@@ -50,6 +50,7 @@ public class InputTextField extends JFXTextField {
     private double inputLineExtension = 0;
 
     private InputValidator validator;
+    private String errorMessage = null;
 
 
     public InputValidator getValidator() {
@@ -58,6 +59,10 @@ public class InputTextField extends JFXTextField {
 
     public void setValidator(InputValidator validator) {
         this.validator = validator;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -71,23 +76,31 @@ public class InputTextField extends JFXTextField {
 
         validationResult.addListener((ov, oldValue, newValue) -> {
             if (newValue != null) {
-                if (newValue.isValid) {
-                    resetValidation();
-                } else {
-                    resetValidation();
-                    validate();
-
-                    jfxValidationWrapper.applyErrorMessage(newValue);
+                resetValidation();
+                if (!newValue.isValid) {
+                    if (this.errorMessage != null) {
+                        jfxValidationWrapper.applyErrorMessage(this.errorMessage);
+                    } else {
+                        jfxValidationWrapper.applyErrorMessage(newValue);
+                    }
                 }
                 validate();
             }
         });
 
-        focusedProperty().addListener((o, oldValue, newValue) -> {
-            if (oldValue && !newValue && validator != null) {
+        textProperty().addListener((o, oldValue, newValue) -> {
+            if (validator != null) {
                 this.validationResult.set(validator.validate(getText()));
-            } else if (!oldValue && newValue && validator != null) {
-                this.validationResult.set(new InputValidator.ValidationResult(true));
+            }
+        });
+
+        focusedProperty().addListener((o, oldValue, newValue) -> {
+            if (validator != null) {
+                if (!oldValue && newValue) {
+                    this.validationResult.set(new InputValidator.ValidationResult(true));
+                } else {
+                    this.validationResult.set(validator.validate(getText()));
+                }
             }
         });
     }

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -368,6 +368,8 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
 
         bisqSetup.setRejectedTxErrorMessageHandler(msg -> new Popup().width(850).warning(msg).show());
 
+        bisqSetup.setShowPopupIfInvalidBtcConfigHandler(this::showPopupIfInvalidBtcConfig);
+
         corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> new Popup()
                 .warning(Res.get("popup.warning.incompatibleDB", files.toString(),
                         bisqEnvironment.getProperty(AppOptionKeys.APP_DATA_DIR_KEY)))
@@ -469,6 +471,14 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         firstPopup.hide();
         preferences.setResyncSpvRequested(false);
         new Popup().information(Res.get("settings.net.reSyncSPVAfterRestartCompleted"))
+                .hideCloseButton()
+                .useShutDownButton()
+                .show();
+    }
+
+    private void showPopupIfInvalidBtcConfig() {
+        preferences.setBitcoinNodesOptionOrdinal(0);
+        new Popup().warning(Res.get("settings.net.warn.invalidBtcConfig"))
                 .hideCloseButton()
                 .useShutDownButton()
                 .show();

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -225,10 +225,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
             selectedBitcoinNodesOption = BtcNodes.BitcoinNodesOption.PROVIDED;
             preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
         }
-        if (!btcNodes.useProvidedBtcNodes()) {
-            selectedBitcoinNodesOption = BtcNodes.BitcoinNodesOption.PUBLIC;
-            preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
-        }
 
         selectBitcoinPeersToggle();
         onBitcoinPeersToggleSelected(false);

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -129,7 +129,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
     private ToggleGroup bitcoinPeersToggleGroup;
     private BtcNodes.BitcoinNodesOption selectedBitcoinNodesOption;
     private ChangeListener<Toggle> bitcoinPeersToggleGroupListener;
-    private ChangeListener<String> btcNodesInputTextFieldListener;
     private ChangeListener<Filter> filterPropertyListener;
 
     @Inject
@@ -236,7 +235,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
 
         bitcoinPeersToggleGroupListener = (observable, oldValue, newValue) -> {
             selectedBitcoinNodesOption = (BtcNodes.BitcoinNodesOption) newValue.getUserData();
-            preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
             onBitcoinPeersToggleSelected(true);
         };
 
@@ -245,8 +243,12 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         btcNodesInputTextField.setValidator(regexValidator);
         btcNodesInputTextField.setErrorMessage(Res.get("validation.invalidAddressList"));
         btcNodesInputTextFieldFocusListener = (observable, oldValue, newValue) -> {
-            if (oldValue && !newValue)
+            if (oldValue && !newValue
+                    && !btcNodesInputTextField.getText().equals(preferences.getBitcoinNodes())
+                    && btcNodesInputTextField.validate()) {
+                preferences.setBitcoinNodes(btcNodesInputTextField.getText());
                 showShutDownPopup();
+            }
         };
         filterPropertyListener = (observable, oldValue, newValue) -> {
             applyPreventPublicBtcNetwork();
@@ -316,7 +318,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
 
         btcNodesInputTextField.setText(preferences.getBitcoinNodes());
 
-        btcNodesInputTextField.textProperty().addListener(btcNodesInputTextFieldListener);
         btcNodesInputTextField.focusedProperty().addListener(btcNodesInputTextFieldFocusListener);
 
         openTorSettingsButton.setOnAction(e -> torNetworkSettingsWindow.show());
@@ -350,7 +351,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         p2pSortedList.comparatorProperty().unbind();
         p2pPeersTableView.getItems().forEach(P2pNetworkListItem::cleanup);
         btcNodesInputTextField.focusedProperty().removeListener(btcNodesInputTextFieldFocusListener);
-        btcNodesInputTextField.textProperty().removeListener(btcNodesInputTextFieldListener);
 
         openTorSettingsButton.setOnAction(null);
     }
@@ -393,49 +393,64 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         useCustomNodesRadio.setDisable(bitcoinLocalhostNodeRunning);
         usePublicNodesRadio.setDisable(bitcoinLocalhostNodeRunning || isPreventPublicBtcNetwork());
 
+        BtcNodes.BitcoinNodesOption currentBitcoinNodesOption = BtcNodes.BitcoinNodesOption.values()[preferences.getBitcoinNodesOptionOrdinal()];
+
         switch (selectedBitcoinNodesOption) {
             case CUSTOM:
                 btcNodesInputTextField.setDisable(false);
                 btcNodesLabel.setDisable(false);
-                if (calledFromUser && !btcNodesInputTextField.getText().isEmpty()) {
-                    if (isPreventPublicBtcNetwork()) {
-                        new Popup().warning(Res.get("settings.net.warn.useCustomNodes.B2XWarning"))
-                                .onAction(() -> {
-                                    UserThread.runAfter(this::showShutDownPopup, 300, TimeUnit.MILLISECONDS);
-                                }).show();
-                    } else {
-                        showShutDownPopup();
+                if (!btcNodesInputTextField.getText().isEmpty()
+                        && btcNodesInputTextField.validate()
+                        && currentBitcoinNodesOption != BtcNodes.BitcoinNodesOption.CUSTOM) {
+                    preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                    if (calledFromUser) {
+                        if (isPreventPublicBtcNetwork()) {
+                            new Popup().warning(Res.get("settings.net.warn.useCustomNodes.B2XWarning"))
+                                    .onAction(() -> {
+                                        UserThread.runAfter(this::showShutDownPopup, 300, TimeUnit.MILLISECONDS);
+                                    }).show();
+                        } else {
+                            showShutDownPopup();
+                        }
                     }
                 }
                 break;
             case PUBLIC:
                 btcNodesInputTextField.setDisable(true);
                 btcNodesLabel.setDisable(true);
-                if (calledFromUser)
-                    new Popup()
-                            .warning(Res.get("settings.net.warn.usePublicNodes"))
-                            .actionButtonText(Res.get("settings.net.warn.usePublicNodes.useProvided"))
-                            .onAction(() -> {
-                                UserThread.runAfter(() -> {
-                                    selectedBitcoinNodesOption = BtcNodes.BitcoinNodesOption.PROVIDED;
-                                    preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
-                                    selectBitcoinPeersToggle();
-                                    onBitcoinPeersToggleSelected(false);
-                                }, 300, TimeUnit.MILLISECONDS);
-                            })
-                            .closeButtonText(Res.get("settings.net.warn.usePublicNodes.usePublic"))
-                            .onClose(() -> {
-                                UserThread.runAfter(this::showShutDownPopup, 300, TimeUnit.MILLISECONDS);
-                            })
-                            .show();
+                if (currentBitcoinNodesOption != BtcNodes.BitcoinNodesOption.PUBLIC) {
+                    preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                    if (calledFromUser) {
+                        new Popup()
+                                .warning(Res.get("settings.net.warn.usePublicNodes"))
+                                .actionButtonText(Res.get("settings.net.warn.usePublicNodes.useProvided"))
+                                .onAction(() -> {
+                                    UserThread.runAfter(() -> {
+                                        selectedBitcoinNodesOption = BtcNodes.BitcoinNodesOption.PROVIDED;
+                                        preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                                        selectBitcoinPeersToggle();
+                                        onBitcoinPeersToggleSelected(false);
+                                    }, 300, TimeUnit.MILLISECONDS);
+                                })
+                                .closeButtonText(Res.get("settings.net.warn.usePublicNodes.usePublic"))
+                                .onClose(() -> {
+                                    UserThread.runAfter(this::showShutDownPopup, 300, TimeUnit.MILLISECONDS);
+                                })
+                                .show();
+                    }
+                }
                 break;
             default:
             case PROVIDED:
                 if (btcNodes.useProvidedBtcNodes()) {
                     btcNodesInputTextField.setDisable(true);
                     btcNodesLabel.setDisable(true);
-                    if (calledFromUser)
-                        showShutDownPopup();
+                    if (currentBitcoinNodesOption != BtcNodes.BitcoinNodesOption.PROVIDED) {
+                        preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                        if (calledFromUser) {
+                            showShutDownPopup();
+                        }
+                    }
                 } else {
                     selectedBitcoinNodesOption = BtcNodes.BitcoinNodesOption.PUBLIC;
                     preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -27,6 +27,7 @@ import bisq.desktop.components.TitledGroupBg;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.TorNetworkSettingsWindow;
 import bisq.desktop.util.GUIUtil;
+import bisq.desktop.util.validation.RegexValidator;
 
 import bisq.core.app.BisqEnvironment;
 import bisq.core.btc.nodes.BtcNodes;
@@ -239,7 +240,10 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
             onBitcoinPeersToggleSelected(true);
         };
 
-        btcNodesInputTextFieldListener = (observable, oldValue, newValue) -> preferences.setBitcoinNodes(newValue);
+        btcNodesInputTextField.setPromptText(Res.get("settings.net.ips"));
+        RegexValidator regexValidator = GUIUtil.addressRegexValidator();
+        btcNodesInputTextField.setValidator(regexValidator);
+        btcNodesInputTextField.setErrorMessage(Res.get("validation.invalidAddressList"));
         btcNodesInputTextFieldFocusListener = (observable, oldValue, newValue) -> {
             if (oldValue && !newValue)
                 showShutDownPopup();
@@ -311,7 +315,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         p2pPeersTableView.setItems(p2pSortedList);
 
         btcNodesInputTextField.setText(preferences.getBitcoinNodes());
-        btcNodesInputTextField.setPromptText(Res.get("settings.net.ips"));
 
         btcNodesInputTextField.textProperty().addListener(btcNodesInputTextFieldListener);
         btcNodesInputTextField.focusedProperty().addListener(btcNodesInputTextFieldFocusListener);

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -28,6 +28,7 @@ import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.ImageUtil;
 import bisq.desktop.util.Layout;
+import bisq.desktop.util.validation.RegexValidator;
 
 import bisq.core.app.BisqEnvironment;
 import bisq.core.btc.wallet.Restrictions;
@@ -324,8 +325,14 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         // ignoreTraders
         ignoreTradersListInputTextField = addInputTextField(root, ++gridRow,
                 Res.get("setting.preferences.ignorePeers"));
-        ignoreTradersListListener = (observable, oldValue, newValue) ->
+        RegexValidator regexValidator = GUIUtil.addressRegexValidator();
+        ignoreTradersListInputTextField.setValidator(regexValidator);
+        ignoreTradersListInputTextField.setErrorMessage(Res.get("validation.invalidAddressList"));
+        ignoreTradersListListener = (observable, oldValue, newValue) -> {
+            if (regexValidator.validate(newValue).isValid && !newValue.equals(oldValue)) {
                 preferences.setIgnoreTradersList(Arrays.asList(StringUtils.deleteWhitespace(newValue).split(",")));
+            }
+        };
 
         // referralId
        /* referralIdInputTextField = addInputTextField(root, ++gridRow, Res.get("setting.preferences.refererId"));

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -27,6 +27,7 @@ import bisq.desktop.main.MainView;
 import bisq.desktop.main.account.AccountView;
 import bisq.desktop.main.account.content.fiataccounts.FiatAccountsView;
 import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.util.validation.RegexValidator;
 
 import bisq.core.account.witness.AccountAgeWitness;
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -1106,5 +1107,15 @@ public class GUIUtil {
         return (state.equals(AccountAgeWitnessService.SignState.ARBITRATOR) ||
                 state.equals(AccountAgeWitnessService.SignState.PEER_SIGNER)) ?
                 MaterialDesignIcon.APPROVAL : MaterialDesignIcon.ALERT_CIRCLE_OUTLINE;
+    }
+
+    public static RegexValidator addressRegexValidator() {
+        RegexValidator regexValidator = new RegexValidator();
+        String portRegexPattern = "(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])";
+        String onionV2RegexPattern = String.format("[a-zA-Z2-7]{16}\\.onion(?:\\:%1$s)?", portRegexPattern);
+        String onionV3RegexPattern = String.format("[a-zA-Z2-7]{56}\\.onion(?:\\:%1$s)?", portRegexPattern);
+        String ipv4RegexPattern = String.format("(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\\:%1$s)?", portRegexPattern);
+        regexValidator.setPattern(String.format("^(?:(?:(?:%1$s)|(?:%2$s)),)*(?:(?:%1$s)|(?:%2$s))*$", onionV2RegexPattern, ipv4RegexPattern));
+        return regexValidator;
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/validation/JFXInputValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/JFXInputValidator.java
@@ -20,7 +20,11 @@ public class JFXInputValidator extends ValidatorBase {
     }
 
     public void applyErrorMessage(InputValidator.ValidationResult newValue) {
-        message.set(newValue.errorMessage);
+        applyErrorMessage(newValue.errorMessage);
+    }
+
+    public void applyErrorMessage(String errorMessage) {
+        message.set(errorMessage);
         hasErrors.set(true);
     }
 }

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -17,6 +17,8 @@
 
 package bisq.desktop.util;
 
+import bisq.desktop.util.validation.RegexValidator;
+
 import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
@@ -44,6 +46,8 @@ import static com.natpryce.makeiteasy.MakeItEasy.with;
 import static org.bitcoinj.core.CoinMaker.oneBitcoin;
 import static org.bitcoinj.core.CoinMaker.satoshis;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -110,6 +114,33 @@ public class GUIUtilTest {
 
         assertEquals("https://www.github.com", captor.getValue().toString());
 */
+    }
+
+    @Test
+    public void testAddressRegexValidator() {
+        RegexValidator regexValidator = GUIUtil.addressRegexValidator();
+
+        assertTrue(regexValidator.validate("").isValid);
+        assertTrue(regexValidator.validate("abcdefghij234567.onion").isValid);
+        assertTrue(regexValidator.validate("abcdefghijklmnop.onion,abcdefghijklmnop.onion").isValid);
+        assertTrue(regexValidator.validate("qrstuvwxyzABCDEF.onion,qrstuvwxyzABCDEF.onion,aaaaaaaaaaaaaaaa.onion").isValid);
+        assertTrue(regexValidator.validate("GHIJKLMNOPQRSTUV.onion:9999").isValid);
+        assertTrue(regexValidator.validate("WXYZ234567abcdef.onion,GHIJKLMNOPQRSTUV.onion:9999").isValid);
+        assertTrue(regexValidator.validate("aaaaaaaaaaaaaaaa.onion:9999,WXYZ234567abcdef.onion:9999,2222222222222222.onion:9999").isValid);
+
+        assertTrue(regexValidator.validate("12.34.56.78").isValid);
+        assertTrue(regexValidator.validate("12.34.56.78:8888").isValid);
+
+        assertFalse(regexValidator.validate(" ").isValid);
+        assertFalse(regexValidator.validate("abcd.onion").isValid);
+        assertFalse(regexValidator.validate("abcdefghijklmnop,abcdefghijklmnop.onion").isValid);
+        assertFalse(regexValidator.validate("abcdefghi2345689.onion:9999").isValid);
+        assertFalse(regexValidator.validate("onion:9999,abcdefghijklmnop.onion:9999").isValid);
+        assertFalse(regexValidator.validate("abcdefghijklmnop.onion:").isValid);
+        assertFalse(regexValidator.validate("32zzibxmqi2ybxpqyggwwuwz7a3lbvtzoloti7cxoevyvijexvgsfeid.onion:8333").isValid);
+
+        assertFalse(regexValidator.validate("12.34.56.788").isValid);
+        assertFalse(regexValidator.validate("12.34.56.78:").isValid);
     }
 
     @Test


### PR DESCRIPTION
In addition to adding input validation for ignored peers and BTC nodes, this PR also fixes #3137.

Since with input validation the user is no longer able to enter an invalid BTC host, to verify #3137 start the app with the following option:
`--btcNodes=32zzibxmqi2ybxpqyggwwuwz7a3lbvtzoloti7cxoevyvijexvgsfeid.onion:8333`

You will be presented with the following:
![image](https://user-images.githubusercontent.com/603793/72237522-9daa4a80-358f-11ea-8921-00587fa26da7.png)

After shutting down the app, restart it without the previous option and observe the BTC config. You will see the invalid custom BTC config but it will be using the provided BTC nodes.

![image](https://user-images.githubusercontent.com/603793/72237696-4193f600-3590-11ea-87ff-884778a6ab96.png)


