### PR TITLE
Fix NullPointerException with external tor usage

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/network/RunningTor.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/RunningTor.java
@@ -64,7 +64,7 @@ public class RunningTor extends TorMode {
         Tor result;
         if (!password.isEmpty())
             result = new ExternalTor(controlPort, password);
-        else if (cookieFile.exists())
+        else if (cookieFile != null && cookieFile.exists())
             result = new ExternalTor(controlPort, cookieFile, useSafeCookieAuthentication);
         else
             result = new ExternalTor(controlPort);


### PR DESCRIPTION
If `torControlPort` is specified, but neither `torControlPassword` nor `torControlCookieFile` are specified, we have `cookieFile == null` in `bisq.network.p2p.network.RunningTor`, but `RunningTor.getTor()` assumes a cookie file has been specified and tries to check that the file exists, causing the thread to crash. Added a check for `null` to fix this.