### PR TITLE
Reload dispute layout on reopen

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -235,6 +235,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                     if (selectedDisputeClosedPropertyListener != null)
                         selectedDispute.isClosedProperty().removeListener(selectedDisputeClosedPropertyListener);
                     selectedDispute.setIsClosed(false);
+                    handleOnSelectDispute(selectedDispute);
                 }
             } else if (Utilities.isAltOrCtrlPressed(KeyCode.R, event)) {
                 if (selectedDispute != null) {


### PR DESCRIPTION
When a dispute is reopened it now shows the chat text entry field. Might help with https://github.com/bisq-network/roles/issues/102#issuecomment-680753125