### PR TITLE
[WIP] Use keyset delta algorithm to speed up GetData requests

### DIFF
--- a/common/src/main/java/bisq/common/app/Capability.java
+++ b/common/src/main/java/bisq/common/app/Capability.java
@@ -40,5 +40,6 @@ public enum Capability {
     SIGNED_ACCOUNT_AGE_WITNESS,         // Supports the signed account age witness feature
     MEDIATION,                          // Supports mediation feature
     REFUND_AGENT,                       // Supports refund agents
-    TRADE_STATISTICS_HASH_UPDATE        // We changed the hash method in 1.2.0 and that requires update to 1.2.2 for handling it correctly, otherwise the seed nodes have to process too much data.
+    TRADE_STATISTICS_HASH_UPDATE,       // We changed the hash method in 1.2.0 and that requires update to 1.2.2 for handling it correctly, otherwise the seed nodes have to process too much data.
+    GET_DATA_KEY_SET_DELTA              // Supports compact key set deltas in incoming GetData requests
 }

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/network/RepublishGovernanceDataHandler.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/network/RepublishGovernanceDataHandler.java
@@ -169,7 +169,7 @@ public final class RepublishGovernanceDataHandler {
     private void connectToAnyFullNode() {
         Capabilities required = new Capabilities(Capability.DAO_FULL_NODE);
 
-        List<Peer> list = peerManager.getLivePeers(null).stream()
+        List<Peer> list = peerManager.getLivePeers().stream()
                 .filter(peer -> peer.getCapabilities().containsAll(required))
                 .collect(Collectors.toList());
 

--- a/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
+++ b/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
@@ -39,7 +39,8 @@ public class CoreNetworkCapabilities {
                 Capability.MEDIATION,
                 Capability.SIGNED_ACCOUNT_AGE_WITNESS,
                 Capability.REFUND_AGENT,
-                Capability.TRADE_STATISTICS_HASH_UPDATE
+                Capability.TRADE_STATISTICS_HASH_UPDATE,
+                Capability.GET_DATA_KEY_SET_DELTA
         );
 
         if (config.daoActivated) {

--- a/monitor/src/main/java/bisq/monitor/metric/P2PMarketStats.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PMarketStats.java
@@ -181,7 +181,7 @@ public class P2PMarketStats extends P2PSeedNodeSnapshotBase {
         List<NetworkEnvelope> result = new ArrayList<>();
 
         Random random = new Random();
-        result.add(new PreliminaryGetDataRequest(random.nextInt(), hashes));
+        result.add(new PreliminaryGetDataRequest(random.nextInt(), hashes, null));
 
         return result;
     }

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
@@ -154,7 +154,7 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
         List<NetworkEnvelope> result = new ArrayList<>();
 
         Random random = new Random();
-        result.add(new PreliminaryGetDataRequest(random.nextInt(), hashes));
+        result.add(new PreliminaryGetDataRequest(random.nextInt(), hashes, null));
 
         result.add(new GetDaoStateHashesRequest(daostateheight, random.nextInt()));
 

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -622,7 +622,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
         Set<Peer> allPeers = peerManager.getPersistedPeers();
         allPeers.addAll(peerManager.getReportedPeers());
-        allPeers.addAll(peerManager.getLivePeers(null));
+        allPeers.addAll(peerManager.getLivePeers());
         // We might have multiple entries of the same peer without the supportedCapabilities field set if we received
         // it from old versions, so we filter those.
         Optional<Peer> optionalPeer = allPeers.stream()

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -656,14 +656,18 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
                 .ifPresent(connection -> connection.shutDown(closeConnectionReason));
     }
 
+    public Set<Peer> getLivePeers() {
+        return getLivePeers(null);
+    }
+
     // Delivers the live peers from the last 30 min (MAX_AGE_LIVE_PEERS)
     // We include older peers to avoid risks for network partitioning
     public Set<Peer> getLivePeers(NodeAddress excludedNodeAddress) {
         int oldNumLatestLivePeers = latestLivePeers.size();
-        Set<Peer> currentLivePeers = new HashSet<>(getConnectedReportedPeers().stream()
+        Set<Peer> currentLivePeers = getConnectedReportedPeers().stream()
                 .filter(e -> !isSeedNode(e))
                 .filter(e -> !e.getNodeAddress().equals(excludedNodeAddress))
-                .collect(Collectors.toSet()));
+                .collect(Collectors.toCollection(HashSet::new));
         latestLivePeers.addAll(currentLivePeers);
         long maxAge = new Date().getTime() - MAX_AGE_LIVE_PEERS;
         latestLivePeers = latestLivePeers.stream()

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/KeySetDelta.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/KeySetDelta.java
@@ -1,0 +1,284 @@
+package bisq.network.p2p.peers.getdata;
+
+import bisq.network.p2p.storage.P2PDataStorage;
+
+import bisq.common.proto.network.NetworkPayload;
+
+import com.google.protobuf.ByteString;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteStreams;
+import com.google.common.math.DoubleMath;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+
+import java.security.SecureRandom;
+
+import java.math.RoundingMode;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collector;
+import java.util.stream.IntStream;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+public class KeySetDelta implements NetworkPayload {
+    @Getter
+    private final DeltaParams params;
+    private final long[][] tables;
+    private transient final int[] sizeExponentSums;
+
+    private KeySetDelta(int... tableSizeExponents) {
+        this(new DeltaParams(Long.MIN_VALUE, Long.MAX_VALUE, tableSizeExponents));
+    }
+
+    private KeySetDelta(DeltaParams params) {
+        this(params, Arrays.stream(params.tableSizeExponents).mapToObj(n -> new long[1 << n]).toArray(long[][]::new));
+    }
+
+    private KeySetDelta(DeltaParams params, long[][] tables) {
+        this.params = params;
+        this.tables = tables;
+
+        sizeExponentSums = params.tableSizeExponents.clone();
+        for (int i = 1; i < sizeExponentSums.length; i++) {
+            sizeExponentSums[i] += sizeExponentSums[i - 1];
+        }
+    }
+
+    private int keyIndex(int i, long encodedKey) {
+        return (int) (encodedKey >>> 64 - sizeExponentSums[i]) & tables[i].length - 1;
+    }
+
+    private OptionalLong readEntry(int i, int j) {
+        long key = tables[i][j];
+        long encodedKey = key * 1518500249; // Square root of 2 ** 61, rounded down (an arbitrary unstructured odd int)
+        return key != 0 && keyIndex(i, encodedKey) == j ? OptionalLong.of(key) : OptionalLong.empty();
+    }
+
+    private void xor(long key) {
+        long encodedKey = key * 1518500249;
+        for (int i = 0; i < tables.length; i++) {
+            tables[i][keyIndex(i, encodedKey)] ^= key;
+        }
+    }
+
+    private void xorFiltered(long key) {
+        if (key >= params.lowerBound && key <= params.upperBound) {
+            xor(key);
+        }
+    }
+
+    public KeySetDelta xorAll(KeySetDelta other) {
+        for (int i = 0; i < tables.length; i++) {
+            for (int j = 0; j < tables[i].length; j++) {
+                tables[i][j] ^= other.tables[i][j];
+            }
+        }
+        return this;
+    }
+
+    private static Set<Long> xorAll(Set<Long> dst, Set<Long> src) {
+        for (long key : src) {
+            if (!dst.remove(key)) {
+                dst.add(key);
+            }
+        }
+        return dst;
+    }
+
+    public Optional<Set<Long>> decode() {
+        KeySetDelta delta = new KeySetDelta(params).xorAll(this);
+        Set<Long> guesses = new HashSet<>();
+        for (int i = 0; i < 25; i++) {
+            if (delta.decode(0, guesses)) {
+                return Optional.of(guesses);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean decode(int i, Set<Long> guesses) {
+        if (i >= tables.length) {
+            return Arrays.stream(tables).flatMapToLong(Arrays::stream).allMatch(x -> x == 0);
+        }
+        if (Arrays.stream(tables[i]).noneMatch(x -> x == 0)) {
+            // Abort round if current table is completely full - this seems to slightly improve decoding ability.
+            return false;
+        }
+
+        Set<Long> newGuesses = IntStream.range(0, tables[i].length).boxed()
+                .flatMapToLong(j -> readEntry(i, j).stream())
+                .collect(HashSet::new, Set::add, Set::addAll);
+
+        newGuesses.forEach(this::xor);
+        return decode(i + 1, xorAll(guesses, newGuesses));
+    }
+
+    public double estimateUnfilteredDeltaSize() {
+        long emptyCount = Arrays.stream(tables[0]).filter(x -> x == 0).count();
+
+        long readableCount = IntStream.range(0, tables[0].length).boxed()
+                .flatMapToLong(j -> readEntry(0, j).stream())
+                .count();
+
+        double densityEstimate = maximumLikelihoodDensityEstimate(tables[0].length, emptyCount, readableCount);
+        if (Double.isInfinite(densityEstimate)) {
+            // Make sure we always return a reasonable (finite) delta size estimate.
+            densityEstimate = maximumLikelihoodDensityEstimate(tables[0].length, 0, 2);
+        }
+        double filteredFraction = 0x1.0p-64 + (params.upperBound * 0x1.0p-64 - params.lowerBound * 0x1.0p-64);
+        return densityEstimate * tables[0].length / filteredFraction;
+    }
+
+    @VisibleForTesting
+    static double maximumLikelihoodDensityEstimate(double N, double n, double m) {
+        if (n == 0 && m <= 1) {
+            return Double.POSITIVE_INFINITY;
+        }
+        if (n == N) {
+            return 0;
+        }
+        double x = -Math.log(Math.max(n, 1) / N), lastX;
+        double dx = 0x1.0p-32;
+        do {
+            double y = likelihoodDerivative(N, n, m, x);
+            double dy = likelihoodDerivative(N, n, m, x + dx) - y;
+            lastX = x;
+            x = Math.min(Math.max(x - y * dx / dy, x - 1), x + 1);
+        } while (!DoubleMath.fuzzyEquals(x, lastX, 0x1.0p-40));
+        return x;
+    }
+
+    private static double likelihoodDerivative(double N, double n, double m, double x) {
+        double p = Math.exp(-x);
+        double q = (x * (1 - 1 / N) - 1 / N) * p + 1 / N;
+        double y = (1 - 1 / N) * (x - 1) - 1 / N;
+        double z = (N - n - m) / (1 - p - q);
+        return (n / p - z) + (m / q - z) * y;
+    }
+
+    @VisibleForTesting
+    public static Collector<Long, ?, KeySetDelta> toKeySetDelta(int... tableSizeExponents) {
+        return Collector.of(() -> new KeySetDelta(tableSizeExponents), KeySetDelta::xor, KeySetDelta::xorAll,
+                Collector.Characteristics.UNORDERED);
+    }
+
+    public static Collector<P2PDataStorage.ByteArray, ?, KeySetDelta> toKeySetDelta(DeltaParams params) {
+        ToLongFunction<P2PDataStorage.ByteArray> hashFn = hashFunction(params.salt);
+        return Collector.of(
+                () -> new KeySetDelta(params),
+                (delta, key) -> delta.xorFiltered(hashFn.applyAsLong(key)),
+                KeySetDelta::xorAll,
+                Collector.Characteristics.UNORDERED
+        );
+    }
+
+    public static ToLongFunction<P2PDataStorage.ByteArray> hashFunction(byte[] salt) {
+        //noinspection UnstableApiUsage
+        ByteArrayDataInput dataInput = ByteStreams.newDataInput(salt);
+        //noinspection UnstableApiUsage
+        HashFunction function = Hashing.sipHash24(dataInput.readLong(), dataInput.readLong());
+        return key -> function.hashBytes(key.bytes).asLong();
+    }
+
+    @Override
+    public protobuf.KeySetDelta toProtoMessage() {
+        return protobuf.KeySetDelta.newBuilder()
+                .setSalt(ByteString.copyFrom(params.salt))
+                .setShortKeyLowerBound(params.lowerBound).setShortKeyUpperBound(params.upperBound)
+                .addAllSizeExponents(Ints.asList(params.tableSizeExponents))
+                .addAllConcatenatedTables(Longs.asList(Arrays.stream(tables).flatMapToLong(Arrays::stream).toArray()))
+                .build();
+    }
+
+    public static KeySetDelta fromProto(protobuf.KeySetDelta proto) {
+        if (proto.getDefaultInstanceForType().equals(proto)) {
+            return null;
+        }
+        Preconditions.checkArgument(proto.getShortKeyLowerBound() <= proto.getShortKeyUpperBound());
+        long[][] tables = new long[proto.getSizeExponentsCount()][];
+        for (int i = 0, j = 0; i < tables.length; i++) {
+            Preconditions.checkPositionIndex(proto.getSizeExponents(i), 32);
+            tables[i] = Longs.toArray(proto.getConcatenatedTablesList().subList(j, j += 1 << proto.getSizeExponents(i)));
+        }
+        return new KeySetDelta(
+                new DeltaParams(
+                        proto.getSalt().toByteArray(),
+                        proto.getShortKeyLowerBound(),
+                        proto.getShortKeyUpperBound(),
+                        Ints.toArray(proto.getSizeExponentsList())),
+                tables
+        );
+    }
+
+    @Getter
+    @EqualsAndHashCode
+    public static class DeltaParams {
+        private final byte[] salt;
+        private final long lowerBound, upperBound;
+        private transient final int[] tableSizeExponents;
+
+        public DeltaParams(long capacity) {
+            this(Long.MIN_VALUE, SizeExponents.forCapacity(capacity).upperBound(capacity),
+                    SizeExponents.forCapacity(capacity).tableSizeExponents);
+        }
+
+        DeltaParams(long lowerBound, long upperBound, int... tableSizeExponents) {
+            this(new byte[16], lowerBound, upperBound, tableSizeExponents);
+            new SecureRandom().nextBytes(salt);
+        }
+
+        DeltaParams(byte[] salt, long lowerBound, long upperBound, int... tableSizeExponents) {
+            this.salt = salt;
+            this.lowerBound = lowerBound;
+            this.upperBound = upperBound;
+            this.tableSizeExponents = tableSizeExponents;
+        }
+    }
+
+    @Getter
+    @VisibleForTesting
+    enum SizeExponents {
+        TINY(550, 9, 8, 7, 6, 5, 4, 4, 4, 4, 4, 3, 3, 3),     //   8.6 KiB
+        SMALL(1200, 10, 9, 8, 7, 6, 5, 4, 4, 3, 3, 3, 2),     //  16.2 KiB
+        LARGE(2500, 11, 10, 9, 8, 7, 6, 5, 4, 4),             //  32.0 KiB
+        LARGER(5150, 12, 11, 10, 9, 8, 7, 7),                 //  64.0 KiB
+        LARGEST(10450, 13, 12, 11, 10, 9, 9);                 // 128.0 KiB
+
+        private final int maxUnfilteredCapacity;
+        private final int[] tableSizeExponents;
+
+        SizeExponents(int maxUnfilteredCapacity, int... tableSizeExponents) {
+            Preconditions.checkArgument(Arrays.stream(tableSizeExponents).sum() == 64);
+            this.maxUnfilteredCapacity = maxUnfilteredCapacity;
+            this.tableSizeExponents = tableSizeExponents;
+        }
+
+        long upperBound(long capacity) {
+            if (capacity <= maxUnfilteredCapacity) {
+                return Long.MAX_VALUE;
+            }
+            double filteredFraction = (double) maxUnfilteredCapacity / capacity;
+            return DoubleMath.roundToLong((filteredFraction - 0.5) * 0x1.0p64, RoundingMode.DOWN) - 1;
+        }
+
+        static SizeExponents forCapacity(long capacity) {
+            return Arrays.stream(values())
+                    .filter(s -> capacity <= s.maxUnfilteredCapacity)
+                    .findFirst()
+                    .orElse(LARGEST);
+        }
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -344,6 +344,12 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                 log.trace("requestDataHandshake with outbound connection failed.\n\tnodeAddress={}\n\t" +
                                         "ErrorMessage={}", nodeAddress, errorMessage);
 
+                                onIncomplete();
+                            }
+
+                            @Override
+                            public void onIncomplete() {
+                                // TODO: Not obvious that this is the best way to retry in the event of incomplete data.
                                 peerManager.handleConnectionFault(nodeAddress);
                                 handlerMap.remove(nodeAddress);
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataRequest.java
@@ -18,6 +18,7 @@
 package bisq.network.p2p.peers.getdata.messages;
 
 import bisq.network.p2p.ExtendedDataSizePermission;
+import bisq.network.p2p.peers.getdata.KeySetDelta;
 
 import bisq.common.proto.network.NetworkEnvelope;
 
@@ -34,12 +35,15 @@ public abstract class GetDataRequest extends NetworkEnvelope implements Extended
     protected final int nonce;
     // Keys for ProtectedStorageEntry items to be excluded from the request because the peer has them already
     protected final Set<byte[]> excludedKeys;
+    protected final KeySetDelta excludedShortKeys;
 
     public GetDataRequest(int messageVersion,
                           int nonce,
-                          Set<byte[]> excludedKeys) {
+                          Set<byte[]> excludedKeys,
+                          KeySetDelta excludedShortKeys) {
         super(messageVersion);
         this.nonce = nonce;
         this.excludedKeys = excludedKeys;
+        this.excludedShortKeys = excludedShortKeys;
     }
 }

--- a/p2p/src/test/java/bisq/network/p2p/peers/getdata/KeySetDeltaTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/peers/getdata/KeySetDeltaTest.java
@@ -1,0 +1,131 @@
+package bisq.network.p2p.peers.getdata;
+
+import bisq.network.p2p.peers.getdata.KeySetDelta.SizeExponents;
+import bisq.network.p2p.storage.P2PDataStorage;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+import java.security.SecureRandom;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class KeySetDeltaTest {
+    private final Random rnd = new SecureRandom();
+
+    @Test
+    @Ignore
+    public void testDecode() {
+        ConcurrentSkipListSet<Integer> decodeLimits = new ConcurrentSkipListSet<>();
+        AtomicInteger i0 = new AtomicInteger(12000);
+        AtomicInteger j0 = new AtomicInteger();
+        IntStream.range(0, 10000000).parallel().forEach(k -> {
+            int i00 = i0.get();
+            List<Long> testKeys = longs(i0.get()).boxed().collect(Collectors.toList());
+            KeySetDelta delta0 = testKeys.stream()
+                    .collect(KeySetDelta.toKeySetDelta(SizeExponents.SMALL.getTableSizeExponents()));
+            int j = j0.getAndIncrement();
+            if (j % 1000 == 999) {
+                System.out.println("Made " + (j + 1) + " attempts.");
+            }
+            Optional<Set<Long>> decoded;
+            if ((decoded = delta0.decode()).isPresent()) {
+                Assert.assertEquals(new HashSet<>(testKeys), decoded.get());
+                return;
+            }
+            for (int i = 500; i <= i00; i++) {
+                KeySetDelta delta = testKeys.subList(0, i).stream()
+                        .collect(KeySetDelta.toKeySetDelta(SizeExponents.SMALL.getTableSizeExponents()));
+
+                if (!(decoded = delta.decode()).isPresent()) {
+                    System.out.println("Failed to decode at " + i + " entries.");
+                    decodeLimits.add(i0.accumulateAndGet(i - 1, Math::min));
+                    break;
+                }
+                Assert.assertEquals(new HashSet<>(testKeys.subList(0, i)), decoded.get());
+            }
+        });
+        System.out.println(decodeLimits);
+        System.out.println("Summary: " + decodeLimits.stream().mapToDouble(n -> n).summaryStatistics());
+    }
+
+    @Test
+    public void testToKeySetDelta() {
+        Map<P2PDataStorage.ByteArray, ?> testMap = Stream.generate(() -> randomBytes(20))
+                .limit(100000)
+                .collect(Collectors.toMap(P2PDataStorage.ByteArray::new, bs -> new Object()));
+
+        Set<P2PDataStorage.ByteArray> set = testMap.keySet();
+        byte[] salt = randomBytes(16);
+        KeySetDelta delta = null;
+        for (int i = 0; i < 100; i++) {
+            delta = set.parallelStream()
+                    .collect(KeySetDelta.toKeySetDelta(new KeySetDelta.DeltaParams(
+                            salt, Long.MIN_VALUE, Long.MAX_VALUE, SizeExponents.LARGER.getTableSizeExponents())));
+        }
+        System.out.println(delta.estimateUnfilteredDeltaSize());
+    }
+
+    @Test
+    public void testProto() {
+        KeySetDelta delta = Stream.generate(() -> randomBytes(20))
+                .limit(1200)
+                .map(P2PDataStorage.ByteArray::new)
+                .collect(KeySetDelta.toKeySetDelta(new KeySetDelta.DeltaParams(0)));
+
+        System.out.println(delta.decode().map(Set::size));
+        System.out.println(delta.toProtoMessage().getSerializedSize());
+        Assert.assertEquals(delta, KeySetDelta.fromProto(delta.toProtoMessage()));
+    }
+
+    @Test
+    public void testMaximumLikelihoodDensityEstimate() {
+        for (int n = 0; n <= 10; n++) {
+            for (int m = 0; m <= 10 - n; m++) {
+                System.out.println("n = " + n + ", m = " + m + ", densityEstimate = " +
+                        KeySetDelta.maximumLikelihoodDensityEstimate(10, n, m));
+            }
+        }
+    }
+
+    @Test
+    public void testKeyDecode() {
+        System.out.println(Integer.toHexString(641));
+        System.out.println(Integer.toHexString(6700417));
+        System.out.println(Math.exp(-32768.0 / 4096) * 4096);
+        new Random(12345).longs().limit(100).forEach(x -> {
+            long y = x * 641 * -0x0ffffffffL;
+            long z = y * 6700417;
+            System.out.println(x + " " + y + " " + z);
+        });
+    }
+
+    private byte[] randomBytes(int length) {
+        byte[] bytes = new byte[length];
+        rnd.nextBytes(bytes);
+        return bytes;
+    }
+
+    // SecureRandom seems to have pretty bad performance on Windows. This is much faster than rnd.longs()
+    // and just as high a quality source of random numbers if the PRF security claims of SipHash are true.
+    private LongStream longs(long n) {
+        //noinspection UnstableApiUsage
+        HashFunction fn = Hashing.sipHash24(rnd.nextLong(), rnd.nextLong());
+        return LongStream.range(0, n).map(x -> fn.hashLong(x).asLong());
+    }
+}

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
@@ -467,7 +467,7 @@ public class P2PDataStorageBuildGetDataResponseTest {
 
         @Override
         GetDataRequest buildGetDataRequest(int nonce, Set<byte[]> knownKeys) {
-            return new PreliminaryGetDataRequest(nonce, knownKeys);
+            return new PreliminaryGetDataRequest(nonce, knownKeys, null);
         }
     }
 
@@ -475,7 +475,7 @@ public class P2PDataStorageBuildGetDataResponseTest {
 
         @Override
         GetDataRequest buildGetDataRequest(int nonce, Set<byte[]> knownKeys) {
-            return new GetUpdatedDataRequest(new NodeAddress("peer", 10), nonce, knownKeys);
+            return new GetUpdatedDataRequest(new NodeAddress("peer", 10), nonce, knownKeys, null);
         }
     }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageGetDataIntegrationTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageGetDataIntegrationTest.java
@@ -79,7 +79,7 @@ public class P2PDataStorageGetDataIntegrationTest {
         ProtectedStorageEntry onSeedNode = getProtectedStorageEntry();
         seedNode.addProtectedStorageEntry(onSeedNode, null, null);
 
-        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1);
+        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1, false);
 
         GetDataResponse getDataResponse = seedNode.buildGetDataResponse(
                 getDataRequest, 1, new AtomicBoolean(), new AtomicBoolean(), new Capabilities());
@@ -109,7 +109,7 @@ public class P2PDataStorageGetDataIntegrationTest {
         clientNodeTestState.simulateRestart();
         clientNode = clientNodeTestState.mockedStorage;
 
-        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1);
+        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1, false);
 
         GetDataResponse getDataResponse = seedNode.buildGetDataResponse(
                 getDataRequest, 1, new AtomicBoolean(), new AtomicBoolean(), new Capabilities());
@@ -142,7 +142,7 @@ public class P2PDataStorageGetDataIntegrationTest {
         clientNodeTestState.simulateRestart();
         clientNode = clientNodeTestState.mockedStorage;
 
-        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1);
+        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1, false);
 
         GetDataResponse getDataResponse = seedNode.buildGetDataResponse(
                 getDataRequest, 1, new AtomicBoolean(), new AtomicBoolean(), new Capabilities());
@@ -178,7 +178,7 @@ public class P2PDataStorageGetDataIntegrationTest {
         seedNode.remove(getProtectedStorageEntry(
                 ownerKeys.getPublic(), protectedStoragePayload, 2), null);
 
-        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1);
+        GetDataRequest getDataRequest = clientNode.buildPreliminaryGetDataRequest(1, false);
 
         GetDataResponse getDataResponse = seedNode.buildGetDataResponse(
                 getDataRequest, 1, new AtomicBoolean(), new AtomicBoolean(), new Capabilities());

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProcessGetDataResponse.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProcessGetDataResponse.java
@@ -71,7 +71,9 @@ public class P2PDataStorageProcessGetDataResponse {
                 new HashSet<>(protectedStorageEntries),
                 new HashSet<>(persistableNetworkPayloads),
                 1,
-                false);
+                false,
+                new HashSet<>(),
+                0);
     }
 
     /**

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRequestDataTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRequestDataTest.java
@@ -94,7 +94,7 @@ public class P2PDataStorageRequestDataTest {
     // TESTCASE: P2PDataStorage with no entries returns an empty PreliminaryGetDataRequest
     @Test
     public void buildPreliminaryGetDataRequest_EmptyP2PDataStore() {
-        PreliminaryGetDataRequest getDataRequest = this.testState.mockedStorage.buildPreliminaryGetDataRequest(1);
+        PreliminaryGetDataRequest getDataRequest = this.testState.mockedStorage.buildPreliminaryGetDataRequest(1, false);
 
         Assert.assertEquals(getDataRequest.getNonce(), 1);
         Assert.assertEquals(getDataRequest.getSupportedCapabilities(), Capabilities.app);
@@ -105,7 +105,7 @@ public class P2PDataStorageRequestDataTest {
     @Test
     public void buildGetUpdatedDataRequest_EmptyP2PDataStore() {
         GetUpdatedDataRequest getDataRequest =
-                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1);
+                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1, false);
 
         Assert.assertEquals(getDataRequest.getNonce(), 1);
         Assert.assertEquals(getDataRequest.getSenderNodeAddress(), this.localNodeAddress);
@@ -127,7 +127,7 @@ public class P2PDataStorageRequestDataTest {
         this.testState.mockedStorage.addProtectedStorageEntry(toAdd3, this.localNodeAddress, null);
         this.testState.mockedStorage.addProtectedStorageEntry(toAdd4, this.localNodeAddress, null);
 
-        PreliminaryGetDataRequest getDataRequest = this.testState.mockedStorage.buildPreliminaryGetDataRequest(1);
+        PreliminaryGetDataRequest getDataRequest = this.testState.mockedStorage.buildPreliminaryGetDataRequest(1, false);
 
         Assert.assertEquals(getDataRequest.getNonce(), 1);
         Assert.assertEquals(getDataRequest.getSupportedCapabilities(), Capabilities.app);
@@ -156,7 +156,7 @@ public class P2PDataStorageRequestDataTest {
         this.testState.mockedStorage.addProtectedStorageEntry(toAdd4, this.localNodeAddress, null);
 
         GetUpdatedDataRequest getDataRequest =
-                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1);
+                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1, false);
 
         Assert.assertEquals(getDataRequest.getNonce(), 1);
         Assert.assertEquals(getDataRequest.getSenderNodeAddress(), this.localNodeAddress);

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -94,6 +94,7 @@ message PreliminaryGetDataRequest {
     int32 nonce = 21;
     repeated bytes excluded_keys = 2;
     repeated int32 supported_capabilities = 3;
+    KeySetDelta excluded_short_keys = 4;
 }
 
 message GetDataResponse {
@@ -102,12 +103,23 @@ message GetDataResponse {
     repeated StorageEntryWrapper data_set = 3;
     repeated int32 supported_capabilities = 4;
     repeated PersistableNetworkPayload persistable_network_payload_items = 5;
+    repeated sfixed64 unrecognized_short_keys = 6;
+    int32 estimated_remaining_delta_size = 7;
 }
 
 message GetUpdatedDataRequest {
     NodeAddress sender_node_address = 1;
     int32 nonce = 2;
     repeated bytes excluded_keys = 3;
+    KeySetDelta excluded_short_keys = 4;
+}
+
+message KeySetDelta {
+    bytes salt = 1;
+    sfixed64 short_key_lower_bound = 2;
+    sfixed64 short_key_upper_bound = 3;
+    repeated int32 size_exponents = 4;
+    repeated sfixed64 concatenated_tables = 5;
 }
 
 // peers


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

When Bisq starts it sends simultaneous `PreliminaryGetDataRequest` packets to two seed nodes to sync the latest trade statistics, offer book, mailbox and other data, followed by a later `GetUpdatedDataRequest` packet. The requests contain a list of keys of all the data to exclude (as we already have it) and are consequently about 2MB each. The responses to the first two `GetData` requests are typically around 3MB, it seems, usually consisting mostly of offer and mailbox items (as those are not persisted and have high turnover anyway).

Thus there is typically about 10MB (in total) being sent/received in the preliminary `GetData` requests/responses to/from the seed nodes. On slow networks, this appears to frequently result in timeouts and difficulty starting up the application, as the 3MB response arrives after the 90s timeout window and gets rejected.

In an attempt to alleviate the problem, this PR replaces the `excluded_keys` list in the `GetData` requests with a delta structure (that is a sort of binary checksum/linear code syndrome), which is XORed with a version computed equivalently at the receiving node, to obtain a decodable list of keys. This is the symmetric difference of the two sets of keys at each node, which tells the responding node which keys are missing from the peer.

The delta is decodable provided the symmetric difference isn't too large compared to the physical delta size (powers-of-two from 8KB to 128KB). With the data structure I used, an 8KB delta can reliably decode up to 550 keys and a 128KB delta can reliably decode up to 10450 keys. Since this holds true only when the keys are randomised, they are all hashed to a fixed 64-bit width using a randomly seeded secure PRF (in this case SipHash) - 64 bits is enough to ensure a very low probability of collision per request and deliberately causing collisions is impossible since the random seed/hash-salt is an ephemeral shared secret.

In case decoding fails, the responding peer estimates the size of the undecodable delta and sends that information back, so that the requesting peer can retry with a delta structure big enough to accommodate the expected symmetric difference. The keys can also be restricted to an arbitrary range of 64-bit values, which effectively filters out items out at random, ensuring that the symmetric difference will be reliably decoded in the next request. The code will keep retrying until it gets everything.

The above requires new fields to be added to the `PreliminaryGetDataRequest`, `GetUpdatedDataRequest` and `GetDataResponse` proto definitions. I've tried to do this in a way which is backwards compatible by adding a provisional `GET_DATA_KEY_SET_DELTA` capability and only using the new delta structure in requests to peers which flag the capability.

This PR is a draft and still needs some work (e.g. to the unit tests and commit messages). I'm also considering making the following possible further enhancements:

- In the initial requests to the pair of seed nodes, use the range filter to split the keyset in two and send a different half to each pair, so each one only sends back approximately 1.5 MB, cutting the network load in half again. After getting one response, wait a little while (rather than the usual 90s) to get the other response before retrying.

- Now that the requests are cheap, it might make sense to limit the responses to 1MB or less and make repeated requests to sync everything, rather than getting it all in one go. This should make startup more reliable on very slow networks. Also possibly add a corresponding progress bar to the splash screen.

- Optimistically persist/cache the offer book and mailbox entries for faster startup next time, in case the application was only shut down for a few hours or days. Since the response now contains a list of unrecognised keys, any items that don't match can be purged from the cache and the rest promoted to the protected store (as the seed node definitely still has them).

I'm not sure whether it would be best to include the above in this PR or consider them for later PRs.