### PR TITLE
Add mynode.local as a block chain explorer option

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -90,6 +90,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             new BlockChainExplorer("Blockonomics", "https://www.blockonomics.co/api/tx?txid=", "https://www.blockonomics.co/#/search?q="),
             new BlockChainExplorer("Chainflyer", "http://chainflyer.bitflyer.jp/Transaction/", "http://chainflyer.bitflyer.jp/Address/"),
             new BlockChainExplorer("Smartbit", "https://www.smartbit.com.au/tx/", "https://www.smartbit.com.au/address/"),
+            new BlockChainExplorer("mynode.local", "http://mynode.local:3002/tx/", "http://mynode.local:3002/address/"),
             new BlockChainExplorer("SoChain. Wow.", "https://chain.so/tx/BTC/", "https://chain.so/address/BTC/"),
             new BlockChainExplorer("Blockchain.info", "https://blockchain.info/tx/", "https://blockchain.info/address/"),
             new BlockChainExplorer("Insight", "https://insight.bitpay.com/tx/", "https://insight.bitpay.com/address/")


### PR DESCRIPTION
Add http://mynode.local:3002 as a URL for the user to select in the preferences for blockchain explorer to use.

This allows the user to use their own blockchain explorer running in a mynode installation on their own network. If not installation is present, then the link launched will not load, however, the user is unlikely to select this option without knowing what this is.

This is a trivial change.
