### PR TITLE
Give LocalBitcoinNode a timeout in case BitcoinJ hangs during handshake attempt

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/LocalBitcoinNode.java
+++ b/core/src/main/java/bisq/core/btc/nodes/LocalBitcoinNode.java
@@ -249,13 +249,13 @@ public class LocalBitcoinNode {
         try {
             var peerVersionMessage = peerVersionMessageFuture.get(HANDSHAKE_TIMEOUT, TimeUnit.MILLISECONDS);
             optionalPeerVersionMessage = Optional.of(peerVersionMessage);
-        } catch (ExecutionException | InterruptedException | CancellationException | TimeoutException ex) {
+        } catch (ExecutionException | InterruptedException | CancellationException ex) {
             optionalPeerVersionMessage = Optional.empty();
-            if (ex instanceof TimeoutException) {
-                log.error("Exploratory handshake attempt with a local Bitcoin node (that may not be there)" +
-                        " unexpectedly timed out. This should never happen; please report this. HANDSHAKE_TIMEOUT" +
-                        " is {} ms. Continuing as if a local BTC node was not found.", HANDSHAKE_TIMEOUT);
-            }
+        } catch (TimeoutException ex) {
+            optionalPeerVersionMessage = Optional.empty();
+            log.error("Exploratory handshake attempt with a local Bitcoin node (that may not be there)" +
+                    " unexpectedly timed out. This should never happen; please report this. HANDSHAKE_TIMEOUT" +
+                    " is {} ms. Continuing as if a local BTC node was not found.", HANDSHAKE_TIMEOUT);
         }
 
         peer.close();


### PR DESCRIPTION
Fixes #4057 

@wiz discovered (#4057) than in some cases LocalBitcoinNode will hang during Bisq setup. This patch gives LocalBitcoinNode's handshake attempt a timeout. Specifically, the part where we block while waiting for BitcoinJ to attempt to return a local BTC node's VersionMessage. I had not originally implemented a timeout, because I was under the impression that in such a case the NioClient would timeout (which does have a timeout).

@wiz has tested this patch and verified that with this patch Bisq handles BitcoinJ hanging gracefully (by timing out the relevant future after 5000 ms).

This patch also prints an error in case a timeout happens, because it normally shouldn't.

The underlying cause is unknown, but seems to come from BitcoinJ.