### PR TITLE
Header and other visual tweaks

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -642,8 +642,8 @@ tree-table-view:focused {
 }
 
 .top-navigation .separator:vertical .line {
-    -fx-border-color: transparent transparent transparent -bs-rd-nav-border-color;
-    -fx-border-width: 1;
+    -fx-border-color: transparent transparent transparent transparent;
+    -fx-border-width: 3;
     -fx-border-insets: 0 0 0 1;
 }
 
@@ -661,7 +661,6 @@ tree-table-view:focused {
 .nav-price-balance {
     -fx-background-color: -bs-color-gray-background;
     -fx-background-radius: 3;
-    -fx-effect: innershadow(gaussian, -bs-text-color-transparent, 3, 0, 0, 1);
     -fx-pref-height: 41;
     -fx-padding: 0 10 0 0;
 }
@@ -2120,4 +2119,3 @@ textfield */
     -fx-stroke: linear-gradient(to bottom, -bs-text-color-transparent, -bs-text-color-transparent-dark) !important;
     -fx-fill: -bs-background-color !important;
 }
-

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -316,15 +316,17 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             }
         });
 
-        HBox primaryNav = new HBox(marketButton, getNavigationSeparator(), buyButton, getNavigationSeparator(),
-                sellButton, getNavigationSeparator(), portfolioButtonWithBadge, getNavigationSeparator(), fundsButton);
+        HBox primaryNav = new HBox(marketButton, getNavigationSeparator(), buyButton,
+                getNavigationSeparator(), sellButton, getNavigationSeparator(),
+                portfolioButtonWithBadge, getNavigationSeparator(), fundsButton);
 
         primaryNav.setAlignment(Pos.CENTER);
         primaryNav.getStyleClass().add("nav-primary");
         HBox.setHgrow(primaryNav, Priority.SOMETIMES);
 
-        HBox secondaryNav = new HBox(supportButtonWithBadge, getNavigationSeparator(), settingsButton,
-                getNavigationSeparator(), accountButtonWithBadge, getNavigationSeparator(), daoButtonWithBadge);
+        HBox secondaryNav = new HBox(supportButtonWithBadge, getNavigationSeparator(),
+                settingsButton, getNavigationSeparator(), accountButtonWithBadge,
+                getNavigationSeparator(), daoButtonWithBadge);
         secondaryNav.getStyleClass().add("nav-secondary");
         HBox.setHgrow(secondaryNav, Priority.SOMETIMES);
 

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -43,11 +43,11 @@ import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Transitions;
 
 import bisq.core.dao.monitoring.DaoStateMonitoringService;
-import bisq.common.BisqException;
 import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.LanguageUtil;
 import bisq.core.locale.Res;
 
+import bisq.common.BisqException;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.Version;
@@ -319,12 +319,12 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
         HBox primaryNav = new HBox(marketButton, getNavigationSeparator(), buyButton, getNavigationSeparator(),
                 sellButton, getNavigationSeparator(), portfolioButtonWithBadge, getNavigationSeparator(), fundsButton);
 
-        primaryNav.setAlignment(Pos.CENTER_LEFT);
+        primaryNav.setAlignment(Pos.CENTER);
         primaryNav.getStyleClass().add("nav-primary");
         HBox.setHgrow(primaryNav, Priority.SOMETIMES);
 
-        HBox secondaryNav = new HBox(supportButtonWithBadge, getNavigationSpacer(), settingsButton,
-                getNavigationSpacer(), accountButtonWithBadge, getNavigationSpacer(), daoButtonWithBadge);
+        HBox secondaryNav = new HBox(supportButtonWithBadge, getNavigationSeparator(), settingsButton,
+                getNavigationSeparator(), accountButtonWithBadge, getNavigationSeparator(), daoButtonWithBadge);
         secondaryNav.getStyleClass().add("nav-secondary");
         HBox.setHgrow(secondaryNav, Priority.SOMETIMES);
 
@@ -339,14 +339,14 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
         priceAndBalance.getStyleClass().add("nav-price-balance");
 
         HBox navPane = new HBox(primaryNav, secondaryNav,
-                priceAndBalance) {{
+                getNavigationSpacer(), priceAndBalance) {{
             setLeftAnchor(this, 0d);
             setRightAnchor(this, 0d);
             setTopAnchor(this, 0d);
             setPadding(new Insets(0, 0, 0, 0));
             getStyleClass().add("top-navigation");
         }};
-        navPane.setAlignment(Pos.CENTER);
+        navPane.setAlignment(Pos.CENTER_LEFT);
 
         AnchorPane contentContainer = new AnchorPane() {{
             getStyleClass().add("content-pane");

--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -524,3 +524,8 @@
 .jfx-date-picker .left-button, .jfx-date-picker .right-button{
     -fx-background-color: derive(-bs-color-gray-0, -10%);
 }
+
+
+.popup-bg, .notification-popup-bg, .peer-info-popup-bg {
+    -fx-effect: dropshadow(gaussian, -bs-color-gray-fafa, 44, 0, 0, 0);
+}


### PR DESCRIPTION
Reduce header visual elements and prevent it from over growing when client widow goes wider.
More minimal and flatter look to keep it current with the times! 💸

<img width="1312" alt="Screen Shot 2020-08-04 at 1 54 01 AM" src="https://user-images.githubusercontent.com/807505/89258065-6962ae00-d5f5-11ea-9ec6-03430d65775c.png">
<img width="1312" alt="Screen Shot 2020-08-04 at 1 53 55 AM" src="https://user-images.githubusercontent.com/807505/89258072-6a93db00-d5f5-11ea-812c-9d1c6b7b6d4e.png">
