### PR TITLE
Update seednode/pricenode install scripts

### DIFF
--- a/pricenode/README.md
+++ b/pricenode/README.md
@@ -72,7 +72,7 @@ curl http://localhost:8080/info
 If you run a main pricenode, you also are obliged to activate the monitoring feed by running
 
 ```bash
-curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh | sudo bash
+bash <(curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh)
 ```
 Follow the instruction given by the script and report your certificate to the [@bisq-network/monitoring](https://github.com/orgs/bisq-network/teams/monitoring-operators) team or via the [Keybase](https://keybase.io/team/bisq) `#monitoring` channel!
 

--- a/pricenode/install_pricenode_debian.sh
+++ b/pricenode/install_pricenode_debian.sh
@@ -34,6 +34,11 @@ echo "[*] Upgrading apt packages"
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get update -q
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get upgrade -qq -y
 
+echo "[*] Installing Git LFS"
+sudo -H -i -u "${ROOT_USER}" curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+sudo -H -i -u "${ROOT_USER}" apt-get install git-lfs
+sudo -H -i -u "${ROOT_USER}" git lfs install
+
 echo "[*] Installing Tor"
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get install -qq -y "${TOR_PKG}"
 
@@ -60,6 +65,9 @@ sudo -H -i -u "${ROOT_USER}" "${BISQ_HOME}/${BISQ_REPO_NAME}/scripts/install_jav
 
 echo "[*] Checking out Bisq ${BISQ_LATEST_RELEASE}"
 sudo -H -i -u "${BISQ_USER}" sh -c "cd ${BISQ_HOME}/${BISQ_REPO_NAME} && git checkout ${BISQ_LATEST_RELEASE}"
+
+echo "[*] Performing Git LFS pull"
+sudo -H -i -u "${BISQ_USER}" sh -c "cd ${BISQ_HOME}/${BISQ_REPO_NAME} && git lfs pull"
 
 echo "[*] Building Bisq from source"
 sudo -H -i -u "${BISQ_USER}" sh -c "cd ${BISQ_HOME}/${BISQ_REPO_NAME} && ./gradlew :pricenode:installDist  -x test < /dev/null" # redirect from /dev/null is necessary to workaround gradlew non-interactive shell hanging issue

--- a/seednode/README.md
+++ b/seednode/README.md
@@ -79,8 +79,7 @@ sudo -u bisq -s
 cd bisq
 git fetch origin
 git checkout v1.2.5 # new tag
-./gradlew clean
-./gradlew build -x test
+./gradlew clean build -x test
 exit
 sudo service bisq restart
 sudo journalctl --unit bisq --follow

--- a/seednode/README.md
+++ b/seednode/README.md
@@ -66,7 +66,7 @@ macOS:
 If you run a main seednode, you also are obliged to activate the monitoring feed by running
 
 ```bash
-curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh | sudo bash
+bash <(curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh)
 ```
 Follow the instruction given by the script and report your certificate to the seednode group!
 

--- a/seednode/README.md
+++ b/seednode/README.md
@@ -10,14 +10,15 @@ Highly recommended to use SSD! Minimum specs:
 
 ## Software
 
-The following OS are known to work well:
+The following OS's are known to work well:
 
-* Ubuntu 18
+* Ubuntu 18.04
+* Ubuntu 20.04
 * FreeBSD 12
 
 ### Installation
 
-Start with a clean Ubuntu 18.04 LTS server installation, and run the script
+Start with a clean Ubuntu server installation, and run the script
 ```bash
 curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/seednode/install_seednode_debian.sh | sudo bash
 ```

--- a/seednode/install_seednode_debian.sh
+++ b/seednode/install_seednode_debian.sh
@@ -60,6 +60,11 @@ sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get upgrade -qq 
 echo "[*] Installing base packages"
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ${ROOT_PKG}
 
+echo "[*] Installing Git LFS"
+sudo -H -i -u "${ROOT_USER}" curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+sudo -H -i -u "${ROOT_USER}" apt-get install git-lfs
+sudo -H -i -u "${ROOT_USER}" git lfs install
+
 echo "[*] Cloning Bisq repo"
 sudo -H -i -u "${ROOT_USER}" git config --global advice.detachedHead false
 sudo -H -i -u "${ROOT_USER}" git clone --branch "${BISQ_REPO_TAG}" "${BISQ_REPO_URL}" "${ROOT_HOME}/${BISQ_REPO_NAME}"
@@ -144,6 +149,9 @@ sudo sed -i -e "s!__BISQ_HOME__!${BISQ_HOME}!" "${SYSTEMD_ENV_HOME}/bisq.env"
 
 echo "[*] Checking out Bisq ${BISQ_LATEST_RELEASE}"
 sudo -H -i -u "${BISQ_USER}" sh -c "cd ${BISQ_HOME}/${BISQ_REPO_NAME} && git checkout ${BISQ_LATEST_RELEASE}"
+
+echo "[*] Performing Git LFS pull"
+sudo -H -i -u "${BISQ_USER}" sh -c "cd ${BISQ_HOME}/${BISQ_REPO_NAME} && git lfs pull"
 
 echo "[*] Building Bisq from source"
 sudo -H -i -u "${BISQ_USER}" sh -c "cd ${BISQ_HOME}/${BISQ_REPO_NAME} && ./gradlew build -x test < /dev/null" # redirect from /dev/null is necessary to workaround gradlew non-interactive shell hanging issue


### PR DESCRIPTION
While deploying a new seednode instance on Ubuntu 20.04, I ran into a few issues with the install script and README. This PR addresses those issues.