### PR TITLE
Limit number of unconfirmed offers

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -609,6 +609,15 @@ public abstract class WalletService {
         return wallet.getLastBlockSeenHeight();
     }
 
+    /**
+     * Check if there are more than 20 unconfirmed transactions in the chain right now.
+     *
+     * @return true when queue is full
+     */
+    public boolean isUnconfirmedTransactionsLimitHit() {
+        return 20 < getTransactions(true).stream().filter(transaction -> transaction.isPending()).count();
+    }
+
     public Set<Transaction> getTransactions(boolean includeDead) {
         return wallet.getTransactions(includeDead);
     }

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -637,6 +637,12 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 availabilityResult = AvailabilityResult.OFFER_TAKEN;
             }
 
+            if (btcWalletService.isUnconfirmedTransactionsLimitHit()) {
+                errorMessage = "There are too many unconfirmed transactions at the moment. Please try again later.";
+                log.warn(errorMessage);
+                availabilityResult = AvailabilityResult.UNKNOWN_FAILURE;
+            }
+
             OfferAvailabilityResponse offerAvailabilityResponse = new OfferAvailabilityResponse(request.offerId,
                     availabilityResult,
                     arbitratorNodeAddress,

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -638,7 +638,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 availabilityResult = AvailabilityResult.OFFER_TAKEN;
             }
 
-            if (btcWalletService.isUnconfirmedTransactionsLimitHit()) {
+            if (btcWalletService.isUnconfirmedTransactionsLimitHit() || bsqWalletService.isUnconfirmedTransactionsLimitHit()) {
                 errorMessage = Res.get("shared.unconfirmedTransactionsLimitReached");
                 log.warn(errorMessage);
                 availabilityResult = AvailabilityResult.UNKNOWN_FAILURE;

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -22,6 +22,7 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.dao.DaoFacade;
 import bisq.core.exceptions.TradePriceOutOfToleranceException;
+import bisq.core.locale.Res;
 import bisq.core.offer.availability.DisputeAgentSelection;
 import bisq.core.offer.messages.OfferAvailabilityRequest;
 import bisq.core.offer.messages.OfferAvailabilityResponse;
@@ -638,7 +639,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
             }
 
             if (btcWalletService.isUnconfirmedTransactionsLimitHit()) {
-                errorMessage = "There are too many unconfirmed transactions at the moment. Please try again later.";
+                errorMessage = Res.get("shared.unconfirmedTransactionsLimitReached");
                 log.warn(errorMessage);
                 availabilityResult = AvailabilityResult.UNKNOWN_FAILURE;
             }

--- a/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferProtocol.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferProtocol.java
@@ -18,6 +18,7 @@
 package bisq.core.offer.placeoffer;
 
 import bisq.core.offer.placeoffer.tasks.AddToOfferBook;
+import bisq.core.offer.placeoffer.tasks.CheckNumberOfUnconfirmedTransactions;
 import bisq.core.offer.placeoffer.tasks.CreateMakerFeeTx;
 import bisq.core.offer.placeoffer.tasks.ValidateOffer;
 import bisq.core.trade.handlers.TransactionResultHandler;
@@ -75,6 +76,7 @@ public class PlaceOfferProtocol {
                 }
         );
         taskRunner.addTasks(
+                CheckNumberOfUnconfirmedTransactions.class,
                 ValidateOffer.class,
                 CreateMakerFeeTx.class,
                 AddToOfferBook.class

--- a/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferProtocol.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferProtocol.java
@@ -72,6 +72,7 @@ public class PlaceOfferProtocol {
                                 },
                                 log::error);
                     }
+                    model.getOffer().setErrorMessage(errorMessage);
                     errorMessageHandler.handleErrorMessage(errorMessage);
                 }
         );

--- a/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferProtocol.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferProtocol.java
@@ -76,8 +76,8 @@ public class PlaceOfferProtocol {
                 }
         );
         taskRunner.addTasks(
-                CheckNumberOfUnconfirmedTransactions.class,
                 ValidateOffer.class,
+                CheckNumberOfUnconfirmedTransactions.class,
                 CreateMakerFeeTx.class,
                 AddToOfferBook.class
         );

--- a/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
@@ -13,7 +13,7 @@ public class CheckNumberOfUnconfirmedTransactions extends Task<PlaceOfferModel> 
 
     @Override
     protected void run() {
-        if (model.getWalletService().isUnconfirmedTransactionsLimitHit())
+        if (model.getWalletService().isUnconfirmedTransactionsLimitHit() || model.getBsqWalletService().isUnconfirmedTransactionsLimitHit())
             failed(Res.get("shared.unconfirmedTransactionsLimitReached"));
         complete();
     }

--- a/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
@@ -12,7 +12,7 @@ public class CheckNumberOfUnconfirmedTransactions extends Task<PlaceOfferModel> 
 
     @Override
     protected void run() {
-        if (10 < model.getWalletService().getTransactions(true).stream().filter(transaction -> transaction.isPending()).count())
+        if (model.getWalletService().isUnconfirmedTransactionsLimitHit())
             failed("There are too many unconfirmed transactions at the moment. Please try again later.");
         complete();
     }

--- a/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
@@ -1,5 +1,6 @@
 package bisq.core.offer.placeoffer.tasks;
 
+import bisq.core.locale.Res;
 import bisq.core.offer.placeoffer.PlaceOfferModel;
 
 import bisq.common.taskrunner.Task;
@@ -13,7 +14,7 @@ public class CheckNumberOfUnconfirmedTransactions extends Task<PlaceOfferModel> 
     @Override
     protected void run() {
         if (model.getWalletService().isUnconfirmedTransactionsLimitHit())
-            failed("There are too many unconfirmed transactions at the moment. Please try again later.");
+            failed(Res.get("shared.unconfirmedTransactionsLimitReached"));
         complete();
     }
 }

--- a/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/tasks/CheckNumberOfUnconfirmedTransactions.java
@@ -1,0 +1,19 @@
+package bisq.core.offer.placeoffer.tasks;
+
+import bisq.core.offer.placeoffer.PlaceOfferModel;
+
+import bisq.common.taskrunner.Task;
+import bisq.common.taskrunner.TaskRunner;
+
+public class CheckNumberOfUnconfirmedTransactions extends Task<PlaceOfferModel> {
+    public CheckNumberOfUnconfirmedTransactions(TaskRunner taskHandler, PlaceOfferModel model) {
+        super(taskHandler, model);
+    }
+
+    @Override
+    protected void run() {
+        if (10 < model.getWalletService().getTransactions(true).stream().filter(transaction -> transaction.isPending()).count())
+            failed("There are too many unconfirmed transactions at the moment. Please try again later.");
+        complete();
+    }
+}

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -439,6 +439,14 @@ public class TradeManager implements PersistedDataHost {
     public void checkOfferAvailability(Offer offer,
                                        ResultHandler resultHandler,
                                        ErrorMessageHandler errorMessageHandler) {
+
+        if (btcWalletService.isUnconfirmedTransactionsLimitHit()) {
+            String errorMessage = "There are too many unconfirmed transactions at the moment. Please try again later.";
+            errorMessageHandler.handleErrorMessage(errorMessage);
+            log.warn(errorMessage);
+            return;
+        }
+
         offer.checkOfferAvailability(getOfferAvailabilityModel(offer), resultHandler, errorMessageHandler);
     }
 

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -440,7 +440,7 @@ public class TradeManager implements PersistedDataHost {
                                        ResultHandler resultHandler,
                                        ErrorMessageHandler errorMessageHandler) {
 
-        if (btcWalletService.isUnconfirmedTransactionsLimitHit()) {
+        if (btcWalletService.isUnconfirmedTransactionsLimitHit() || bsqWalletService.isUnconfirmedTransactionsLimitHit()) {
             String errorMessage = Res.get("shared.unconfirmedTransactionsLimitReached");
             errorMessageHandler.handleErrorMessage(errorMessage);
             log.warn(errorMessage);

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -441,7 +441,7 @@ public class TradeManager implements PersistedDataHost {
                                        ErrorMessageHandler errorMessageHandler) {
 
         if (btcWalletService.isUnconfirmedTransactionsLimitHit()) {
-            String errorMessage = "There are too many unconfirmed transactions at the moment. Please try again later.";
+            String errorMessage = Res.get("shared.unconfirmedTransactionsLimitReached");
             errorMessageHandler.handleErrorMessage(errorMessage);
             log.warn(errorMessage);
             return;

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -214,6 +214,7 @@ shared.arbitrator=Arbitrator
 shared.refundAgent=Arbitrator
 shared.refundAgentForSupportStaff=Refund agent
 shared.delayedPayoutTxId=Refund collateral transaction ID
+shared.unconfirmedTransactionsLimitReached=You have too many unconfirmed transactions at the moment. Please try again later.
 
 
 ####################################################################


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes https://github.com/bisq-network/bisq/issues/3705

It seems that Bisq can reach a critical mass of unconfirmed transactions. Exceeding this mass causes all sorts of failures. In the corresponding issue it has been suggested to just limit the number of unconfirmed transactions.

After thorough discussion with @chimp1984, @sqrrm, @wiz and @ripcurlx, we agreed on a first step, namely, to introduce Bisqs own hard limit, get it into the next release and ultimately see if we can reduce support cases (currently 8-10 cases per month out of [2k5 trades](https://monitor.bisq.network/d/SzHBCGjmz/trades-playground?orgId=1&fullscreen&panelId=19))

This PR introduces Bisqs own hard limit of 20 unconfirmed transactions. If the limit is exceeded during
- offer creation at the makers side,
- taking the offer at the takers side,
- and taking the offer at the makers side,
processes are stopped so that no harm can be done.

# Considerations
- Although these errors are non-blocking and not meant to be reportet, the error handling framework does not allow for a more correct interaction with the user. We agreed on (@ripcurlx) creating an independent issue regarding the GUI error handling and keep this PR focused. The error handling is tracked in https://github.com/bisq-network/bisq/issues/4079.
- Note that there is hardly any synchronization in there and race conditions are to be expected. First, because of how Bisq uses BitcoinJ, there is no correct sync possible. Second, the hard limit is set to 20 which is less than the actual default hard limit of the bitcoin network (25) to allow for some race conditions. Third, this PR is designed to reduce the number of support requests. If time raises the need for more proper handling, we shall do it then.
- I considered extending the protocol to properly report the error. However, by doing so, newer clients cannot take offers of older clients because of how protobuf works. Again, if the need arises over time, we shall do it.


<details>

# Discussions, findings and strategies
To all the experts out there, here are some points to be discussed
- does this "hard limit" only affect offers (I guess the fee txs) or does it affect all txs. The question is should we create a more general safety net?
- is that something to be fixed in bitcoinj?


Please note that I am no expert in the BTC parts of the Bisq code plus the PR is currently largely untested. It is just there to get things moving.

EDIT: seems to be related to https://github.com/bisq-network/proposals/issues/132 and https://github.com/bisq-network/bisq/issues/3489

EDIT2: update after talking to @chimp1984 and @sqrrm 

- future impact
  - once the API can create offers and trading bots are used, this can get critical fast
  
- brainstormed strategies
  - report trade fail to trading partner
    - minor changes to the trade protocol implementation (check!)
    - what happens if the trade succeeds afterwards? because transactions are accepted later?
    - need for a cancellation feature
      - how to revert already committed transactions..
  - only publish offers once fee transaction is confirmed
    - hugely impacts usability because it can take a lot of time until transactions get confirmed (eg. 1h to confirmation, 5 offers take 5h to publish (implement a queue?)
    - might take way to long and thus, might break the trade protocol (does it during offer creation?)
    - does not prevent #3705 from happening
  - make best effort to prevent error
    - introduce Bisqs own hard limit for pending transactions
      - check before offer is created
      - check before offer is taken
        - on the takers side
        - on the makers side triggered by OfferAvailableRequest + error code in case we are close to the limit (maybe not necessary (yet), because maker only creates the fee transactions in sequence, multisig transactions coming in later might result in a tree (check!))
    - does not work with external wallet
    	- however, someone using an external wallet might not be using the same wallet for multiple trades for privacy
      - if the wallet funding transaction fails, it is out of scope for Bisq? (for now at least?)
  - others?

EDIT3: update after a call with @wiz:

https://github.com/bisq-network/bisq/issues/3705#issuecomment-600037511

</details>