### PR TITLE
Fix incorrect rounding of BSQ dollar price to whole number

### DIFF
--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -116,6 +116,10 @@ public class DisplayUtils {
         return formatVolume(volume, FIAT_VOLUME_FORMAT, true);
     }
 
+    static String formatAverageVolumeWithCode(Volume volume) {
+        return formatVolume(volume, FIAT_VOLUME_FORMAT.minDecimals(2), true);
+    }
+
     public static String formatVolumeLabel(String currencyCode) {
         return formatVolumeLabel(currencyCode, "");
     }

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -949,7 +949,7 @@ public class GUIUtil {
         showBsqFeeInfoPopup(fee, miningFee, null, txSize, bsqFormatter, btcFormatter, type, actionHandler);
     }
 
-    public static void setFitToRowsForTableView(TableView tableView,
+    public static void setFitToRowsForTableView(TableView<?> tableView,
                                                 int rowHeight,
                                                 int headerHeight,
                                                 int minNumRows,
@@ -1100,7 +1100,7 @@ public class GUIUtil {
         Volume bsqAmountAsVolume = Volume.parse(bsqAmountAsString, "BSQ");
         Coin requiredBtc = bsqPrice.getAmountByVolume(bsqAmountAsVolume);
         Volume volumeByAmount = usdPrice.getVolumeByAmount(requiredBtc);
-        return DisplayUtils.formatVolumeWithCode(volumeByAmount);
+        return DisplayUtils.formatAverageVolumeWithCode(volumeByAmount);
     }
 
     public static MaterialDesignIcon getIconForSignState(AccountAgeWitnessService.SignState state) {

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -22,8 +22,12 @@ import bisq.desktop.util.validation.RegexValidator;
 import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
+import bisq.core.monetary.Price;
+import bisq.core.provider.price.MarketPrice;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
+import bisq.core.util.coin.BsqFormatter;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.CoinMaker;
@@ -51,7 +55,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
 @Ignore
 public class GUIUtilTest {
 
@@ -65,7 +68,7 @@ public class GUIUtilTest {
 
     @Test
     public void testTradeCurrencyConverter() {
-        Map<String, Integer> offerCounts = new HashMap<String, Integer>() {{
+        Map<String, Integer> offerCounts = new HashMap<>() {{
             put("BTC", 11);
             put("EUR", 10);
         }};
@@ -80,7 +83,7 @@ public class GUIUtilTest {
     }
 
     @Test
-    public void testOpenURLWithCampaignParameters() throws Exception {
+    public void testOpenURLWithCampaignParameters() {
         Preferences preferences = mock(Preferences.class);
         DontShowAgainLookup.setPreferences(preferences);
         GUIUtil.setPreferences(preferences);
@@ -101,7 +104,7 @@ public class GUIUtilTest {
     }
 
     @Test
-    public void testOpenURLWithoutCampaignParameters() throws Exception {
+    public void testOpenURLWithoutCampaignParameters() {
         Preferences preferences = mock(Preferences.class);
         DontShowAgainLookup.setPreferences(preferences);
         GUIUtil.setPreferences(preferences);
@@ -141,6 +144,18 @@ public class GUIUtilTest {
 
         assertFalse(regexValidator.validate("12.34.56.788").isValid);
         assertFalse(regexValidator.validate("12.34.56.78:").isValid);
+    }
+
+    @Test
+    public void testGetBsqInUsd() {
+        PriceFeedService priceFeedService = mock(PriceFeedService.class);
+        when(priceFeedService.getMarketPrice("USD"))
+                .thenReturn(new MarketPrice("USD", 12345.6789, 0, true));
+
+        Coin oneBsq = Coin.valueOf(100);
+        Price avgPrice = Price.valueOf("BSQ", 10000);
+
+        assertEquals("1.23 USD", GUIUtil.getBsqInUsd(avgPrice, oneBsq, priceFeedService, new BsqFormatter()));
     }
 
     @Test


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Add a new method to `DisplayUtils` to restore the old rounding behaviour of `formatVolumeWithCode` whenever a fractional volume is required. This fixes a regression caused by #3926 to remove unnecessarily displayed decimals for fiat volumes - it appears that in every case but the average dollar price on the BSQ dashboard a whole number should be shown.

Without this fix, the 30/90 day average price on the BSQ dashboard displays:
> 1 BSQ = 1 USD

(I believe the issue needs to be fixed in the 1.2.6 release branch as well.)