### PR TITLE
Dump delayed txs of closed trades

### DIFF
--- a/core/src/main/java/bisq/core/trade/DumpDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/DumpDelayedPayoutTx.java
@@ -49,13 +49,14 @@ public class DumpDelayedPayoutTx {
         }
     }
 
-    public void maybeDumpDelayedPayoutTxs(TradableList<Trade> tradableList, String fileName) {
+    public <T extends Tradable> void maybeDumpDelayedPayoutTxs(TradableList<T> tradableList, String fileName) {
         if (!dumpDelayedPayoutTxs)
             return;
 
         var delayedPayoutHashes = tradableList.stream()
+                .filter(tradable -> tradable instanceof Trade)
                 .map(trade -> new DelayedPayoutHash(trade.getId(),
-                        Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes())))
+                        Utilities.bytesAsHexString(((Trade) trade).getDelayedPayoutTxBytes())))
                 .collect(Collectors.toList());
         jsonFileManager.writeToDisc(Utilities.objectToJson(delayedPayoutHashes), fileName);
     }

--- a/core/src/main/java/bisq/core/trade/closed/ClosedTradableManager.java
+++ b/core/src/main/java/bisq/core/trade/closed/ClosedTradableManager.java
@@ -20,6 +20,7 @@ package bisq.core.trade.closed;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.DumpDelayedPayoutTx;
 import bisq.core.trade.Tradable;
 import bisq.core.trade.TradableList;
 import bisq.core.trade.Trade;
@@ -45,19 +46,21 @@ public class ClosedTradableManager implements PersistedDataHost {
     private final KeyRing keyRing;
     private final PriceFeedService priceFeedService;
     private final BtcWalletService btcWalletService;
+    private final DumpDelayedPayoutTx dumpDelayedPayoutTx;
 
     @Inject
     public ClosedTradableManager(KeyRing keyRing,
                                  PriceFeedService priceFeedService,
                                  BtcWalletService btcWalletService,
-                                 Storage<TradableList<Tradable>> storage) {
+                                 Storage<TradableList<Tradable>> storage,
+                                 DumpDelayedPayoutTx dumpDelayedPayoutTx) {
         this.keyRing = keyRing;
         this.priceFeedService = priceFeedService;
         this.btcWalletService = btcWalletService;
         tradableListStorage = storage;
+        this.dumpDelayedPayoutTx = dumpDelayedPayoutTx;
         // The ClosedTrades object can become a few MB so we don't keep so many backups
         tradableListStorage.setNumMaxBackupFiles(3);
-
     }
 
     @Override
@@ -70,6 +73,8 @@ public class ClosedTradableManager implements PersistedDataHost {
                 trade.setTransientFields(tradableListStorage, btcWalletService);
             }
         });
+
+        dumpDelayedPayoutTx.maybeDumpDelayedPayoutTxs(closedTradables, "delayed_payout_txs_closed");
     }
 
     public void add(Tradable tradable) {


### PR DESCRIPTION
Dump delayed payout txs of closed trades as well. Now `--dumpDelayedPayoutTxs=true` dumps three files
- delayed_payout_txs_closed.json
- delayed_payout_txs_failed.json
- delayed_payout_txs_pending.json