### PR TITLE
WIP Bitcoinj usage refactor example

### DIFF
--- a/core/src/main/java/bisq/core/btc/low/PeerGroup.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroup.java
@@ -2,7 +2,12 @@ package bisq.core.btc.low;
 
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.PeerAddress;
+import org.bitcoinj.params.RegTestParams;
+
 import org.bitcoinj.net.BlockingClientManager;
+import org.bitcoinj.net.discovery.PeerDiscovery;
+import org.bitcoinj.net.discovery.DnsDiscovery;
 
 import bisq.core.btc.nodes.ProxySocketFactory;
 import bisq.core.btc.nodes.LocalBitcoinNode;
@@ -69,6 +74,25 @@ final public class PeerGroup extends PeerGroupProxy {
             peerGroup.setUseLocalhostPeerWhenPossible(false);
 
         return peerGroup;
+    }
+
+    public void setupPeerAddressesOrDiscovery(
+            PeerAddress[] peerAddresses,
+            int numConnectionsForBtc,
+            NetworkParameters params,
+            PeerDiscovery discovery
+    ) {
+        if (peerAddresses != null) {
+            for (PeerAddress addr : peerAddresses) this.addAddress(addr);
+            int maxConnections = Math.min(numConnectionsForBtc, peerAddresses.length);
+            //log.info("We try to connect to {} btc nodes", maxConnections);
+            this.setMaxConnections(maxConnections);
+            this.setAddPeersFromAddressMessage(false);
+            peerAddresses = null;
+        } else if (!params.equals(RegTestParams.get())) {
+            this.addPeerDiscovery(discovery != null ? discovery : new DnsDiscovery(params));
+        }
+
     }
 
 }

--- a/core/src/main/java/bisq/core/btc/low/PeerGroup.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroup.java
@@ -18,15 +18,14 @@ final public class PeerGroup extends PeerGroupProxy {
 
     // These constructors will be subsequently factored out of this class
 
-    public PeerGroup(
+    private PeerGroup(
             NetworkParameters params,
             BlockChain vChain
     ) {
-
         super(new org.bitcoinj.core.PeerGroup(params, vChain));
     }
 
-    public PeerGroup(
+    private PeerGroup(
             NetworkParameters params,
             BlockChain vChain,
             BlockingClientManager blockingClientManager

--- a/core/src/main/java/bisq/core/btc/low/PeerGroup.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroup.java
@@ -16,8 +16,6 @@ import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 
 final public class PeerGroup extends PeerGroupProxy {
 
-    // These constructors will be subsequently factored out of this class
-
     private PeerGroup(
             NetworkParameters params,
             BlockChain vChain

--- a/core/src/main/java/bisq/core/btc/low/PeerGroup.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroup.java
@@ -4,6 +4,16 @@ import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.net.BlockingClientManager;
 
+import bisq.core.btc.nodes.ProxySocketFactory;
+import bisq.core.btc.nodes.LocalBitcoinNode;
+
+import bisq.common.config.Config;
+
+import java.net.Proxy;
+import java.net.InetSocketAddress;
+
+import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
+
 final public class PeerGroup extends PeerGroupProxy {
 
     // These constructors will be subsequently factored out of this class
@@ -22,6 +32,46 @@ final public class PeerGroup extends PeerGroupProxy {
             BlockingClientManager blockingClientManager
     ) {
         super(new org.bitcoinj.core.PeerGroup(params, vChain, blockingClientManager));
+    }
+
+    public static PeerGroup createPeerGroup(
+            Socks5Proxy socks5Proxy,
+            NetworkParameters params,
+            BlockChain vChain,
+            LocalBitcoinNode localBitcoinNode,
+            Config config,
+            int torSocketTimeout,
+            int torVersionExchangeTimeout
+    ) {
+        PeerGroup peerGroup;
+        // no proxy case.
+        if (socks5Proxy == null) {
+            peerGroup = new PeerGroup(params, vChain);
+        } else {
+            // proxy case (tor).
+            Proxy proxy = new Proxy(Proxy.Type.SOCKS,
+                    new InetSocketAddress(
+                        socks5Proxy.getInetAddress().getHostName(),
+                        socks5Proxy.getPort()));
+
+            ProxySocketFactory proxySocketFactory =
+                new ProxySocketFactory(proxy);
+            // We don't use tor mode if we have a local node running
+            BlockingClientManager blockingClientManager =
+                config.ignoreLocalBtcNode ?
+                new BlockingClientManager() :
+                new BlockingClientManager(proxySocketFactory);
+
+            peerGroup = new PeerGroup(params, vChain, blockingClientManager);
+
+            blockingClientManager.setConnectTimeoutMillis(torSocketTimeout);
+            peerGroup.setConnectTimeoutMillis(torVersionExchangeTimeout);
+        }
+
+        if (!localBitcoinNode.shouldBeUsed())
+            peerGroup.setUseLocalhostPeerWhenPossible(false);
+
+        return peerGroup;
     }
 
 }

--- a/core/src/main/java/bisq/core/btc/low/PeerGroup.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroup.java
@@ -1,0 +1,27 @@
+package bisq.core.btc.low;
+
+import org.bitcoinj.core.BlockChain;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.net.BlockingClientManager;
+
+final public class PeerGroup extends PeerGroupProxy {
+
+    // These constructors will be subsequently factored out of this class
+
+    public PeerGroup(
+            NetworkParameters params,
+            BlockChain vChain
+    ) {
+
+        super(new org.bitcoinj.core.PeerGroup(params, vChain));
+    }
+
+    public PeerGroup(
+            NetworkParameters params,
+            BlockChain vChain,
+            BlockingClientManager blockingClientManager
+    ) {
+        super(new org.bitcoinj.core.PeerGroup(params, vChain, blockingClientManager));
+    }
+
+}

--- a/core/src/main/java/bisq/core/btc/low/PeerGroupProxy.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroupProxy.java
@@ -60,11 +60,11 @@ abstract class PeerGroupProxy {
         this.bitcoinjPeerGroup.addWallet(wallet);
     }
 
-    public void setUseLocalhostPeerWhenPossible(boolean useLocalhostPeerWhenPossible) {
+    protected void setUseLocalhostPeerWhenPossible(boolean useLocalhostPeerWhenPossible) {
         this.bitcoinjPeerGroup.setUseLocalhostPeerWhenPossible(useLocalhostPeerWhenPossible);
     }
 
-    public void setConnectTimeoutMillis(int connectTimeoutMillis) {
+    protected void setConnectTimeoutMillis(int connectTimeoutMillis) {
         this.bitcoinjPeerGroup.setConnectTimeoutMillis(connectTimeoutMillis);
     }
 

--- a/core/src/main/java/bisq/core/btc/low/PeerGroupProxy.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroupProxy.java
@@ -1,0 +1,111 @@
+package bisq.core.btc.low;
+
+import org.bitcoinj.core.listeners.PeerDataEventListener;
+import org.bitcoinj.core.listeners.PeerConnectedEventListener;
+import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
+import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
+import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
+
+import org.bitcoinj.core.Peer;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionBroadcast;
+import org.bitcoinj.core.PeerAddress;
+import org.bitcoinj.net.discovery.PeerDiscovery;
+import org.bitcoinj.wallet.Wallet;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+abstract class PeerGroupProxy {
+
+    protected final org.bitcoinj.core.PeerGroup bitcoinjPeerGroup;
+
+    protected PeerGroupProxy(org.bitcoinj.core.PeerGroup bitcoinjPeerGroup) {
+        this.bitcoinjPeerGroup = bitcoinjPeerGroup;
+    }
+
+    /* Subset of BitcoinJ API that is used by Bisq: */
+
+    public void start() {
+        this.bitcoinjPeerGroup.start();
+    }
+
+    public ListenableFuture startAsync() {
+        return this.bitcoinjPeerGroup.startAsync();
+    }
+
+    public void stop() {
+        this.bitcoinjPeerGroup.stop();
+    }
+
+    public void startBlockChainDownload(PeerDataEventListener listener) {
+        this.bitcoinjPeerGroup.startBlockChainDownload(listener);
+    }
+
+    public TransactionBroadcast broadcastTransaction(final Transaction tx) {
+        return this.bitcoinjPeerGroup.broadcastTransaction(tx);
+    }
+
+    public void addAddress(PeerAddress peerAddress) {
+        this.bitcoinjPeerGroup.addAddress(peerAddress);
+    }
+
+    public void addPeerDiscovery(PeerDiscovery peerDiscovery) {
+        this.bitcoinjPeerGroup.addPeerDiscovery(peerDiscovery);
+    }
+
+    public void addWallet(Wallet wallet) {
+        this.bitcoinjPeerGroup.addWallet(wallet);
+    }
+
+    public void setUseLocalhostPeerWhenPossible(boolean useLocalhostPeerWhenPossible) {
+        this.bitcoinjPeerGroup.setUseLocalhostPeerWhenPossible(useLocalhostPeerWhenPossible);
+    }
+
+    public void setConnectTimeoutMillis(int connectTimeoutMillis) {
+        this.bitcoinjPeerGroup.setConnectTimeoutMillis(connectTimeoutMillis);
+    }
+
+    public void setMinBroadcastConnections(int value) {
+        this.bitcoinjPeerGroup.setMinBroadcastConnections(value);
+    }
+
+    public void setUserAgent(String name, String version) {
+        this.bitcoinjPeerGroup.setUserAgent(name, version);
+    }
+
+    public void setMaxConnections(int maxConnections) {
+        this.bitcoinjPeerGroup.setMaxConnections(maxConnections);
+    }
+
+    public void setAddPeersFromAddressMessage(boolean addPeersFromAddressMessage) {
+        this.bitcoinjPeerGroup.setAddPeersFromAddressMessage(addPeersFromAddressMessage);
+    }
+
+    public static void setIgnoreHttpSeeds(boolean ignoreHttpSeeds) {
+        org.bitcoinj.core.PeerGroup.setIgnoreHttpSeeds(ignoreHttpSeeds);
+    }
+
+    public void addConnectedEventListener(PeerConnectedEventListener listener) {
+        this.bitcoinjPeerGroup.addConnectedEventListener(listener);
+    }
+
+    public void addDisconnectedEventListener(PeerDisconnectedEventListener listener) {
+        this.bitcoinjPeerGroup.addDisconnectedEventListener(listener);
+    }
+
+    public void addBlocksDownloadedEventListener(BlocksDownloadedEventListener listener) {
+        this.bitcoinjPeerGroup.addBlocksDownloadedEventListener(listener);
+    }
+
+    public void addPreMessageReceivedEventListener(Executor executor, PreMessageReceivedEventListener listener) {
+        this.bitcoinjPeerGroup.addPreMessageReceivedEventListener(executor, listener);
+    }
+
+    public List<Peer> getConnectedPeers() {
+        return this.bitcoinjPeerGroup.getConnectedPeers();
+    }
+
+}

--- a/core/src/main/java/bisq/core/btc/low/PeerGroupProxy.java
+++ b/core/src/main/java/bisq/core/btc/low/PeerGroupProxy.java
@@ -48,11 +48,11 @@ abstract class PeerGroupProxy {
         return this.bitcoinjPeerGroup.broadcastTransaction(tx);
     }
 
-    public void addAddress(PeerAddress peerAddress) {
+    protected void addAddress(PeerAddress peerAddress) {
         this.bitcoinjPeerGroup.addAddress(peerAddress);
     }
 
-    public void addPeerDiscovery(PeerDiscovery peerDiscovery) {
+    protected void addPeerDiscovery(PeerDiscovery peerDiscovery) {
         this.bitcoinjPeerGroup.addPeerDiscovery(peerDiscovery);
     }
 
@@ -76,7 +76,7 @@ abstract class PeerGroupProxy {
         this.bitcoinjPeerGroup.setUserAgent(name, version);
     }
 
-    public void setMaxConnections(int maxConnections) {
+    protected void setMaxConnections(int maxConnections) {
         this.bitcoinjPeerGroup.setMaxConnections(maxConnections);
     }
 

--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -403,16 +403,8 @@ public class WalletConfig extends AbstractIdleService {
 
             // Set up peer addresses or discovery first, so if wallet extensions try to broadcast a transaction
             // before we're actually connected the broadcast waits for an appropriate number of connections.
-            if (peerAddresses != null) {
-                for (PeerAddress addr : peerAddresses) vPeerGroup.addAddress(addr);
-                int maxConnections = Math.min(numConnectionsForBtc, peerAddresses.length);
-                log.info("We try to connect to {} btc nodes", maxConnections);
-                vPeerGroup.setMaxConnections(maxConnections);
-                vPeerGroup.setAddPeersFromAddressMessage(false);
-                peerAddresses = null;
-            } else if (!params.equals(RegTestParams.get())) {
-                vPeerGroup.addPeerDiscovery(discovery != null ? discovery : new DnsDiscovery(params));
-            }
+            setupPeerAddressesOrDiscovery(vPeerGroup, peerAddresses, numConnectionsForBtc, params, discovery);
+
             vChain.addWallet(vBtcWallet);
             vPeerGroup.addWallet(vBtcWallet);
 
@@ -451,6 +443,26 @@ public class WalletConfig extends AbstractIdleService {
         } catch (BlockStoreException e) {
             throw new IOException(e);
         }
+    }
+
+    static void setupPeerAddressesOrDiscovery(
+            PeerGroup vPeerGroup,
+            PeerAddress[] peerAddresses,
+            int numConnectionsForBtc,
+            NetworkParameters params,
+            PeerDiscovery discovery
+    ) {
+        if (peerAddresses != null) {
+            for (PeerAddress addr : peerAddresses) vPeerGroup.addAddress(addr);
+            int maxConnections = Math.min(numConnectionsForBtc, peerAddresses.length);
+            log.info("We try to connect to {} btc nodes", maxConnections);
+            vPeerGroup.setMaxConnections(maxConnections);
+            vPeerGroup.setAddPeersFromAddressMessage(false);
+            peerAddresses = null;
+        } else if (!params.equals(RegTestParams.get())) {
+            vPeerGroup.addPeerDiscovery(discovery != null ? discovery : new DnsDiscovery(params));
+        }
+
     }
 
     void setPeerNodesForLocalHost() {

--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -403,7 +403,7 @@ public class WalletConfig extends AbstractIdleService {
 
             // Set up peer addresses or discovery first, so if wallet extensions try to broadcast a transaction
             // before we're actually connected the broadcast waits for an appropriate number of connections.
-            setupPeerAddressesOrDiscovery(vPeerGroup, peerAddresses, numConnectionsForBtc, params, discovery);
+            vPeerGroup.setupPeerAddressesOrDiscovery(peerAddresses, numConnectionsForBtc, params, discovery);
 
             vChain.addWallet(vBtcWallet);
             vPeerGroup.addWallet(vBtcWallet);
@@ -443,26 +443,6 @@ public class WalletConfig extends AbstractIdleService {
         } catch (BlockStoreException e) {
             throw new IOException(e);
         }
-    }
-
-    static void setupPeerAddressesOrDiscovery(
-            PeerGroup vPeerGroup,
-            PeerAddress[] peerAddresses,
-            int numConnectionsForBtc,
-            NetworkParameters params,
-            PeerDiscovery discovery
-    ) {
-        if (peerAddresses != null) {
-            for (PeerAddress addr : peerAddresses) vPeerGroup.addAddress(addr);
-            int maxConnections = Math.min(numConnectionsForBtc, peerAddresses.length);
-            log.info("We try to connect to {} btc nodes", maxConnections);
-            vPeerGroup.setMaxConnections(maxConnections);
-            vPeerGroup.setAddPeersFromAddressMessage(false);
-            peerAddresses = null;
-        } else if (!params.equals(RegTestParams.get())) {
-            vPeerGroup.addPeerDiscovery(discovery != null ? discovery : new DnsDiscovery(params));
-        }
-
     }
 
     void setPeerNodesForLocalHost() {

--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -20,6 +20,7 @@ package bisq.core.btc.setup;
 import bisq.core.btc.nodes.LocalBitcoinNode;
 import bisq.core.btc.nodes.ProxySocketFactory;
 import bisq.core.btc.wallet.BisqRiskAnalysis;
+import bisq.core.btc.low.PeerGroup;
 
 import bisq.common.app.Version;
 import bisq.common.config.Config;
@@ -29,7 +30,6 @@ import org.bitcoinj.core.CheckpointManager;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PeerAddress;
-import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.core.listeners.PeerDataEventListener;

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -28,6 +28,7 @@ import bisq.core.btc.nodes.BtcNodes.BtcNode;
 import bisq.core.btc.nodes.BtcNodesRepository;
 import bisq.core.btc.nodes.BtcNodesSetupPreferences;
 import bisq.core.user.Preferences;
+import bisq.core.btc.low.PeerGroup;
 
 import bisq.network.Socks5MultiDiscovery;
 import bisq.network.Socks5ProxyProvider;
@@ -45,7 +46,6 @@ import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerAddress;
-import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.RejectMessage;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.params.RegTestParams;

--- a/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
@@ -19,11 +19,11 @@ package bisq.core.btc.wallet;
 
 import bisq.core.btc.exceptions.TxBroadcastException;
 import bisq.core.btc.exceptions.TxBroadcastTimeoutException;
+import bisq.core.btc.low.PeerGroup;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
 
-import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.wallet.Wallet;
 


### PR DESCRIPTION
Related project proposal: https://github.com/bisq-network/projects/issues/30

This example PR is meant to be read commit by commit.

It's a simple refactor of `WalletConfig` focusing on moving `PeerGroup` related code. I chose `PeerGroup`, because it's probably the simplest important group of BitcoinJ endpoints. Moving code is the simplest (and least interesting) form of refactoring, but while doing it (similarly to shuffling puzzle pieces while solving a puzzle) you come up with more interesting refactorings, though it's a time-intensive process. This example is about that shuffling.

There are a few quirks here that are still to be ironed out:

- Naming of `low.PeerGroup` clashes with BitcoinJ's PeerGroup. Might come up with something better;
-  The whole `PeerGroup extends PeerGroupProxy` scheme has its upsides, but a few downsides too. Might come up with something better;
- `PeerGroupProxy` name clashes with `Socks5Proxy` and the like; naming isn't worked out in general;
- Part of the logic moved from `WalletConfig` to `low.PeerGroup` in this example might actually do better left in WalletConfig, which will require dissecting it further.