### PR TITLE
Re-ordering Stream APIs

### DIFF
--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -78,8 +78,8 @@ public class CurrencyUtil {
     private static Map<String, FiatCurrency> createFiatCurrencyMap() {
         return CountryUtil.getAllCountries().stream()
                 .map(country -> getCurrencyByCountryCode(country.code))
-                .distinct()
                 .sorted(TradeCurrency::compareTo)
+                .distinct()
                 .collect(Collectors.toMap(TradeCurrency::getCode, Function.identity(), (x, y) -> x, LinkedHashMap::new));
     }
 


### PR DESCRIPTION
We are conducting a research project on re-ordering Stream APIs for improving program execution speed.

Before and after re-ordering, we measured running time of tests which execute target Stream.
Command for running tests is : 
`time ./gradlew -Dtest.single=PriceTest test`

and the result is :
```
the order of Stream API      test running time
===============================================
distinct().sorted()                 4.614s
sorted().distinct()                 4.472s
```