### PR TITLE
Add link to Lombok plugin in IDEA setup guide

### DIFF
--- a/docs/idea-import.md
+++ b/docs/idea-import.md
@@ -4,7 +4,7 @@ Most Bisq contributors use IDEA for development. The following instructions have
 
  1. Follow the instructions in [build.md](build.md) to clone and build Bisq at the command line.
  1. Open IDEA
- 1. Go to `Preferences->Plugins` (`File->Settings, Plugins for Windows`). Search for and install the _Lombok_ plugin. When prompted, do not restart IDEA.
+ 1. Go to `Preferences->Plugins` (`File->Settings, Plugins for Windows`). Search for and install the _Lombok_ plugin. (See [here](https://plugins.jetbrains.com/plugin/6317-lombok) if not found in Marketplace.) When prompted, do not restart IDEA.
  1. Go to `Preferences->Build, Execution, Deployment->Compiler->Annotation Processors` and check the `Enable annotation processing` option (to enable processing of Lombok annotations)
  1. Restart IDEA
  1. Go to `Import Project`, select the `settings.gradle` file and click `Open`


### PR DESCRIPTION
In the latest version of IDEA (2020.1), the Lombok plugin could not be found via the Plugins menu, as per the setup guide.

Apparently there were some incompatibilities between the latest versions of the plugin / of IDEA, which lead to it appearing as incompatible with this version.

Therefore, I added a link to the plugin's page (JetBrains Plugin Repository). The linked page contains the plugin changelog (describing the version incompatibility + fix). It also contains a top-right button called "Install to IDE", which properly installs the plugin in IDEA 2020.1.