### PR TITLE
Add rpc method 'getfundingaddresses'

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -230,6 +230,7 @@ public class CliMain {
             stream.format("%-19s%-30s%s%n", "------", "------", "------------");
             stream.format("%-19s%-30s%s%n", "getversion", "", "Get server version");
             stream.format("%-19s%-30s%s%n", "getbalance", "", "Get server wallet balance");
+            stream.format("%-19s%-30s%s%n", "getfundingaddresses", "", "Get BTC funding addresses");
             stream.format("%-19s%-30s%s%n", "lockwallet", "", "Remove wallet password from memory, locking the wallet");
             stream.format("%-19s%-30s%s%n", "unlockwallet", "password timeout",
                     "Store wallet password in memory for timeout seconds");

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -18,6 +18,7 @@
 package bisq.cli;
 
 import bisq.proto.grpc.GetBalanceRequest;
+import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.GetVersionGrpc;
 import bisq.proto.grpc.GetVersionRequest;
 import bisq.proto.grpc.LockWalletRequest;
@@ -58,6 +59,7 @@ public class CliMain {
     private enum Method {
         getversion,
         getbalance,
+        getfundingaddresses,
         lockwallet,
         unlockwallet,
         removewalletpassword,
@@ -152,6 +154,12 @@ public class CliMain {
                     out.println(btcBalance);
                     return;
                 }
+                case getfundingaddresses: {
+                    var request = GetFundingAddressesRequest.newBuilder().build();
+                    var reply = walletService.getFundingAddresses(request);
+                    out.println(reply.getFundingAddressesInfo());
+                    return;
+                }
                 case lockwallet: {
                     var request = LockWalletRequest.newBuilder().build();
                     walletService.lockWallet(request);
@@ -201,7 +209,7 @@ public class CliMain {
                 }
                 default: {
                     throw new RuntimeException(format("unhandled method '%s'", method));
-               }
+                }
             }
         } catch (StatusRuntimeException ex) {
             // Remove the leading gRPC status code (e.g. "UNKNOWN: ") from the message

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -147,6 +147,11 @@
   [ "$output" = "0.00000000" ]
 }
 
+@test "test getfundingaddresses" {
+  run ./bisq-cli --password=xyz getfundingaddresses
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -48,17 +48,99 @@
   run ./bisq-cli --password="xyz" getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
 @test "test getversion" {
   run ./bisq-cli --password=xyz getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
-@test "test getbalance (available & unlocked wallet with 0 btc balance)" {
+@test "test setwalletpassword \"a b c\"" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted" ]
+  sleep 1
+}
+
+@test "test unlockwallet without password & timeout args" {
+  run ./bisq-cli --password=xyz unlockwallet
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no password specified" ]
+}
+
+@test "test unlockwallet without timeout arg" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no unlock timeout specified" ]
+}
+
+
+@test "test unlockwallet \"a b c\" 8" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 8
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test getbalance while wallet unlocked for 8s" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "0.00000000" ]
+  sleep 8
+}
+
+@test "test unlockwallet \"a b c\" 6" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 6
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test lockwallet before unlockwallet timeout=6s expires" {
+  run ./bisq-cli --password=xyz lockwallet
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet locked" ]
+}
+
+@test "test setwalletpassword incorrect old pwd error" {
+  run ./bisq-cli --password=xyz setwalletpassword "z z z"  "d e f"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: incorrect old password" ]
+}
+
+@test "test setwalletpassword oldpwd newpwd" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"  "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted with new password" ]
+  sleep 1
+}
+
+@test "test getbalance wallet locked error" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: wallet is locked" ]
+}
+
+@test "test removewalletpassword" {
+  run ./bisq-cli --password=xyz removewalletpassword "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet decrypted" ]
+  sleep 1
+}
+
+@test "test getbalance when wallet available & unlocked with 0 btc balance" {
   run ./bisq-cli --password=xyz getbalance
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
@@ -69,7 +151,7 @@
   run ./bisq-cli
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }
 
@@ -77,6 +159,6 @@
   run ./bisq-cli --help
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Slf4j
-class CoreWalletService {
+class CoreWalletsService {
 
     private final Balances balances;
     private final WalletsManager walletsManager;
@@ -31,7 +31,7 @@ class CoreWalletService {
     private KeyParameter tempAesKey;
 
     @Inject
-    public CoreWalletService(Balances balances, WalletsManager walletsManager) {
+    public CoreWalletsService(Balances balances, WalletsManager walletsManager) {
         this.balances = balances;
         this.walletsManager = walletsManager;
     }

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -20,17 +20,17 @@ import javax.inject.Inject;
 
 class GrpcWalletService extends WalletGrpc.WalletImplBase {
 
-    private final CoreWalletService walletService;
+    private final CoreWalletsService walletsService;
 
     @Inject
-    public GrpcWalletService(CoreWalletService walletService) {
-        this.walletService = walletService;
+    public GrpcWalletService(CoreWalletsService walletsService) {
+        this.walletsService = walletsService;
     }
 
     @Override
     public void getBalance(GetBalanceRequest req, StreamObserver<GetBalanceReply> responseObserver) {
         try {
-            long result = walletService.getAvailableBalance();
+            long result = walletsService.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -45,7 +45,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void setWalletPassword(SetWalletPasswordRequest req,
                                   StreamObserver<SetWalletPasswordReply> responseObserver) {
         try {
-            walletService.setWalletPassword(req.getPassword(), req.getNewPassword());
+            walletsService.setWalletPassword(req.getPassword(), req.getNewPassword());
             var reply = SetWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -60,7 +60,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void removeWalletPassword(RemoveWalletPasswordRequest req,
                                      StreamObserver<RemoveWalletPasswordReply> responseObserver) {
         try {
-            walletService.removeWalletPassword(req.getPassword());
+            walletsService.removeWalletPassword(req.getPassword());
             var reply = RemoveWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -75,7 +75,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void lockWallet(LockWalletRequest req,
                            StreamObserver<LockWalletReply> responseObserver) {
         try {
-            walletService.lockWallet();
+            walletsService.lockWallet();
             var reply = LockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -90,7 +90,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void unlockWallet(UnlockWalletRequest req,
                              StreamObserver<UnlockWalletReply> responseObserver) {
         try {
-            walletService.unlockWallet(req.getPassword(), req.getTimeout());
+            walletsService.unlockWallet(req.getPassword(), req.getTimeout());
             var reply = UnlockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -2,6 +2,8 @@ package bisq.core.grpc;
 
 import bisq.proto.grpc.GetBalanceReply;
 import bisq.proto.grpc.GetBalanceRequest;
+import bisq.proto.grpc.GetFundingAddressesReply;
+import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.LockWalletReply;
 import bisq.proto.grpc.LockWalletRequest;
 import bisq.proto.grpc.RemoveWalletPasswordReply;
@@ -32,6 +34,21 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
         try {
             long result = walletsService.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (IllegalStateException cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
+    }
+    
+    @Override
+    public void getFundingAddresses(GetFundingAddressesRequest req,
+                                    StreamObserver<GetFundingAddressesReply> responseObserver) {
+        try {
+            String result = walletsService.getFundingAddresses();
+            var reply = GetFundingAddressesReply.newBuilder().setFundingAddressesInfo(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -119,6 +119,8 @@ message PlaceOfferReply {
 service Wallet {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
+    rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
+    }
     rpc SetWalletPassword (SetWalletPasswordRequest) returns (SetWalletPasswordReply) {
     }
     rpc RemoveWalletPassword (RemoveWalletPasswordRequest) returns (RemoveWalletPasswordReply) {
@@ -134,6 +136,13 @@ message GetBalanceRequest {
 
 message GetBalanceReply {
     uint64 balance = 1;
+}
+
+message GetFundingAddressesRequest {
+}
+
+message GetFundingAddressesReply {
+    string fundingAddressesInfo = 1;
 }
 
 message SetWalletPasswordRequest {


### PR DESCRIPTION
This addresses task 1 in issue [4257](https://github.com/bisq-network/bisq/issues/4257).

This new gRPC Wallet service method displays the BTC wallet's list of receiving addresses.  The balance and number of confirmations for the most recent transaction is displayed to the right of each address.  Instead of returning a gRPC data structure to the client, the service method returns a formatted String.

If the BTC wallet has no unused addresses, one will be created and included in the returned list, and it can be used to fund the wallet.

The new method required injection of the `BtcWalletService` into `CoreWalletsService`, and the usual boilerplate changes to `grpc.proto`, `CliMain`, and `GrpcWalletService`.

Some of the next PRs (for issue [4257](https://github.com/bisq-network/bisq/issues/4257)) will require some common functionality within `CoreWalletsService`.  These additional changes were made:

  * a private, class level `formatSatoshis` function
  * a public `getNumConfirmationsForMostRecentTransaction` method
  * a public `getAddressBalance` method
  * a private `getAddressEntry` method

A unit test that verifies a successful return status was added to `cli/test.sh`.


This PR should be reviewed/merged after PR [4296](https://github.com/bisq-network/bisq/pull/4296).