### PR TITLE
More readable tables and lists: Alternate row background colors

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -248,7 +248,9 @@
 .list-view .list-cell:even {
     -fx-background-color: derive(-bs-background-color, 5%);
 }
+.list-view .list-cell:hover,
 .list-view .list-cell:selected,
+.table-view .table-cell:hover,
 .table-view .table-cell:selected {
     -fx-background: -fx-accent;
     -fx-background-color: -fx-selection-bar;
@@ -897,6 +899,7 @@ textfield */
     -fx-background-color: derive(-bs-background-color,-5%);
     -fx-border-color: derive(-bs-background-color,-5%);
 }
+.table-view .table-row-cell:hover .table-cell,
 .table-view .table-row-cell:selected .table-cell {
     -fx-background: -fx-accent;
     -fx-background-color: -fx-selection-bar;

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -237,6 +237,28 @@
     -fx-background-color: -fx-selection-bar;
 }
 
+
+/* list view */
+.list-view .list-cell {
+    -fx-background-color: -bs-background-color;
+}
+.list-view .list-cell:odd {
+    -fx-background-color: derive(-bs-background-color, -5%);
+}
+.list-view .list-cell:even {
+    -fx-background-color: derive(-bs-background-color, 5%);
+}
+.list-view .list-cell:selected,
+.table-view .table-cell:selected {
+    -fx-background: -fx-accent;
+    -fx-background-color: -fx-selection-bar;
+    -fx-border-color: -fx-selection-bar;
+}
+
+.number-column.table-cell {
+    -fx-background-color: -bs-background-color;
+}
+
 .list-view:focused,
 .tree-view:focused,
 .table-view:focused,
@@ -867,6 +889,31 @@ textfield */
  * Table                                                                       *
  *                                                                             *
  ******************************************************************************/
+.table-view .table-row-cell:even .table-cell {
+    -fx-background-color: derive(-bs-background-color, 5%);
+    -fx-border-color: derive(-bs-background-color,5%);
+}
+.table-view .table-row-cell:odd .table-cell {
+    -fx-background-color: derive(-bs-background-color,-5%);
+    -fx-border-color: derive(-bs-background-color,-5%);
+}
+.table-view .table-row-cell:selected .table-cell {
+    -fx-background: -fx-accent;
+    -fx-background-color: -fx-selection-bar;
+    -fx-border-color: -fx-selection-bar;
+}
+.table-row-cell {
+    -fx-border-color: -bs-background-color;
+}
+.table-row-cell:empty, .table-row-cell:empty:even, .table-row-cell:empty:odd {
+    -fx-background-color: -bs-background-color;
+    -fx-min-height: 36;
+}
+.offer-table .table-row-cell {
+    -fx-background: -fx-accent;
+    -fx-background-color: -bs-color-gray-6;
+}
+
 .table-view .table-cell {
     -fx-alignment: center-left;
     -fx-padding: 2 0 2 0;

--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -135,55 +135,6 @@
     -bs-chart-dao-line2: -bs-color-blue-2;
 }
 
-/* list view */
-.list-view .list-cell {
-    -fx-background-color: -bs-background-color;
-}
-.list-view .list-cell:odd {
-    -fx-background-color: derive(-bs-background-color, -5%);
-}
-.list-view .list-cell:even {
-    -fx-background-color: derive(-bs-background-color, 5%);
-}
-.list-view .list-cell:selected,
-.table-view .table-cell:selected {
-    -fx-background: -fx-accent;
-    -fx-background-color: -fx-selection-bar;
-    -fx-border-color: -fx-selection-bar;
-}
-
-.number-column.table-cell {
-    -fx-background-color: -bs-background-color;
-}
-
-/* table view */
-.table-view, .table-cell:focused, .table-row-cell {
-    -fx-background: transparent;
-}
-.table-view .table-row-cell:even .table-cell {
-    -fx-background-color: derive(-bs-background-color, 5%);
-    -fx-border-color: derive(-bs-background-color,5%);
-}
-.table-view .table-row-cell:odd .table-cell {
-    -fx-background-color: derive(-bs-background-color,-5%);
-    -fx-border-color: derive(-bs-background-color,-5%);
-}
-.table-view .table-row-cell:selected .table-cell {
-    -fx-background: -fx-accent;
-    -fx-background-color: -fx-selection-bar;
-    -fx-border-color: -fx-selection-bar;
-}
-.table-row-cell {
-    -fx-border-color: -bs-background-color;
-}
-.table-row-cell:empty, .table-row-cell:empty:even, .table-row-cell:empty:odd {
-    -fx-background-color: -bs-background-color;
-    -fx-min-height: 36;
-}
-.offer-table .table-row-cell {
-    -fx-background: -fx-accent;
-    -fx-background-color: -bs-color-gray-6;
-}
 
 /* tab pane */
 .jfx-tab-pane .tab-content-area {


### PR DESCRIPTION
Alternate row background colors are now available, regardless of theme.

A few CSS selectors affecting table and list row coloring were moved the dark theme stylesheet (theme-dark.css) to the common stylesheet (bisq.css).

These selectors are theme-independent, since they re-use variables defined in each theme stylesheet (like -bs-background-color). Therefore a more appropriate place for them is in the common stylesheet.

This move means that alternating row background colors are now available for all tables and lists, in all views, in both dark and light themes.