### PR TITLE
Switch to more accurate fee estimation endpoint

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/settings/about/AboutView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/about/AboutView.java
@@ -83,7 +83,7 @@ public class AboutView extends ActivatableView<GridPane, Void> {
                 "Poloniex (https://poloniex.com)",
                 "Coinmarketcap (https://coinmarketcap.com)"));
         if (isBtc)
-            addCompactTopLabelTextField(root, ++gridRow, Res.get("setting.about.feeEstimation.label"), "Earn.com (https://bitcoinfees.earn.com)");
+            addCompactTopLabelTextField(root, ++gridRow, Res.get("setting.about.feeEstimation.label"), "mempool.space (https://mempool.space)");
 
         addTitledGroupBg(root, ++gridRow, 2, Res.get("setting.about.versionDetails"), Layout.GROUP_DISTANCE);
         addCompactTopLabelTextField(root, gridRow, Res.get("setting.about.version"), Version.VERSION, Layout.TWICE_FIRST_ROW_AND_GROUP_DISTANCE);

--- a/pricenode/src/main/java/bisq/price/mining/providers/BitcoinFeeRateProvider.java
+++ b/pricenode/src/main/java/bisq/price/mining/providers/BitcoinFeeRateProvider.java
@@ -34,7 +34,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.time.Duration;
 import java.time.Instant;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -42,14 +41,18 @@ import java.util.stream.Stream;
 @Component
 class BitcoinFeeRateProvider extends FeeRateProvider {
 
-    protected static final long MIN_FEE_RATE = 10; // satoshi/byte
-    protected static final long MAX_FEE_RATE = 1000;
+    static final long MIN_FEE_RATE = 10; // satoshi/byte
+    static final long MAX_FEE_RATE = 1000;
 
     private static final int DEFAULT_MAX_BLOCKS = 2;
     private static final int DEFAULT_REFRESH_INTERVAL = 2;
 
     private final RestTemplate restTemplate = new RestTemplate();
 
+    // TODO: As of the switch to the mempool.space API this field and related members are
+    //  now dead code and should be removed, including removing the positional
+    //  command-line argument from startup scripts. Operators need to be notified of this
+    //  when it happens.
     private final int maxBlocks;
 
     public BitcoinFeeRateProvider(Environment env) {
@@ -79,11 +82,12 @@ class BitcoinFeeRateProvider extends FeeRateProvider {
         return restTemplate.exchange(
             RequestEntity
                 .get(UriComponentsBuilder
-                    // Temporarily call mempool.space centralized API endpoint
-                    // A more de-centralized solution discussed in https://github.com/bisq-network/projects/issues/27
+                    // Temporarily call mempool.space centralized API endpoint as an
+                    // alternative to the too-expensive bitcoinfees.earn.com until a more
+                    // decentralized solution is available as per
+                    // https://github.com/bisq-network/projects/issues/27
                     .fromUriString("https://mempool.space/api/v1/fees/recommended")
                     .build().toUri())
-                .header("User-Agent", "") // required to avoid 403
                 .build(),
             new ParameterizedTypeReference<Map<String, Long>>() { }
         ).getBody().entrySet().stream();

--- a/pricenode/src/test/java/bisq/price/mining/providers/BitcoinFeeRateProviderTest.java
+++ b/pricenode/src/test/java/bisq/price/mining/providers/BitcoinFeeRateProviderTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.price.mining.providers;
+
+import bisq.price.mining.FeeRate;
+
+import org.springframework.context.support.GenericXmlApplicationContext;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class BitcoinFeeRateProviderTest {
+
+    @Test
+    public void doGet_successfulCall() {
+
+        GenericXmlApplicationContext ctx = new GenericXmlApplicationContext();
+        BitcoinFeeRateProvider feeRateProvider = new BitcoinFeeRateProvider(ctx.getEnvironment());
+
+        // Make a call to the API, retrieve the recommended fee rate
+        // If the API call fails, or the response body cannot be parsed, the test will fail with an exception
+        FeeRate retrievedFeeRate = feeRateProvider.doGet();
+
+        // Check that the FeeRateProvider returns a fee within the defined parameters
+        assertTrue(retrievedFeeRate.getPrice() >= BitcoinFeeRateProvider.MIN_FEE_RATE);
+        assertTrue(retrievedFeeRate.getPrice() <= BitcoinFeeRateProvider.MAX_FEE_RATE);
+    }
+
+}

--- a/pricenode/src/test/java/bisq/price/mining/providers/BitcoinFeeRateProviderTest.java
+++ b/pricenode/src/test/java/bisq/price/mining/providers/BitcoinFeeRateProviderTest.java
@@ -29,17 +29,16 @@ public class BitcoinFeeRateProviderTest {
 
     @Test
     public void doGet_successfulCall() {
-
         GenericXmlApplicationContext ctx = new GenericXmlApplicationContext();
         BitcoinFeeRateProvider feeRateProvider = new BitcoinFeeRateProvider(ctx.getEnvironment());
 
         // Make a call to the API, retrieve the recommended fee rate
-        // If the API call fails, or the response body cannot be parsed, the test will fail with an exception
+        // If the API call fails, or the response body cannot be parsed, the test will
+        // fail with an exception
         FeeRate retrievedFeeRate = feeRateProvider.doGet();
 
         // Check that the FeeRateProvider returns a fee within the defined parameters
         assertTrue(retrievedFeeRate.getPrice() >= BitcoinFeeRateProvider.MIN_FEE_RATE);
         assertTrue(retrievedFeeRate.getPrice() <= BitcoinFeeRateProvider.MAX_FEE_RATE);
     }
-
 }


### PR DESCRIPTION
The API endpoint for fee estimations has been changed to one that delivers more accurate fee estimations.

This is a temporary solution, until a more decentralized approach is found.

Fixes projects/issues/27
