### PR TITLE
Only show signing state if signing for payment method is required

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -1153,19 +1153,20 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                             String info;
                             String timeSinceSigning;
 
-                            if (accountAgeWitnessService.hasSignedWitness(item.getOffer())) {
-                                AccountAgeWitnessService.SignState signState = accountAgeWitnessService.getSignState(item.getOffer());
-                                icon = GUIUtil.getIconForSignState(signState);
-                                info = Res.get("offerbook.timeSinceSigning.info",
-                                        signState.getPresentation());
-                                long daysSinceSigning = TimeUnit.MILLISECONDS.toDays(
-                                        accountAgeWitnessService.getWitnessSignAge(item.getOffer(), new Date()));
-                                timeSinceSigning = Res.get("offerbook.timeSinceSigning.daysSinceSigning",
-                                        daysSinceSigning);
-                            } else {
-                                boolean needsSigning = PaymentMethod.hasChargebackRisk(
-                                        item.getOffer().getPaymentMethod(), item.getOffer().getCurrencyCode());
-                                if (needsSigning) {
+                            boolean needsSigning = PaymentMethod.hasChargebackRisk(
+                                    item.getOffer().getPaymentMethod(), item.getOffer().getCurrencyCode());
+
+                            if (needsSigning) {
+                                if (accountAgeWitnessService.hasSignedWitness(item.getOffer())) {
+                                    AccountAgeWitnessService.SignState signState = accountAgeWitnessService.getSignState(item.getOffer());
+                                    icon = GUIUtil.getIconForSignState(signState);
+                                    info = Res.get("offerbook.timeSinceSigning.info",
+                                            signState.getPresentation());
+                                    long daysSinceSigning = TimeUnit.MILLISECONDS.toDays(
+                                            accountAgeWitnessService.getWitnessSignAge(item.getOffer(), new Date()));
+                                    timeSinceSigning = Res.get("offerbook.timeSinceSigning.daysSinceSigning",
+                                            daysSinceSigning);
+                                } else {
                                     AccountAgeWitnessService.SignState signState = accountAgeWitnessService.getSignState(item.getOffer());
 
                                     icon = GUIUtil.getIconForSignState(signState);
@@ -1180,11 +1181,12 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                         info = Res.get("shared.notSigned");
                                         timeSinceSigning = Res.get("offerbook.timeSinceSigning.notSigned");
                                     }
-                                } else {
-                                    icon = MaterialDesignIcon.INFORMATION_OUTLINE;
-                                    info = Res.get("shared.notSigned.noNeed");
-                                    timeSinceSigning = Res.get("offerbook.timeSinceSigning.notSigned.noNeed");
                                 }
+
+                            } else {
+                                icon = MaterialDesignIcon.INFORMATION_OUTLINE;
+                                info = Res.get("shared.notSigned.noNeed");
+                                timeSinceSigning = Res.get("offerbook.timeSinceSigning.notSigned.noNeed");
                             }
 
                             InfoAutoTooltipLabel label = new InfoAutoTooltipLabel(timeSinceSigning, icon, ContentDisplay.RIGHT, info);


### PR DESCRIPTION
While testing the USPMO payment account for v1.3.7 I recognized that there is a display issue that surfaced because of https://github.com/bisq-network/bisq/pull/4305. We are signing all payment accounts with the exact same name to have already a couple of seeds if we need to enable account signing for other payment methods as well.

This wasn't handled properly in the offerbook.

Displaying `0 days` for USPMO offer 
![Bildschirmfoto 2020-08-03 um 11 55 40](https://user-images.githubusercontent.com/170962/89171732-d89eba80-d581-11ea-9815-40a7ea8f07af.png)

Should be `N/A`
![Bildschirmfoto 2020-08-03 um 12 00 25](https://user-images.githubusercontent.com/170962/89171793-ebb18a80-d581-11ea-9362-a7c31e20394e.png)

