### PR TITLE
Move gRPC boilerplate from :core to :daemon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,19 +328,6 @@ configure(project(':core')) {
             exclude(module: 'jackson-annotations')
         }
         implementation "com.google.protobuf:protobuf-java:$protobufVersion"
-        implementation("io.grpc:grpc-protobuf:$grpcVersion") {
-            exclude(module: 'guava')
-            exclude(module: 'animal-sniffer-annotations')
-        }
-        implementation("io.grpc:grpc-stub:$grpcVersion") {
-            exclude(module: 'guava')
-            exclude(module: 'animal-sniffer-annotations')
-        }
-        compileOnly "javax.annotation:javax.annotation-api:$javaxAnnotationVersion"
-        runtimeOnly("io.grpc:grpc-netty-shaded:$grpcVersion") {
-            exclude(module: 'guava')
-            exclude(module: 'animal-sniffer-annotations')
-        }
         compileOnly "org.projectlombok:lombok:$lombokVersion"
         annotationProcessor "org.projectlombok:lombok:$lombokVersion"
 
@@ -574,6 +561,10 @@ configure(project(':daemon')) {
             exclude(module: 'animal-sniffer-annotations')
         }
         implementation("io.grpc:grpc-stub:$grpcVersion") {
+            exclude(module: 'guava')
+            exclude(module: 'animal-sniffer-annotations')
+        }
+        runtimeOnly("io.grpc:grpc-netty-shaded:$grpcVersion") {
             exclude(module: 'guava')
             exclude(module: 'animal-sniffer-annotations')
         }

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -15,9 +15,9 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.core.api;
 
-import bisq.core.grpc.model.AddressBalanceInfo;
+import bisq.core.api.model.AddressBalanceInfo;
 import bisq.core.monetary.Price;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.core.api;
 
 import bisq.core.monetary.Price;
 import bisq.core.offer.CreateOfferService;
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import static bisq.core.offer.OfferPayload.Direction.BUY;
 
 @Slf4j
-public class CoreOffersService {
+class CoreOffersService {
 
     private final CreateOfferService createOfferService;
     private final OfferBookService offerBookService;

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.core.api;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.locale.FiatCurrency;
@@ -34,7 +34,7 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class CorePaymentAccountsService {
+class CorePaymentAccountsService {
 
     private final Config config;
     private final AccountAgeWitnessService accountAgeWitnessService;

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -15,13 +15,13 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.core.api;
 
+import bisq.core.api.model.AddressBalanceInfo;
 import bisq.core.btc.Balances;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletsManager;
-import bisq.core.grpc.model.AddressBalanceInfo;
 
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.TransactionConfidence;

--- a/core/src/main/java/bisq/core/api/model/AddressBalanceInfo.java
+++ b/core/src/main/java/bisq/core/api/model/AddressBalanceInfo.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc.model;
+package bisq.core.api.model;
 
 import bisq.common.Payload;
 

--- a/core/src/main/java/bisq/core/api/model/OfferInfo.java
+++ b/core/src/main/java/bisq/core/api/model/OfferInfo.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc.model;
+package bisq.core.api.model;
 
 import bisq.common.Payload;
 

--- a/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
+++ b/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
@@ -20,7 +20,6 @@ package bisq.daemon.app;
 import bisq.core.app.BisqHeadlessAppMain;
 import bisq.core.app.BisqSetup;
 import bisq.core.app.CoreModule;
-import bisq.core.grpc.GrpcServer;
 
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
@@ -33,10 +32,14 @@ import java.util.concurrent.ThreadFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
+
+
+import bisq.daemon.grpc.GrpcServer;
+
 @Slf4j
 public class BisqDaemonMain extends BisqHeadlessAppMain implements BisqSetup.BisqSetupListener {
 
-    public static void main(String[] args)  {
+    public static void main(String[] args) {
         new BisqDaemonMain().execute(args);
     }
 
@@ -66,7 +69,6 @@ public class BisqDaemonMain extends BisqHeadlessAppMain implements BisqSetup.Bis
         super.onApplicationLaunched();
         headlessApp.setGracefulShutDownHandler(this);
     }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // We continue with a series of synchronous execution tasks

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -15,9 +15,10 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.daemon.grpc;
 
-import bisq.core.grpc.model.OfferInfo;
+import bisq.core.api.CoreApi;
+import bisq.core.api.model.OfferInfo;
 import bisq.core.trade.handlers.TransactionResultHandler;
 
 import bisq.proto.grpc.CreateOfferReply;

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
@@ -15,8 +15,9 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.daemon.grpc;
 
+import bisq.core.api.CoreApi;
 import bisq.core.payment.PaymentAccount;
 
 import bisq.proto.grpc.CreatePaymentAccountReply;
@@ -32,7 +33,7 @@ import javax.inject.Inject;
 import java.util.stream.Collectors;
 
 
-public class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccountsImplBase {
+class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccountsImplBase {
 
     private final CoreApi coreApi;
 

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
@@ -15,8 +15,9 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.daemon.grpc;
 
+import bisq.core.api.CoreApi;
 import bisq.core.trade.statistics.TradeStatistics2;
 
 import bisq.common.config.Config;

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -15,9 +15,10 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.daemon.grpc;
 
-import bisq.core.grpc.model.AddressBalanceInfo;
+import bisq.core.api.CoreApi;
+import bisq.core.api.model.AddressBalanceInfo;
 
 import bisq.proto.grpc.GetAddressBalanceReply;
 import bisq.proto.grpc.GetAddressBalanceRequest;

--- a/daemon/src/main/java/bisq/daemon/grpc/PasswordAuthInterceptor.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/PasswordAuthInterceptor.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.core.grpc;
+package bisq.daemon.grpc;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;


### PR DESCRIPTION
This change moves `gRPC` boilerplate code from the `:core.grpc` pkg into a new `:daemon.grpc` pkg.

* The `:core.grpc` pkg was renamed `:core.api`, and no longer has a dependency on `gRPC` libs.

* All core service classes in the `:core.api` pkg are now package protected, excepting `CoreApi`, making `CoreApi` the only possible entry point for all `Grpc*Service -> Core*Service` calls.

* All `gRPC` service classes in the `:daemon.grpc` pkg are now package protected, excepting `GrpcServer`;  the only class depending on `Grpc*Service` class is `GrpcServer`.

* `gRPC` dependencies were moved from the `gradle.build` file's `:core` subproject to `:daemon`.

This PR replaces [4417](https://github.com/bisq-network/bisq/pull/4417).