### PR TITLE
Increase contrast of date picker colors in Dark Theme v2

### DIFF
--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -516,3 +516,11 @@
 .warning-box {
     -fx-background-color: -bs-color-primary-dark;
 }
+
+.jfx-date-picker .date-picker-popup{
+    -fx-background-color: -bs-color-gray-background;
+}
+
+.jfx-date-picker .left-button, .jfx-date-picker .right-button{
+    -fx-background-color: derive(-bs-color-gray-0, -10%);
+}


### PR DESCRIPTION
Before:
<img width="306" alt="Screen Shot 2020-07-07 at 3 18 39" src="https://user-images.githubusercontent.com/232186/86625881-cec87c80-c000-11ea-9b6a-779105fce1bb.png">

After:
<img width="306" alt="Screen Shot 2020-07-07 at 3 28 24" src="https://user-images.githubusercontent.com/232186/86626659-f3712400-c001-11ea-8f01-d00b6c1a2222.png">

@pedromvpg are you sure this is the correct CSS? it doesn't look right