### PR TITLE
Revert "Header and other visual tweaks"

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -642,8 +642,8 @@ tree-table-view:focused {
 }
 
 .top-navigation .separator:vertical .line {
-    -fx-border-color: transparent transparent transparent transparent;
-    -fx-border-width: 3;
+    -fx-border-color: transparent transparent transparent -bs-rd-nav-border-color;
+    -fx-border-width: 1;
     -fx-border-insets: 0 0 0 1;
 }
 
@@ -661,6 +661,7 @@ tree-table-view:focused {
 .nav-price-balance {
     -fx-background-color: -bs-color-gray-background;
     -fx-background-radius: 3;
+    -fx-effect: innershadow(gaussian, -bs-text-color-transparent, 3, 0, 0, 1);
     -fx-pref-height: 41;
     -fx-padding: 0 10 0 0;
 }
@@ -2119,3 +2120,4 @@ textfield */
     -fx-stroke: linear-gradient(to bottom, -bs-text-color-transparent, -bs-text-color-transparent-dark) !important;
     -fx-fill: -bs-background-color !important;
 }
+

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -43,12 +43,12 @@ import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Transitions;
 
 import bisq.core.dao.monitoring.DaoStateMonitoringService;
+import bisq.common.BisqException;
 import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.LanguageUtil;
 import bisq.core.locale.Res;
 import bisq.core.provider.price.MarketPrice;
 
-import bisq.common.BisqException;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.Version;
@@ -318,17 +318,15 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             }
         });
 
-        HBox primaryNav = new HBox(marketButton, getNavigationSeparator(), buyButton,
-                getNavigationSeparator(), sellButton, getNavigationSeparator(),
-                portfolioButtonWithBadge, getNavigationSeparator(), fundsButton);
+        HBox primaryNav = new HBox(marketButton, getNavigationSeparator(), buyButton, getNavigationSeparator(),
+                sellButton, getNavigationSeparator(), portfolioButtonWithBadge, getNavigationSeparator(), fundsButton);
 
-        primaryNav.setAlignment(Pos.CENTER);
+        primaryNav.setAlignment(Pos.CENTER_LEFT);
         primaryNav.getStyleClass().add("nav-primary");
         HBox.setHgrow(primaryNav, Priority.SOMETIMES);
 
-        HBox secondaryNav = new HBox(supportButtonWithBadge, getNavigationSeparator(),
-                settingsButton, getNavigationSeparator(), accountButtonWithBadge,
-                getNavigationSeparator(), daoButtonWithBadge);
+        HBox secondaryNav = new HBox(supportButtonWithBadge, getNavigationSpacer(), settingsButton,
+                getNavigationSpacer(), accountButtonWithBadge, getNavigationSpacer(), daoButtonWithBadge);
         secondaryNav.getStyleClass().add("nav-secondary");
         HBox.setHgrow(secondaryNav, Priority.SOMETIMES);
 
@@ -343,14 +341,14 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
         priceAndBalance.getStyleClass().add("nav-price-balance");
 
         HBox navPane = new HBox(primaryNav, secondaryNav,
-                getNavigationSpacer(), priceAndBalance) {{
+                priceAndBalance) {{
             setLeftAnchor(this, 0d);
             setRightAnchor(this, 0d);
             setTopAnchor(this, 0d);
             setPadding(new Insets(0, 0, 0, 0));
             getStyleClass().add("top-navigation");
         }};
-        navPane.setAlignment(Pos.CENTER_LEFT);
+        navPane.setAlignment(Pos.CENTER);
 
         AnchorPane contentContainer = new AnchorPane() {{
             getStyleClass().add("content-pane");

--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -524,8 +524,3 @@
 .jfx-date-picker .left-button, .jfx-date-picker .right-button{
     -fx-background-color: derive(-bs-color-gray-0, -10%);
 }
-
-
-.popup-bg, .notification-popup-bg, .peer-info-popup-bg {
-    -fx-effect: dropshadow(gaussian, -bs-color-gray-fafa, 44, 0, 0, 0);
-}


### PR DESCRIPTION
Reverts bisq-network/bisq#4398 due to breaking entire top GUI using Japanese language, possibly other languages affected as well?

<img width="1201" alt="Screen Shot 2020-08-29 at 18 07 49" src="https://user-images.githubusercontent.com/232186/91633450-4922e500-ea23-11ea-9605-923de0ab06c1.png">
