### PR TITLE
Trade process refresh

### DIFF
--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -75,6 +75,8 @@ message NetworkEnvelope {
         DelayedPayoutTxSignatureResponse delayed_payout_tx_signature_response = 47;
         DepositTxAndDelayedPayoutTxMessage deposit_tx_and_delayed_payout_tx_message = 48;
         PeerPublishedDelayedPayoutTxMessage peer_published_delayed_payout_tx_message = 49;
+
+        RefreshTradeStateRequest refresh_trade_state_request = 50;
     }
 }
 
@@ -319,6 +321,12 @@ message MediatedPayoutTxSignatureMessage {
     string trade_id = 3;
     bytes tx_signature = 2;
     NodeAddress sender_node_address = 4;
+}
+
+message RefreshTradeStateRequest {
+    string uid = 1;
+    string trade_id = 2;
+    NodeAddress sender_node_address = 3;
 }
 
 // dispute

--- a/common/src/main/proto/pb.proto
+++ b/common/src/main/proto/pb.proto
@@ -1387,6 +1387,7 @@ message Trade {
     NodeAddress refund_agent_node_address = 33;
     PubKeyRing refund_agent_pub_key_ring = 34;
     RefundResultState refund_result_state = 35;
+    int64 last_refresh_request_date = 36;
 }
 
 message BuyerAsMakerTrade {

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -57,6 +57,7 @@ import bisq.core.trade.messages.MediatedPayoutTxPublishedMessage;
 import bisq.core.trade.messages.MediatedPayoutTxSignatureMessage;
 import bisq.core.trade.messages.PayoutTxPublishedMessage;
 import bisq.core.trade.messages.PeerPublishedDelayedPayoutTxMessage;
+import bisq.core.trade.messages.RefreshTradeStateRequest;
 import bisq.core.trade.statistics.TradeStatistics;
 
 import bisq.network.p2p.AckMessage;
@@ -142,6 +143,8 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                     return PrefixedSealedAndSignedMessage.fromProto(proto.getPrefixedSealedAndSignedMessage(), messageVersion);
 
                 // trade protocol messages
+                case REFRESH_TRADE_STATE_REQUEST:
+                    return RefreshTradeStateRequest.fromProto(proto.getRefreshTradeStateRequest(), messageVersion);
                 case INPUTS_FOR_DEPOSIT_TX_REQUEST:
                     return InputsForDepositTxRequest.fromProto(proto.getInputsForDepositTxRequest(), this, messageVersion);
                 case INPUTS_FOR_DEPOSIT_TX_RESPONSE:

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -76,6 +76,8 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import java.time.temporal.ChronoUnit;
+
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
@@ -418,6 +420,10 @@ public abstract class Trade implements Tradable, Model {
     private RefundResultState refundResultState = RefundResultState.UNDEFINED_REFUND_RESULT;
     transient final private ObjectProperty<RefundResultState> refundResultStateProperty = new SimpleObjectProperty<>(refundResultState);
 
+    // Added in v1.2.6
+    @Getter
+    @Setter
+    private long lastRefreshRequestDate;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor, initialization
@@ -502,7 +508,8 @@ public abstract class Trade implements Tradable, Model {
                 .addAllChatMessage(chatMessages.stream()
                         .map(msg -> msg.toProtoNetworkEnvelope().getChatMessage())
                         .collect(Collectors.toList()))
-                .setLockTime(lockTime);
+                .setLockTime(lockTime)
+                .setLastRefreshRequestDate(lastRefreshRequestDate);
 
         Optional.ofNullable(takerFeeTxId).ifPresent(builder::setTakerFeeTxId);
         Optional.ofNullable(depositTxId).ifPresent(builder::setDepositTxId);
@@ -557,6 +564,7 @@ public abstract class Trade implements Tradable, Model {
         trade.setRefundResultState(RefundResultState.fromProto(proto.getRefundResultState()));
         trade.setDelayedPayoutTxBytes(ProtoUtil.byteArrayOrNullFromProto(proto.getDelayedPayoutTxBytes()));
         trade.setLockTime(proto.getLockTime());
+        trade.setLastRefreshRequestDate(proto.getLastRefreshRequestDate());
 
         trade.chatMessages.addAll(proto.getChatMessageList().stream()
                 .map(ChatMessage::fromPayloadProto)
@@ -1051,6 +1059,19 @@ public abstract class Trade implements Tradable, Model {
         return arbitratorBtcPubKey;
     }
 
+    public boolean allowedRefresh() {
+        var allowRefresh = new Date().getTime() > lastRefreshRequestDate + ChronoUnit.DAYS.getDuration().toMillis();
+        if (!allowRefresh) {
+            log.info("Refresh not allowed, last refresh at {}", lastRefreshRequestDate);
+        }
+        return allowRefresh;
+    }
+
+    public void logRefresh() {
+        var time = new Date().getTime();
+        log.debug("Log refresh at {}", time);
+        lastRefreshRequestDate = time;
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
@@ -1160,6 +1181,7 @@ public abstract class Trade implements Tradable, Model {
                 ",\n     refundAgentPubKeyRing=" + refundAgentPubKeyRing +
                 ",\n     refundResultState=" + refundResultState +
                 ",\n     refundResultStateProperty=" + refundResultStateProperty +
+                ",\n     lastRefreshRequestDate=" + lastRefreshRequestDate +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -101,6 +101,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 public abstract class Trade implements Tradable, Model {
 
+    public static final long REFRESH_INTERVAL = ChronoUnit.DAYS.getDuration().toMillis();
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Enums
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -453,6 +455,7 @@ public abstract class Trade implements Tradable, Model {
         takerFeeAsLong = takerFee.value;
         takeOfferDate = new Date().getTime();
         processModel = new ProcessModel();
+        lastRefreshRequestDate = takeOfferDate;
     }
 
 
@@ -1060,7 +1063,7 @@ public abstract class Trade implements Tradable, Model {
     }
 
     public boolean allowedRefresh() {
-        var allowRefresh = new Date().getTime() > lastRefreshRequestDate + ChronoUnit.DAYS.getDuration().toMillis();
+        var allowRefresh = new Date().getTime() > lastRefreshRequestDate + REFRESH_INTERVAL;
         if (!allowRefresh) {
             log.info("Refresh not allowed, last refresh at {}", lastRefreshRequestDate);
         }

--- a/core/src/main/java/bisq/core/trade/messages/RefreshTradeStateRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/RefreshTradeStateRequest.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.messages;
+
+import bisq.network.p2p.MailboxMessage;
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.app.Version;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class RefreshTradeStateRequest extends TradeMessage implements MailboxMessage {
+    private final NodeAddress senderNodeAddress;
+
+    public RefreshTradeStateRequest(String uid,
+                                    String tradeId,
+                                    NodeAddress senderNodeAddress) {
+        this(Version.getP2PMessageVersion(),
+                uid,
+                tradeId,
+                senderNodeAddress);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private RefreshTradeStateRequest(int messageVersion,
+                                     String uid,
+                                     String tradeId,
+                                     NodeAddress senderNodeAddress) {
+        super(messageVersion, tradeId, uid);
+        this.senderNodeAddress = senderNodeAddress;
+    }
+
+    @Override
+    public protobuf.NetworkEnvelope toProtoNetworkEnvelope() {
+        final protobuf.RefreshTradeStateRequest.Builder builder = protobuf.RefreshTradeStateRequest.newBuilder();
+        builder.setUid(uid)
+                .setTradeId(tradeId)
+                .setSenderNodeAddress(senderNodeAddress.toProtoMessage());
+        return getNetworkEnvelopeBuilder().setRefreshTradeStateRequest(builder).build();
+    }
+
+    public static RefreshTradeStateRequest fromProto(protobuf.RefreshTradeStateRequest proto, int messageVersion) {
+        return new RefreshTradeStateRequest(messageVersion,
+                proto.getUid(),
+                proto.getTradeId(),
+                NodeAddress.fromProto(proto.getSenderNodeAddress()));
+    }
+
+    @Override
+    public String toString() {
+        return "RefreshTradeStateRequest{" +
+                "\n     senderNodeAddress=" + senderNodeAddress +
+                "\n} " + super.toString();
+    }
+
+}

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -109,7 +109,7 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
         } else if (tradeMessage instanceof PayoutTxPublishedMessage) {
             handle((PayoutTxPublishedMessage) tradeMessage, peerNodeAddress);
         } else if (tradeMessage instanceof RefreshTradeStateRequest) {
-            handle((RefreshTradeStateRequest) tradeMessage, peerNodeAddress);
+            handle();
         }
     }
 
@@ -173,9 +173,7 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
         processModel.setTempTradingPeerNodeAddress(sender);
 
         TradeTaskRunner taskRunner = new TradeTaskRunner(buyerAsTakerTrade,
-                () -> {
-                    handleTaskRunnerSuccess(tradeMessage, "handle DelayedPayoutTxSignatureRequest");
-                },
+                () -> handleTaskRunnerSuccess(tradeMessage, "handle DelayedPayoutTxSignatureRequest"),
                 errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
         taskRunner.addTasks(
                 BuyerProcessDelayedPayoutTxSignatureRequest.class,
@@ -191,9 +189,7 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
         processModel.setTempTradingPeerNodeAddress(peerNodeAddress);
 
         TradeTaskRunner taskRunner = new TradeTaskRunner(buyerAsTakerTrade,
-                () -> {
-                    handleTaskRunnerSuccess(tradeMessage, "handle DepositTxAndDelayedPayoutTxMessage");
-                },
+                () -> handleTaskRunnerSuccess(tradeMessage, "handle DepositTxAndDelayedPayoutTxMessage"),
                 errorMessage -> handleTaskRunnerFault(tradeMessage, errorMessage));
         taskRunner.addTasks(
                 BuyerProcessDepositTxAndDelayedPayoutTxMessage.class,
@@ -218,7 +214,7 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
         taskRunner.run();
     }
 
-    private void handle(RefreshTradeStateRequest tradeMessage, NodeAddress peerNodeAddress) {
+    private void handle() {
         log.debug("handle RefreshTradeStateRequest called");
         // Resend CounterCurrencyTransferStartedMessage if it hasn't been acked yet and counterparty asked for a refresh
         if (trade.getState().getPhase() == Trade.Phase.FIAT_SENT &&
@@ -283,7 +279,7 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
         } else if (tradeMessage instanceof PayoutTxPublishedMessage) {
             handle((PayoutTxPublishedMessage) tradeMessage, sender);
         } else if (tradeMessage instanceof RefreshTradeStateRequest) {
-            handle((RefreshTradeStateRequest) tradeMessage, sender);
+            handle();
         }
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -634,7 +634,8 @@ portfolio.pending.step2_seller.waitPayment.msg=The deposit transaction has at le
 portfolio.pending.step2_seller.warn=The BTC buyer still has not done the {0} payment.\nYou need to wait until they have started the payment.\nIf the trade has not been completed on {1} the arbitrator will investigate.
 portfolio.pending.step2_seller.openForDispute=The BTC buyer has not started their payment!\nThe max. allowed period for the trade has elapsed.\nYou can wait longer and give the trading peer more time or contact the mediator for assistance.
 portfolio.pending.step2_seller.refresh=Refresh Trade State
-
+portfolio.pending.step2_seller.refreshInfo=Sometimes P2P network messages acknowledging payment are not delivered, \
+  causing trades to get stuck. Hit the button below to make your peer resend the last message.
 tradeChat.chatWindowTitle=Chat window for trade with ID ''{0}''
 tradeChat.openChat=Open chat window
 tradeChat.rules=You can communicate with your trade peer to resolve potential problems with this trade.\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -633,6 +633,7 @@ portfolio.pending.step2_seller.f2fInfo.headline=Buyer's contact information
 portfolio.pending.step2_seller.waitPayment.msg=The deposit transaction has at least one blockchain confirmation.\nYou need to wait until the BTC buyer starts the {0} payment.
 portfolio.pending.step2_seller.warn=The BTC buyer still has not done the {0} payment.\nYou need to wait until they have started the payment.\nIf the trade has not been completed on {1} the arbitrator will investigate.
 portfolio.pending.step2_seller.openForDispute=The BTC buyer has not started their payment!\nThe max. allowed period for the trade has elapsed.\nYou can wait longer and give the trading peer more time or contact the mediator for assistance.
+portfolio.pending.step2_seller.refresh=Refresh Trade State
 
 tradeChat.chatWindowTitle=Chat window for trade with ID ''{0}''
 tradeChat.openChat=Open chat window

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -270,6 +270,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                     }
                 }
         );
+        tradeManager.persistTrades();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -49,10 +49,13 @@ import bisq.core.trade.BuyerTrade;
 import bisq.core.trade.SellerTrade;
 import bisq.core.trade.Trade;
 import bisq.core.trade.TradeManager;
+import bisq.core.trade.messages.RefreshTradeStateRequest;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 
+import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
+import bisq.network.p2p.SendMailboxMessageListener;
 
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
@@ -77,6 +80,7 @@ import javafx.collections.ObservableList;
 
 import org.spongycastle.crypto.params.KeyParameter;
 
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import lombok.Getter;
@@ -229,6 +233,42 @@ public class PendingTradesDataModel extends ActivatableDataModel {
 
     public void onMoveToFailedTrades() {
         tradeManager.addTradeToFailedTrades(getTrade());
+    }
+
+    // Ask counterparty to resend last action (in case message was lost)
+    public void refreshTradeState() {
+        Trade trade = getTrade();
+        if (trade == null) return;
+
+        NodeAddress tradingPeerNodeAddress = trade.getTradingPeerNodeAddress();
+
+        RefreshTradeStateRequest refreshReq = new RefreshTradeStateRequest(UUID.randomUUID().toString(),
+                trade.getId(),
+                tradingPeerNodeAddress);
+        p2PService.sendEncryptedMailboxMessage(
+                tradingPeerNodeAddress,
+                trade.getProcessModel().getTradingPeer().getPubKeyRing(),
+                refreshReq,
+                new SendMailboxMessageListener() {
+                    @Override
+                    public void onArrived() {
+                        log.info("SendMailboxMessageListener onArrived tradeId={} at peer {}",
+                                trade.getId(), tradingPeerNodeAddress);
+                    }
+
+                    @Override
+                    public void onStoredInMailbox() {
+                        log.info("SendMailboxMessageListener onStoredInMailbox tradeId={} at peer {}",
+                                trade.getId(), tradingPeerNodeAddress);
+                    }
+
+                    @Override
+                    public void onFault(String errorMessage) {
+                        log.error("SendMailboxMessageListener onFault tradeId={} at peer {}",
+                                trade.getId(), tradingPeerNodeAddress);
+                    }
+                }
+        );
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -238,8 +238,9 @@ public class PendingTradesDataModel extends ActivatableDataModel {
     // Ask counterparty to resend last action (in case message was lost)
     public void refreshTradeState() {
         Trade trade = getTrade();
-        if (trade == null) return;
+        if (trade == null || !trade.allowedRefresh()) return;
 
+        trade.logRefresh();
         NodeAddress tradingPeerNodeAddress = trade.getTradingPeerNodeAddress();
 
         RefreshTradeStateRequest refreshReq = new RefreshTradeStateRequest(UUID.randomUUID().toString(),

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -37,13 +37,11 @@ import bisq.core.support.messages.ChatMessage;
 import bisq.core.support.traderchat.TradeChatSession;
 import bisq.core.support.traderchat.TraderChatManager;
 import bisq.core.trade.Trade;
-import bisq.core.trade.messages.RefreshTradeStateRequest;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.SendMailboxMessageListener;
 
 import bisq.common.UserThread;
 import bisq.common.config.Config;
@@ -96,7 +94,6 @@ import javafx.util.Callback;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 @FxmlView
 public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTradesViewModel> {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -37,11 +37,13 @@ import bisq.core.support.messages.ChatMessage;
 import bisq.core.support.traderchat.TradeChatSession;
 import bisq.core.support.traderchat.TraderChatManager;
 import bisq.core.trade.Trade;
+import bisq.core.trade.messages.RefreshTradeStateRequest;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.SendMailboxMessageListener;
 
 import bisq.common.UserThread;
 import bisq.common.config.Config;
@@ -94,6 +96,7 @@ import javafx.util.Callback;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @FxmlView
 public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTradesViewModel> {
@@ -213,6 +216,8 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                 new Popup().warning(Res.get("portfolio.pending.removeFailedTrade"))
                         .onAction(model.dataModel::onMoveToFailedTrades)
                         .show();
+            } else if (Utilities.isAltOrCtrlPressed(KeyCode.R, keyEvent)) {
+                model.dataModel.refreshTradeState();
             }
         };
 
@@ -455,7 +460,6 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
             });
         }
     }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // CellFactories

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep2View.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.portfolio.pendingtrades.steps.seller;
 
-import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.paymentmethods.F2FForm;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import bisq.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
@@ -30,16 +29,21 @@ import bisq.core.trade.Trade;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 
+import javafx.scene.control.Button;
+import javafx.scene.layout.GridPane;
+
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import static bisq.desktop.util.FormBuilder.addButtonAfterGroup;
+import static bisq.desktop.util.FormBuilder.addMultilineLabel;
 import static bisq.desktop.util.FormBuilder.addTitledGroupBg;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SellerStep2View extends TradeStepView {
 
-    private AutoTooltipButton refreshButton;
+    private Button refreshButton;
+    private GridPane refreshButtonPane;
     private Timer timer;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -62,10 +66,25 @@ public class SellerStep2View extends TradeStepView {
             gridRow = F2FForm.addFormForBuyer(gridPane, --gridRow, model.dataModel.getSellersPaymentAccountPayload(),
                     model.dataModel.getTrade().getOffer(), Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE);
         }
-        refreshButton = (AutoTooltipButton) addButtonAfterGroup(gridPane, ++gridRow,
-                Res.get("portfolio.pending.step2_seller.refresh"));
-        refreshButton.setOnAction(event -> onRefreshButton());
+
+        addRefreshBlock();
     }
+
+    private void addRefreshBlock() {
+        refreshButtonPane = new GridPane();
+        addTitledGroupBg(refreshButtonPane, 0, 1,
+                Res.get("portfolio.pending.step2_seller.refresh"), Layout.COMPACT_GROUP_DISTANCE);
+        addMultilineLabel(refreshButtonPane, 1, Res.get("portfolio.pending.step2_seller.refreshInfo"),
+                Layout.COMPACT_FIRST_ROW_DISTANCE);
+        refreshButton = addButtonAfterGroup(refreshButtonPane, 2, Res.get("portfolio.pending.step2_seller.refresh"));
+        refreshButton.setOnAction(event -> onRefreshButton());
+
+        GridPane.setRowIndex(refreshButtonPane, ++gridRow);
+        GridPane.setColumnIndex(refreshButtonPane, 0);
+        GridPane.setColumnSpan(refreshButtonPane, 2);
+        gridPane.getChildren().add(refreshButtonPane);
+    }
+
 
     @Override
     public void activate() {
@@ -84,9 +103,9 @@ public class SellerStep2View extends TradeStepView {
         var timeToNextRefresh =
                 model.dataModel.getTrade().getLastRefreshRequestDate() + Trade.REFRESH_INTERVAL - new Date().getTime();
         if (timeToNextRefresh <= 0) {
-            refreshButton.setDisable(false);
+            refreshButtonPane.setVisible(true);
         } else {
-            refreshButton.setDisable(true);
+            refreshButtonPane.setVisible(false);
             timer = UserThread.runAfter(this::activateRefreshButton, timeToNextRefresh, TimeUnit.MILLISECONDS);
         }
     }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep2View.java
@@ -42,7 +42,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SellerStep2View extends TradeStepView {
 
-    private Button refreshButton;
     private GridPane refreshButtonPane;
     private Timer timer;
 
@@ -76,7 +75,7 @@ public class SellerStep2View extends TradeStepView {
                 Res.get("portfolio.pending.step2_seller.refresh"), Layout.COMPACT_GROUP_DISTANCE);
         addMultilineLabel(refreshButtonPane, 1, Res.get("portfolio.pending.step2_seller.refreshInfo"),
                 Layout.COMPACT_FIRST_ROW_DISTANCE);
-        refreshButton = addButtonAfterGroup(refreshButtonPane, 2, Res.get("portfolio.pending.step2_seller.refresh"));
+        Button refreshButton = addButtonAfterGroup(refreshButtonPane, 2, Res.get("portfolio.pending.step2_seller.refresh"));
         refreshButton.setOnAction(event -> onRefreshButton());
 
         GridPane.setRowIndex(refreshButtonPane, ++gridRow);


### PR DESCRIPTION
Fix #3905 

A seller can ask to refresh the trade process once every 24 hours. This step has been a problem causing a lot of mediation lately so this is a way to ask the buyer to resend the CounterCurrencyTransferStartedMessage

This fixes the problem when a mailbox message was lost. To test the seller need to not get the first CounterCurrencyTransferStartedMessage sent by the buyer, for example by letting the seednode drop it instead of sending to the seller. When button is pressed
- a RefreshTradeStateRequest is sent from seller to buyer
- the buyer receives the RefreshTradeStateRequest and
  - ignores it if it's not in FIAT_SENT phase
  - responds with a CounterCurrencyTransferStartedMessage if in FIAT_SENT phase and has already sent a CounterCurrencyTransferStartedMessage