### PR TITLE
Use the index of a seed node address in the list of nodes at the

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -55,6 +55,7 @@ class RequestDataHandler implements MessageListener {
     private static final long TIMEOUT = 180;
 
     private NodeAddress peersNodeAddress;
+    private String getDataRequestType;
     /*
      */
 
@@ -138,7 +139,8 @@ class RequestDataHandler implements MessageListener {
                         TIMEOUT);
             }
 
-            log.info("We send a {} to peer {}. ", getDataRequest.getClass().getSimpleName(), nodeAddress);
+            getDataRequestType = getDataRequest.getClass().getSimpleName();
+            log.info("We send a {} to peer {}. ", getDataRequestType, nodeAddress);
             networkNode.addMessageListener(this);
             SettableFuture<Connection> future = networkNode.sendMessage(nodeAddress, getDataRequest);
             //noinspection UnstableApiUsage
@@ -259,8 +261,9 @@ class RequestDataHandler implements MessageListener {
         StringBuilder sb = new StringBuilder();
         sb.append("\n#################################################################\n");
         sb.append("Connected to node: " + peersNodeAddress.getFullAddress() + "\n");
-        final int items = dataSet.size() + persistableNetworkPayloadSet.size();
-        sb.append("Received ").append(items).append(" instances\n");
+        int items = dataSet.size() + persistableNetworkPayloadSet.size();
+        sb.append("Received ").append(items).append(" instances from a ")
+                .append(getDataRequestType).append("\n");
         payloadByClassName.forEach((key, value) -> sb.append(key)
                 .append(": ")
                 .append(value.size())

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -101,22 +101,27 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
         injector.getInstance(P2PService.class).addP2PServiceListener(new P2PServiceListener() {
             @Override
             public void onDataReceived() {
+                // Do nothing
             }
 
             @Override
             public void onNoSeedNodeAvailable() {
+                // Do nothing
             }
 
             @Override
             public void onNoPeersAvailable() {
+                // Do nothing
             }
 
             @Override
             public void onUpdatedDataReceived() {
+                // Do nothing
             }
 
             @Override
             public void onTorNodeReady() {
+                // Do nothing
             }
 
             @Override
@@ -126,10 +131,12 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
 
             @Override
             public void onSetupFailed(Throwable throwable) {
+                // Do nothing
             }
 
             @Override
             public void onRequestCustomBridges() {
+                // Do nothing
             }
         });
     }

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -20,6 +20,9 @@ package bisq.seednode;
 import bisq.core.app.misc.ExecutableForAppWithP2p;
 import bisq.core.app.misc.ModuleForAppWithP2p;
 
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.P2PServiceListener;
+
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
 import bisq.common.app.Capabilities;
@@ -47,7 +50,6 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
         super.doExecute();
 
         checkMemory(config, this);
-        startShutDownInterval(this);
         CommonSetup.setup(this);
 
         keepRunning();
@@ -95,5 +97,40 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
     @Override
     protected void startApplication() {
         seedNode.startApplication();
+
+        injector.getInstance(P2PService.class).addP2PServiceListener(new P2PServiceListener() {
+            @Override
+            public void onDataReceived() {
+            }
+
+            @Override
+            public void onNoSeedNodeAvailable() {
+            }
+
+            @Override
+            public void onNoPeersAvailable() {
+            }
+
+            @Override
+            public void onUpdatedDataReceived() {
+            }
+
+            @Override
+            public void onTorNodeReady() {
+            }
+
+            @Override
+            public void onHiddenServicePublished() {
+                startShutDownInterval(SeedNodeMain.this);
+            }
+
+            @Override
+            public void onSetupFailed(Throwable throwable) {
+            }
+
+            @Override
+            public void onRequestCustomBridges() {
+            }
+        });
     }
 }


### PR DESCRIPTION
Use the index of a seed node address in the list of nodes at the repository to determine the hour to restart.
This should avoid the riks that multiple seed nodes restart at the same time which can lead to data loss.
