### PR TITLE
Pricenode: Remove unused maxBlocks param

### DIFF
--- a/pricenode/bisq-pricenode.service
+++ b/pricenode/bisq-pricenode.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 SyslogIdentifier=bisq-pricenode
 EnvironmentFile=/etc/default/bisq-pricenode.env
-ExecStart=/bisq/bisq/bisq-pricenode 2 2
+ExecStart=/bisq/bisq/bisq-pricenode 2
 ExecStop=/bin/kill -TERM ${MAINPID}
 Restart=on-failure
 


### PR DESCRIPTION
Since the new fee estimation API does not require this parameter anymore, remove it and all references to it.

As @cbeams mentioned in https://github.com/bisq-network/bisq/pull/4235#pullrequestreview-405917893: merging this change should be coordinated with the pricenode operators.

What this changes for running a pricenode: starting the pricenode now takes one argument instead of two, so make sure to **update any startup scripts and remove the first argument** (which used to represent `maxBlocks`).

See bisq-network/projects#27