### PR TITLE
Add rpc method 'getoffers'

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -28,7 +28,7 @@ import bisq.proto.grpc.PaymentAccountsGrpc;
 import bisq.proto.grpc.RemoveWalletPasswordRequest;
 import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.UnlockWalletRequest;
-import bisq.proto.grpc.WalletGrpc;
+import bisq.proto.grpc.WalletsGrpc;
 
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
@@ -139,7 +139,7 @@ public class CliMain {
 
         var versionService = GetVersionGrpc.newBlockingStub(channel).withCallCredentials(credentials);
         var paymentAccountsService = PaymentAccountsGrpc.newBlockingStub(channel).withCallCredentials(credentials);
-        var walletService = WalletGrpc.newBlockingStub(channel).withCallCredentials(credentials);
+        var walletsService = WalletsGrpc.newBlockingStub(channel).withCallCredentials(credentials);
 
         try {
             switch (method) {
@@ -151,7 +151,7 @@ public class CliMain {
                 }
                 case getbalance: {
                     var request = GetBalanceRequest.newBuilder().build();
-                    var reply = walletService.getBalance(request);
+                    var reply = walletsService.getBalance(request);
                     var satoshiBalance = reply.getBalance();
                     var satoshiDivisor = new BigDecimal(100000000);
                     var btcFormat = new DecimalFormat("###,##0.00000000");
@@ -166,13 +166,13 @@ public class CliMain {
 
                     var request = GetAddressBalanceRequest.newBuilder()
                             .setAddress(nonOptionArgs.get(1)).build();
-                    var reply = walletService.getAddressBalance(request);
+                    var reply = walletsService.getAddressBalance(request);
                     out.println(reply.getAddressBalanceInfo());
                     return;
                 }
                 case getfundingaddresses: {
                     var request = GetFundingAddressesRequest.newBuilder().build();
-                    var reply = walletService.getFundingAddresses(request);
+                    var reply = walletsService.getFundingAddresses(request);
                     out.println(reply.getFundingAddressesInfo());
                     return;
                 }
@@ -202,7 +202,7 @@ public class CliMain {
                 }
                 case lockwallet: {
                     var request = LockWalletRequest.newBuilder().build();
-                    walletService.lockWallet(request);
+                    walletsService.lockWallet(request);
                     out.println("wallet locked");
                     return;
                 }
@@ -222,7 +222,7 @@ public class CliMain {
                     var request = UnlockWalletRequest.newBuilder()
                             .setPassword(nonOptionArgs.get(1))
                             .setTimeout(timeout).build();
-                    walletService.unlockWallet(request);
+                    walletsService.unlockWallet(request);
                     out.println("wallet unlocked");
                     return;
                 }
@@ -231,7 +231,7 @@ public class CliMain {
                         throw new IllegalArgumentException("no password specified");
 
                     var request = RemoveWalletPasswordRequest.newBuilder().setPassword(nonOptionArgs.get(1)).build();
-                    walletService.removeWalletPassword(request);
+                    walletsService.removeWalletPassword(request);
                     out.println("wallet decrypted");
                     return;
                 }
@@ -243,7 +243,7 @@ public class CliMain {
                     var hasNewPassword = nonOptionArgs.size() == 3;
                     if (hasNewPassword)
                         requestBuilder.setNewPassword(nonOptionArgs.get(2));
-                    walletService.setWalletPassword(requestBuilder.build());
+                    walletsService.setWalletPassword(requestBuilder.build());
                     out.println("wallet encrypted" + (hasNewPassword ? " with new password" : ""));
                     return;
                 }

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -184,14 +184,14 @@ public class CliMain {
                     if (nonOptionArgs.size() < 2)
                         throw new IllegalArgumentException("no buy/sell direction specified");
 
-                    var direction = nonOptionArgs.get(1).toUpperCase();
-                    if (!direction.equals("BUY") && !direction.equals("SELL"))
+                    var direction = nonOptionArgs.get(1);
+                    if (!direction.equalsIgnoreCase("BUY") && !direction.equalsIgnoreCase("SELL"))
                         throw new IllegalArgumentException("no buy/sell direction specified");
 
                     if (nonOptionArgs.size() < 3)
                         throw new IllegalArgumentException("no fiat currency specified");
 
-                    var fiatCurrency = nonOptionArgs.get(2).toUpperCase();
+                    var fiatCurrency = nonOptionArgs.get(2);
 
                     var request = GetOffersRequest.newBuilder()
                             .setDirection(direction)
@@ -215,7 +215,7 @@ public class CliMain {
                     if (nonOptionArgs.size() < 4)
                         throw new IllegalArgumentException("no fiat currency specified");
 
-                    var fiatCurrencyCode = nonOptionArgs.get(3).toUpperCase();
+                    var fiatCurrencyCode = nonOptionArgs.get(3);
 
                     var request = CreatePaymentAccountRequest.newBuilder()
                             .setAccountName(accountName)

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -56,10 +56,12 @@ import static java.lang.String.format;
 import static java.lang.System.err;
 import static java.lang.System.exit;
 import static java.lang.System.out;
+import static java.util.Collections.singletonList;
 
 /**
  * A command-line client for the Bisq gRPC API.
  */
+@SuppressWarnings("ResultOfMethodCallIgnored")
 @Slf4j
 public class CliMain {
 
@@ -174,16 +176,13 @@ public class CliMain {
                     var request = GetAddressBalanceRequest.newBuilder()
                             .setAddress(nonOptionArgs.get(1)).build();
                     var reply = walletsService.getAddressBalance(request);
-                    out.println(addressBalanceInfoHeader());
-                    out.println(addressBalanceInfoDetail(reply.getAddressBalanceInfo()));
+                    out.println(formatTable(singletonList(reply.getAddressBalanceInfo())));
                     return;
                 }
                 case getfundingaddresses: {
                     var request = GetFundingAddressesRequest.newBuilder().build();
                     var reply = walletsService.getFundingAddresses(request);
-                    out.println(addressBalanceInfoHeader());
-                    reply.getAddressBalanceInfoList().forEach(balanceInfo ->
-                            out.println(addressBalanceInfoDetail(balanceInfo)));
+                    out.println(formatTable(reply.getAddressBalanceInfoList()));
                     return;
                 }
                 case createpaymentacct: {
@@ -309,14 +308,13 @@ public class CliMain {
         }
     }
 
-    private static String addressBalanceInfoHeader() {
-        return format("%-35s %13s  %s", "Address", "Balance", "Confirmations");
-    }
-
-    private static String addressBalanceInfoDetail(AddressBalanceInfo addressBalanceInfo) {
-        return format("%-35s %13s %14d",
-                addressBalanceInfo.getAddress(),
-                formatSatoshis.apply(addressBalanceInfo.getBalance()),
-                addressBalanceInfo.getNumConfirmations());
+    private static String formatTable(List<AddressBalanceInfo> addressBalanceInfo) {
+        return format("%-35s %13s  %s%n", "Address", "Balance", "Confirmations")
+                + addressBalanceInfo.stream()
+                .map(info -> format("%-35s %13s %14d",
+                        info.getAddress(),
+                        formatSatoshis.apply(info.getBalance()),
+                        info.getNumConfirmations()))
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -181,16 +181,10 @@ public class CliMain {
                     return;
                 }
                 case getoffers: {
-                    if (nonOptionArgs.size() < 2)
-                        throw new IllegalArgumentException("no buy/sell direction specified");
+                    if (nonOptionArgs.size() < 3)
+                        throw new IllegalArgumentException("incorrect parameter count, expecting direction (buy|sell), currency code");
 
                     var direction = nonOptionArgs.get(1);
-                    if (!direction.equalsIgnoreCase("BUY") && !direction.equalsIgnoreCase("SELL"))
-                        throw new IllegalArgumentException("no buy/sell direction specified");
-
-                    if (nonOptionArgs.size() < 3)
-                        throw new IllegalArgumentException("no fiat currency specified");
-
                     var fiatCurrency = nonOptionArgs.get(2);
 
                     var request = GetOffersRequest.newBuilder()

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -17,6 +17,7 @@
 
 package bisq.cli;
 
+import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.GetVersionGrpc;
@@ -59,6 +60,7 @@ public class CliMain {
     private enum Method {
         getversion,
         getbalance,
+        getaddressbalance,
         getfundingaddresses,
         lockwallet,
         unlockwallet,
@@ -154,6 +156,16 @@ public class CliMain {
                     out.println(btcBalance);
                     return;
                 }
+                case getaddressbalance: {
+                    if (nonOptionArgs.size() < 2)
+                        throw new IllegalArgumentException("no address specified");
+
+                    var request = GetAddressBalanceRequest.newBuilder()
+                            .setAddress(nonOptionArgs.get(1)).build();
+                    var reply = walletService.getAddressBalance(request);
+                    out.println(reply.getAddressBalanceInfo());
+                    return;
+                }
                 case getfundingaddresses: {
                     var request = GetFundingAddressesRequest.newBuilder().build();
                     var reply = walletService.getFundingAddresses(request);
@@ -230,6 +242,7 @@ public class CliMain {
             stream.format("%-19s%-30s%s%n", "------", "------", "------------");
             stream.format("%-19s%-30s%s%n", "getversion", "", "Get server version");
             stream.format("%-19s%-30s%s%n", "getbalance", "", "Get server wallet balance");
+            stream.format("%-19s%-30s%s%n", "getaddressbalance", "", "Get server wallet address balance");
             stream.format("%-19s%-30s%s%n", "getfundingaddresses", "", "Get BTC funding addresses");
             stream.format("%-19s%-30s%s%n", "lockwallet", "", "Remove wallet password from memory, locking the wallet");
             stream.format("%-19s%-30s%s%n", "unlockwallet", "password timeout",

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -202,19 +202,12 @@ public class CliMain {
                     return;
                 }
                 case createpaymentacct: {
-                    if (nonOptionArgs.size() < 2)
-                        throw new IllegalArgumentException("no account name specified");
+                    if (nonOptionArgs.size() < 4)
+                        throw new IllegalArgumentException(
+                                "incorrect parameter count, expecting account name, account number, currency code");
 
                     var accountName = nonOptionArgs.get(1);
-
-                    if (nonOptionArgs.size() < 3)
-                        throw new IllegalArgumentException("no account number specified");
-
                     var accountNumber = nonOptionArgs.get(2);
-
-                    if (nonOptionArgs.size() < 4)
-                        throw new IllegalArgumentException("no fiat currency specified");
-
                     var fiatCurrencyCode = nonOptionArgs.get(3);
 
                     var request = CreatePaymentAccountRequest.newBuilder()

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -230,6 +230,7 @@ public class CliMain {
             stream.format("%-19s%-30s%s%n", "------", "------", "------------");
             stream.format("%-19s%-30s%s%n", "getversion", "", "Get server version");
             stream.format("%-19s%-30s%s%n", "getbalance", "", "Get server wallet balance");
+            stream.format("%-19s%-30s%s%n", "getfundingaddresses", "", "Get BTC funding addresses");
             stream.format("%-19s%-30s%s%n", "lockwallet", "", "Remove wallet password from memory, locking the wallet");
             stream.format("%-19s%-30s%s%n", "unlockwallet", "password timeout",
                     "Store wallet password in memory for timeout seconds");

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -65,8 +65,6 @@ import static java.lang.System.err;
 import static java.lang.System.exit;
 import static java.lang.System.out;
 import static java.util.Collections.singletonList;
-import static protobuf.OfferPayload.Direction.BUY;
-import static protobuf.OfferPayload.Direction.SELL;
 
 /**
  * A command-line client for the Bisq gRPC API.
@@ -223,7 +221,7 @@ public class CliMain {
                             "Payment Method", "Creation Date", "ID"));
                     out.println(reply.getOffersList().stream()
                             .map(o -> format("%-8s %22s  %-25s %12s  %-14s %-24s  %s",
-                                    o.getDirection().equals(BUY.name()) ? SELL.name() : BUY.name(),
+                                    o.getDirection().equals("BUY") ? "SELL" : "BUY",
                                     formatPrice(o.getPrice()),
                                     o.getMinAmount() != o.getAmount() ? formatSatoshis.apply(o.getMinAmount())
                                             + " - " + formatSatoshis.apply(o.getAmount())

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -44,13 +44,13 @@ import java.io.PrintStream;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
 import static bisq.cli.CurrencyFormat.formatSatoshis;
 import static bisq.cli.TableFormat.formatAddressBalanceTbl;
 import static bisq.cli.TableFormat.formatOfferTable;
+import static bisq.cli.TableFormat.formatPaymentAcctTbl;
 import static java.lang.String.format;
 import static java.lang.System.err;
 import static java.lang.System.exit;
@@ -228,15 +228,7 @@ public class CliMain {
                 case getpaymentaccts: {
                     var request = GetPaymentAccountsRequest.newBuilder().build();
                     var reply = paymentAccountsService.getPaymentAccounts(request);
-                    var columnFormatSpec = "%-41s %-25s %-14s %s";
-                    out.println(format(columnFormatSpec, "ID", "Name", "Currency", "Payment Method"));
-                    out.println(reply.getPaymentAccountsList().stream()
-                            .map(a -> format(columnFormatSpec,
-                                    a.getId(),
-                                    a.getAccountName(),
-                                    a.getSelectedTradeCurrency().getCode(),
-                                    a.getPaymentMethod().getId()))
-                            .collect(Collectors.joining("\n")));
+                    out.println(formatPaymentAcctTbl(reply.getPaymentAccountsList()));
                     return;
                 }
                 case lockwallet: {

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -18,6 +18,7 @@
 package bisq.cli;
 
 import bisq.proto.grpc.GetBalanceRequest;
+import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.GetVersionGrpc;
 import bisq.proto.grpc.GetVersionRequest;
 import bisq.proto.grpc.LockWalletRequest;
@@ -58,6 +59,7 @@ public class CliMain {
     private enum Method {
         getversion,
         getbalance,
+        getfundingaddresses,
         lockwallet,
         unlockwallet,
         removewalletpassword,
@@ -152,6 +154,12 @@ public class CliMain {
                     out.println(btcBalance);
                     return;
                 }
+                case getfundingaddresses: {
+                    var request = GetFundingAddressesRequest.newBuilder().build();
+                    var reply = walletService.getFundingAddresses(request);
+                    out.println(reply.getFundingAddressesInfo());
+                    return;
+                }
                 case lockwallet: {
                     var request = LockWalletRequest.newBuilder().build();
                     walletService.lockWallet(request);
@@ -201,7 +209,7 @@ public class CliMain {
                 }
                 default: {
                     throw new RuntimeException(format("unhandled method '%s'", method));
-               }
+                }
             }
         } catch (StatusRuntimeException ex) {
             // Remove the leading gRPC status code (e.g. "UNKNOWN: ") from the message

--- a/cli/src/main/java/bisq/cli/CurrencyFormat.java
+++ b/cli/src/main/java/bisq/cli/CurrencyFormat.java
@@ -1,0 +1,47 @@
+package bisq.cli;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import java.util.Locale;
+
+class CurrencyFormat {
+
+    private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance(Locale.US);
+
+    static final BigDecimal SATOSHI_DIVISOR = new BigDecimal(100000000);
+    static final DecimalFormat BTC_FORMAT = new DecimalFormat("###,##0.00000000");
+
+    @SuppressWarnings("BigDecimalMethodWithoutRoundingCalled")
+    static final String formatSatoshis(long sats) {
+        return BTC_FORMAT.format(BigDecimal.valueOf(sats).divide(SATOSHI_DIVISOR));
+    }
+
+    static String formatAmountRange(long minAmount, long amount) {
+        return minAmount != amount
+                ? formatSatoshis(minAmount) + " - " + formatSatoshis(amount)
+                : formatSatoshis(amount);
+    }
+
+    static String formatVolumeRange(long minVolume, long volume) {
+        return minVolume != volume
+                ? formatOfferVolume(minVolume) + " - " + formatOfferVolume(volume)
+                : formatOfferVolume(volume);
+    }
+
+    static String formatOfferPrice(long price) {
+        NUMBER_FORMAT.setMaximumFractionDigits(4);
+        NUMBER_FORMAT.setMinimumFractionDigits(4);
+        NUMBER_FORMAT.setRoundingMode(RoundingMode.UNNECESSARY);
+        return NUMBER_FORMAT.format((double) price / 10000);
+    }
+
+    static String formatOfferVolume(long volume) {
+        NUMBER_FORMAT.setMaximumFractionDigits(0);
+        NUMBER_FORMAT.setRoundingMode(RoundingMode.UNNECESSARY);
+        return NUMBER_FORMAT.format((double) volume / 10000);
+    }
+}

--- a/cli/src/main/java/bisq/cli/PasswordCallCredentials.java
+++ b/cli/src/main/java/bisq/cli/PasswordCallCredentials.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.cli;
 
 import io.grpc.CallCredentials;

--- a/cli/src/main/java/bisq/cli/TableFormat.java
+++ b/cli/src/main/java/bisq/cli/TableFormat.java
@@ -92,7 +92,7 @@ class TableFormat {
         return headerLine
                 + offerInfo.stream()
                 .map(o -> format(colDataFormat,
-                        o.getDirection().equals("BUY") ? "SELL" : "BUY",
+                        o.getDirection(),
                         formatOfferPrice(o.getPrice()),
                         formatAmountRange(o.getMinAmount(), o.getAmount()),
                         formatVolumeRange(o.getMinVolume(), o.getVolume()),

--- a/cli/src/main/java/bisq/cli/TableFormat.java
+++ b/cli/src/main/java/bisq/cli/TableFormat.java
@@ -1,0 +1,116 @@
+package bisq.cli;
+
+import bisq.proto.grpc.AddressBalanceInfo;
+import bisq.proto.grpc.OfferInfo;
+
+import java.text.DateFormat;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import static bisq.cli.CurrencyFormat.formatAmountRange;
+import static bisq.cli.CurrencyFormat.formatOfferPrice;
+import static bisq.cli.CurrencyFormat.formatSatoshis;
+import static bisq.cli.CurrencyFormat.formatVolumeRange;
+import static com.google.common.base.Strings.padEnd;
+import static java.lang.String.format;
+import static java.text.DateFormat.DEFAULT;
+import static java.text.DateFormat.getDateInstance;
+import static java.text.DateFormat.getTimeInstance;
+import static java.util.Collections.max;
+import static java.util.Comparator.comparing;
+import static java.util.TimeZone.getTimeZone;
+
+class TableFormat {
+
+    // For inserting 2 spaces between column headers.
+    private static final String COL_HEADER_DELIMITER = "  ";
+
+    // Table column header format specs, right padded with two spaces.  In some cases
+    // such as COL_HEADER_CREATION_DATE, COL_HEADER_VOLUME and COL_HEADER_UUID, the
+    // expected max data string length is accounted for.  In others, the column header length
+    // are expected to be greater than any column value length.
+    private static final String COL_HEADER_AMOUNT = padEnd("BTC(min - max)", 24, ' ');
+    private static final String COL_HEADER_CREATION_DATE = padEnd("Creation Date", 24, ' ');
+    private static final String COL_HEADER_DIRECTION = "Buy/Sell";
+    private static final String COL_HEADER_PAYMENT_METHOD = "Payment Method";
+    private static final String COL_HEADER_PRICE = "Price in %-3s for 1 BTC";
+    private static final String COL_HEADER_VOLUME = padEnd("%-3s(min - max)", 15, ' ');
+    private static final String COL_HEADER_UUID = padEnd("ID", 52, ' ');
+
+    static String formatAddressBalanceTbl(List<AddressBalanceInfo> addressBalanceInfo) {
+        return format("%-35s %13s  %s%n", "Address", "Balance", "Confirmations")
+                + addressBalanceInfo.stream()
+                .map(info -> format("%-35s %13s %14d",
+                        info.getAddress(),
+                        formatSatoshis(info.getBalance()),
+                        info.getNumConfirmations()))
+                .collect(Collectors.joining("\n"));
+    }
+
+    static String formatOfferTable(List<OfferInfo> offerInfo, String fiatCurrency) {
+
+        // Some column values might be longer than header, so we need to calculated them.
+        int paymentMethodColWidth = getLengthOfLongestColumn(
+                COL_HEADER_PAYMENT_METHOD.length(),
+                offerInfo.stream()
+                        .map(o -> o.getPaymentMethodShortName())
+                        .collect(Collectors.toList()));
+
+        String headersFormat = COL_HEADER_DIRECTION + COL_HEADER_DELIMITER
+                + COL_HEADER_PRICE + COL_HEADER_DELIMITER   // includes %s -> fiatCurrency
+                + COL_HEADER_AMOUNT + COL_HEADER_DELIMITER
+                + COL_HEADER_VOLUME + COL_HEADER_DELIMITER  // includes %s -> fiatCurrency
+                + padEnd(COL_HEADER_PAYMENT_METHOD, paymentMethodColWidth, ' ') + COL_HEADER_DELIMITER
+                + COL_HEADER_CREATION_DATE + COL_HEADER_DELIMITER
+                + COL_HEADER_UUID.trim() + "%n";
+        String headerLine = format(headersFormat, fiatCurrency, fiatCurrency);
+
+        String colDataFormat = "%-" + (COL_HEADER_DIRECTION.length() + COL_HEADER_DELIMITER.length()) + "s" // left
+                + "%" + (COL_HEADER_PRICE.length() - 1) + "s" // rt justify to end of hdr
+                + "  %-" + (COL_HEADER_AMOUNT.length() - 1) + "s" // left justify
+                + "  %" + COL_HEADER_VOLUME.length() + "s" // right justify
+                + "  %-" + paymentMethodColWidth + "s" // left justify
+                + "  %-" + (COL_HEADER_CREATION_DATE.length()) + "s" // left justify
+                + "  %-" + COL_HEADER_UUID.length() + "s";
+        return headerLine
+                + offerInfo.stream()
+                .map(o -> format(colDataFormat,
+                        o.getDirection().equals("BUY") ? "SELL" : "BUY",
+                        formatOfferPrice(o.getPrice()),
+                        formatAmountRange(o.getMinAmount(), o.getAmount()),
+                        formatVolumeRange(o.getMinVolume(), o.getVolume()),
+                        o.getPaymentMethodShortName(),
+                        formatDateTime(o.getDate(), true),
+                        o.getId()))
+                .collect(Collectors.joining("\n"));
+    }
+
+    // Return length of the longest string value, or the header.len, whichever is greater.
+    private static int getLengthOfLongestColumn(int headerLength, List<String> strings) {
+        int longest = max(strings, comparing(s -> s.length())).length();
+        return longest > headerLength ? longest : headerLength;
+    }
+
+    private static String formatDateTime(long timestamp, boolean useLocaleAndLocalTimezone) {
+        Date date = new Date(timestamp);
+        Locale locale = useLocaleAndLocalTimezone ? Locale.getDefault() : Locale.US;
+        DateFormat dateInstance = getDateInstance(DEFAULT, locale);
+        DateFormat timeInstance = getTimeInstance(DEFAULT, locale);
+        if (!useLocaleAndLocalTimezone) {
+            dateInstance.setTimeZone(getTimeZone("UTC"));
+            timeInstance.setTimeZone(getTimeZone("UTC"));
+        }
+        return formatDateTime(date, dateInstance, timeInstance);
+    }
+
+    private static String formatDateTime(Date date, DateFormat dateFormatter, DateFormat timeFormatter) {
+        if (date != null) {
+            return dateFormatter.format(date) + " " + timeFormatter.format(date);
+        } else {
+            return "";
+        }
+    }
+}

--- a/cli/src/main/java/bisq/cli/TableFormat.java
+++ b/cli/src/main/java/bisq/cli/TableFormat.java
@@ -15,6 +15,7 @@ import static bisq.cli.CurrencyFormat.formatOfferPrice;
 import static bisq.cli.CurrencyFormat.formatSatoshis;
 import static bisq.cli.CurrencyFormat.formatVolumeRange;
 import static com.google.common.base.Strings.padEnd;
+import static com.google.common.base.Strings.padStart;
 import static java.lang.String.format;
 import static java.text.DateFormat.DEFAULT;
 import static java.text.DateFormat.getDateInstance;
@@ -32,18 +33,27 @@ class TableFormat {
     // such as COL_HEADER_CREATION_DATE, COL_HEADER_VOLUME and COL_HEADER_UUID, the
     // expected max data string length is accounted for.  In others, the column header length
     // are expected to be greater than any column value length.
+    private static final String COL_HEADER_ADDRESS = padEnd("Address", 34, ' ');
     private static final String COL_HEADER_AMOUNT = padEnd("BTC(min - max)", 24, ' ');
+    private static final String COL_HEADER_BALANCE = padStart("Balance", 12, ' ');
+    private static final String COL_HEADER_CONFIRMATIONS = "Confirmations";
     private static final String COL_HEADER_CREATION_DATE = padEnd("Creation Date", 24, ' ');
-    private static final String COL_HEADER_DIRECTION = "Buy/Sell";
+    private static final String COL_HEADER_DIRECTION = "Buy/Sell";  // TODO "Take Offer to
     private static final String COL_HEADER_PAYMENT_METHOD = "Payment Method";
     private static final String COL_HEADER_PRICE = "Price in %-3s for 1 BTC";
     private static final String COL_HEADER_VOLUME = padEnd("%-3s(min - max)", 15, ' ');
     private static final String COL_HEADER_UUID = padEnd("ID", 52, ' ');
 
     static String formatAddressBalanceTbl(List<AddressBalanceInfo> addressBalanceInfo) {
-        return format("%-35s %13s  %s%n", "Address", "Balance", "Confirmations")
+        String headerLine = (COL_HEADER_ADDRESS + COL_HEADER_DELIMITER
+                + COL_HEADER_BALANCE + COL_HEADER_DELIMITER
+                + COL_HEADER_CONFIRMATIONS + COL_HEADER_DELIMITER + "\n");
+        String colDataFormat = "%-" + COL_HEADER_ADDRESS.length() + "s" // left justify
+                + "  %" + COL_HEADER_BALANCE.length() + "s" // right justify
+                + "  %" + COL_HEADER_CONFIRMATIONS.length() + "d"; // right justify
+        return headerLine
                 + addressBalanceInfo.stream()
-                .map(info -> format("%-35s %13s %14d",
+                .map(info -> format(colDataFormat,
                         info.getAddress(),
                         formatSatoshis(info.getBalance()),
                         info.getNumConfirmations()))
@@ -86,6 +96,26 @@ class TableFormat {
                         formatDateTime(o.getDate(), true),
                         o.getId()))
                 .collect(Collectors.joining("\n"));
+    }
+
+    static String formatPaymentAcctTbl() {
+        /*
+        case getpaymentaccts: {
+                    var request = GetPaymentAccountsRequest.newBuilder().build();
+                    var reply = paymentAccountsService.getPaymentAccounts(request);
+                    var columnFormatSpec = "%-41s %-25s %-14s %s";
+                    out.println(format(columnFormatSpec, "ID", "Name", "Currency", "Payment Method"));
+                    out.println(reply.getPaymentAccountsList().stream()
+                            .map(a -> format(columnFormatSpec,
+                                    a.getId(),
+                                    a.getAccountName(),
+                                    a.getSelectedTradeCurrency().getCode(),
+                                    a.getPaymentMethod().getId()))
+                            .collect(Collectors.joining("\n")));
+                    return;
+                }
+         */
+        return "";
     }
 
     // Return length of the longest string value, or the header.len, whichever is greater.

--- a/cli/src/test/java/bisq/cli/GetOffersSmokeTest.java
+++ b/cli/src/test/java/bisq/cli/GetOffersSmokeTest.java
@@ -1,0 +1,39 @@
+package bisq.cli;
+
+import static java.lang.System.out;
+
+/**
+ Smoke tests for getoffers method.  Useful for examining the format of the console output.
+
+ Prerequisites:
+
+ - Run `./bisq-daemon --apiPassword=xyz --appDataDir=$TESTDIR`
+
+ This can be run on mainnet.
+ */
+public class GetOffersSmokeTest {
+
+    public static void main(String[] args) {
+
+        out.println(">>> getoffers buy usd");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "buy", "usd"});
+        out.println(">>> getoffers sell usd");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "sell", "usd"});
+
+        out.println(">>> getoffers buy eur");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "buy", "eur"});
+        out.println(">>> getoffers sell eur");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "sell", "eur"});
+
+        out.println(">>> getoffers buy gbp");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "buy", "gbp"});
+        out.println(">>> getoffers sell gbp");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "sell", "gbp"});
+
+        out.println(">>> getoffers buy brl");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "buy", "brl"});
+        out.println(">>> getoffers sell brl");
+        CliMain.main(new String[]{"--password=xyz", "getoffers", "sell", "brl"});
+    }
+
+}

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -171,6 +171,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "test getpaymentaccts" {
+  run ./bisq-cli --password=xyz getpaymentaccts
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -166,6 +166,13 @@
   [ "$output" = "Error: address bogus not found in wallet" ]
 }
 
+@test "test createpaymentacct PerfectMoneyDummy (missing nbr, ccy params)" {
+  run ./bisq-cli --password=xyz createpaymentacct PerfectMoneyDummy
+  [ "$status" -eq 1 ]
+ echo "actual output:  $output" >&2
+  [ "$output" = "Error: incorrect parameter count, expecting account name, account number, currency code" ]
+}
+
 @test "test createpaymentacct PerfectMoneyDummy 0123456789 USD" {
   run ./bisq-cli --password=xyz createpaymentacct PerfectMoneyDummy 0123456789 USD
   [ "$status" -eq 0 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -152,6 +152,20 @@
   [ "$status" -eq 0 ]
 }
 
+@test "test getaddressbalance missing address argument" {
+  run ./bisq-cli --password=xyz getaddressbalance
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no address specified" ]
+}
+
+@test "test getaddressbalance bogus address argument" {
+  run ./bisq-cli --password=xyz getaddressbalance bogus
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: address bogus not found in wallet" ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -147,6 +147,11 @@
   [ "$output" = "0.00000000" ]
 }
 
+@test "test getfundingaddresses" {
+  run ./bisq-cli --password=xyz getfundingaddresses
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -176,6 +176,35 @@
   [ "$status" -eq 0 ]
 }
 
+@test "test getoffers missing direction argument" {
+  run ./bisq-cli --password=xyz getoffers
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no buy/sell direction specified" ]
+}
+
+@test "test getoffers missing ccy argument" {
+  run ./bisq-cli --password=xyz getoffers buy
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no fiat currency specified" ]
+}
+
+@test "test getoffers buy eur check return status" {
+  run ./bisq-cli --password=xyz getoffers buy eur
+  [ "$status" -eq 0 ]
+}
+
+@test "test getoffers buy eur check return status" {
+  run ./bisq-cli --password=xyz getoffers buy eur
+  [ "$status" -eq 0 ]
+}
+
+@test "test getoffers sell gbp check return status" {
+  run ./bisq-cli --password=xyz getoffers sell gbp
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -187,14 +187,7 @@
   run ./bisq-cli --password=xyz getoffers
   [ "$status" -eq 1 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "Error: no buy/sell direction specified" ]
-}
-
-@test "test getoffers missing ccy argument" {
-  run ./bisq-cli --password=xyz getoffers buy
-  [ "$status" -eq 1 ]
-  echo "actual output:  $output" >&2
-  [ "$output" = "Error: no fiat currency specified" ]
+  [ "$output" = "Error: incorrect parameter count, expecting direction (buy|sell), currency code" ]
 }
 
 @test "test getoffers buy eur check return status" {

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -48,17 +48,99 @@
   run ./bisq-cli --password="xyz" getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
 @test "test getversion" {
   run ./bisq-cli --password=xyz getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.2" ]
+  [ "$output" = "1.3.4" ]
 }
 
-@test "test getbalance (available & unlocked wallet with 0 btc balance)" {
+@test "test setwalletpassword \"a b c\"" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted" ]
+  sleep 1
+}
+
+@test "test unlockwallet without password & timeout args" {
+  run ./bisq-cli --password=xyz unlockwallet
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no password specified" ]
+}
+
+@test "test unlockwallet without timeout arg" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: no unlock timeout specified" ]
+}
+
+
+@test "test unlockwallet \"a b c\" 8" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 8
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test getbalance while wallet unlocked for 8s" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "0.00000000" ]
+  sleep 8
+}
+
+@test "test unlockwallet \"a b c\" 6" {
+  run ./bisq-cli --password=xyz unlockwallet "a b c" 6
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet unlocked" ]
+}
+
+@test "test lockwallet before unlockwallet timeout=6s expires" {
+  run ./bisq-cli --password=xyz lockwallet
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet locked" ]
+}
+
+@test "test setwalletpassword incorrect old pwd error" {
+  run ./bisq-cli --password=xyz setwalletpassword "z z z"  "d e f"
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: incorrect old password" ]
+}
+
+@test "test setwalletpassword oldpwd newpwd" {
+  run ./bisq-cli --password=xyz setwalletpassword "a b c"  "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet encrypted with new password" ]
+  sleep 1
+}
+
+@test "test getbalance wallet locked error" {
+  run ./bisq-cli --password=xyz getbalance
+  [ "$status" -eq 1 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "Error: wallet is locked" ]
+}
+
+@test "test removewalletpassword" {
+  run ./bisq-cli --password=xyz removewalletpassword "d e f"
+  [ "$status" -eq 0 ]
+  echo "actual output:  $output" >&2
+  [ "$output" = "wallet decrypted" ]
+  sleep 1
+}
+
+@test "test getbalance when wallet available & unlocked with 0 btc balance" {
   run ./bisq-cli --password=xyz getbalance
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
@@ -69,7 +151,7 @@
   run ./bisq-cli
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }
 
@@ -77,6 +159,6 @@
   run ./bisq-cli --help
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "Bisq RPC Client" ]
-  [ "${lines[1]}" = "Usage: bisq-cli [options] <method>" ]
+  [ "${lines[1]}" = "Usage: bisq-cli [options] <method> [params]" ]
   # TODO add asserts after help text is modified for new endpoints
 }

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -166,6 +166,11 @@
   [ "$output" = "Error: address bogus not found in wallet" ]
 }
 
+@test "test createpaymentacct PerfectMoneyDummy 0123456789 USD" {
+  run ./bisq-cli --password=xyz createpaymentacct PerfectMoneyDummy 0123456789 USD
+  [ "$status" -eq 0 ]
+}
+
 @test "test help displayed on stderr if no options or arguments" {
   run ./bisq-cli
   [ "$status" -eq 1 ]

--- a/core/src/main/java/bisq/core/grpc/CoreApi.java
+++ b/core/src/main/java/bisq/core/grpc/CoreApi.java
@@ -47,6 +47,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class CoreApi {
+    private final CorePaymentAccountsService paymentAccountsService;
     private final OfferBookService offerBookService;
     private final TradeStatisticsManager tradeStatisticsManager;
     private final CreateOfferService createOfferService;
@@ -54,11 +55,13 @@ public class CoreApi {
     private final User user;
 
     @Inject
-    public CoreApi(OfferBookService offerBookService,
+    public CoreApi(CorePaymentAccountsService paymentAccountsService,
+                   OfferBookService offerBookService,
                    TradeStatisticsManager tradeStatisticsManager,
                    CreateOfferService createOfferService,
                    OpenOfferManager openOfferManager,
                    User user) {
+        this.paymentAccountsService = paymentAccountsService;
         this.offerBookService = offerBookService;
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.createOfferService = createOfferService;
@@ -78,8 +81,12 @@ public class CoreApi {
         return offerBookService.getOffers();
     }
 
+    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
+        paymentAccountsService.createPaymentAccount(accountName, accountNumber, fiatCurrencyCode);
+    }
+
     public Set<PaymentAccount> getPaymentAccounts() {
-        return user.getPaymentAccounts();
+        return paymentAccountsService.getPaymentAccounts();
     }
 
     public void placeOffer(String currencyCode,

--- a/core/src/main/java/bisq/core/grpc/CoreApi.java
+++ b/core/src/main/java/bisq/core/grpc/CoreApi.java
@@ -48,6 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CoreApi {
     private final CorePaymentAccountsService paymentAccountsService;
+    private final CoreWalletsService walletsService;
     private final OfferBookService offerBookService;
     private final TradeStatisticsManager tradeStatisticsManager;
     private final CreateOfferService createOfferService;
@@ -56,12 +57,14 @@ public class CoreApi {
 
     @Inject
     public CoreApi(CorePaymentAccountsService paymentAccountsService,
+                   CoreWalletsService walletsService,
                    OfferBookService offerBookService,
                    TradeStatisticsManager tradeStatisticsManager,
                    CreateOfferService createOfferService,
                    OpenOfferManager openOfferManager,
                    User user) {
         this.paymentAccountsService = paymentAccountsService;
+        this.walletsService = walletsService;
         this.offerBookService = offerBookService;
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.createOfferService = createOfferService;
@@ -73,20 +76,52 @@ public class CoreApi {
         return Version.VERSION;
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Wallets
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public long getAvailableBalance() {
+        return walletsService.getAvailableBalance();
+    }
+
+    public long getAddressBalance(String addressString) {
+        return walletsService.getAddressBalance(addressString);
+    }
+
+    public String getAddressBalanceInfo(String addressString) {
+        return walletsService.getAddressBalanceInfo(addressString);
+    }
+
+    public String getFundingAddresses() {
+        return walletsService.getFundingAddresses();
+    }
+
+    public void setWalletPassword(String password, String newPassword) {
+        walletsService.setWalletPassword(password, newPassword);
+    }
+
+    public void lockWallet() {
+        walletsService.lockWallet();
+    }
+
+    public void unlockWallet(String password, long timeout) {
+        walletsService.unlockWallet(password, timeout);
+    }
+
+    public void removeWalletPassword(String password) {
+        walletsService.removeWalletPassword(password);
+    }
+
     public List<TradeStatistics2> getTradeStatistics() {
         return new ArrayList<>(tradeStatisticsManager.getObservableTradeStatisticsSet());
     }
 
+    public int getNumConfirmationsForMostRecentTransaction(String addressString) {
+        return walletsService.getNumConfirmationsForMostRecentTransaction(addressString);
+    }
+
     public List<Offer> getOffers() {
         return offerBookService.getOffers();
-    }
-
-    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
-        paymentAccountsService.createPaymentAccount(accountName, accountNumber, fiatCurrencyCode);
-    }
-
-    public Set<PaymentAccount> getPaymentAccounts() {
-        return paymentAccountsService.getPaymentAccounts();
     }
 
     public void placeOffer(String currencyCode,
@@ -152,4 +187,15 @@ public class CoreApi {
                 log::error);
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PaymentAccounts
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
+        paymentAccountsService.createPaymentAccount(accountName, accountNumber, fiatCurrencyCode);
+    }
+
+    public Set<PaymentAccount> getPaymentAccounts() {
+        return paymentAccountsService.getPaymentAccounts();
+    }
 }

--- a/core/src/main/java/bisq/core/grpc/CoreApi.java
+++ b/core/src/main/java/bisq/core/grpc/CoreApi.java
@@ -17,6 +17,7 @@
 
 package bisq.core.grpc;
 
+import bisq.core.grpc.model.AddressBalanceInfo;
 import bisq.core.monetary.Price;
 import bisq.core.offer.CreateOfferService;
 import bisq.core.offer.Offer;
@@ -88,11 +89,11 @@ public class CoreApi {
         return walletsService.getAddressBalance(addressString);
     }
 
-    public String getAddressBalanceInfo(String addressString) {
+    public AddressBalanceInfo getAddressBalanceInfo(String addressString) {
         return walletsService.getAddressBalanceInfo(addressString);
     }
 
-    public String getFundingAddresses() {
+    public List<AddressBalanceInfo> getFundingAddresses() {
         return walletsService.getFundingAddresses();
     }
 

--- a/core/src/main/java/bisq/core/grpc/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreOffersService.java
@@ -60,8 +60,8 @@ public class CoreOffersService {
 
     public List<Offer> getOffers(String direction, String fiatCurrencyCode) {
         List<Offer> offers = offerBookService.getOffers().stream()
-                .filter(o -> !o.getDirection().name().equals(direction)
-                        && o.getOfferPayload().getCounterCurrencyCode().equals(fiatCurrencyCode))
+                .filter(o -> !o.getDirection().name().equalsIgnoreCase(direction)
+                        && o.getOfferPayload().getCounterCurrencyCode().equalsIgnoreCase(fiatCurrencyCode))
                 .collect(Collectors.toList());
 
         if (direction.equals(BUY.name()))

--- a/core/src/main/java/bisq/core/grpc/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreOffersService.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.grpc;
+
+import bisq.core.monetary.Price;
+import bisq.core.offer.CreateOfferService;
+import bisq.core.offer.Offer;
+import bisq.core.offer.OfferBookService;
+import bisq.core.offer.OfferPayload;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.payment.PaymentAccount;
+import bisq.core.trade.handlers.TransactionResultHandler;
+import bisq.core.user.User;
+
+import org.bitcoinj.core.Coin;
+
+import javax.inject.Inject;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.core.offer.OfferPayload.Direction.BUY;
+
+@Slf4j
+public class CoreOffersService {
+
+    private final CreateOfferService createOfferService;
+    private final OfferBookService offerBookService;
+    private final OpenOfferManager openOfferManager;
+    private final User user;
+
+    @Inject
+    public CoreOffersService(CreateOfferService createOfferService,
+                             OfferBookService offerBookService,
+                             OpenOfferManager openOfferManager,
+                             User user) {
+        this.createOfferService = createOfferService;
+        this.offerBookService = offerBookService;
+        this.openOfferManager = openOfferManager;
+        this.user = user;
+    }
+
+    public List<Offer> getOffers(String direction, String fiatCurrencyCode) {
+        List<Offer> offers = offerBookService.getOffers().stream()
+                .filter(o -> !o.getDirection().name().equals(direction)
+                        && o.getOfferPayload().getCounterCurrencyCode().equals(fiatCurrencyCode))
+                .collect(Collectors.toList());
+
+        if (direction.equals(BUY.name()))
+            offers.sort(Comparator.comparing(Offer::getPrice));
+        else
+            offers.sort(Comparator.comparing(Offer::getPrice).reversed());
+
+        return offers;
+    }
+
+    public void createOffer(String currencyCode,
+                            String directionAsString,
+                            long priceAsLong,
+                            boolean useMarketBasedPrice,
+                            double marketPriceMargin,
+                            long amountAsLong,
+                            long minAmountAsLong,
+                            double buyerSecurityDeposit,
+                            String paymentAccountId,
+                            TransactionResultHandler resultHandler) {
+        String offerId = createOfferService.getRandomOfferId();
+        OfferPayload.Direction direction = OfferPayload.Direction.valueOf(directionAsString);
+        Price price = Price.valueOf(currencyCode, priceAsLong);
+        Coin amount = Coin.valueOf(amountAsLong);
+        Coin minAmount = Coin.valueOf(minAmountAsLong);
+        PaymentAccount paymentAccount = user.getPaymentAccount(paymentAccountId);
+        // We don't support atm funding from external wallet to keep it simple
+        boolean useSavingsWallet = true;
+
+        //noinspection ConstantConditions
+        createOffer(offerId,
+                currencyCode,
+                direction,
+                price,
+                useMarketBasedPrice,
+                marketPriceMargin,
+                amount,
+                minAmount,
+                buyerSecurityDeposit,
+                paymentAccount,
+                useSavingsWallet,
+                resultHandler);
+    }
+
+    public void createOffer(String offerId,
+                            String currencyCode,
+                            OfferPayload.Direction direction,
+                            Price price,
+                            boolean useMarketBasedPrice,
+                            double marketPriceMargin,
+                            Coin amount,
+                            Coin minAmount,
+                            double buyerSecurityDeposit,
+                            PaymentAccount paymentAccount,
+                            boolean useSavingsWallet,
+                            TransactionResultHandler resultHandler) {
+        Offer offer = createOfferService.createAndGetOffer(offerId,
+                direction,
+                currencyCode,
+                amount,
+                minAmount,
+                price,
+                useMarketBasedPrice,
+                marketPriceMargin,
+                buyerSecurityDeposit,
+                paymentAccount);
+
+        openOfferManager.placeOffer(offer,
+                buyerSecurityDeposit,
+                useSavingsWallet,
+                resultHandler,
+                log::error);
+    }
+}

--- a/core/src/main/java/bisq/core/grpc/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreOffersService.java
@@ -60,14 +60,19 @@ public class CoreOffersService {
 
     public List<Offer> getOffers(String direction, String fiatCurrencyCode) {
         List<Offer> offers = offerBookService.getOffers().stream()
-                .filter(o -> !o.getDirection().name().equalsIgnoreCase(direction)
-                        && o.getOfferPayload().getCounterCurrencyCode().equalsIgnoreCase(fiatCurrencyCode))
+                .filter(o -> {
+                    var offerOfWantedDirection = o.getDirection().name().equalsIgnoreCase(direction);
+                    var offerInWantedCurrency = o.getOfferPayload().getCounterCurrencyCode().equalsIgnoreCase(fiatCurrencyCode);
+                    return offerOfWantedDirection && offerInWantedCurrency;
+                })
                 .collect(Collectors.toList());
 
-        if (direction.equals(BUY.name()))
-            offers.sort(Comparator.comparing(Offer::getPrice));
-        else
+        // A buyer probably wants to see sell orders in price ascending order.
+        // A seller probably wants to see buy orders in price descending order.
+        if (direction.equalsIgnoreCase(BUY.name()))
             offers.sort(Comparator.comparing(Offer::getPrice).reversed());
+        else
+            offers.sort(Comparator.comparing(Offer::getPrice));
 
         return offers;
     }

--- a/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.core.grpc;
 
 import bisq.core.account.witness.AccountAgeWitnessService;

--- a/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
@@ -1,0 +1,57 @@
+package bisq.core.grpc;
+
+import bisq.core.account.witness.AccountAgeWitnessService;
+import bisq.core.locale.FiatCurrency;
+import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.PaymentAccountFactory;
+import bisq.core.payment.PerfectMoneyAccount;
+import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.user.User;
+
+import bisq.common.config.Config;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CorePaymentAccountsService {
+
+    private final Config config;
+    private final AccountAgeWitnessService accountAgeWitnessService;
+    private final User user;
+
+    @Inject
+    public CorePaymentAccountsService(Config config,
+                                      AccountAgeWitnessService accountAgeWitnessService,
+                                      User user) {
+        this.config = config;
+        this.accountAgeWitnessService = accountAgeWitnessService;
+        this.user = user;
+    }
+
+    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
+        // Create and persist a PerfectMoney dummy payment account.  There is no guard
+        // against creating accounts with duplicate names & numbers, only the uuid and
+        // creation date are unique.
+        PaymentMethod dummyPaymentMethod = PaymentMethod.getDummyPaymentMethod(PaymentMethod.PERFECT_MONEY_ID);
+        PaymentAccount paymentAccount = PaymentAccountFactory.getPaymentAccount(dummyPaymentMethod);
+        paymentAccount.init();
+        paymentAccount.setAccountName(accountName);
+        ((PerfectMoneyAccount) paymentAccount).setAccountNr(accountNumber);
+        paymentAccount.setSingleTradeCurrency(new FiatCurrency(fiatCurrencyCode));
+        user.addPaymentAccount(paymentAccount);
+
+        // Don't do this on mainnet until thoroughly tested.
+        if (config.baseCurrencyNetwork.isRegtest())
+            accountAgeWitnessService.publishMyAccountAgeWitness(paymentAccount.getPaymentAccountPayload());
+
+        log.info("Payment account {} saved", paymentAccount.getId());
+    }
+
+    public Set<PaymentAccount> getPaymentAccounts() {
+        return user.getPaymentAccounts();
+    }
+}

--- a/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
@@ -58,7 +58,7 @@ public class CorePaymentAccountsService {
         paymentAccount.init();
         paymentAccount.setAccountName(accountName);
         ((PerfectMoneyAccount) paymentAccount).setAccountNr(accountNumber);
-        paymentAccount.setSingleTradeCurrency(new FiatCurrency(fiatCurrencyCode));
+        paymentAccount.setSingleTradeCurrency(new FiatCurrency(fiatCurrencyCode.toUpperCase()));
         user.addPaymentAccount(paymentAccount);
 
         // Don't do this on mainnet until thoroughly tested.

--- a/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/CorePaymentAccountsService.java
@@ -1,20 +1,3 @@
-/*
- * This file is part of Bisq.
- *
- * Bisq is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * Bisq is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
- * License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
- */
-
 package bisq.core.grpc;
 
 import bisq.core.account.witness.AccountAgeWitnessService;

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -54,7 +54,6 @@ class CoreWalletsService {
     private final Function<Long, String> formatSatoshis = (sats) ->
             btcFormat.format(BigDecimal.valueOf(sats).divide(satoshiDivisor));
 
-
     @Inject
     public CoreWalletsService(Balances balances,
                               WalletsManager walletsManager,

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Slf4j
-class CoreWalletService {
+class CoreWalletsService {
 
     private final Balances balances;
     private final WalletsManager walletsManager;
@@ -31,7 +31,7 @@ class CoreWalletService {
     private KeyParameter tempAesKey;
 
     @Inject
-    public CoreWalletService(Balances balances, WalletsManager walletsManager) {
+    public CoreWalletsService(Balances balances, WalletsManager walletsManager) {
         this.balances = balances;
         this.walletsManager = walletsManager;
     }

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -80,6 +80,15 @@ class CoreWalletsService {
         return btcWalletService.getBalanceForAddress(address).value;
     }
 
+    public String getAddressBalanceInfo(String addressString) {
+        var satoshiBalance = getAddressBalance(addressString);
+        var btcBalance = formatSatoshis.apply(satoshiBalance);
+        var numConfirmations = getNumConfirmationsForMostRecentTransaction(addressString);
+        return addressString
+                + "  balance: " + format("%13s", btcBalance)
+                + ((numConfirmations > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "");
+    }
+
     public String getFundingAddresses() {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -65,8 +65,7 @@ class CoreWalletsService {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");
 
-        if (walletsManager.areWalletsEncrypted() && tempAesKey == null)
-            throw new IllegalStateException("wallet is locked");
+        verifyEncryptedWalletIsUnlocked();
 
         var balance = balances.getAvailableBalance().get();
         if (balance == null)
@@ -93,8 +92,7 @@ class CoreWalletsService {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");
 
-        if (walletsManager.areWalletsEncrypted() && tempAesKey == null)
-            throw new IllegalStateException("wallet is locked");
+        verifyEncryptedWalletIsUnlocked();
 
         // Create a new funding address if none exists.
         if (btcWalletService.getAvailableAddressEntries().size() == 0)
@@ -244,6 +242,12 @@ class CoreWalletsService {
 
         if (!walletsManager.areWalletsEncrypted())
             throw new IllegalStateException("wallet is not encrypted with a password");
+    }
+
+    // Throws a RuntimeException if wallets are encrypted and locked.
+    private void verifyEncryptedWalletIsUnlocked() {
+        if (walletsManager.areWalletsEncrypted() && tempAesKey == null)
+            throw new IllegalStateException("wallet is locked");
     }
 
     private KeyCrypterScrypt getKeyCrypterScrypt() {

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.core.grpc;
 
 import bisq.core.btc.Balances;

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -30,6 +30,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.LoadingCache;
+
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -88,6 +92,20 @@ class CoreWalletsService {
                 + ((numConfirmations > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "");
     }
 
+    /**
+     * Memoization stores the results of expensive function calls and returns
+     * the cached result when the same input occurs again.
+     *
+     * Resulting LoadingCache is used by calling `.get(input I)` or
+     * `.getUnchecked(input I)`, depending on whether or not `f` can return null.
+     * That's because CacheLoader throws an exception on null output from `f`.
+     */
+    private static <I,O> LoadingCache<I,O> memoize(Function<I,O> f) {
+        // f::apply is used, because Guava 20.0 Function doesn't yet extend
+        // Java Function.
+        return CacheBuilder.newBuilder().build(CacheLoader.from(f::apply));
+    }
+
     public String getFundingAddresses() {
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");
@@ -98,44 +116,43 @@ class CoreWalletsService {
         if (btcWalletService.getAvailableAddressEntries().size() == 0)
             btcWalletService.getFreshAddressEntry();
 
-        // Populate a list of Tuple3<AddressString, Balance, NumConfirmations>
-        List<Tuple3<String, Long, Integer>> addrBalanceConfirms =
-                btcWalletService.getAvailableAddressEntries().stream()
-                        .map(a -> new Tuple3<>(a.getAddressString(),
-                                getAddressBalance(a.getAddressString()),
-                                getNumConfirmationsForMostRecentTransaction(a.getAddressString())))
-                        .collect(Collectors.toList());
+        List<String> addressStrings =
+            btcWalletService
+            .getAvailableAddressEntries()
+            .stream()
+            .map(addressEntry -> addressEntry.getAddressString())
+            .collect(Collectors.toList());
 
-        // Check to see if at least one of the existing addresses has a zero balance.
-        boolean hasZeroBalance = false;
-        for (Tuple3<String, Long, Integer> abc : addrBalanceConfirms) {
-            if (abc.second == 0) {
-                hasZeroBalance = true;
-                break;
-            }
-        }
-        if (!hasZeroBalance) {
-            // None of the existing addresses have a zero balance, create a new address.
-            addrBalanceConfirms.add(
-                    new Tuple3<>(btcWalletService.getFreshAddressEntry().getAddressString(),
-                            0L,
-                            0));
+        // getAddressBalance is memoized, because we'll map it over addresses twice.
+        // To get the balances, we'll be using .getUnchecked, because we know that
+        // this::getAddressBalance cannot return null.
+        var balances = memoize(this::getAddressBalance);
+
+        boolean noAddressHasZeroBalance =
+            addressStrings.stream()
+            .allMatch(addressString -> balances.getUnchecked(addressString) != 0);
+
+        if (noAddressHasZeroBalance) {
+            var newZeroBalanceAddress = btcWalletService.getFreshAddressEntry();
+            addressStrings.add(newZeroBalanceAddress.getAddressString());
         }
 
-        // Iterate the list of Tuple3<AddressString, Balance, NumConfirmations> objects
-        // and build the formatted info string.
-        StringBuilder addressInfoBuilder = new StringBuilder();
-        addrBalanceConfirms.forEach(a -> {
-            var btcBalance = formatSatoshis.apply(a.second);
-            var numConfirmations = getNumConfirmationsForMostRecentTransaction(a.first);
-            String addressInfo = "" + a.first
-                    + "  balance: " + format("%13s", btcBalance)
-                    + ((a.second > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "")
-                    + "\n";
-            addressInfoBuilder.append(addressInfo);
-        });
+        String fundingAddressTable =
+            addressStrings.stream()
+            .map(addressString -> {
+                var balance = balances.getUnchecked(addressString);
+                var stringFormattedBalance = formatSatoshis.apply(balance);
+                var numConfirmations =
+                    getNumConfirmationsForMostRecentTransaction(addressString);
+                String addressInfo =
+                    "" + addressString
+                    + "  balance: " + format("%13s", stringFormattedBalance)
+                    + ((balance > 0) ? ("  confirmations: " + format("%6d", numConfirmations)) : "");
+                return addressInfo;
+            })
+            .collect(Collectors.joining("\n"));
 
-        return addressInfoBuilder.toString().trim();
+        return fundingAddressTable;
     }
 
     public int getNumConfirmationsForMostRecentTransaction(String addressString) {

--- a/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/CoreWalletsService.java
@@ -72,9 +72,7 @@ class CoreWalletsService {
     }
 
     public long getAvailableBalance() {
-        if (!walletsManager.areWalletsAvailable())
-            throw new IllegalStateException("wallet is not yet available");
-
+        verifyWalletsAreAvailable();
         verifyEncryptedWalletIsUnlocked();
 
         var balance = balances.getAvailableBalance().get();
@@ -96,9 +94,7 @@ class CoreWalletsService {
     }
 
     public List<AddressBalanceInfo> getFundingAddresses() {
-        if (!walletsManager.areWalletsAvailable())
-            throw new IllegalStateException("wallet is not yet available");
-
+        verifyWalletsAreAvailable();
         verifyEncryptedWalletIsUnlocked();
 
         // Create a new funding address if none exists.
@@ -140,8 +136,7 @@ class CoreWalletsService {
     }
 
     public void setWalletPassword(String password, String newPassword) {
-        if (!walletsManager.areWalletsAvailable())
-            throw new IllegalStateException("wallet is not yet available");
+        verifyWalletsAreAvailable();
 
         KeyCrypterScrypt keyCrypterScrypt = getKeyCrypterScrypt();
 
@@ -228,6 +223,12 @@ class CoreWalletsService {
 
         walletsManager.decryptWallets(aesKey);
         walletsManager.backupWallets();
+    }
+
+    // Throws a RuntimeException if wallets are not available (encrypted or not).
+    private void verifyWalletsAreAvailable() {
+        if (!walletsManager.areWalletsAvailable())
+            throw new IllegalStateException("wallet is not yet available");
     }
 
     // Throws a RuntimeException if wallets are not available or not encrypted.

--- a/core/src/main/java/bisq/core/grpc/GrpcOffersService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcOffersService.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.grpc;
+
+import bisq.core.grpc.model.OfferInfo;
+import bisq.core.trade.handlers.TransactionResultHandler;
+
+import bisq.proto.grpc.CreateOfferReply;
+import bisq.proto.grpc.CreateOfferRequest;
+import bisq.proto.grpc.GetOffersReply;
+import bisq.proto.grpc.GetOffersRequest;
+import bisq.proto.grpc.OffersGrpc;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class GrpcOffersService extends OffersGrpc.OffersImplBase {
+
+    private final CoreApi coreApi;
+
+    @Inject
+    public GrpcOffersService(CoreApi coreApi) {
+        this.coreApi = coreApi;
+    }
+
+    @Override
+    public void getOffers(GetOffersRequest req,
+                          StreamObserver<GetOffersReply> responseObserver) {
+        // The client cannot see bisq.core.Offer or its fromProto method.
+        // We use the lighter weight OfferInfo proto wrapper instead, containing just
+        // enough fields to view and create offers.
+        List<OfferInfo> result = coreApi.getOffers(req.getDirection(), req.getFiatCurrencyCode())
+                .stream().map(offer -> new OfferInfo.OfferInfoBuilder()
+                        .withId(offer.getId())
+                        .withDirection(offer.getDirection().name())
+                        .withPrice(offer.getPrice().getValue())
+                        .withUseMarketBasedPrice(offer.isUseMarketBasedPrice())
+                        .withMarketPriceMargin(offer.getMarketPriceMargin())
+                        .withAmount(offer.getAmount().value)
+                        .withMinAmount(offer.getMinAmount().value)
+                        .withVolume(offer.getVolume().getValue())
+                        .withMinVolume(offer.getMinVolume().getValue())
+                        .withBuyerSecurityDeposit(offer.getBuyerSecurityDeposit().value)
+                        .withPaymentAccountId("")  // only used when creating offer (?)
+                        .withPaymentMethodId(offer.getPaymentMethod().getId())
+                        .withPaymentMethodShortName(offer.getPaymentMethod().getShortName())
+                        .withBaseCurrencyCode(offer.getOfferPayload().getBaseCurrencyCode())
+                        .withCounterCurrencyCode(offer.getOfferPayload().getCounterCurrencyCode())
+                        .withDate(offer.getDate().getTime())
+                        .build())
+                .collect(Collectors.toList());
+
+        var reply = GetOffersReply.newBuilder()
+                .addAllOffers(
+                        result.stream()
+                                .map(OfferInfo::toProtoMessage)
+                                .collect(Collectors.toList()))
+                .build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void createOffer(CreateOfferRequest req,
+                            StreamObserver<CreateOfferReply> responseObserver) {
+        TransactionResultHandler resultHandler = transaction -> {
+            CreateOfferReply reply = CreateOfferReply.newBuilder().setResult(true).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        };
+        coreApi.createOffer(
+                req.getCurrencyCode(),
+                req.getDirection(),
+                req.getPrice(),
+                req.getUseMarketBasedPrice(),
+                req.getMarketPriceMargin(),
+                req.getAmount(),
+                req.getMinAmount(),
+                req.getBuyerSecurityDeposit(),
+                req.getPaymentAccountId(),
+                resultHandler);
+    }
+}

--- a/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
@@ -25,8 +25,6 @@ import bisq.proto.grpc.GetPaymentAccountsReply;
 import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.PaymentAccountsGrpc;
 
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
@@ -46,32 +44,20 @@ public class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccou
     @Override
     public void createPaymentAccount(CreatePaymentAccountRequest req,
                                      StreamObserver<CreatePaymentAccountReply> responseObserver) {
-        try {
-            coreApi.createPaymentAccount(req.getAccountName(), req.getAccountNumber(), req.getFiatCurrencyCode());
-            var reply = CreatePaymentAccountReply.newBuilder().build();
-            responseObserver.onNext(reply);
-            responseObserver.onCompleted();
-        } catch (Exception cause) {
-            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
-            responseObserver.onError(ex);
-            throw ex;
-        }
+        coreApi.createPaymentAccount(req.getAccountName(), req.getAccountNumber(), req.getFiatCurrencyCode());
+        var reply = CreatePaymentAccountReply.newBuilder().build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
     }
 
     @Override
     public void getPaymentAccounts(GetPaymentAccountsRequest req,
                                    StreamObserver<GetPaymentAccountsReply> responseObserver) {
-        try {
-            var tradeStatistics = coreApi.getPaymentAccounts().stream()
-                    .map(PaymentAccount::toProtoMessage)
-                    .collect(Collectors.toList());
-            var reply = GetPaymentAccountsReply.newBuilder().addAllPaymentAccounts(tradeStatistics).build();
-            responseObserver.onNext(reply);
-            responseObserver.onCompleted();
-        } catch (Exception cause) {
-            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
-            responseObserver.onError(ex);
-            throw ex;
-        }
+        var tradeStatistics = coreApi.getPaymentAccounts().stream()
+                .map(PaymentAccount::toProtoMessage)
+                .collect(Collectors.toList());
+        var reply = GetPaymentAccountsReply.newBuilder().addAllPaymentAccounts(tradeStatistics).build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
     }
 }

--- a/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.core.grpc;
 
 import bisq.core.payment.PaymentAccount;
@@ -8,6 +25,8 @@ import bisq.proto.grpc.GetPaymentAccountsReply;
 import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.PaymentAccountsGrpc;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
@@ -27,20 +46,32 @@ public class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccou
     @Override
     public void createPaymentAccount(CreatePaymentAccountRequest req,
                                      StreamObserver<CreatePaymentAccountReply> responseObserver) {
-        coreApi.createPaymentAccount(req.getAccountName(), req.getAccountNumber(), req.getFiatCurrencyCode());
-        var reply = CreatePaymentAccountReply.newBuilder().build();
-        responseObserver.onNext(reply);
-        responseObserver.onCompleted();
+        try {
+            coreApi.createPaymentAccount(req.getAccountName(), req.getAccountNumber(), req.getFiatCurrencyCode());
+            var reply = CreatePaymentAccountReply.newBuilder().build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Exception cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
     }
 
     @Override
     public void getPaymentAccounts(GetPaymentAccountsRequest req,
                                    StreamObserver<GetPaymentAccountsReply> responseObserver) {
-        var tradeStatistics = coreApi.getPaymentAccounts().stream()
-                .map(PaymentAccount::toProtoMessage)
-                .collect(Collectors.toList());
-        var reply = GetPaymentAccountsReply.newBuilder().addAllPaymentAccounts(tradeStatistics).build();
-        responseObserver.onNext(reply);
-        responseObserver.onCompleted();
+        try {
+            var tradeStatistics = coreApi.getPaymentAccounts().stream()
+                    .map(PaymentAccount::toProtoMessage)
+                    .collect(Collectors.toList());
+            var reply = GetPaymentAccountsReply.newBuilder().addAllPaymentAccounts(tradeStatistics).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Exception cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
     }
 }

--- a/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcPaymentAccountsService.java
@@ -1,0 +1,46 @@
+package bisq.core.grpc;
+
+import bisq.core.payment.PaymentAccount;
+
+import bisq.proto.grpc.CreatePaymentAccountReply;
+import bisq.proto.grpc.CreatePaymentAccountRequest;
+import bisq.proto.grpc.GetPaymentAccountsReply;
+import bisq.proto.grpc.GetPaymentAccountsRequest;
+import bisq.proto.grpc.PaymentAccountsGrpc;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.stream.Collectors;
+
+
+public class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccountsImplBase {
+
+    private final CoreApi coreApi;
+
+    @Inject
+    public GrpcPaymentAccountsService(CoreApi coreApi) {
+        this.coreApi = coreApi;
+    }
+
+    @Override
+    public void createPaymentAccount(CreatePaymentAccountRequest req,
+                                     StreamObserver<CreatePaymentAccountReply> responseObserver) {
+        coreApi.createPaymentAccount(req.getAccountName(), req.getAccountNumber(), req.getFiatCurrencyCode());
+        var reply = CreatePaymentAccountReply.newBuilder().build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getPaymentAccounts(GetPaymentAccountsRequest req,
+                                   StreamObserver<GetPaymentAccountsReply> responseObserver) {
+        var tradeStatistics = coreApi.getPaymentAccounts().stream()
+                .map(PaymentAccount::toProtoMessage)
+                .collect(Collectors.toList());
+        var reply = GetPaymentAccountsReply.newBuilder().addAllPaymentAccounts(tradeStatistics).build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+}

--- a/core/src/main/java/bisq/core/grpc/GrpcServer.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcServer.java
@@ -59,7 +59,7 @@ public class GrpcServer {
     public GrpcServer(Config config,
                       CoreApi coreApi,
                       GrpcPaymentAccountsService paymentAccountsService,
-                      GrpcWalletService walletService) {
+                      GrpcWalletsService walletService) {
         this.coreApi = coreApi;
         this.server = ServerBuilder.forPort(config.apiPort)
                 .addService(new GetVersionService())

--- a/core/src/main/java/bisq/core/grpc/GrpcServer.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcServer.java
@@ -17,24 +17,16 @@
 
 package bisq.core.grpc;
 
-import bisq.core.offer.Offer;
-import bisq.core.trade.handlers.TransactionResultHandler;
 import bisq.core.trade.statistics.TradeStatistics2;
 
 import bisq.common.config.Config;
 
-import bisq.proto.grpc.GetOffersGrpc;
-import bisq.proto.grpc.GetOffersReply;
-import bisq.proto.grpc.GetOffersRequest;
 import bisq.proto.grpc.GetTradeStatisticsGrpc;
 import bisq.proto.grpc.GetTradeStatisticsReply;
 import bisq.proto.grpc.GetTradeStatisticsRequest;
 import bisq.proto.grpc.GetVersionGrpc;
 import bisq.proto.grpc.GetVersionReply;
 import bisq.proto.grpc.GetVersionRequest;
-import bisq.proto.grpc.PlaceOfferGrpc;
-import bisq.proto.grpc.PlaceOfferReply;
-import bisq.proto.grpc.PlaceOfferRequest;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -58,16 +50,16 @@ public class GrpcServer {
     @Inject
     public GrpcServer(Config config,
                       CoreApi coreApi,
+                      GrpcOffersService offersService,
                       GrpcPaymentAccountsService paymentAccountsService,
-                      GrpcWalletsService walletService) {
+                      GrpcWalletsService walletsService) {
         this.coreApi = coreApi;
         this.server = ServerBuilder.forPort(config.apiPort)
                 .addService(new GetVersionService())
                 .addService(new GetTradeStatisticsService())
-                .addService(new GetOffersService())
-                .addService(new PlaceOfferService())
+                .addService(offersService)
                 .addService(paymentAccountsService)
-                .addService(walletService)
+                .addService(walletsService)
                 .intercept(new PasswordAuthInterceptor(config.apiPassword))
                 .build();
     }
@@ -94,7 +86,6 @@ public class GrpcServer {
         }
     }
 
-
     class GetTradeStatisticsService extends GetTradeStatisticsGrpc.GetTradeStatisticsImplBase {
         @Override
         public void getTradeStatistics(GetTradeStatisticsRequest req,
@@ -107,42 +98,6 @@ public class GrpcServer {
             var reply = GetTradeStatisticsReply.newBuilder().addAllTradeStatistics(tradeStatistics).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
-        }
-    }
-
-    class GetOffersService extends GetOffersGrpc.GetOffersImplBase {
-        @Override
-        public void getOffers(GetOffersRequest req, StreamObserver<GetOffersReply> responseObserver) {
-
-            var tradeStatistics = coreApi.getOffers().stream()
-                    .map(Offer::toProtoMessage)
-                    .collect(Collectors.toList());
-
-            var reply = GetOffersReply.newBuilder().addAllOffers(tradeStatistics).build();
-            responseObserver.onNext(reply);
-            responseObserver.onCompleted();
-        }
-    }
-
-    class PlaceOfferService extends PlaceOfferGrpc.PlaceOfferImplBase {
-        @Override
-        public void placeOffer(PlaceOfferRequest req, StreamObserver<PlaceOfferReply> responseObserver) {
-            TransactionResultHandler resultHandler = transaction -> {
-                PlaceOfferReply reply = PlaceOfferReply.newBuilder().setResult(true).build();
-                responseObserver.onNext(reply);
-                responseObserver.onCompleted();
-            };
-            coreApi.placeOffer(
-                    req.getCurrencyCode(),
-                    req.getDirection(),
-                    req.getPrice(),
-                    req.getUseMarketBasedPrice(),
-                    req.getMarketPriceMargin(),
-                    req.getAmount(),
-                    req.getMinAmount(),
-                    req.getBuyerSecurityDeposit(),
-                    req.getPaymentAccountId(),
-                    resultHandler);
         }
     }
 }

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -1,5 +1,7 @@
 package bisq.core.grpc;
 
+import bisq.proto.grpc.GetAddressBalanceReply;
+import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalanceReply;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesReply;
@@ -42,7 +44,22 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
             throw ex;
         }
     }
-    
+
+    @Override
+    public void getAddressBalance(GetAddressBalanceRequest req,
+                                  StreamObserver<GetAddressBalanceReply> responseObserver) {
+        try {
+            String result = walletsService.getAddressBalanceInfo(req.getAddress());
+            var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (IllegalStateException cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
+    }
+
     @Override
     public void getFundingAddresses(GetFundingAddressesRequest req,
                                     StreamObserver<GetFundingAddressesReply> responseObserver) {

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -20,17 +20,17 @@ import javax.inject.Inject;
 
 class GrpcWalletService extends WalletGrpc.WalletImplBase {
 
-    private final CoreWalletService walletService;
+    private final CoreWalletsService walletsService;
 
     @Inject
-    public GrpcWalletService(CoreWalletService walletService) {
-        this.walletService = walletService;
+    public GrpcWalletService(CoreWalletsService walletsService) {
+        this.walletsService = walletsService;
     }
 
     @Override
     public void getBalance(GetBalanceRequest req, StreamObserver<GetBalanceReply> responseObserver) {
         try {
-            long result = walletService.getAvailableBalance();
+            long result = walletsService.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -45,7 +45,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void setWalletPassword(SetWalletPasswordRequest req,
                                   StreamObserver<SetWalletPasswordReply> responseObserver) {
         try {
-            walletService.setWalletPassword(req.getPassword(), req.getNewPassword());
+            walletsService.setWalletPassword(req.getPassword(), req.getNewPassword());
             var reply = SetWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -60,7 +60,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void removeWalletPassword(RemoveWalletPasswordRequest req,
                                      StreamObserver<RemoveWalletPasswordReply> responseObserver) {
         try {
-            walletService.removeWalletPassword(req.getPassword());
+            walletsService.removeWalletPassword(req.getPassword());
             var reply = RemoveWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -75,7 +75,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void lockWallet(LockWalletRequest req,
                            StreamObserver<LockWalletReply> responseObserver) {
         try {
-            walletService.lockWallet();
+            walletsService.lockWallet();
             var reply = LockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -90,7 +90,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void unlockWallet(UnlockWalletRequest req,
                              StreamObserver<UnlockWalletReply> responseObserver) {
         try {
-            walletService.unlockWallet(req.getPassword(), req.getTimeout());
+            walletsService.unlockWallet(req.getPassword(), req.getTimeout());
             var reply = UnlockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletService.java
@@ -2,6 +2,8 @@ package bisq.core.grpc;
 
 import bisq.proto.grpc.GetBalanceReply;
 import bisq.proto.grpc.GetBalanceRequest;
+import bisq.proto.grpc.GetFundingAddressesReply;
+import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.LockWalletReply;
 import bisq.proto.grpc.LockWalletRequest;
 import bisq.proto.grpc.RemoveWalletPasswordReply;
@@ -32,6 +34,21 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
         try {
             long result = walletsService.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (IllegalStateException cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
+    }
+    
+    @Override
+    public void getFundingAddresses(GetFundingAddressesRequest req,
+                                    StreamObserver<GetFundingAddressesReply> responseObserver) {
+        try {
+            String result = walletsService.getFundingAddresses();
+            var reply = GetFundingAddressesReply.newBuilder().setFundingAddressesInfo(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
@@ -14,7 +14,7 @@ import bisq.proto.grpc.SetWalletPasswordReply;
 import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.UnlockWalletReply;
 import bisq.proto.grpc.UnlockWalletRequest;
-import bisq.proto.grpc.WalletGrpc;
+import bisq.proto.grpc.WalletsGrpc;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -22,19 +22,19 @@ import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
 
-class GrpcWalletService extends WalletGrpc.WalletImplBase {
+class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
 
-    private final CoreWalletsService walletsService;
+    private final CoreApi coreApi;
 
     @Inject
-    public GrpcWalletService(CoreWalletsService walletsService) {
-        this.walletsService = walletsService;
+    public GrpcWalletsService(CoreApi coreApi) {
+        this.coreApi = coreApi;
     }
 
     @Override
     public void getBalance(GetBalanceRequest req, StreamObserver<GetBalanceReply> responseObserver) {
         try {
-            long result = walletsService.getAvailableBalance();
+            long result = coreApi.getAvailableBalance();
             var reply = GetBalanceReply.newBuilder().setBalance(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -49,7 +49,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void getAddressBalance(GetAddressBalanceRequest req,
                                   StreamObserver<GetAddressBalanceReply> responseObserver) {
         try {
-            String result = walletsService.getAddressBalanceInfo(req.getAddress());
+            String result = coreApi.getAddressBalanceInfo(req.getAddress());
             var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -64,7 +64,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void getFundingAddresses(GetFundingAddressesRequest req,
                                     StreamObserver<GetFundingAddressesReply> responseObserver) {
         try {
-            String result = walletsService.getFundingAddresses();
+            String result = coreApi.getFundingAddresses();
             var reply = GetFundingAddressesReply.newBuilder().setFundingAddressesInfo(result).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -79,7 +79,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void setWalletPassword(SetWalletPasswordRequest req,
                                   StreamObserver<SetWalletPasswordReply> responseObserver) {
         try {
-            walletsService.setWalletPassword(req.getPassword(), req.getNewPassword());
+            coreApi.setWalletPassword(req.getPassword(), req.getNewPassword());
             var reply = SetWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -94,7 +94,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void removeWalletPassword(RemoveWalletPasswordRequest req,
                                      StreamObserver<RemoveWalletPasswordReply> responseObserver) {
         try {
-            walletsService.removeWalletPassword(req.getPassword());
+            coreApi.removeWalletPassword(req.getPassword());
             var reply = RemoveWalletPasswordReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -109,7 +109,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void lockWallet(LockWalletRequest req,
                            StreamObserver<LockWalletReply> responseObserver) {
         try {
-            walletsService.lockWallet();
+            coreApi.lockWallet();
             var reply = LockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -124,7 +124,7 @@ class GrpcWalletService extends WalletGrpc.WalletImplBase {
     public void unlockWallet(UnlockWalletRequest req,
                              StreamObserver<UnlockWalletReply> responseObserver) {
         try {
-            walletsService.unlockWallet(req.getPassword(), req.getTimeout());
+            coreApi.unlockWallet(req.getPassword(), req.getTimeout());
             var reply = UnlockWalletReply.newBuilder().build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
@@ -1,5 +1,7 @@
 package bisq.core.grpc;
 
+import bisq.core.grpc.model.AddressBalanceInfo;
+
 import bisq.proto.grpc.GetAddressBalanceReply;
 import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalanceReply;
@@ -21,6 +23,9 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
 
@@ -49,8 +54,8 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
     public void getAddressBalance(GetAddressBalanceRequest req,
                                   StreamObserver<GetAddressBalanceReply> responseObserver) {
         try {
-            String result = coreApi.getAddressBalanceInfo(req.getAddress());
-            var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result).build();
+            AddressBalanceInfo result = coreApi.getAddressBalanceInfo(req.getAddress());
+            var reply = GetAddressBalanceReply.newBuilder().setAddressBalanceInfo(result.toProtoMessage()).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {
@@ -64,8 +69,13 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
     public void getFundingAddresses(GetFundingAddressesRequest req,
                                     StreamObserver<GetFundingAddressesReply> responseObserver) {
         try {
-            String result = coreApi.getFundingAddresses();
-            var reply = GetFundingAddressesReply.newBuilder().setFundingAddressesInfo(result).build();
+            List<AddressBalanceInfo> result = coreApi.getFundingAddresses();
+            var reply = GetFundingAddressesReply.newBuilder()
+                    .addAllAddressBalanceInfo(
+                            result.stream()
+                                    .map(AddressBalanceInfo::toProtoMessage)
+                                    .collect(Collectors.toList()))
+                    .build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {

--- a/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
+++ b/core/src/main/java/bisq/core/grpc/GrpcWalletsService.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.core.grpc;
 
 import bisq.core.grpc.model.AddressBalanceInfo;

--- a/core/src/main/java/bisq/core/grpc/PasswordAuthInterceptor.java
+++ b/core/src/main/java/bisq/core/grpc/PasswordAuthInterceptor.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.core.grpc;
 
 import io.grpc.Metadata;

--- a/core/src/main/java/bisq/core/grpc/model/AddressBalanceInfo.java
+++ b/core/src/main/java/bisq/core/grpc/model/AddressBalanceInfo.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.core.grpc.model;
 
 import bisq.common.Payload;

--- a/core/src/main/java/bisq/core/grpc/model/AddressBalanceInfo.java
+++ b/core/src/main/java/bisq/core/grpc/model/AddressBalanceInfo.java
@@ -1,0 +1,43 @@
+package bisq.core.grpc.model;
+
+import bisq.common.Payload;
+
+public class AddressBalanceInfo implements Payload {
+
+    private final String address;
+    private final long balance;             // address' balance in satoshis
+    private final long numConfirmations;    // # confirmations for address' most recent tx
+
+    public AddressBalanceInfo(String address, long balance, long numConfirmations) {
+        this.address = address;
+        this.balance = balance;
+        this.numConfirmations = numConfirmations;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.AddressBalanceInfo toProtoMessage() {
+        return bisq.proto.grpc.AddressBalanceInfo.newBuilder()
+                .setAddress(address)
+                .setBalance(balance)
+                .setNumConfirmations(numConfirmations).build();
+    }
+
+    public static AddressBalanceInfo fromProto(bisq.proto.grpc.AddressBalanceInfo proto) {
+        return new AddressBalanceInfo(proto.getAddress(),
+                proto.getBalance(),
+                proto.getNumConfirmations());
+    }
+
+    @Override
+    public String toString() {
+        return "AddressBalanceInfo{" +
+                "address='" + address + '\'' +
+                ", balance=" + balance +
+                ", numConfirmations=" + numConfirmations +
+                '}';
+    }
+}

--- a/core/src/main/java/bisq/core/grpc/model/OfferInfo.java
+++ b/core/src/main/java/bisq/core/grpc/model/OfferInfo.java
@@ -94,16 +94,18 @@ public class OfferInfo implements Payload {
 
     public static OfferInfo fromProto(bisq.proto.grpc.OfferInfo proto) {
         /*
-        TODO (needed by createoffer)
+        TODO (will be needed by the createoffer method)
         return new OfferInfo(proto.getOfferPayload().getId(),
                 proto.getOfferPayload().getDate());
         */
         return null;
     }
 
-    /**
-     * OfferInfoBuilder helps avoid bungling use of the OfferInfo constructor
-     * argument list, which is large, of all one type, and not wise to overload.
+    /*
+     * OfferInfoBuilder helps avoid bungling use of a large OfferInfo constructor
+     * argument list.  If consecutive argument values of the same type are not
+     * ordered correctly, the compiler won't complain but the resulting bugs could
+     * be hard to find and fix.
      */
     public static class OfferInfoBuilder {
         private String id;

--- a/core/src/main/java/bisq/core/grpc/model/OfferInfo.java
+++ b/core/src/main/java/bisq/core/grpc/model/OfferInfo.java
@@ -1,0 +1,213 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.grpc.model;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Getter
+public class OfferInfo implements Payload {
+
+    private final String id;
+    private final String direction;
+    private final long price;
+    private final boolean useMarketBasedPrice;
+    private final double marketPriceMargin;
+    private final long amount;
+    private final long minAmount;
+    private final long volume;
+    private final long minVolume;
+    private final long buyerSecurityDeposit;
+    private final String paymentAccountId;   // only used when creating offer
+    private final String paymentMethodId;
+    private final String paymentMethodShortName;
+    // For fiat offer the baseCurrencyCode is BTC and the counterCurrencyCode is the fiat currency
+    // For altcoin offers it is the opposite. baseCurrencyCode is the altcoin and the counterCurrencyCode is BTC.
+    private final String baseCurrencyCode;
+    private final String counterCurrencyCode;
+    private final long date;
+
+    public OfferInfo(OfferInfoBuilder builder) {
+        this.id = builder.id;
+        this.direction = builder.direction;
+        this.price = builder.price;
+        this.useMarketBasedPrice = builder.useMarketBasedPrice;
+        this.marketPriceMargin = builder.marketPriceMargin;
+        this.amount = builder.amount;
+        this.minAmount = builder.minAmount;
+        this.volume = builder.volume;
+        this.minVolume = builder.minVolume;
+        this.buyerSecurityDeposit = builder.buyerSecurityDeposit;
+        this.paymentAccountId = builder.paymentAccountId;
+        this.paymentMethodId = builder.paymentMethodId;
+        this.paymentMethodShortName = builder.paymentMethodShortName;
+        this.baseCurrencyCode = builder.baseCurrencyCode;
+        this.counterCurrencyCode = builder.counterCurrencyCode;
+        this.date = builder.date;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.OfferInfo toProtoMessage() {
+        return bisq.proto.grpc.OfferInfo.newBuilder()
+                .setId(id)
+                .setDirection(direction)
+                .setPrice(price)
+                .setUseMarketBasedPrice(useMarketBasedPrice)
+                .setMarketPriceMargin(marketPriceMargin)
+                .setAmount(amount)
+                .setMinAmount(minAmount)
+                .setVolume(volume)
+                .setMinVolume(minVolume)
+                .setBuyerSecurityDeposit(buyerSecurityDeposit)
+                .setPaymentAccountId(paymentAccountId)
+                .setPaymentMethodId(paymentMethodId)
+                .setPaymentMethodShortName(paymentMethodShortName)
+                .setBaseCurrencyCode(baseCurrencyCode)
+                .setCounterCurrencyCode(counterCurrencyCode)
+                .setDate(date)
+                .build();
+    }
+
+    public static OfferInfo fromProto(bisq.proto.grpc.OfferInfo proto) {
+        /*
+        TODO (needed by createoffer)
+        return new OfferInfo(proto.getOfferPayload().getId(),
+                proto.getOfferPayload().getDate());
+        */
+        return null;
+    }
+
+    /**
+     * OfferInfoBuilder helps avoid bungling use of the OfferInfo constructor
+     * argument list, which is large, of all one type, and not wise to overload.
+     */
+    public static class OfferInfoBuilder {
+        private String id;
+        private String direction;
+        private long price;
+        private boolean useMarketBasedPrice;
+        private double marketPriceMargin;
+        private long amount;
+        private long minAmount;
+        private long volume;
+        private long minVolume;
+        private long buyerSecurityDeposit;
+        private String paymentAccountId;
+        private String paymentMethodId;
+        private String paymentMethodShortName;
+        private String baseCurrencyCode;
+        private String counterCurrencyCode;
+        private long date;
+
+        public OfferInfoBuilder() {
+        }
+
+        public OfferInfoBuilder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public OfferInfoBuilder withDirection(String direction) {
+            this.direction = direction;
+            return this;
+        }
+
+        public OfferInfoBuilder withPrice(long price) {
+            this.price = price;
+            return this;
+        }
+
+        public OfferInfoBuilder withUseMarketBasedPrice(boolean useMarketBasedPrice) {
+            this.useMarketBasedPrice = useMarketBasedPrice;
+            return this;
+        }
+
+        public OfferInfoBuilder withMarketPriceMargin(double useMarketBasedPrice) {
+            this.marketPriceMargin = useMarketBasedPrice;
+            return this;
+        }
+
+        public OfferInfoBuilder withAmount(long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public OfferInfoBuilder withMinAmount(long minAmount) {
+            this.minAmount = minAmount;
+            return this;
+        }
+
+        public OfferInfoBuilder withVolume(long volume) {
+            this.volume = volume;
+            return this;
+        }
+
+        public OfferInfoBuilder withMinVolume(long minVolume) {
+            this.minVolume = minVolume;
+            return this;
+        }
+
+        public OfferInfoBuilder withBuyerSecurityDeposit(long buyerSecurityDeposit) {
+            this.buyerSecurityDeposit = buyerSecurityDeposit;
+            return this;
+        }
+
+        public OfferInfoBuilder withPaymentAccountId(String paymentAccountId) {
+            this.paymentAccountId = paymentAccountId;
+            return this;
+        }
+
+        public OfferInfoBuilder withPaymentMethodId(String paymentMethodId) {
+            this.paymentMethodId = paymentMethodId;
+            return this;
+        }
+
+        public OfferInfoBuilder withPaymentMethodShortName(String paymentMethodShortName) {
+            this.paymentMethodShortName = paymentMethodShortName;
+            return this;
+        }
+
+        public OfferInfoBuilder withBaseCurrencyCode(String baseCurrencyCode) {
+            this.baseCurrencyCode = baseCurrencyCode;
+            return this;
+        }
+
+        public OfferInfoBuilder withCounterCurrencyCode(String counterCurrencyCode) {
+            this.counterCurrencyCode = counterCurrencyCode;
+            return this;
+        }
+
+        public OfferInfoBuilder withDate(long date) {
+            this.date = date;
+            return this;
+        }
+
+        public OfferInfo build() {
+            return new OfferInfo(this);
+        }
+    }
+}

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -119,6 +119,8 @@ message PlaceOfferReply {
 service Wallet {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
+    rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
+    }
     rpc SetWalletPassword (SetWalletPasswordRequest) returns (SetWalletPasswordReply) {
     }
     rpc RemoveWalletPassword (RemoveWalletPasswordRequest) returns (RemoveWalletPasswordReply) {
@@ -134,6 +136,13 @@ message GetBalanceRequest {
 
 message GetBalanceReply {
     uint64 balance = 1;
+}
+
+message GetFundingAddressesRequest {
+}
+
+message GetFundingAddressesReply {
+    string fundingAddressesInfo = 1;
 }
 
 message SetWalletPasswordRequest {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -40,35 +40,58 @@ message GetVersionReply {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// TradeStatistics
+// Offers
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-service GetTradeStatistics {
-    rpc GetTradeStatistics (GetTradeStatisticsRequest) returns (GetTradeStatisticsReply) {
-    }
-}
-
-message GetTradeStatisticsRequest {
-}
-
-message GetTradeStatisticsReply {
-    repeated TradeStatistics2 TradeStatistics = 1;
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////
-// Offer
-///////////////////////////////////////////////////////////////////////////////////////////
-
-service GetOffers {
+service Offers {
     rpc GetOffers (GetOffersRequest) returns (GetOffersReply) {
+    }
+    rpc CreateOffer (CreateOfferRequest) returns (CreateOfferReply) {
     }
 }
 
 message GetOffersRequest {
+    string direction = 1;
+    string fiatCurrencyCode = 2;
 }
 
 message GetOffersReply {
-    repeated Offer offers = 1;
+    repeated OfferInfo offers = 1;
+}
+
+message CreateOfferRequest {
+    string currencyCode = 1; // TODO switch order w/ direction field in next PR
+    string direction = 2;
+    uint64 price = 3;
+    bool useMarketBasedPrice = 4;
+    double marketPriceMargin = 5;
+    uint64 amount = 6;
+    uint64 minAmount = 7;
+    double buyerSecurityDeposit = 8;
+    string paymentAccountId = 9;
+}
+
+message CreateOfferReply {
+    bool result = 1;
+}
+
+message OfferInfo {
+    string id = 1;
+    string direction = 2;
+    uint64 price = 3;
+    bool useMarketBasedPrice = 4;
+    double marketPriceMargin = 5;
+    uint64 amount = 6;
+    uint64 minAmount = 7;
+    uint64 volume = 8;
+    uint64 minVolume = 9;
+    uint64 buyerSecurityDeposit = 10;
+    string paymentAccountId = 11; // only used when creating offer
+    string paymentMethodId = 12;
+    string paymentMethodShortName = 13;
+    string baseCurrencyCode = 14;
+    string counterCurrencyCode = 15;
+    uint64 date = 16;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -99,28 +122,19 @@ message GetPaymentAccountsReply {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// PlaceOffer
+// TradeStatistics
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-service PlaceOffer {
-    rpc PlaceOffer (PlaceOfferRequest) returns (PlaceOfferReply) {
+service GetTradeStatistics {
+    rpc GetTradeStatistics (GetTradeStatisticsRequest) returns (GetTradeStatisticsReply) {
     }
 }
 
-message PlaceOfferRequest {
-    string currencyCode = 1;
-    string direction = 2;
-    uint64 price = 3;
-    bool useMarketBasedPrice = 4;
-    double marketPriceMargin = 5;
-    uint64 amount = 6;
-    uint64 minAmount = 7;
-    double buyerSecurityDeposit = 8;
-    string paymentAccountId = 9;
+message GetTradeStatisticsRequest {
 }
 
-message PlaceOfferReply {
-    bool result = 1;
+message GetTradeStatisticsReply {
+    repeated TradeStatistics2 TradeStatistics = 1;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -156,14 +156,14 @@ message GetAddressBalanceRequest {
 }
 
 message GetAddressBalanceReply {
-    string addressBalanceInfo = 1;
+    AddressBalanceInfo addressBalanceInfo = 1;
 }
 
 message GetFundingAddressesRequest {
 }
 
 message GetFundingAddressesReply {
-    string fundingAddressesInfo = 1;
+    repeated AddressBalanceInfo addressBalanceInfo = 1;
 }
 
 message SetWalletPasswordRequest {
@@ -193,4 +193,10 @@ message UnlockWalletRequest {
 }
 
 message UnlockWalletReply {
+}
+
+message AddressBalanceInfo {
+    string address = 1;
+    int64 balance = 2;
+    int64 numConfirmations = 3;
 }

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -119,6 +119,8 @@ message PlaceOfferReply {
 service Wallet {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
+    rpc GetAddressBalance (GetAddressBalanceRequest) returns (GetAddressBalanceReply) {
+    }
     rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
     }
     rpc SetWalletPassword (SetWalletPasswordRequest) returns (SetWalletPasswordReply) {
@@ -136,6 +138,14 @@ message GetBalanceRequest {
 
 message GetBalanceReply {
     uint64 balance = 1;
+}
+
+message GetAddressBalanceRequest {
+    string address = 1;
+}
+
+message GetAddressBalanceReply {
+    string addressBalanceInfo = 1;
 }
 
 message GetFundingAddressesRequest {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -124,10 +124,10 @@ message PlaceOfferReply {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// Wallet
+// Wallets
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-service Wallet {
+service Wallets {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
     rpc GetAddressBalance (GetAddressBalanceRequest) returns (GetAddressBalanceReply) {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -72,12 +72,23 @@ message GetOffersReply {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// PaymentAccount
+// PaymentAccounts
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-service GetPaymentAccounts {
+service PaymentAccounts {
+    rpc CreatePaymentAccount (CreatePaymentAccountRequest) returns (CreatePaymentAccountReply) {
+    }
     rpc GetPaymentAccounts (GetPaymentAccountsRequest) returns (GetPaymentAccountsReply) {
     }
+}
+
+message CreatePaymentAccountRequest {
+    string accountName = 1;
+    string accountNumber = 2;
+    string fiatCurrencyCode = 3;
+}
+
+message CreatePaymentAccountReply {
 }
 
 message GetPaymentAccountsRequest {


### PR DESCRIPTION
The new method returns current buy or sell offers for a fiat ccy.

This PR should be reviewed/merged after PR [4324](https://github.com/bisq-network/bisq/pull/4324).

Changes include:

* New core.grpc classes
CoreOffersService
GrpcOffersService
model.OfferInfo

* CoreApi -- The new CoreOffersService is injected into CoreApi and
the old getOffers() and placeOffer() impls were moved into the
new CoreOffersService.  The getOffers implementation was re-done.
Other changes are just rearranging location of core method calls.

* GrpcServer -- The new GrpcOffersService replaced the old
GetOffersService and PlaceOfferService.

* grpc.proto -- The old GetOffers and PlaceOffer services were combined
into a single Offers service, and the PlaceOffer rpc was renamed
as CreateOffer.  These are the only substantive changes; the rest
is just rearranging location of the service defs in the file.
Also created a lighterweight OfferInfo proto message wrapper to
be passed between server & client (client has no access to core's
Offer and OfferPayload).

* OfferInfo -- A new wrapper around the OfferInfo proto message.

* CliMain -- The new GetOffers service stub was added.
Some (maybe too much) number and ccy formatting logic was
copied & modified from core.  Some tedius string formatting
was added too (needs to be tidied up).

* License comments were also copied to several classes, and I
made a mistake in reverting changes to the wrong file.

* Added unit tests to cli/test.sh.