### PR TITLE
Reduce codeowners to the required minimum

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,13 @@
 *gradle* @cbeams
 /pricenode/ @cbeams
 /core/main/java/bisq/core/dao/ @ManfredKarrer
+
+# For seednode configuration changes
+/seednode/bisq-seednode.env @wiz
+/seednode/bisq-seednode.service @wiz
+/seednode/bitcoin.conf @wiz
+/seednode/bitcoin.service @wiz
+/seednode/docker-compose.yml @wiz
+/seednode/install_seednode_debian.sh @wiz
+/seednode/torrc @wiz
+/seednode/uninstall_seednode_debian.sh @wiz

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,6 @@
 # This doc specifies who gets requested to review GitHub pull requests.
 # See https://help.github.com/articles/about-codeowners/.
 
-* @ripcurlx
-/assets/ @blabno
-/desktop/ @ripcurlx @sqrrm
 *gradle* @cbeams
 /pricenode/ @cbeams
+/core/main/java/bisq/core/dao/ @ManfredKarrer


### PR DESCRIPTION
This is done to deactivate auto assignment of reviewers in most cases and should encourage everyone to start reviewing PRs on their own.
