### PR TITLE
Use InetAddress.getLoopbackAddress instead of InetAddress.getLocalHost()

### DIFF
--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -61,7 +61,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.net.UnknownHostException;
 
 import java.nio.channels.FileLock;
 
@@ -482,14 +481,7 @@ public class WalletConfig extends AbstractIdleService {
     }
 
     void setPeerNodesForLocalHost() {
-        try {
-            setPeerNodes(new PeerAddress(InetAddress.getLocalHost(), params.getPort()));
-        } catch (UnknownHostException e) {
-            log.error(e.toString());
-            e.printStackTrace();
-            // Borked machine with no loopback adapter configured properly.
-            throw new RuntimeException(e);
-        }
+        setPeerNodes(new PeerAddress(InetAddress.getLoopbackAddress(), params.getPort()));
     }
 
     private Wallet createOrLoadWallet(File walletFile,


### PR DESCRIPTION
On OSX InetAddress.getLocalHost() can cause problems. On my machine I
get a 5 sec. delay at each start up in localhost mode. The
InetAddress.getLoopbackAddress call is super fast.

Both versions connect to my local btc node, but not sure what can be
the differences if local environment is configured differently as
default. But as those issues with very slow getLocalHost lookup seems
to be more risky I would recommend that we change it.

It only affects localhost regtest mode and users who have a local btc
node running. The detection code for that is using getLoopbackAddress
as well.
See: https://github.com/bisq-network/bisq/pull/4373/commits/a5cca0ee1e63089b9a5a0d8b2793e31006499288
