### PR TITLE
Make CoreApi a singleton

### DIFF
--- a/common/src/main/java/bisq/common/config/CompositeOptionSet.java
+++ b/common/src/main/java/bisq/common/config/CompositeOptionSet.java
@@ -4,6 +4,8 @@ import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,6 +19,7 @@ import java.util.List;
  * the command line with those provided via config file, such that those provided at the
  * command line take precedence over those provided in the config file.
  */
+@VisibleForTesting
 public class CompositeOptionSet {
 
     private final List<OptionSet> optionSets = new ArrayList<>();

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -31,6 +31,7 @@ import bisq.common.app.Version;
 import org.bitcoinj.core.Coin;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
  * Provides high level interface to functionality of core Bisq features.
  * E.g. useful for different APIs to access data of different domains of Bisq.
  */
+@Singleton
 @Slf4j
 public class CoreApi {
 

--- a/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
@@ -62,7 +62,6 @@ public class BisqAppMain extends BisqExecutable {
         log.debug("onSetupComplete");
     }
 
-
     ///////////////////////////////////////////////////////////////////////////////////////////
     // First synchronous execution tasks
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -86,7 +85,6 @@ public class BisqAppMain extends BisqExecutable {
 
         Application.launch(BisqApp.class);
     }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // As application is a JavaFX application we need to wait for onApplicationLaunched
@@ -123,21 +121,13 @@ public class BisqAppMain extends BisqExecutable {
 
     @Override
     protected void startApplication() {
-        // We need to be in user thread! We mapped at launchApplication already...
-
-        // Once the UI is ready we get onApplicationStarted called and start the setup there
+        // We need to be in user thread! We mapped at launchApplication already.  Once
+        // the UI is ready we get onApplicationStarted called and start the setup there.
         application.startApplication(this::onApplicationStarted);
     }
 
     @Override
     protected void onApplicationStarted() {
         super.onApplicationStarted();
-
-        /*
-        if (runWithGrpcApi()) {
-            CoreApi coreApi = injector.getInstance(CoreApi.class);
-            bisqGrpcServer = new BisqGrpcServer(coreApi);
-        }
-        */
     }
 }


### PR DESCRIPTION
This PR ensures a daemon never creates more than one `CoreApi` instance, but two additional, minor changes are included:

 * Add `@VisibleForTesting` annotation to `CompositeOptionSet` to explain why it is no longer package protected.

 *  Remove commented code from `BisqAppMain`.
