### PR TITLE
Remove @cbeams as build and pricenode code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,6 @@
 # This doc specifies who gets requested to review GitHub pull requests.
 # See https://help.github.com/articles/about-codeowners/.
 
-*gradle* @cbeams
-/pricenode/ @cbeams
 /core/main/java/bisq/core/dao/ @ManfredKarrer
 
 # For seednode configuration changes


### PR DESCRIPTION
This is to avoid automatically requesting a review from me on all PRs that touch the Gradle build and pricenode codebase, e.g. as just happened in #4339.