### PR TITLE
Revert setting of null to deposit tx id

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/tasks/PublishTradeStatistics.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/PublishTradeStatistics.java
@@ -70,7 +70,7 @@ public class PublishTradeStatistics extends TradeTask {
                         trade.getTradePrice(),
                         trade.getTradeAmount(),
                         trade.getDate(),
-                        null,
+                        trade.getDepositTxId(),
                         extraDataMap);
                 processModel.getP2PService().addPersistableNetworkPayload(tradeStatistics, true);
             }

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -47,7 +47,6 @@ import org.bitcoinj.utils.Fiat;
 import com.google.common.base.Charsets;
 
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.Map;
 import java.util.Optional;
 
@@ -70,8 +69,6 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
 
     public static final String MEDIATOR_ADDRESS = "medAddr";
     public static final String REFUND_AGENT_ADDRESS = "refAddr";
-
-    public static final Date CUT_OFF_DATE_FOR_DEPOSIT_TX_ID = Utilities.getUTCDate(2019, GregorianCalendar.FEBRUARY, 13);
 
     private final OfferPayload.Direction direction;
     private final String baseCurrency;

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -159,7 +159,6 @@ public class TradeStatisticsManager {
         private TradeStatistics2 tradeStatistics;
 
         public WrapperTradeStatistics2(TradeStatistics2 tradeStatistics) {
-
             this.tradeStatistics = tradeStatistics;
         }
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -40,6 +40,7 @@ import java.io.File;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -81,6 +82,9 @@ public class TradeStatisticsManager {
         Set<TradeStatistics2> collect = tradeStatistics2StorageService.getMap().values().stream()
                 .filter(e -> e instanceof TradeStatistics2)
                 .map(e -> (TradeStatistics2) e)
+                .map(WrapperTradeStatistics2::new)
+                .distinct()
+                .map(WrapperTradeStatistics2::unwrap)
                 .filter(TradeStatistics2::isValid)
                 .collect(Collectors.toSet());
         observableTradeStatisticsSet.addAll(collect);
@@ -148,6 +152,32 @@ public class TradeStatisticsManager {
             TradeStatisticsForJson[] array = new TradeStatisticsForJson[list.size()];
             list.toArray(array);
             jsonFileManager.writeToDisc(Utilities.objectToJson(array), "trade_statistics");
+        }
+    }
+
+    static class WrapperTradeStatistics2 {
+        private TradeStatistics2 tradeStatistics;
+
+        public WrapperTradeStatistics2(TradeStatistics2 tradeStatistics) {
+
+            this.tradeStatistics = tradeStatistics;
+        }
+
+        public TradeStatistics2 unwrap() {
+            return this.tradeStatistics;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            var wrapper = (WrapperTradeStatistics2) obj;
+            return Objects.equals(tradeStatistics.getOfferId(), wrapper.tradeStatistics.getOfferId());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tradeStatistics.getOfferId());
         }
     }
 }


### PR DESCRIPTION
As we saw some unexpected behavior during testing we decided to move this change to v1.2.7

Additionally we'll remove even more information from the trade statistics objects and will deploy it together with changes
in the offer objects.