### PR TITLE
Suppress netty.shaded debug stack traces in cli

### DIFF
--- a/cli/src/main/java/bisq/cli/app/BisqCliMain.java
+++ b/cli/src/main/java/bisq/cli/app/BisqCliMain.java
@@ -57,10 +57,6 @@ import static java.lang.String.format;
 
 /**
  * gRPC client.
- *
- * FIXME We get warning 'DEBUG io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0 - direct buffer constructor: unavailable
- * java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled' which is
- * related to Java 10 changes. Requests are working but we should find out why we get that warning
  */
 @Slf4j
 public class BisqCliMain {
@@ -80,10 +76,8 @@ public class BisqCliMain {
     }
 
     private BisqCliMain(String host, int port) {
-        this(ManagedChannelBuilder.forAddress(host, port)
-                // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
-                // needing certificates.
-                .usePlaintext(true).build());
+        // Channels are secure by default (via SSL/TLS);  for the example disable TLS to avoid needing certificates.
+        this(ManagedChannelBuilder.forAddress(host, port).usePlaintext().build());
 
         // Simple input scanner
         // TODO use some more sophisticated input processing with validation....

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
+        </encoder>
+    </appender>
+
+    <root level="TRACE">
+        <appender-ref ref="CONSOLE_APPENDER"/>
+    </root>
+
+    <logger name="io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0" level="WARN"/>
+    <logger name="io.grpc.netty.shaded.io.netty.util.internal.NativeLibraryLoader" level="WARN"/>
+    <logger name="io.grpc.netty" level="TRACE"/>
+
+</configuration>


### PR DESCRIPTION
Configure cli loggers to avoid scary but ignorable netty debug
log messages with stack traces:  "Reflective setAccessible(true)",
and those showing unsuccessful netty native lib load attempts.
It may be preferable to not use logback in cli, and achieve the
same result programmatically with slf4j, but this shows how to
hide this ugly log output in the meantime.

Remove comment about why these messages were logged, and switch
to non-deprecated ManagedChannelBuilder.forAddress(host, port)
		.usePlaintext().build()
in BisqCliMain.
