### PR TITLE
Deposit improvements

### DIFF
--- a/common/src/main/java/bisq/common/util/MathUtils.java
+++ b/common/src/main/java/bisq/common/util/MathUtils.java
@@ -107,4 +107,29 @@ public class MathUtils {
         }
         return median;
     }
+
+    public static class MovingAverage {
+        private long[] window;
+        private int n, insert;
+        private long sum;
+
+        public MovingAverage(int size) {
+            window = new long[size];
+            insert = 0;
+            sum = 0;
+        }
+
+        public double next(long val) {
+            if (n < window.length) n++;
+            sum -= window[insert];
+            sum += val;
+            window[insert] = val;
+            insert = (insert + 1) % window.length;
+            return (double) sum / n;
+        }
+
+        public boolean fullWindow() {
+            return n == window.length;
+        }
+    }
 }

--- a/common/src/test/java/bisq/common/util/MathUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/MathUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class MathUtilsTest {
+
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
+    public void testMovingAverageWithoutOutlierExclusion() {
+        var values = new int[]{4, 5, 3, 1, 2, 4};
+        // Moving average = 4, 4.5, 4, 3, 2, 7/3
+        var movingAverage = new MathUtils.MovingAverage(3, 0);
+        int i = 0;
+        assertEquals(4, movingAverage.next(values[i++]).get(),0.001);
+        assertEquals(4.5, movingAverage.next(values[i++]).get(),0.001);
+        assertEquals(4, movingAverage.next(values[i++]).get(),0.001);
+        assertEquals(3, movingAverage.next(values[i++]).get(),0.001);
+        assertEquals(2, movingAverage.next(values[i++]).get(),0.001);
+        assertEquals((double) 7 / 3, movingAverage.next(values[i]).get(),0.001);
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
+    public void testMovingAverageWithOutlierExclusion() {
+        var values = new int[]{100, 102, 95, 101, 120, 115};
+        // Moving average = N/A, N/A, 99, 99.333..., N/A, 103.666...
+        var movingAverage = new MathUtils.MovingAverage(3, 0.2);
+        int i = 0;
+        assertFalse(movingAverage.next(values[i++]).isPresent());
+        assertFalse(movingAverage.next(values[i++]).isPresent());
+        assertEquals(99, movingAverage.next(values[i++]).get(),0.001);
+        assertEquals(99.333, movingAverage.next(values[i++]).get(),0.001);
+        assertFalse(movingAverage.next(values[i++]).isPresent());
+        assertEquals(103.666, movingAverage.next(values[i]).get(),0.001);
+    }
+}

--- a/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
+++ b/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
@@ -90,4 +90,9 @@ public class Restrictions {
             MIN_REFUND_AT_MEDIATED_DISPUTE = Coin.parseCoin("0.003"); // 0.003 BTC about 21 USD @ 7000 USD/BTC
         return MIN_REFUND_AT_MEDIATED_DISPUTE;
     }
+
+    public static int getLockTime(boolean isAsset) {
+        // 10 days for altcoins, 20 days for other payment methods
+        return isAsset ? 144 * 10 : 144 * 20;
+    }
 }

--- a/core/src/main/java/bisq/core/offer/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/CreateOfferService.java
@@ -181,7 +181,7 @@ public class CreateOfferService {
         List<String> acceptedCountryCodes = PaymentAccountUtil.getAcceptedCountryCodes(paymentAccount);
         String bankId = PaymentAccountUtil.getBankId(paymentAccount);
         List<String> acceptedBanks = PaymentAccountUtil.getAcceptedBanks(paymentAccount);
-        double sellerSecurityDeposit = getSellerSecurityDepositAsDouble();
+        double sellerSecurityDeposit = getSellerSecurityDepositAsDouble(buyerSecurityDepositAsDouble);
         Coin txFeeFromFeeService = getEstimatedFeeAndTxSize(amount, direction, buyerSecurityDepositAsDouble, sellerSecurityDeposit).first;
         Coin makerFeeAsCoin = getMakerFee(amount);
         boolean isCurrencyForMakerFeeBtc = OfferUtil.isCurrencyForMakerFeeBtc(preferences, bsqWalletService, amount);
@@ -285,8 +285,9 @@ public class CreateOfferService {
                 getSellerSecurityDeposit(amount, sellerSecurityDeposit);
     }
 
-    public double getSellerSecurityDepositAsDouble() {
-        return Restrictions.getSellerSecurityDepositAsPercent();
+    public double getSellerSecurityDepositAsDouble(double buyerSecurityDeposit) {
+        return Preferences.USE_SYMMETRIC_SECURITY_DEPOSIT ? buyerSecurityDeposit :
+                Restrictions.getSellerSecurityDepositAsPercent();
     }
 
     public Coin getMakerFee(Coin amount) {

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -22,8 +22,8 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.dao.DaoFacade;
 import bisq.core.exceptions.TradePriceOutOfToleranceException;
-import bisq.core.locale.Res;
 import bisq.core.filter.FilterManager;
+import bisq.core.locale.Res;
 import bisq.core.offer.availability.DisputeAgentSelection;
 import bisq.core.offer.messages.OfferAvailabilityRequest;
 import bisq.core.offer.messages.OfferAvailabilityResponse;
@@ -353,7 +353,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         Coin reservedFundsForOffer = createOfferService.getReservedFundsForOffer(offer.getDirection(),
                 offer.getAmount(),
                 buyerSecurityDeposit,
-                createOfferService.getSellerSecurityDepositAsDouble());
+                createOfferService.getSellerSecurityDepositAsDouble(buyerSecurityDeposit));
 
         PlaceOfferModel model = new PlaceOfferModel(offer,
                 reservedFundsForOffer,

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSetsLockTime.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSetsLockTime.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade.protocol.tasks.maker;
 
+import bisq.core.btc.wallet.Restrictions;
 import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.tasks.TradeTask;
 
@@ -38,7 +39,7 @@ public class MakerSetsLockTime extends TradeTask {
             runInterceptHook();
 
             // 10 days for altcoins, 20 days for other payment methods
-            int delay = processModel.getOffer().getPaymentMethod().isAsset() ? 144 * 10 : 144 * 20;
+            int delay = Restrictions.getLockTime(processModel.getOffer().getPaymentMethod().isAsset());
             if (Config.baseCurrencyNetwork().isRegtest()) {
                 delay = 5;
             }

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -118,6 +118,9 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             new BlockChainExplorer("bsq.bisq.cc (@m52go)", "https://bsq.bisq.cc/tx.html?tx=", "https://bsq.bisq.cc/Address.html?addr=")
     ));
 
+    public static final boolean USE_SYMMETRIC_SECURITY_DEPOSIT = true;
+
+
     // payload is initialized so the default values are available for Property initialization.
     @Setter
     @Delegate(excludes = ExcludesDelegateMethods.class)

--- a/core/src/main/java/bisq/core/util/FormattingUtils.java
+++ b/core/src/main/java/bisq/core/util/FormattingUtils.java
@@ -211,6 +211,10 @@ public class FormattingUtils {
         return formatToPercent(value) + "%";
     }
 
+    public static String formatToRoundedPercentWithSymbol(double value) {
+        return formatToPercent(value, new DecimalFormat("#")) + "%";
+    }
+
     public static String formatPercentagePrice(double value) {
         return formatToPercentWithSymbol(value);
     }
@@ -219,6 +223,11 @@ public class FormattingUtils {
         DecimalFormat decimalFormat = new DecimalFormat("#.##");
         decimalFormat.setMinimumFractionDigits(2);
         decimalFormat.setMaximumFractionDigits(2);
+
+        return formatToPercent(value, decimalFormat);
+    }
+
+    public static String formatToPercent(double value, DecimalFormat decimalFormat) {
         return decimalFormat.format(MathUtils.roundDouble(value * 100.0, 2)).replace(",", ".");
     }
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -357,7 +357,7 @@ shared.notSigned.noNeed=This account type doesn't use signing
 
 offerbook.nrOffers=No. of offers: {0}
 offerbook.volume={0} (min - max)
-offerbook.deposit=Deposit
+offerbook.deposit=Deposit BTC (%)
 offerbook.deposit.help=Deposit paid by each trader to guarantee the trade. Will be returned when the trade is completed.
 
 offerbook.createOfferToBuy=Create new offer to buy {0}

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -482,6 +482,7 @@ createOffer.tac=With publishing this offer I agree to trade with any trader who 
 createOffer.currencyForFee=Trade fee
 createOffer.setDeposit=Set buyer's security deposit (%)
 createOffer.setDepositAsBuyer=Set my security deposit as buyer (%)
+createOffer.setDepositForBothTraders=Set both traders' security deposit (%)
 createOffer.securityDepositInfo=Your buyer''s security deposit will be {0}
 createOffer.securityDepositInfoAsBuyer=Your security deposit as buyer will be {0}
 createOffer.minSecurityDepositUsed=Min. buyer security deposit is used

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -357,6 +357,8 @@ shared.notSigned.noNeed=This account type doesn't use signing
 
 offerbook.nrOffers=No. of offers: {0}
 offerbook.volume={0} (min - max)
+offerbook.deposit=Deposit
+offerbook.deposit.help=Deposit paid by each trader to guarantee the trade. Will be returned when the trade is completed.
 
 offerbook.createOfferToBuy=Create new offer to buy {0}
 offerbook.createOfferToSell=Create new offer to sell {0}

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -303,7 +303,7 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
         Tuple2<Coin, Integer> estimatedFeeAndTxSize = createOfferService.getEstimatedFeeAndTxSize(amount.get(),
                 direction,
                 buyerSecurityDeposit.get(),
-                createOfferService.getSellerSecurityDepositAsDouble());
+                createOfferService.getSellerSecurityDepositAsDouble(buyerSecurityDeposit.get()));
         txFeeFromFeeService = estimatedFeeAndTxSize.first;
         feeTxSize = estimatedFeeAndTxSize.second;
     }
@@ -701,7 +701,8 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
         if (amountAsCoin == null)
             amountAsCoin = Coin.ZERO;
 
-        Coin percentOfAmountAsCoin = CoinUtil.getPercentOfAmountAsCoin(createOfferService.getSellerSecurityDepositAsDouble(), amountAsCoin);
+        Coin percentOfAmountAsCoin = CoinUtil.getPercentOfAmountAsCoin(
+                createOfferService.getSellerSecurityDepositAsDouble(buyerSecurityDeposit.get()), amountAsCoin);
         return getBoundedSellerSecurityDepositAsCoin(percentOfAmountAsCoin);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -421,7 +421,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         securityDepositStringListener = (ov, oldValue, newValue) -> {
             if (!ignoreSecurityDepositStringListener) {
                 if (securityDepositValidator.validate(newValue).isValid) {
-                    setBuyerSecurityDepositToModel();
+                    setBuyerSecurityDepositToModel(false);
                     dataModel.calculateTotalToPay();
                 }
                 updateButtonDisableState();
@@ -898,7 +898,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                             .width(800)
                             .actionButtonText(Res.get("createOffer.resetToDefault"))
                             .onAction(() -> {
-                                dataModel.setBuyerSecurityDeposit(defaultSecurityDeposit);
+                                dataModel.setBuyerSecurityDeposit(defaultSecurityDeposit, false);
                                 ignoreSecurityDepositStringListener = true;
                                 buyerSecurityDeposit.set(FormattingUtils.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
                                 ignoreSecurityDepositStringListener = false;
@@ -915,7 +915,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     }
 
     private void applyBuyerSecurityDepositOnFocusOut() {
-        setBuyerSecurityDepositToModel();
+        setBuyerSecurityDepositToModel(true);
         ignoreSecurityDepositStringListener = true;
         buyerSecurityDeposit.set(FormattingUtils.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
         ignoreSecurityDepositStringListener = false;
@@ -1145,11 +1145,13 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         }
     }
 
-    private void setBuyerSecurityDepositToModel() {
+    private void setBuyerSecurityDepositToModel(boolean persistPreference) {
         if (buyerSecurityDeposit.get() != null && !buyerSecurityDeposit.get().isEmpty()) {
-            dataModel.setBuyerSecurityDeposit(ParsingUtils.parsePercentStringToDouble(buyerSecurityDeposit.get()));
+            dataModel.setBuyerSecurityDeposit(ParsingUtils.parsePercentStringToDouble(buyerSecurityDeposit.get()),
+                    persistPreference);
         } else {
-            dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent());
+            dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent(),
+                    persistPreference);
         }
     }
 
@@ -1157,7 +1159,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         // If the security deposit in the model is not valid percent
         String value = FormattingUtils.formatToPercent(dataModel.getBuyerSecurityDeposit().get());
         if (!securityDepositValidator.validate(value).isValid) {
-            dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent());
+            dataModel.setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent(), false);
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -966,7 +966,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     }
 
     public String getSecurityDepositLabel() {
-        return dataModel.isBuyOffer() ? Res.get("createOffer.setDepositAsBuyer") : Res.get("createOffer.setDeposit");
+        return Preferences.USE_SYMMETRIC_SECURITY_DEPOSIT ? Res.get("createOffer.setDepositForBothTraders") :
+                dataModel.isBuyOffer() ? Res.get("createOffer.setDepositAsBuyer") : Res.get("createOffer.setDeposit");
     }
 
     public String getSecurityDepositPopOverLabel(String depositInBTC) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferDataModel.java
@@ -32,6 +32,7 @@ import bisq.core.offer.CreateOfferService;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
@@ -63,6 +64,7 @@ class CreateOfferDataModel extends MutableOfferDataModel {
                                 FeeService feeService,
                                 @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter,
                                 MakerFeeProvider makerFeeProvider,
+                                TradeStatisticsManager tradeStatisticsManager,
                                 Navigation navigation) {
         super(createOfferService,
                 openOfferManager,
@@ -76,6 +78,7 @@ class CreateOfferDataModel extends MutableOfferDataModel {
                 feeService,
                 btcFormatter,
                 makerFeeProvider,
+                tradeStatisticsManager,
                 navigation);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -934,7 +934,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 Res.get("offerbook.deposit"),
                 Res.get("offerbook.deposit.help")) {
             {
-                setMinWidth(70);
+                setMinWidth(80);
                 setSortable(true);
             }
         };

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -934,7 +934,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 Res.get("offerbook.deposit"),
                 Res.get("offerbook.deposit.help")) {
             {
-                setMinWidth(80);
+                setMinWidth(70);
                 setSortable(true);
             }
         };
@@ -977,7 +977,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
     private TableColumn<OfferBookListItem, OfferBookListItem> getActionColumn() {
         TableColumn<OfferBookListItem, OfferBookListItem> column = new AutoTooltipTableColumn<>(Res.get("shared.actions")) {
             {
-                setMinWidth(200);
+                setMinWidth(180);
                 setSortable(false);
             }
         };
@@ -1194,8 +1194,8 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
     private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> getAvatarColumn() {
         AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> column = new AutoTooltipTableColumn<>(Res.get("offerbook.trader")) {
             {
-                setMinWidth(80);
-                setMaxWidth(80);
+                setMinWidth(60);
+                setMaxWidth(60);
                 setSortable(true);
             }
         };

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -246,6 +246,14 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         volumeColumn.setComparator(Comparator.comparing(o -> o.getOffer().getMinVolume(), Comparator.nullsFirst(Comparator.naturalOrder())));
         paymentMethodColumn.setComparator(Comparator.comparing(o -> o.getOffer().getPaymentMethod()));
         avatarColumn.setComparator(Comparator.comparing(o -> o.getOffer().getOwnerNodeAddress().getFullAddress()));
+        depositColumn.setComparator(Comparator.comparing(o -> {
+            var isSellOffer = o.getOffer().getDirection() == OfferPayload.Direction.SELL;
+            var deposit = isSellOffer ? o.getOffer().getBuyerSecurityDeposit() :
+                    o.getOffer().getSellerSecurityDeposit();
+
+            return (deposit == null) ? 0.0 : deposit.getValue() / (double) o.getOffer().getAmount().getValue();
+
+        }, Comparator.nullsFirst(Comparator.naturalOrder())));
 
         nrOfOffersLabel = new AutoTooltipLabel("");
         nrOfOffersLabel.setId("num-offers");

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -645,7 +645,7 @@ class OfferBookViewModel extends ActivatableViewModel {
     }
 
     public String formatDepositString(Coin deposit, long amount) {
-        var percentage = FormattingUtils.formatToPercentWithSymbol(deposit.getValue() / (double) amount);
+        var percentage = FormattingUtils.formatToRoundedPercentWithSymbol(deposit.getValue() / (double) amount);
         return btcFormatter.formatCoin(deposit) + " (" + percentage + ")";
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -645,7 +645,7 @@ class OfferBookViewModel extends ActivatableViewModel {
     }
 
     public String formatDepositString(Coin deposit, long amount) {
-        return btcFormatter.formatCoinWithCode(deposit) + " (" + deposit.getValue() / (double) amount + "%)";
+        var percentage = FormattingUtils.formatToPercentWithSymbol(deposit.getValue() / (double) amount);
+        return btcFormatter.formatCoin(deposit) + " (" + percentage + ")";
     }
-
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -47,8 +47,8 @@ import bisq.core.trade.Trade;
 import bisq.core.trade.closed.ClosedTradableManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
-import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
@@ -168,9 +168,7 @@ class OfferBookViewModel extends ActivatableViewModel {
         this.filteredItems = new FilteredList<>(offerBook.getOfferBookListItems());
         this.sortedItems = new SortedList<>(filteredItems);
 
-        tradeCurrencyListChangeListener = c -> {
-            fillAllTradeCurrencies();
-        };
+        tradeCurrencyListChangeListener = c -> fillAllTradeCurrencies();
 
         filterItemsListener = c -> {
             final Optional<OfferBookListItem> highestAmountOffer = filteredItems.stream()
@@ -645,4 +643,9 @@ class OfferBookViewModel extends ActivatableViewModel {
         else
             return (direction == OfferPayload.Direction.SELL) ? Res.get("shared.buyingCurrency", currencyCode) : Res.get("shared.sellingCurrency", currencyCode);
     }
+
+    public String formatDepositString(Coin deposit, long amount) {
+        return btcFormatter.formatCoinWithCode(deposit) + " (" + deposit.getValue() / (double) amount + "%)";
+    }
+
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModel.java
@@ -37,6 +37,7 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.proto.persistable.CorePersistenceProtoResolver;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
@@ -74,6 +75,7 @@ class EditOfferDataModel extends MutableOfferDataModel {
                        @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter,
                        CorePersistenceProtoResolver corePersistenceProtoResolver,
                        MakerFeeProvider makerFeeProvider,
+                       TradeStatisticsManager tradeStatisticsManager,
                        Navigation navigation) {
         super(createOfferService,
                 openOfferManager,
@@ -87,6 +89,7 @@ class EditOfferDataModel extends MutableOfferDataModel {
                 feeService,
                 btcFormatter,
                 makerFeeProvider,
+                tradeStatisticsManager,
                 navigation);
         this.corePersistenceProtoResolver = corePersistenceProtoResolver;
     }

--- a/desktop/src/test/java/bisq/desktop/main/offer/createoffer/CreateOfferDataModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/createoffer/CreateOfferDataModelTest.java
@@ -15,10 +15,13 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.RevolutAccount;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
 import org.bitcoinj.core.Coin;
+
+import javafx.collections.FXCollections;
 
 import java.util.HashSet;
 import java.util.UUID;
@@ -52,17 +55,19 @@ public class CreateOfferDataModelTest {
         CreateOfferService createOfferService = mock(CreateOfferService.class);
         preferences = mock(Preferences.class);
         user = mock(User.class);
+        var tradeStats = mock(TradeStatisticsManager.class);
 
         when(btcWalletService.getOrCreateAddressEntry(anyString(), any())).thenReturn(addressEntry);
         when(preferences.isUsePercentageBasedPrice()).thenReturn(true);
         when(preferences.getBuyerSecurityDepositAsPercent(null)).thenReturn(0.01);
         when(createOfferService.getRandomOfferId()).thenReturn(UUID.randomUUID().toString());
+        when(tradeStats.getObservableTradeStatisticsSet()).thenReturn(FXCollections.observableSet());
 
         makerFeeProvider = mock(MakerFeeProvider.class);
         model = new CreateOfferDataModel(createOfferService, null, btcWalletService,
                 null, preferences, user, null,
                 priceFeedService, null,
-                feeService, null, makerFeeProvider, null);
+                feeService, null, makerFeeProvider, tradeStats, null);
     }
 
     @Test

--- a/desktop/src/test/java/bisq/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -34,14 +34,16 @@ import bisq.core.locale.Res;
 import bisq.core.offer.CreateOfferService;
 import bisq.core.offer.OfferPayload;
 import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
-import bisq.core.util.coin.ImmutableCoinFormatter;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
+import bisq.core.util.coin.ImmutableCoinFormatter;
 import bisq.core.util.validation.InputValidator;
 
 import bisq.common.config.Config;
@@ -95,6 +97,7 @@ public class CreateOfferViewModelTest {
         SecurityDepositValidator securityDepositValidator = mock(SecurityDepositValidator.class);
         AccountAgeWitnessService accountAgeWitnessService = mock(AccountAgeWitnessService.class);
         CreateOfferService createOfferService = mock(CreateOfferService.class);
+        var tradeStats = mock(TradeStatisticsManager.class);
 
         when(btcWalletService.getOrCreateAddressEntry(anyString(), any())).thenReturn(addressEntry);
         when(btcWalletService.getBalanceForAddress(any())).thenReturn(Coin.valueOf(1000L));
@@ -102,6 +105,7 @@ public class CreateOfferViewModelTest {
         when(priceFeedService.getMarketPrice(anyString())).thenReturn(new MarketPrice("USD", 12684.0450, Instant.now().getEpochSecond(), true));
         when(feeService.getTxFee(anyInt())).thenReturn(Coin.valueOf(1000L));
         when(user.findFirstPaymentAccountWithCurrency(any())).thenReturn(paymentAccount);
+        when(paymentAccount.getPaymentMethod()).thenReturn(mock(PaymentMethod.class));
         when(user.getPaymentAccountsAsObservable()).thenReturn(FXCollections.observableSet());
         when(securityDepositValidator.validate(any())).thenReturn(new InputValidator.ValidationResult(false));
         when(accountAgeWitnessService.getMyTradeLimit(any(), any(), any())).thenReturn(100000000L);
@@ -109,11 +113,12 @@ public class CreateOfferViewModelTest {
         when(bsqFormatter.formatCoin(any())).thenReturn("0");
         when(bsqWalletService.getAvailableConfirmedBalance()).thenReturn(Coin.ZERO);
         when(createOfferService.getRandomOfferId()).thenReturn(UUID.randomUUID().toString());
+        when(tradeStats.getObservableTradeStatisticsSet()).thenReturn(FXCollections.observableSet());
 
         CreateOfferDataModel dataModel = new CreateOfferDataModel(createOfferService, null, btcWalletService,
                 bsqWalletService, empty, user, null, priceFeedService,
                 accountAgeWitnessService, feeService,
-                coinFormatter, mock(MakerFeeProvider.class), null);
+                coinFormatter, mock(MakerFeeProvider.class), tradeStats, null);
         dataModel.initWithData(OfferPayload.Direction.BUY, new CryptoCurrency("BTC", "bitcoin"));
         dataModel.activate();
 

--- a/desktop/src/test/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/portfolio/editoffer/EditOfferDataModelTest.java
@@ -19,6 +19,7 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.util.coin.BsqFormatter;
@@ -95,7 +96,7 @@ public class EditOfferDataModelTest {
                 btcWalletService, bsqWalletService, empty, user,
                 null, priceFeedService,
                 accountAgeWitnessService, feeService, null, null,
-                mock(MakerFeeProvider.class), null);
+                mock(MakerFeeProvider.class), mock(TradeStatisticsManager.class), null);
     }
 
     @Test

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -345,7 +345,7 @@ public abstract class NetworkNode implements MessageListener {
             allConnections.forEach(c -> c.shutDown(CloseConnectionReason.APP_SHUT_DOWN,
                     () -> {
                         shutdownCompleted.getAndIncrement();
-                        log.info("Shutdown o fnode {} completed", c.getPeersNodeAddressOptional());
+                        log.info("Shutdown of node {} completed", c.getPeersNodeAddressOptional());
                         if (shutdownCompleted.get() == numConnections) {
                             log.info("Shutdown completed with all connections closed");
                             timeoutHandler.stop();


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Implements suggestion in https://github.com/bisq-network/proposals/issues/233#issuecomment-650780056

Increased visibility of security deposit in offer overview.

Set suggested deposit to double of trade range over the trade period.

Both traders have the same security deposit.