### PR TITLE
[WIP] Add list to filter to set btc fee receiver addresses

### DIFF
--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -101,6 +101,10 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
     @Nullable
     private final List<String> refundAgents;
 
+    // added in v1.3.2
+    @Nullable
+    private final List<String> btcFeeReceiverAddresses;
+
     public Filter(List<String> bannedOfferIds,
                   List<String> bannedNodeAddress,
                   List<PaymentAccountFilter> bannedPaymentAccounts,
@@ -115,7 +119,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                   @Nullable String disableDaoBelowVersion,
                   @Nullable String disableTradeBelowVersion,
                   @Nullable List<String> mediators,
-                  @Nullable List<String> refundAgents) {
+                  @Nullable List<String> refundAgents,
+                  @Nullable List<String> btcFeeReceiverAddresses) {
         this.bannedOfferIds = bannedOfferIds;
         this.bannedNodeAddress = bannedNodeAddress;
         this.bannedPaymentAccounts = bannedPaymentAccounts;
@@ -131,6 +136,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
         this.disableTradeBelowVersion = disableTradeBelowVersion;
         this.mediators = mediators;
         this.refundAgents = refundAgents;
+        this.btcFeeReceiverAddresses = btcFeeReceiverAddresses;
     }
 
 
@@ -156,7 +162,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                   byte[] ownerPubKeyBytes,
                   @Nullable Map<String, String> extraDataMap,
                   @Nullable List<String> mediators,
-                  @Nullable List<String> refundAgents) {
+                  @Nullable List<String> refundAgents,
+                  @Nullable List<String> btcFeeReceiverAddresses) {
         this(bannedOfferIds,
                 bannedNodeAddress,
                 bannedPaymentAccounts,
@@ -171,7 +178,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                 disableDaoBelowVersion,
                 disableTradeBelowVersion,
                 mediators,
-                refundAgents);
+                refundAgents,
+                btcFeeReceiverAddresses);
         this.signatureAsBase64 = signatureAsBase64;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
         this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
@@ -206,6 +214,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
         Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         Optional.ofNullable(mediators).ifPresent(builder::addAllMediators);
         Optional.ofNullable(refundAgents).ifPresent(builder::addAllRefundAgents);
+        Optional.ofNullable(btcFeeReceiverAddresses).ifPresent(builder::addAllBtcFeeReceiverAddresses);
 
         return protobuf.StoragePayload.newBuilder().setFilter(builder).build();
     }
@@ -230,7 +239,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                 proto.getOwnerPubKeyBytes().toByteArray(),
                 CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap(),
                 CollectionUtils.isEmpty(proto.getMediatorsList()) ? null : new ArrayList<>(proto.getMediatorsList()),
-                CollectionUtils.isEmpty(proto.getRefundAgentsList()) ? null : new ArrayList<>(proto.getRefundAgentsList()));
+                CollectionUtils.isEmpty(proto.getRefundAgentsList()) ? null : new ArrayList<>(proto.getRefundAgentsList()),
+                CollectionUtils.isEmpty(proto.getBtcFeeReceiverAddressesList()) ? null : new ArrayList<>(proto.getBtcFeeReceiverAddressesList()));
     }
 
 
@@ -269,6 +279,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                 ",\n     disableTradeBelowVersion='" + disableTradeBelowVersion + '\'' +
                 ",\n     mediators=" + mediators +
                 ",\n     refundAgents=" + refundAgents +
+                ",\n     btcFeeReceiverAddresses=" + btcFeeReceiverAddresses +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -22,6 +22,7 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.dao.DaoFacade;
 import bisq.core.exceptions.TradePriceOutOfToleranceException;
+import bisq.core.filter.FilterManager;
 import bisq.core.offer.availability.DisputeAgentSelection;
 import bisq.core.offer.messages.OfferAvailabilityRequest;
 import bisq.core.offer.messages.OfferAvailabilityResponse;
@@ -110,6 +111,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     private final MediatorManager mediatorManager;
     private final RefundAgentManager refundAgentManager;
     private final DaoFacade daoFacade;
+    private final FilterManager filterManager;
     private final Storage<TradableList<OpenOffer>> openOfferTradableListStorage;
     private final Map<String, OpenOffer> offersToBeEdited = new HashMap<>();
     private boolean stopped;
@@ -138,6 +140,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                             MediatorManager mediatorManager,
                             RefundAgentManager refundAgentManager,
                             DaoFacade daoFacade,
+                            FilterManager filterManager,
                             Storage<TradableList<OpenOffer>> storage) {
         this.createOfferService = createOfferService;
         this.keyRing = keyRing;
@@ -155,6 +158,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         this.mediatorManager = mediatorManager;
         this.refundAgentManager = refundAgentManager;
         this.daoFacade = daoFacade;
+        this.filterManager = filterManager;
 
         openOfferTradableListStorage = storage;
 
@@ -359,7 +363,8 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 arbitratorManager,
                 tradeStatisticsManager,
                 daoFacade,
-                user);
+                user,
+                filterManager);
         PlaceOfferProtocol placeOfferProtocol = new PlaceOfferProtocol(
                 model,
                 transaction -> {

--- a/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferModel.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/PlaceOfferModel.java
@@ -21,6 +21,7 @@ import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.dao.DaoFacade;
+import bisq.core.filter.FilterManager;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferBookService;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
@@ -51,6 +52,8 @@ public class PlaceOfferModel implements Model {
     private final TradeStatisticsManager tradeStatisticsManager;
     private final DaoFacade daoFacade;
     private final User user;
+    @Getter
+    private final FilterManager filterManager;
 
     // Mutable
     @Setter
@@ -68,7 +71,8 @@ public class PlaceOfferModel implements Model {
                            ArbitratorManager arbitratorManager,
                            TradeStatisticsManager tradeStatisticsManager,
                            DaoFacade daoFacade,
-                           User user) {
+                           User user,
+                           FilterManager filterManager) {
         this.offer = offer;
         this.reservedFundsForOffer = reservedFundsForOffer;
         this.useSavingsWallet = useSavingsWallet;
@@ -80,6 +84,7 @@ public class PlaceOfferModel implements Model {
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.daoFacade = daoFacade;
         this.user = user;
+        this.filterManager = filterManager;
     }
 
     @Override

--- a/core/src/main/java/bisq/core/offer/placeoffer/tasks/CreateMakerFeeTx.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/tasks/CreateMakerFeeTx.java
@@ -25,10 +25,10 @@ import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.btc.wallet.TxBroadcaster;
 import bisq.core.btc.wallet.WalletService;
 import bisq.core.dao.exceptions.DaoDisabledException;
-import bisq.core.dao.governance.param.Param;
 import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.offer.Offer;
 import bisq.core.offer.placeoffer.PlaceOfferModel;
+import bisq.core.util.FeeReceiverSelector;
 
 import bisq.common.UserThread;
 import bisq.common.taskrunner.Task;
@@ -65,7 +65,8 @@ public class CreateMakerFeeTx extends Task<PlaceOfferModel> {
             Address changeAddress = walletService.getFreshAddressEntry().getAddress();
 
             TradeWalletService tradeWalletService = model.getTradeWalletService();
-            String feeReceiver = model.getDaoFacade().getParamValue(Param.RECIPIENT_BTC_ADDRESS);
+
+            String feeReceiver = FeeReceiverSelector.getAddress(model.getDaoFacade(), model.getFilterManager());
 
             if (offer.isCurrencyForMakerFeeBtc()) {
                 tradeWalletService.createBtcTradingFeeTx(

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
@@ -22,9 +22,9 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.btc.wallet.WalletService;
 import bisq.core.dao.exceptions.DaoDisabledException;
-import bisq.core.dao.governance.param.Param;
 import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.tasks.TradeTask;
+import bisq.core.util.FeeReceiverSelector;
 
 import bisq.common.taskrunner.TaskRunner;
 
@@ -65,7 +65,9 @@ public class CreateTakerFeeTx extends TradeTask {
             Address changeAddress = changeAddressEntry.getAddress();
             TradeWalletService tradeWalletService = processModel.getTradeWalletService();
             Transaction transaction;
-            String feeReceiver = processModel.getDaoFacade().getParamValue(Param.RECIPIENT_BTC_ADDRESS);
+
+            String feeReceiver = FeeReceiverSelector.getAddress(processModel.getDaoFacade(), processModel.getFilterManager());
+
             if (trade.isCurrencyForTakerFeeBtc()) {
                 transaction = tradeWalletService.createBtcTradingFeeTx(
                         fundingAddress,

--- a/core/src/main/java/bisq/core/util/FeeReceiverSelector.java
+++ b/core/src/main/java/bisq/core/util/FeeReceiverSelector.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.util;
+
+import bisq.core.dao.DaoFacade;
+import bisq.core.dao.governance.param.Param;
+import bisq.core.filter.Filter;
+import bisq.core.filter.FilterManager;
+
+import java.util.List;
+import java.util.Random;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FeeReceiverSelector {
+    public static String getAddress(DaoFacade daoFacade, FilterManager filterManager) {
+        // We keep default value as fallback in case no filter value is available or user has old version.
+        String feeReceiver = daoFacade.getParamValue(Param.RECIPIENT_BTC_ADDRESS);
+
+        Filter filter = filterManager.getFilter();
+        if (filter != null) {
+            List<String> feeReceivers = filter.getBtcFeeReceiverAddresses();
+            if (feeReceivers != null && !feeReceivers.isEmpty()) {
+                int index = new Random().nextInt(feeReceivers.size());
+                feeReceiver = feeReceivers.get(index);
+            }
+        }
+
+        return feeReceiver;
+    }
+}

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2410,6 +2410,7 @@ filterWindow.disableDaoBelowVersion=Min. version required for DAO
 filterWindow.disableTradeBelowVersion=Min. version required for trading
 filterWindow.add=Add filter
 filterWindow.remove=Remove filter
+filterWindow.btcFeeReceiverAddresses=BTC fee receiver addresses
 
 offerDetailsWindow.minBtcAmount=Min. BTC amount
 offerDetailsWindow.min=(min. {0})

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -111,6 +111,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
         InputTextField arbitratorsInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("filterWindow.arbitrators"));
         InputTextField mediatorsInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("filterWindow.mediators"));
         InputTextField refundAgentsInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("filterWindow.refundAgents"));
+        InputTextField btcFeeReceiverAddressesInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("filterWindow.btcFeeReceiverAddresses"));
         InputTextField seedNodesInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("filterWindow.seedNode"));
         InputTextField priceRelayNodesInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("filterWindow.priceRelayNode"));
         InputTextField btcNodesInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("filterWindow.btcNode"));
@@ -129,6 +130,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
             setupFieldFromList(arbitratorsInputTextField, filter.getArbitrators());
             setupFieldFromList(mediatorsInputTextField, filter.getMediators());
             setupFieldFromList(refundAgentsInputTextField, filter.getRefundAgents());
+            setupFieldFromList(btcFeeReceiverAddressesInputTextField, filter.getBtcFeeReceiverAddresses());
             setupFieldFromList(seedNodesInputTextField, filter.getSeedNodes());
             setupFieldFromList(priceRelayNodesInputTextField, filter.getPriceRelayNodes());
             setupFieldFromList(btcNodesInputTextField, filter.getBtcNodes());
@@ -155,7 +157,8 @@ public class FilterWindow extends Overlay<FilterWindow> {
                             disableDaoBelowVersionInputTextField.getText(),
                             disableTradeBelowVersionInputTextField.getText(),
                             readAsList(mediatorsInputTextField),
-                            readAsList(refundAgentsInputTextField)
+                            readAsList(refundAgentsInputTextField),
+                            readAsList(btcFeeReceiverAddressesInputTextField)
                     ),
                     keyInputTextField.getText())
             )

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -628,6 +628,7 @@ message Filter {
     string disable_trade_below_version = 16;
     repeated string mediators = 17;
     repeated string refundAgents = 18;
+    repeated string btc_fee_receiver_addresses = 19;
 }
 
 // not used anymore from v0.6 on. But leave it for receiving TradeStatistics objects from older


### PR DESCRIPTION
This adds support for distributing trade fees in BTC to a list of addresses defined in the Filter object. The Filter can be set dynamically via the P2P network so it is a fast tool to adjust once the list should be altered. In case no values are provided or the user has not updated the default donation address from the DAO param is used.

This might be an option how we can handle the losses of the victims from the recent security issue. If the idea finds support among Bisq contributors and is accepted by the victims this would be a way how they get reimbursed over a period of time from the trade fees paid by users who use BTC instead of BSQ.  

The selection is a simple random selection, so it would benefit those victims with smaller losses to get refunded earlier. We could alter the algorithm by using the index in the list as weight, so the first items have higher chances to get selected and thus create a more fair payout schedule. I leave this for a future addition if the idea finds support.