### PR TITLE
Add support for user name for Revolut accounts

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
@@ -96,6 +96,7 @@ public class BisqHeadlessApp implements HeadlessApp {
         bisqSetup.setVoteResultExceptionHandler(voteResultException -> log.warn("voteResultException={}", voteResultException.toString()));
         bisqSetup.setRejectedTxErrorMessageHandler(errorMessage -> log.warn("setRejectedTxErrorMessageHandler. errorMessage={}", errorMessage));
         bisqSetup.setShowPopupIfInvalidBtcConfigHandler(() -> log.error("onShowPopupIfInvalidBtcConfigHandler"));
+        bisqSetup.setRevolutAccountsUpdateHandler(revolutAccountList -> log.info("setRevolutAccountsUpdateHandler: revolutAccountList={}", revolutAccountList));
 
         //TODO move to bisqSetup
         corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> log.warn("getCorruptedDatabaseFiles. files={}", files));

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -44,6 +44,7 @@ import bisq.core.notifications.alerts.market.MarketAlerts;
 import bisq.core.notifications.alerts.price.PriceAlert;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.RevolutAccount;
 import bisq.core.payment.TradeLimits;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.fee.FeeService;
@@ -221,6 +222,9 @@ public class BisqSetup {
     @Setter
     @Nullable
     private Runnable showPopupIfInvalidBtcConfigHandler;
+    @Setter
+    @Nullable
+    private Consumer<List<RevolutAccount>> revolutAccountsUpdateHandler;
 
     @Getter
     final BooleanProperty newVersionAvailableProperty = new SimpleBooleanProperty(false);
@@ -823,6 +827,8 @@ public class BisqSetup {
         disputeMsgEvents.onAllServicesInitialized();
         priceAlert.onAllServicesInitialized();
         marketAlerts.onAllServicesInitialized();
+
+        user.onAllServicesInitialized(revolutAccountsUpdateHandler);
 
         allBasicServicesInitialized = true;
     }

--- a/core/src/main/java/bisq/core/payment/RevolutAccount.java
+++ b/core/src/main/java/bisq/core/payment/RevolutAccount.java
@@ -36,11 +36,15 @@ public final class RevolutAccount extends PaymentAccount {
         return new RevolutAccountPayload(paymentMethod.getId(), id);
     }
 
-    public void setAccountId(String accountId) {
-        ((RevolutAccountPayload) paymentAccountPayload).setAccountId(accountId);
+    public void setUserName(String userName) {
+        ((RevolutAccountPayload) paymentAccountPayload).setUserName(userName);
     }
 
-    public String getAccountId() {
-        return ((RevolutAccountPayload) paymentAccountPayload).getAccountId();
+    public String getUserName() {
+        return ((RevolutAccountPayload) paymentAccountPayload).getUserName();
+    }
+
+    public boolean userNameNotSet() {
+        return ((RevolutAccountPayload) paymentAccountPayload).userNameNotSet();
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
@@ -19,26 +19,36 @@ package bisq.core.payment.payload;
 
 import bisq.core.locale.Res;
 
+import bisq.common.proto.ProtoUtil;
+
 import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
+
 @EqualsAndHashCode(callSuper = true)
 @ToString
-@Setter
-@Getter
 @Slf4j
 public final class RevolutAccountPayload extends PaymentAccountPayload {
-    private String accountId = "";
+    // Not used anymore from outside. Only used as internal Id to not break existing account witness objects
+    private String accountId = null;
+
+    // Was added in 1.3.8
+    // To not break signed accounts we keep accountId as internal id used for signing.
+    // Old accounts get a popup to add the new required field userName but accountId is
+    // left unchanged. Newly created accounts fill accountId with the value of userName.
+    // In the UI we only use userName.
+    @Nullable
+    private String userName = null;
 
     public RevolutAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
@@ -52,6 +62,7 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
     private RevolutAccountPayload(String paymentMethod,
                                   String id,
                                   String accountId,
+                                  @Nullable String userName,
                                   long maxTradePeriod,
                                   Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
@@ -60,20 +71,23 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
                 excludeFromJsonDataMap);
 
         this.accountId = accountId;
+        this.userName = userName;
     }
 
     @Override
     public Message toProtoMessage() {
-        return getPaymentAccountPayloadBuilder()
-                .setRevolutAccountPayload(protobuf.RevolutAccountPayload.newBuilder()
-                        .setAccountId(accountId))
-                .build();
+        protobuf.RevolutAccountPayload.Builder revolutBuilder = protobuf.RevolutAccountPayload.newBuilder().setAccountId(accountId);
+        Optional.ofNullable(userName).ifPresent(revolutBuilder::setUserName);
+        return getPaymentAccountPayloadBuilder().setRevolutAccountPayload(revolutBuilder).build();
     }
 
+
     public static RevolutAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
+        protobuf.RevolutAccountPayload revolutAccountPayload = proto.getRevolutAccountPayload();
         return new RevolutAccountPayload(proto.getPaymentMethodId(),
                 proto.getId(),
-                proto.getRevolutAccountPayload().getAccountId(),
+                revolutAccountPayload.getAccountId(),
+                ProtoUtil.stringOrNullFromProto(revolutAccountPayload.getUserName()),
                 proto.getMaxTradePeriod(),
                 new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
@@ -85,7 +99,7 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account") + " " + accountId;
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.userName") + " " + userName;
     }
 
     @Override
@@ -95,6 +109,26 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(accountId.getBytes(StandardCharsets.UTF_8));
+        // getAgeWitnessInputData is called at new account creation when accountId is null, we use empty string as
+        // it has been the case before
+        String input = this.accountId == null ? "" : this.accountId;
+        return super.getAgeWitnessInputData(input.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public void setUserName(@Nullable String userName) {
+        this.userName = userName;
+        // We only set accountId to userName for new accounts. Existing accounts have accountId set with email
+        // or phone nr. and we keep that to not break account signing.
+        if (accountId == null) {
+            accountId = userName;
+        }
+    }
+
+    public String getUserName() {
+        return userName != null ? userName : accountId;
+    }
+
+    public boolean userNameNotSet() {
+        return userName == null;
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
 @Slf4j
 public final class RevolutAccountPayload extends PaymentAccountPayload {
     // Not used anymore from outside. Only used as internal Id to not break existing account witness objects
-    private String accountId = null;
+    private String accountId = "";
 
     // Was added in 1.3.8
     // To not break signed accounts we keep accountId as internal id used for signing.
@@ -76,7 +76,8 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
 
     @Override
     public Message toProtoMessage() {
-        protobuf.RevolutAccountPayload.Builder revolutBuilder = protobuf.RevolutAccountPayload.newBuilder().setAccountId(accountId);
+        protobuf.RevolutAccountPayload.Builder revolutBuilder = protobuf.RevolutAccountPayload.newBuilder()
+                .setAccountId(accountId);
         Optional.ofNullable(userName).ifPresent(revolutBuilder::setUserName);
         return getPaymentAccountPayloadBuilder().setRevolutAccountPayload(revolutBuilder).build();
     }
@@ -99,7 +100,7 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.userName") + " " + userName;
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account.userName") + " " + getUserName();
     }
 
     @Override
@@ -109,17 +110,15 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        // getAgeWitnessInputData is called at new account creation when accountId is null, we use empty string as
-        // it has been the case before
-        String input = this.accountId == null ? "" : this.accountId;
-        return super.getAgeWitnessInputData(input.getBytes(StandardCharsets.UTF_8));
+        // getAgeWitnessInputData is called at new account creation when accountId is empty string.
+        return super.getAgeWitnessInputData(accountId.getBytes(StandardCharsets.UTF_8));
     }
 
     public void setUserName(@Nullable String userName) {
         this.userName = userName;
         // We only set accountId to userName for new accounts. Existing accounts have accountId set with email
         // or phone nr. and we keep that to not break account signing.
-        if (accountId == null) {
+        if (accountId.isEmpty()) {
             accountId = userName;
         }
     }

--- a/core/src/main/java/bisq/core/user/User.java
+++ b/core/src/main/java/bisq/core/user/User.java
@@ -24,6 +24,7 @@ import bisq.core.locale.TradeCurrency;
 import bisq.core.notifications.alerts.market.MarketAlertFilter;
 import bisq.core.notifications.alerts.price.PriceAlertFilter;
 import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.RevolutAccount;
 import bisq.core.support.dispute.arbitration.arbitrator.Arbitrator;
 import bisq.core.support.dispute.mediation.mediator.Mediator;
 import bisq.core.support.dispute.refund.refundagent.RefundAgent;
@@ -50,6 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
@@ -125,6 +127,16 @@ public class User implements PersistedDataHost {
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public void onAllServicesInitialized(@Nullable Consumer<List<RevolutAccount>> resultHandler) {
+        if (resultHandler != null) {
+            resultHandler.accept(paymentAccountsAsObservable.stream()
+                    .filter(paymentAccount -> paymentAccount instanceof RevolutAccount)
+                    .map(paymentAccount -> (RevolutAccount) paymentAccount)
+                    .filter(RevolutAccount::userNameNotSet)
+                    .collect(Collectors.toList()));
+        }
+    }
 
     @Nullable
     public Arbitrator getAcceptedArbitratorByAddress(NodeAddress nodeAddress) {

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2987,6 +2987,7 @@ seed.restore.error=An error occurred when restoring the wallets with seed words.
 payment.account=Account
 payment.account.no=Account no.
 payment.account.name=Account name
+payment.account.userName=User name
 payment.account.owner=Account owner full name
 payment.account.fullName=Full name (first, middle, last)
 payment.account.state=State/Province/Region
@@ -3021,8 +3022,6 @@ payment.cashApp.cashTag=$Cashtag
 payment.moneyBeam.accountId=Email or phone no.
 payment.venmo.venmoUserName=Venmo username
 payment.popmoney.accountId=Email or phone no.
-payment.revolut.email=Email
-payment.revolut.phoneNr=Registered phone no.
 payment.promptPay.promptPayId=Citizen ID/Tax ID or phone no.
 payment.supportedCurrencies=Supported currencies
 payment.limitations=Limitations
@@ -3126,8 +3125,12 @@ payment.limits.info.withSigning=To limit chargeback risk, Bisq sets per-trade li
 payment.cashDeposit.info=Please confirm your bank allows you to send cash deposits into other peoples' accounts. \
   For example, Bank of America and Wells Fargo no longer allow such deposits.
 
-payment.revolut.info=Please be sure that the phone number you used for your Revolut account is registered at Revolut \
-  otherwise the BTC buyer cannot send you the funds.
+payment.revolut.info=Revolut requires the 'User name' as account ID not the phone number or email as it was the case in the past.
+payment.account.revolut.addUserNameInfo={0}\n\
+  Your existing Revolut account ({1}) does not has set the ''User name''.\n\
+  Please enter your Revolut ''User name'' to update your account data.\n\
+  This will not affect your account age signing status.
+payment.revolut.addUserNameInfo.headLine=Update Revolut account
 
 payment.usPostalMoneyOrder.info=Trading using US Postal Money Orders (USPMO) on Bisq requires that you understand the following:\n\
 \n\

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -28,6 +28,7 @@ import bisq.desktop.main.overlays.windows.DisplayAlertMessageWindow;
 import bisq.desktop.main.overlays.windows.NewTradeProtocolLaunchWindow;
 import bisq.desktop.main.overlays.windows.TacWindow;
 import bisq.desktop.main.overlays.windows.TorNetworkSettingsWindow;
+import bisq.desktop.main.overlays.windows.UpdateRevolutAccountWindow;
 import bisq.desktop.main.overlays.windows.WalletPasswordWindow;
 import bisq.desktop.main.overlays.windows.downloadupdate.DisplayUpdateDownloadWindow;
 import bisq.desktop.main.presentation.AccountPresentation;
@@ -49,6 +50,7 @@ import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.payment.AliPayAccount;
 import bisq.core.payment.CryptoCurrencyAccount;
+import bisq.core.payment.RevolutAccount;
 import bisq.core.presentation.BalancePresentation;
 import bisq.core.presentation.SupportTicketsPresentation;
 import bisq.core.presentation.TradePresentation;
@@ -87,12 +89,15 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -300,10 +305,11 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                         .useReportBugButton()
                         .show()));
         bisqSetup.setDisplayTorNetworkSettingsHandler(show -> {
-            if (show)
+            if (show) {
                 torNetworkSettingsWindow.show();
-            else
+            } else if (torNetworkSettingsWindow.isDisplayed()) {
                 torNetworkSettingsWindow.hide();
+            }
         });
         bisqSetup.setSpvFileCorruptedHandler(msg -> new Popup().warning(msg)
                 .actionButtonText(Res.get("settings.net.reSyncSPVChainButton"))
@@ -374,6 +380,12 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
 
         bisqSetup.setShowPopupIfInvalidBtcConfigHandler(this::showPopupIfInvalidBtcConfig);
 
+        bisqSetup.setRevolutAccountsUpdateHandler(revolutAccountList -> {
+            // We copy the array as we will mutate it later
+            showRevolutAccountUpdateWindow(new ArrayList<>(revolutAccountList));
+        });
+
+
         corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> new Popup()
                 .warning(Res.get("popup.warning.incompatibleDB", files.toString(), config.appDataDir))
                 .useShutDownButton()
@@ -401,6 +413,17 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         daoPresentation.getBsqSyncProgress().addListener((observable, oldValue, newValue) -> updateBtcSyncProgress());
 
         bisqSetup.setFilterWarningHandler(warning -> new Popup().warning(warning).show());
+    }
+
+    private void showRevolutAccountUpdateWindow(List<RevolutAccount> revolutAccountList) {
+        if (!revolutAccountList.isEmpty()) {
+            RevolutAccount revolutAccount = revolutAccountList.get(0);
+            revolutAccountList.remove(0);
+            new UpdateRevolutAccountWindow(revolutAccount, user).onClose(() -> {
+                // We delay a bit in case we have multiple account for better UX
+                UserThread.runAfter(() -> showRevolutAccountUpdateWindow(revolutAccountList), 300, TimeUnit.MILLISECONDS);
+            }).show();
+        }
     }
 
     private void setupP2PNumPeersWatcher() {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/UpdateRevolutAccountWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/UpdateRevolutAccountWindow.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.overlays.windows;
+
+import bisq.desktop.components.InputTextField;
+import bisq.desktop.main.overlays.Overlay;
+import bisq.desktop.util.Layout;
+import bisq.desktop.util.validation.RevolutValidator;
+
+import bisq.core.locale.Res;
+import bisq.core.payment.RevolutAccount;
+import bisq.core.user.User;
+
+import javafx.scene.Scene;
+
+import static bisq.desktop.util.FormBuilder.addInputTextField;
+import static bisq.desktop.util.FormBuilder.addLabel;
+
+public class UpdateRevolutAccountWindow extends Overlay<UpdateRevolutAccountWindow> {
+    private final RevolutValidator revolutValidator;
+    private final RevolutAccount revolutAccount;
+    private final User user;
+    private InputTextField userNameInputTextField;
+
+    public UpdateRevolutAccountWindow(RevolutAccount revolutAccount, User user) {
+        super();
+        this.revolutAccount = revolutAccount;
+        this.user = user;
+        type = Type.Attention;
+        hideCloseButton = true;
+        revolutValidator = new RevolutValidator();
+        actionButtonText = Res.get("shared.save");
+    }
+
+    @Override
+    protected void setupKeyHandler(Scene scene) {
+        // We do not support enter or escape here
+    }
+
+    @Override
+    public void show() {
+        if (headLine == null)
+            headLine = Res.get("payment.revolut.addUserNameInfo.headLine");
+
+        width = 868;
+        createGridPane();
+        addHeadLine();
+        addContent();
+        addButtons();
+        applyStyles();
+        display();
+    }
+
+    private void addContent() {
+        addLabel(gridPane, ++rowIndex, Res.get("payment.account.revolut.addUserNameInfo", Res.get("payment.revolut.info"), revolutAccount.getAccountName()));
+        userNameInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("payment.account.userName"), Layout.COMPACT_FIRST_ROW_DISTANCE);
+        userNameInputTextField.setValidator(revolutValidator);
+        userNameInputTextField.textProperty().addListener((observable, oldValue, newValue) ->
+                actionButton.setDisable(!revolutValidator.validate(newValue).isValid));
+    }
+
+    @Override
+    protected void addButtons() {
+        super.addButtons();
+
+        // We do not allow close in case the userName is not correctly added so we
+        // overwrote the default handler
+        actionButton.setOnAction(event -> {
+            String userName = userNameInputTextField.getText();
+            if (revolutValidator.validate(userName).isValid) {
+                revolutAccount.setUserName(userName);
+                user.persist();
+                closeHandlerOptional.ifPresent(Runnable::run);
+                hide();
+            }
+        });
+        actionButton.setDisable(true);
+    }
+
+}
+

--- a/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
@@ -20,6 +20,10 @@ package bisq.desktop.util.validation;
 public final class RevolutValidator extends LengthValidator {
     public RevolutValidator() {
         // Not sure what are requirements for Revolut user names
+        // Please keep in mind that even we force users to set user name at startup we should handle also the case
+        // that the old accountID as phone number or email is displayed at the username text field and we do not
+        // want to break validation in those cases. So being too strict on the validators might cause more troubles
+        // as its worth...
         super(5, 100);
     }
 

--- a/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
@@ -17,10 +17,13 @@
 
 package bisq.desktop.util.validation;
 
-public final class RevolutValidator extends PhoneNumberValidator {
+public final class RevolutValidator extends LengthValidator {
+    public RevolutValidator() {
+        // Not sure what are requirements for Revolut user names
+        super(5, 100);
+    }
 
-    public ValidationResult validate(String input, String code) {
-        super.setIsoCountryCode(code);
+    public ValidationResult validate(String input) {
         return super.validate(input);
     }
 

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1085,6 +1085,7 @@ message PopmoneyAccountPayload {
 
 message RevolutAccountPayload {
     string account_id = 1;
+    string user_name = 2;
 }
 
 message PerfectMoneyAccountPayload {


### PR DESCRIPTION
If a user has an existing account with phone number or email as
account ID we show a popup at startup where we require that he sets the
user name. This popup has no close button so he is forced to enter a
value. If there are multiple account multiple popups will be shown.

To not break signed accounts we keep accountId as internal id used for signing.
Old accounts get a popup to add the new required field userName but accountId is
left unchanged. Newly created accounts fill accountId with the value of userName.
In the UI we only use userName.

Input validation does only check for length (5-100 chars). Not sure what
are the requirements at Revolut. Can be changes easily if anyone gets
the specs.