### PR TITLE
Limit MaxRAM for all java apps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,11 +137,9 @@ configure([project(':cli'),
             unixScriptFile.text = unixScriptFile.text.replace(
                 'cd "`dirname \\"$PRG\\"`/.." >/dev/null', 'cd "`dirname \\"$PRG\\"`" >/dev/null')
 
-            if (applicationName == 'desktop') {
-                def script = file("${rootProject.projectDir}/bisq-$applicationName")
-                script.text = script.text.replace(
-                    'DEFAULT_JVM_OPTS=""', 'DEFAULT_JVM_OPTS="-XX:MaxRAM=4g"')
-            }
+            def script = file("${rootProject.projectDir}/bisq-$applicationName")
+            script.text = script.text.replace(
+                'DEFAULT_JVM_OPTS=""', 'DEFAULT_JVM_OPTS="-XX:MaxRAM=4g"')
 
             if (osdetector.os != 'windows')
                 delete fileTree(dir: rootProject.projectDir, include: 'bisq-*.bat')


### PR DESCRIPTION
Setting DEFAULT_JVM_OPTS="-XX:MaxRAM=4g" in bisq-desktop has not
resulted in any reported issues, so this jvm option can be used in other
launch scripts to reduce the amount of memory reserved by headless
apps.  This change is based on the assumption none of the headless
apps require as much memory as desktop.
