### PR TITLE
Fix address regex

### DIFF
--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -1113,9 +1113,31 @@ public class GUIUtil {
         RegexValidator regexValidator = new RegexValidator();
         String portRegexPattern = "(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])";
         String onionV2RegexPattern = String.format("[a-zA-Z2-7]{16}\\.onion(?:\\:%1$s)?", portRegexPattern);
-        String onionV3RegexPattern = String.format("[a-zA-Z2-7]{56}\\.onion(?:\\:%1$s)?", portRegexPattern);
-        String ipv4RegexPattern = String.format("(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\\:%1$s)?", portRegexPattern);
-        regexValidator.setPattern(String.format("^(?:(?:(?:%1$s)|(?:%2$s)),)*(?:(?:%1$s)|(?:%2$s))*$", onionV2RegexPattern, ipv4RegexPattern));
+        String ipv4RegexPattern = String.format("(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}" +
+                "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
+                "(?:\\:%1$s)?", portRegexPattern);
+        String ipv6RegexPattern = "(" +
+                "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|" +          // 1:2:3:4:5:6:7:8
+                "([0-9a-fA-F]{1,4}:){1,7}:|" +                         // 1::                              1:2:3:4:5:6:7::
+                "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|" +         // 1::8             1:2:3:4:5:6::8  1:2:3:4:5:6::8
+                "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|" +  // 1::7:8           1:2:3:4:5::7:8  1:2:3:4:5::8
+                "([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|" +  // 1::6:7:8         1:2:3:4::6:7:8  1:2:3:4::8
+                "([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|" +  // 1::5:6:7:8       1:2:3::5:6:7:8  1:2:3::8
+                "([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|" +  // 1::4:5:6:7:8     1:2::4:5:6:7:8  1:2::8
+                "[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|" +       // 1::3:4:5:6:7:8   1::3:4:5:6:7:8  1::8
+                ":((:[0-9a-fA-F]{1,4}){1,7}|:)|" +                     // ::2:3:4:5:6:7:8  ::2:3:4:5:6:7:8 ::8       ::
+                "fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|" +     // fe80::7:8%eth0   fe80::7:8%1
+                "::(ffff(:0{1,4}){0,1}:){0,1}" +                       // (link-local IPv6 addresses with zone index)
+                "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}" +
+                "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|" +          // ::255.255.255.255   ::ffff:255.255.255.255  ::ffff:0:255.255.255.255
+                "([0-9a-fA-F]{1,4}:){1,4}:" +                          // (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
+                "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}" +
+                "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])" +           // 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33
+                ")";                                                   // (IPv4-Embedded IPv6 Address)
+        ipv6RegexPattern = String.format("(?:%1$s)|(?:\\[%1$s\\]\\:%2$s)", ipv6RegexPattern, portRegexPattern);
+        String fqdnRegexPattern = String.format("(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+(?!onion)[a-zA-Z]{2,63}(?:\\:%1$s)?$)", portRegexPattern);
+        regexValidator.setPattern(String.format("^(?:(?:(?:%1$s)|(?:%2$s)|(?:%3$s)|(?:%4$s)),)*(?:(?:%1$s)|(?:%2$s)|(?:%3$s)|(?:%4$s))*$",
+                onionV2RegexPattern, ipv4RegexPattern, ipv6RegexPattern, fqdnRegexPattern));
         return regexValidator;
     }
 }

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Ignore
+
 public class GUIUtilTest {
 
     @Before
@@ -124,26 +124,47 @@ public class GUIUtilTest {
         RegexValidator regexValidator = GUIUtil.addressRegexValidator();
 
         assertTrue(regexValidator.validate("").isValid);
+        assertFalse(regexValidator.validate(" ").isValid);
+
+        // onion V2 addresses
         assertTrue(regexValidator.validate("abcdefghij234567.onion").isValid);
         assertTrue(regexValidator.validate("abcdefghijklmnop.onion,abcdefghijklmnop.onion").isValid);
         assertTrue(regexValidator.validate("qrstuvwxyzABCDEF.onion,qrstuvwxyzABCDEF.onion,aaaaaaaaaaaaaaaa.onion").isValid);
         assertTrue(regexValidator.validate("GHIJKLMNOPQRSTUV.onion:9999").isValid);
         assertTrue(regexValidator.validate("WXYZ234567abcdef.onion,GHIJKLMNOPQRSTUV.onion:9999").isValid);
         assertTrue(regexValidator.validate("aaaaaaaaaaaaaaaa.onion:9999,WXYZ234567abcdef.onion:9999,2222222222222222.onion:9999").isValid);
-
-        assertTrue(regexValidator.validate("12.34.56.78").isValid);
-        assertTrue(regexValidator.validate("12.34.56.78:8888").isValid);
-
-        assertFalse(regexValidator.validate(" ").isValid);
         assertFalse(regexValidator.validate("abcd.onion").isValid);
         assertFalse(regexValidator.validate("abcdefghijklmnop,abcdefghijklmnop.onion").isValid);
         assertFalse(regexValidator.validate("abcdefghi2345689.onion:9999").isValid);
         assertFalse(regexValidator.validate("onion:9999,abcdefghijklmnop.onion:9999").isValid);
         assertFalse(regexValidator.validate("abcdefghijklmnop.onion:").isValid);
+
+        // onion v3 addresses
         assertFalse(regexValidator.validate("32zzibxmqi2ybxpqyggwwuwz7a3lbvtzoloti7cxoevyvijexvgsfeid.onion:8333").isValid);
 
+        // ipv4 addresses
+        assertTrue(regexValidator.validate("12.34.56.78").isValid);
+        assertTrue(regexValidator.validate("12.34.56.78,87.65.43.21").isValid);
+        assertTrue(regexValidator.validate("12.34.56.78:8888").isValid);
         assertFalse(regexValidator.validate("12.34.56.788").isValid);
         assertFalse(regexValidator.validate("12.34.56.78:").isValid);
+
+        // ipv6 addresses
+        assertTrue(regexValidator.validate("FE80:0000:0000:0000:0202:B3FF:FE1E:8329").isValid);
+        assertTrue(regexValidator.validate("FE80::0202:B3FF:FE1E:8329").isValid);
+        assertTrue(regexValidator.validate("FE80::0202:B3FF:FE1E:8329,FE80:0000:0000:0000:0202:B3FF:FE1E:8329").isValid);
+        assertTrue(regexValidator.validate("::1").isValid);
+        assertTrue(regexValidator.validate("fe80::").isValid);
+        assertTrue(regexValidator.validate("2001::").isValid);
+        assertTrue(regexValidator.validate("[::1]:8333").isValid);
+        assertTrue(regexValidator.validate("[FE80::0202:B3FF:FE1E:8329]:8333").isValid);
+        assertTrue(regexValidator.validate("[2001:db8::1]:80").isValid);
+        assertTrue(regexValidator.validate("[aaaa::bbbb]:8333").isValid);
+        assertFalse(regexValidator.validate("1200:0000:AB00:1234:O000:2552:7777:1313").isValid);
+
+        // fqdn addresses
+        assertTrue(regexValidator.validate("example.com").isValid);
+        assertTrue(regexValidator.validate("mynode.local:8333").isValid);
     }
 
     @Test


### PR DESCRIPTION
The original implementation of #3895 did not validate IPv6 nor FQDN addresses.