### PR TITLE
Make price providers cmdline param more readable

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -373,7 +373,7 @@ public class Config {
                         .defaultsTo(false);
 
         ArgumentAcceptingOptionSpec<String> providersOpt =
-                parser.accepts(PROVIDERS, "List custom providers")
+                parser.accepts(PROVIDERS, "List custom price providers")
                         .withRequiredArg()
                         .withValuesSeparatedBy(',')
                         .describedAs("host:port[,...]");

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -373,7 +373,7 @@ public class Config {
                         .defaultsTo(false);
 
         ArgumentAcceptingOptionSpec<String> providersOpt =
-                parser.accepts(PROVIDERS, "List custom price providers")
+                parser.accepts(PROVIDERS, "List custom pricenodes")
                         .withRequiredArg()
                         .withValuesSeparatedBy(',')
                         .describedAs("host:port[,...]");


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

We have a line in `bisq-desktop --help` saying:
```
  --providers=<host:port[,...]>
        List custom providers
```
Like so, it is not clear what providers you can set using that config option.

This PR only adds "price" to `List custom /price/ providers`.

Stumbled upon this during network size metric testing.