### PR TITLE
Remove 'monero:' prefix when adding a XMR account

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
@@ -38,6 +38,7 @@ import bisq.core.payment.validation.AltCoinAddressValidator;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.InputValidator;
 
+import bisq.common.UserThread;
 import bisq.common.util.Tuple3;
 
 import org.apache.commons.lang3.StringUtils;
@@ -123,6 +124,13 @@ public class AssetsForm extends PaymentMethodForm {
         addressInputTextField.setValidator(altCoinAddressValidator);
 
         addressInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            if (newValue.startsWith("monero:")) {
+                UserThread.execute(() -> {
+                    String addressWithoutPrefix = newValue.replace("monero:", "");
+                    addressInputTextField.setText(addressWithoutPrefix);
+                });
+                return;
+            }
             assetAccount.setAddress(newValue);
             updateFromInputs();
         });


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/4477

Some wallets copy the address with a 'monero:' prefix. If user pastes
that directly into the form he gets a validation error. We remove now
that prefix so the input is automatically adjusted to the address only.

Not sure if that can make it into 1.3.8 as the PR is not a bugfix, bu tI guess its such a small issues that we might allow to break the rule ;-). But anyway also not that important to delay to 1.3.9....