### PR TITLE
Return protos from funding address methods

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -28,7 +28,7 @@ import bisq.proto.grpc.PaymentAccountsGrpc;
 import bisq.proto.grpc.RemoveWalletPasswordRequest;
 import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.UnlockWalletRequest;
-import bisq.proto.grpc.WalletGrpc;
+import bisq.proto.grpc.WalletsGrpc;
 
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
@@ -139,7 +139,7 @@ public class CliMain {
 
         var versionService = GetVersionGrpc.newBlockingStub(channel).withCallCredentials(credentials);
         var paymentAccountsService = PaymentAccountsGrpc.newBlockingStub(channel).withCallCredentials(credentials);
-        var walletService = WalletGrpc.newBlockingStub(channel).withCallCredentials(credentials);
+        var walletsService = WalletsGrpc.newBlockingStub(channel).withCallCredentials(credentials);
 
         try {
             switch (method) {
@@ -151,7 +151,7 @@ public class CliMain {
                 }
                 case getbalance: {
                     var request = GetBalanceRequest.newBuilder().build();
-                    var reply = walletService.getBalance(request);
+                    var reply = walletsService.getBalance(request);
                     var satoshiBalance = reply.getBalance();
                     var satoshiDivisor = new BigDecimal(100000000);
                     var btcFormat = new DecimalFormat("###,##0.00000000");
@@ -166,13 +166,13 @@ public class CliMain {
 
                     var request = GetAddressBalanceRequest.newBuilder()
                             .setAddress(nonOptionArgs.get(1)).build();
-                    var reply = walletService.getAddressBalance(request);
+                    var reply = walletsService.getAddressBalance(request);
                     out.println(reply.getAddressBalanceInfo());
                     return;
                 }
                 case getfundingaddresses: {
                     var request = GetFundingAddressesRequest.newBuilder().build();
-                    var reply = walletService.getFundingAddresses(request);
+                    var reply = walletsService.getFundingAddresses(request);
                     out.println(reply.getFundingAddressesInfo());
                     return;
                 }
@@ -202,7 +202,7 @@ public class CliMain {
                 }
                 case lockwallet: {
                     var request = LockWalletRequest.newBuilder().build();
-                    walletService.lockWallet(request);
+                    walletsService.lockWallet(request);
                     out.println("wallet locked");
                     return;
                 }
@@ -222,7 +222,7 @@ public class CliMain {
                     var request = UnlockWalletRequest.newBuilder()
                             .setPassword(nonOptionArgs.get(1))
                             .setTimeout(timeout).build();
-                    walletService.unlockWallet(request);
+                    walletsService.unlockWallet(request);
                     out.println("wallet unlocked");
                     return;
                 }
@@ -231,7 +231,7 @@ public class CliMain {
                         throw new IllegalArgumentException("no password specified");
 
                     var request = RemoveWalletPasswordRequest.newBuilder().setPassword(nonOptionArgs.get(1)).build();
-                    walletService.removeWalletPassword(request);
+                    walletsService.removeWalletPassword(request);
                     out.println("wallet decrypted");
                     return;
                 }
@@ -243,7 +243,7 @@ public class CliMain {
                     var hasNewPassword = nonOptionArgs.size() == 3;
                     if (hasNewPassword)
                         requestBuilder.setNewPassword(nonOptionArgs.get(2));
-                    walletService.setWalletPassword(requestBuilder.build());
+                    walletsService.setWalletPassword(requestBuilder.build());
                     out.println("wallet encrypted" + (hasNewPassword ? " with new password" : ""));
                     return;
                 }

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -56,10 +56,12 @@ import static java.lang.String.format;
 import static java.lang.System.err;
 import static java.lang.System.exit;
 import static java.lang.System.out;
+import static java.util.Collections.singletonList;
 
 /**
  * A command-line client for the Bisq gRPC API.
  */
+@SuppressWarnings("ResultOfMethodCallIgnored")
 @Slf4j
 public class CliMain {
 
@@ -174,16 +176,13 @@ public class CliMain {
                     var request = GetAddressBalanceRequest.newBuilder()
                             .setAddress(nonOptionArgs.get(1)).build();
                     var reply = walletsService.getAddressBalance(request);
-                    out.println(addressBalanceInfoHeader());
-                    out.println(addressBalanceInfoDetail(reply.getAddressBalanceInfo()));
+                    out.println(formatTable(singletonList(reply.getAddressBalanceInfo())));
                     return;
                 }
                 case getfundingaddresses: {
                     var request = GetFundingAddressesRequest.newBuilder().build();
                     var reply = walletsService.getFundingAddresses(request);
-                    out.println(addressBalanceInfoHeader());
-                    reply.getAddressBalanceInfoList().forEach(balanceInfo ->
-                            out.println(addressBalanceInfoDetail(balanceInfo)));
+                    out.println(formatTable(reply.getAddressBalanceInfoList()));
                     return;
                 }
                 case createpaymentacct: {
@@ -309,14 +308,13 @@ public class CliMain {
         }
     }
 
-    private static String addressBalanceInfoHeader() {
-        return format("%-35s %13s  %s", "Address", "Balance", "Confirmations");
-    }
-
-    private static String addressBalanceInfoDetail(AddressBalanceInfo addressBalanceInfo) {
-        return format("%-35s %13s %14d",
-                addressBalanceInfo.getAddress(),
-                formatSatoshis.apply(addressBalanceInfo.getBalance()),
-                addressBalanceInfo.getNumConfirmations());
+    private static String formatTable(List<AddressBalanceInfo> addressBalanceInfo) {
+        return format("%-35s %13s  %s%n", "Address", "Balance", "Confirmations")
+                + addressBalanceInfo.stream()
+                .map(info -> format("%-35s %13s %14d",
+                        info.getAddress(),
+                        formatSatoshis.apply(info.getBalance()),
+                        info.getNumConfirmations()))
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -17,6 +17,7 @@
 
 package bisq.cli;
 
+import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.GetVersionGrpc;
@@ -59,6 +60,7 @@ public class CliMain {
     private enum Method {
         getversion,
         getbalance,
+        getaddressbalance,
         getfundingaddresses,
         lockwallet,
         unlockwallet,
@@ -154,6 +156,16 @@ public class CliMain {
                     out.println(btcBalance);
                     return;
                 }
+                case getaddressbalance: {
+                    if (nonOptionArgs.size() < 2)
+                        throw new IllegalArgumentException("no address specified");
+
+                    var request = GetAddressBalanceRequest.newBuilder()
+                            .setAddress(nonOptionArgs.get(1)).build();
+                    var reply = walletService.getAddressBalance(request);
+                    out.println(reply.getAddressBalanceInfo());
+                    return;
+                }
                 case getfundingaddresses: {
                     var request = GetFundingAddressesRequest.newBuilder().build();
                     var reply = walletService.getFundingAddresses(request);
@@ -230,6 +242,7 @@ public class CliMain {
             stream.format("%-19s%-30s%s%n", "------", "------", "------------");
             stream.format("%-19s%-30s%s%n", "getversion", "", "Get server version");
             stream.format("%-19s%-30s%s%n", "getbalance", "", "Get server wallet balance");
+            stream.format("%-19s%-30s%s%n", "getaddressbalance", "", "Get server wallet address balance");
             stream.format("%-19s%-30s%s%n", "getfundingaddresses", "", "Get BTC funding addresses");
             stream.format("%-19s%-30s%s%n", "lockwallet", "", "Remove wallet password from memory, locking the wallet");
             stream.format("%-19s%-30s%s%n", "unlockwallet", "password timeout",

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -230,6 +230,7 @@ public class CliMain {
             stream.format("%-19s%-30s%s%n", "------", "------", "------------");
             stream.format("%-19s%-30s%s%n", "getversion", "", "Get server version");
             stream.format("%-19s%-30s%s%n", "getbalance", "", "Get server wallet balance");
+            stream.format("%-19s%-30s%s%n", "getfundingaddresses", "", "Get BTC funding addresses");
             stream.format("%-19s%-30s%s%n", "lockwallet", "", "Remove wallet password from memory, locking the wallet");
             stream.format("%-19s%-30s%s%n", "unlockwallet", "password timeout",
                     "Store wallet password in memory for timeout seconds");

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -18,6 +18,7 @@
 package bisq.cli;
 
 import bisq.proto.grpc.GetBalanceRequest;
+import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.GetVersionGrpc;
 import bisq.proto.grpc.GetVersionRequest;
 import bisq.proto.grpc.LockWalletRequest;
@@ -58,6 +59,7 @@ public class CliMain {
     private enum Method {
         getversion,
         getbalance,
+        getfundingaddresses,
         lockwallet,
         unlockwallet,
         removewalletpassword,
@@ -152,6 +154,12 @@ public class CliMain {
                     out.println(btcBalance);
                     return;
                 }
+                case getfundingaddresses: {
+                    var request = GetFundingAddressesRequest.newBuilder().build();
+                    var reply = walletService.getFundingAddresses(request);
+                    out.println(reply.getFundingAddressesInfo());
+                    return;
+                }
                 case lockwallet: {
                     var request = LockWalletRequest.newBuilder().build();
                     walletService.lockWallet(request);
@@ -201,7 +209,7 @@ public class CliMain {
                 }
                 default: {
                     throw new RuntimeException(format("unhandled method '%s'", method));
-               }
+                }
             }
         } catch (StatusRuntimeException ex) {
             // Remove the leading gRPC status code (e.g. "UNKNOWN: ") from the message

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -171,6 +171,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "test getpaymentaccts" {
+  run ./bisq-cli --password=xyz getpaymentaccts
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -152,6 +152,20 @@
   [ "$status" -eq 0 ]
 }
 
+@test "test getaddressbalance missing address argument" {
+  run ./bisq-cli --password=xyz getaddressbalance
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no address specified" ]
+}
+
+@test "test getaddressbalance bogus address argument" {
+  run ./bisq-cli --password=xyz getaddressbalance bogus
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: address bogus not found in wallet" ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -147,6 +147,11 @@
   [ "$output" = "0.00000000" ]
 }
 
+@test "test getfundingaddresses" {
+  run ./bisq-cli --password=xyz getfundingaddresses
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -48,17 +48,99 @@
   run ./bisq-cli --password="xyz" getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
 @test "test getversion" {
   run ./bisq-cli --password=xyz getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
-@test "test getbalance (available & unlocked wallet with 0 btc balance)" {
+@test "test setwalletpassword \"a b c\"" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted" ]
+  sleep 1
+}
+
+@test "test unlockwallet without password & timeout args" {
+  run ./bisq-cli --password=xyz unlockwallet
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no password specified" ]
+}
+
+@test "test unlockwallet without timeout arg" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no unlock timeout specified" ]
+}
+
+
+@test "test unlockwallet \"a b c\" 8" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 8
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test getbalance while wallet unlocked for 8s" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "0.00000000" ]
+  sleep 8
+}
+
+@test "test unlockwallet \"a b c\" 6" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 6
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test lockwallet before unlockwallet timeout=6s expires" {
+  run ./bisq-cli --password=xyz lockwallet
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet locked" ]
+}
+
+@test "test setwalletpassword incorrect old pwd error" {
+  run ./bisq-cli --password=xyz setwalletpassword "z z z"  "d e f"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: incorrect old password" ]
+}
+
+@test "test setwalletpassword oldpwd newpwd" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"  "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted with new password" ]
+  sleep 1
+}
+
+@test "test getbalance wallet locked error" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: wallet is locked" ]
+}
+
+@test "test removewalletpassword" {
+  run ./bisq-cli --password=xyz removewalletpassword "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet decrypted" ]
+  sleep 1
+}
+
+@test "test getbalance when wallet available & unlocked with 0 btc balance" {
   run ./bisq-cli --password=xyz getbalance
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
@@ -69,7 +151,7 @@
   run ./bisq-cli
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }
 
@@ -77,6 +159,6 @@
   run ./bisq-cli --help
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -166,6 +166,11 @@
   [ "$output" = "Error: address bogus not found in wallet" ]
 }
 
+@test "test createpaymentacct PerfectMoneyDummy 0123456789 USD" {
+  run ./bisq-cli --password=xyz createpaymentacct PerfectMoneyDummy 0123456789 USD
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/core/src/main/java/bisq/core/grpc/CoreApi.java
+++ b/core/src/main/java/bisq/core/grpc/CoreApi.java
@@ -47,6 +47,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class CoreApi {
+    private final CorePaymentAccountsService paymentAccountsService;
     private final OfferBookService offerBookService;
     private final TradeStatisticsManager tradeStatisticsManager;
     private final CreateOfferService createOfferService;
@@ -54,11 +55,13 @@ public class CoreApi {
     private final User user;
 
     @Inject
-    public CoreApi(OfferBookService offerBookService,
+    public CoreApi(CorePaymentAccountsService paymentAccountsService,
+                   OfferBookService offerBookService,
                    TradeStatisticsManager tradeStatisticsManager,
                    CreateOfferService createOfferService,
                    OpenOfferManager openOfferManager,
                    User user) {
+        this.paymentAccountsService = paymentAccountsService;
         this.offerBookService = offerBookService;
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.createOfferService = createOfferService;
@@ -78,8 +81,12 @@ public class CoreApi {
         return offerBookService.getOffers();
     }
 
+    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
+        paymentAccountsService.createPaymentAccount(accountName, accountNumber, fiatCurrencyCode);
+    }
+
     public Set<PaymentAccount> getPaymentAccounts() {
-        return user.getPaymentAccounts();
+        return paymentAccountsService.getPaymentAccounts();
     }
 
     public void placeOffer(String currencyCode,

--- a/core/src/main/java/bisq/core/grpc/CoreApi.java
+++ b/core/src/main/java/bisq/core/grpc/CoreApi.java
@@ -48,6 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CoreApi {
     private final CorePaymentAccountsService paymentAccountsService;
+    private final CoreWalletsService walletsService;
     private final OfferBookService offerBookService;
     private final TradeStatisticsManager tradeStatisticsManager;
     private final CreateOfferService createOfferService;
@@ -56,12 +57,14 @@ public class CoreApi {
 
     @Inject
     public CoreApi(CorePaymentAccountsService paymentAccountsService,
+                   CoreWalletsService walletsService,
                    OfferBookService offerBookService,
                    TradeStatisticsManager tradeStatisticsManager,
                    CreateOfferService createOfferService,
                    OpenOfferManager openOfferManager,
                    User user) {
         this.paymentAccountsService = paymentAccountsService;
+        this.walletsService = walletsService;
         this.offerBookService = offerBookService;
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.createOfferService = createOfferService;
@@ -73,20 +76,52 @@ public class CoreApi {
         return Version.VERSION;
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Wallets
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public long getAvailableBalance() {
+        return walletsService.getAvailableBalance();
+    }
+
+    public long getAddressBalance(String addressString) {
+        return walletsService.getAddressBalance(addressString);
+    }
+
+    public String getAddressBalanceInfo(String addressString) {
+        return walletsService.getAddressBalanceInfo(addressString);
+    }
+
+    public String getFundingAddresses() {
+        return walletsService.getFundingAddresses();
+    }
+
+    public void setWalletPassword(String password, String newPassword) {
+        walletsService.setWalletPassword(password, newPassword);
+    }
+
+    public void lockWallet() {
+        walletsService.lockWallet();
+    }
+
+    public void unlockWallet(String password, long timeout) {
+        walletsService.unlockWallet(password, timeout);
+    }
+
+    public void removeWalletPassword(String password) {
+        walletsService.removeWalletPassword(password);
+    }
+
     public List<TradeStatistics2> getTradeStatistics() {
         return new ArrayList<>(tradeStatisticsManager.getObservableTradeStatisticsSet());
     }
 
+    public int getNumConfirmationsForMostRecentTransaction(String addressString) {
+        return walletsService.getNumConfirmationsForMostRecentTransaction(addressString);
+    }
+
     public List<Offer> getOffers() {
         return offerBookService.getOffers();
-    }
-
-    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
-        paymentAccountsService.createPaymentAccount(accountName, accountNumber, fiatCurrencyCode);
-    }
-
-    public Set<PaymentAccount> getPaymentAccounts() {
-        return paymentAccountsService.getPaymentAccounts();
     }
 
     public void placeOffer(String currencyCode,
@@ -152,4 +187,15 @@ public class CoreApi {
                 log::error);
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PaymentAccounts
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
+        paymentAccountsService.createPaymentAccount(accountName, accountNumber, fiatCurrencyCode);
+    }
+
+    public Set<PaymentAccount> getPaymentAccounts() {
+        return paymentAccountsService.getPaymentAccounts();
+    }
 }

--- a/core/src/main/java/bisq/core/grpc/CoreApi.java
+++ b/core/src/main/java/bisq/core/grpc/CoreApi.java
@@ -17,6 +17,7 @@
 
 package bisq.core.grpc;
 
+import bisq.core.grpc.model.AddressBalanceInfo;
 import bisq.core.monetary.Price;
 import bisq.core.offer.CreateOfferService;
 import bisq.core.offer.Offer;
@@ -88,11 +89,11 @@ public class CoreApi {
         return walletsService.getAddressBalance(addressString);
     }
 
-    public String getAddressBalanceInfo(String addressString) {
+    public AddressBalanceInfo getAddressBalanceInfo(String addressString) {
         return walletsService.getAddressBalanceInfo(addressString);
     }
 
-    public String getFundingAddresses() {
+    public List<AddressBalanceInfo> getFundingAddresses() {
         return walletsService.getFundingAddresses();
     }
 

--- a/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
@@ -1,0 +1,57 @@
+package bisq.core.grpc;
+
+import bisq.core.account.witness.AccountAgeWitnessService;
+import bisq.core.locale.FiatCurrency;
+import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.PaymentAccountFactory;
+import bisq.core.payment.PerfectMoneyAccount;
+import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.user.User;
+
+import bisq.common.config.Config;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CorePaymentAccountsService {
+
+    private final Config config;
+    private final AccountAgeWitnessService accountAgeWitnessService;
+    private final User user;
+
+    @Inject
+    public CorePaymentAccountsService(Config config,
+                                      AccountAgeWitnessService accountAgeWitnessService,
+                                      User user) {
+        this.config = config;
+        this.accountAgeWitnessService = accountAgeWitnessService;
+        this.user = user;
+    }
+
+    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
+        // Create and persist a PerfectMoney dummy payment account.  There is no guard
+        // against creating accounts with duplicate names & numbers, only the uuid and
+        // creation date are unique.
+        PaymentMethod dummyPaymentMethod = PaymentMethod.getDummyPaymentMethod(PaymentMethod.PERFECT_MONEY_ID);
+        PaymentAccount paymentAccount = PaymentAccountFactory.getPaymentAccount(dummyPaymentMethod);
+        paymentAccount.init();
+        paymentAccount.setAccountName(accountName);
+        ((PerfectMoneyAccount) paymentAccount).setAccountNr(accountNumber);
+        paymentAccount.setSingleTradeCurrency(new FiatCurrency(fiatCurrencyCode));
+        user.addPaymentAccount(paymentAccount);
+
+        // Don't do this on mainnet until thoroughly tested.
+        if (config.baseCurrencyNetwork.isRegtest())
+            accountAgeWitnessService.publishMyAccountAgeWitness(paymentAccount.getPaymentAccountPayload());
+
+        log.info("Payment account {} saved", paymentAccount.getId());
+    }
+
+    public Set<PaymentAccount> getPaymentAccounts() {
+        return user.getPaymentAccounts();
+    }
+}

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -54,7 +54,6 @@ class CoreWalletsService {
     private final Function<Long, String> formatSatoshis = (sats) ->
             btcFormat.format(BigDecimal.valueOf(sats).divide(satoshiDivisor));
 
-
     @Inject
     public CoreWalletsService(Balances balances,
                               WalletsManager walletsManager,

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Slf4j
-class CoreWalletService {
+class CoreWalletsService {
 
     private final Balances balances;
     private final WalletsManager walletsManager;
@@ -31,7 +31,7 @@ class CoreWalletService {
     private KeyParameter tempAesKey;
 
     @Inject
-    public CoreWalletService(Balances balances, WalletsManager walletsManager) {
+    public CoreWalletsService(Balances balances, WalletsManager walletsManager) {
         this.balances = balances;
         this.walletsManager = walletsManager;
     }

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -80,6 +80,15 @@ class CoreWalletsService {
         return btcWalletService.getBalanceForAddress(address).value;
     }
 
+    public String getAddressBalanceInfo(String addressString) {
+        var satoshiBalance = getAddressBalance(addressString);
+        var btcBalance = formatSatoshis.apply(satoshiBalance);
+        var numConfirmations = getNumConfirmationsForMostRecentTransaction(addressString);
+        return addressString
+                + "  balance: " + format("%13s", btcBalance)
+                + ((numConfirmations > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "");
+    }
+
     public String getFundingAddresses() {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -65,8 +65,7 @@ class CoreWalletsService {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");
 
-        if (walletsManager.areWalletsEncrypted() && tempAesKey == null)
-            throw new IllegalStateException("wallet is locked");
+        verifyEncryptedWalletIsUnlocked();
 
         var balance = balances.getAvailableBalance().get();
         if (balance == null)
@@ -93,8 +92,7 @@ class CoreWalletsService {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");
 
-        if (walletsManager.areWalletsEncrypted() && tempAesKey == null)
-            throw new IllegalStateException("wallet is locked");
+        verifyEncryptedWalletIsUnlocked();
 
         // Create a new funding address if none exists.
         if (btcWalletService.getAvailableAddressEntries().size() == 0)
@@ -244,6 +242,12 @@ class CoreWalletsService {
 
         if (!walletsManager.areWalletsEncrypted())
             throw new IllegalStateException("wallet is not encrypted with a password");
+    }
+
+    // Throws a RuntimeException if wallets are encrypted and locked.
+    private void verifyEncryptedWalletIsUnlocked() {
+        if (walletsManager.areWalletsEncrypted() && tempAesKey == null)
+            throw new IllegalStateException("wallet is locked");
     }
 
     private KeyCrypterScrypt getKeyCrypterScrypt() {

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -30,6 +30,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.LoadingCache;
+
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -88,6 +92,20 @@ class CoreWalletsService {
                 + ((numConfirmations > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "");
     }
 
+    /**
+     * Memoization stores the results of expensive function calls and returns
+     * the cached result when the same input occurs again.
+     *
+     * Resulting LoadingCache is used by calling `.get(input I)` or
+     * `.getUnchecked(input I)`, depending on whether or not `f` can return null.
+     * That's because CacheLoader throws an exception on null output from `f`.
+     */
+    private static <I,O> LoadingCache<I,O> memoize(Function<I,O> f) {
+        // f::apply is used, because Guava 20.0 Function doesn't yet extend
+        // Java Function.
+        return CacheBuilder.newBuilder().build(CacheLoader.from(f::apply));
+    }
+
     public String getFundingAddresses() {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");
@@ -98,44 +116,43 @@ class CoreWalletsService {
         if (btcWalletService.getAvailableAddressEntries().size() == 0)
             btcWalletService.getFreshAddressEntry();
 
-        // Populate a list of Tuple3<AddressString, Balance, NumConfirmations>
-        List<Tuple3<String, Long, Integer>> addrBalanceConfirms =
-                btcWalletService.getAvailableAddressEntries().stream()
-                        .map(a -> new Tuple3<>(a.getAddressString(),
-                                getAddressBalance(a.getAddressString()),
-                                getNumConfirmationsForMostRecentTransaction(a.getAddressString())))
-                        .collect(Collectors.toList());
+        List<String> addressStrings =
+            btcWalletService
+            .getAvailableAddressEntries()
+            .stream()
+            .map(addressEntry -> addressEntry.getAddressString())
+            .collect(Collectors.toList());
 
-        // Check to see if at least one of the existing addresses has a zero balance.
-        boolean hasZeroBalance = false;
-        for (Tuple3<String, Long, Integer> abc : addrBalanceConfirms) {
-            if (abc.second == 0) {
-                hasZeroBalance = true;
-                break;
-            }
-        }
-        if (!hasZeroBalance) {
-            // None of the existing addresses have a zero balance, create a new address.
-            addrBalanceConfirms.add(
-                    new Tuple3<>(btcWalletService.getFreshAddressEntry().getAddressString(),
-                            0L,
-                            0));
+        // getAddressBalance is memoized, because we'll map it over addresses twice.
+        // To get the balances, we'll be using .getUnchecked, because we know that
+        // this::getAddressBalance cannot return null.
+        var balances = memoize(this::getAddressBalance);
+
+        boolean noAddressHasZeroBalance =
+            addressStrings.stream()
+            .allMatch(addressString -> balances.getUnchecked(addressString) != 0);
+
+        if (noAddressHasZeroBalance) {
+            var newZeroBalanceAddress = btcWalletService.getFreshAddressEntry();
+            addressStrings.add(newZeroBalanceAddress.getAddressString());
         }
 
-        // Iterate the list of Tuple3<AddressString, Balance, NumConfirmations> objects
-        // and build the formatted info string.
-        StringBuilder addressInfoBuilder = new StringBuilder();
-        addrBalanceConfirms.forEach(a -> {
-            var btcBalance = formatSatoshis.apply(a.second);
-            var numConfirmations = getNumConfirmationsForMostRecentTransaction(a.first);
-            String addressInfo = "" + a.first
-                    + "  balance: " + format("%13s", btcBalance)
-                    + ((a.second > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "")
-                    + "\n";
-            addressInfoBuilder.append(addressInfo);
-        });
+        String fundingAddressTable =
+            addressStrings.stream()
+            .map(addressString -> {
+                var balance = balances.getUnchecked(addressString);
+                var stringFormattedBalance = formatSatoshis.apply(balance);
+                var numConfirmations =
+                    getNumConfirmationsForMostRecentTransaction(addressString);
+                String addressInfo =
+                    "" + addressString
+                    + "  balance: " + format("%13s", stringFormattedBalance)
+                    + ((balance > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "");
+                return addressInfo;
+            })
+            .collect(Collectors.joining("\n"));
 
-        return addressInfoBuilder.toString().trim();
+        return fundingAddressTable;
     }
 
     public int getNumConfirmationsForMostRecentTransaction(String addressString) {

--- a/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
@@ -1,0 +1,46 @@
+package bisq.core.grpc;
+
+import bisq.core.payment.PaymentAccount;
+
+import bisq.proto.grpc.CreatePaymentAccountReply;
+import bisq.proto.grpc.CreatePaymentAccountRequest;
+import bisq.proto.grpc.GetPaymentAccountsReply;
+import bisq.proto.grpc.GetPaymentAccountsRequest;
+import bisq.proto.grpc.PaymentAccountsGrpc;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.stream.Collectors;
+
+
+public class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccountsImplBase {
+
+    private final CoreApi coreApi;
+
+    @Inject
+    public GrpcPaymentAccountsService(CoreApi coreApi) {
+        this.coreApi = coreApi;
+    }
+
+    @Override
+    public void createPaymentAccount(CreatePaymentAccountRequest req,
+                                     StreamObserver<CreatePaymentAccountReply> responseObserver) {
+        coreApi.createPaymentAccount(req.getAccountName(), req.getAccountNumber(), req.getFiatCurrencyCode());
+        var reply = CreatePaymentAccountReply.newBuilder().build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getPaymentAccounts(GetPaymentAccountsRequest req,
+                                   StreamObserver<GetPaymentAccountsReply> responseObserver) {
+        var tradeStatistics = coreApi.getPaymentAccounts().stream()
+                .map(PaymentAccount::toProtoMessage)
+                .collect(Collectors.toList());
+        var reply = GetPaymentAccountsReply.newBuilder().addAllPaymentAccounts(tradeStatistics).build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+}

--- a/core/src/main/java/bisq/core/grpc/GrpcServer.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcServer.java
@@ -59,7 +59,7 @@ public class GrpcServer {
     public GrpcServer(Config config,
                       CoreApi coreApi,
                       GrpcPaymentAccountsService paymentAccountsService,
-                      GrpcWalletService walletService) {
+                      GrpcWalletsService walletService) {
         this.coreApi = coreApi;
         this.server = ServerBuilder.forPort(config.apiPort)
                 .addService(new GetVersionService())

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -1,5 +1,7 @@
 package bisq.core.grpc;
 
+import bisq.proto.grpc.GetAddressBalanceReply;
+import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalanceReply;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesReply;
@@ -42,7 +44,22 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
             throw ex;
         }
     }
-    
+
+    @Override
+    public void getAddressBalance(GetAddressBalanceRequest req,
+                                  StreamObserver<GetAddressBalanceReply> responseObserver) {
+        try {
+            String result = walletsService.getAddressBalanceInfo(req.getAddress());
+            var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (IllegalStateException cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
+    }
+
     @Override
     public void getFundingAddresses(GetFundingAddressesRequest req,
                                     StreamObserver<GetFundingAddressesReply> responseObserver) {

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -20,17 +20,17 @@ import javax.inject.Inject;
 
 class GrpcWalletService extends WalletGrpc.WalletImplBase {
 
-    private final CoreWalletService walletService;
+    private final CoreWalletsService walletsService;
 
     @Inject
-    public GrpcWalletService(CoreWalletService walletService) {
-        this.walletService = walletService;
+    public GrpcWalletService(CoreWalletsService walletsService) {
+        this.walletsService = walletsService;
     }
 
     @Override
     public void getBalance(GetBalanceRequest req, StreamObserver<GetBalanceReply> responseObserver) {
         try {
-            long result = walletService.getAvailableBalance();
+            long result = walletsService.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -45,7 +45,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void setWalletPassword(SetWalletPasswordRequest req,
                                   StreamObserver<SetWalletPasswordReply> responseObserver) {
         try {
-            walletService.setWalletPassword(req.getPassword(), req.getNewPassword());
+            walletsService.setWalletPassword(req.getPassword(), req.getNewPassword());
             var reply = SetWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -60,7 +60,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void removeWalletPassword(RemoveWalletPasswordRequest req,
                                      StreamObserver<RemoveWalletPasswordReply> responseObserver) {
         try {
-            walletService.removeWalletPassword(req.getPassword());
+            walletsService.removeWalletPassword(req.getPassword());
             var reply = RemoveWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -75,7 +75,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void lockWallet(LockWalletRequest req,
                            StreamObserver<LockWalletReply> responseObserver) {
         try {
-            walletService.lockWallet();
+            walletsService.lockWallet();
             var reply = LockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -90,7 +90,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void unlockWallet(UnlockWalletRequest req,
                              StreamObserver<UnlockWalletReply> responseObserver) {
         try {
-            walletService.unlockWallet(req.getPassword(), req.getTimeout());
+            walletsService.unlockWallet(req.getPassword(), req.getTimeout());
             var reply = UnlockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -2,6 +2,8 @@ package bisq.core.grpc;
 
 import bisq.proto.grpc.GetBalanceReply;
 import bisq.proto.grpc.GetBalanceRequest;
+import bisq.proto.grpc.GetFundingAddressesReply;
+import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.LockWalletReply;
 import bisq.proto.grpc.LockWalletRequest;
 import bisq.proto.grpc.RemoveWalletPasswordReply;
@@ -32,6 +34,21 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
         try {
             long result = walletsService.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (IllegalStateException cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
+    }
+    
+    @Override
+    public void getFundingAddresses(GetFundingAddressesRequest req,
+                                    StreamObserver<GetFundingAddressesReply> responseObserver) {
+        try {
+            String result = walletsService.getFundingAddresses();
+            var reply = GetFundingAddressesReply.newBuilder().setFundingAddressesInfo(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
@@ -14,7 +14,7 @@ import bisq.proto.grpc.SetWalletPasswordReply;
 import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.UnlockWalletReply;
 import bisq.proto.grpc.UnlockWalletRequest;
-import bisq.proto.grpc.WalletGrpc;
+import bisq.proto.grpc.WalletsGrpc;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -22,19 +22,19 @@ import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
 
-class GrpcWalletService extends WalletGrpc.WalletImplBase {
+class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
 
-    private final CoreWalletsService walletsService;
+    private final CoreApi coreApi;
 
     @Inject
-    public GrpcWalletService(CoreWalletsService walletsService) {
-        this.walletsService = walletsService;
+    public GrpcWalletsService(CoreApi coreApi) {
+        this.coreApi = coreApi;
     }
 
     @Override
     public void getBalance(GetBalanceRequest req, StreamObserver<GetBalanceReply> responseObserver) {
         try {
-            long result = walletsService.getAvailableBalance();
+            long result = coreApi.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -49,7 +49,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void getAddressBalance(GetAddressBalanceRequest req,
                                   StreamObserver<GetAddressBalanceReply> responseObserver) {
         try {
-            String result = walletsService.getAddressBalanceInfo(req.getAddress());
+            String result = coreApi.getAddressBalanceInfo(req.getAddress());
             var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -64,7 +64,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void getFundingAddresses(GetFundingAddressesRequest req,
                                     StreamObserver<GetFundingAddressesReply> responseObserver) {
         try {
-            String result = walletsService.getFundingAddresses();
+            String result = coreApi.getFundingAddresses();
             var reply = GetFundingAddressesReply.newBuilder().setFundingAddressesInfo(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -79,7 +79,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void setWalletPassword(SetWalletPasswordRequest req,
                                   StreamObserver<SetWalletPasswordReply> responseObserver) {
         try {
-            walletsService.setWalletPassword(req.getPassword(), req.getNewPassword());
+            coreApi.setWalletPassword(req.getPassword(), req.getNewPassword());
             var reply = SetWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -94,7 +94,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void removeWalletPassword(RemoveWalletPasswordRequest req,
                                      StreamObserver<RemoveWalletPasswordReply> responseObserver) {
         try {
-            walletsService.removeWalletPassword(req.getPassword());
+            coreApi.removeWalletPassword(req.getPassword());
             var reply = RemoveWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -109,7 +109,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void lockWallet(LockWalletRequest req,
                            StreamObserver<LockWalletReply> responseObserver) {
         try {
-            walletsService.lockWallet();
+            coreApi.lockWallet();
             var reply = LockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -124,7 +124,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void unlockWallet(UnlockWalletRequest req,
                              StreamObserver<UnlockWalletReply> responseObserver) {
         try {
-            walletsService.unlockWallet(req.getPassword(), req.getTimeout());
+            coreApi.unlockWallet(req.getPassword(), req.getTimeout());
             var reply = UnlockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
@@ -1,5 +1,7 @@
 package bisq.core.grpc;
 
+import bisq.core.grpc.model.AddressBalanceInfo;
+
 import bisq.proto.grpc.GetAddressBalanceReply;
 import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalanceReply;
@@ -21,6 +23,9 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
 
@@ -49,8 +54,8 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
     public void getAddressBalance(GetAddressBalanceRequest req,
                                   StreamObserver<GetAddressBalanceReply> responseObserver) {
         try {
-            String result = coreApi.getAddressBalanceInfo(req.getAddress());
-            var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result).build();
+            AddressBalanceInfo result = coreApi.getAddressBalanceInfo(req.getAddress());
+            var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result.toProtoMessage()).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {
@@ -64,8 +69,13 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
     public void getFundingAddresses(GetFundingAddressesRequest req,
                                     StreamObserver<GetFundingAddressesReply> responseObserver) {
         try {
-            String result = coreApi.getFundingAddresses();
-            var reply = GetFundingAddressesReply.newBuilder().setFundingAddressesInfo(result).build();
+            List<AddressBalanceInfo> result = coreApi.getFundingAddresses();
+            var reply = GetFundingAddressesReply.newBuilder()
+                    .addAllAddressBalanceInfo(
+                            result.stream()
+                                    .map(AddressBalanceInfo::toProtoMessage)
+                                    .collect(Collectors.toList()))
+                    .build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {

--- a/core/src/main/java/bisq/core/grpc/model/AddressBalanceInfo.java
+++ b/core/src/main/java/bisq/core/grpc/model/AddressBalanceInfo.java
@@ -1,0 +1,43 @@
+package bisq.core.grpc.model;
+
+import bisq.common.Payload;
+
+public class AddressBalanceInfo implements Payload {
+
+    private final String address;
+    private final long balance;             // address' balance in satoshis
+    private final long numConfirmations;    // # confirmations for address' most recent tx
+
+    public AddressBalanceInfo(String address, long balance, long numConfirmations) {
+        this.address = address;
+        this.balance = balance;
+        this.numConfirmations = numConfirmations;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.AddressBalanceInfo toProtoMessage() {
+        return bisq.proto.grpc.AddressBalanceInfo.newBuilder()
+                .setAddress(address)
+                .setBalance(balance)
+                .setNumConfirmations(numConfirmations).build();
+    }
+
+    public static AddressBalanceInfo fromProto(bisq.proto.grpc.AddressBalanceInfo proto) {
+        return new AddressBalanceInfo(proto.getAddress(),
+                proto.getBalance(),
+                proto.getNumConfirmations());
+    }
+
+    @Override
+    public String toString() {
+        return "AddressBalanceInfo{" +
+                "address='" + address + '\'' +
+                ", balance=" + balance +
+                ", numConfirmations=" + numConfirmations +
+                '}';
+    }
+}

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -119,6 +119,8 @@ message PlaceOfferReply {
 service Wallet {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
+    rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
+    }
     rpc SetWalletPassword (SetWalletPasswordRequest) returns (SetWalletPasswordReply) {
     }
     rpc RemoveWalletPassword (RemoveWalletPasswordRequest) returns (RemoveWalletPasswordReply) {
@@ -134,6 +136,13 @@ message GetBalanceRequest {
 
 message GetBalanceReply {
     uint64 balance = 1;
+}
+
+message GetFundingAddressesRequest {
+}
+
+message GetFundingAddressesReply {
+    string fundingAddressesInfo = 1;
 }
 
 message SetWalletPasswordRequest {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -156,14 +156,14 @@ message GetAddressBalanceRequest {
 }
 
 message GetAddressBalanceReply {
-    string addressBalanceInfo = 1;
+    AddressBalanceInfo addressBalanceInfo = 1;
 }
 
 message GetFundingAddressesRequest {
 }
 
 message GetFundingAddressesReply {
-    string fundingAddressesInfo = 1;
+    repeated AddressBalanceInfo addressBalanceInfo = 1;
 }
 
 message SetWalletPasswordRequest {
@@ -193,4 +193,10 @@ message UnlockWalletRequest {
 }
 
 message UnlockWalletReply {
+}
+
+message AddressBalanceInfo {
+    string address = 1;
+    int64 balance = 2;
+    int64 numConfirmations = 3;
 }

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -119,6 +119,8 @@ message PlaceOfferReply {
 service Wallet {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
+    rpc GetAddressBalance (GetAddressBalanceRequest) returns (GetAddressBalanceReply) {
+    }
     rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
     }
     rpc SetWalletPassword (SetWalletPasswordRequest) returns (SetWalletPasswordReply) {
@@ -136,6 +138,14 @@ message GetBalanceRequest {
 
 message GetBalanceReply {
     uint64 balance = 1;
+}
+
+message GetAddressBalanceRequest {
+    string address = 1;
+}
+
+message GetAddressBalanceReply {
+    string addressBalanceInfo = 1;
 }
 
 message GetFundingAddressesRequest {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -124,10 +124,10 @@ message PlaceOfferReply {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// Wallet
+// Wallets
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-service Wallet {
+service Wallets {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
     rpc GetAddressBalance (GetAddressBalanceRequest) returns (GetAddressBalanceReply) {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -72,12 +72,23 @@ message GetOffersReply {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// PaymentAccount
+// PaymentAccounts
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-service GetPaymentAccounts {
+service PaymentAccounts {
+    rpc CreatePaymentAccount (CreatePaymentAccountRequest) returns (CreatePaymentAccountReply) {
+    }
     rpc GetPaymentAccounts (GetPaymentAccountsRequest) returns (GetPaymentAccountsReply) {
     }
+}
+
+message CreatePaymentAccountRequest {
+    string accountName = 1;
+    string accountNumber = 2;
+    string fiatCurrencyCode = 3;
+}
+
+message CreatePaymentAccountReply {
 }
 
 message GetPaymentAccountsRequest {


### PR DESCRIPTION
The `getaddressbalance` and `getfundingaddresses` methods now send new `AddressBalanceInfo` proto messages instead of a formatted String to the client.  The `AddressBalanceInfo` message contains address string, balance, and # of confirmations (transaction confidence) fields.

Changes include:
* A new `AddressBalanceInfo` proto message
* A wrapper class for the new `AddressBalanceInfo` proto
* New `getaddressbalance` and `getfundingaddresses` signatures in server
* `AddressBalanceInfo` display logic in client
* Removal of balance formatting logic in server
* Refactoring of balance formatting logic in client

This PR should be reviewed/merged after PR [4323](https://github.com/bisq-network/bisq/pull/4323).

The first cut of these methods methods were hacked because of uncertainty about whether or not we were going to ditch gRPC for an exclusively RESTful API.  But it seems likely we will serve both kinds of clients from the gRPC server.