### PR TITLE
Make prompt text readable in dark mode

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -701,11 +701,11 @@ tree-table-view:focused {
 }
 
 .text-field {
-    -fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);
+    -fx-prompt-text-fill: derive(-bs-prompt-text, -30%);
 }
 
 .text-area {
-    -fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);
+    -fx-prompt-text-fill: derive(-bs-prompt-text, -30%);
 }
 
 #label-url {
@@ -1485,7 +1485,7 @@ textfield */
     -fx-text-fill: -fx-text-inner-color;
     -fx-highlight-fill: derive(-fx-control-inner-background, -20%);
     -fx-highlight-text-fill: -fx-text-inner-color;
-    -fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);
+    -fx-prompt-text-fill: derive(-bs-prompt-text, -30%);
     -fx-background-color: linear-gradient(to bottom, derive(-fx-text-box-border, -10%), -fx-text-box-border),
     linear-gradient(from 0px 0px to 0px 5px, derive(-fx-control-inner-background, -9%), -fx-control-inner-background);
     -fx-background-insets: 0, 1;
@@ -1497,7 +1497,7 @@ textfield */
     -fx-text-fill: -fx-text-inner-color;
     -fx-highlight-fill: derive(-fx-control-inner-background, -20%);
     -fx-highlight-text-fill: -fx-text-inner-color;
-    -fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);
+    -fx-prompt-text-fill: derive(-bs-prompt-text, -30%);
     -fx-background-color: linear-gradient(to bottom, derive(-fx-text-box-border, -10%), -fx-text-box-border),
     linear-gradient(from 0px 0px to 0px 5px, derive(-fx-control-inner-background, -9%), -bs-color-gray-1);
     -fx-background-insets: 0, 1;

--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -128,6 +128,7 @@
     -bs-chart-tick: rgba(255, 255, 255, 0.7);
     -bs-chart-lines: rgba(0, 0, 0, 0.3);
     -bs-white: white;
+    -bs-prompt-text: -bs-color-gray-3;
 
     /* dao chart colors */
     -bs-chart-dao-line1: -bs-color-green-5;

--- a/desktop/src/main/java/bisq/desktop/theme-light.css
+++ b/desktop/src/main/java/bisq/desktop/theme-light.css
@@ -101,6 +101,7 @@
     -fx-default-button: derive(-fx-accent, 95%);
     -bs-progress-bar-track: #e0e0e0;
     -bs-white: white;
+    -bs-prompt-text: -fx-control-inner-background;
 
     /* dao chart colors */
     -bs-chart-dao-line1: -bs-color-green-3;


### PR DESCRIPTION
As this annoys me for a long time when using dark mode, I quickly fixed this issue.
No compensation necessary - just fixing this was satisfaction enough ;-)

### Before
<img width="1268" alt="Bildschirmfoto 2020-03-24 um 10 41 02" src="https://user-images.githubusercontent.com/170962/77411298-802e0400-6dbc-11ea-9343-e70f1a35c60d.png">

### After
<img width="1268" alt="Bildschirmfoto 2020-03-24 um 10 38 21" src="https://user-images.githubusercontent.com/170962/77411304-845a2180-6dbc-11ea-8090-3be19fdc40e8.png">
