### PR TITLE
Adjust NetworkSize metric installer

### DIFF
--- a/pricenode/README.md
+++ b/pricenode/README.md
@@ -67,6 +67,21 @@ curl http://localhost:8080/getVersion
 curl http://localhost:8080/info
 ```
 
+### Monitoring
+
+If you run a main pricenode, you also are obliged to activate the monitoring feed by running
+
+```bash
+curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh | sudo bash
+```
+Follow the instruction given by the script and report your certificate to the seednode group!
+
+Furthermore, you are obliged to provide network size data to the monitor by running
+```bash
+curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/pricenode/install_networksize_debian.sh | sudo bash
+```
+
+
 ## How to deploy elsewhere
 
  - [README-HEROKU.md](README-HEROKU.md)

--- a/pricenode/README.md
+++ b/pricenode/README.md
@@ -74,7 +74,7 @@ If you run a main pricenode, you also are obliged to activate the monitoring fee
 ```bash
 curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh | sudo bash
 ```
-Follow the instruction given by the script and report your certificate to the seednode group!
+Follow the instruction given by the script and report your certificate to the [@bisq-network/monitoring](https://github.com/orgs/bisq-network/teams/monitoring-operators) team or via the [Keybase](https://keybase.io/team/bisq) `#monitoring` channel!
 
 Furthermore, you are obliged to provide network size data to the monitor by running
 ```bash

--- a/pricenode/bisq-pricenode.service
+++ b/pricenode/bisq-pricenode.service
@@ -3,6 +3,7 @@ Description=Bisq Price Node
 After=network.target
 
 [Service]
+SyslogIdentifier=bisq-pricenode
 EnvironmentFile=/etc/default/bisq-pricenode.env
 ExecStart=/bisq/bisq/bisq-pricenode 2 2
 ExecStop=/bin/kill -TERM ${MAINPID}

--- a/pricenode/journalscraper.sh
+++ b/pricenode/journalscraper.sh
@@ -8,7 +8,7 @@ while true;
 do
 	now=$(date +"%F %T")
 
-	journalctl -u bisq --since="$last" --until="$now" | grep -Eo "getAllMarketPrices.*bisq/[0-9].[0-9].[0-9]" | cut -d / -f 2 | sort | uniq -c | while read -r line; do
+	journalctl -u bisq-pricenode --since="$last" --until="$now" | grep -Eo "getAllMarketPrices.*bisq/[0-9].[0-9].[0-9]" | cut -d / -f 2 | sort | uniq -c | while read -r line; do
 		number=$(echo "${line}" | cut -d ' ' -f 1);
 		version=$(echo "${line}" | cut -d \  -f 2);
 		version=${version//./_};


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

followup to #3997, part of https://github.com/bisq-network/projects/issues/13

Tweak the networksize metric scraper script, the pricenode installer and amend the readme on how to use it.

<details><summary>notes to self:</summary>
cannot make the JVM fire up a jmx-service.

standin jar works
```
% jcmd 28970 PerfCounter.print
[snip]
java.rt.vmArgs="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.port=6969 -Dcom.sun.management.jmxremote.rmi.port=6969 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
[snip]
sun.management.JMXConnectorServer.0.authenticate="false"
sun.management.JMXConnectorServer.0.remoteAddress="service:jmx:rmi:///jndi/rmi://workstation:6969/jmxrmi"
sun.management.JMXConnectorServer.0.ssl="false"
sun.management.JMXConnectorServer.0.sslNeedClientAuth="false"
sun.management.JMXConnectorServer.0.sslRegistry="false"
sun.management.JMXConnectorServer.address="service:jmx:rmi://127.0.0.1/stub/rO0ABXNyAC5qYXZheC5tYW5hZ2VtZW50LnJlbW90ZS5ybWkuUk1JU2VydmVySW1wbF9TdHViAAAAAAAAAAICAAB4cgAaamF2YS5ybWkuc2VydmVyLlJlbW90ZVN0dWLp/tzJi+FlGgIAAHhyABxqYXZhLnJtaS5zZXJ2ZXIuUmVtb3RlT2JqZWN002G0kQxhMx4DAAB4cHc5AAtVbmljYXN0UmVmMgAADjE5Mi4xNjguOTMuMTAyAACyuWmYcsfkIQJcg+K0sQAAAXB3S81MgAIAeA=="
sun.management.JMXConnectorServer.remote.enabled=0
```
[snip]

price node does not
```
root@bisqserver ~ # /usr/lib/jvm/openjdk-10.0.2/bin/jcmd 18831 PerfCounter.print
[snip]
java.rt.vmArgs="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.port=6969 -Dcom.sun.management.jmxremote.rmi.port=6969 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
[snip]
```

I can exclude these from the list of reasons
- java version
- using it with a .jar
- running with an unprivileged user
- is caused by service hardening

still open:
- [x] the pricenode is fired up via .jar and not with the startup scripts (used for seednodes for example) see https://github.com/bisq-network/bisq/pull/3997#pullrequestreview-363446739
- there seems to be an embedded tomcat within the pricenode, can that be the reason? but why should it be?

I currently tend to just leave it. It takes too much efforts to find the cause. We did not have any JVM heap data on pricenodes until now, we might visit that again once it issues show up.