### PR TITLE
Add guava dependency to seednode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -488,6 +488,7 @@ configure(project(':seednode')) {
     dependencies {
         compile project(':core')
         compileOnly "org.projectlombok:lombok:$lombokVersion"
+        implementation "com.google.guava:guava:$guavaVersion"
         annotationProcessor "org.projectlombok:lombok:$lombokVersion"
         testCompile "org.mockito:mockito-core:$mockitoVersion"
     }


### PR DESCRIPTION
Merging PR #4096, which moved protobuf defs out of core and common,
left :seednode without its required dependency on guava, causing
NoSuchMethodErrors.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
