### PR TITLE
Bugfixes related to switch statements

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
@@ -139,12 +139,8 @@ public class ChangeParamValidator extends ProposalValidator implements Consensus
             case PROPOSAL_FEE:
             case BLIND_VOTE_FEE:
                 break;
-
             case COMPENSATION_REQUEST_MIN_AMOUNT:
             case REIMBURSEMENT_MIN_AMOUNT:
-                checkArgument(inputValueAsCoin.value >= Restrictions.getMinNonDustOutput().value,
-                        Res.get("validation.amountBelowDust", Restrictions.getMinNonDustOutput().value));
-                break;
             case COMPENSATION_REQUEST_MAX_AMOUNT:
             case REIMBURSEMENT_MAX_AMOUNT:
                 checkArgument(inputValueAsCoin.value >= Restrictions.getMinNonDustOutput().value,
@@ -152,7 +148,6 @@ public class ChangeParamValidator extends ProposalValidator implements Consensus
                 checkArgument(inputValueAsCoin.value <= 200000000,
                         Res.get("validation.inputTooLarge", "200 000 BSQ"));
                 break;
-
             case QUORUM_COMP_REQUEST:
             case QUORUM_REIMBURSEMENT:
             case QUORUM_CHANGE_PARAM:

--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamValidator.java
@@ -144,6 +144,7 @@ public class ChangeParamValidator extends ProposalValidator implements Consensus
             case REIMBURSEMENT_MIN_AMOUNT:
                 checkArgument(inputValueAsCoin.value >= Restrictions.getMinNonDustOutput().value,
                         Res.get("validation.amountBelowDust", Restrictions.getMinNonDustOutput().value));
+                break;
             case COMPENSATION_REQUEST_MAX_AMOUNT:
             case REIMBURSEMENT_MAX_AMOUNT:
                 checkArgument(inputValueAsCoin.value >= Restrictions.getMinNonDustOutput().value,

--- a/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -293,6 +293,7 @@ class TxOutputParser {
                         long blindVoteFee = daoStateService.getParamValueAsCoin(Param.BLIND_VOTE_FEE, tempTxOutput.getBlockHeight()).value;
                         return availableInputValue == blindVoteFee;
                     }
+                    break;
                 case VOTE_REVEAL:
                     break;
                 case LOCKUP:

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -235,7 +235,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                     protobuf.NetworkEnvelope proto = networkEnvelope.toProtoNetworkEnvelope();
                     log.trace("Sending message: {}", Utilities.toTruncatedString(proto.toString(), 10000));
 
-                    if (networkEnvelope instanceof Ping | networkEnvelope instanceof RefreshOfferMessage) {
+                    if (networkEnvelope instanceof Ping || networkEnvelope instanceof RefreshOfferMessage) {
                         // pings and offer refresh msg we don't want to log in production
                         log.trace("\n\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n" +
                                         "Sending direct message to peer" +


### PR DESCRIPTION
This is a second go at https://github.com/bisq-network/bisq/pull/4212, which was reverted. The previous PR was fixing some problems with switch statements and a typo where a short-circuit boolean operator was used without need. This PR is the same as the last one, but the semantic/cosmetic changes (why the original PR was reverted) are removed and it also implements a suggestion by @ManfredKarrer to add a (forgotten) check.