### PR TITLE
standardize tense in trade process wording

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -564,9 +564,9 @@ portfolio.pending.invalidDelayedPayoutTx=Please do NOT send the Altcoin or Fiat 
 portfolio.pending.step1.waitForConf=Wait for blockchain confirmation
 portfolio.pending.step2_buyer.startPayment=Start payment
 portfolio.pending.step2_seller.waitPaymentStarted=Wait until payment has started
-portfolio.pending.step3_buyer.waitPaymentArrived=Wait until payment arrived
+portfolio.pending.step3_buyer.waitPaymentArrived=Wait for payment to arrive
 portfolio.pending.step3_seller.confirmPaymentReceived=Confirm payment received
-portfolio.pending.step5.completed=Completed
+portfolio.pending.step5.completed=Complete
 
 portfolio.pending.step1.info=Deposit transaction has been published.\n{0} need to wait for at least one blockchain confirmation before starting the payment.
 portfolio.pending.step1.warn=The deposit transaction is still not confirmed. This sometimes happens in rare cases when the funding fee of one trader from an external wallet was too low.


### PR DESCRIPTION
Adjust the wording in the trade process to all have a matching tense.