### PR TITLE
Remove unused uid in fee provider service

### DIFF
--- a/core/src/main/java/bisq/core/provider/fee/FeeProvider.java
+++ b/core/src/main/java/bisq/core/provider/fee/FeeProvider.java
@@ -45,7 +45,7 @@ public class FeeProvider extends HttpClientProvider {
     }
 
     public Tuple2<Map<String, Long>, Map<String, Long>> getFees() throws IOException {
-        String json = httpClient.requestWithGET("getFees", "User-Agent", "bisq/" + Version.VERSION + ", uid:" + httpClient.getUid());
+        String json = httpClient.requestWithGET("getFees", "User-Agent", "bisq/" + Version.VERSION);
 
         LinkedTreeMap<?, ?> linkedTreeMap = new Gson().fromJson(json, LinkedTreeMap.class);
         Map<String, Long> tsMap = new HashMap<>();


### PR DESCRIPTION
Bisq frequently (once per minute) queries our price nodes for up-to-date
fee information. It does so by HTTP GET request. However, it provided
a UID via the "User-Agent" HTTP header field. This UID has been a random
number which changed everytime Bisq gets started up.

This UID has never been used. Thus, remove it.

We had a similar case with the price-feed service. Now, pricenode logs should not contain any uid info anymore.

(this has been pointed out in https://github.com/bisq-network/bisq/pull/3937)
