### PR TITLE
Avoid startup failure when appDataDir is a symbolic link

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -798,10 +798,12 @@ public class Config {
      * @return the given directory, now guaranteed to exist
      */
     private static File mkAppDataDir(File dir) {
-        try {
-            Files.createDirectories(dir.toPath());
-        } catch (IOException ex) {
-            throw new UncheckedIOException(format("Application data directory '%s' could not be created", dir), ex);
+        if (!dir.exists()) {
+            try {
+                Files.createDirectories(dir.toPath());
+            } catch (IOException ex) {
+                throw new UncheckedIOException(format("Application data directory '%s' could not be created", dir), ex);
+            }
         }
         return dir;
     }

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -797,14 +797,13 @@ public class Config {
      * nothing if the directory already exists.
      * @return the given directory, now guaranteed to exist
      */
-    private static File mkAppDataDir(File appDataDir) {
-        Path path = appDataDir.toPath();
+    private static File mkAppDataDir(File dir) {
         try {
-            Files.createDirectories(path);
+            Files.createDirectories(dir.toPath());
         } catch (IOException ex) {
-            throw new UncheckedIOException(format("Application data directory '%s' could not be created", path), ex);
+            throw new UncheckedIOException(format("Application data directory '%s' could not be created", dir), ex);
         }
-        return appDataDir;
+        return dir;
     }
 
     /**
@@ -815,11 +814,10 @@ public class Config {
     private static File mkdir(File parent, String child) {
         File dir = new File(parent, child);
         if (!dir.exists()) {
-            Path path = dir.toPath();
             try {
-                Files.createDirectory(path);
+                Files.createDirectory(dir.toPath());
             } catch (IOException ex) {
-                throw new UncheckedIOException(format("Directory '%s' could not be created", path), ex);
+                throw new UncheckedIOException(format("Directory '%s' could not be created", dir), ex);
             }
         }
         return dir;

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -802,7 +802,7 @@ public class Config {
         try {
             Files.createDirectories(path);
         } catch (IOException ex) {
-            throw new ConfigException(ex, "Application data directory '%s' could not be created", path);
+            throw new UncheckedIOException(format("Application data directory '%s' could not be created", path), ex);
         }
         return appDataDir;
     }
@@ -819,7 +819,7 @@ public class Config {
             try {
                 Files.createDirectory(path);
             } catch (IOException ex) {
-                throw new ConfigException(ex, "Directory '%s' could not be created", path);
+                throw new UncheckedIOException(format("Directory '%s' could not be created", path), ex);
             }
         }
         return dir;

--- a/common/src/main/java/bisq/common/config/ConfigException.java
+++ b/common/src/main/java/bisq/common/config/ConfigException.java
@@ -7,8 +7,4 @@ public class ConfigException extends BisqException {
     public ConfigException(String format, Object... args) {
         super(format, args);
     }
-
-    public ConfigException(Throwable cause, String format, Object... args) {
-        super(cause, format, args);
-    }
 }

--- a/common/src/test/java/bisq/common/config/ConfigTests.java
+++ b/common/src/test/java/bisq/common/config/ConfigTests.java
@@ -1,6 +1,7 @@
 package bisq.common.config;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -236,6 +237,22 @@ public class ConfigTests {
         exceptionRule.expectMessage(containsString("Application data directory"));
         exceptionRule.expectMessage(containsString("could not be created"));
         configWithOpts(opt(USER_DATA_DIR, aFile));
+    }
+
+    @Test
+    public void whenAppDataDirIsSymbolicLink_thenAppDataDirCreationIsNoOp() throws IOException {
+        Path parentDir = Files.createTempDirectory("parent");
+        Path targetDir = parentDir.resolve("target");
+        Path symlink = parentDir.resolve("symlink");
+        Files.createDirectory(targetDir);
+        try {
+            Files.createSymbolicLink(symlink, targetDir);
+        } catch (Throwable ex) {
+            // An error occurred trying to create a symbolic link, likely because the
+            // operating system (e.g. Windows) does not support it, so we abort the test.
+            return;
+        }
+        configWithOpts(opt(APP_DATA_DIR, symlink));
     }
 
 

--- a/common/src/test/java/bisq/common/config/ConfigTests.java
+++ b/common/src/test/java/bisq/common/config/ConfigTests.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.UncheckedIOException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -228,10 +229,10 @@ public class ConfigTests {
     }
 
     @Test
-    public void whenAppDataDirCannotBeCreated_thenConfigExceptionIsThrown() throws IOException {
+    public void whenAppDataDirCannotBeCreated_thenUncheckedIoExceptionIsThrown() throws IOException {
         // set a userDataDir that is actually a file so appDataDir cannot be created
         File aFile = Files.createTempFile("A", "File").toFile();
-        exceptionRule.expect(ConfigException.class);
+        exceptionRule.expect(UncheckedIOException.class);
         exceptionRule.expectMessage(containsString("Application data directory"));
         exceptionRule.expectMessage(containsString("could not be created"));
         configWithOpts(opt(USER_DATA_DIR, aFile));


### PR DESCRIPTION
This PR fixes #3998 as explained in the commit comment for cbe6f19.