### PR TITLE
Set syslog identifier as "bisq" in systemd service config

### DIFF
--- a/seednode/bisq.service
+++ b/seednode/bisq.service
@@ -7,6 +7,7 @@ After=bitcoin.service
 #BindsTo=bitcoin.service
 
 [Service]
+SyslogIdentifier=bisq
 EnvironmentFile=/etc/default/bisq.env
 
 ExecStart=/bin/sh __BISQ_HOME__/__BISQ_REPO_NAME__/${BISQ_ENTRYPOINT} \


### PR DESCRIPTION
### Before
```
Feb  7 23:42:18 seednode systemd[1]: Starting Bisq Node...
Feb  7 23:42:18 seednode systemd[1]: Started Bisq Node.
Feb  7 23:42:19 seednode sh[2680]: #033[34mFeb-07 23:42:19.912 [main] INFO  b.s.SeedNodeMain: SeedNode.VERSION: 1.2.6
Feb  7 23:42:20 seednode sh[2680]: #033[0;39m#033[34mFeb-07 23:42:20.213 [main] INFO  b.c.s.CoreSetup:
Feb  7 23:42:20 seednode sh[2680]: Log files under: /bisq/bisq-seednode/bisq
Feb  7 23:42:20 seednode sh[2680]: #033[0;39m#033[34mFeb-07 23:42:20.220 [main] INFO  b.c.u.Utilities: System info: os.name=Linux; os.version=4.15.0-76-generic; os.arch=amd64; sun.arch.data.model=64; JRE=10.0.2+13 (Oracle Corporation); JVM=10.0.2+13 (OpenJDK 64-Bit Server VM)
```

### After
```
Feb  8 03:03:09 seednode systemd[1]: Starting Bisq Node...
Feb  8 03:03:09 seednode systemd[1]: Started Bisq Node.
Feb  8 03:03:10 seednode bisq[6843]: #033[34mFeb-08 03:03:10.509 [main] INFO  b.s.SeedNodeMain: SeedNode.VERSION: 1.2.6
Feb  8 03:03:10 seednode bisq[6843]: #033[0;39m#033[34mFeb-08 03:03:10.762 [main] INFO  b.c.s.CoreSetup:
Feb  8 03:03:10 seednode bisq[6843]: Log files under: /bisq/bisq-seednode/bisq
Feb  8 03:03:10 seednode bisq[6843]: #033[0;39m#033[34mFeb-08 03:03:10.773 [main] INFO  b.c.u.Utilities: System info: os.name=Linux; os.version=4.15.0-76-generic; os.arch=amd64; sun.arch.data.model=64; JRE=10.0.2+13 (Oracle Corporation); JVM=10.0.2+13 (OpenJDK 64-Bit Server VM)
```