### PR TITLE
Speed up DAO state monitor view load

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -133,7 +133,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
     private Timer checkNumberOfP2pNetworkPeersTimer;
     @SuppressWarnings("FieldCanBeLocal")
     private MonadicBinding<Boolean> tradesAndUIReady;
-    private Queue<Overlay> popupQueue = new PriorityQueue<>(Comparator.comparing(Overlay::getDisplayOrderPriority));
+    private Queue<Overlay<?>> popupQueue = new PriorityQueue<>(Comparator.comparing(Overlay::getDisplayOrderPriority));
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -362,7 +362,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                         .show());
         bisqSetup.setDisplayLocalhostHandler(key -> {
             if (!DevEnv.isDevMode()) {
-                Overlay popup = new Popup().backgroundInfo(Res.get("popup.bitcoinLocalhostNode.msg") +
+                Popup popup = new Popup().backgroundInfo(Res.get("popup.bitcoinLocalhostNode.msg") +
                         Res.get("popup.bitcoinLocalhostNode.additionalRequirements"))
                         .dontShowAgainId(key);
                 popup.setDisplayOrderPriority(5);
@@ -396,14 +396,14 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         tradeManager.getTradesWithoutDepositTx().addListener((ListChangeListener<Trade>) c -> {
             c.next();
             if (c.wasAdded()) {
-                c.getAddedSubList().forEach(trade -> {
-                    new Popup().warning(Res.get("popup.warning.trade.depositTxNull", trade.getShortId()))
-                            .actionButtonText(Res.get("popup.warning.trade.depositTxNull.shutDown"))
-                            .onAction(() -> BisqApp.getShutDownHandler().run())
-                            .secondaryActionButtonText(Res.get("popup.warning.trade.depositTxNull.moveToFailedTrades"))
-                            .onSecondaryAction(() -> tradeManager.addTradeToFailedTrades(trade))
-                            .show();
-                });
+                c.getAddedSubList().forEach(trade ->
+                        new Popup().warning(Res.get("popup.warning.trade.depositTxNull", trade.getShortId()))
+                                .actionButtonText(Res.get("popup.warning.trade.depositTxNull.shutDown"))
+                                .onAction(() -> BisqApp.getShutDownHandler().run())
+                                .secondaryActionButtonText(Res.get("popup.warning.trade.depositTxNull.moveToFailedTrades"))
+                                .onSecondaryAction(() -> tradeManager.addTradeToFailedTrades(trade))
+                                .show()
+                );
             }
         });
 
@@ -682,7 +682,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
 
     private void maybeShowPopupsFromQueue() {
         if (!popupQueue.isEmpty()) {
-            Overlay overlay = popupQueue.poll();
+            Overlay<?> overlay = popupQueue.poll();
             overlay.getIsHiddenProperty().addListener((observable, oldValue, newValue) -> {
                 if (newValue) {
                     UserThread.runAfter(this::maybeShowPopupsFromQueue, 2);

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateBlockListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateBlockListItem.java
@@ -22,6 +22,8 @@ import bisq.desktop.main.dao.monitor.StateBlockListItem;
 import bisq.core.dao.monitoring.model.DaoStateBlock;
 import bisq.core.dao.monitoring.model.DaoStateHash;
 
+import java.util.function.IntSupplier;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Value
 @EqualsAndHashCode(callSuper = true)
 class DaoStateBlockListItem extends StateBlockListItem<DaoStateHash, DaoStateBlock> {
-    DaoStateBlockListItem(DaoStateBlock stateBlock, int cycleIndex) {
-        super(stateBlock, cycleIndex);
+    DaoStateBlockListItem(DaoStateBlock stateBlock, IntSupplier cycleIndexSupplier) {
+        super(stateBlock, cycleIndexSupplier);
     }
 }
-

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateMonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateMonitorView.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.dao.monitor.daostate;
 
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.main.dao.monitor.StateMonitorView;
-import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.util.FormBuilder;
 
@@ -53,7 +52,7 @@ public class DaoStateMonitorView extends StateMonitorView<DaoStateHash, DaoState
         implements DaoStateMonitoringService.Listener {
     private final DaoStateMonitoringService daoStateMonitoringService;
     private ListChangeListener<UtxoMismatch> utxoMismatchListChangeListener;
-    private Overlay warningPopup;
+    private Popup warningPopup;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -208,17 +207,16 @@ public class DaoStateMonitorView extends StateMonitorView<DaoStateHash, DaoState
     private void updateUtxoMismatches() {
         if (!daoStateMonitoringService.getUtxoMismatches().isEmpty()) {
             StringBuilder sb = new StringBuilder();
-            daoStateMonitoringService.getUtxoMismatches().forEach(e -> {
-                sb.append("\n").append(Res.get("dao.monitor.daoState.utxoConflicts.blockHeight", e.getHeight())).append("\n")
-                        .append(Res.get("dao.monitor.daoState.utxoConflicts.sumUtxo", e.getSumUtxo() / 100)).append("\n")
-                        .append(Res.get("dao.monitor.daoState.utxoConflicts.sumBsq", e.getSumBsq() / 100));
-            });
+            daoStateMonitoringService.getUtxoMismatches().forEach(e -> sb.append("\n")
+                    .append(Res.get("dao.monitor.daoState.utxoConflicts.blockHeight", e.getHeight())).append("\n")
+                    .append(Res.get("dao.monitor.daoState.utxoConflicts.sumUtxo", e.getSumUtxo() / 100)).append("\n")
+                    .append(Res.get("dao.monitor.daoState.utxoConflicts.sumBsq", e.getSumBsq() / 100))
+            );
 
             if (warningPopup == null) {
                 warningPopup = new Popup().headLine(Res.get("dao.monitor.daoState.utxoConflicts"))
-                        .warning(Utilities.toTruncatedString(sb.toString(), 500, false)).onClose(() -> {
-                            warningPopup = null;
-                        });
+                        .warning(Utilities.toTruncatedString(sb.toString(), 500, false))
+                        .onClose(() -> warningPopup = null);
                 warningPopup.show();
             }
         }

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateMonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/daostate/DaoStateMonitorView.java
@@ -45,6 +45,7 @@ import javafx.collections.ListChangeListener;
 import java.io.File;
 
 import java.util.Map;
+import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 
 @FxmlView
@@ -126,8 +127,10 @@ public class DaoStateMonitorView extends StateMonitorView<DaoStateHash, DaoState
 
     @Override
     protected DaoStateBlockListItem getStateBlockListItem(DaoStateBlock daoStateBlock) {
-        int cycleIndex = periodService.getCycle(daoStateBlock.getHeight()).map(cycleService::getCycleIndex).orElse(0);
-        return new DaoStateBlockListItem(daoStateBlock, cycleIndex);
+        IntSupplier cycleIndexSupplier = () -> periodService.getCycle(daoStateBlock.getHeight())
+                .map(cycleService::getCycleIndex)
+                .orElse(0);
+        return new DaoStateBlockListItem(daoStateBlock, cycleIndexSupplier);
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -20,7 +20,6 @@ package bisq.desktop.main.portfolio.pendingtrades.steps;
 import bisq.desktop.components.InfoTextField;
 import bisq.desktop.components.TitledGroupBg;
 import bisq.desktop.components.TxIdTextField;
-import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import bisq.desktop.main.portfolio.pendingtrades.TradeStepInfo;
@@ -93,7 +92,7 @@ public abstract class TradeStepView extends AnchorPane {
     private ClockWatcher.Listener clockListener;
     private final ChangeListener<String> errorMessageListener;
     protected Label infoLabel;
-    private Overlay acceptMediationResultPopup;
+    private Popup acceptMediationResultPopup;
     private BootstrapListener bootstrapListener;
 
 

--- a/desktop/src/test/java/bisq/desktop/main/dao/monitor/daostate/DaoStateBlockListItemTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/dao/monitor/daostate/DaoStateBlockListItemTest.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.dao.monitor.daostate;
+
+import bisq.core.dao.monitoring.model.DaoStateBlock;
+import bisq.core.dao.monitoring.model.DaoStateHash;
+import bisq.core.locale.Res;
+
+import java.util.Locale;
+import java.util.function.IntSupplier;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class DaoStateBlockListItemTest {
+
+    @Before
+    public void setup() {
+        Locale.setDefault(new Locale("en", "US"));
+        Res.setBaseCurrencyCode("BTC");
+        Res.setBaseCurrencyName("Bitcoin");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        var block = new DaoStateBlock(new DaoStateHash(0, new byte[0], new byte[0]));
+        var item1 = new DaoStateBlockListItem(block, newSupplier(1));
+        var item2 = new DaoStateBlockListItem(block, newSupplier(2));
+        var item3 = new DaoStateBlockListItem(block, newSupplier(1));
+        assertNotEquals(item1, item2);
+        assertNotEquals(item2, item3);
+        assertEquals(item1, item3);
+        assertEquals(item1.hashCode(), item3.hashCode());
+    }
+
+    private IntSupplier newSupplier(int i) {
+        //noinspection Convert2Lambda
+        return new IntSupplier() {
+            @Override
+            public int getAsInt() {
+                return i;
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Compute height cells lazily to speed up `DaoStateMonitorView`

Avoid a bottleneck computing the cycle index & calling `Res.get(..)` for every block since genesis in the DAO state monitor view, when building the `DaoStateBlockListItem` objects, by making the `height` field lazy. To do this, pass the cycle index into the constructor using an `IntSupplier` and make the height a memoised `Supplier<String>` with a custom getter.

Also add a unit test to check that the auto-generated `equals` & `hashCode` methods still work as expected, as it isn't totally clear what Lombok would do when a field type differs from its getter return type.

--

Flippling back and forth between the _Network monitor_ tab and the _Governance_ tab revealed the following call tree in JProfiler:

![Screenshot from 2020-03-06 10-16-21](https://user-images.githubusercontent.com/54855381/76194185-9b2b4080-6220-11ea-911d-73f6df162636.png)

As can be seen above, most of the time is spent in the stream pipeline collecting new `DaoStateBlockListItem` objects, in `DaoStateMonitorView.onDataUpdate`. After the change, the main bottleneck appeared to be from internal JavaFX code, in the `listItems.setAll` call in `onDataUpdate` (perhaps from one of the listeners on `DaoStateMonitorView.sortedList`). However, I believe there was a noticeable speedup. Also, the slowdown over time is likely to be quadratic without the change, as the number of cycles and block grows linearly. (The main bottleneck appears to be computing the cycle index of each block.)
