### PR TITLE
Avoid startup failure when bannedSeedNodes arg is empty

### DIFF
--- a/core/src/main/java/bisq/core/network/p2p/seed/DefaultSeedNodeRepository.java
+++ b/core/src/main/java/bisq/core/network/p2p/seed/DefaultSeedNodeRepository.java
@@ -81,7 +81,11 @@ public class DefaultSeedNodeRepository implements SeedNodeRepository {
             });
 
             // filter
-            cache.removeAll(config.bannedSeedNodes.stream().map(NodeAddress::new).collect(Collectors.toSet()));
+            cache.removeAll(
+                    config.bannedSeedNodes.stream()
+                            .filter(n -> !n.isEmpty())
+                            .map(NodeAddress::new)
+                            .collect(Collectors.toSet()));
 
             log.info("Seed nodes: {}", cache);
         } catch (Throwable t) {


### PR DESCRIPTION
This commit fixes #4103, where it was demonstrated that a
bisq.properties file containing the following entries would cause Bisq
to fail at startup:

    baseCurrencyNetwork=BTC_MAINNET
    bannedSeedNodes=
    bannedBtcNodes=
    bannedPriceRelayNodes=5bmpx76qllutpcyp

The source of the problem was that the jOptSimple argument parsing
library converts the empty value of bannedSeedNodes to a List<String> of
size 1 where the 0th element of the list is an empty string. This empty
string was then attempted to be converted into a new NodeAddress,
causing a validation error. This conversion happened during Guice
wiring, and manifested as a blank white screen appearing as wiring
errors often do in Bisq.

The fix is simple and surgical. We now filter out any empty string
elements before attempting to convert the banned seed node value to a
new node address. I have reviewed the other related options, such as
bannedPriceRelayNodes and bannedBtcNodes, and they do not cause the
problem described above, so no filtering or other changes have been made
to the way they work.


<!--
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.