### PR TITLE
Add Readme section on updating a pricenode

### DIFF
--- a/pricenode/README.md
+++ b/pricenode/README.md
@@ -81,6 +81,12 @@ Furthermore, you are obliged to provide network size data to the monitor by runn
 curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/pricenode/install_networksize_debian.sh | sudo bash
 ```
 
+### Updating
+
+Update your bisq code in /bisq/bisq with ```git pull```
+
+Then build an updated pricenode:
+```./gradlew :pricenode:installDist  -x test```
 
 ## How to deploy elsewhere
 


### PR DESCRIPTION
The Readme is missing an explanation on how to update a running pricenode.
This PR is adding the commands used for this. 