### PR TITLE
Improve zelle payment account info text

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3027,27 +3027,14 @@ payment.accountType=Account type
 payment.checking=Checking
 payment.savings=Savings
 payment.personalId=Personal ID
-payment.clearXchange.info=Please be sure that you fulfill the requirements for the usage of Zelle (ClearXchange).\n\n\
-1. You need to have your Zelle (ClearXchange) account verified on their platform \
-before starting a trade or creating an offer.\n\n\
-2. You need to have a bank account at one of the following member banks:\n\
-\t● Bank of America\n\
-\t● Capital One P2P Payments\n\
-\t● Chase QuickPay\n\
-\t● FirstBank Person to Person Transfers\n\
-\t● Frost Send Money\n\
-\t● U.S. Bank Send Money\n\
-\t● TD Bank\n\
-\t● Citibank\n\
-\t● Wells Fargo SurePay\n\n\
-3. You need to be sure to not exceed the daily or monthly Zelle (ClearXchange) transfer limits.\n\n\
-Please use Zelle (ClearXchange) only if you fulfill all those requirements, \
-otherwise it is very likely that the Zelle (ClearXchange) transfer fails and the trade ends up in a dispute.\n\
-If you have not fulfilled the above requirements you will lose your security deposit.\n\n\
-  Please also be aware of a higher chargeback risk when using Zelle (ClearXchange).\n\
-  For the {0} seller it is highly recommended \
-to get in contact with the {1} buyer by using the provided email address or mobile number to verify that he or she \
-  is really the owner of the Zelle (ClearXchange) account.
+payment.clearXchange.info=Zelle is a money transfer service that works best *through* another bank.\n\n\
+  1. Check this page to see if (and how) your bank works with Zelle:\nhttps://www.zellepay.com/get-started\n\n\
+  2. Take special note of your transfer limits—sending limits vary by bank, and banks often specify separate daily, weekly, and monthly limits.\n\n\
+  3. If your bank does not work with Zelle, you can still use it through the Zelle mobile app, but your transfer limits will be much lower.\n\n\
+  4. The name specified on your Bisq account MUST match the name on your Zelle/bank account. \n\n\
+  If you cannot complete a Zelle transaction as specified in your trade contract, you may lose some (or all) of your security deposit.\n\n\
+  Because of Zelle''s somewhat higher chargeback risk, sellers are advised to contact unsigned buyers through email or SMS to verify that the buyer \
+  really owns the Zelle account specified in Bisq.
 payment.fasterPayments.newRequirements.info=Some banks have started verifying the receiver''s full name for Faster \
   Payments transfers. Your current Faster Payments account does not specify a full name.\n\n\
   Please consider recreating your Faster Payments account in Bisq to provide future {0} buyers with a full name.\n\n\


### PR DESCRIPTION
This PR updates the popup with Zelle guidance. The list of banks currently in the program no longer applies...Zelle now works with hundreds of banks, and there's now a website with more thorough guidance.

Other notable changes to address common questions:
- point out that transfer limits vary by bank, so users should check
- mention that zelle can be used without a bank, but limits are much lower
- specify that names MUST match

![Screenshot from 2020-07-01 14-53-39](https://user-images.githubusercontent.com/735155/86280955-48f59d00-bbcc-11ea-9b19-0da2b6aec8a8.png)
