### PR TITLE
BondsView: Fix sorting of numeric columns

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
@@ -169,6 +169,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
         column = new AutoTooltipTableColumn<>(Res.get("shared.amountWithCur", "BSQ"));
         column.setMinWidth(80);
         column.getStyleClass().add("first-column");
+        column.setComparator(Comparator.comparingLong(v -> v.getBond().getAmount()));
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override
@@ -189,6 +190,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
         tableView.getColumns().add(column);
         column = new AutoTooltipTableColumn<>(Res.get("dao.bond.table.column.lockTime"));
         column.setMinWidth(40);
+        column.setComparator(Comparator.comparingInt(v -> v.getBond().getLockTime()));
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override
@@ -287,6 +289,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
 
         column = new AutoTooltipTableColumn<>(Res.get("dao.bond.table.column.lockupDate"));
         column.setMinWidth(140);
+        column.setComparator(Comparator.comparingLong(v -> v.getBond().getLockupDate()));
         column.setCellValueFactory((item) -> new ReadOnlyObjectWrapper<>(item.getValue()));
         column.setCellFactory(new Callback<>() {
             @Override


### PR DESCRIPTION
The table in the BondsView uses string sorting by default. This results in unexpected behavior when sorting non-string columns.

This commit adds custom comparators to the numeric columns to address that.

Fixes #3231
