### PR TITLE
Extend CONTRIBUTING.md with info on IDEA settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,12 +64,14 @@ See https://help.github.com/articles/setting-your-username-in-git/ for instructi
 From https://chris.beams.io/posts/git-commit/#seven-rules:
 
  1. Separate subject from body with a blank line
- 2. Limit the subject line to 50 characters
+ 2. Limit the subject line to 50 characters (*)
  3. Capitalize the subject line
  4. Do not end the subject line with a period
  5. Use the imperative mood in the subject line
- 6. Wrap the body at 72 characters
+ 6. Wrap the body at 72 characters (*)
  7. Use the body to explain what and why vs. how
+
+*) See [here](https://stackoverflow.com/a/45563628/8340320) for how to enforce these two checks in IntelliJ IDEA.
 
 See also [bisq-network/style#9](https://github.com/bisq-network/style/issues/9).
 


### PR DESCRIPTION
Add a link to a StackOverflow answer showing how to configure IDEA to
automatically check and enforce the format of the commit message.

More specifically, the 50-character limit for the commit title and
72-character limit for the commit body.