### PR TITLE
Fix bug with all mobile notifications for disputes are sent at startup.

### DIFF
--- a/core/src/main/java/bisq/core/support/messages/ChatMessage.java
+++ b/core/src/main/java/bisq/core/support/messages/ChatMessage.java
@@ -351,8 +351,7 @@ public final class ChatMessage extends SupportMessage {
     @Override
     public String toString() {
         return "ChatMessage{" +
-                "\n     type='" + supportType + '\'' +
-                ",\n     tradeId='" + tradeId + '\'' +
+                "\n     tradeId='" + tradeId + '\'' +
                 ",\n     traderId=" + traderId +
                 ",\n     senderIsTrader=" + senderIsTrader +
                 ",\n     message='" + message + '\'' +
@@ -360,10 +359,9 @@ public final class ChatMessage extends SupportMessage {
                 ",\n     senderNodeAddress=" + senderNodeAddress +
                 ",\n     date=" + date +
                 ",\n     isSystemMessage=" + isSystemMessage +
+                ",\n     wasDisplayed=" + wasDisplayed +
                 ",\n     arrivedProperty=" + arrivedProperty +
                 ",\n     storedInMailboxProperty=" + storedInMailboxProperty +
-                ",\n     ChatMessage.uid='" + uid + '\'' +
-                ",\n     messageVersion=" + messageVersion +
                 ",\n     acknowledgedProperty=" + acknowledgedProperty +
                 ",\n     sendMessageErrorProperty=" + sendMessageErrorProperty +
                 ",\n     ackErrorProperty=" + ackErrorProperty +

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -231,7 +231,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         if (DevEnv.isDevMode()) {
             UserThread.runAfter(() -> {
                 amount.set("0.001");
-                price.set("0.0001"); // for BSQ
+                price.set("0.008");
                 minAmount.set(amount.get());
                 onFocusOutPriceAsPercentageTextField(true, false);
                 applyMakerFee();


### PR DESCRIPTION
Before: 
If mobile notifications have been set up at startup for each dispute there was sent a notification.

Now:
Only new mailbox messages trigger a notification at startup.

Any new dispute message triggers a notification as well.