### PR TITLE
Fix proof-of-burn signing for password protected wallets

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
@@ -199,7 +199,9 @@ public class ProofOfBurnService implements DaoSetupService, DaoStateListener {
             return Optional.empty();
 
         try {
-            String signatureBase64 = key.signMessage(message);
+            String signatureBase64 = bsqWalletService.isEncrypted()
+                    ? key.signMessage(message, bsqWalletService.getAesKey())
+                    : key.signMessage(message);
             return Optional.of(signatureBase64);
         } catch (Throwable t) {
             log.error(t.toString());


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Add a missing `bsqWalletService.isEncrypted()` check and optional AES key argument to the `signMessage(..)` call in `ProofOfBurnService`, analogous to the BitcoinJ call to sign with an EC key in `MyBlindVoteListService`.

This fixes #3836 (Proof of burn signing does not work if wallet password is set).

--

Unfortunately this PR touches the core DAO packages again, although it is fairly trivial.
