### PR TITLE
Move bats based mainnet test from :cli to :apitest

### DIFF
--- a/apitest/scripts/mainnet-test.sh
+++ b/apitest/scripts/mainnet-test.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
 #
-# Integration tests for bisq-cli running against a live bisq-daemon
+# Smoke tests for bisq-cli running against a live bisq-daemon (on mainnet)
 #
 # Prerequisites:
 #
-#  - bats v0.4.0 must be installed (brew install bats on macOS)
-#    see https://github.com/sstephenson/bats/tree/v0.4.0
+#  - bats-core 1.2.0+ must be installed (brew install bats-core on macOS)
+#    see https://github.com/bats-core/bats-core
 #
 #  - Run `./bisq-daemon --apiPassword=xyz --appDataDir=$TESTDIR` where $TESTDIR
 #    is empty or otherwise contains an unencrypted wallet with a 0 BTC balance
@@ -48,14 +48,14 @@
   run ./bisq-cli --password="xyz" getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.5" ]
+  [ "$output" = "1.3.7" ]
 }
 
 @test "test getversion" {
   run ./bisq-cli --password=xyz getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.5" ]
+  [ "$output" = "1.3.7" ]
 }
 
 @test "test setwalletpassword \"a b c\"" {
@@ -190,8 +190,8 @@
   [ "$output" = "Error: incorrect parameter count, expecting direction (buy|sell), currency code" ]
 }
 
-@test "test getoffers buy eur check return status" {
-  run ./bisq-cli --password=xyz getoffers buy eur
+@test "test getoffers sell eur check return status" {
+  run ./bisq-cli --password=xyz getoffers sell eur
   [ "$status" -eq 0 ]
 }
 

--- a/apitest/src/test/java/bisq/apitest/ApiTestCase.java
+++ b/apitest/src/test/java/bisq/apitest/ApiTestCase.java
@@ -73,9 +73,9 @@ public class ApiTestCase {
         grpcStubs = new GrpcStubs(alicedaemon, config).init();
     }
 
-    public static void setUpScaffold()
+    public static void setUpScaffold(String[] params)
             throws InterruptedException, ExecutionException, IOException {
-        scaffold = new Scaffold(new String[]{}).setUp();
+        scaffold = new Scaffold(params).setUp();
         config = scaffold.config;
         grpcStubs = new GrpcStubs(alicedaemon, config).init();
     }


### PR DESCRIPTION
Move `:cli test.sh` to `:apitest mainnet-test.sh`

* The bats test script was moved to the apitest subproject and renamed.

* Version tests were updated for release 1.3.7.

* The duplicated "test getoffers buy eur check return status" was 
  replaced by a new "test getoffers sell eur check return status" test.

* The bats dependency was switched to bats-core because development
  has halted on https://github.com/sstephenson/bats/tree/master.
  The new bats repository is https://github.com/bats-core/bats-core/tree/master.

_PR 2 of 5, to be reviewed/merged in PR number order._
          