### PR TITLE
Rename "Rocket Chat Admin" role to "Keybase Admin"

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
@@ -44,7 +44,7 @@ public enum BondedRoleType {
     GITHUB_ADMIN(50, 110, "https://bisq.network/roles/16", true),
     FORUM_ADMIN(20, 110, "https://bisq.network/roles/19", true),
     TWITTER_ADMIN(20, 110, "https://bisq.network/roles/21", true),
-    ROCKET_CHAT_ADMIN(20, 110, "https://bisq.network/roles/79", true),
+    ROCKET_CHAT_ADMIN(20, 110, "https://bisq.network/roles/79", true),// Now Keybase Admin
     YOUTUBE_ADMIN(10, 110, "https://bisq.network/roles/56", true),
 
     // maintainers

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1866,7 +1866,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Forum admin
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Twitter admin
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Rocket chat admin
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Keybase admin
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=YouTube admin
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Forum Administrator
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Twitter Administrator
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Rocket chat Admin
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Keybase Admin
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=YouTube Administrator
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Admin foro
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Admin Twitter
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Administrador Rocket chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Administrador Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=Admin Youtube
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=مدیر تالار
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=مدیر توئیتر
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=مدیر Rocket chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=مدیر Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=مدیر یوتیوب
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Admin du Forum
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Admin Twitter
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Admin Rocket chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Admin Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=Admin YouTube
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ja.properties
+++ b/core/src/main/resources/i18n/displayStrings_ja.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=フォーラム管理者
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Twitter管理者
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Rocket chat管理者
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Keybase管理者
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=YouTube管理者
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Admin do Fórum
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Admin do Twitter
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Admin do Rocket chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Admin do Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=Admin do YouTube
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Admin do Fórum
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Admin do Twitter
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Admin do Rocket chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Admin do Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=Admin do Youtube
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ru.properties
+++ b/core/src/main/resources/i18n/displayStrings_ru.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Администратор форума
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Администратор Twitter
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Администратор Rocket Chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Администратор Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=Администратор YouTube
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=แอดมินฟอรั่ม
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=แอดมินทวิตเตอร์
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=แอดมิน Rocket chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=แอดมิน Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=YouTube admin
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=Quản trị diễn đàn
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Quản trị Twitter
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Quản trị Rocket chat
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Quản trị Keybase
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=Quản trị Youtube
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hans.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hans.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=论坛管理
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Twitter 管理
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Rocket chat 管理
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Keybase 管理
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=YouTube 管理
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hant.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hant.properties
@@ -1483,7 +1483,7 @@ dao.bond.bondedRoleType.FORUM_ADMIN=論壇管理
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Twitter 管理
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Rocket chat 管理
+dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Keybase 管理
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.YOUTUBE_ADMIN=YouTube 管理
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
Per https://github.com/bisq-network/roles/issues/79#issuecomment-618483481

Note that the ROCKET_CHAT_ADMIN enum label has not been renamed for
the backward compatibility reasons discussed in BondedRoleType Javadoc.

See also bisq-network/roles#60.