### PR TITLE
Dump delayed tx

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -114,6 +114,7 @@ public class Config {
     public static final String GENESIS_BLOCK_HEIGHT = "genesisBlockHeight";
     public static final String GENESIS_TOTAL_SUPPLY = "genesisTotalSupply";
     public static final String DAO_ACTIVATED = "daoActivated";
+    public static final String DUMP_DELAYED_PAYOUT_TXS = "dumpDelayedPayoutTxs";
 
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
@@ -195,6 +196,7 @@ public class Config {
     public final String genesisTxId;
     public final int genesisBlockHeight;
     public final long genesisTotalSupply;
+    public final boolean dumpDelayedPayoutTxs;
 
     // Properties derived from options but not exposed as options themselves
     public final File torDir;
@@ -597,6 +599,12 @@ public class Config {
                         .ofType(boolean.class)
                         .defaultsTo(true);
 
+        ArgumentAcceptingOptionSpec<Boolean> dumpDelayedPayoutTxsOpt =
+                parser.accepts(DUMP_DELAYED_PAYOUT_TXS, "Dump delayed payout transactions to file")
+                        .withRequiredArg()
+                        .ofType(boolean.class)
+                        .defaultsTo(false);
+
         try {
             CompositeOptionSet options = new CompositeOptionSet();
 
@@ -701,6 +709,7 @@ public class Config {
             this.genesisBlockHeight = options.valueOf(genesisBlockHeightOpt);
             this.genesisTotalSupply = options.valueOf(genesisTotalSupplyOpt);
             this.daoActivated = options.valueOf(daoActivatedOpt) || !baseCurrencyNetwork.isMainnet();
+            this.dumpDelayedPayoutTxs = options.valueOf(dumpDelayedPayoutTxsOpt);
         } catch (OptionException ex) {
             throw new ConfigException("problem parsing option '%s': %s",
                     ex.options().get(0),

--- a/core/src/main/java/bisq/core/trade/TradeModule.java
+++ b/core/src/main/java/bisq/core/trade/TradeModule.java
@@ -33,6 +33,7 @@ import bisq.common.config.Config;
 
 import com.google.inject.Singleton;
 
+import static bisq.common.config.Config.DUMP_DELAYED_PAYOUT_TXS;
 import static bisq.common.config.Config.DUMP_STATISTICS;
 import static com.google.inject.name.Names.named;
 
@@ -56,5 +57,6 @@ public class TradeModule extends AppModule {
         bind(ReferralIdService.class).in(Singleton.class);
         bind(AssetTradeActivityCheck.class).in(Singleton.class);
         bindConstant().annotatedWith(named(DUMP_STATISTICS)).to(config.dumpStatistics);
+        bindConstant().annotatedWith(named(DUMP_DELAYED_PAYOUT_TXS)).to(config.dumpDelayedPayoutTxs);
     }
 }


### PR DESCRIPTION
I'm currently investigating an issue from a user where the trades have been corrupted and they're not able to open arbitration.

As a way to recover funds it's still possible to publish the delayed payout tx manually as long as that data is available. This PR adds a config option to dump delayed payout tx hashes to file.