### PR TITLE
Add parsing to pricenode cmdline inputs

### DIFF
--- a/core/src/main/java/bisq/core/provider/ProvidersRepository.java
+++ b/core/src/main/java/bisq/core/provider/ProvidersRepository.java
@@ -122,6 +122,8 @@ public class ProvidersRepository {
                         !bannedNodes.contains(e.replace("http://", "")
                                 .replace("/", "")
                                 .replace(".onion", "")))
+                .map(e -> e.endsWith("/") ? e : e + "/")
+                .map(e -> e.startsWith("http") ? e : "http://" + e)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Stumbled over during https://github.com/bisq-network/bisq/pull/4027

This PR adds basic input validation and correction for the custom pricenode command line parameter:
- `--help` says
```
  --providers=<host:port[,...]>
        List custom pricenodes
```
- yet, setting the value to `44mgyoe2b6oqiytt.onion:80` fails.
- because the correct formatting requires "http" in front and a "/" at the end
