### PR TITLE
Increase BSQ explorer TMPFS allocation to 2GB for growing datastore

### DIFF
--- a/seednode/bisq.service
+++ b/seednode/bisq.service
@@ -31,7 +31,7 @@ ExecStart=/bin/sh __BISQ_HOME__/__BISQ_REPO_NAME__/${BISQ_ENTRYPOINT} \
 ExecStop=/bin/kill -9 ${MAINPID}
 Restart=on-failure
 
-ExecStartPre=+/bin/bash -c "if [ $BISQ_DUMP_BLOCKCHAIN = true ];then mount -t tmpfs none -o size=812M,uid=bisq,gid=bisq $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json;else true;fi"
+ExecStartPre=+/bin/bash -c "if [ $BISQ_DUMP_BLOCKCHAIN = true ];then mount -t tmpfs none -o size=2000M,uid=bisq,gid=bisq $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json;else true;fi"
 ExecStopPost=+/bin/bash -c "if [ $BISQ_DUMP_BLOCKCHAIN = true ];then umount $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json;else true;fi"
 
 User=bisq


### PR DESCRIPTION
BSQ explorers now require a larger TMPFS to store growing blockchain data