### PR TITLE
Add Tether token support via ERC20 and Omni

### DIFF
--- a/assets/src/main/java/bisq/asset/LiquidBitcoinAddressValidator.java
+++ b/assets/src/main/java/bisq/asset/LiquidBitcoinAddressValidator.java
@@ -1,0 +1,12 @@
+package bisq.asset;
+
+public class LiquidBitcoinAddressValidator extends RegexAddressValidator {
+    static private final String REGEX = "^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,87}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,87})$";
+    public LiquidBitcoinAddressValidator() {
+        super(REGEX);
+    }
+
+    public LiquidBitcoinAddressValidator(String regex, String errorMessageI18nKey) {
+        super(REGEX, "validation.altcoin.liquidBitcoin.invalidAddress");
+    }
+}

--- a/assets/src/main/java/bisq/asset/coins/LiquidBitcoin.java
+++ b/assets/src/main/java/bisq/asset/coins/LiquidBitcoin.java
@@ -19,12 +19,13 @@ package bisq.asset.coins;
 
 import bisq.asset.AltCoinAccountDisclaimer;
 import bisq.asset.Coin;
+import bisq.asset.LiquidBitcoinAddressValidator;
 import bisq.asset.RegexAddressValidator;
 
 @AltCoinAccountDisclaimer("account.altcoin.popup.liquidbitcoin.msg")
 public class LiquidBitcoin extends Coin {
 
     public LiquidBitcoin() {
-        super("Liquid Bitcoin", "L-BTC", new RegexAddressValidator("^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,87}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,87})$", "validation.altcoin.liquidBitcoin.invalidAddress"));
+        super("Liquid Bitcoin", "L-BTC", new LiquidBitcoinAddressValidator());
     }
 }

--- a/assets/src/main/java/bisq/asset/coins/TetherUSDLiquid.java
+++ b/assets/src/main/java/bisq/asset/coins/TetherUSDLiquid.java
@@ -1,0 +1,12 @@
+package bisq.asset.coins;
+
+import bisq.asset.Coin;
+import bisq.asset.LiquidBitcoinAddressValidator;
+
+public class TetherUSDLiquid extends Coin {
+    public TetherUSDLiquid() {
+        // If you add a new USDT variant or want to change this ticker symbol you should also look here:
+        // core/src/main/java/bisq/core/provider/price/PriceProvider.java:getAll()
+        super("Tether USD (Liquid Bitcoin)", "L-USDT", new LiquidBitcoinAddressValidator());
+    }
+}

--- a/assets/src/main/java/bisq/asset/coins/TetherUSDOmni.java
+++ b/assets/src/main/java/bisq/asset/coins/TetherUSDOmni.java
@@ -1,0 +1,12 @@
+package bisq.asset.coins;
+
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+
+public class TetherUSDOmni extends Coin {
+    public TetherUSDOmni() {
+        // If you add a new USDT variant or want to change this ticker symbol you should also look here:
+        // core/src/main/java/bisq/core/provider/price/PriceProvider.java:getAll()
+        super("Tether USD (Omni)", "USDT-O", new Base58BitcoinAddressValidator());
+    }
+}

--- a/assets/src/main/java/bisq/asset/tokens/TetherUSDERC20.java
+++ b/assets/src/main/java/bisq/asset/tokens/TetherUSDERC20.java
@@ -1,0 +1,11 @@
+package bisq.asset.tokens;
+
+import bisq.asset.Erc20Token;
+
+public class TetherUSDERC20 extends Erc20Token {
+    public TetherUSDERC20() {
+        // If you add a new USDT variant or want to change this ticker symbol you should also look here:
+        // core/src/main/java/bisq/core/provider/price/PriceProvider.java:getAll()
+        super("Tether USD (ERC20)", "USDT-E");
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -104,6 +104,8 @@ bisq.asset.coins.Spectrecoin
 bisq.asset.coins.Starwels
 bisq.asset.coins.SUB1X
 bisq.asset.coins.TEO
+bisq.asset.coins.TetherUSDLiquid
+bisq.asset.coins.TetherUSDOmni
 bisq.asset.coins.TurtleCoin
 bisq.asset.coins.UnitedCommunityCoin
 bisq.asset.coins.Unobtanium
@@ -123,6 +125,7 @@ bisq.asset.coins.ZeroClassic
 bisq.asset.tokens.AugmintEuro
 bisq.asset.tokens.DaiStablecoin
 bisq.asset.tokens.EtherStone
+bisq.asset.tokens.TetherUSDERC20
 bisq.asset.tokens.TrueUSD
 bisq.asset.tokens.USDCoin
 bisq.asset.tokens.VectorspaceAI

--- a/core/src/main/java/bisq/core/provider/price/PriceProvider.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceProvider.java
@@ -70,7 +70,12 @@ public class PriceProvider extends HttpClientProvider {
                 final double price = (Double) treeMap.get("price");
                 // json uses double for our timestampSec long value...
                 final long timestampSec = MathUtils.doubleToLong((Double) treeMap.get("timestampSec"));
-                marketPriceMap.put(currencyCode, new MarketPrice(currencyCode, price, timestampSec, true));
+                if (currencyCode.equals("USDT")) {
+                    addPrice(marketPriceMap, "USDT-O", price, timestampSec);
+                    addPrice(marketPriceMap, "USDT-E", price, timestampSec);
+                    addPrice(marketPriceMap, "L-USDT", price, timestampSec);
+                }
+                addPrice(marketPriceMap, currencyCode, price, timestampSec);
             } catch (Throwable t) {
                 log.error(t.toString());
                 t.printStackTrace();
@@ -78,6 +83,10 @@ public class PriceProvider extends HttpClientProvider {
 
         });
         return new Tuple2<>(tsMap, marketPriceMap);
+    }
+
+    private void addPrice(Map<String, MarketPrice> marketPriceMap, String currencyCode, double price, long timestampSec) {
+        marketPriceMap.put(currencyCode, new MarketPrice(currencyCode, price, timestampSec, true));
     }
 
     public String getBaseUrl() {

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -534,11 +534,10 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
 
         String selectedCurrencyCode = model.getPriceFeedService().getCurrencyCode();
         MarketPrice selectedMarketPrice = model.getPriceFeedService().getMarketPrice(selectedCurrencyCode);
-
         return Res.get("mainView.marketPrice.tooltip",
                 "Bisq Price Index for " + selectedCurrencyCode,
                 "",
-                DisplayUtils.formatTime(new Date(selectedMarketPrice.getTimestampSec())),
+                selectedMarketPrice != null ? DisplayUtils.formatTime(new Date(selectedMarketPrice.getTimestampSec())) : Res.get("shared.na"),
                 model.getPriceFeedService().getProviderNodeAddress());
     }
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Related: https://github.com/bisq-network/proposals/issues/170, #2369

From the proposal and the discussion in Keybase it is clear that the USDT token is wanted on Bisq. This PR adds basic support for the ERC20 based token and the Omni based token. 

I think a discussion should be had about the best way to make this implementation better. As of now, it adds two altcoins and thus two new markets are possible. I think it can be improved by joining these accounts or these markets in some way, for when users want to be able to trade both versions of USDT. On centralised markets there is only one USDT/XBT market, and the two tokens are considered equal. I think this behaviour is desirable.
