### PR TITLE
Log delayed payout tx bytes as soon as it's signed during trade init

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -26,6 +26,7 @@ import bisq.core.trade.protocol.tasks.TradeTask;
 import bisq.core.util.Validator;
 
 import bisq.common.taskrunner.TaskRunner;
+import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Transaction;
 
@@ -61,6 +62,7 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             byte[] delayedPayoutTxBytes = message.getDelayedPayoutTx();
             trade.applyDelayedPayoutTxBytes(delayedPayoutTxBytes);
             BtcWalletService.printTx("delayedPayoutTx received from peer", trade.getDelayedPayoutTx());
+            log.info("DelayedPayoutTxBytes = {}", Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()));
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
@@ -23,6 +23,7 @@ import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
+import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Transaction;
 
@@ -65,6 +66,7 @@ public class SellerFinalizesDelayedPayoutTx extends TradeTask {
                     sellerSignature);
 
             trade.applyDelayedPayoutTx(signedDelayedPayoutTx);
+            log.info("DelayedPayoutTxBytes = {}", Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()));
 
             complete();
         } catch (Throwable t) {


### PR DESCRIPTION
Log the delayed payout tx bytes before deposittx is broadcast as a desperate measure to at least have it logged at some point.
