### PR TITLE
Improve handling of p2pNetworkAndWalletReady

### DIFF
--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
@@ -148,10 +148,6 @@ public class XmrTxProofService implements AssetTxProofService {
 
     @Override
     public void shutDown() {
-        if (p2pNetworkAndWalletReady != null) {
-            p2pNetworkAndWalletReady.removeListener(p2pNetworkAndWalletReadyListener);
-        }
-
         servicesByTradeId.values().forEach(XmrTxProofRequestsPerTrade::terminate);
         servicesByTradeId.clear();
     }
@@ -162,6 +158,12 @@ public class XmrTxProofService implements AssetTxProofService {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void onP2pNetworkAndWalletReady() {
+        if (p2pNetworkAndWalletReady != null) {
+            p2pNetworkAndWalletReady.removeListener(p2pNetworkAndWalletReadyListener);
+            p2pNetworkAndWalletReady = null;
+            p2pNetworkAndWalletReadyListener = null;
+        }
+
         if (!preferences.findAutoConfirmSettings("XMR").isPresent()) {
             log.error("AutoConfirmSettings is not present");
         }


### PR DESCRIPTION
The p2pNetworkAndWalletReady MonadicBinding might be removed from GC
if its a local variable. I observed that in BisqSetup with a similar
setup. It might be an implementation weakness in MonadicBinding
(usage of weak references?). A tester reported that he does not see any
result, which might be cause that the service never gets the
onP2pNetworkAndWalletReady triggered if the MonadicBinding is not there
anymore.
By removing the listener we need at shutdown we need it anyway as class
field (so codacy does not complain anymore). As well added a check if
all is already complete to skip the MonadicBinding at all
(not expected case in onAllServicesInitialized).
