### PR TITLE
Fix false deletion of hsdir when using --appDataDir

### DIFF
--- a/common/src/main/java/bisq/common/storage/FileUtil.java
+++ b/common/src/main/java/bisq/common/storage/FileUtil.java
@@ -108,14 +108,14 @@ public class FileUtil {
             File[] files = file.listFiles();
             if (files != null)
                 for (File f : files) {
-                    if (!excludeFileFound)
-                        excludeFileFound = f.equals(exclude);
-                    if (!f.equals(exclude))
+                    boolean excludeFileFoundLocal = exclude != null ? f.getAbsolutePath().equals(exclude.getAbsolutePath()) : false;
+                    excludeFileFound |= excludeFileFoundLocal;
+                    if (!excludeFileFoundLocal)
                         deleteDirectory(f, exclude, ignoreLockedFiles);
                 }
         }
         // Finally delete main file/dir if exclude file was not found in directory
-        if (!excludeFileFound && !file.equals(exclude)) {
+        if (!excludeFileFound && !(exclude != null ? file.getAbsolutePath().equals(exclude.getAbsolutePath()) : false)) {
             try {
                 deleteFileIfExists(file, ignoreLockedFiles);
             } catch (Throwable t) {


### PR DESCRIPTION
Probably fixes https://github.com/bisq-network/bisq/issues/3995

There are circumstances where input via --appDataDir
will lead to the hiddenservice-directory to be deleted.
Successfully reproduced using

  --appDataDir=~/foo

Although the "~" does not get interpreted correctly on
my linux system, it does manage to throw off the
mechanics of sparing the hiddenservice-directory from
being deleted on startup.
