### PR TITLE
[WIP] Split trade statistics between recent data and historical data 

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/PrunablePersistableNetworkPayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/PrunablePersistableNetworkPayload.java
@@ -17,11 +17,9 @@
 
 package bisq.network.p2p.storage.payload;
 
-import bisq.common.Payload;
-
 /**
  * Interface for PersistableNetworkPayloads which can be pruned (e.g. old objects will be removed from data store).
  */
-public interface PrunablePersistableNetworkPayload extends Payload {
+public interface PrunablePersistableNetworkPayload extends PersistableNetworkPayload {
     boolean doExclude();
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/PrunablePersistableNetworkPayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/PrunablePersistableNetworkPayload.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.payload;
+
+import bisq.common.Payload;
+
+/**
+ * Interface for PersistableNetworkPayloads which can be pruned (e.g. old objects will be removed from data store).
+ */
+public interface PrunablePersistableNetworkPayload extends Payload {
+    boolean doExclude();
+}

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
@@ -66,4 +66,11 @@ public class AppendOnlyDataStoreService {
                 .filter(service -> service.canHandle(payload))
                 .forEach(service -> service.putIfAbsent(hashAsByteArray, payload));
     }
+
+    public void prune() {
+        services.stream()
+                .filter(e -> e instanceof PrunableStoreService)
+                .map((e -> (PrunableStoreService) e))
+                .forEach(PrunableStoreService::prune);
+    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/PrunableStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/PrunableStoreService.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.persistence;
+
+/**
+ * Interface for StoreService which can be pruned (e.g. old objects will be removed from data store).
+ */
+public interface PrunableStoreService {
+    void prune();
+}


### PR DESCRIPTION
First part: Add pruning support for trade statistics:

We add an interface for prunable PersistableNetworkPayloads so we can
handle it generically in the p2p module. We check at startup if our
persisted data has old elements and remove those. Data we receive from
the seed node at startup will get checked as well for old objects as
well data we receive from the network.

Next steps: Add historical data handling