### PR TITLE
Add V3 seednodes wizseed3 and wizseed7, retire seednode ef5qnzx6znifo3df

### DIFF
--- a/core/src/main/resources/btc_mainnet.seednodes
+++ b/core/src/main/resources/btc_mainnet.seednodes
@@ -1,9 +1,10 @@
 # nodeaddress.onion:port [(@owner,@backup)]
 5quyxpxheyvzmb2d.onion:8000 (@miker)
 s67qglwhkgkyvr74.onion:8000 (@emzy)
-ef5qnzx6znifo3df.onion:8000 (@wiz,@emzy)
 3f3cu2yw7u457ztq.onion:8000 (@devinbileck,@ripcurlx)
 723ljisnynbtdohi.onion:8000 (@emzy)
 rm7b56wbrcczpjvl.onion:8000 (@miker)
 fl3mmribyxgrv63c.onion:8000 (@devinbileck,@ripcurlx)
 wizseedscybbttk4bmb2lzvbuk2jtect37lcpva4l3twktmkzemwbead.onion:8000 (@wiz)
+wizseed3d376esppbmbjxk2fhk2jg5fpucddrzj2kxtbxbx4vrnwclad.onion:8000 (@wiz)
+wizseed7ab2gi3x267xahrp2pkndyrovczezzb46jk6quvguciuyqrid.onion:8000 (@wiz)


### PR DESCRIPTION
As part of the Tor V3 upgrade, and the effort to increase the number of
Bisq seednodes from 8 to 12, this PR adds 2 new V3 seednodes, and will
start the process to retire the old V2 seednode ef5qnzx6znifo3df.

The ef5qnzx6znifo3df seednode will continue operating for 2-3 months
during the retirement phase-out period, after which time we can filter
it out from the network for clients who have not upgraded if necessary.