### PR TITLE
Add holder name for new Faster Payments accounts

### DIFF
--- a/core/src/main/java/bisq/core/payment/FasterPaymentsAccount.java
+++ b/core/src/main/java/bisq/core/payment/FasterPaymentsAccount.java
@@ -36,6 +36,14 @@ public final class FasterPaymentsAccount extends PaymentAccount {
         return new FasterPaymentsAccountPayload(paymentMethod.getId(), id);
     }
 
+    public void setHolderName(String value) {
+        ((FasterPaymentsAccountPayload) paymentAccountPayload).setHolderName(value);
+    }
+
+    public String getHolderName() {
+        return ((FasterPaymentsAccountPayload) paymentAccountPayload).getHolderName();
+    }
+
     public void setSortCode(String value) {
         ((FasterPaymentsAccountPayload) paymentAccountPayload).setSortCode(value);
     }

--- a/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +31,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -57,7 +53,7 @@ public final class AdvancedCashAccountPayload extends PaymentAccountPayload {
                                        String id,
                                        String accountNr,
                                        long maxTradePeriod,
-                                       @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                       Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -79,7 +75,7 @@ public final class AdvancedCashAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getAdvancedCashAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -99,6 +95,6 @@ public final class AdvancedCashAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/AliPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AliPayAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,8 +30,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @Getter
@@ -55,7 +51,7 @@ public final class AliPayAccountPayload extends PaymentAccountPayload {
                                  String id,
                                  String accountNr,
                                  long maxTradePeriod,
-                                 @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                 Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -76,7 +72,7 @@ public final class AliPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getAliPayAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -96,6 +92,6 @@ public final class AliPayAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/AssetsAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AssetsAccountPayload.java
@@ -19,7 +19,7 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.Map;
 
@@ -28,8 +28,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -52,7 +50,7 @@ public abstract class AssetsAccountPayload extends PaymentAccountPayload {
                                    String id,
                                    String address,
                                    long maxTradePeriod,
-                                   @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                   Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -77,6 +75,6 @@ public abstract class AssetsAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(address.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(address.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/BankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/BankAccountPayload.java
@@ -21,7 +21,7 @@ import bisq.core.locale.BankUtil;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +56,7 @@ public abstract class BankAccountPayload extends CountryBasedPaymentAccountPaylo
     @Nullable
     protected String nationalAccountId;
 
-    public BankAccountPayload(String paymentMethod, String id) {
+    protected BankAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
     }
 
@@ -64,20 +64,19 @@ public abstract class BankAccountPayload extends CountryBasedPaymentAccountPaylo
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    @SuppressWarnings("NullableProblems")
     protected BankAccountPayload(String paymentMethodName,
                                  String id,
                                  String countryCode,
                                  String holderName,
-                                 String bankName,
-                                 String branchId,
-                                 String accountNr,
-                                 String accountType,
-                                 String holderTaxId,
-                                 String bankId,
-                                 String nationalAccountId,
+                                 @Nullable String bankName,
+                                 @Nullable String branchId,
+                                 @Nullable String accountNr,
+                                 @Nullable String accountType,
+                                 @Nullable String holderTaxId,
+                                 @Nullable String bankId,
+                                 @Nullable String nationalAccountId,
                                  long maxTradePeriod,
-                                 @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                 Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -178,6 +177,6 @@ public abstract class BankAccountPayload extends CountryBasedPaymentAccountPaylo
                 holderTaxIdString +
                 nationalAccountId;
 
-        return super.getAgeWitnessInputData(all.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(all.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/CashAppAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CashAppAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -80,7 +78,7 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getCashAppAccountPayload().getCashTag(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -100,6 +98,6 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(cashTag.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(cashTag.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/CashDepositAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CashDepositAccountPayload.java
@@ -21,11 +21,9 @@ import bisq.core.locale.BankUtil;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -88,7 +86,7 @@ public class CashDepositAccountPayload extends CountryBasedPaymentAccountPayload
                                       @Nullable String bankId,
                                       @Nullable String nationalAccountId,
                                       long maxTradePeriod,
-                                      @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                      Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -146,7 +144,7 @@ public class CashDepositAccountPayload extends CountryBasedPaymentAccountPayload
                 cashDepositAccountPayload.getBankId().isEmpty() ? null : cashDepositAccountPayload.getBankId(),
                 cashDepositAccountPayload.getNationalAccountId().isEmpty() ? null : cashDepositAccountPayload.getNationalAccountId(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -224,6 +222,6 @@ public class CashDepositAccountPayload extends CountryBasedPaymentAccountPayload
                 holderTaxIdString +
                 nationalAccountId;
 
-        return super.getAgeWitnessInputData(all.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(all.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/ChaseQuickPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/ChaseQuickPayAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +31,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -59,7 +55,7 @@ public final class ChaseQuickPayAccountPayload extends PaymentAccountPayload {
                                         String email,
                                         String holderName,
                                         long maxTradePeriod,
-                                        @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                        Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -84,7 +80,7 @@ public final class ChaseQuickPayAccountPayload extends PaymentAccountPayload {
                 proto.getChaseQuickPayAccountPayload().getEmail(),
                 proto.getChaseQuickPayAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -94,7 +90,8 @@ public final class ChaseQuickPayAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.owner") + " " + holderName + ", " + Res.get("payment.email") + " " + email;
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.owner") + " " + holderName + ", " +
+                Res.get("payment.email") + " " + email;
     }
 
     @Override
@@ -107,6 +104,6 @@ public final class ChaseQuickPayAccountPayload extends PaymentAccountPayload {
     public byte[] getAgeWitnessInputData() {
         // We don't add holderName because we don't want to break age validation if the user recreates an account with
         // slight changes in holder name (e.g. add or remove middle name)
-        return super.getAgeWitnessInputData(email.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(email.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/ClearXchangeAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/ClearXchangeAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +31,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -59,7 +55,7 @@ public final class ClearXchangeAccountPayload extends PaymentAccountPayload {
                                        String emailOrMobileNr,
                                        String holderName,
                                        long maxTradePeriod,
-                                       @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                       Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -84,7 +80,7 @@ public final class ClearXchangeAccountPayload extends PaymentAccountPayload {
                 proto.getClearXchangeAccountPayload().getEmailOrMobileNr(),
                 proto.getClearXchangeAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -94,7 +90,8 @@ public final class ClearXchangeAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.owner") + " " + holderName + ", " + Res.getWithCol("payment.emailOrMobile") + " " + emailOrMobileNr;
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.owner") + " " + holderName + ", " +
+                Res.getWithCol("payment.emailOrMobile") + " " + emailOrMobileNr;
     }
 
     @Override
@@ -107,6 +104,6 @@ public final class ClearXchangeAccountPayload extends PaymentAccountPayload {
     public byte[] getAgeWitnessInputData() {
         // We don't add holderName because we don't want to break age validation if the user recreates an account with
         // slight changes in holder name (e.g. add or remove middle name)
-        return super.getAgeWitnessInputData(emailOrMobileNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(emailOrMobileNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/CountryBasedPaymentAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CountryBasedPaymentAccountPayload.java
@@ -17,10 +17,9 @@
 
 package bisq.core.payment.payload;
 
-
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.Map;
 
@@ -29,8 +28,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -48,7 +45,7 @@ public abstract class CountryBasedPaymentAccountPayload extends PaymentAccountPa
                                                 String id,
                                                 String countryCode,
                                                 long maxTradePeriod,
-                                                @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                                Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 maxTradePeriod,
@@ -71,6 +68,6 @@ public abstract class CountryBasedPaymentAccountPayload extends PaymentAccountPa
 
     @Override
     protected byte[] getAgeWitnessInputData(byte[] data) {
-        return super.getAgeWitnessInputData(ArrayUtils.addAll(countryCode.getBytes(Charset.forName("UTF-8")), data));
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(countryCode.getBytes(StandardCharsets.UTF_8), data));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/CryptoCurrencyAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CryptoCurrencyAccountPayload.java
@@ -17,9 +17,6 @@
 
 package bisq.core.payment.payload;
 
-
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import java.util.HashMap;
@@ -30,8 +27,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -53,7 +48,7 @@ public final class CryptoCurrencyAccountPayload extends AssetsAccountPayload {
                                          String id,
                                          String address,
                                          long maxTradePeriod,
-                                         @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                         Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 address,
@@ -74,7 +69,6 @@ public final class CryptoCurrencyAccountPayload extends AssetsAccountPayload {
                 proto.getId(),
                 proto.getCryptoCurrencyAccountPayload().getAddress(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
-
 }

--- a/core/src/main/java/bisq/core/payment/payload/F2FAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/F2FAccountPayload.java
@@ -19,13 +19,11 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +33,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -64,7 +60,7 @@ public final class F2FAccountPayload extends CountryBasedPaymentAccountPayload {
                               String city,
                               String extraInfo,
                               long maxTradePeriod,
-                              @Nullable Map<String, String> excludeFromJsonDataMap) {
+                              Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -99,7 +95,7 @@ public final class F2FAccountPayload extends CountryBasedPaymentAccountPayload {
                 f2fAccountPayloadPB.getCity(),
                 f2fAccountPayloadPB.getExtraInfo(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -125,7 +121,7 @@ public final class F2FAccountPayload extends CountryBasedPaymentAccountPayload {
     @Override
     public byte[] getAgeWitnessInputData() {
         // We use here the city because the address alone seems to be too weak
-        return super.getAgeWitnessInputData(ArrayUtils.addAll(contact.getBytes(Charset.forName("UTF-8")),
-                city.getBytes(Charset.forName("UTF-8"))));
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(contact.getBytes(StandardCharsets.UTF_8),
+                city.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/FasterPaymentsAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/FasterPaymentsAccountPayload.java
@@ -19,13 +19,11 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +33,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -64,7 +60,7 @@ public final class FasterPaymentsAccountPayload extends PaymentAccountPayload {
                                          String accountNr,
                                          String email,
                                          long maxTradePeriod,
-                                         @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                         Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -91,7 +87,7 @@ public final class FasterPaymentsAccountPayload extends PaymentAccountPayload {
                 proto.getFasterPaymentsAccountPayload().getAccountNr(),
                 proto.getFasterPaymentsAccountPayload().getEmail(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -112,7 +108,7 @@ public final class FasterPaymentsAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(ArrayUtils.addAll(sortCode.getBytes(Charset.forName("UTF-8")),
-                accountNr.getBytes(Charset.forName("UTF-8"))));
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(sortCode.getBytes(StandardCharsets.UTF_8),
+                accountNr.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/FasterPaymentsAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/FasterPaymentsAccountPayload.java
@@ -21,6 +21,8 @@ import bisq.core.locale.Res;
 
 import com.google.protobuf.Message;
 
+import com.google.common.base.Strings;
+
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -95,14 +97,23 @@ public final class FasterPaymentsAccountPayload extends PaymentAccountPayload {
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    public String getHolderName() {
+        return excludeFromJsonDataMap.getOrDefault(HOLDER_NAME, "");
+    }
+
+    public void setHolderName(String holderName) {
+        excludeFromJsonDataMap.compute(HOLDER_NAME, (k, v) -> Strings.emptyToNull(holderName));
+    }
+
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - UK Sort code: " + sortCode + ", " + Res.getWithCol("payment.accountNr") + " " + accountNr;
+        return Res.get(paymentMethodId) + " - " + getPaymentDetailsForTradePopup().replace("\n", ", ");
     }
 
     @Override
     public String getPaymentDetailsForTradePopup() {
-        return "UK Sort code: " + sortCode + "\n" +
+        return (getHolderName().isEmpty() ? "" : Res.getWithCol("payment.account.owner") + " " + getHolderName() + "\n") +
+                "UK Sort code: " + sortCode + "\n" +
                 Res.getWithCol("payment.accountNr") + " " + accountNr;
     }
 

--- a/core/src/main/java/bisq/core/payment/payload/HalCashAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/HalCashAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +31,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -56,7 +52,7 @@ public final class HalCashAccountPayload extends PaymentAccountPayload {
     private HalCashAccountPayload(String paymentMethod, String id,
                                   String mobileNr,
                                   long maxTradePeriod,
-                                  @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                  Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -77,7 +73,7 @@ public final class HalCashAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getHalCashAccountPayload().getMobileNr(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -97,6 +93,6 @@ public final class HalCashAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(mobileNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(mobileNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/InstantCryptoCurrencyPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/InstantCryptoCurrencyPayload.java
@@ -17,9 +17,6 @@
 
 package bisq.core.payment.payload;
 
-
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import java.util.HashMap;
@@ -30,8 +27,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -53,7 +48,7 @@ public final class InstantCryptoCurrencyPayload extends AssetsAccountPayload {
                                          String id,
                                          String address,
                                          long maxTradePeriod,
-                                         @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                         Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 address,
@@ -74,6 +69,6 @@ public final class InstantCryptoCurrencyPayload extends AssetsAccountPayload {
                 proto.getId(),
                 proto.getInstantCryptoCurrencyAccountPayload().getAddress(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/InteracETransferAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/InteracETransferAccountPayload.java
@@ -19,13 +19,11 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +33,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -65,7 +61,7 @@ public final class InteracETransferAccountPayload extends PaymentAccountPayload 
                                            String question,
                                            String answer,
                                            long maxTradePeriod,
-                                           @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                           Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -95,7 +91,7 @@ public final class InteracETransferAccountPayload extends PaymentAccountPayload 
                 proto.getInteracETransferAccountPayload().getQuestion(),
                 proto.getInteracETransferAccountPayload().getAnswer(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -120,8 +116,8 @@ public final class InteracETransferAccountPayload extends PaymentAccountPayload 
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(ArrayUtils.addAll(email.getBytes(Charset.forName("UTF-8")),
-                ArrayUtils.addAll(question.getBytes(Charset.forName("UTF-8")),
-                        answer.getBytes(Charset.forName("UTF-8")))));
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(email.getBytes(StandardCharsets.UTF_8),
+                ArrayUtils.addAll(question.getBytes(StandardCharsets.UTF_8),
+                        answer.getBytes(StandardCharsets.UTF_8))));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/JapanBankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/JapanBankAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -61,16 +59,16 @@ public final class JapanBankAccountPayload extends PaymentAccountPayload {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private JapanBankAccountPayload(String paymentMethod,
-                                  String id,
-                                  String bankName,
-                                  String bankCode,
-                                  String bankBranchName,
-                                  String bankBranchCode,
-                                  String bankAccountType,
-                                  String bankAccountName,
-                                  String bankAccountNumber,
-                                  long maxTradePeriod,
-                                  Map<String, String> excludeFromJsonDataMap) {
+                                    String id,
+                                    String bankName,
+                                    String bankCode,
+                                    String bankBranchName,
+                                    String bankBranchCode,
+                                    String bankAccountType,
+                                    String bankAccountName,
+                                    String bankAccountNumber,
+                                    long maxTradePeriod,
+                                    Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -90,13 +88,13 @@ public final class JapanBankAccountPayload extends PaymentAccountPayload {
         return getPaymentAccountPayloadBuilder()
                 .setJapanBankAccountPayload(
                         protobuf.JapanBankAccountPayload.newBuilder()
-                        .setBankName(bankName)
-                        .setBankCode(bankCode)
-                        .setBankBranchName(bankBranchName)
-                        .setBankBranchCode(bankBranchCode)
-                        .setBankAccountType(bankAccountType)
-                        .setBankAccountName(bankAccountName)
-                        .setBankAccountNumber(bankAccountNumber)
+                                .setBankName(bankName)
+                                .setBankCode(bankCode)
+                                .setBankBranchName(bankBranchName)
+                                .setBankBranchCode(bankBranchCode)
+                                .setBankAccountType(bankAccountType)
+                                .setBankAccountName(bankAccountName)
+                                .setBankAccountNumber(bankAccountNumber)
                 ).build();
     }
 
@@ -112,7 +110,7 @@ public final class JapanBankAccountPayload extends PaymentAccountPayload {
                 japanBankAccountPayload.getBankAccountName(),
                 japanBankAccountPayload.getBankAccountNumber(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -121,24 +119,22 @@ public final class JapanBankAccountPayload extends PaymentAccountPayload {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public String getPaymentDetails()
-    {
+    public String getPaymentDetails() {
         return Res.get(paymentMethodId) + " - " + getPaymentDetailsForTradePopup().replace("\n", ", ");
     }
 
     @Override
-    public String getPaymentDetailsForTradePopup()
-    {
-        return
-        Res.get("payment.japan.bank") + ": " + bankName + "(" + bankCode + ")\n" +
-        Res.get("payment.japan.branch") + ": " +  bankBranchName + "(" + bankBranchCode + ")\n" +
-        Res.get("payment.japan.account") + ": " + bankAccountType + " " + bankAccountNumber + "\n" + Res.get("payment.japan.recipient") + ": " + bankAccountName;
+    public String getPaymentDetailsForTradePopup() {
+        return Res.get("payment.japan.bank") + ": " + bankName + "(" + bankCode + ")\n" +
+                Res.get("payment.japan.branch") + ": " + bankBranchName + "(" + bankBranchCode + ")\n" +
+                Res.get("payment.japan.account") + ": " + bankAccountType + " " + bankAccountNumber + "\n" +
+                Res.get("payment.japan.recipient") + ": " + bankAccountName;
     }
 
 
     @Override
     public byte[] getAgeWitnessInputData() {
         String all = this.bankName + this.bankBranchName + this.bankAccountType + this.bankAccountNumber + this.bankAccountName;
-        return super.getAgeWitnessInputData(all.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(all.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/MoneyBeamAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/MoneyBeamAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +75,7 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getMoneyBeamAccountPayload().getAccountId(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -97,6 +95,6 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountId.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountId.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/MoneyGramAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/MoneyGramAccountPayload.java
@@ -21,11 +21,9 @@ import bisq.core.locale.BankUtil;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +33,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -65,7 +61,7 @@ public class MoneyGramAccountPayload extends PaymentAccountPayload {
                                     String state,
                                     String email,
                                     long maxTradePeriod,
-                                    @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                    Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 maxTradePeriod,
@@ -99,7 +95,7 @@ public class MoneyGramAccountPayload extends PaymentAccountPayload {
                 moneyGramAccountPayload.getState(),
                 moneyGramAccountPayload.getEmail(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -128,6 +124,6 @@ public class MoneyGramAccountPayload extends PaymentAccountPayload {
                 this.state +
                 this.holderName +
                 this.email;
-        return super.getAgeWitnessInputData(all.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(all.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/NationalBankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/NationalBankAccountPayload.java
@@ -19,8 +19,6 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import java.util.HashMap;
@@ -29,8 +27,6 @@ import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -58,7 +54,7 @@ public final class NationalBankAccountPayload extends BankAccountPayload {
                                        String bankId,
                                        String nationalAccountId,
                                        long maxTradePeriod,
-                                       @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                       Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -105,7 +101,7 @@ public final class NationalBankAccountPayload extends BankAccountPayload {
                 bankAccountPayloadPB.getBankId().isEmpty() ? null : bankAccountPayloadPB.getBankId(),
                 bankAccountPayloadPB.getNationalAccountId().isEmpty() ? null : bankAccountPayloadPB.getNationalAccountId(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/OKPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/OKPayAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -79,7 +77,7 @@ public final class OKPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getOKPayAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -99,6 +97,6 @@ public final class OKPayAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
@@ -49,6 +49,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
 
     // Keys for excludeFromJsonDataMap
     public static final String SALT = "salt";
+    public static final String HOLDER_NAME = "holderName";
 
     protected final String paymentMethodId;
     protected final String id;

--- a/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
@@ -25,21 +25,17 @@ import bisq.common.util.Utilities;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.annotation.Nullable;
-
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 // That class is used in the contract for creating the contract json. Any change will break the contract.
 // If a field gets added it need to be be annotated with @JsonExclude (excluded from contract).
@@ -67,7 +63,6 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
     // PaymentAccountPayload is used for the json contract and a trade with a user who has an older version would
     // fail the contract verification.
     @JsonExclude
-    @Nullable
     protected final Map<String, String> excludeFromJsonDataMap;
 
 
@@ -79,7 +74,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
         this(paymentMethodId,
                 id,
                 -1,
-                null);
+                new HashMap<>());
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -89,11 +84,11 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
     protected PaymentAccountPayload(String paymentMethodId,
                                     String id,
                                     long maxTradePeriod,
-                                    @Nullable Map<String, String> excludeFromJsonDataMapParam) {
+                                    Map<String, String> excludeFromJsonDataMapParam) {
         this.paymentMethodId = paymentMethodId;
         this.id = id;
         this.maxTradePeriod = maxTradePeriod;
-        this.excludeFromJsonDataMap = excludeFromJsonDataMapParam == null ? new HashMap<>() : excludeFromJsonDataMapParam;
+        this.excludeFromJsonDataMap = excludeFromJsonDataMapParam;
 
         // If not set (old versions) we set by default a random 256 bit salt.
         // User can set salt as well by hex string.
@@ -108,7 +103,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
                 .setMaxTradePeriod(maxTradePeriod)
                 .setId(id);
 
-        Optional.ofNullable(excludeFromJsonDataMap).ifPresent(builder::putAllExcludeFromJsonData);
+        builder.putAllExcludeFromJsonData(excludeFromJsonDataMap);
 
         return builder;
     }
@@ -123,13 +118,11 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
     public abstract String getPaymentDetailsForTradePopup();
 
     public byte[] getSalt() {
-        checkNotNull(excludeFromJsonDataMap, "excludeFromJsonDataMap must not be null");
         checkArgument(excludeFromJsonDataMap.containsKey(SALT), "Salt must have been set in excludeFromJsonDataMap.");
         return Utilities.decodeFromHex(excludeFromJsonDataMap.get(SALT));
     }
 
     public void setSalt(byte[] salt) {
-        checkNotNull(excludeFromJsonDataMap, "excludeFromJsonDataMap must not be null");
         excludeFromJsonDataMap.put(SALT, Utilities.encodeToHex(salt));
     }
 
@@ -139,6 +132,6 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
     public abstract byte[] getAgeWitnessInputData();
 
     protected byte[] getAgeWitnessInputData(byte[] data) {
-        return ArrayUtils.addAll(paymentMethodId.getBytes(Charset.forName("UTF-8")), data);
+        return ArrayUtils.addAll(paymentMethodId.getBytes(StandardCharsets.UTF_8), data);
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/PerfectMoneyAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PerfectMoneyAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +31,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -57,7 +53,7 @@ public final class PerfectMoneyAccountPayload extends PaymentAccountPayload {
                                        String id,
                                        String accountNr,
                                        long maxTradePeriod,
-                                       @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                       Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -79,7 +75,7 @@ public final class PerfectMoneyAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getPerfectMoneyAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -99,6 +95,6 @@ public final class PerfectMoneyAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/PopmoneyAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PopmoneyAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -82,7 +80,7 @@ public final class PopmoneyAccountPayload extends PaymentAccountPayload {
                 proto.getPopmoneyAccountPayload().getAccountId(),
                 proto.getPopmoneyAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -103,6 +101,6 @@ public final class PopmoneyAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountId.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountId.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/PromptPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PromptPayAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +31,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -56,7 +52,7 @@ public final class PromptPayAccountPayload extends PaymentAccountPayload {
     private PromptPayAccountPayload(String paymentMethod, String id,
                                     String promptPayId,
                                     long maxTradePeriod,
-                                    @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                    Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -78,7 +74,7 @@ public final class PromptPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getPromptPayAccountPayload().getPromptPayId(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -98,6 +94,6 @@ public final class PromptPayAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(promptPayId.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(promptPayId.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +75,7 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getRevolutAccountPayload().getAccountId(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -97,6 +95,6 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountId.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountId.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/SameBankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SameBankAccountPayload.java
@@ -19,8 +19,6 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import java.util.HashMap;
@@ -29,8 +27,6 @@ import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -58,7 +54,7 @@ public final class SameBankAccountPayload extends BankAccountPayload {
                                    String bankId,
                                    String nationalAccountId,
                                    long maxTradePeriod,
-                                   @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                   Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -72,7 +68,6 @@ public final class SameBankAccountPayload extends BankAccountPayload {
                 nationalAccountId,
                 maxTradePeriod,
                 excludeFromJsonDataMap);
-
     }
 
     @Override
@@ -106,7 +101,7 @@ public final class SameBankAccountPayload extends BankAccountPayload {
                 bankAccountPayload.getBankId().isEmpty() ? null : bankAccountPayload.getBankId(),
                 bankAccountPayload.getNationalAccountId().isEmpty() ? null : bankAccountPayload.getNationalAccountId(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/payment/payload/SepaAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SepaAccountPayload.java
@@ -21,19 +21,16 @@ import bisq.core.locale.Country;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
@@ -41,8 +38,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -57,15 +52,16 @@ public final class SepaAccountPayload extends CountryBasedPaymentAccountPayload 
     private String bic = "";
     private String email = ""; // not used anymore but need to keep it for backward compatibility, must not be null but empty string, otherwise hash check fails for contract
 
-    // Dont use a set here as we need a deterministic ordering, otherwise the contract hash does not match
+    // Don't use a set here as we need a deterministic ordering, otherwise the contract hash does not match
     private final List<String> acceptedCountryCodes;
 
     public SepaAccountPayload(String paymentMethod, String id, List<Country> acceptedCountries) {
         super(paymentMethod, id);
-        Set<String> acceptedCountryCodesAsSet = acceptedCountries.stream()
-                .map(e -> e.code).collect(Collectors.toSet());
-        acceptedCountryCodes = new ArrayList<>(acceptedCountryCodesAsSet);
-        acceptedCountryCodes.sort(String::compareTo);
+        acceptedCountryCodes = acceptedCountries.stream()
+                .map(e -> e.code)
+                .sorted()
+                .distinct()
+                .collect(Collectors.toList());
     }
 
 
@@ -82,7 +78,7 @@ public final class SepaAccountPayload extends CountryBasedPaymentAccountPayload 
                                String email,
                                List<String> acceptedCountryCodes,
                                long maxTradePeriod,
-                               @Nullable Map<String, String> excludeFromJsonDataMap) {
+                               Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -125,7 +121,7 @@ public final class SepaAccountPayload extends CountryBasedPaymentAccountPayload 
                 sepaAccountPayloadPB.getEmail(),
                 new ArrayList<>(sepaAccountPayloadPB.getAcceptedCountryCodesList()),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -139,13 +135,13 @@ public final class SepaAccountPayload extends CountryBasedPaymentAccountPayload 
     }
 
     public void removeAcceptedCountry(String countryCode) {
-        if (acceptedCountryCodes.contains(countryCode))
-            acceptedCountryCodes.remove(countryCode);
+        acceptedCountryCodes.remove(countryCode);
     }
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.owner") + " " + holderName + ", IBAN: " + iban + ", BIC: " + bic + ", " + Res.getWithCol("payment.bank.country") + " " + getCountryCode();
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.owner") + " " + holderName + ", IBAN: " +
+                iban + ", BIC: " + bic + ", " + Res.getWithCol("payment.bank.country") + " " + getCountryCode();
     }
 
     @Override
@@ -160,6 +156,6 @@ public final class SepaAccountPayload extends CountryBasedPaymentAccountPayload 
     public byte[] getAgeWitnessInputData() {
         // We don't add holderName because we don't want to break age validation if the user recreates an account with
         // slight changes in holder name (e.g. add or remove middle name)
-        return super.getAgeWitnessInputData(ArrayUtils.addAll(iban.getBytes(Charset.forName("UTF-8")), bic.getBytes(Charset.forName("UTF-8"))));
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(iban.getBytes(StandardCharsets.UTF_8), bic.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/SepaInstantAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SepaInstantAccountPayload.java
@@ -21,19 +21,16 @@ import bisq.core.locale.Country;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
@@ -41,8 +38,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -61,10 +56,11 @@ public final class SepaInstantAccountPayload extends CountryBasedPaymentAccountP
 
     public SepaInstantAccountPayload(String paymentMethod, String id, List<Country> acceptedCountries) {
         super(paymentMethod, id);
-        Set<String> acceptedCountryCodesAsSet = acceptedCountries.stream()
-                .map(e -> e.code).collect(Collectors.toSet());
-        acceptedCountryCodes = new ArrayList<>(acceptedCountryCodesAsSet);
-        acceptedCountryCodes.sort(String::compareTo);
+        acceptedCountryCodes = acceptedCountries.stream()
+                .map(e -> e.code)
+                .sorted()
+                .distinct()
+                .collect(Collectors.toList());
     }
 
 
@@ -80,7 +76,7 @@ public final class SepaInstantAccountPayload extends CountryBasedPaymentAccountP
                                       String bic,
                                       List<String> acceptedCountryCodes,
                                       long maxTradePeriod,
-                                      @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                      Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -120,7 +116,7 @@ public final class SepaInstantAccountPayload extends CountryBasedPaymentAccountP
                 sepaInstantAccountPayloadPB.getBic(),
                 new ArrayList<>(sepaInstantAccountPayloadPB.getAcceptedCountryCodesList()),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -134,8 +130,7 @@ public final class SepaInstantAccountPayload extends CountryBasedPaymentAccountP
     }
 
     public void removeAcceptedCountry(String countryCode) {
-        if (acceptedCountryCodes.contains(countryCode))
-            acceptedCountryCodes.remove(countryCode);
+        acceptedCountryCodes.remove(countryCode);
     }
 
     @Override
@@ -156,6 +151,6 @@ public final class SepaInstantAccountPayload extends CountryBasedPaymentAccountP
     public byte[] getAgeWitnessInputData() {
         // We don't add holderName because we don't want to break age validation if the user recreates an account with
         // slight changes in holder name (e.g. add or remove middle name)
-        return super.getAgeWitnessInputData(ArrayUtils.addAll(iban.getBytes(Charset.forName("UTF-8")), bic.getBytes(Charset.forName("UTF-8"))));
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(iban.getBytes(StandardCharsets.UTF_8), bic.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/SpecificBanksAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SpecificBanksAccountPayload.java
@@ -19,8 +19,6 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import com.google.common.base.Joiner;
@@ -34,14 +32,12 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.annotation.Nullable;
-
 @EqualsAndHashCode(callSuper = true)
 @ToString
 @Getter
 @Slf4j
 public final class SpecificBanksAccountPayload extends BankAccountPayload {
-    // Dont use a set here as we need a deterministic ordering, otherwise the contract hash does not match
+    // Don't use a set here as we need a deterministic ordering, otherwise the contract hash does not match
     private ArrayList<String> acceptedBanks = new ArrayList<>();
 
     public SpecificBanksAccountPayload(String paymentMethod, String id) {
@@ -66,7 +62,7 @@ public final class SpecificBanksAccountPayload extends BankAccountPayload {
                                         String nationalAccountId,
                                         ArrayList<String> acceptedBanks,
                                         long maxTradePeriod,
-                                        @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                        Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -120,7 +116,7 @@ public final class SpecificBanksAccountPayload extends BankAccountPayload {
                 bankAccountPayload.getNationalAccountId().isEmpty() ? null : bankAccountPayload.getNationalAccountId(),
                 new ArrayList<>(specificBanksAccountPayload.getAcceptedBanksList()),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/SwishAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SwishAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +31,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -58,7 +54,7 @@ public final class SwishAccountPayload extends PaymentAccountPayload {
                                 String mobileNr,
                                 String holderName,
                                 long maxTradePeriod,
-                                @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -82,7 +78,7 @@ public final class SwishAccountPayload extends PaymentAccountPayload {
                 proto.getSwishAccountPayload().getMobileNr(),
                 proto.getSwishAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -106,6 +102,6 @@ public final class SwishAccountPayload extends PaymentAccountPayload {
     public byte[] getAgeWitnessInputData() {
         // We don't add holderName because we don't want to break age validation if the user recreates an account with
         // slight changes in holder name (e.g. add or remove middle name)
-        return super.getAgeWitnessInputData(mobileNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(mobileNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/USPostalMoneyOrderAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/USPostalMoneyOrderAccountPayload.java
@@ -19,13 +19,11 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +33,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -60,7 +56,7 @@ public final class USPostalMoneyOrderAccountPayload extends PaymentAccountPayloa
                                              String postalAddress,
                                              String holderName,
                                              long maxTradePeriod,
-                                             @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                             Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -84,7 +80,7 @@ public final class USPostalMoneyOrderAccountPayload extends PaymentAccountPayloa
                 proto.getUSPostalMoneyOrderAccountPayload().getPostalAddress(),
                 proto.getUSPostalMoneyOrderAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -108,7 +104,7 @@ public final class USPostalMoneyOrderAccountPayload extends PaymentAccountPayloa
     @Override
     public byte[] getAgeWitnessInputData() {
         // We use here the holderName because the address alone seems to be too weak
-        return super.getAgeWitnessInputData(ArrayUtils.addAll(holderName.getBytes(Charset.forName("UTF-8")),
-                postalAddress.getBytes(Charset.forName("UTF-8"))));
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(holderName.getBytes(StandardCharsets.UTF_8),
+                postalAddress.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/UpholdAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/UpholdAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +75,7 @@ public final class UpholdAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getUpholdAccountPayload().getAccountId(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -97,6 +95,6 @@ public final class UpholdAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountId.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountId.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/VenmoAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/VenmoAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -85,7 +83,7 @@ public final class VenmoAccountPayload extends PaymentAccountPayload {
                 proto.getVenmoAccountPayload().getVenmoUserName(),
                 proto.getVenmoAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -106,6 +104,6 @@ public final class VenmoAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(venmoUserName.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(venmoUserName.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/WeChatPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/WeChatPayAccountPayload.java
@@ -19,11 +19,9 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,8 +30,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @Getter
@@ -55,7 +51,7 @@ public final class WeChatPayAccountPayload extends PaymentAccountPayload {
                                     String id,
                                     String accountNr,
                                     long maxTradePeriod,
-                                    @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                    Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -76,7 +72,7 @@ public final class WeChatPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getWeChatPayAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -96,6 +92,6 @@ public final class WeChatPayAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountNr.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(accountNr.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/WesternUnionAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/WesternUnionAccountPayload.java
@@ -21,11 +21,9 @@ import bisq.core.locale.BankUtil;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 
-import bisq.common.util.CollectionUtils;
-
 import com.google.protobuf.Message;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +33,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -66,7 +62,7 @@ public class WesternUnionAccountPayload extends CountryBasedPaymentAccountPayloa
                                        String state,
                                        String email,
                                        long maxTradePeriod,
-                                       @Nullable Map<String, String> excludeFromJsonDataMap) {
+                                       Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -106,7 +102,7 @@ public class WesternUnionAccountPayload extends CountryBasedPaymentAccountPayloa
                 westernUnionAccountPayload.getState(),
                 westernUnionAccountPayload.getEmail(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
 
 
@@ -121,7 +117,8 @@ public class WesternUnionAccountPayload extends CountryBasedPaymentAccountPayloa
 
     @Override
     public String getPaymentDetailsForTradePopup() {
-        String cityState = BankUtil.isStateRequired(countryCode) ? (Res.get("payment.account.city") + " / " + Res.getWithCol("payment.account.state") + " " + city + " / " + state + "\n")
+        String cityState = BankUtil.isStateRequired(countryCode)
+                ? (Res.get("payment.account.city") + " / " + Res.getWithCol("payment.account.state") + " " + city + " / " + state + "\n")
                 : (Res.getWithCol("payment.account.city") + " " + city + "\n");
         return Res.getWithCol("payment.account.fullName") + " " + holderName + "\n" +
                 cityState +
@@ -134,6 +131,6 @@ public class WesternUnionAccountPayload extends CountryBasedPaymentAccountPayloa
         String all = this.countryCode +
                 this.holderName +
                 this.email;
-        return super.getAgeWitnessInputData(all.getBytes(Charset.forName("UTF-8")));
+        return super.getAgeWitnessInputData(all.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3020,7 +3020,13 @@ If you have not fulfilled the above requirements you will lose your security dep
   For the {0} seller it is highly recommended \
 to get in contact with the {1} buyer by using the provided email address or mobile number to verify that he or she \
   is really the owner of the Zelle (ClearXchange) account.
-
+payment.fasterPayments.newRequirements.info=When using Faster Payments some banks have started verifying the receiver''s \
+  full name. Your current Faster Payments account only specifies a UK bank account number and sort code. This used to be \
+  sufficient, but may not be now for some sender''s banks. New Faster Payments accounts in Bisq now include an owner \
+  full name. Please consider recreating your account in Bisq to provide future {0} buyers with a recipient name.\n\n\
+  When recreating a Faster Payments account, take care to copy the account age verification salt from your old account \
+  and use the same sort code and account number. (The owner full name or account name need not be the same, however.) \
+  This preserves the public hash, so that the new account need not be aged or signed from scratch.
 payment.moneyGram.info=When using MoneyGram the BTC buyer has to send the Authorisation number and a photo of the receipt by email to the BTC seller. \
   The receipt must clearly show the seller's full name, country, state and the amount. The buyer will get displayed the seller's email in the trade process.
 payment.westernUnion.info=When using Western Union the BTC buyer has to send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller. \

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -621,10 +621,9 @@ portfolio.pending.step2_buyer.halCashInfo.headline=Send HalCash code
 portfolio.pending.step2_buyer.halCashInfo.msg=You need to send a text message with the HalCash code as well as the \
   trade ID ({0}) to the BTC seller.\nThe seller''s mobile nr. is {1}.\n\n\
   Did you send the code to the seller?
-portfolio.pending.step2_buyer.fasterPaymentsHolderNameInfo=Some banks might require the receiver's name. \
-  The UK sort code and account number used to be sufficient for a Faster Payment transfer, but since then some banks \
-  have started verifying the receiver's name. For this reason, accounts created in old Bisq clients do not provide the \
-  trade partner with an owner full name. Please use trade chat to avoid any issues in such cases.
+portfolio.pending.step2_buyer.fasterPaymentsHolderNameInfo=Some banks might verify the receiver's name. \
+  Faster Payments accounts created in old Bisq clients do not provide the receiver's name, \
+  so please use trade chat to obtain it (if needed).
 portfolio.pending.step2_buyer.confirmStart.headline=Confirm that you have started the payment
 portfolio.pending.step2_buyer.confirmStart.msg=Did you initiate the {0} payment to your trading partner?
 portfolio.pending.step2_buyer.confirmStart.yes=Yes, I have started the payment
@@ -3020,13 +3019,12 @@ If you have not fulfilled the above requirements you will lose your security dep
   For the {0} seller it is highly recommended \
 to get in contact with the {1} buyer by using the provided email address or mobile number to verify that he or she \
   is really the owner of the Zelle (ClearXchange) account.
-payment.fasterPayments.newRequirements.info=When using Faster Payments some banks have started verifying the receiver''s \
-  full name. Your current Faster Payments account only specifies a UK bank account number and sort code. This used to be \
-  sufficient, but may not be now for some sender''s banks. New Faster Payments accounts in Bisq now include an owner \
-  full name. Please consider recreating your account in Bisq to provide future {0} buyers with a recipient name.\n\n\
-  When recreating a Faster Payments account, take care to copy the account age verification salt from your old account \
-  and use the same sort code and account number. (The owner full name or account name need not be the same, however.) \
-  This preserves the public hash, so that the new account need not be aged or signed from scratch.
+payment.fasterPayments.newRequirements.info=Some banks have started verifying the receiver''s full name for Faster \
+  Payments transfers. Your current Faster Payments account does not specify a full name.\n\n\
+  Please consider recreating your Faster Payments account in Bisq to provide future {0} buyers with a full name.\n\n\
+  When you recreate the account, make sure to copy the precise sort code, account number and account age verification \
+  salt values from your old account to your new account. This will ensure your existing account''s age and signing \
+  status are preserved.
 payment.moneyGram.info=When using MoneyGram the BTC buyer has to send the Authorisation number and a photo of the receipt by email to the BTC seller. \
   The receipt must clearly show the seller's full name, country, state and the amount. The buyer will get displayed the seller's email in the trade process.
 payment.westernUnion.info=When using Western Union the BTC buyer has to send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller. \

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -622,8 +622,9 @@ portfolio.pending.step2_buyer.halCashInfo.msg=You need to send a text message wi
   trade ID ({0}) to the BTC seller.\nThe seller''s mobile nr. is {1}.\n\n\
   Did you send the code to the seller?
 portfolio.pending.step2_buyer.fasterPaymentsHolderNameInfo=Some banks might require the receiver's name. \
-  The UK sort code and account number is sufficient for a Faster Payment transfer and the receivers name is not verified \
-  by any of the banks.
+  The UK sort code and account number used to be sufficient for a Faster Payment transfer, but since then some banks \
+  have started verifying the receiver's name. For this reason, accounts created in old Bisq clients do not provide the \
+  trade partner with an owner full name. Please use trade chat to avoid any issues in such cases.
 portfolio.pending.step2_buyer.confirmStart.headline=Confirm that you have started the payment
 portfolio.pending.step2_buyer.confirmStart.msg=Did you initiate the {0} payment to your trading partner?
 portfolio.pending.step2_buyer.confirmStart.yes=Yes, I have started the payment

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/FasterPaymentsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/FasterPaymentsForm.java
@@ -44,6 +44,10 @@ public class FasterPaymentsForm extends PaymentMethodForm {
 
     public static int addFormForBuyer(GridPane gridPane, int gridRow,
                                       PaymentAccountPayload paymentAccountPayload) {
+        if (!((FasterPaymentsAccountPayload) paymentAccountPayload).getHolderName().isEmpty()) {
+            addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                    ((FasterPaymentsAccountPayload) paymentAccountPayload).getHolderName());
+        }
         // do not translate as it is used in English only
         addCompactTopLabelTextField(gridPane, ++gridRow, UK_SORT_CODE,
                 ((FasterPaymentsAccountPayload) paymentAccountPayload).getSortCode());
@@ -54,11 +58,16 @@ public class FasterPaymentsForm extends PaymentMethodForm {
 
 
     private final FasterPaymentsAccount fasterPaymentsAccount;
+    private InputTextField holderNameInputTextField;
     private InputTextField accountNrInputTextField;
     private InputTextField sortCodeInputTextField;
 
-    public FasterPaymentsForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService, InputValidator inputValidator, GridPane gridPane,
-                              int gridRow, CoinFormatter formatter) {
+    public FasterPaymentsForm(PaymentAccount paymentAccount,
+                              AccountAgeWitnessService accountAgeWitnessService,
+                              InputValidator inputValidator,
+                              GridPane gridPane,
+                              int gridRow,
+                              CoinFormatter formatter) {
         super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
         this.fasterPaymentsAccount = (FasterPaymentsAccount) paymentAccount;
     }
@@ -66,6 +75,13 @@ public class FasterPaymentsForm extends PaymentMethodForm {
     @Override
     public void addFormForAddAccount() {
         gridRowFrom = gridRow + 1;
+        holderNameInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, Res.get("payment.account.owner"));
+        holderNameInputTextField.setValidator(inputValidator);
+        holderNameInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            fasterPaymentsAccount.setHolderName(newValue);
+            updateFromInputs();
+        });
+
         // do not translate as it is used in English only
         sortCodeInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, UK_SORT_CODE);
         sortCodeInputTextField.setValidator(inputValidator);
@@ -102,6 +118,10 @@ public class FasterPaymentsForm extends PaymentMethodForm {
                 fasterPaymentsAccount.getAccountName(), Layout.FIRST_ROW_AND_GROUP_DISTANCE);
         addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"),
                 Res.get(fasterPaymentsAccount.getPaymentMethod().getId()));
+        if (!fasterPaymentsAccount.getHolderName().isEmpty()) {
+            addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                    fasterPaymentsAccount.getHolderName());
+        }
         // do not translate as it is used in English only
         addCompactTopLabelTextField(gridPane, ++gridRow, UK_SORT_CODE, fasterPaymentsAccount.getSortCode());
         TextField field = addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.accountNr"),
@@ -116,6 +136,7 @@ public class FasterPaymentsForm extends PaymentMethodForm {
     @Override
     public void updateAllInputsValid() {
         allInputsValid.set(isAccountNameValid()
+                && holderNameInputTextField.getValidator().validate(fasterPaymentsAccount.getHolderName()).isValid
                 && sortCodeInputTextField.getValidator().validate(fasterPaymentsAccount.getSortCode()).isValid
                 && accountNrInputTextField.getValidator().validate(fasterPaymentsAccount.getAccountNr()).isValid
                 && fasterPaymentsAccount.getTradeCurrencies().size() > 0);

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/FasterPaymentsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/FasterPaymentsForm.java
@@ -51,7 +51,7 @@ public class FasterPaymentsForm extends PaymentMethodForm {
         // do not translate as it is used in English only
         addCompactTopLabelTextField(gridPane, ++gridRow, UK_SORT_CODE,
                 ((FasterPaymentsAccountPayload) paymentAccountPayload).getSortCode());
-        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.accountNr"),
+        addCompactTopLabelTextField(gridPane, gridRow, 1, Res.get("payment.accountNr"),
                 ((FasterPaymentsAccountPayload) paymentAccountPayload).getAccountNr());
         return gridRow;
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -51,6 +51,7 @@ import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
+import bisq.core.payment.FasterPaymentsAccount;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.user.DontShowAgainLookup;
@@ -170,7 +171,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
     protected int gridRow = 0;
     private final List<Node> editOfferElements = new ArrayList<>();
-    private boolean clearXchangeWarningDisplayed, isActivated;
+    private boolean clearXchangeWarningDisplayed, fasterPaymentsWarningDisplayed, isActivated;
     private InfoInputTextField marketBasedPriceInfoInputTextField, volumeInfoInputTextField,
             buyerSecurityDepositInfoInputTextField;
     private AutoTooltipSlideToggleButton tradeFeeInBtcToggle, tradeFeeInBsqToggle;
@@ -492,8 +493,16 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         if (paymentAccount.getPaymentMethod().getId().equals(PaymentMethod.CLEAR_X_CHANGE_ID) &&
                 !clearXchangeWarningDisplayed) {
             clearXchangeWarningDisplayed = true;
-            UserThread.runAfter(GUIUtil::showClearXchangeWarning,
-                    500, TimeUnit.MILLISECONDS);
+            UserThread.runAfter(GUIUtil::showClearXchangeWarning, 500, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void maybeShowFasterPaymentsWarning(PaymentAccount paymentAccount) {
+        if (paymentAccount.getPaymentMethod().getId().equals(PaymentMethod.FASTER_PAYMENTS_ID) &&
+                ((FasterPaymentsAccount) paymentAccount).getHolderName().isEmpty() &&
+                !fasterPaymentsWarningDisplayed) {
+            fasterPaymentsWarningDisplayed = true;
+            UserThread.runAfter(() -> GUIUtil.showFasterPaymentsWarning(navigation), 500, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -505,6 +514,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         PaymentAccount paymentAccount = paymentAccountsComboBox.getSelectionModel().getSelectedItem();
         if (paymentAccount != null) {
             maybeShowClearXchangeWarning(paymentAccount);
+            maybeShowFasterPaymentsWarning(paymentAccount);
 
             currencySelection.setVisible(paymentAccount.hasMultipleCurrencies());
             currencySelection.setManaged(paymentAccount.hasMultipleCurrencies());

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -170,7 +170,9 @@ public class GUIUtil {
         GUIUtil.preferences = preferences;
     }
 
-    public static String getUserLanguage() { return preferences.getUserLanguage(); }
+    public static String getUserLanguage() {
+        return preferences.getUserLanguage();
+    }
 
     public static double getScrollbarWidth(Node scrollablePane) {
         Node node = scrollablePane.lookup(".scroll-bar");
@@ -696,6 +698,20 @@ public class GUIUtil {
         new Popup().information(Res.get("payment.clearXchange.info", currencyName, currencyName))
                 .width(900)
                 .closeButtonText(Res.get("shared.iConfirm"))
+                .dontShowAgainId(key)
+                .show();
+    }
+
+    public static void showFasterPaymentsWarning(Navigation navigation) {
+        String key = "recreateFasterPaymentsAccount";
+        String currencyName = Config.baseCurrencyNetwork().getCurrencyName();
+        new Popup().information(Res.get("payment.fasterPayments.newRequirements.info", currencyName))
+                .width(900)
+                .actionButtonTextWithGoTo("navigation.account")
+                .onAction(() -> {
+                    navigation.setReturnPath(navigation.getCurrentPath());
+                    navigation.navigateTo(MainView.class, AccountView.class, FiatAccountsView.class);
+                })
                 .dontShowAgainId(key)
                 .show();
     }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Use `excludeFromJsonDataMap` to add an optional owner full name property to Faster Payments (GBP) accounts, without affecting the trade JSON contract (for backwards compatibility). This is to fix #3976, that some banks have started checking the recipient name.

This uses the new map key: `public static final String HOLDER_NAME = "holderName";`

Make the full name a non-optional field for _new_ accounts, but display the details for old Faster Payments accounts in exactly the same way as before, only showing the extra field in the info popup, account and trade step views when it is present.

Also update the now misleading payment instructions in the buyer popup. With the change, it shows as:
![Screenshot from 2020-03-25 23-01-39](https://user-images.githubusercontent.com/54855381/77550995-b8346480-6eec-11ea-875c-33051313b3be.png)

Also add a popup to advise the user to recreate their Faster Payments account.

Make an info popup open in the take/create offer view, upon choosing to take or make a new offer, to instruct the user to recreate their old Faster Payments account with an owner full name (and preserved salt). Also show the popup upon manual selection of any old (i.e. missing full name) Faster Payments account from the trading account combo box, analogously to the ClearXchange (Zelle) warning popup logic.
![Screenshot from 2020-03-25 23-36-33](https://user-images.githubusercontent.com/54855381/77554904-9ee1e700-6ef1-11ea-99fd-972fb327ce0e.png)

I've also copied/overwritten the two new/updated English resource bundle strings into the non-English resource files, so that the translations stay in sync with the updated information. (As it is a UK-only payment method, the non-English translations are probably not all that important anyway.)

--

Finally, I removed some redundant null-handling of the `excludeFromJsonDataMap` field
and constructor parameters. This touched all the `PaymentAccountPayload` subclasses, which was quite a lot of files (although fairly trivial changes).