### PR TITLE
Remove unused uid in pricefeed service

### DIFF
--- a/core/src/main/java/bisq/core/provider/price/PriceProvider.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceProvider.java
@@ -48,7 +48,7 @@ public class PriceProvider extends HttpClientProvider {
     public Tuple2<Map<String, Long>, Map<String, MarketPrice>> getAll() throws IOException {
         Map<String, MarketPrice> marketPriceMap = new HashMap<>();
         String json = httpClient.requestWithGET("getAllMarketPrices", "User-Agent", "bisq/"
-                + Version.VERSION + ", uid:" + httpClient.getUid());
+                + Version.VERSION);
 
         LinkedTreeMap<?, ?> map = new Gson().fromJson(json, LinkedTreeMap.class);
         Map<String, Long> tsMap = new HashMap<>();


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This came up during work on https://github.com/bisq-network/bisq/issues/3916.

Bisq frequently (once per minute) queries our price nodes for up-to-date
price information. It does so by HTTP GET request. However, it provided
a UID via the "User-Agent" HTTP header field. This UID has been a random
number which changed everytime Bisq got started up.

This UID has never been used. Thus, remove it.
