### PR TITLE
Adding PicPay as a new payment method

### DIFF
--- a/core/src/main/java/bisq/core/payment/PicPayAccount.java
+++ b/core/src/main/java/bisq/core/payment/PicPayAccount.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment;
+
+import bisq.core.locale.FiatCurrency;
+import bisq.core.payment.payload.PicPayAccountPayload;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.payment.payload.PaymentMethod;
+
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public final class PicPayAccount extends PaymentAccount {
+    public PicPayAccount() {
+        super(PaymentMethod.PIC_PAY);
+        setSingleTradeCurrency(new FiatCurrency("BRL"));
+    }
+
+    @Override
+    protected PicPayAccountPayload createPayload() {
+        return new PicPayAccountPayload(paymentMethod.getId(), id);
+    }
+
+    public void setAccountName(String accountName) {
+        ((PicPayAccountPayload) paymentAccountPayload).setAccountName(username);
+    }
+
+    public String getAccountName() {
+        return ((PicPayAccountPayload) paymentAccountPayload).setAccountName();
+    }
+}

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -92,6 +92,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static final String PROMPT_PAY_ID = "PROMPT_PAY";
     public static final String ADVANCED_CASH_ID = "ADVANCED_CASH";
     public static final String BLOCK_CHAINS_INSTANT_ID = "BLOCK_CHAINS_INSTANT";
+    public static final String PICPAY_ID = "PIC_PAY";
 
     // Cannot be deleted as it would break old trade history entries
     @Deprecated
@@ -129,6 +130,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static PaymentMethod PROMPT_PAY;
     public static PaymentMethod ADVANCED_CASH;
     public static PaymentMethod BLOCK_CHAINS_INSTANT;
+    public static PaymentMethod PIC_PAY;
 
     // Cannot be deleted as it would break old trade history entries
     @Deprecated
@@ -188,6 +190,9 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
 
             // Thailand
             PROMPT_PAY = new PaymentMethod(PROMPT_PAY_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),
+
+            //Brazil
+            PIC_PAY = new PaymentMethod(PICPAY_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
 
             // Altcoins
             BLOCK_CHAINS = new PaymentMethod(BLOCK_CHAINS_ID, DAY, DEFAULT_TRADE_LIMIT_VERY_LOW_RISK),
@@ -354,6 +359,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
                 id.equals(PaymentMethod.CHASE_QUICK_PAY_ID) ||
                 id.equals(PaymentMethod.POPMONEY_ID) ||
                 id.equals(PaymentMethod.MONEY_BEAM_ID) ||
-                id.equals(PaymentMethod.UPHOLD_ID);
+                id.equals(PaymentMethod.UPHOLD_ID) ||
+                id.equals(PaymentMethod.PICPAY_ID);
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/PicPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PicPayAccountPayload.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import bisq.core.locale.Res;
+
+import com.google.protobuf.Message;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Setter
+@Getter
+@Slf4j
+public final class PicPayAccountPayload extends PaymentAccountPayload {
+    private String accountName = "";
+
+    public PicPayAccountPayload(String paymentMethod, String id) {
+        super(paymentMethod, id);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private PicPayAccountPayload(String paymentMethod,
+                                String id,
+                                String accountName,
+                                long maxTradePeriod,
+                                Map<String, String> excludeFromJsonDataMap) {
+        super(paymentMethod,
+                id,
+                maxTradePeriod,
+                excludeFromJsonDataMap);
+        this.accountName = accountName;
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        return getPaymentAccountPayloadBuilder()
+                .setPicPayAccountPayload(protobuf.PicPayAccountPayload.newBuilder()
+                        .setAccountName(accountName))
+                .build();
+    }
+
+    public static PicPayAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
+        return new PicPayAccountPayload(proto.getPaymentMethodId(),
+                proto.getId(),
+                proto.getPicPayAccountPayload().getAccountName(),
+                proto.getMaxTradePeriod(),
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public String getPaymentDetails() {
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.no") + " " + accountName;
+    }
+
+    @Override
+    public String getPaymentDetailsForTradePopup() {
+        return Res.getWithCol("payment.account.no") + " " + accountName;
+    }
+
+    @Override
+    public byte[] getAgeWitnessInputData() {
+        return super.getAgeWitnessInputData(accountName.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Inclusion of the PicPay payment option for users, as it is a popular method in Brazil, anonymous and fast, already widely used in P2P transactions.