### PR TITLE
Secondary sort order for offer book (rewrite)

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -279,6 +279,14 @@ class OfferBookChartViewModel extends ActivatableViewModel {
 
         // Offer price can be null (if price feed unavailable), thus a null-tolerant comparator is used.
         Comparator<Offer> offerPriceComparator = Comparator.comparing(Offer::getPrice, Comparator.nullsLast(Comparator.naturalOrder()));
+
+        // Trading btc-fiat is considered as buying/selling BTC, but trading btc-altcoin is
+        // considered as buying/selling Altcoin. Because of this, when viewing a btc-altcoin pair,
+        // the buy column is actually the sell column and vice versa. To maintain the expected
+        // ordering, we have to reverse the price comparator.
+        boolean isCrypto = CurrencyUtil.isCryptoCurrency(getCurrencyCode());
+        if (isCrypto) offerPriceComparator = offerPriceComparator.reversed();
+
         // Offer amounts are used for the secondary sort. They are sorted from high to low.
         Comparator<Offer> offerAmountComparator = Comparator.comparing(Offer::getAmount).reversed();
 

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -276,22 +276,24 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     }
 
     private void updateChartData() {
+
+        // Offer price can be null (if price feed unavailable), thus a null-tolerant comparator is used.
+        Comparator<Offer> offerPriceComparator = Comparator.comparing(Offer::getPrice, Comparator.nullsLast(Comparator.naturalOrder()));
+        // Offer amounts are used for the secondary sort. They are sorted from high to low.
+        Comparator<Offer> offerAmountComparator = Comparator.comparing(Offer::getAmount).reversed();
+
+        var buyOfferSortComparator =
+            offerPriceComparator.reversed() // Buy offers, as opposed to sell offers, are primarily sorted from high price to low.
+            .thenComparing(offerAmountComparator);
+        var sellOfferSortComparator =
+            offerPriceComparator
+            .thenComparing(offerAmountComparator);
+
         List<Offer> allBuyOffers = offerBookListItems.stream()
                 .map(OfferBookListItem::getOffer)
                 .filter(e -> e.getCurrencyCode().equals(selectedTradeCurrencyProperty.get().getCode())
                         && e.getDirection().equals(OfferPayload.Direction.BUY))
-                .sorted((o1, o2) -> {
-                    long a = o1.getPrice() != null ? o1.getPrice().getValue() : 0;
-                    long b = o2.getPrice() != null ? o2.getPrice().getValue() : 0;
-                    if (a != b) {
-                        if (CurrencyUtil.isCryptoCurrency(o1.getCurrencyCode()))
-                            return a > b ? 1 : -1;
-                        else
-                            return a < b ? 1 : -1;
-                    } else {
-                        return 0;
-                    }
-                })
+                .sorted(buyOfferSortComparator)
                 .collect(Collectors.toList());
 
         final Optional<Offer> highestBuyPriceOffer = allBuyOffers.stream()
@@ -320,18 +322,7 @@ class OfferBookChartViewModel extends ActivatableViewModel {
                 .map(OfferBookListItem::getOffer)
                 .filter(e -> e.getCurrencyCode().equals(selectedTradeCurrencyProperty.get().getCode())
                         && e.getDirection().equals(OfferPayload.Direction.SELL))
-                .sorted((o1, o2) -> {
-                    long a = o1.getPrice() != null ? o1.getPrice().getValue() : 0;
-                    long b = o2.getPrice() != null ? o2.getPrice().getValue() : 0;
-                    if (a != b) {
-                        if (CurrencyUtil.isCryptoCurrency(o1.getCurrencyCode()))
-                            return a < b ? 1 : -1;
-                        else
-                            return a > b ? 1 : -1;
-                    } else {
-                        return 0;
-                    }
-                })
+                .sorted(sellOfferSortComparator)
                 .collect(Collectors.toList());
 
         final Optional<Offer> highestSellPriceOffer = allSellOffers.stream()


### PR DESCRIPTION
Supersedes https://github.com/bisq-network/bisq/pull/4168. This is a rewrite of that PR.

Adds a secondary sort order to offers in market offer book by offer amount that goes from high to low. Also, replaces previous complicated implementation of primary sort.

Co-authored-by: @freimair 
Co-authored-by: @cd2357 

![offerbook-secondary-sort-refactor](https://user-images.githubusercontent.com/2715476/82078128-eb22f980-96e0-11ea-800b-af281a06899a.png)