### PR TITLE
Add check for option trade

### DIFF
--- a/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
@@ -159,11 +159,13 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable implements 
         UserThread.runAfter(() -> {
             // We check every hour if we are in the target hour.
             UserThread.runPeriodically(() -> {
-                int currentHour = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("GMT0")).getHour();
+                int currentHour = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")).getHour();
                 if (currentHour == target) {
                     log.warn("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" +
-                            "Shut down node at hour {}" +
-                            "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n", target);
+                                    "Shut down node at hour {} (UTC time is {})" +
+                                    "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n",
+                            target,
+                            ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")).toString());
                     shutDown(gracefulShutDownHandler);
                 }
             }, TimeUnit.MINUTES.toSeconds(10));

--- a/core/src/main/java/bisq/core/monetary/Price.java
+++ b/core/src/main/java/bisq/core/monetary/Price.java
@@ -129,7 +129,9 @@ public class Price extends MonetaryWrapper implements Comparable<Price> {
     }
 
     public String toFriendlyString() {
-        return monetary instanceof Altcoin ? ((Altcoin) monetary).toFriendlyString() : ((Fiat) monetary).toFriendlyString();
+        return monetary instanceof Altcoin ?
+                ((Altcoin) monetary).toFriendlyString() + "/BTC" :
+                ((Fiat) monetary).toFriendlyString().replace(((Fiat) monetary).currencyCode, "") + "BTC/" + ((Fiat) monetary).currencyCode;
     }
 
     public String toPlainString() {

--- a/core/src/main/java/bisq/core/support/SupportManager.java
+++ b/core/src/main/java/bisq/core/support/SupportManager.java
@@ -62,10 +62,14 @@ public abstract class SupportManager {
 
         // We get first the message handler called then the onBootstrapped
         p2PService.addDecryptedDirectMessageListener((decryptedMessageWithPubKey, senderAddress) -> {
+            // As decryptedDirectMessageWithPubKeys is a CopyOnWriteArraySet we do not need to check if it was
+            // already stored
             decryptedDirectMessageWithPubKeys.add(decryptedMessageWithPubKey);
             tryApplyMessages();
         });
         p2PService.addDecryptedMailboxListener((decryptedMessageWithPubKey, senderAddress) -> {
+            // As decryptedMailboxMessageWithPubKeys is a CopyOnWriteArraySet we do not need to check if it was
+            // already stored
             decryptedMailboxMessageWithPubKeys.add(decryptedMessageWithPubKey);
             tryApplyMessages();
         });

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
@@ -28,6 +28,7 @@ import bisq.core.btc.wallet.WalletService;
 import bisq.core.locale.Res;
 import bisq.core.offer.OpenOffer;
 import bisq.core.offer.OpenOfferManager;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.DisputeManager;
@@ -88,9 +89,10 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
                               ClosedTradableManager closedTradableManager,
                               OpenOfferManager openOfferManager,
                               PubKeyRing pubKeyRing,
-                              ArbitrationDisputeListService arbitrationDisputeListService) {
+                              ArbitrationDisputeListService arbitrationDisputeListService,
+                              PriceFeedService priceFeedService) {
         super(p2PService, tradeWalletService, walletService, walletsSetup, tradeManager, closedTradableManager,
-                openOfferManager, pubKeyRing, arbitrationDisputeListService);
+                openOfferManager, pubKeyRing, arbitrationDisputeListService, priceFeedService);
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
@@ -165,6 +165,11 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
         return Res.get("support.youOpenedDispute", disputeInfo, Version.VERSION);
     }
 
+    @Override
+    protected void addPriceInfoMessage(Dispute dispute, int counter) {
+        // Arbitrator is not used anymore.
+    }
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Message handler
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -23,6 +23,7 @@ import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.locale.Res;
 import bisq.core.offer.OpenOffer;
 import bisq.core.offer.OpenOfferManager;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.DisputeManager;
@@ -80,9 +81,10 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
                             ClosedTradableManager closedTradableManager,
                             OpenOfferManager openOfferManager,
                             PubKeyRing pubKeyRing,
-                            MediationDisputeListService mediationDisputeListService) {
+                            MediationDisputeListService mediationDisputeListService,
+                            PriceFeedService priceFeedService) {
         super(p2PService, tradeWalletService, walletService, walletsSetup, tradeManager, closedTradableManager,
-                openOfferManager, pubKeyRing, mediationDisputeListService);
+                openOfferManager, pubKeyRing, mediationDisputeListService, priceFeedService);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -23,6 +23,7 @@ import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.locale.Res;
 import bisq.core.offer.OpenOffer;
 import bisq.core.offer.OpenOfferManager;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.DisputeManager;
@@ -74,9 +75,10 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
                          ClosedTradableManager closedTradableManager,
                          OpenOfferManager openOfferManager,
                          PubKeyRing pubKeyRing,
-                         RefundDisputeListService refundDisputeListService) {
+                         RefundDisputeListService refundDisputeListService,
+                         PriceFeedService priceFeedService) {
         super(p2PService, tradeWalletService, walletService, walletsSetup, tradeManager, closedTradableManager,
-                openOfferManager, pubKeyRing, refundDisputeListService);
+                openOfferManager, pubKeyRing, refundDisputeListService, priceFeedService);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -142,6 +142,14 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
         return Res.get("support.youOpenedDispute", disputeInfo, Version.VERSION);
     }
 
+    @Override
+    protected void addPriceInfoMessage(Dispute dispute, int counter) {
+        // At refund agent we do not add the option trade price check as the time for dispute opening is not correct.
+        // In case of an option trade the mediator adds to the result summary message automatically the system message
+        // with the option trade detection info so the refund agent can see that as well.
+    }
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Message handler
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1039,7 +1039,7 @@ support.youOpenedDisputeForMediation=You requested mediation.\n\n{0}\n\nBisq ver
 support.peerOpenedTicket=Your trading peer has requested support due to technical problems.\n\n{0}\n\nBisq version: {1}
 support.peerOpenedDispute=Your trading peer has requested a dispute.\n\n{0}\n\nBisq version: {1}
 support.peerOpenedDisputeForMediation=Your trading peer has requested mediation.\n\n{0}\n\nBisq version: {1}
-support.mediatorsDisputeSummary=System message:\nMediator''s dispute summary:\n{0}
+support.mediatorsDisputeSummary=System message: Mediator''s dispute summary:\n{0}
 support.mediatorsAddress=Mediator''s node address: {0}
 
 
@@ -2374,18 +2374,32 @@ disputeSummaryWindow.payoutAmount.buyer=Buyer's payout amount
 disputeSummaryWindow.payoutAmount.seller=Seller's payout amount
 disputeSummaryWindow.payoutAmount.invert=Use loser as publisher
 disputeSummaryWindow.reason=Reason of dispute
-disputeSummaryWindow.reason.bug=Bug
-disputeSummaryWindow.reason.usability=Usability
-disputeSummaryWindow.reason.protocolViolation=Protocol violation
-disputeSummaryWindow.reason.noReply=No reply
-disputeSummaryWindow.reason.scam=Scam
-disputeSummaryWindow.reason.other=Other
-disputeSummaryWindow.reason.bank=Bank
-disputeSummaryWindow.reason.optionTrade=Option trade
-disputeSummaryWindow.reason.sellerNotResponding=Seller not responding
-disputeSummaryWindow.reason.wrongSenderAccount=Wrong sender account
-disputeSummaryWindow.reason.peerWasLate=Peer was late
-disputeSummaryWindow.reason.tradeAlreadySettled=Trade already settled
+
+# dynamic values are not recognized by IntelliJ
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.BUG=Bug
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.USABILITY=Usability
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.PROTOCOL_VIOLATION=Protocol violation
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.NO_REPLY=No reply
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.SCAM=Scam
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.OTHER=Other
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.BANK_PROBLEMS=Bank
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.OPTION_TRADE=Option trade
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.SELLER_NOT_RESPONDING=Seller not responding
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.WRONG_SENDER_ACCOUNT=Wrong sender account
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.PEER_WAS_LATE=Peer was late
+# suppress inspection "UnusedProperty"
+disputeSummaryWindow.reason.TRADE_ALREADY_SETTLED=Trade already settled
 
 disputeSummaryWindow.summaryNotes=Summary notes
 disputeSummaryWindow.addSummaryNotes=Add summary notes
@@ -2394,7 +2408,8 @@ disputeSummaryWindow.close.msg=Ticket closed on {0}\n\n\
 Summary:\n\
 Payout amount for BTC buyer: {1}\n\
 Payout amount for BTC seller: {2}\n\n\
-Summary notes:\n{3}
+Reason for dispute: {3}\n\n\
+Summary notes:\n{4}
 disputeSummaryWindow.close.nextStepsForMediation=\n\nNext steps:\n\
 Open trade and accept or reject suggestion from mediator
 disputeSummaryWindow.close.nextStepsForRefundAgentArbitration=\n\nNext steps:\n\

--- a/core/src/test/java/bisq/core/monetary/PriceTest.java
+++ b/core/src/test/java/bisq/core/monetary/PriceTest.java
@@ -27,14 +27,14 @@ public class PriceTest {
         Price result = Price.parse("USD", "0.1");
         Assert.assertEquals(
                 "Fiat value should be formatted with two decimals.",
-                "0.10 USD",
+                "0.10 BTC/USD",
                 result.toFriendlyString()
         );
 
         result = Price.parse("EUR", "0.1234");
         Assert.assertEquals(
                 "Fiat value should be given two decimals",
-                "0.1234 EUR",
+                "0.1234 BTC/EUR",
                 result.toFriendlyString()
         );
 
@@ -57,19 +57,19 @@ public class PriceTest {
 
         Assert.assertEquals(
                 "Comma (',') as decimal separator should be converted to period ('.')",
-                "0.0001 USD",
+                "0.0001 BTC/USD",
                 Price.parse("USD", "0,0001").toFriendlyString()
         );
 
         Assert.assertEquals(
                 "Too many decimals should get rounded up properly.",
-                "10000.2346 LTC",
+                "10000.2346 LTC/BTC",
                 Price.parse("LTC", "10000,23456789").toFriendlyString()
         );
 
         Assert.assertEquals(
                 "Too many decimals should get rounded down properly.",
-                "10000.2345 LTC",
+                "10000.2345 LTC/BTC",
                 Price.parse("LTC", "10000,23454999").toFriendlyString()
         );
 
@@ -95,14 +95,14 @@ public class PriceTest {
         Price result = Price.valueOf("USD", 1);
         Assert.assertEquals(
                 "Fiat value should have four decimals.",
-                "0.0001 USD",
+                "0.0001 BTC/USD",
                 result.toFriendlyString()
         );
 
         result = Price.valueOf("EUR", 1234);
         Assert.assertEquals(
                 "Fiat value should be given two decimals",
-                "0.1234 EUR",
+                "0.1234 BTC/EUR",
                 result.toFriendlyString()
         );
 
@@ -114,13 +114,13 @@ public class PriceTest {
 
         Assert.assertEquals(
                 "Too many decimals should get rounded up properly.",
-                "10000.2346 LTC",
+                "10000.2346 LTC/BTC",
                 Price.valueOf("LTC", 1000023456789L).toFriendlyString()
         );
 
         Assert.assertEquals(
                 "Too many decimals should get rounded down properly.",
-                "10000.2345 LTC",
+                "10000.2345 LTC/BTC",
                 Price.valueOf("LTC", 1000023454999L).toFriendlyString()
         );
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -486,18 +486,18 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
     }
 
     private void addReasonControls() {
-        reasonWasBugRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.bug"));
-        reasonWasUsabilityIssueRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.usability"));
-        reasonProtocolViolationRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.protocolViolation"));
-        reasonNoReplyRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.noReply"));
-        reasonWasScamRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.scam"));
-        reasonWasBankRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.bank"));
-        reasonWasOtherRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.other"));
-        reasonWasOptionTradeRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.optionTrade"));
-        reasonWasSellerNotRespondingRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.sellerNotResponding"));
-        reasonWasWrongSenderAccountRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.wrongSenderAccount"));
-        reasonWasPeerWasLateRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.peerWasLate"));
-        reasonWasTradeAlreadySettledRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason.tradeAlreadySettled"));
+        reasonWasBugRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.BUG.name()));
+        reasonWasUsabilityIssueRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.USABILITY.name()));
+        reasonProtocolViolationRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.PROTOCOL_VIOLATION.name()));
+        reasonNoReplyRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.NO_REPLY.name()));
+        reasonWasScamRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.SCAM.name()));
+        reasonWasBankRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.BANK_PROBLEMS.name()));
+        reasonWasOtherRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.OTHER.name()));
+        reasonWasOptionTradeRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.OPTION_TRADE.name()));
+        reasonWasSellerNotRespondingRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.SELLER_NOT_RESPONDING.name()));
+        reasonWasWrongSenderAccountRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.WRONG_SENDER_ACCOUNT.name()));
+        reasonWasPeerWasLateRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.PEER_WAS_LATE.name()));
+        reasonWasTradeAlreadySettledRadioButton = new AutoTooltipRadioButton(Res.get("disputeSummaryWindow.reason." + DisputeResult.Reason.TRADE_ALREADY_SETTLED.name()));
 
         HBox feeRadioButtonPane = new HBox();
         feeRadioButtonPane.setSpacing(20);
@@ -745,11 +745,19 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         disputeResult.setCloseDate(new Date());
         dispute.setDisputeResult(disputeResult);
         dispute.setIsClosed(true);
+        DisputeResult.Reason reason = disputeResult.getReason();
         String text = Res.get("disputeSummaryWindow.close.msg",
                 DisplayUtils.formatDateTime(disputeResult.getCloseDate()),
                 formatter.formatCoinWithCode(disputeResult.getBuyerPayoutAmount()),
                 formatter.formatCoinWithCode(disputeResult.getSellerPayoutAmount()),
+                Res.get("disputeSummaryWindow.reason." + reason.name()),
                 disputeResult.summaryNotesProperty().get());
+
+        if (reason == DisputeResult.Reason.OPTION_TRADE &&
+                dispute.getChatMessages().size() > 1 &&
+                dispute.getChatMessages().get(1).isSystemMessage()) {
+            text += "\n\n" + dispute.getChatMessages().get(1).getMessage();
+        }
 
         if (dispute.getSupportType() == SupportType.MEDIATION) {
             text += Res.get("disputeSummaryWindow.close.nextStepsForMediation");


### PR DESCRIPTION
Show message as below to mediators.

Reufnd agent receives option trade info in case the mediator has closed it with reason option trade as part of the result summary (also visible to traders).

Add reason for dispute to summary.

If price is not available (e.g. BSQ) no message gets added. If price feed is not ready we try 3 times with 10 sec. delays before we give up.

Option trade: 
<img width="1187" alt="Screen Shot 2020-08-29 at 18 01 13" src="https://user-images.githubusercontent.com/54558767/91647560-ae75d680-ea21-11ea-9c9a-42fc13b73073.png">

No option trade:
<img width="1149" alt="Screen Shot 2020-08-29 at 18 01 59" src="https://user-images.githubusercontent.com/54558767/91647566-c188a680-ea21-11ea-8045-74c060477ea8.png">
