### PR TITLE
Fix popup message about trade limits

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -580,10 +580,9 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 final long tradeLimit = model.accountAgeWitnessService.getMyTradeLimit(account.get(),
                         offer.getCurrencyCode(), offer.getMirroredDirection());
                 new Popup()
-                        .warning(Res.get("offerbook.warning.tradeLimitNotMatching",
-                                DisplayUtils.formatAccountAge(model.accountAgeWitnessService.getMyAccountAge(account.get().getPaymentAccountPayload())),
+                        .warning(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.buyer",
                                 formatter.formatCoinWithCode(Coin.valueOf(tradeLimit)),
-                                formatter.formatCoinWithCode(offer.getMinAmount())))
+                                Res.get("offerbook.warning.newVersionAnnouncement")))
                         .show();
             } else {
                 log.warn("We don't found a payment account but got called the isInsufficientTradeLimit case. That must not happen.");


### PR DESCRIPTION
When a user tries to take an offer which is above his limit, the old popup is still being shown.
It says that the user limits will be raised when his account is 2 months old.
But that is not true anymore, now we have account signing etc...
This fix uses the string that is already used for offer creation, which is good since preserves translations.
But I think we would need a better message, which I am afraid I cannot get done, showing the sign state and age.
I am submitting this PR as is now since I think this is a big issue.
New users might try to use Bisq to accept an offer, get this message and then decide to wait 2 months, in vain.
So, it partially fixes #3885.