### PR TITLE
Add rpc wallet endpoint tests and update version check

### DIFF
--- a/cli/test.sh
+++ b/cli/test.sh
@@ -48,17 +48,99 @@
   run ./bisq-cli --password="xyz" getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
 @test "test getversion" {
   run ./bisq-cli --password=xyz getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
-@test "test getbalance (available & unlocked wallet with 0 btc balance)" {
+@test "test setwalletpassword \"a b c\"" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted" ]
+  sleep 1
+}
+
+@test "test unlockwallet without password & timeout args" {
+  run ./bisq-cli --password=xyz unlockwallet
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no password specified" ]
+}
+
+@test "test unlockwallet without timeout arg" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no unlock timeout specified" ]
+}
+
+
+@test "test unlockwallet \"a b c\" 8" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 8
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test getbalance while wallet unlocked for 8s" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "0.00000000" ]
+  sleep 8
+}
+
+@test "test unlockwallet \"a b c\" 6" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 6
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test lockwallet before unlockwallet timeout=6s expires" {
+  run ./bisq-cli --password=xyz lockwallet
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet locked" ]
+}
+
+@test "test setwalletpassword incorrect old pwd error" {
+  run ./bisq-cli --password=xyz setwalletpassword "z z z"  "d e f"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: incorrect old password" ]
+}
+
+@test "test setwalletpassword oldpwd newpwd" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"  "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted with new password" ]
+  sleep 1
+}
+
+@test "test getbalance wallet locked error" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: wallet is locked" ]
+}
+
+@test "test removewalletpassword" {
+  run ./bisq-cli --password=xyz removewalletpassword "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet decrypted" ]
+  sleep 1
+}
+
+@test "test getbalance when wallet available & unlocked with 0 btc balance" {
   run ./bisq-cli --password=xyz getbalance
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
@@ -69,7 +151,7 @@
   run ./bisq-cli
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }
 
@@ -77,6 +159,6 @@
   run ./bisq-cli --help
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }


### PR DESCRIPTION
This commit includes the following changes:

 * New tests for methods `lockwallet`, `unlockwallet`,
   `removewalletpassword`, and `setwalletpassword`.

 * New `getbalance` method error handing tests to verify
   error message correctness when wallet is locked.

 * Update to `getversion` method test -- now expects `1.3.4`.

 * Check for new `[params]` column header in help text.

This PR replaces [4243](https://github.com/bisq-network/bisq/pull/4243), which had not been kept in sync with commits to tested methods in [4214](https://github.com/bisq-network/bisq/pull/4214) .