### PR TITLE
Remove btcnodes not operated by Bisq btcnode team members

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -70,18 +70,12 @@ public class BtcNodes {
                         // Devin Bileck
                         new BtcNode("btc1.dnsalias.net", "lva54pnbq2nsmjyr.onion", "165.227.34.198", BtcNode.DEFAULT_PORT, "@devinbileck"),
 
-                        // sgeisler - temporarily disabled due to recent uptime falling below acceptable threshold
-                        // new BtcNode("bcwat.ch", "z33nukt7ngik3cpe.onion", "5.189.166.193", BtcNode.DEFAULT_PORT, "@sgeisler"),
-
                         // m52go
                         new BtcNode("btc.bisq.cc", "4nnuyxm5k5tlyjq3.onion", "167.71.168.194", BtcNode.DEFAULT_PORT, "@m52go"),
 
                         // wiz
                         new BtcNode("node130.hnl.wiz.biz", "22tg6ufbwz6o3l2u.onion", "103.99.168.130", BtcNode.DEFAULT_PORT, "@wiz"),
-                        new BtcNode("node140.hnl.wiz.biz", "jiuuuislm7ooesic.onion", "103.99.168.140", BtcNode.DEFAULT_PORT, "@wiz"),
-
-                        // others
-                        new BtcNode("btc.jochen-hoenicke.de", "sslnjjhnmwllysv4.onion", "88.198.39.205", BtcNode.DEFAULT_PORT, "@jhoenicke")
+                        new BtcNode("node140.hnl.wiz.biz", "jiuuuislm7ooesic.onion", "103.99.168.140", BtcNode.DEFAULT_PORT, "@wiz")
                 ) :
                 new ArrayList<>();
     }


### PR DESCRIPTION
### Background
Due to a change starting from Bitcoin 0.19.x, a non-default `bitcoin.conf` configuration is now required for usage with Bisq nodes: `peerbloomfilters=1` must be set.

### Summary
Because of the change in Bitcoin, a Bisq node can no longer use a Bitcoin node with default settings. Therefore, Bisq must ensure that all of its hard-coded Bitcoin nodes have the `peerbloomfilters=1` setting enabled.

Currently we have 2 hard-coded Bitcoin nodes whose operators are not members of the #btcnodes team/channel on Keybase or Github, and do not make regular reports to the Bisq DAO. Additionally, we have seen availability issues with these 2 btcnodes in the past, with no way to communicate or coordinate with these btcnode operators.

Because of the above concerns, this PR removes these 2 btcnodes. If the btcnode operators confirm they fulfill the above requirements, they can request to be re-added.