### PR TITLE
Upgrade firebase-admin, avoid gRPC version conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ configure(subprojects) {
         easybindVersion = '1.0.3'
         easyVersion = '4.0.1'
         findbugsVersion = '3.0.2'
-        firebaseVersion = '6.2.0'
+        firebaseVersion = '6.12.2'
         fontawesomefxVersion = '8.0.0'
         fontawesomefxCommonsVersion = '9.1.2'
         fontawesomefxMaterialdesignfontVersion = '2.0.26-9.1.2'
@@ -65,7 +65,7 @@ configure(subprojects) {
         pushyVersion = '0.13.2'
         qrgenVersion = '1.3'
         sarxosVersion = '0.3.12'
-        slf4jVersion = '1.7.22'
+        slf4jVersion = '1.7.25'
         sparkVersion = '2.5.2'
         springBootVersion = '1.5.10.RELEASE'
 
@@ -428,7 +428,16 @@ configure(project(':relay')) {
         compile project(':common')
         compile "com.sparkjava:spark-core:$sparkVersion"
         compile "com.turo:pushy:$pushyVersion"
-        compile "com.google.firebase:firebase-admin:$firebaseVersion"
+        implementation("com.google.firebase:firebase-admin:$firebaseVersion") {
+            exclude(module: 'grpc-core')
+            exclude(module: 'grpc-api')
+            exclude(module: 'grpc-context')
+            exclude(module: 'grpc-protobuf')
+            exclude(module: 'grpc-protobuf-lite')
+            exclude(module: 'grpc-protobuf-stub')
+            exclude(module: 'grpc-protobuf-grpclb')
+            exclude(module: 'grpc-netty-shaded')
+        }
         compile "commons-codec:commons-codec:$codecVersion"
     }
 }

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -84,7 +84,7 @@ dependencyVerification {
         'org.jetbrains.kotlin:kotlin-stdlib-jdk8:f7dbbaee3e0841758187a213c052388a4e619e11c87ab16f4bc229cfe7ce5fed',
         'org.jetbrains.kotlin:kotlin-stdlib:6ea3d0921b26919b286f05cbdb906266666a36f9a7c096197114f7495708ffbc',
         'org.jetbrains:annotations:ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478',
-        'org.slf4j:slf4j-api:3a4cd4969015f3beb4b5b4d81dbafc01765fb60b8a439955ca64d8476fef553e',
+        'org.slf4j:slf4j-api:18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79',
         'org.tukaani:xz:a594643d73cc01928cf6ca5ce100e094ea9d73af760a5d4fb6b75fa673ecec96',
     ]
 }


### PR DESCRIPTION
The latest firebase-admin (v6.12.2) depends on grpc-api v1.24.1,
which is as close as we can get to the grpc v1.25.0 specified in
build.gradle.  Currently, the firebase-admin version requirement
is causing the build to download grpc v1.10.1 jars, but at runtime,
grpc 1.25.0 jars are loaded.

Transitive dependencies grpc-netty-shaded, grpc-protobuf, grpc-protobuf-lite, 
grpc-protobuf-stub, grpc-protobuf-grpclb (v1.23.0) are also excluded.

Eliminating version conflicts saves a dev time thinking about which
source jar to choose from while examining exception stack traces.

Partial fix for #4086

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
