### PR TITLE
Tweak seednode bitcoin.conf, remove timeout, separate testnet block

### DIFF
--- a/seednode/bitcoin.conf
+++ b/seednode/bitcoin.conf
@@ -1,13 +1,21 @@
 server=1
+daemon=1
+listen=1
+discover=1
 txindex=1
 dbcache=1337
 maxconnections=1337
-timeout=30000
-listen=1
-discover=1
 peerbloomfilters=1
 onion=127.0.0.1:9050
 rpcallowip=127.0.0.1
 rpcuser=__BITCOIN_RPC_USER__
 rpcpassword=__BITCOIN_RPC_PASS__
 blocknotify=/bitcoin/blocknotify.sh %s
+
+[main]
+bind=127.0.0.1:8333
+rpcbind=127.0.0.1:8332
+
+[test]
+bind=127.0.0.1:18333
+rpcbind=127.0.0.1:18332


### PR DESCRIPTION
The `timeout` line of our bitcoin.conf occasionally causes it to get stuck, should remove it from all nodes.
Also separate testnet into its own block