### PR TITLE
Changes to local BTC node reminder in Settings > Network info

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1093,7 +1093,7 @@ settings.net.warn.useCustomNodes.B2XWarning=Please be sure that your Bitcoin nod
   Any resulting disputes will be decided in favor of the other peer. No technical support will be given \
   to users who ignore this warning and protection mechanisms!
 settings.net.warn.invalidBtcConfig=Connection to the Bitcoin network failed because your configuration is invalid.\n\nYour configuration has been reset to use the provided Bitcoin nodes instead. You will need to restart the application.
-settings.net.localhostBtcNodeInfo=(Background information: If you are running a local Bitcoin node (localhost) you can connect exclusively to it.)
+settings.net.localhostBtcNodeInfo=Background information: Bisq looks for a local Bitcoin node when starting. If it is found, Bisq will communicate with the Bitcoin network exclusively through it.
 settings.net.p2PPeersLabel=Connected peers
 settings.net.onionAddressColumn=Onion address
 settings.net.creationDateColumn=Established

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -165,9 +165,6 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         bitcoinPeerSubVersionColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.subVersionColumn")));
         bitcoinPeerHeightColumn.setGraphic(new AutoTooltipLabel(Res.get("settings.net.heightColumn")));
         localhostBtcNodeInfoLabel.setText(Res.get("settings.net.localhostBtcNodeInfo"));
-        if (localBitcoinNode.shouldBeIgnored()) {
-            localhostBtcNodeInfoLabel.setVisible(false);
-        }
         useProvidedNodesRadio.setText(Res.get("settings.net.useProvidedNodesRadio"));
         useCustomNodesRadio.setText(Res.get("settings.net.useCustomNodesRadio"));
         usePublicNodesRadio.setText(Res.get("settings.net.usePublicNodesRadio"));


### PR DESCRIPTION
Under "Settings" > "Network info" we have a list of connected Bitcoin nodes. Under this list we provide a reminder in small font about Bisq being able to use a local Bitcoin node. This makes changes to that reminder:

1) the text is changed to be more accurate;
2) the condition under which the reminder used to be disabled is removed (because it doesn't seem to be necessary);
3) the formatting is slighty changed by dropping the parantheses: the paratheses serve to visually show that the reminder is background information, but that is already achieved by using small print.

Screenshot of reminder after change:

![small letters - local btc usage explanation](https://user-images.githubusercontent.com/2715476/75805059-5f582d00-5d81-11ea-83dd-d55fc8daab98.png)
