### PR TITLE
Fix setUpScaffold() signature

### DIFF
--- a/apitest/src/test/java/bisq/apitest/ApiTestCase.java
+++ b/apitest/src/test/java/bisq/apitest/ApiTestCase.java
@@ -73,9 +73,9 @@ public class ApiTestCase {
         grpcStubs = new GrpcStubs(alicedaemon, config).init();
     }
 
-    public static void setUpScaffold()
+    public static void setUpScaffold(String[] params)
             throws InterruptedException, ExecutionException, IOException {
-        scaffold = new Scaffold(new String[]{}).setUp();
+        scaffold = new Scaffold(params).setUp();
         config = scaffold.config;
         grpcStubs = new GrpcStubs(alicedaemon, config).init();
     }


### PR DESCRIPTION
Adds the missing String[] params to the method signature, so test cases can pass any needed combination of options to the scaffolding setup from a `@BeforeAll` method.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

_PR 1 of 5, to be reviewed/merged in PR number order._