### PR TITLE
Make UserThread::run* methods thread safe

### DIFF
--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -159,9 +159,8 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         openOfferTradableListStorage = storage;
 
         // In case the app did get killed the shutDown from the modules is not called, so we use a shutdown hook
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            UserThread.execute(OpenOfferManager.this::shutDown);
-        }, "OpenOfferManager.ShutDownHook"));
+        Runtime.getRuntime().addShutdownHook(new Thread(() ->
+                UserThread.execute(OpenOfferManager.this::shutDown), "OpenOfferManager.ShutDownHook"));
     }
 
     @Override
@@ -220,7 +219,9 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         int size = openOffers != null ? openOffers.size() : 0;
         log.info("Remove open offers at shutDown. Number of open offers: {}", size);
         if (offerBookService.isBootstrapped() && size > 0) {
-            openOffers.forEach(openOffer -> offerBookService.removeOfferAtShutDown(openOffer.getOffer().getOfferPayload()));
+            UserThread.execute(() -> openOffers.forEach(
+                    openOffer -> offerBookService.removeOfferAtShutDown(openOffer.getOffer().getOfferPayload())
+            ));
             if (completeHandler != null)
                 UserThread.runAfter(completeHandler, size * 200 + 500, TimeUnit.MILLISECONDS);
         } else {


### PR DESCRIPTION
The `UserThread::run*` methods delegate to `UITimer::run(Later|Periodically)` in the case of the desktop application. These use the JavaFX `TimeLine` API (via `bisq.common.reactfx.FXTimer`) to schedule future events. However, this API isn't thread safe and isn't meant to be called outside the FX application thread. This causes occasional task misfires and out-of-order scheduling when `UserThread::runAfter` is called outside the user thread.

Make the `UITimer::run*` methods safe to call from any thread by checking we are in the application thread and delegating to `UserThread::execute` otherwise. This also improves consistency between the contracts of the `run*` and `execute` methods. As the former has many call sites, this is safer than trying to track down all the non-thread-safe uses.

(The `Timer` used in the headless app already appears to be thread-safe.)

This fixes #4055, caused by out-of-order scheduling of the `execute` and `runAfter` tasks in the `WalletConfig.onSetupCompleted` anonymous class method in `bisq.core.btc.setup.WalletsSetup.initialize`.

Also prevent an exception caused by non-thread-safe calls into JavaFX during the shutdown of `OpenOfferManager`, which was uncovered by the above, by adding a missing `UserThread::execute` call.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->