### PR TITLE
Reduce seednode maxconnections setting from 50 to 40 in bisq.env

### DIFF
--- a/seednode/bisq.env
+++ b/seednode/bisq.env
@@ -29,7 +29,7 @@ BISQ_BASE_CURRENCY=btc_mainnet
 
 # bisq node settings
 BISQ_NODE_PORT=8000
-BISQ_MAX_CONNECTIONS=50
+BISQ_MAX_CONNECTIONS=40
 BISQ_MAX_MEMORY=4000
 
 # set to true for BSQ seednode


### PR DESCRIPTION
Due to a potential Tor rate limiting issue, it would be safer to reduce the `--maxconnections` settings on all seednodes from 50 to 40.