### PR TITLE
Change IP for local node connection to Loopback address

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/LocalBitcoinNode.java
+++ b/core/src/main/java/bisq/core/btc/nodes/LocalBitcoinNode.java
@@ -81,7 +81,7 @@ public class LocalBitcoinNode {
      */
     private static boolean detect(int port) {
         try (Socket socket = new Socket()) {
-            var address = new InetSocketAddress(InetAddress.getLocalHost(), port);
+            var address = new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
             socket.connect(address, CONNECTION_TIMEOUT);
             log.info("Local Bitcoin node detected on port {}", port);
             return true;


### PR DESCRIPTION
If the local Bitcoin full node is bound to only listen on the loopback interface (127.0.0.1), attempting to open a socket to `InetAddress.getLocalHost()` - the return of which is variable but usually NOT 127.0.0.1 - will not work. Changing to `InetAddress.getLoopbackAddress()` resolves this.
