### PR TITLE
Add note to SetXmrTxKeyWindow

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2551,8 +2551,9 @@ showWalletDataWindow.walletData=Wallet data
 showWalletDataWindow.includePrivKeys=Include private keys
 
 setXMRTxKeyWindow.headline=Prove sending of XMR
-setXMRTxKeyWindow.txHash=Transaction ID
-setXMRTxKeyWindow.txKey=Transaction key
+setXMRTxKeyWindow.note=Adding tx info below enables auto-confirm for quicker trades. See more: https://bisq.wiki/Trading_Monero
+setXMRTxKeyWindow.txHash=Transaction ID (optional)
+setXMRTxKeyWindow.txKey=Transaction key (optional)
 
 # We do not translate the tac because of the legal nature. We would need translations checked by lawyers
 # in each language which is too expensive atm.

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SetXmrTxKeyWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SetXmrTxKeyWindow.java
@@ -36,6 +36,7 @@ import lombok.Getter;
 import javax.annotation.Nullable;
 
 import static bisq.common.app.DevEnv.isDevMode;
+import static bisq.desktop.util.FormBuilder.addMultilineLabel;
 import static bisq.desktop.util.FormBuilder.addInputTextField;
 import static javafx.beans.binding.Bindings.createBooleanBinding;
 
@@ -114,6 +115,7 @@ public class SetXmrTxKeyWindow extends Overlay<SetXmrTxKeyWindow> {
     }
 
     private void addContent() {
+        addMultilineLabel(gridPane, ++rowIndex, Res.get("setXMRTxKeyWindow.note"), 0);
         txHashInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("setXMRTxKeyWindow.txHash"), 10);
         txKeyInputTextField = addInputTextField(gridPane, ++rowIndex, Res.get("setXMRTxKeyWindow.txKey"));
     }


### PR DESCRIPTION
This PR adds a small note on the SetXmrTxKeyWindow about auto-confirm, and it makes clear that the inputs for tx info are optional.

**Before:**

![Screenshot from 2020-09-07 11-43-56](https://user-images.githubusercontent.com/735155/92403451-ffbc4f00-f120-11ea-8878-122505d5648f.png)

**After:**

![Screenshot from 2020-09-07 11-33-13](https://user-images.githubusercontent.com/735155/92403194-74db5480-f120-11ea-8a22-2f02b26e19fc.png)