### PR TITLE
Send signed witness to counterparty

### DIFF
--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -42,10 +42,6 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 
-import javax.crypto.Cipher;
-
-import java.security.NoSuchAlgorithmException;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -462,8 +458,7 @@ public class Utilities {
     }
 
     // Helper to filter unique elements by key
-    public static <T> Predicate<T> distinctByKey(Function<? super T, Object> keyExtractor)
-    {
+    public static <T> Predicate<T> distinctByKey(Function<? super T, Object> keyExtractor) {
         Map<Object, Boolean> map = new ConcurrentHashMap<>();
         return t -> map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
     }

--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -56,15 +56,19 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -451,5 +455,12 @@ public class Utilities {
             result = result << 8 | aByte & 0xff;
         }
         return result;
+    }
+
+    // Helper to filter unique elements by key
+    public static <T> Predicate<T> distinctByKey(Function<? super T, Object> keyExtractor)
+    {
+        Map<Object, Boolean> map = new ConcurrentHashMap<>();
+        return t -> map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
     }
 }

--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -334,6 +334,10 @@ public class Utilities {
         return new KeyCodeCombination(keyCode, KeyCombination.ALT_DOWN).match(keyEvent);
     }
 
+    public static boolean isCtrlShiftPressed(KeyCode keyCode, KeyEvent keyEvent) {
+        return new KeyCodeCombination(keyCode, KeyCombination.CONTROL_DOWN, KeyCombination.SHIFT_DOWN).match(keyEvent);
+    }
+
     public static byte[] concatenateByteArrays(byte[] array1, byte[] array2) {
         return ArrayUtils.addAll(array1, array2);
     }

--- a/core/src/main/java/bisq/core/account/sign/SignedWitness.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitness.java
@@ -168,7 +168,7 @@ public class SignedWitness implements ProcessOncePersistableNetworkPayload, Pers
     // Getters
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    P2PDataStorage.ByteArray getHashAsByteArray() {
+    public P2PDataStorage.ByteArray getHashAsByteArray() {
         return new P2PDataStorage.ByteArray(hash);
     }
 

--- a/core/src/main/java/bisq/core/account/sign/SignedWitness.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitness.java
@@ -117,7 +117,7 @@ public class SignedWitness implements ProcessOncePersistableNetworkPayload, Pers
         return protobuf.PersistableNetworkPayload.newBuilder().setSignedWitness(builder).build();
     }
 
-    protobuf.SignedWitness toProtoSignedWitness() {
+    public protobuf.SignedWitness toProtoSignedWitness() {
         return toProtoMessage().getSignedWitness();
     }
 

--- a/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
@@ -29,6 +29,7 @@ import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
 
 import bisq.common.UserThread;
 import bisq.common.crypto.CryptoException;
+import bisq.common.crypto.Hash;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.Sig;
 import bisq.common.util.Utilities;
@@ -63,6 +64,8 @@ import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import static bisq.common.util.Utilities.distinctByKey;
 
 @Slf4j
 public class SignedWitnessService {
@@ -344,6 +347,13 @@ public class SignedWitnessService {
                 .filter(witness -> getSignedWitnessSetByOwnerPubKey(witness.getSignerPubKey(), new Stack<>()).isEmpty())
                 .filter(witness -> includeSignedByArbitrator ||
                         witness.getVerificationMethod() != SignedWitness.VerificationMethod.ARBITRATOR)
+                .collect(Collectors.toSet());
+    }
+
+    public Set<byte[]> getUnsignedSignersPubKeys() {
+        return getRootSignedWitnessSet(false).stream()
+                .map(SignedWitness::getSignerPubKey)
+                .filter(distinctByKey(key -> Utilities.bytesAsHexString(Hash.getRipemd160hash(key))))
                 .collect(Collectors.toSet());
     }
 

--- a/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collector;
@@ -263,17 +264,17 @@ public class SignedWitnessService {
     }
 
     // Any peer can sign with DSA key
-    public void signAccountAgeWitness(Coin tradeAmount,
-                                      AccountAgeWitness accountAgeWitness,
-                                      PublicKey peersPubKey) throws CryptoException {
+    public Optional<SignedWitness> signAccountAgeWitness(Coin tradeAmount,
+                                                         AccountAgeWitness accountAgeWitness,
+                                                         PublicKey peersPubKey) throws CryptoException {
         if (isSignedAccountAgeWitness(accountAgeWitness)) {
             log.warn("Trader trying to sign already signed accountagewitness {}", accountAgeWitness.toString());
-            return;
+            return Optional.empty();
         }
 
         if (!isSufficientTradeAmountForSigning(tradeAmount)) {
             log.warn("Trader tried to sign account with too little trade amount");
-            return;
+            return Optional.empty();
         }
 
         byte[] signature = Sig.sign(keyRing.getSignatureKeyPair().getPrivate(), accountAgeWitness.getHash());
@@ -286,6 +287,7 @@ public class SignedWitnessService {
                 tradeAmount.value);
         publishSignedWitness(signedWitness);
         log.info("Trader signed witness {}", signedWitness.toString());
+        return Optional.of(signedWitness);
     }
 
     public boolean verifySignature(SignedWitness signedWitness) {
@@ -362,8 +364,8 @@ public class SignedWitnessService {
         var oldestUnsignedSigners = new HashMap<P2PDataStorage.ByteArray, SignedWitness>();
         getRootSignedWitnessSet(false).forEach(signedWitness ->
                 oldestUnsignedSigners.compute(new P2PDataStorage.ByteArray(signedWitness.getSignerPubKey()),
-                (key, oldValue) -> oldValue == null ? signedWitness :
-                        oldValue.getDate() > signedWitness.getDate() ? signedWitness : oldValue));
+                        (key, oldValue) -> oldValue == null ? signedWitness :
+                                oldValue.getDate() > signedWitness.getDate() ? signedWitness : oldValue));
         return new HashSet<>(oldestUnsignedSigners.values());
     }
 

--- a/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
@@ -334,10 +334,11 @@ public class SignedWitnessService {
                 .collect(Collectors.toSet());
     }
 
-    public Set<SignedWitness> getOrphanSignedWitnessSet() {
+    public Set<SignedWitness> getRootSignedWitnessSet(boolean includeSignedByArbitrator) {
         return signedWitnessMap.values().stream()
                 .filter(witness -> getSignedWitnessSetByOwnerPubKey(witness.getSignerPubKey(), new Stack<>()).isEmpty())
-                .filter(witness -> witness.getVerificationMethod() != SignedWitness.VerificationMethod.ARBITRATOR)
+                .filter(witness -> includeSignedByArbitrator ||
+                        witness.getVerificationMethod() != SignedWitness.VerificationMethod.ARBITRATOR)
                 .collect(Collectors.toSet());
     }
 

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -679,6 +679,10 @@ public class AccountAgeWitnessService {
         return Optional.empty();
     }
 
+    public boolean publishOwnSignedWitness(SignedWitness signedWitness) {
+        return signedWitnessService.publishOwnSignedWitness(signedWitness);
+    }
+
     // Arbitrator signing
     public List<TraderDataItem> getTraderPaymentAccounts(long safeDate,
                                                          PaymentMethod paymentMethod,

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -17,6 +17,7 @@
 
 package bisq.core.account.witness;
 
+import bisq.core.account.sign.SignedWitness;
 import bisq.core.account.sign.SignedWitnessService;
 import bisq.core.filter.FilterManager;
 import bisq.core.filter.PaymentAccountFilter;
@@ -648,6 +649,12 @@ public class AccountAgeWitnessService {
                 time);
     }
 
+    public String arbitratorSignOrphanPubKey(ECKey key,
+                                             byte[] peersPubKey,
+                                             long childSignTime) {
+        return signedWitnessService.signTraderPubKey(key, peersPubKey, childSignTime);
+    }
+
     public void arbitratorSignAccountAgeWitness(AccountAgeWitness accountAgeWitness,
                                                 ECKey key,
                                                 byte[] tradersPubKey,
@@ -805,5 +812,9 @@ public class AccountAgeWitnessService {
                 .map(signedWitness -> getWitnessByHash(signedWitness.getAccountAgeWitnessHash()).orElse(null))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
+    }
+
+    public Set<SignedWitness> getUnsignedSignerPubKeys() {
+        return signedWitnessService.getUnsignedSignerPubKeys();
     }
 }

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -662,7 +662,7 @@ public class AccountAgeWitnessService {
         signedWitnessService.signAccountAgeWitness(accountAgeWitness, key, tradersPubKey, time);
     }
 
-    public void traderSignPeersAccountAgeWitness(Trade trade) {
+    public Optional<SignedWitness> traderSignPeersAccountAgeWitness(Trade trade) {
         AccountAgeWitness peersWitness = findTradePeerWitness(trade).orElse(null);
         Coin tradeAmount = trade.getTradeAmount();
         checkNotNull(trade.getProcessModel().getTradingPeer().getPubKeyRing(), "Peer must have a keyring");
@@ -672,10 +672,11 @@ public class AccountAgeWitnessService {
         checkNotNull(peersPubKey, "Peers pub key must not be null");
 
         try {
-            signedWitnessService.signAccountAgeWitness(tradeAmount, peersWitness, peersPubKey);
+            return signedWitnessService.signAccountAgeWitness(tradeAmount, peersWitness, peersPubKey);
         } catch (CryptoException e) {
             log.warn("Trader failed to sign witness, exception {}", e.toString());
         }
+        return Optional.empty();
     }
 
     // Arbitrator signing

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
@@ -32,7 +32,6 @@ import bisq.common.util.Utilities;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Stack;
-import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,8 +59,8 @@ public class AccountAgeWitnessUtils {
         log.info("Orphaned signed account age witnesses:");
         orphanSigners.forEach(w -> {
             log.info("{}: Signer PKH: {} Owner PKH: {} time: {}", w.getVerificationMethod().toString(),
-                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getSignerPubKey())).substring(0,7),
-                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getWitnessOwnerPubKey())).substring(0,7),
+                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getSignerPubKey())).substring(0, 7),
+                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getWitnessOwnerPubKey())).substring(0, 7),
                     w.getDate());
             logChild(w, "  ", new Stack<>());
         });
@@ -100,8 +99,10 @@ public class AccountAgeWitnessUtils {
 
     public void logUnsignedSignerPubKeys() {
         log.info("Unsigned signer pubkeys");
-        signedWitnessService.getUnsignedSignersPubKeys().forEach(pubKey ->
-                log.info("PK hash {}",Utilities.bytesAsHexString(Hash.getRipemd160hash(pubKey))));
+        signedWitnessService.getUnsignedSignerPubKeys().forEach(signedWitness ->
+                log.info("PK hash {} date {}",
+                        Utilities.bytesAsHexString(Hash.getRipemd160hash(signedWitness.getSignerPubKey())),
+                        signedWitness.getDate()));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.account.witness;
+
+import bisq.core.account.sign.SignedWitness;
+import bisq.core.account.sign.SignedWitnessService;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.trade.Trade;
+
+import bisq.network.p2p.storage.P2PDataStorage;
+
+import bisq.common.crypto.Hash;
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.util.Utilities;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Stack;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Slf4j
+public class AccountAgeWitnessUtils {
+    private final AccountAgeWitnessService accountAgeWitnessService;
+    private final SignedWitnessService signedWitnessService;
+    private final KeyRing keyRing;
+
+    AccountAgeWitnessUtils(AccountAgeWitnessService accountAgeWitnessService,
+                           SignedWitnessService signedWitnessService,
+                           KeyRing keyRing) {
+        this.accountAgeWitnessService = accountAgeWitnessService;
+        this.signedWitnessService = signedWitnessService;
+        this.keyRing = keyRing;
+    }
+
+    // Log tree of signed witnesses
+    public void logSignedWitnesses() {
+        var orphanSigners = signedWitnessService.getRootSignedWitnessSet(false);
+        log.info("Orphaned signed account age witnesses:");
+        orphanSigners.forEach(w -> {
+            log.warn("{}: {}", w.getVerificationMethod().toString(),
+                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getSignerPubKey())));
+            logChild(w, "  ", new Stack<>());
+        });
+    }
+
+    private void logChild(SignedWitness sigWit, String initString, Stack<P2PDataStorage.ByteArray> excluded) {
+        var allSig = signedWitnessService.getSignedWitnessMap();
+        log.warn("{}{}", initString, Utilities.bytesAsHexString(sigWit.getAccountAgeWitnessHash()));
+        allSig.values().forEach(w -> {
+            if (!excluded.contains(new P2PDataStorage.ByteArray(w.getWitnessOwnerPubKey())) &&
+                    Arrays.equals(w.getSignerPubKey(), sigWit.getWitnessOwnerPubKey())) {
+                excluded.push(new P2PDataStorage.ByteArray(w.getWitnessOwnerPubKey()));
+                logChild(w, initString + "  ", excluded);
+                excluded.pop();
+            }
+        });
+    }
+
+    // Log signers per
+    public void logSigners() {
+        log.info("signers per AEW");
+        var allSig = signedWitnessService.getSignedWitnessMap();
+        allSig.values().forEach(w -> {
+                    log.info("AEW {}", Utilities.bytesAsHexString(w.getAccountAgeWitnessHash()));
+                    allSig.values().forEach(ww -> {
+                        if (Arrays.equals(w.getSignerPubKey(), ww.getWitnessOwnerPubKey())) {
+                            log.info("  {}", Utilities.bytesAsHexString(ww.getAccountAgeWitnessHash()));
+                        }
+                    });
+                }
+        );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Debug logs
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private String getWitnessDebugLog(PaymentAccountPayload paymentAccountPayload,
+                                      PubKeyRing pubKeyRing) {
+        Optional<AccountAgeWitness> accountAgeWitness =
+                accountAgeWitnessService.findWitness(paymentAccountPayload, pubKeyRing);
+        if (!accountAgeWitness.isPresent()) {
+            byte[] accountInputDataWithSalt =
+                    accountAgeWitnessService.getAccountInputDataWithSalt(paymentAccountPayload);
+            byte[] hash = Hash.getSha256Ripemd160hash(Utilities.concatenateByteArrays(accountInputDataWithSalt,
+                    pubKeyRing.getSignaturePubKeyBytes()));
+            return "No accountAgeWitness found for paymentAccountPayload with hash " + Utilities.bytesAsHexString(hash);
+        }
+
+        AccountAgeWitnessService.SignState signState =
+                accountAgeWitnessService.getSignState(accountAgeWitness.get());
+        return signState.name() + " " + signState.getPresentation() +
+                "\n" + accountAgeWitness.toString();
+    }
+
+    public void witnessDebugLog(Trade trade, @Nullable AccountAgeWitness myWitness) {
+        // Log to find why accounts sometimes don't get signed as expected
+        // TODO: Demote to debug or remove once account signing is working ok
+        checkNotNull(trade.getContract());
+        checkNotNull(trade.getContract().getBuyerPaymentAccountPayload());
+        boolean checkingSignTrade = true;
+        boolean isBuyer = trade.getContract().isMyRoleBuyer(keyRing.getPubKeyRing());
+        AccountAgeWitness witness = myWitness;
+        if (witness == null) {
+            witness = isBuyer ?
+                    accountAgeWitnessService.getMyWitness(trade.getContract().getBuyerPaymentAccountPayload()) :
+                    accountAgeWitnessService.getMyWitness(trade.getContract().getSellerPaymentAccountPayload());
+            checkingSignTrade = false;
+        }
+        boolean isSignWitnessTrade = accountAgeWitnessService.accountIsSigner(witness) &&
+                !accountAgeWitnessService.peerHasSignedWitness(trade) &&
+                accountAgeWitnessService.tradeAmountIsSufficient(trade.getTradeAmount());
+        log.info("AccountSigning: " +
+                        "\ntradeId: {}" +
+                        "\nis buyer: {}" +
+                        "\nbuyer account age witness info: {}" +
+                        "\nseller account age witness info: {}" +
+                        "\nchecking for sign trade: {}" +
+                        "\nis myWitness signer: {}" +
+                        "\npeer has signed witness: {}" +
+                        "\ntrade amount: {}" +
+                        "\ntrade amount is sufficient: {}" +
+                        "\nisSignWitnessTrade: {}",
+                trade.getId(),
+                isBuyer,
+                getWitnessDebugLog(trade.getContract().getBuyerPaymentAccountPayload(),
+                        trade.getContract().getBuyerPubKeyRing()),
+                getWitnessDebugLog(trade.getContract().getSellerPaymentAccountPayload(),
+                        trade.getContract().getSellerPubKeyRing()),
+                checkingSignTrade, // Following cases added to use same logic as in seller signing check
+                accountAgeWitnessService.accountIsSigner(witness),
+                accountAgeWitnessService.peerHasSignedWitness(trade),
+                trade.getTradeAmount(),
+                accountAgeWitnessService.tradeAmountIsSufficient(trade.getTradeAmount()),
+                isSignWitnessTrade);
+    }
+}

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
@@ -32,6 +32,7 @@ import bisq.common.util.Utilities;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Stack;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -84,7 +85,7 @@ public class AccountAgeWitnessUtils {
 
     // Log signers per
     public void logSigners() {
-        log.info("signers per AEW");
+        log.info("Signers per AEW");
         var allSig = signedWitnessService.getSignedWitnessMap();
         allSig.values().forEach(w -> {
                     log.info("AEW {}", Utilities.bytesAsHexString(w.getAccountAgeWitnessHash()));
@@ -95,6 +96,12 @@ public class AccountAgeWitnessUtils {
                     });
                 }
         );
+    }
+
+    public void logUnsignedSignerPubKeys() {
+        log.info("Unsigned signer pubkeys");
+        signedWitnessService.getUnsignedSignersPubKeys().forEach(pubKey ->
+                log.info("PK hash {}",Utilities.bytesAsHexString(Hash.getRipemd160hash(pubKey))));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessUtils.java
@@ -55,18 +55,23 @@ public class AccountAgeWitnessUtils {
 
     // Log tree of signed witnesses
     public void logSignedWitnesses() {
-        var orphanSigners = signedWitnessService.getRootSignedWitnessSet(false);
+        var orphanSigners = signedWitnessService.getRootSignedWitnessSet(true);
         log.info("Orphaned signed account age witnesses:");
         orphanSigners.forEach(w -> {
-            log.warn("{}: {}", w.getVerificationMethod().toString(),
-                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getSignerPubKey())));
+            log.info("{}: Signer PKH: {} Owner PKH: {} time: {}", w.getVerificationMethod().toString(),
+                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getSignerPubKey())).substring(0,7),
+                    Utilities.bytesAsHexString(Hash.getRipemd160hash(w.getWitnessOwnerPubKey())).substring(0,7),
+                    w.getDate());
             logChild(w, "  ", new Stack<>());
         });
     }
 
     private void logChild(SignedWitness sigWit, String initString, Stack<P2PDataStorage.ByteArray> excluded) {
         var allSig = signedWitnessService.getSignedWitnessMap();
-        log.warn("{}{}", initString, Utilities.bytesAsHexString(sigWit.getAccountAgeWitnessHash()));
+        log.info("{}AEW: {} PKH: {} time: {}", initString,
+                Utilities.bytesAsHexString(sigWit.getAccountAgeWitnessHash()).substring(0, 7),
+                Utilities.bytesAsHexString(Hash.getRipemd160hash(sigWit.getWitnessOwnerPubKey())).substring(0, 7),
+                sigWit.getDate());
         allSig.values().forEach(w -> {
             if (!excluded.contains(new P2PDataStorage.ByteArray(w.getWitnessOwnerPubKey())) &&
                     Arrays.equals(w.getSignerPubKey(), sigWit.getWitnessOwnerPubKey())) {

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -58,6 +58,7 @@ import bisq.core.trade.messages.MediatedPayoutTxSignatureMessage;
 import bisq.core.trade.messages.PayoutTxPublishedMessage;
 import bisq.core.trade.messages.PeerPublishedDelayedPayoutTxMessage;
 import bisq.core.trade.messages.RefreshTradeStateRequest;
+import bisq.core.trade.messages.TraderSignedWitnessMessage;
 import bisq.core.trade.statistics.TradeStatistics;
 
 import bisq.network.p2p.AckMessage;
@@ -165,6 +166,8 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                     return PayoutTxPublishedMessage.fromProto(proto.getPayoutTxPublishedMessage(), messageVersion);
                 case PEER_PUBLISHED_DELAYED_PAYOUT_TX_MESSAGE:
                     return PeerPublishedDelayedPayoutTxMessage.fromProto(proto.getPeerPublishedDelayedPayoutTxMessage(), messageVersion);
+                case TRADER_SIGNED_WITNESS_MESSAGE:
+                    return TraderSignedWitnessMessage.fromProto(proto.getTraderSignedWitnessMessage(), messageVersion);
 
                 case MEDIATED_PAYOUT_TX_SIGNATURE_MESSAGE:
                     return MediatedPayoutTxSignatureMessage.fromProto(proto.getMediatedPayoutTxSignatureMessage(), messageVersion);

--- a/core/src/main/java/bisq/core/trade/messages/TraderSignedWitnessMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/TraderSignedWitnessMessage.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.messages;
+
+import bisq.core.account.sign.SignedWitness;
+
+import bisq.network.p2p.MailboxMessage;
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.app.Version;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class TraderSignedWitnessMessage extends TradeMessage implements MailboxMessage {
+    private final NodeAddress senderNodeAddress;
+    private final SignedWitness signedWitness;
+
+    public TraderSignedWitnessMessage(String uid,
+                                      String tradeId,
+                                      NodeAddress senderNodeAddress,
+                                      SignedWitness signedWitness) {
+        this(Version.getP2PMessageVersion(),
+                uid,
+                tradeId,
+                senderNodeAddress,
+                signedWitness);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private TraderSignedWitnessMessage(int messageVersion,
+                                       String uid,
+                                       String tradeId,
+                                       NodeAddress senderNodeAddress,
+                                       SignedWitness signedWitness) {
+        super(messageVersion, tradeId, uid);
+        this.senderNodeAddress = senderNodeAddress;
+        this.signedWitness = signedWitness;
+    }
+
+    @Override
+    public protobuf.NetworkEnvelope toProtoNetworkEnvelope() {
+        final protobuf.TraderSignedWitnessMessage.Builder builder = protobuf.TraderSignedWitnessMessage.newBuilder();
+        builder.setUid(uid)
+                .setTradeId(tradeId)
+                .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
+                .setSignedWitness(signedWitness.toProtoSignedWitness());
+        return getNetworkEnvelopeBuilder().setTraderSignedWitnessMessage(builder).build();
+    }
+
+    public static TraderSignedWitnessMessage fromProto(protobuf.TraderSignedWitnessMessage proto, int messageVersion) {
+        return new TraderSignedWitnessMessage(messageVersion,
+                proto.getUid(),
+                proto.getTradeId(),
+                NodeAddress.fromProto(proto.getSenderNodeAddress()),
+                SignedWitness.fromProto(proto.getSignedWitness()));
+    }
+
+    @Override
+    public String toString() {
+        return "TraderSignedWitnessMessage{" +
+                "\n     senderNodeAddress=" + senderNodeAddress +
+                "\n     signedWitness=" + signedWitness +
+                "\n} " + super.toString();
+    }
+
+}

--- a/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
@@ -358,6 +358,6 @@ public class ProcessModel implements Model, PersistablePayload {
     }
 
     void logTrade(Trade trade) {
-        accountAgeWitnessService.witnessDebugLog(trade, null);
+        accountAgeWitnessService.getAccountAgeWitnessUtils().witnessDebugLog(trade, null);
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -26,6 +26,7 @@ import bisq.core.trade.messages.MediatedPayoutTxPublishedMessage;
 import bisq.core.trade.messages.MediatedPayoutTxSignatureMessage;
 import bisq.core.trade.messages.PeerPublishedDelayedPayoutTxMessage;
 import bisq.core.trade.messages.TradeMessage;
+import bisq.core.trade.messages.TraderSignedWitnessMessage;
 import bisq.core.trade.protocol.tasks.ApplyFilter;
 import bisq.core.trade.protocol.tasks.ProcessPeerPublishedDelayedPayoutTxMessage;
 import bisq.core.trade.protocol.tasks.mediation.BroadcastMediatedPayoutTx;
@@ -228,6 +229,15 @@ public abstract class TradeProtocol {
         taskRunner.run();
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Peer has sent a SignedWitness
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private void handle(TraderSignedWitnessMessage tradeMessage, NodeAddress sender) {
+        // Publish signed witness, if it is valid and ours
+        processModel.getAccountAgeWitnessService().publishOwnSignedWitness(tradeMessage.getSignedWitness());
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Dispatcher
@@ -240,6 +250,8 @@ public abstract class TradeProtocol {
             handle((MediatedPayoutTxPublishedMessage) tradeMessage, sender);
         } else if (tradeMessage instanceof PeerPublishedDelayedPayoutTxMessage) {
             handle((PeerPublishedDelayedPayoutTxMessage) tradeMessage, sender);
+        } else if (tradeMessage instanceof TraderSignedWitnessMessage) {
+            handle((TraderSignedWitnessMessage) tradeMessage, sender);
         }
     }
 
@@ -287,6 +299,8 @@ public abstract class TradeProtocol {
             handle((MediatedPayoutTxPublishedMessage) tradeMessage, peerNodeAddress);
         } else if (tradeMessage instanceof PeerPublishedDelayedPayoutTxMessage) {
             handle((PeerPublishedDelayedPayoutTxMessage) tradeMessage, peerNodeAddress);
+        } else if (tradeMessage instanceof TraderSignedWitnessMessage) {
+            handle((TraderSignedWitnessMessage) tradeMessage, peerNodeAddress);
         }
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -233,7 +233,7 @@ public abstract class TradeProtocol {
     // Peer has sent a SignedWitness
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private void handle(TraderSignedWitnessMessage tradeMessage, NodeAddress sender) {
+    private void handle(TraderSignedWitnessMessage tradeMessage) {
         // Publish signed witness, if it is valid and ours
         processModel.getAccountAgeWitnessService().publishOwnSignedWitness(tradeMessage.getSignedWitness());
     }
@@ -251,7 +251,7 @@ public abstract class TradeProtocol {
         } else if (tradeMessage instanceof PeerPublishedDelayedPayoutTxMessage) {
             handle((PeerPublishedDelayedPayoutTxMessage) tradeMessage, sender);
         } else if (tradeMessage instanceof TraderSignedWitnessMessage) {
-            handle((TraderSignedWitnessMessage) tradeMessage, sender);
+            handle((TraderSignedWitnessMessage) tradeMessage);
         }
     }
 
@@ -300,7 +300,7 @@ public abstract class TradeProtocol {
         } else if (tradeMessage instanceof PeerPublishedDelayedPayoutTxMessage) {
             handle((PeerPublishedDelayedPayoutTxMessage) tradeMessage, peerNodeAddress);
         } else if (tradeMessage instanceof TraderSignedWitnessMessage) {
-            handle((TraderSignedWitnessMessage) tradeMessage, peerNodeAddress);
+            handle((TraderSignedWitnessMessage) tradeMessage);
         }
     }
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2729,6 +2729,17 @@ popup.accountSigning.peerLimitLifted=The initial limit for one of your accounts 
 popup.accountSigning.peerSigner=One of your accounts is mature enough to sign other payment accounts \
   and the initial limit for one of your accounts has been lifted.\n\n{0}
 
+popup.accountSigning.singleAccountSelect.headline=Select account age witness
+popup.accountSigning.singleAccountSelect.description=Search for account age witness.
+popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
+popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
+popup.accountSigning.confirmSingleAccount.button=Sign account age witness
+popup.accountSigning.successSingleAccount.description=Witness {0} was signed
+popup.accountSigning.successSingleAccount.success.headline=Success
+popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
+
+
 ####################################################################
 # Notifications
 ####################################################################

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2739,6 +2739,12 @@ popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
 popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
+popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
+popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
+popup.accountSigning.unsignedPubKeys.signed=Pubkeys were signed
+popup.accountSigning.unsignedPubKeys.result.headline=Signing completed
+popup.accountSigning.unsignedPubKeys.result.signed=Signed pubkeys
+popup.accountSigning.unsignedPubKeys.result.failed=Failed to sign
 
 ####################################################################
 # Notifications

--- a/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
@@ -324,11 +324,11 @@ public class AccountAgeWitnessServiceTest {
         assertFalse(signedWitnessService.isSignedAccountAgeWitness(aew2));
 
         // Sign dummy AccountAgeWitness using signer key from SW_1
-        assertEquals(signedWitnessService.getOrphanSignedWitnessSet().size(), 1);
+        assertEquals(signedWitnessService.getRootSignedWitnessSet().size(), 1);
 
         // TODO: move this to accountagewitnessservice
         @SuppressWarnings("OptionalGetWithoutIsPresent")
-        var orphanedSignedWitness = signedWitnessService.getOrphanSignedWitnessSet().stream().findAny().get();
+        var orphanedSignedWitness = signedWitnessService.getRootSignedWitnessSet().stream().findAny().get();
         var dummyAccountAgeWitnessHash = Hash.getRipemd160hash(orphanedSignedWitness.getSignerPubKey());
         var dummyAEW = new AccountAgeWitness(dummyAccountAgeWitnessHash,
                 orphanedSignedWitness.getDate() -

--- a/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
@@ -324,11 +324,11 @@ public class AccountAgeWitnessServiceTest {
         assertFalse(signedWitnessService.isSignedAccountAgeWitness(aew2));
 
         // Sign dummy AccountAgeWitness using signer key from SW_1
-        assertEquals(signedWitnessService.getRootSignedWitnessSet().size(), 1);
+        assertEquals(signedWitnessService.getRootSignedWitnessSet(false).size(), 1);
 
         // TODO: move this to accountagewitnessservice
         @SuppressWarnings("OptionalGetWithoutIsPresent")
-        var orphanedSignedWitness = signedWitnessService.getRootSignedWitnessSet().stream().findAny().get();
+        var orphanedSignedWitness = signedWitnessService.getRootSignedWitnessSet(false).stream().findAny().get();
         var dummyAccountAgeWitnessHash = Hash.getRipemd160hash(orphanedSignedWitness.getSignerPubKey());
         var dummyAEW = new AccountAgeWitness(dummyAccountAgeWitnessHash,
                 orphanedSignedWitness.getDate() -

--- a/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
@@ -16,6 +16,8 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentMethod;
 
 import bisq.common.UserThread;
+import bisq.common.app.DevEnv;
+import bisq.common.util.Utilities;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -26,9 +28,13 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 
 import javafx.beans.value.ChangeListener;
+
+import javafx.event.EventHandler;
 
 import javafx.collections.ObservableList;
 
@@ -41,8 +47,8 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
     protected ListView<PaymentAccount> paymentAccountsListView;
     private ChangeListener<PaymentAccount> paymentAccountChangeListener;
     protected Button addAccountButton, exportButton, importButton;
-    SignedWitnessService signedWitnessService;
     protected AccountAgeWitnessService accountAgeWitnessService;
+    private EventHandler<KeyEvent> keyEventEventHandler;
 
     public PaymentAccountsView(M model, AccountAgeWitnessService accountAgeWitnessService) {
         super(model);
@@ -51,6 +57,14 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
 
     @Override
     public void initialize() {
+        keyEventEventHandler = event -> {
+            if (Utilities.isCtrlShiftPressed(KeyCode.L, event)) {
+                accountAgeWitnessService.getAccountAgeWitnessUtils().logSignedWitnesses();
+            } else if (Utilities.isCtrlShiftPressed(KeyCode.S, event)) {
+                accountAgeWitnessService.getAccountAgeWitnessUtils().logSigners();
+            }
+        };
+
         buildForm();
         paymentAccountChangeListener = (observable, oldValue, newValue) -> {
             if (newValue != null)
@@ -68,6 +82,8 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
         addAccountButton.setOnAction(event -> addNewAccount());
         exportButton.setOnAction(event -> exportAccounts());
         importButton.setOnAction(event -> importAccounts());
+        if (root.getScene() != null)
+            root.getScene().addEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
     }
 
     @Override
@@ -76,6 +92,8 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
         addAccountButton.setOnAction(null);
         exportButton.setOnAction(null);
         importButton.setOnAction(null);
+        if (root.getScene() != null)
+            root.getScene().removeEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
     }
 
     protected void onDeleteAccount(PaymentAccount paymentAccount) {

--- a/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
@@ -62,6 +62,8 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
                 accountAgeWitnessService.getAccountAgeWitnessUtils().logSignedWitnesses();
             } else if (Utilities.isCtrlShiftPressed(KeyCode.S, event)) {
                 accountAgeWitnessService.getAccountAgeWitnessUtils().logSigners();
+            } else if (Utilities.isCtrlShiftPressed(KeyCode.U, event)) {
+                accountAgeWitnessService.getAccountAgeWitnessUtils().logUnsignedSignerPubKeys();
             }
         };
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignSpecificWitnessWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignSpecificWitnessWindow.java
@@ -1,0 +1,207 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.overlays.windows;
+
+import bisq.desktop.components.AutoTooltipButton;
+import bisq.desktop.components.InputTextField;
+import bisq.desktop.main.overlays.Overlay;
+import bisq.desktop.main.overlays.popups.Popup;
+
+import bisq.core.account.witness.AccountAgeWitness;
+import bisq.core.account.witness.AccountAgeWitnessService;
+import bisq.core.locale.Res;
+import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
+
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.Utils;
+
+import javax.inject.Inject;
+
+import com.jfoenix.controls.JFXAutoCompletePopup;
+
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.ListCell;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+
+import javafx.geometry.VPos;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.desktop.util.FormBuilder.*;
+
+@Slf4j
+public class SignSpecificWitnessWindow extends Overlay<SignSpecificWitnessWindow> {
+
+    private InputTextField searchTextField;
+    private JFXAutoCompletePopup<AccountAgeWitness> searchAutoComplete;
+    private AccountAgeWitness selectedWitness;
+    private DatePicker datePicker;
+    private InputTextField privateKey;
+    private final AccountAgeWitnessService accountAgeWitnessService;
+    private final ArbitratorManager arbitratorManager;
+
+
+    @Inject
+    public SignSpecificWitnessWindow(AccountAgeWitnessService accountAgeWitnessService,
+                                     ArbitratorManager arbitratorManager) {
+        this.accountAgeWitnessService = accountAgeWitnessService;
+        this.arbitratorManager = arbitratorManager;
+    }
+
+    @Override
+    public void show() {
+        width = 1000;
+        rowIndex = -1;
+        createGridPane();
+
+        gridPane.setPrefHeight(600);
+        gridPane.getColumnConstraints().get(1).setHgrow(Priority.NEVER);
+        headLine(Res.get("popup.accountSigning.singleAccountSelect.headline"));
+        type = Type.Attention;
+
+        addHeadLine();
+        addSelectWitnessContent();
+        addButtons();
+        applyStyles();
+
+        display();
+    }
+
+    private void addSelectWitnessContent() {
+        searchTextField = addInputTextField(gridPane, ++rowIndex,
+                Res.get("popup.accountSigning.singleAccountSelect.description"));
+
+        searchAutoComplete = new JFXAutoCompletePopup<>();
+        searchAutoComplete.setPrefWidth(400);
+        searchAutoComplete.getSuggestions().addAll(accountAgeWitnessService.getAccountAgeWitnessMap().values());
+        searchAutoComplete.setSuggestionsCellFactory(param -> new ListCell<>() {
+            @Override
+            protected void updateItem(AccountAgeWitness item, boolean empty) {
+                super.updateItem(item, empty);
+                if (item != null) {
+                    setText(Utilities.bytesAsHexString(item.getHash()));
+                } else {
+                    setText("");
+                }
+            }
+        });
+        searchAutoComplete.setSelectionHandler(event -> {
+            searchTextField.setText(Utilities.bytesAsHexString(event.getObject().getHash()));
+            selectedWitness = event.getObject();
+            if (selectedWitness != null) {
+                datePicker.setValue(Instant.ofEpochMilli(selectedWitness.getDate()).atZone(
+                        ZoneId.systemDefault()).toLocalDate());
+            }
+        });
+
+        searchTextField.textProperty().addListener(observable -> {
+            searchAutoComplete.filter(witness -> Utilities.bytesAsHexString(witness.getHash()).startsWith(
+                    searchTextField.getText().toLowerCase()));
+            if (searchAutoComplete.getFilteredSuggestions().isEmpty()) {
+                searchAutoComplete.hide();
+            } else {
+                searchAutoComplete.show(searchTextField);
+            }
+        });
+
+        datePicker = addTopLabelDatePicker(gridPane, ++rowIndex,
+                Res.get("popup.accountSigning.singleAccountSelect.datePicker"),
+                0).second;
+        datePicker.setOnAction(e -> updateWitnessSelectionState());
+    }
+
+    private void addECKeyField() {
+        privateKey = addInputTextField(gridPane, ++rowIndex, Res.get("popup.accountSigning.signAccounts.ECKey"));
+        GridPane.setVgrow(privateKey, Priority.ALWAYS);
+        GridPane.setValignment(privateKey, VPos.TOP);
+    }
+
+    private void updateWitnessSelectionState() {
+        actionButton.setDisable(selectedWitness == null || datePicker.getValue() == null);
+    }
+
+    private void removeContent() {
+        removeRowsFromGridPane(gridPane, 1, 3);
+        rowIndex = 1;
+    }
+
+    private void selectAccountAgeWitness() {
+        removeContent();
+        headLineLabel.setText(Res.get("popup.accountSigning.confirmSingleAccount.headline"));
+        var selectedWitnessTextField = addTopLabelTextField(gridPane, ++rowIndex,
+                Res.get("popup.accountSigning.confirmSingleAccount.selectedHash")).second;
+        selectedWitnessTextField.setText(Utilities.bytesAsHexString(selectedWitness.getHash()));
+        addECKeyField();
+        ((AutoTooltipButton) actionButton).updateText(Res.get("popup.accountSigning.confirmSingleAccount.button"));
+        actionButton.setOnAction(a -> {
+            var arbitratorKey = arbitratorManager.getRegistrationKey(privateKey.getText());
+            if (arbitratorKey != null) {
+                var arbitratorPubKeyAsHex = Utils.HEX.encode(arbitratorKey.getPubKey());
+                var isKeyValid = arbitratorManager.isPublicKeyInList(arbitratorPubKeyAsHex);
+                if (isKeyValid) {
+                    var result = accountAgeWitnessService.arbitratorSignAccountAgeWitness(selectedWitness, arbitratorKey,
+                            datePicker.getValue().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000);
+                    if (result.isEmpty()) {
+                        addSuccessContent();
+                    } else {
+                        new Popup().error(Res.get("popup.accountSigning.successSingleAccount.signError", result))
+                                .onClose(this::hide).show();
+                    }
+                }
+            } else {
+                new Popup().error(Res.get("popup.accountSigning.signAccounts.ECKey.error")).onClose(this::hide).show();
+            }
+
+        });
+    }
+
+
+    private void addSuccessContent() {
+        removeContent();
+        closeButton.setVisible(false);
+        closeButton.setManaged(false);
+        headLineLabel.setText(Res.get("popup.accountSigning.successSingleAccount.success.headline"));
+        var descriptionLabel = addMultilineLabel(gridPane, ++rowIndex,
+                Res.get("popup.accountSigning.successSingleAccount.description",
+                        Utilities.bytesAsHexString(selectedWitness.getHash())));
+        GridPane.setVgrow(descriptionLabel, Priority.ALWAYS);
+        GridPane.setValignment(descriptionLabel, VPos.TOP);
+        ((AutoTooltipButton) actionButton).updateText(Res.get("shared.ok"));
+        actionButton.setOnAction(a -> hide());
+    }
+
+    @Override
+    protected void addButtons() {
+        var buttonTuple = add2ButtonsAfterGroup(gridPane, ++rowIndex + 1,
+                Res.get("popup.accountSigning.singleAccountSelect.headline"), Res.get("shared.cancel"));
+
+        actionButton = buttonTuple.first;
+        actionButton.setDisable(true);
+        actionButton.setOnAction(e -> selectAccountAgeWitness());
+
+        closeButton = (AutoTooltipButton) buttonTuple.second;
+        closeButton.setOnAction(e -> hide());
+
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignSpecificWitnessWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignSpecificWitnessWindow.java
@@ -94,7 +94,7 @@ public class SignSpecificWitnessWindow extends Overlay<SignSpecificWitnessWindow
 
         searchAutoComplete = new JFXAutoCompletePopup<>();
         searchAutoComplete.setPrefWidth(400);
-        searchAutoComplete.getSuggestions().addAll(accountAgeWitnessService.getAccountAgeWitnessMap().values());
+        searchAutoComplete.getSuggestions().addAll(accountAgeWitnessService.getOrphanSignedWitnesses());
         searchAutoComplete.setSuggestionsCellFactory(param -> new ListCell<>() {
             @Override
             protected void updateItem(AccountAgeWitness item, boolean empty) {
@@ -160,7 +160,8 @@ public class SignSpecificWitnessWindow extends Overlay<SignSpecificWitnessWindow
                 var arbitratorPubKeyAsHex = Utils.HEX.encode(arbitratorKey.getPubKey());
                 var isKeyValid = arbitratorManager.isPublicKeyInList(arbitratorPubKeyAsHex);
                 if (isKeyValid) {
-                    var result = accountAgeWitnessService.arbitratorSignAccountAgeWitness(selectedWitness, arbitratorKey,
+                    var result = accountAgeWitnessService.arbitratorSignOrphanWitness(selectedWitness,
+                            arbitratorKey,
                             datePicker.getValue().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000);
                     if (result.isEmpty()) {
                         addSuccessContent();

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignUnsignedPubKeysWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SignUnsignedPubKeysWindow.java
@@ -1,0 +1,196 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.overlays.windows;
+
+import bisq.desktop.components.AutoTooltipButton;
+import bisq.desktop.components.InputTextField;
+import bisq.desktop.main.overlays.Overlay;
+import bisq.desktop.main.overlays.popups.Popup;
+
+import bisq.core.account.sign.SignedWitness;
+import bisq.core.account.witness.AccountAgeWitnessService;
+import bisq.core.locale.Res;
+import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
+
+import bisq.common.crypto.Hash;
+import bisq.common.util.Tuple3;
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.Utils;
+
+import javax.inject.Inject;
+
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+import javafx.geometry.VPos;
+
+import javafx.collections.FXCollections;
+
+import javafx.util.Callback;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.desktop.util.FormBuilder.*;
+
+@Slf4j
+public class SignUnsignedPubKeysWindow extends Overlay<SignUnsignedPubKeysWindow> {
+
+    private InputTextField searchTextField;
+    private ListView<SignedWitness> unsignedPubKeys = new ListView<>();
+    private InputTextField privateKey;
+    private final AccountAgeWitnessService accountAgeWitnessService;
+    private final ArbitratorManager arbitratorManager;
+    private ListView<SignedWitness> signedWitnessListView = new ListView<>();
+    private ListView<String> failedView = new ListView<>();
+    private List<SignedWitness> signedWitnessList = new ArrayList<>();
+    private List<String> failed = new ArrayList<>();
+    private Callback<ListView<SignedWitness>, ListCell<SignedWitness>> signedWitnessCellFactory;
+
+    @Inject
+    public SignUnsignedPubKeysWindow(AccountAgeWitnessService accountAgeWitnessService,
+                                     ArbitratorManager arbitratorManager) {
+        this.accountAgeWitnessService = accountAgeWitnessService;
+        this.arbitratorManager = arbitratorManager;
+
+        signedWitnessCellFactory = new Callback<>() {
+            @Override
+            public ListCell<SignedWitness> call(
+                    ListView<SignedWitness> param) {
+                return new ListCell<>() {
+                    @Override
+                    protected void updateItem(SignedWitness item, boolean empty) {
+                        super.updateItem(item, empty);
+
+                        if (item != null && !empty) {
+                            setText(Utilities.bytesAsHexString(Hash.getRipemd160hash(item.getSignerPubKey())));
+                        } else {
+                            setText(null);
+                        }
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public void show() {
+        width = 1000;
+        rowIndex = -1;
+        createGridPane();
+
+        gridPane.setPrefHeight(600);
+        gridPane.getColumnConstraints().get(1).setHgrow(Priority.NEVER);
+        headLine(Res.get("popup.accountSigning.singleAccountSelect.headline"));
+        type = Type.Attention;
+
+        addHeadLine();
+        addUnsignedPubKeysContent();
+        addECKeyField();
+        addButtons();
+        applyStyles();
+
+        display();
+    }
+
+    private void addUnsignedPubKeysContent() {
+        Tuple3<Label, ListView<SignedWitness>, VBox> unsignedPubKeysTuple = addTopLabelListView(gridPane, ++rowIndex,
+                Res.get("popup.accountSigning.unsignedPubKeys.headline"));
+        unsignedPubKeys = unsignedPubKeysTuple.second;
+        unsignedPubKeys.setCellFactory(signedWitnessCellFactory);
+        unsignedPubKeys.setItems(FXCollections.observableArrayList(
+                accountAgeWitnessService.getUnsignedSignerPubKeys()));
+    }
+
+    private void addECKeyField() {
+        privateKey = addInputTextField(gridPane, ++rowIndex, Res.get("popup.accountSigning.signAccounts.ECKey"));
+        GridPane.setVgrow(privateKey, Priority.ALWAYS);
+        GridPane.setValignment(privateKey, VPos.TOP);
+    }
+
+    private void removeContent() {
+        removeRowsFromGridPane(gridPane, 1, 3);
+        rowIndex = 1;
+    }
+
+    private void signPubKeys() {
+        removeContent();
+        headLineLabel.setText(Res.get("popup.accountSigning.unsignedPubKeys.signed"));
+        var arbitratorKey = arbitratorManager.getRegistrationKey(privateKey.getText());
+        if (arbitratorKey != null) {
+            var arbitratorPubKeyAsHex = Utils.HEX.encode(arbitratorKey.getPubKey());
+            var isKeyValid = arbitratorManager.isPublicKeyInList(arbitratorPubKeyAsHex);
+            failed.clear();
+            if (isKeyValid) {
+                unsignedPubKeys.getItems().forEach(signedWitness -> {
+                    var result = accountAgeWitnessService.arbitratorSignOrphanPubKey(arbitratorKey,
+                            signedWitness.getSignerPubKey(), signedWitness.getDate());
+                    if (result.isEmpty()) {
+                        signedWitnessList.add(signedWitness);
+                    } else {
+                        failed.add("Signing pubkey " + Utilities.bytesAsHexString(Hash.getRipemd160hash(
+                                signedWitness.getSignerPubKey())) + " failed with error " + result);
+                    }
+                });
+                showResult();
+            }
+        } else {
+            new Popup().error(Res.get("popup.accountSigning.signAccounts.ECKey.error")).onClose(this::hide).show();
+        }
+    }
+
+    private void showResult() {
+        removeContent();
+        closeButton.setVisible(false);
+        closeButton.setManaged(false);
+
+        Tuple3<Label, ListView<SignedWitness>, VBox> signedTuple = addTopLabelListView(gridPane, ++rowIndex,
+                Res.get("popup.accountSigning.unsignedPubKeys.result.signed"));
+        signedWitnessListView = signedTuple.second;
+        signedWitnessListView.setCellFactory(signedWitnessCellFactory);
+        signedWitnessListView.setItems(FXCollections.observableArrayList(signedWitnessList));
+        Tuple3<Label, ListView<String>, VBox> failedTuple = addTopLabelListView(gridPane, ++rowIndex,
+                Res.get("popup.accountSigning.unsignedPubKeys.result.failed"));
+        failedView = failedTuple.second;
+        failedView.setItems(FXCollections.observableArrayList(failed));
+
+        ((AutoTooltipButton) actionButton).updateText(Res.get("shared.ok"));
+        actionButton.setOnAction(a -> hide());
+    }
+
+    @Override
+    protected void addButtons() {
+        var buttonTuple = add2ButtonsAfterGroup(gridPane, ++rowIndex + 1,
+                Res.get("popup.accountSigning.unsignedPubKeys.sign"), Res.get("shared.cancel"));
+
+        actionButton = buttonTuple.first;
+        actionButton.setDisable(unsignedPubKeys.getItems().size() == 0);
+        actionButton.setOnAction(e -> signPubKeys());
+
+        closeButton = (AutoTooltipButton) buttonTuple.second;
+        closeButton.setOnAction(e -> hide());
+
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -22,6 +22,7 @@ import bisq.desktop.common.model.ViewModel;
 import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 
+import bisq.core.account.sign.SignedWitness;
 import bisq.core.account.witness.AccountAgeWitness;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.btc.wallet.Restrictions;
@@ -33,13 +34,17 @@ import bisq.core.provider.fee.FeeService;
 import bisq.core.trade.Contract;
 import bisq.core.trade.Trade;
 import bisq.core.trade.closed.ClosedTradableManager;
+import bisq.core.trade.messages.RefreshTradeStateRequest;
+import bisq.core.trade.messages.TraderSignedWitnessMessage;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.BtcAddressValidator;
 
+import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
+import bisq.network.p2p.SendMailboxMessageListener;
 
 import bisq.common.ClockWatcher;
 import bisq.common.app.DevEnv;
@@ -58,6 +63,7 @@ import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
 import java.util.Date;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import lombok.Getter;
@@ -389,8 +395,43 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
 
     public void maybeSignWitness() {
         if (isSignWitnessTrade()) {
-            accountAgeWitnessService.traderSignPeersAccountAgeWitness(trade);
+            var signedWitness = accountAgeWitnessService.traderSignPeersAccountAgeWitness(trade);
+            signedWitness.ifPresent(this::sendSignedWitnessToPeer);
         }
+    }
+
+    private void sendSignedWitnessToPeer(SignedWitness signedWitness) {
+        Trade trade = getTrade();
+        if (trade == null) return;
+
+        NodeAddress tradingPeerNodeAddress = trade.getTradingPeerNodeAddress();
+        var traderSignedWitnessMessage = new TraderSignedWitnessMessage(UUID.randomUUID().toString(), trade.getId(),
+                tradingPeerNodeAddress, signedWitness);
+
+        p2PService.sendEncryptedMailboxMessage(
+                tradingPeerNodeAddress,
+                trade.getProcessModel().getTradingPeer().getPubKeyRing(),
+                traderSignedWitnessMessage,
+                new SendMailboxMessageListener() {
+                    @Override
+                    public void onArrived() {
+                        log.info("SendMailboxMessageListener onArrived tradeId={} at peer {} SignedWitness {}",
+                                trade.getId(), tradingPeerNodeAddress, signedWitness);
+                    }
+
+                    @Override
+                    public void onStoredInMailbox() {
+                        log.info("SendMailboxMessageListener onStoredInMailbox tradeId={} at peer {} SignedWitness {}",
+                                trade.getId(), tradingPeerNodeAddress, signedWitness);
+                    }
+
+                    @Override
+                    public void onFault(String errorMessage) {
+                        log.error("SendMailboxMessageListener onFault tradeId={} at peer {} SignedWitness {}",
+                                trade.getId(), tradingPeerNodeAddress, signedWitness);
+                    }
+                }
+        );
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -380,7 +380,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
         checkNotNull(trade.getOffer(), "offer must not be null");
         AccountAgeWitness myWitness = accountAgeWitnessService.getMyWitness(dataModel.getSellersPaymentAccountPayload());
 
-        accountAgeWitnessService.witnessDebugLog(trade, myWitness);
+        accountAgeWitnessService.getAccountAgeWitnessUtils().witnessDebugLog(trade, myWitness);
 
         return accountAgeWitnessService.accountIsSigner(myWitness) &&
                 !accountAgeWitnessService.peerHasSignedWitness(trade) &&

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
@@ -24,6 +24,7 @@ import bisq.desktop.main.overlays.windows.ContractWindow;
 import bisq.desktop.main.overlays.windows.DisputeSummaryWindow;
 import bisq.desktop.main.overlays.windows.SignPaymentAccountsWindow;
 import bisq.desktop.main.overlays.windows.SignSpecificWitnessWindow;
+import bisq.desktop.main.overlays.windows.SignUnsignedPubKeysWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
 import bisq.desktop.main.support.dispute.agent.DisputeAgentView;
 
@@ -51,6 +52,7 @@ public class ArbitratorView extends DisputeAgentView {
 
     private final SignPaymentAccountsWindow signPaymentAccountsWindow;
     private final SignSpecificWitnessWindow signSpecificWitnessWindow;
+    private final SignUnsignedPubKeysWindow signUnsignedPubKeysWindow;
 
     @Inject
     public ArbitratorView(ArbitrationManager arbitrationManager,
@@ -64,7 +66,8 @@ public class ArbitratorView extends DisputeAgentView {
                           AccountAgeWitnessService accountAgeWitnessService,
                           @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys,
                           SignPaymentAccountsWindow signPaymentAccountsWindow,
-                          SignSpecificWitnessWindow signSpecificWitnessWindow) {
+                          SignSpecificWitnessWindow signSpecificWitnessWindow,
+                          SignUnsignedPubKeysWindow signUnsignedPubKeysWindow) {
         super(arbitrationManager,
                 keyRing,
                 tradeManager,
@@ -77,6 +80,7 @@ public class ArbitratorView extends DisputeAgentView {
                 useDevPrivilegeKeys);
         this.signPaymentAccountsWindow = signPaymentAccountsWindow;
         this.signSpecificWitnessWindow = signSpecificWitnessWindow;
+        this.signUnsignedPubKeysWindow = signUnsignedPubKeysWindow;
     }
 
     @Override
@@ -95,6 +99,8 @@ public class ArbitratorView extends DisputeAgentView {
             signPaymentAccountsWindow.show();
         } else if (Utilities.isAltOrCtrlPressed(KeyCode.P, event)) {
             signSpecificWitnessWindow.show();
+        } else if (Utilities.isAltOrCtrlPressed(KeyCode.O, event)) {
+            signUnsignedPubKeysWindow.show();
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
@@ -23,6 +23,7 @@ import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.main.overlays.windows.ContractWindow;
 import bisq.desktop.main.overlays.windows.DisputeSummaryWindow;
 import bisq.desktop.main.overlays.windows.SignPaymentAccountsWindow;
+import bisq.desktop.main.overlays.windows.SignSpecificWitnessWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
 import bisq.desktop.main.support.dispute.agent.DisputeAgentView;
 
@@ -49,6 +50,7 @@ import javax.inject.Inject;
 public class ArbitratorView extends DisputeAgentView {
 
     private final SignPaymentAccountsWindow signPaymentAccountsWindow;
+    private final SignSpecificWitnessWindow signSpecificWitnessWindow;
 
     @Inject
     public ArbitratorView(ArbitrationManager arbitrationManager,
@@ -61,7 +63,8 @@ public class ArbitratorView extends DisputeAgentView {
                           TradeDetailsWindow tradeDetailsWindow,
                           AccountAgeWitnessService accountAgeWitnessService,
                           @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys,
-                          SignPaymentAccountsWindow signPaymentAccountsWindow) {
+                          SignPaymentAccountsWindow signPaymentAccountsWindow,
+                          SignSpecificWitnessWindow signSpecificWitnessWindow) {
         super(arbitrationManager,
                 keyRing,
                 tradeManager,
@@ -73,6 +76,7 @@ public class ArbitratorView extends DisputeAgentView {
                 accountAgeWitnessService,
                 useDevPrivilegeKeys);
         this.signPaymentAccountsWindow = signPaymentAccountsWindow;
+        this.signSpecificWitnessWindow = signSpecificWitnessWindow;
     }
 
     @Override
@@ -89,6 +93,8 @@ public class ArbitratorView extends DisputeAgentView {
     protected void handleKeyPressed(KeyEvent event) {
         if (Utilities.isAltOrCtrlPressed(KeyCode.S, event)) {
             signPaymentAccountsWindow.show();
+        } else if (Utilities.isAltOrCtrlPressed(KeyCode.P, event)) {
+            signSpecificWitnessWindow.show();
         }
     }
 }

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -77,6 +77,7 @@ message NetworkEnvelope {
         PeerPublishedDelayedPayoutTxMessage peer_published_delayed_payout_tx_message = 49;
 
         RefreshTradeStateRequest refresh_trade_state_request = 50;
+        TraderSignedWitnessMessage trader_signed_witness_message = 51;
     }
 }
 
@@ -327,6 +328,13 @@ message RefreshTradeStateRequest {
     string uid = 1;
     string trade_id = 2;
     NodeAddress sender_node_address = 3;
+}
+
+message TraderSignedWitnessMessage {
+    string uid = 1;
+    string trade_id = 2;
+    NodeAddress sender_node_address = 3;
+    SignedWitness signed_witness = 4;
 }
 
 // dispute


### PR DESCRIPTION
Signer sends SignedWitness to signee after trade is completed. This allows the signee to make sure their witness is properly published in case the signer isn't well connected. An extra measure to assure that signed witnesses are well distributed upon signing.

I made this on top of PR #4280 as it's touching a lot of the same code. That PR should be merged before this one.