### PR TITLE
OfferBook: Show min-max range for amount and volume

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -31,6 +31,7 @@ import bisq.desktop.main.offer.BuyOfferView;
 import bisq.desktop.main.offer.SellOfferView;
 import bisq.desktop.main.offer.offerbook.OfferBookListItem;
 import bisq.desktop.util.CurrencyListItem;
+import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.locale.CurrencyUtil;
@@ -216,7 +217,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         tradeCurrencySubscriber = EasyBind.subscribe(model.selectedTradeCurrencyProperty,
                 tradeCurrency -> {
                     String code = tradeCurrency.getCode();
-                    volumeColumnLabel.set(Res.get("shared.amountWithCur", code));
+                    volumeColumnLabel.set(Res.get("offerbook.volume", code));
                     xAxis.setTickLabelFormatter(new StringConverter<>() {
                         int cryptoPrecision = 3;
 
@@ -499,9 +500,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                                 @Override
                                 public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
                                     if (offer != null && offer.getPrice() != null) {
-                                        setText("");
-                                        setGraphic(new ColoredDecimalPlacesWithZerosText(model.getVolume(offer),
-                                                model.getMaxNumberOfPriceZeroDecimalsToColorize(offer)));
+                                        renderCellContentRange();
                                         model.priceFeedService.updateCounterProperty().removeListener(listener);
                                     }
                                 }
@@ -517,9 +516,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                                         model.priceFeedService.updateCounterProperty().addListener(listener);
                                         setText(Res.get("shared.na"));
                                     } else {
-                                        setText("");
-                                        setGraphic(new ColoredDecimalPlacesWithZerosText(model.getVolume(offer),
-                                                model.getMaxNumberOfPriceZeroDecimalsToColorize(offer)));
+                                        renderCellContentRange();
                                     }
                                 } else {
                                     model.priceFeedService.updateCounterProperty().removeListener(listener);
@@ -528,12 +525,25 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                                     setGraphic(null);
                                 }
                             }
+
+                            /**
+                             * Renders cell content, if it has a single value or a range.
+                             * Should not be called for empty cells
+                             */
+                            private void renderCellContentRange() {
+                                String volumeRange = DisplayUtils.formatVolume(offer, true, 2);
+
+                                setText("");
+                                setGraphic(new ColoredDecimalPlacesWithZerosText(volumeRange,
+                                        model.getMaxNumberOfPriceZeroDecimalsToColorize(offer)));
+                            }
+
                         };
                     }
                 });
 
         // amount
-        TableColumn<OfferListItem, OfferListItem> amountColumn = new AutoTooltipTableColumn<>(Res.get("shared.amountWithCur", Res.getBaseCurrencyCode()));
+        TableColumn<OfferListItem, OfferListItem> amountColumn = new AutoTooltipTableColumn<>(Res.get("shared.BTCMinMax"));
         amountColumn.setMinWidth(115);
         amountColumn.setSortable(false);
         amountColumn.getStyleClass().add("number-column");
@@ -547,8 +557,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                             public void updateItem(final OfferListItem offerListItem, boolean empty) {
                                 super.updateItem(offerListItem, empty);
                                 if (offerListItem != null && !empty) {
-                                    setGraphic(new ColoredDecimalPlacesWithZerosText(formatter.formatCoin(offerListItem.offer.getAmount(),
-                                            4), GUIUtil.AMOUNT_DECIMALS_WITH_ZEROS));
+                                    String amountRange = DisplayUtils.formatAmount(offerListItem.offer, formatter);
+                                    setGraphic(new ColoredDecimalPlacesWithZerosText(amountRange, GUIUtil.AMOUNT_DECIMALS_WITH_ZEROS));
                                 } else {
                                     setGraphic(null);
                                 }


### PR DESCRIPTION
The OfferBook tables now show the amount and the volume as min-max range, where appropriate.

For the offers that have no range defined, the single values are shown.

Fixes #3129
