### PR TITLE
Don't use `kill -9` to restart seednodes now that SIGTERM is handled

### DIFF
--- a/seednode/bisq.service
+++ b/seednode/bisq.service
@@ -28,7 +28,7 @@ ExecStart=/bin/sh __BISQ_HOME__/__BISQ_REPO_NAME__/${BISQ_ENTRYPOINT} \
           --dumpBlockchainData=${BISQ_DUMP_BLOCKCHAIN} \
           --dumpStatistics=${BISQ_DUMP_STATISTICS} \
 
-ExecStop=/bin/kill -9 ${MAINPID}
+ExecStop=/bin/kill ${MAINPID}
 Restart=on-failure
 
 ExecStartPre=+/bin/bash -c "if [ $BISQ_DUMP_BLOCKCHAIN = true ];then mount -t tmpfs none -o size=2000M,uid=bisq,gid=bisq $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json;else true;fi"


### PR DESCRIPTION
Now that we can gracefully restart from #4047