### PR TITLE
Add mempool.bisq.services explorer and mempool fee estimation provider

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -82,6 +82,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             new BlockChainExplorer("mempool.space Tor V3", "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/tx/", "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/address/"),
             new BlockChainExplorer("mempool.emzy.de (@emzy)", "https://mempool.emzy.de/tx/", "https://mempool.emzy.de/address/"),
             new BlockChainExplorer("mempool.emzy.de Tor V3", "http://mempool4t6mypeemozyterviq3i5de4kpoua65r3qkn5i3kknu5l2cad.onion/tx/", "http://mempool4t6mypeemozyterviq3i5de4kpoua65r3qkn5i3kknu5l2cad.onion/address/"),
+            new BlockChainExplorer("mempool.bisq.services (@devinbileck)", "https://mempool.bisq.services/tx/", "https://mempool.bisq.services/address/"),
+            new BlockChainExplorer("mempool.bisq.services Tor V3", "http://mempoolusb2f67qi7mz2it7n5e77a6komdzx6wftobcduxszkdfun2yd.onion/tx/", "http://mempoolusb2f67qi7mz2it7n5e77a6komdzx6wftobcduxszkdfun2yd.onion/address/"),
             new BlockChainExplorer("Blockstream.info", "https://blockstream.info/tx/", "https://blockstream.info/address/"),
             new BlockChainExplorer("Blockstream.info Tor V3", "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/tx/", "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/address/"),
             new BlockChainExplorer("OXT", "https://oxt.me/transaction/", "https://oxt.me/address/"),

--- a/pricenode/src/main/resources/application.properties
+++ b/pricenode/src/main/resources/application.properties
@@ -5,5 +5,5 @@ spring.jackson.serialization.indent_output=true
 bisq.price.mining.providers.mempoolHostname.1=mempool.space
 bisq.price.mining.providers.mempoolHostname.2=mempool.emzy.de
 bisq.price.mining.providers.mempoolHostname.3=mempool.ninja
-# bisq.price.mining.providers.mempoolHostname.4=someHostOrIP
+bisq.price.mining.providers.mempoolHostname.4=mempool.bisq.services
 # bisq.price.mining.providers.mempoolHostname.5=someHostOrIP


### PR DESCRIPTION
It is running both a Bitcoin and BSQ explorer:
https://mempool.bisq.services
https://mempool.bisq.services/bisq

It is also accessible over Tor:
http://mempoolusb2f67qi7mz2it7n5e77a6komdzx6wftobcduxszkdfun2yd.onion

And is providing a mempool fee estimation endpoint:
https://mempool.bisq.services/api/v1/fees/recommended