### PR TITLE
Update ops team bonded role titles to match current names

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1861,11 +1861,11 @@ dao.bond.bondedRoleType.FORUM_OPERATOR=Forum operator
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.SEED_NODE_OPERATOR=Seed node operator
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.DATA_RELAY_NODE_OPERATOR=Data relay node operator
+dao.bond.bondedRoleType.DATA_RELAY_NODE_OPERATOR=Price node operator
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.BTC_NODE_OPERATOR=BTC node operator
+dao.bond.bondedRoleType.BTC_NODE_OPERATOR=Bitcoin node operator
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.MARKETS_OPERATOR=Markets operator
+dao.bond.bondedRoleType.MARKETS_OPERATOR=Markets API operator
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.BSQ_EXPLORER_OPERATOR=BSQ explorer operator
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
* Rename "Data relay node operator" to "Price node operator"
* Rename "Markets operator" to "Markets API operator"
* Rename "BTC node operator" to "Bitcoin node operator"
