### PR TITLE
Fixed wrongly removed listeners

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -284,6 +284,9 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void onTabSelected(boolean isSelected) {
+        if (isSelected == model.getDataModel().isTabSelected)
+            return;
+
         if (isSelected && !model.getDataModel().isTabSelected)
             doActivate();
         else


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes https://github.com/bisq-network/bisq/issues/2779

This is a 2 part fix:
- [x] prevent listener from being removed
- [ ] keep changes to EditOfferView even when navigating elsewhere

<details>

the second one is trickier, that is what I got so far:
- when switching to another tab of the main toolbar and returning, 

https://github.com/bisq-network/bisq/blob/0501b54633eb49d71f58bfbec1806ce83eb747be/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java#L225-L226

 gets called from outside. When negating the "if", values are kept.
- however, once that works and you switch to another subtab and back, everything is reset again
- going forth, the lines below disable the tab right before it is reenabled and therefore resets the model
https://github.com/bisq-network/bisq/blob/0501b54633eb49d71f58bfbec1806ce83eb747be/desktop/src/main/java/bisq/desktop/main/portfolio/PortfolioView.java#L105-L106

the thing is, this line received a change from @ManfredKarrer:

https://github.com/bisq-network/bisq/commit/3b91f08ce48042e237a8635f28a4616cd885c237#diff-8d842486c5cbb597c1a8c4ab576f274fL108-L109

with a comment saying that has been done because deactivated offers kept being republished.

</details>