### PR TITLE
Add equals check to prevent resetting of newly set Filter

### DIFF
--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -17,7 +17,6 @@
 
 package bisq.core.filter;
 
-import bisq.core.account.witness.AccountAgeWitness;
 import bisq.core.btc.nodes.BtcNodes;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PaymentMethod;
@@ -153,7 +152,7 @@ public class FilterManager {
                     protectedStorageEntries.forEach(protectedStorageEntry -> {
                         if (protectedStorageEntry.getProtectedStoragePayload() instanceof Filter) {
                             Filter filter = (Filter) protectedStorageEntry.getProtectedStoragePayload();
-                            if (verifySignature(filter))
+                            if (verifySignature(filter) && getFilter().equals(filter))
                                 resetFilters();
                         }
                     });


### PR DESCRIPTION
While testing #4294 I recognized that when adding a new filter object to the network one of my regtest nodes got its filter reset. This was caused by a timing issue that the added filter message was received before the removed filter message. In that case the filter was reset and the new filter never applied. This is only a problem during runtime when a new filter is set. After a restart the correct filter is applied. This PR adds a equals check to prevent the reseting of a filter by mistake. As the added filter message overwrites all fields anyways not having the removed filter message is not essential.