### PR TITLE
Allow 4 refreshes per trade

### DIFF
--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -76,8 +76,6 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
-import java.time.temporal.ChronoUnit;
-
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
@@ -100,8 +98,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @Slf4j
 public abstract class Trade implements Tradable, Model {
-
-    public static final long REFRESH_INTERVAL = ChronoUnit.DAYS.getDuration().toMillis();
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Enums
@@ -426,6 +422,8 @@ public abstract class Trade implements Tradable, Model {
     @Getter
     @Setter
     private long lastRefreshRequestDate;
+    @Getter
+    private long refreshInterval;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor, initialization
@@ -456,6 +454,7 @@ public abstract class Trade implements Tradable, Model {
         takeOfferDate = new Date().getTime();
         processModel = new ProcessModel();
         lastRefreshRequestDate = takeOfferDate;
+        refreshInterval = offer.getPaymentMethod().getMaxTradePeriod() / 5;
     }
 
 
@@ -1063,7 +1062,7 @@ public abstract class Trade implements Tradable, Model {
     }
 
     public boolean allowedRefresh() {
-        var allowRefresh = new Date().getTime() > lastRefreshRequestDate + REFRESH_INTERVAL;
+        var allowRefresh = new Date().getTime() > lastRefreshRequestDate + getRefreshInterval();
         if (!allowRefresh) {
             log.info("Refresh not allowed, last refresh at {}", lastRefreshRequestDate);
         }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep2View.java
@@ -99,8 +99,10 @@ public class SellerStep2View extends TradeStepView {
 
     private void activateRefreshButton() {
         checkNotNull(model.dataModel.getTrade(), "No trade found");
+
+        Trade trade = model.dataModel.getTrade();
         var timeToNextRefresh =
-                model.dataModel.getTrade().getLastRefreshRequestDate() + Trade.REFRESH_INTERVAL - new Date().getTime();
+                trade.getLastRefreshRequestDate() + trade.getRefreshInterval() - new Date().getTime();
         if (timeToNextRefresh <= 0) {
             refreshButtonPane.setVisible(true);
         } else {


### PR DESCRIPTION
Change refresh interval to be dependent on the trade period rather than a fix 24 hours (which is obviously not that helpful for a 1 hour trade.