### PR TITLE
Use a prog arg for the hour of the restart to avoid the risk that

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -118,7 +118,6 @@ public class Config {
     public static final String ALLOW_FAULTY_DELAYED_TXS = "allowFaultyDelayedTxs";
     public static final String API_PASSWORD = "apiPassword";
     public static final String API_PORT = "apiPort";
-    public static final String SEED_NODE_RESTART_TIME = "seedNodeRestartTime";
 
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
@@ -204,7 +203,6 @@ public class Config {
     public final boolean allowFaultyDelayedTxs;
     public final String apiPassword;
     public final int apiPort;
-    public final int seedNodeRestartTime;
 
     // Properties derived from options but not exposed as options themselves
     public final File torDir;
@@ -632,12 +630,6 @@ public class Config {
                         .ofType(Integer.class)
                         .defaultsTo(9998);
 
-        ArgumentAcceptingOptionSpec<Integer> seedNodeRestartTimeOpt =
-                parser.accepts(SEED_NODE_RESTART_TIME, "Seed node restart time in GMT-0 (values: 0-23)")
-                        .withRequiredArg()
-                        .ofType(Integer.class)
-                        .defaultsTo(-1);
-
         try {
             CompositeOptionSet options = new CompositeOptionSet();
 
@@ -752,7 +744,6 @@ public class Config {
             this.allowFaultyDelayedTxs = options.valueOf(allowFaultyDelayedTxsOpt);
             this.apiPassword = options.valueOf(apiPasswordOpt);
             this.apiPort = options.valueOf(apiPortOpt);
-            this.seedNodeRestartTime = options.valueOf(seedNodeRestartTimeOpt);
         } catch (OptionException ex) {
             throw new ConfigException("problem parsing option '%s': %s",
                     ex.options().get(0),

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -118,6 +118,7 @@ public class Config {
     public static final String ALLOW_FAULTY_DELAYED_TXS = "allowFaultyDelayedTxs";
     public static final String API_PASSWORD = "apiPassword";
     public static final String API_PORT = "apiPort";
+    public static final String SEED_NODE_RESTART_TIME = "seedNodeRestartTime";
 
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
@@ -203,6 +204,7 @@ public class Config {
     public final boolean allowFaultyDelayedTxs;
     public final String apiPassword;
     public final int apiPort;
+    public final int seedNodeRestartTime;
 
     // Properties derived from options but not exposed as options themselves
     public final File torDir;
@@ -630,6 +632,12 @@ public class Config {
                         .ofType(Integer.class)
                         .defaultsTo(9998);
 
+        ArgumentAcceptingOptionSpec<Integer> seedNodeRestartTimeOpt =
+                parser.accepts(SEED_NODE_RESTART_TIME, "Seed node restart time in GMT-0 (values: 0-23)")
+                        .withRequiredArg()
+                        .ofType(Integer.class)
+                        .defaultsTo(-1);
+
         try {
             CompositeOptionSet options = new CompositeOptionSet();
 
@@ -744,6 +752,7 @@ public class Config {
             this.allowFaultyDelayedTxs = options.valueOf(allowFaultyDelayedTxsOpt);
             this.apiPassword = options.valueOf(apiPasswordOpt);
             this.apiPort = options.valueOf(apiPortOpt);
+            this.seedNodeRestartTime = options.valueOf(seedNodeRestartTimeOpt);
         } catch (OptionException ex) {
             throw new ConfigException("problem parsing option '%s': %s",
                     ex.options().get(0),

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -20,6 +20,9 @@ package bisq.seednode;
 import bisq.core.app.misc.ExecutableForAppWithP2p;
 import bisq.core.app.misc.ModuleForAppWithP2p;
 
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.P2PServiceListener;
+
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
 import bisq.common.app.Capabilities;
@@ -47,7 +50,6 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
         super.doExecute();
 
         checkMemory(config, this);
-        startShutDownInterval(this);
         CommonSetup.setup(this);
 
         keepRunning();
@@ -95,5 +97,40 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
     @Override
     protected void startApplication() {
         seedNode.startApplication();
+
+        injector.getInstance(P2PService.class).addP2PServiceListener(new P2PServiceListener() {
+            @Override
+            public void onDataReceived() {
+            }
+
+            @Override
+            public void onNoSeedNodeAvailable() {
+            }
+
+            @Override
+            public void onNoPeersAvailable() {
+            }
+
+            @Override
+            public void onUpdatedDataReceived() {
+            }
+
+            @Override
+            public void onTorNodeReady() {
+            }
+
+            @Override
+            public void onHiddenServicePublished() {
+                startShutDownInterval(SeedNodeMain.this);
+            }
+
+            @Override
+            public void onSetupFailed(Throwable throwable) {
+            }
+
+            @Override
+            public void onRequestCustomBridges() {
+            }
+        });
     }
 }


### PR DESCRIPTION
multiple seeds restart around the same time which can cause loss of
data.

The option --seedNodeRestartTime=[0-23] is used to determine the hour
when the node restarts. GMT-0 is used. All nodes need to have a synced
clock (timezone does not matter).

A coordinator need to define which seed uses which hour for the restart.