### PR TITLE
Update offer address to new hidden service files

### DIFF
--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -735,15 +735,24 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                     !OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.REFUND_AGENT)) {
                 // We rewrite our offer with the additional capabilities entry
 
-                Map<String, String> originalExtraDataMap = originalOfferPayload.getExtraDataMap();
+                // - Capabilities changed?
+                // We rewrite our offer with the additional capabilities entry
                 Map<String, String> updatedExtraDataMap = new HashMap<>();
+                if (!OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.MEDIATION) ||
+                        !OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.REFUND_AGENT)) {
+                    Map<String, String> originalExtraDataMap = originalOfferPayload.getExtraDataMap();
 
-                if (originalExtraDataMap != null) {
-                    updatedExtraDataMap.putAll(originalExtraDataMap);
+                    if (originalExtraDataMap != null) {
+                        updatedExtraDataMap.putAll(originalExtraDataMap);
+                    }
+
+                    // We overwrite any entry with our current capabilities
+                    updatedExtraDataMap.put(OfferPayload.CAPABILITIES, Capabilities.app.toStringList());
+
+                    log.info("Converted offer to support new Capability.MEDIATION and Capability.REFUND_AGENT capability. id={}", originalOffer.getId());
+                } else {
+                    updatedExtraDataMap = originalOfferPayload.getExtraDataMap();
                 }
-
-                // We overwrite any entry with our current capabilities
-                updatedExtraDataMap.put(OfferPayload.CAPABILITIES, Capabilities.app.toStringList());
 
                 // - Protocol version changed?
                 int protocolVersion = originalOfferPayload.getProtocolVersion();

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -732,8 +732,8 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
             if (originalOfferPayload.getProtocolVersion() < Version.TRADE_PROTOCOL_VERSION ||
                     !OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.MEDIATION) ||
-                    !OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.REFUND_AGENT)) {
-                // We rewrite our offer with the additional capabilities entry
+                    !OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.REFUND_AGENT) ||
+                    !originalOfferPayload.getOwnerNodeAddress().equals(p2PService.getAddress())) {
 
                 // - Capabilities changed?
                 // We rewrite our offer with the additional capabilities entry
@@ -762,9 +762,16 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                     log.info("Updated the protocol version of offer id={}", originalOffer.getId());
                 }
 
+                // - node address changed? (due to a faulty tor dir)
+                NodeAddress ownerNodeAddress = originalOfferPayload.getOwnerNodeAddress();
+                if (!ownerNodeAddress.equals(p2PService.getAddress())) {
+                    ownerNodeAddress = p2PService.getAddress();
+                    log.info("Updated the owner nodeaddress of offer id={}", originalOffer.getId());
+                }
+
                 OfferPayload updatedPayload = new OfferPayload(originalOfferPayload.getId(),
                         originalOfferPayload.getDate(),
-                        originalOfferPayload.getOwnerNodeAddress(),
+                        ownerNodeAddress,
                         originalOfferPayload.getPubKeyRing(),
                         originalOfferPayload.getDirection(),
                         originalOfferPayload.getPrice(),

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -745,8 +745,13 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 // We overwrite any entry with our current capabilities
                 updatedExtraDataMap.put(OfferPayload.CAPABILITIES, Capabilities.app.toStringList());
 
-                // We update the trade protocol version
-                int protocolVersion = Version.TRADE_PROTOCOL_VERSION;
+                // - Protocol version changed?
+                int protocolVersion = originalOfferPayload.getProtocolVersion();
+                if (protocolVersion < Version.TRADE_PROTOCOL_VERSION) {
+                    // We update the trade protocol version
+                    protocolVersion = Version.TRADE_PROTOCOL_VERSION;
+                    log.info("Updated the protocol version of offer id={}", originalOffer.getId());
+                }
 
                 OfferPayload updatedPayload = new OfferPayload(originalOfferPayload.getId(),
                         originalOfferPayload.getDate(),
@@ -807,7 +812,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 updatedOpenOffer.setStorage(openOfferTradableListStorage);
                 openOffers.add(updatedOpenOffer);
 
-                log.info("Converted offer to support new Capability.MEDIATION and Capability.REFUND_AGENT capability. id={}", originalOffer.getId());
+                log.info("Updating offer completed. id={}", originalOffer.getId());
             }
         });
     }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

motivated by and fixes https://github.com/bisq-network/bisq/issues/3995, at least its symptoms

When the hiddenservice address changes, offers now get updated to the new address before republishing. If there are open trades, they will still fail but at least there are no faulty offers out there anymore. Plus, a user might wonder why nobody takes his offers.

Happens if Bisq silently starts a fresh hiddenservice. Reasons for that to happen might be:
- hidden service files get damaged ([example](https://bisq.community/t/failed-to-decode-rsa-key/8961))
- antivirus software deleting hidden service files
- https://github.com/bisq-network/bisq/issues/3884
- support tells them to do so to fix network connectivity issues
