### PR TITLE
Limit system ram to 4GB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,10 @@ configure([project(':cli'),
             unixScriptFile.text = unixScriptFile.text.replace(
                 'cd "`dirname \\"$PRG\\"`/.." >/dev/null', 'cd "`dirname \\"$PRG\\"`" >/dev/null')
 
+            def script = file("${rootProject.projectDir}/bisq-$applicationName")
+            script.text = script.text.replace(
+                'DEFAULT_JVM_OPTS=""', 'DEFAULT_JVM_OPTS="-XX:MaxRAM=4GB"')
+
             if (osdetector.os != 'windows')
                 delete fileTree(dir: rootProject.projectDir, include: 'bisq-*.bat')
             else

--- a/build.gradle
+++ b/build.gradle
@@ -133,9 +133,11 @@ configure([project(':cli'),
             unixScriptFile.text = unixScriptFile.text.replace(
                 'cd "`dirname \\"$PRG\\"`/.." >/dev/null', 'cd "`dirname \\"$PRG\\"`" >/dev/null')
 
-            def script = file("${rootProject.projectDir}/bisq-$applicationName")
-            script.text = script.text.replace(
-                'DEFAULT_JVM_OPTS=""', 'DEFAULT_JVM_OPTS="-XX:MaxRAM=4GB"')
+            if (applicationName == 'desktop') {
+                def script = file("${rootProject.projectDir}/bisq-$applicationName")
+                script.text = script.text.replace(
+                    'DEFAULT_JVM_OPTS=""', 'DEFAULT_JVM_OPTS="-XX:MaxRAM=4g"')
+            }
 
             if (osdetector.os != 'windows')
                 delete fileTree(dir: rootProject.projectDir, include: 'bisq-*.bat')

--- a/desktop/package/linux/package.sh
+++ b/desktop/package/linux/package.sh
@@ -108,6 +108,7 @@ $JAVA_HOME/bin/javapackager \
     -srcfiles desktop-$version-all.jar \
     -appclass bisq.desktop.app.BisqAppMain \
     -BjvmOptions=-Xss1280k \
+    -BjvmOptions=-XX:MaxRAM=4g \
     -BjvmOptions=-Djava.net.preferIPv4Stack=true \
     -outfile Bisq-$version \
     -v
@@ -134,6 +135,7 @@ $JAVA_HOME/bin/javapackager \
     -srcfiles desktop-$version-all.jar \
     -appclass bisq.desktop.app.BisqAppMain \
     -BjvmOptions=-Xss1280k \
+    -BjvmOptions=-XX:MaxRAM=4g \
     -BjvmOptions=-Djava.net.preferIPv4Stack=true \
     -outfile Bisq-$version \
     -v


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Might treat some symptoms of #3128, #3657, #3918, #3917, #3686, #3677

OpenJDK assumes total system RAM of 128GB. Setting it to 4GB manually
reduces the greediness of the JVM drastically.

Only after setting the MaxRAM to 1.5GB it finally went into a heap space error. 2GB work fine on my machine.

Proposed strategy: do a full release test with this, see how it goes.

This find is courtesy of @ghubstan https://github.com/bisq-network/bisq/issues/3918#issuecomment-594236960
