### PR TITLE
Increase data request timeout

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -132,10 +132,8 @@ public abstract class NetworkNode implements MessageListener {
                     }
                     Socket socket = createSocket(peersNodeAddress);
                     long duration = System.currentTimeMillis() - startTs;
-                    if (log.isDebugEnabled()) {
-                        log.debug("Socket creation to peersNodeAddress {} took {} ms", peersNodeAddress.getFullAddress(),
-                                duration);
-                    }
+                    log.info("Socket creation to peersNodeAddress {} took {} ms", peersNodeAddress.getFullAddress(),
+                            duration);
 
                     if (duration > CREATE_SOCKET_TIMEOUT)
                         throw new TimeoutException("A timeout occurred when creating a socket.");

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -52,7 +52,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 class RequestDataHandler implements MessageListener {
-    private static final long TIMEOUT = 90;
+    private static final long TIMEOUT = 180;
 
     private NodeAddress peersNodeAddress;
     /*


### PR DESCRIPTION
At slow internet connections the current timeout make it impossible to
get the initial data and therefor to use Bisq.
The timeout is containing the request and response as well as the time
it takes to start up the network connection which can also be quite
slow.
In my scenario, it took about 6-10 sec for the connection and the
request is atm nearly 3 MB which takes about 24 sec on a 1 Mbit/s
connection (note that over tor connection is slower so if normal speed
is 3-5 Mbit tors speed can be considerable lower). The response data
depends on the missing data/last update but can be easily 6 MB which
adds about another 48 sec. So one can easily hit the 90 sec. limit.

There is work in development for optimizing the initial data request,
but as that is more complex and not clear when it will be deployed I
recommend that we increase the current timeout to 180 sec. to avoid
that critical issue that users get "locked out".