### PR TITLE
Check BTC node config without IO overhead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ configure(subprojects) {
 
     ext { // in alphabetical order
         bcVersion = '1.63'
-        bitcoinjVersion = '2a80db4'
+        bitcoinjVersion = '0.15.8.bisq.14'
         btcdCli4jVersion = '27b94333'
         codecVersion = '1.13'
         easybindVersion = '1.0.3'
@@ -79,6 +79,7 @@ configure(subprojects) {
     repositories {
         mavenCentral()
         maven { url 'https://jitpack.io' }
+        mavenLocal()
     }
 
     dependencies {
@@ -212,7 +213,7 @@ configure(project(':proto')) {
 
 configure(project(':assets')) {
     dependencies {
-        compile("com.github.bisq-network:bitcoinj:$bitcoinjVersion") {
+        compile("org.bitcoinj:bitcoinj-core:$bitcoinjVersion") {
             exclude(module: 'jsr305')
             exclude(module: 'slf4j-api')
             exclude(module: 'guava')
@@ -245,7 +246,7 @@ configure(project(':common')) {
         compile("com.google.inject:guice:$guiceVersion") {
             exclude(module: 'guava')
         }
-        compile("com.github.bisq-network:bitcoinj:$bitcoinjVersion") {
+        compile("org.bitcoinj:bitcoinj-core:$bitcoinjVersion") {
             exclude(module: 'jsr305')
             exclude(module: 'slf4j-api')
             exclude(module: 'guava')

--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -107,7 +107,7 @@ public class WalletAppSetup {
               Runnable downloadCompleteHandler,
               Runnable walletInitializedHandler) {
         log.info("Initialize WalletAppSetup with BitcoinJ version {} and hash of BitcoinJ commit {}",
-                VersionMessage.BITCOINJ_VERSION, "2a80db4");
+                VersionMessage.BITCOINJ_VERSION, "-"); // TODO what's the purpose of specifying the commit hash here?
 
         ObjectProperty<Throwable> walletServiceException = new SimpleObjectProperty<>();
         btcInfoBinding = EasyBind.combine(walletsSetup.downloadPercentageProperty(),

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2786,6 +2786,7 @@ Please check if you have the latest version of Bisq installed.\n\
 You can download it at: [HYPERLINK:https://bisq.network/downloads].\n\n\
 Please restart the application.
 popup.warning.startupFailed.twoInstances=Bisq is already running. You cannot run two instances of Bisq.
+popup.warning.userBtcNodeMisconfigured.explanation=The user-provided Bitcoin node {0} was found to be misconfigured. A user-provided BTC node is either a locally running node that was automatically detected and used, or a node explicitly specified via the --btcNodes command-line option. Bisq requires BTC nodes to have bloom filters enabled and pruning disabled. Automatic use of a local Bitcoin node can be disabled by using the --ignoreLocalBtcNode option.
 popup.warning.tradePeriod.halfReached=Your trade with ID {0} has reached the half of the max. allowed trading period and is still not completed.\n\nThe trade period ends on {1}\n\nPlease check your trade state at \"Portfolio/Open trades\" for further information.
 popup.warning.tradePeriod.ended=Your trade with ID {0} has reached the max. allowed trading period and is not completed.\n\n\
   The trade period ended on {1}\n\n\

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -474,6 +474,15 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                 }
             });
         }
+
+        walletsSetup.setDisplayUserBtcNodeMisconfigurationHandler(
+                (String peer) ->
+                    new Popup()
+                        .hideCloseButton()
+                        .warning(Res.get("popup.warning.userBtcNodeMisconfigured.explanation", peer))
+                        .useShutDownButton()
+                        .show()
+                );
     }
 
     private void showRevolutAccountUpdateWindow(List<RevolutAccount> revolutAccountList) {

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -23,7 +23,7 @@ dependencyVerification {
         'com.github.bisq-network.netlayer:tor.external:a3606a592d6b6caa6a2fb7db224eaf43c6874c6730da4815bd37ad686b283dcb',
         'com.github.bisq-network.netlayer:tor.native:b15aba7fe987185037791c7ec7c529cb001b90d723d047d54aab87aceb3b3d45',
         'com.github.bisq-network.netlayer:tor:a974190aa3a031067ccd1dda28a3ae58cad14060792299d86ea38a05fb21afc5',
-        'com.github.bisq-network:bitcoinj:65ed08fa5777ea4a08599bdd575e7dc1f4ba2d4d5835472551439d6f6252e68a',
+        //'com.github.bisq-network:bitcoinj:65ed08fa5777ea4a08599bdd575e7dc1f4ba2d4d5835472551439d6f6252e68a',
         'com.github.cd2357.tor-binary:tor-binary-geoip:ae27b6aca1a3a50a046eb11e38202b6d21c2fcd2b8643bbeb5ea85e065fbc1be',
         'com.github.cd2357.tor-binary:tor-binary-linux32:7b5d6770aa442ef6d235e8a9bfbaa7c62560690f9fe69ff03c7a752eae84f7dc',
         'com.github.cd2357.tor-binary:tor-binary-linux64:24111fa35027599a750b0176392dc1e9417d919414396d1b221ac2e707eaba76',


### PR DESCRIPTION
Edit: not proof of concept anymore; this initial post is outdated. TLDR is that this PR has Bisq check if nodes it connects to are suitable for use by Bisq (e.g. that the node isn't pruning). That's currently most useful with a local BTC node or custom nodes (because otherwise Bisq uses our own federated nodes that are known to be well configured), but it checks all BTC nodes it connects to, with negligible overhead. This PR is currently stagnating in large part because it depends on a (minor) BitcoinJ PR.

This is a proof of concept for checking BTC node's configuration. It's an alternative approach to what I had proposed earlier (that was merged and reverted due to reliability issues). In contrast to the previous attempt, this approach doesn't incur additional IO and doesn't use blocking. Whereas the previous attempt initiated a short lived BitcoinJ connection to a node, this approach just listens into the connections we are already establishing. Also, while previously the checking applied only to a local BTC node, this approach generalizes checking to all BTC nodes we connect to.

Currently, it has two problems:

a) connecting to a pruning node, on my setup at least, causes the connection to crash, and the listener never gets triggered; this is a rare BitcoinJ edge case bug and I opened an issue for it https://github.com/bisq-network/bisq/issues/4080 ;

and, b) this WIP implementation just does `peer.close()`, which causes the PeerGroup to just retry the connection, in case we're in local mode, or possibly retry later in case we're in non-local mode (didn't explore non-local behaviour yet); I'm pondering if this is indeed undesirable or if we would want to use this to get free auto-retry.

Another open question is what to do in case a remote node is found to be misconfigured. Just an error log?