### PR TITLE
Fix btcnode validation regex to handle multiple FQDNs, add tests

### DIFF
--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -1135,7 +1135,7 @@ public class GUIUtil {
                 "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])" +           // 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33
                 ")";                                                   // (IPv4-Embedded IPv6 Address)
         ipv6RegexPattern = String.format("(?:%1$s)|(?:\\[%1$s\\]\\:%2$s)", ipv6RegexPattern, portRegexPattern);
-        String fqdnRegexPattern = String.format("(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+(?!onion)[a-zA-Z]{2,63}(?:\\:%1$s)?$)", portRegexPattern);
+        String fqdnRegexPattern = String.format("(((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+(?!onion)[a-zA-Z]{2,63}(?:\\:%1$s)?)", portRegexPattern);
         regexValidator.setPattern(String.format("^(?:(?:(?:%1$s)|(?:%2$s)|(?:%3$s)|(?:%4$s)),)*(?:(?:%1$s)|(?:%2$s)|(?:%3$s)|(?:%4$s))*$",
                 onionV2RegexPattern, ipv4RegexPattern, ipv6RegexPattern, fqdnRegexPattern));
         return regexValidator;

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -165,6 +165,12 @@ public class GUIUtilTest {
         // fqdn addresses
         assertTrue(regexValidator.validate("example.com").isValid);
         assertTrue(regexValidator.validate("mynode.local:8333").isValid);
+        assertTrue(regexValidator.validate("foo.example.com,bar.example.com").isValid);
+        assertTrue(regexValidator.validate("foo.example.com:8333,bar.example.com:8333").isValid);
+
+        assertFalse(regexValidator.validate("mynode.local:65536").isValid);
+        assertFalse(regexValidator.validate("-example.com").isValid);
+        assertFalse(regexValidator.validate("example-.com").isValid);
     }
 
     @Test


### PR DESCRIPTION
@devinbileck's PR #3961 fixed almost everything except one case for btcnode configuration, multiple FQDNs:
```
foo.example.com:8333,bar.example.com:8333
```

This PR fixes the FQDN regex to handle multiple cases and adds new testcases to verify