### PR TITLE
Fix using /bin/sh instead of /bin/bash in journalscraper.sh

### DIFF
--- a/pricenode/journalscraper.sh
+++ b/pricenode/journalscraper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 HOSTNAME="${COLLECTD_HOSTNAME:-localhost}"
 INTERVAL=750


### PR DESCRIPTION
Fixes error @freimair 
```
Mar 12 13:43:19 gztmprecgqjq64zh collectd[1218]: exec plugin: exec_read_one: error = /journalreader/scraperscript.sh: 14: /journalreader/scraperscript.sh: Bad substitution
```