### PR TITLE
Upgrade JFoenix to v9.0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ configure(subprojects) {
         javaxAnnotationVersion = '1.2'
         jcsvVersion = '1.4.0'
         jetbrainsAnnotationsVersion = '13.0'
-        jfoenixVersion = '9.0.6'
+        jfoenixVersion = '9.0.10'
         joptVersion = '5.0.4'
         jsonsimpleVersion = '1.1.1'
         junitVersion = '4.12'

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -42,7 +42,7 @@ dependencyVerification {
         'com.google.zxing:core:11aae8fd974ab25faa8208be50468eb12349cd239e93e7c797377fa13e381729',
         'com.google.zxing:javase:0ec23e2ec12664ddd6347c8920ad647bb3b9da290f897a88516014b56cc77eb9',
         'com.googlecode.jcsv:jcsv:73ca7d715e90c8d2c2635cc284543b038245a34f70790660ed590e157b8714a2',
-        'com.jfoenix:jfoenix:4739e37a05e67c3bc9d5b391a1b93717b5a48fa872992616b0964d3f827f8fe6',
+        'com.jfoenix:jfoenix:8060235fec5eb49617ec8d81d379e8c945f6cc722d0645e97190045100de2084',
         'com.lambdaworks:scrypt:9a82d218099fb14c10c0e86e7eefeebd8c104de920acdc47b8b4b7a686fb73b4',
         'com.madgag.spongycastle:core:8d6240b974b0aca4d3da9c7dd44d42339d8a374358aca5fc98e50a995764511f',
         'com.nativelibs4java:bridj:101bcd9b6637e6bc16e56deb3daefba62b1f5e8e9e37e1b3e56e3b5860d659cf',


### PR DESCRIPTION
This PR upgrades `JFoenix` from v9.0.6 to v9.0.10, to avoid an NPE thrown when registering a dispute agent in an arbitrator (regtest) desktop's account view.

The JFoenix `com.jfoenix.adapters.ReflectionHelper` class has a `getFieldContent` method that silently swallows a Throwable and returns null.  After clicking `ALT-D` or `ALT-N` in the an arbitrator's desktop -> accounts view (register dispute agents) a private field cannot be accessed via reflection, and `bisq.desktop.components.JFXTextFieldSkinBisqStyle#updateTextPos` throws an NPE.

![1-UI-Error](https://user-images.githubusercontent.com/36207203/91487448-260dff00-e884-11ea-9006-1eeb54fb9d6f.png)

```
Aug-27 12:59:45.970 [JavaFX Application Thread] ERROR b.c.s.CommonSetup: Uncaught Exception from thread JavaFX Application Thread 
Aug-27 12:59:45.970 [JavaFX Application Thread] ERROR b.c.s.CommonSetup: throwableMessage= null 
Aug-27 12:59:45.970 [JavaFX Application Thread] ERROR b.c.s.CommonSetup: throwableClass= class java.lang.NullPointerException 
Aug-27 12:59:45.971 [JavaFX Application Thread] ERROR b.c.s.CommonSetup: Stack trace:
java.lang.NullPointerException
	at bisq.desktop.components.JFXTextFieldSkinBisqStyle.updateTextPos(JFXTextFieldSkinBisqStyle.java:95)
	at bisq.desktop.components.JFXTextFieldSkinBisqStyle.layoutChildren(JFXTextFieldSkinBisqStyle.java:79)
	at javafx.scene.control.Control.layoutChildren(Control.java:601)
	at javafx.scene.Parent.layout(Parent.java:1204)
	at javafx.scene.Parent.layout(Parent.java:1211)
	at javafx.scene.Parent.layout(Parent.java:1211)
	at javafx.scene.Scene.doLayoutPass(Scene.java:576)
	at javafx.scene.Scene.preferredSize(Scene.java:1748)
	at javafx.scene.Scene$2.preferredSize(Scene.java:393)
	at com.sun.javafx.scene.SceneHelper.preferredSize(SceneHelper.java:66)
	at javafx.stage.Window$12.invalidated(Window.java:1086)
	at javafx.beans.property.BooleanPropertyBase.markInvalid(BooleanPropertyBase.java:110)
	at javafx.beans.property.BooleanPropertyBase.set(BooleanPropertyBase.java:145)
	at javafx.stage.Window.setShowing(Window.java:1174)
	at javafx.stage.Window.show(Window.java:1189)
	at javafx.stage.Stage.show(Stage.java:273)
	at bisq.desktop.main.overlays.Overlay.display(Overlay.java:538)
	at bisq.desktop.main.overlays.windows.UnlockDisputeAgentRegistrationWindow.show(UnlockDisputeAgentRegistrationWindow.java:85)
	at bisq.desktop.main.account.register.AgentRegistrationView.onTabSelection(AgentRegistrationView.java:121)
	at bisq.desktop.main.account.AccountView.loadView(AccountView.java:269)
	at bisq.desktop.main.account.AccountView.lambda$initialize$0(AccountView.java:114)
	at bisq.desktop.Navigation.lambda$navigateTo$1(Navigation.java:138)
	at java.base/java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:804)
	at java.base/java.util.concurrent.CopyOnWriteArraySet.forEach(CopyOnWriteArraySet.java:425)
	at bisq.desktop.Navigation.navigateTo(Navigation.java:138)
	at bisq.desktop.Navigation.navigateTo(Navigation.java:103)
	at bisq.desktop.main.account.AccountView.lambda$initialize$1(AccountView.java:132)
	at com.sun.javafx.event.CompositeEventHandler$NormalEventHandlerRecord.handleBubblingEvent(CompositeEventHandler.java:218)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:80)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:238)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.event.Event.fireEvent(Event.java:198)
	at javafx.scene.Scene$KeyHandler.process(Scene.java:4058)
	at javafx.scene.Scene$KeyHandler.access$1500(Scene.java:4004)
	at javafx.scene.Scene.processKeyEvent(Scene.java:2121)
	at javafx.scene.Scene$ScenePeerListener.keyEvent(Scene.java:2595)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$KeyEventNotification.run(GlassViewEventHandler.java:217)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$KeyEventNotification.run(GlassViewEventHandler.java:149)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler.lambda$handleKeyEvent$1(GlassViewEventHandler.java:248)
	at com.sun.javafx.tk.quantum.QuantumToolkit.runWithoutRenderLock(QuantumToolkit.java:390)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler.handleKeyEvent(GlassViewEventHandler.java:247)
	at com.sun.glass.ui.View.handleKeyEvent(View.java:547)
	at com.sun.glass.ui.View.notifyKey(View.java:971)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$11(GtkApplication.java:277)
	at java.base/java.lang.Thread.run(Thread.java:832)
 ```

The NPE follows the failure to create a `textNode` instance using reflection, in the `JFXTextFieldSkinBisqStyle` constructor:
` textNode = ReflectionHelper.getFieldContent(TextFieldSkin.class, this, "textNode");`

If this happens, the UI becomes unusable -- many views are blank.

![3-BlankSettings](https://user-images.githubusercontent.com/36207203/91487577-52c21680-e884-11ea-9657-9cd97c742991.png)

![4-BlankDAO](https://user-images.githubusercontent.com/36207203/91487593-5786ca80-e884-11ea-83eb-250abc348b5d.png)

This problem has not been reproduced when running the `bisq-desktop` cmd below from a Linux (Ubuntu 20) bash shell:

`$ ./bisq-desktop --appName=bisq-BTC_REGTEST_Arb_dao --appDataDir=<project-path>/apitest/build/resources/main/bisq-BTC_REGTEST_Arb_dao --nodePort=4444 --rpcBlockNotificationPort=5121 --rpcUser=apitest --rpcPassword=apitest --rpcPort=19443 --daoActivated=true --fullDaoNode=true --seedNodes=localhost:2002 --baseCurrencyNetwork=BTC_REGTEST --useDevPrivilegeKeys=true --useLocalhostForP2P=true --genesisBlockHeight=111 --genesisTxId=30af0050040befd8af25068cc697e418e09c2d8ebd8d411d2240591b9ec203cf
`

The same bisq-desktop cmd run by `:apitest` (using a java `ProcessBuilder`) reproduces the NPE every time.  We need to be able to register dispute agents from an arbitration node started by any API test case.
