### PR TITLE
Migrate expect based rpc test suite to bats

### DIFF
--- a/cli/test.sh
+++ b/cli/test.sh
@@ -1,156 +1,82 @@
-#!/bin/bash
+#!/usr/bin/env bats
 #
-# References & examples for expect:
+# bats v0.4.0 project
 #
-#  - https://pantz.org/software/expect/expect_examples_and_tips.html
-#  - https://stackoverflow.com/questions/13982310/else-string-matching-in-expect
-#  - https://gist.github.com/Fluidbyte/6294378
-#  - https://www.oreilly.com/library/view/exploring-expect/9781565920903/ch04.html
+#  https://github.com/sstephenson/bats/tree/v0.4.0
 #
 # Prior to running this script, run:
 #
 #     ./bisq-daemon --apiPassword=xyz
 #
+# To run this script:
+#
+#	  cd <project-root-dir>
+#	  bats cli/test.sh
+#
 # The data directory used must contain an unencrypted wallet with a 0 BTC balance
 
-# Ensure project root is the current working directory
-cd $(dirname $0)/..
+@test "test unsupported method error" {
+  run ./bisq-cli --password=xyz bogus
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2  # printed only on test failure
+  [ "$output" = "Error: 'bogus' is not a supported method" ]
+}
 
-OUTPUT=$(expect -c '
-    # exp_internal 1
-    puts "TEST unsupported cmd error"
-    set expected "Error: '\''bogus'\'' is not a supported method"
-    spawn ./bisq-cli --password=xyz bogus
-    expect {
-        $expected { puts "PASS" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test unrecognized option error" {
+  run ./bisq-cli --bogus getversion
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: bogus is not a recognized option" ]
+}
 
-OUTPUT=$(expect -c '
-    puts "TEST unrecognized option error"
-    set expected "Error: bogus is not a recognized option"
-    spawn ./bisq-cli --bogus getversion
-    expect {
-        $expected { puts "PASS" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test missing required password option error" {
+  run ./bisq-cli getversion
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: missing required 'password' option" ]
+}
 
-OUTPUT=$(expect -c '
-    # exp_internal 1
-    puts "TEST missing required password option error"
-    set expected "Error: missing required '\''password'\'' option"
-    spawn ./bisq-cli getversion
-    expect {
-        $expected { puts "PASS" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test incorrect password error" {
+  run ./bisq-cli --password=bogus getversion
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: incorrect 'password' rpc header value" ]
+}
 
-OUTPUT=$(expect -c '
-    # exp_internal 1
-    puts "TEST getversion (incorrect password error)"
-    set expected "Error: incorrect '\''password'\'' rpc header value"
-    spawn ./bisq-cli --password=bogus getversion
-    expect {
-        $expected { puts "PASS\n" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test getversion call with quoted password" {
+  run ./bisq-cli --password="xyz" getversion
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "1.3.2" ]
+}
 
-OUTPUT=$(expect -c '
-    # exp_internal 1
-    puts "TEST getversion (password value in quotes)"
-    set expected "1.3.2"
-    # Note: have to define quoted argument in a variable as "''value''"
-    set pwd_in_quotes "''xyz''"
-    spawn ./bisq-cli --password=$pwd_in_quotes getversion
-    expect {
-        $expected { puts "PASS" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test getversion" {
+  run ./bisq-cli --password=xyz getversion
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "1.3.2" ]
+}
 
-OUTPUT=$(expect -c '
-    puts "TEST getversion"
-    set expected "1.3.2"
-    spawn ./bisq-cli --password=xyz getversion
-    expect {
-        $expected { puts "PASS" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test getbalance (available & unlocked wallet with 0 btc balance)" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "0.00000000" ]
+}
 
-OUTPUT=$(expect -c '
-    puts "TEST getbalance"
-    # exp_internal 1
-    set expected "0.00000000"
-    spawn ./bisq-cli --password=xyz getbalance
-    expect {
-        $expected { puts "PASS" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test help displayed on stderr if no options or arguments" {
+  run ./bisq-cli
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" = "Bisq RPC Client" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  # TODO add asserts after help text is modified for new endpoints
+}
 
-OUTPUT=$(expect -c '
-    puts "TEST running with no options or arguments prints help text"
-    # exp_internal 1
-    set expected "Bisq RPC Client"
-    spawn ./bisq-cli
-    expect {
-        $expected { puts "PASS" }
-        default {
-            set results $expect_out(buffer)
-            puts "FAIL expected = $expected"
-            puts "       actual = $results"
-        }
-    }
-')
-echo "$OUTPUT"
-echo "========================================================================"
+@test "test --help option" {
+  run ./bisq-cli --help
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "Bisq RPC Client" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  # TODO add asserts after help text is modified for new endpoints
+}
 
-echo "TEST --help option prints help text"
-./bisq-cli --help

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -10,8 +10,8 @@
 #
 # To run this script:
 #
-#	  cd <project-root-dir>
-#	  bats cli/test.sh
+#     cd <project-root-dir>
+#     bats cli/test.sh
 #
 # The data directory used must contain an unencrypted wallet with a 0 BTC balance
 
@@ -79,4 +79,3 @@
   [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
   # TODO add asserts after help text is modified for new endpoints
 }
-

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bats
 #
-# bats v0.4.0 project
+# Integration tests for bisq-cli running against a live bisq-daemon
 #
-#  https://github.com/sstephenson/bats/tree/v0.4.0
+# Prerequisites:
 #
-# Prior to running this script, run:
+#  - bats v0.4.0 must be installed (brew install bats on macOS)
+#    see https://github.com/sstephenson/bats/tree/v0.4.0
 #
-#     ./bisq-daemon --apiPassword=xyz
+#  - Run `./bisq-daemon --apiPassword=xyz --appDataDir=$TESTDIR` where $TESTDIR
+#    is empty or otherwise contains an unencrypted wallet with a 0 BTC balance
 #
-# To run this script:
+# Usage:
 #
-#     cd <project-root-dir>
-#     bats cli/test.sh
+#  This script must be run from the root of the project, e.g.:
 #
-# The data directory used must contain an unencrypted wallet with a 0 BTC balance
+#     ./cli/test.sh
 
 @test "test unsupported method error" {
   run ./bisq-cli --password=xyz bogus


### PR DESCRIPTION
The [bats](https://github.com/sstephenson/bats) automated bash testing system is more concise and easier to work with than the older `tcl - expect` based test program.  