### PR TITLE
Unfail with reattach

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -115,6 +115,7 @@ public class Config {
     public static final String GENESIS_TOTAL_SUPPLY = "genesisTotalSupply";
     public static final String DAO_ACTIVATED = "daoActivated";
     public static final String DUMP_DELAYED_PAYOUT_TXS = "dumpDelayedPayoutTxs";
+    public static final String ALLOW_FAULTY_DELAYED_TXS = "allowFaultyDelayedTxs";
 
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
@@ -197,6 +198,7 @@ public class Config {
     public final int genesisBlockHeight;
     public final long genesisTotalSupply;
     public final boolean dumpDelayedPayoutTxs;
+    public final boolean allowFaultyDelayedTxs;
 
     // Properties derived from options but not exposed as options themselves
     public final File torDir;
@@ -606,6 +608,13 @@ public class Config {
                         .ofType(boolean.class)
                         .defaultsTo(false);
 
+        ArgumentAcceptingOptionSpec<Boolean> allowFaultyDelayedTxsOpt =
+                parser.accepts(ALLOW_FAULTY_DELAYED_TXS, "Allow completion of trades with faulty delayed " +
+                        "payout transactions")
+                        .withRequiredArg()
+                        .ofType(boolean.class)
+                        .defaultsTo(true);
+
         try {
             CompositeOptionSet options = new CompositeOptionSet();
 
@@ -717,6 +726,7 @@ public class Config {
             this.genesisTotalSupply = options.valueOf(genesisTotalSupplyOpt);
             this.daoActivated = options.valueOf(daoActivatedOpt);
             this.dumpDelayedPayoutTxs = options.valueOf(dumpDelayedPayoutTxsOpt);
+            this.allowFaultyDelayedTxs = options.valueOf(allowFaultyDelayedTxsOpt);
         } catch (OptionException ex) {
             throw new ConfigException("problem parsing option '%s': %s",
                     ex.options().get(0),

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -613,7 +613,7 @@ public class Config {
                         "payout transactions")
                         .withRequiredArg()
                         .ofType(boolean.class)
-                        .defaultsTo(true);
+                        .defaultsTo(false);
 
         try {
             CompositeOptionSet options = new CompositeOptionSet();

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -598,6 +598,13 @@ public class BtcWalletService extends WalletService {
         return entry;
     }
 
+    public AddressEntry recoverAddressEntry(String offerId, String address, AddressEntry.Context context) {
+        var available = findAddressEntry(address, AddressEntry.Context.AVAILABLE);
+        if (!available.isPresent())
+            return null;
+        return addressEntryList.swapAvailableToAddressEntryWithOfferId(available.get(), context, offerId);
+    }
+
     private AddressEntry getOrCreateAddressEntry(AddressEntry.Context context, Optional<AddressEntry> addressEntry) {
         if (addressEntry.isPresent()) {
             return addressEntry.get();

--- a/core/src/main/java/bisq/core/trade/DelayedPayoutTxValidation.java
+++ b/core/src/main/java/bisq/core/trade/DelayedPayoutTxValidation.java
@@ -58,6 +58,12 @@ public class DelayedPayoutTxValidation {
         }
     }
 
+    public static class AmountMismatchException extends Exception {
+        AmountMismatchException(String msg) {
+            super(msg);
+        }
+    }
+
     public static class InvalidLockTimeException extends Exception {
         InvalidLockTimeException(String msg) {
             super(msg);
@@ -69,7 +75,7 @@ public class DelayedPayoutTxValidation {
                                         DaoFacade daoFacade,
                                         BtcWalletService btcWalletService)
             throws DonationAddressException, MissingDelayedPayoutTxException,
-            InvalidTxException, InvalidLockTimeException {
+            InvalidTxException, InvalidLockTimeException, AmountMismatchException {
         String errorMsg;
         if (delayedPayoutTx == null) {
             errorMsg = "DelayedPayoutTx must not be null";
@@ -122,7 +128,7 @@ public class DelayedPayoutTxValidation {
             errorMsg = "Output value of deposit tx and delayed payout tx is not matching. Output: " + output + " / msOutputAmount: " + msOutputAmount;
             log.error(errorMsg);
             log.error(delayedPayoutTx.toString());
-            throw new InvalidTxException(errorMsg);
+            throw new AmountMismatchException(errorMsg);
         }
 
 

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -312,6 +312,8 @@ public class TradeManager implements PersistedDataHost {
                         log.warn("We move the trade with ID '{}' to failed trades because of exception {}",
                                 trade.getId(), e.getMessage());
                         addTradeToFailedTradesList.add(trade);
+                    } catch (DelayedPayoutTxValidation.AmountMismatchException e) {
+                        log.warn("Delayed payout tx exception, trade {}, exception {}", trade.getId(), e.getMessage());
                     }
                 }
         );

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -283,10 +283,7 @@ public class TradeManager implements PersistedDataHost {
         tradableList.forEach(trade -> {
                     if (trade.isDepositPublished() ||
                             (trade.isTakerFeePublished() && !trade.hasFailed())) {
-                        initTrade(trade, trade.getProcessModel().isUseSavingsWallet(),
-                                trade.getProcessModel().getFundsNeededForTradeAsLong());
-                        trade.updateDepositTxFromWallet();
-                        tradesForStatistics.add(trade);
+                        initPendingTrade(trade);
                     } else if (trade.isTakerFeePublished() && !trade.isFundsLockedIn()) {
                         addTradeToFailedTradesList.add(trade);
                         trade.appendErrorMessage("Invalid state: trade.isTakerFeePublished() && !trade.isFundsLockedIn()");
@@ -338,6 +335,13 @@ public class TradeManager implements PersistedDataHost {
         cleanUpAddressEntries();
 
         pendingTradesInitialized.set(true);
+    }
+
+    private void initPendingTrade(Trade trade) {
+        initTrade(trade, trade.getProcessModel().isUseSavingsWallet(),
+                trade.getProcessModel().getFundsNeededForTradeAsLong());
+        trade.updateDepositTxFromWallet();
+        tradesForStatistics.add(trade);
     }
 
     private void onTradesChanged() {
@@ -613,6 +617,8 @@ public class TradeManager implements PersistedDataHost {
             log.warn("Failed to recover address during unfail trade");
             return false;
         }
+
+        initPendingTrade(trade);
 
         if (!tradableList.contains(trade)) {
             tradableList.add(trade);

--- a/core/src/main/java/bisq/core/trade/TradeModule.java
+++ b/core/src/main/java/bisq/core/trade/TradeModule.java
@@ -33,6 +33,7 @@ import bisq.common.config.Config;
 
 import com.google.inject.Singleton;
 
+import static bisq.common.config.Config.ALLOW_FAULTY_DELAYED_TXS;
 import static bisq.common.config.Config.DUMP_DELAYED_PAYOUT_TXS;
 import static bisq.common.config.Config.DUMP_STATISTICS;
 import static com.google.inject.name.Names.named;
@@ -58,5 +59,6 @@ public class TradeModule extends AppModule {
         bind(AssetTradeActivityCheck.class).in(Singleton.class);
         bindConstant().annotatedWith(named(DUMP_STATISTICS)).to(config.dumpStatistics);
         bindConstant().annotatedWith(named(DUMP_DELAYED_PAYOUT_TXS)).to(config.dumpDelayedPayoutTxs);
+        bindConstant().annotatedWith(named(ALLOW_FAULTY_DELAYED_TXS)).to(config.allowFaultyDelayedTxs);
     }
 }

--- a/core/src/main/java/bisq/core/trade/TradeUtils.java
+++ b/core/src/main/java/bisq/core/trade/TradeUtils.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade;
+
+import bisq.core.btc.wallet.BtcWalletService;
+
+import bisq.common.crypto.KeyRing;
+import bisq.common.util.Tuple2;
+import bisq.common.util.Utilities;
+
+import java.util.Objects;
+
+public class TradeUtils {
+
+    // Returns <MULTI_SIG, TRADE_PAYOUT> if both are AVAILABLE, otherwise null
+    static Tuple2<String, String> getAvailableAddresses(Trade trade, BtcWalletService btcWalletService,
+                                                        KeyRing keyRing) {
+        var addresses = getTradeAddresses(trade, btcWalletService, keyRing);
+        if (addresses == null)
+            return null;
+
+        if (btcWalletService.getAvailableAddressEntries().stream()
+                .noneMatch(e -> Objects.equals(e.getAddressString(), addresses.first)))
+            return null;
+        if (btcWalletService.getAvailableAddressEntries().stream()
+                .noneMatch(e -> Objects.equals(e.getAddressString(), addresses.second)))
+            return null;
+
+        return new Tuple2<>(addresses.first, addresses.second);
+    }
+
+    // Returns <MULTI_SIG, TRADE_PAYOUT> addresses as strings if they're known by the wallet
+    public static Tuple2<String, String> getTradeAddresses(Trade trade, BtcWalletService btcWalletService,
+                                                           KeyRing keyRing) {
+        var contract = trade.getContract();
+        if (contract == null)
+            return null;
+
+        // Get multisig address
+        var isMyRoleBuyer = contract.isMyRoleBuyer(keyRing.getPubKeyRing());
+        var multiSigPubKey = isMyRoleBuyer ? contract.getBuyerMultiSigPubKey() : contract.getSellerMultiSigPubKey();
+        if (multiSigPubKey == null)
+            return null;
+        var multiSigPubKeyString = Utilities.bytesAsHexString(multiSigPubKey);
+        var multiSigAddress = btcWalletService.getAddressEntryListAsImmutableList().stream()
+                .filter(e -> e.getKeyPair().getPublicKeyAsHex().equals(multiSigPubKeyString))
+                .findAny()
+                .orElse(null);
+        if (multiSigAddress == null)
+            return null;
+
+        // Get payout address
+        var payoutAddress = isMyRoleBuyer ?
+                contract.getBuyerPayoutAddressString() : contract.getSellerPayoutAddressString();
+        var payoutAddressEntry = btcWalletService.getAddressEntryListAsImmutableList().stream()
+                .filter(e -> Objects.equals(e.getAddressString(), payoutAddress))
+                .findAny()
+                .orElse(null);
+        if (payoutAddressEntry == null)
+            return null;
+
+        return new Tuple2<>(multiSigAddress.getAddressString(), payoutAddress);
+    }
+}

--- a/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
+++ b/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
@@ -26,11 +26,14 @@ import bisq.core.trade.TradableList;
 import bisq.core.trade.Trade;
 import bisq.core.trade.TradeUtils;
 
+import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
 import bisq.common.proto.persistable.PersistedDataHost;
 import bisq.common.storage.Storage;
 
 import com.google.inject.Inject;
+
+import javax.inject.Named;
 
 import javafx.collections.ObservableList;
 
@@ -109,6 +112,7 @@ public class FailedTradesManager implements PersistedDataHost {
             return;
 
         if (unfailTradeCallback.apply(trade)) {
+            log.info("Unfailing trade {}", trade.getId());
             failedTrades.remove(trade);
         }
     }

--- a/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
+++ b/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
@@ -33,10 +33,13 @@ import com.google.inject.Inject;
 import javafx.collections.ObservableList;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import lombok.Setter;
 
 public class FailedTradesManager implements PersistedDataHost {
     private static final Logger log = LoggerFactory.getLogger(FailedTradesManager.class);
@@ -46,6 +49,8 @@ public class FailedTradesManager implements PersistedDataHost {
     private final BtcWalletService btcWalletService;
     private final Storage<TradableList<Trade>> tradableListStorage;
     private final DumpDelayedPayoutTx dumpDelayedPayoutTx;
+    @Setter
+    private Consumer<Trade> unfailTradeCallback;
 
     @Inject
     public FailedTradesManager(KeyRing keyRing,
@@ -95,5 +100,11 @@ public class FailedTradesManager implements PersistedDataHost {
     public Stream<Trade> getTradesStreamWithFundsLockedIn() {
         return failedTrades.stream()
                 .filter(Trade::isFundsLockedIn);
+    }
+
+    public void unfailTrade(Trade trade) {
+        if (unfailTradeCallback == null) return;
+        unfailTradeCallback.accept(trade);
+        failedTrades.remove(trade);
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerVerifiesFinalDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerVerifiesFinalDelayedPayoutTx.java
@@ -50,7 +50,8 @@ public class BuyerVerifiesFinalDelayedPayoutTx extends TradeTask {
         } catch (DelayedPayoutTxValidation.DonationAddressException |
                 DelayedPayoutTxValidation.MissingDelayedPayoutTxException |
                 DelayedPayoutTxValidation.InvalidTxException |
-                DelayedPayoutTxValidation.InvalidLockTimeException e) {
+                DelayedPayoutTxValidation.InvalidLockTimeException |
+                DelayedPayoutTxValidation.AmountMismatchException e) {
             failed(e.getMessage());
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerVerifiesPreparedDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerVerifiesPreparedDelayedPayoutTx.java
@@ -46,7 +46,8 @@ public class BuyerVerifiesPreparedDelayedPayoutTx extends TradeTask {
         } catch (DelayedPayoutTxValidation.DonationAddressException |
                 DelayedPayoutTxValidation.MissingDelayedPayoutTxException |
                 DelayedPayoutTxValidation.InvalidTxException |
-                DelayedPayoutTxValidation.InvalidLockTimeException e) {
+                DelayedPayoutTxValidation.InvalidLockTimeException |
+                DelayedPayoutTxValidation.AmountMismatchException e) {
             failed(e.getMessage());
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -859,8 +859,11 @@ portfolio.closed.ticketClosed=Arbitrated
 portfolio.closed.mediationTicketClosed=Mediated
 portfolio.closed.canceled=Canceled
 portfolio.failed.Failed=Failed
-portfolio.failed.unfail=Do you want to move this trade back to pending trades? \
-  Only do this if you need to open a support ticket.
+portfolio.failed.unfail=Before proceeding, make sure you have a backup of your data directory!\n\
+  Do you want to move this trade back to open trades?\n\
+  This is a way to unlock funds stuck in a failed trade.
+portfolio.failed.cantUnfail=This trade cannot be moved back to open trades at the moment. \n\
+  Try again after completion of trade(s) {0}
 
 
 ####################################################################

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -864,6 +864,8 @@ portfolio.failed.unfail=Before proceeding, make sure you have a backup of your d
   This is a way to unlock funds stuck in a failed trade.
 portfolio.failed.cantUnfail=This trade cannot be moved back to open trades at the moment. \n\
   Try again after completion of trade(s) {0}
+portfolio.failed.depositTxNull=The trade cannot be completed. Deposit transaction is null
+portfolio.failed.delayedPayoutTxNull=The trade cannot be completed. Delayed payout transaction is null
 
 
 ####################################################################

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -791,6 +791,8 @@ portfolio.pending.error.depositTxNull=The deposit transaction is null. You canno
   For further help please contact the Bisq support channel at the Bisq Keybase team.
 portfolio.pending.mediationResult.error.depositTxNull=The deposit transaction is null. The trade gets moved to the \
   failed trades section.
+portfolio.pending.mediationResult.error.delayedPayoutTxNull=The delayed payout transaction is null. The trade gets \
+   moved to the failed trades section.
 portfolio.pending.error.depositTxNotConfirmed=The deposit transaction is not confirmed. You can not open an arbitration dispute \
   with an unconfirmed deposit transaction. Please wait until it is confirmed or go to \"Settings/Network info\" and do a SPV resync.\n\n\
   For further help please contact the Bisq support channel at the Bisq Keybase team.

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -859,6 +859,8 @@ portfolio.closed.ticketClosed=Arbitrated
 portfolio.closed.mediationTicketClosed=Mediated
 portfolio.closed.canceled=Canceled
 portfolio.failed.Failed=Failed
+portfolio.failed.unfail=Do you want to move this trade back to pending trades? \
+  Only do this if you need to open a support ticket.
 
 
 ####################################################################

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -557,9 +557,8 @@ portfolio.tab.history=History
 portfolio.tab.failed=Failed
 portfolio.tab.editOpenOffer=Edit offer
 
-portfolio.pending.invalidDelayedPayoutTx=The donation address in the delayed payout transaction is invalid.\n\n\
-  Please do NOT send the Altcoin or Fiat payment but contact the Bisq developers at 'https://bisq.community' or \
-  the Keybase channel.\n\n\
+portfolio.pending.invalidDelayedPayoutTx=Please do NOT send the Altcoin or Fiat payment but contact the Bisq \
+  developers at 'https://bisq.community' or the Keybase channel.\n\n\
   {0}
 
 portfolio.pending.step1.waitForConf=Wait for blockchain confirmation

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
@@ -74,4 +74,7 @@ class FailedTradesDataModel extends ActivatableDataModel {
         list.sort((o1, o2) -> o2.getTrade().getDate().compareTo(o1.getTrade().getDate()));
     }
 
+    public void unfailTrade(Trade trade) {
+        failedTradesManager.unfailTrade(trade);
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
@@ -77,4 +77,8 @@ class FailedTradesDataModel extends ActivatableDataModel {
     public void unfailTrade(Trade trade) {
         failedTradesManager.unfailTrade(trade);
     }
+
+    public String checkUnfail(Trade trade) {
+        return failedTradesManager.checkUnfail(trade);
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -21,21 +21,30 @@ import bisq.desktop.common.view.ActivatableViewAndModel;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.HyperlinkWithIcon;
+import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
 
 import bisq.core.locale.Res;
+import bisq.core.trade.Trade;
+
+import bisq.common.util.Utilities;
 
 import javax.inject.Inject;
 
 import javafx.fxml.FXML;
 
+import javafx.scene.Scene;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.VBox;
 
 import javafx.beans.property.ReadOnlyObjectWrapper;
+
+import javafx.event.EventHandler;
 
 import javafx.collections.transformation.SortedList;
 
@@ -53,6 +62,8 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
             marketColumn, directionColumn, dateColumn, tradeIdColumn, stateColumn;
     private final TradeDetailsWindow tradeDetailsWindow;
     private SortedList<FailedTradesListItem> sortedList;
+    private EventHandler<KeyEvent> keyEventEventHandler;
+    private Scene scene;
 
     @Inject
     public FailedTradesView(FailedTradesViewModel model, TradeDetailsWindow tradeDetailsWindow) {
@@ -95,10 +106,28 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
         dateColumn.setSortType(TableColumn.SortType.DESCENDING);
         tableView.getSortOrder().add(dateColumn);
 
+        keyEventEventHandler = keyEvent -> {
+            if (Utilities.isAltOrCtrlPressed(KeyCode.Y, keyEvent)) {
+                new Popup().warning(Res.get("portfolio.failed.unfail"))
+                        .onAction(this::onUnfail)
+                        .show();
+            }
+        };
+
+    }
+
+    private void onUnfail() {
+        Trade trade = sortedList.get(tableView.getSelectionModel().getFocusedIndex()).getTrade();
+        model.dataModel.unfailTrade(trade);
+
     }
 
     @Override
     protected void activate() {
+        scene = root.getScene();
+        if (scene != null) {
+            scene.addEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
+        }
         sortedList = new SortedList<>(model.getList());
         sortedList.comparatorProperty().bind(tableView.comparatorProperty());
         tableView.setItems(sortedList);
@@ -106,6 +135,9 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
 
     @Override
     protected void deactivate() {
+        if (scene != null) {
+            scene.removeEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
+        }
         sortedList.comparatorProperty().unbind();
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -123,7 +123,6 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
                 }
             }
         };
-
     }
 
     private void onUnfail() {
@@ -141,7 +140,7 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
         if (trade.getDepositTx() == null) {
             return Res.get("portfolio.failed.depositTxNull");
         }
-        if (trade.getDelayedPayoutTx() == null) {
+        if (trade.getDelayedPayoutTxBytes() == null) {
             return Res.get("portfolio.failed.delayedPayoutTxNull");
         }
         return "";

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -108,9 +108,16 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
 
         keyEventEventHandler = keyEvent -> {
             if (Utilities.isAltOrCtrlPressed(KeyCode.Y, keyEvent)) {
-                new Popup().warning(Res.get("portfolio.failed.unfail"))
-                        .onAction(this::onUnfail)
-                        .show();
+                var checkUnfailString = checkUnfail();
+                if (!checkUnfailString.isEmpty()) {
+                    new Popup().warning(Res.get("portfolio.failed.cantUnfail", checkUnfailString))
+                            .onAction(this::onUnfail)
+                            .show();
+                } else {
+                    new Popup().warning(Res.get("portfolio.failed.unfail"))
+                            .onAction(this::onUnfail)
+                            .show();
+                }
             }
         };
 
@@ -119,6 +126,11 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private void onUnfail() {
         Trade trade = sortedList.get(tableView.getSelectionModel().getFocusedIndex()).getTrade();
         model.dataModel.unfailTrade(trade);
+    }
+
+    private String checkUnfail() {
+        Trade trade = sortedList.get(tableView.getSelectionModel().getFocusedIndex()).getTrade();
+        return model.dataModel.checkUnfail(trade);
 
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -108,10 +108,13 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
 
         keyEventEventHandler = keyEvent -> {
             if (Utilities.isAltOrCtrlPressed(KeyCode.Y, keyEvent)) {
+                var checkTxs = checkTxs();
                 var checkUnfailString = checkUnfail();
-                if (!checkUnfailString.isEmpty()) {
+                if (!checkTxs.isEmpty()) {
+                    new Popup().warning(checkTxs)
+                            .show();
+                } else if (!checkUnfailString.isEmpty()) {
                     new Popup().warning(Res.get("portfolio.failed.cantUnfail", checkUnfailString))
-                            .onAction(this::onUnfail)
                             .show();
                 } else {
                     new Popup().warning(Res.get("portfolio.failed.unfail"))
@@ -131,7 +134,17 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
     private String checkUnfail() {
         Trade trade = sortedList.get(tableView.getSelectionModel().getFocusedIndex()).getTrade();
         return model.dataModel.checkUnfail(trade);
+    }
 
+    private String checkTxs() {
+        Trade trade = sortedList.get(tableView.getSelectionModel().getFocusedIndex()).getTrade();
+        if (trade.getDepositTx() == null) {
+            return Res.get("portfolio.failed.depositTxNull");
+        }
+        if (trade.getDelayedPayoutTx() == null) {
+            return Res.get("portfolio.failed.delayedPayoutTxNull");
+        }
+        return "";
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -591,6 +591,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
             resultHandler = () -> navigation.navigateTo(MainView.class, SupportView.class, RefundClientView.class);
 
             if (trade.getDelayedPayoutTx() == null) {
+                log.error("Delayed payout tx is missing");
                 return;
             }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -522,11 +522,16 @@ public abstract class TradeStepView extends AnchorPane {
             return;
         }
 
-        if (trade.getDepositTx() == null || trade.getDelayedPayoutTx() == null) {
-            log.error("trade.getDepositTx() or trade.getDelayedPayoutTx() was null at openMediationResultPopup. " +
+        if (trade.getDepositTx() == null) {
+            log.error("trade.getDepositTx() was null at openMediationResultPopup. " +
                     "We add the trade to failed trades. TradeId={}", trade.getId());
             model.dataModel.addTradeToFailedTrades();
             new Popup().warning(Res.get("portfolio.pending.mediationResult.error.depositTxNull")).show();
+            return;
+        } else if (trade.getDelayedPayoutTx() == null) {
+            log.error("trade.getDelayedPayoutTx() was null at openMediationResultPopup. " +
+                    "We add the trade to failed trades. TradeId={}", trade.getId());
+            new Popup().warning(Res.get("portfolio.pending.mediationResult.error.delayedPayoutTxNull")).show();
             return;
         }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep1View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep1View.java
@@ -45,11 +45,16 @@ public class BuyerStep1View extends TradeStepView {
                     model.dataModel.btcWalletService);
         } catch (DelayedPayoutTxValidation.DonationAddressException |
                 DelayedPayoutTxValidation.InvalidTxException |
+//                DelayedPayoutTxValidation.AmountMismatchException | // todo activate june 2020
                 DelayedPayoutTxValidation.InvalidLockTimeException e) {
             new Popup().warning(Res.get("portfolio.pending.invalidDelayedPayoutTx", e.getMessage())).show();
-        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException ignore) {
+        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException |
+                DelayedPayoutTxValidation.AmountMismatchException ignore) {
             // We don't react on those errors as a failed trade might get listed initially but getting removed from the
             // trade manager after initPendingTrades which happens after activate might be called.
+
+            // Allow amount mismatch until june 2020 to get trades through as it's due to a bug that has now been fixed.
+            // No new trades with mismatch can be created after v1.3.1
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep1View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep1View.java
@@ -45,16 +45,14 @@ public class BuyerStep1View extends TradeStepView {
                     model.dataModel.btcWalletService);
         } catch (DelayedPayoutTxValidation.DonationAddressException |
                 DelayedPayoutTxValidation.InvalidTxException |
-//                DelayedPayoutTxValidation.AmountMismatchException | // todo activate june 2020
+                DelayedPayoutTxValidation.AmountMismatchException |
                 DelayedPayoutTxValidation.InvalidLockTimeException e) {
-            new Popup().warning(Res.get("portfolio.pending.invalidDelayedPayoutTx", e.getMessage())).show();
-        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException |
-                DelayedPayoutTxValidation.AmountMismatchException ignore) {
+            if (!model.dataModel.tradeManager.isAllowFaultyDelayedTxs()) {
+                new Popup().warning(Res.get("portfolio.pending.invalidDelayedPayoutTx", e.getMessage())).show();
+            }
+        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException ignore) {
             // We don't react on those errors as a failed trade might get listed initially but getting removed from the
             // trade manager after initPendingTrades which happens after activate might be called.
-
-            // Allow amount mismatch until june 2020 to get trades through as it's due to a bug that has now been fixed.
-            // No new trades with mismatch can be created after v1.3.1
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -122,11 +122,16 @@ public class BuyerStep2View extends TradeStepView {
                     model.dataModel.btcWalletService);
         } catch (DelayedPayoutTxValidation.DonationAddressException |
                 DelayedPayoutTxValidation.InvalidTxException |
+//                DelayedPayoutTxValidation.AmountMismatchException | // todo activate june 2020
                 DelayedPayoutTxValidation.InvalidLockTimeException e) {
             new Popup().warning(Res.get("portfolio.pending.invalidDelayedPayoutTx", e.getMessage())).show();
-        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException ignore) {
+        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException |
+                DelayedPayoutTxValidation.AmountMismatchException ignore) {
             // We don't react on those errors as a failed trade might get listed initially but getting removed from the
             // trade manager after initPendingTrades which happens after activate might be called.
+
+            // Allow amount mismatch until june 2020 to get trades through as it's due to a bug that has now been fixed.
+            // No new trades with mismatch can be created after v1.3.1
         }
 
         if (timeoutTimer != null)

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -122,16 +122,14 @@ public class BuyerStep2View extends TradeStepView {
                     model.dataModel.btcWalletService);
         } catch (DelayedPayoutTxValidation.DonationAddressException |
                 DelayedPayoutTxValidation.InvalidTxException |
-//                DelayedPayoutTxValidation.AmountMismatchException | // todo activate june 2020
+                DelayedPayoutTxValidation.AmountMismatchException |
                 DelayedPayoutTxValidation.InvalidLockTimeException e) {
-            new Popup().warning(Res.get("portfolio.pending.invalidDelayedPayoutTx", e.getMessage())).show();
-        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException |
-                DelayedPayoutTxValidation.AmountMismatchException ignore) {
+            if (!model.dataModel.tradeManager.isAllowFaultyDelayedTxs()) {
+                new Popup().warning(Res.get("portfolio.pending.invalidDelayedPayoutTx", e.getMessage())).show();
+            }
+        } catch (DelayedPayoutTxValidation.MissingDelayedPayoutTxException ignore) {
             // We don't react on those errors as a failed trade might get listed initially but getting removed from the
             // trade manager after initPendingTrades which happens after activate might be called.
-
-            // Allow amount mismatch until june 2020 to get trades through as it's due to a bug that has now been fixed.
-            // No new trades with mismatch can be created after v1.3.1
         }
 
         if (timeoutTimer != null)


### PR DESCRIPTION
Unfail trades from failed tab with ctrl+y

A check is done if the trade can be unfailed, first by checking that it has the required txs (deposittx and delayedpayouttx) and that the addresses needed are available. If they are the trade is moved to pending trades and the addresses tagged appropriately to allow for mediation or normal completion of the trade.
