### PR TITLE
Fix taker use all BSQ for fee payment

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -694,6 +694,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
         coinSelection.gathered.forEach(tx::addInput);
         try {
             Coin change = bsqCoinSelector.getChange(fee, coinSelection);
+            // Change can be ZERO, then no change output is created so don't rely on a BSQ change output
             if (change.isPositive()) {
                 checkArgument(Restrictions.isAboveDust(change),
                         "The change output of " + change.value / 100d + " BSQ is below the min. dust value of "

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerCreatesDepositTxInputs.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerCreatesDepositTxInputs.java
@@ -42,19 +42,14 @@ public class BuyerAsTakerCreatesDepositTxInputs extends TradeTask {
         try {
             runInterceptHook();
 
-            // In case we pay the taker fee in bsq we reduce tx fee by that as the burned bsq satoshis goes to miners.
-            Coin bsqTakerFee = trade.isCurrencyForTakerFeeBtc() ? Coin.ZERO : trade.getTakerFee();
-
             Coin txFee = trade.getTxFee();
             Coin takerInputAmount = checkNotNull(trade.getOffer()).getBuyerSecurityDeposit()
                     .add(txFee)
-                    .add(txFee)
-                    .subtract(bsqTakerFee);
-            Coin fee = txFee.subtract(bsqTakerFee);
+                    .add(txFee);
             InputsAndChangeOutput result = processModel.getTradeWalletService().takerCreatesDepositTxInputs(
                     processModel.getTakeOfferFeeTx(),
                     takerInputAmount,
-                    fee);
+                    txFee);
             processModel.setRawTransactionInputs(result.rawTransactionInputs);
             processModel.setChangeOutputValue(result.changeOutputValue);
             processModel.setChangeOutputAddress(result.changeOutputAddress);


### PR DESCRIPTION
Fixes https://github.com/bisq-network/security/issues/4

Issue: if a taker used exactly all BSQ from the BSQ inputs to pay the
trading fee, there was no BSQ change in the takeOfferFeeTx. It was
assumed that the second output was the reservedForTrade output, but in
the case of missing BSQ change it was the first output.

Fix: added a check to make sure the value of the inputs to the deposit
tx match the expected inputAmount.

Added a check that if there is no BSQ outputs in the bsqTradingFeeTx a
change output is added of value 1 satoshi more than the BSQ input value.
This ensures that the second output is always the reservedForTrade
output. It also ensures that the BSQ is burnt, even in the very unlikely
case that the amount of BSQ burnt is larger than the reservedForTrade
amount.


