### PR TITLE
List Liquid Bitcoin (L-BTC)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/LiquidBitcoin.java
+++ b/assets/src/main/java/bisq/asset/coins/LiquidBitcoin.java
@@ -17,9 +17,11 @@
 
 package bisq.asset.coins;
 
+import bisq.asset.AltCoinAccountDisclaimer;
 import bisq.asset.Coin;
 import bisq.asset.RegexAddressValidator;
 
+@AltCoinAccountDisclaimer("account.altcoin.popup.liquidbitcoin.msg")
 public class LiquidBitcoin extends Coin {
 
     public LiquidBitcoin() {

--- a/assets/src/main/java/bisq/asset/coins/LiquidBitcoin.java
+++ b/assets/src/main/java/bisq/asset/coins/LiquidBitcoin.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.Coin;
+import bisq.asset.RegexAddressValidator;
+
+public class LiquidBitcoin extends Coin {
+
+    public LiquidBitcoin() {
+        super("Liquid Bitcoin", "L-BTC", new RegexAddressValidator("^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,87}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,87})$"));
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -62,6 +62,7 @@ bisq.asset.coins.KnowYourDeveloper
 bisq.asset.coins.Kore
 bisq.asset.coins.Krypton
 bisq.asset.coins.LBRYCredits
+bisq.asset.coins.LiquidBitcoin
 bisq.asset.coins.Litecoin
 bisq.asset.coins.LitecoinPlus
 bisq.asset.coins.LitecoinZ

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -136,6 +136,7 @@ public class CurrencyUtil {
         result.add(new CryptoCurrency("DCR", "Decred"));
         result.add(new CryptoCurrency("ETH", "Ether"));
         result.add(new CryptoCurrency("GRIN", "Grin"));
+        result.add(new CryptoCurrency("L-BTC", "Liquid Bitcoin"));
         result.add(new CryptoCurrency("LTC", "Litecoin"));
         result.add(new CryptoCurrency("XMR", "Monero"));
         result.add(new CryptoCurrency("NMC", "Namecoin"));

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1446,6 +1446,18 @@ As burnt blackcoins are unspendable, they can not be reselled. “Selling” bur
 burning ordinary blackcoins (with associated data equal to the destination address).\n\n\
 In case of a dispute, the BLK seller needs to provide the transaction hash.
 
+account.altcoin.popup.liquidbitcoin.msg=Trading L-BTC on Bisq requires that you understand the following:\n\n\
+When receiving L-BTC for a trade on Bisq, you cannot use the mobile Blockstream Green Wallet app or a \
+custodial/exchange wallet. You must only receive L-BTC into the Liquid Elements Core wallet, or another \
+L-BTC wallet which allows you to obtain the blinding key for your blinded L-BTC address.\n\n\
+In the event mediation is necessary, or if a trade dispute arises, you must disclose the blinding key for \
+your receiving L-BTC address to the Bisq mediator or refund agent so they can verify the details of \
+your Confidential Transaction on their own Elements Core full node.\n\n\
+Failure to provide the required information to the mediator or refund agent will result in losing the \
+dispute case. In all cases of dispute, the L-BTC receiver bears 100% of the burden of responsibility in \
+providing cryptographic proof to the mediator or refund agent.\n\n\
+If you do not understand these requirements, do not trade L-BTC on Bisq.
+
 account.fiat.yourFiatAccounts=Your national currency accounts
 
 account.backup.title=Backup wallet


### PR DESCRIPTION
### Asset name

Liquid Bitcoin

### Ticker

L-BTC

### Website

https://liquid.net

### Block explorer

https://blockstream.info/liquid/

### Additional technical requirements

Due to base layer privacy aka Confidential Transactions, the Bisq mediators / refund agents must obtain the Blinding Key from the L-BTC sender to verify transactions for any trade dispute, similar to Monero. 

While the [full documentation](https://docs.blockstream.com/liquid/developer-guide/confidential-transactions.html?highlight=blinding%20key) explains all the details, I will make a separate PR to docs repo for use by support agents, mediators, and refund agents with simple steps to verify trade funds were sent.