### PR TITLE
Xmr tool bugfix: Ignore future results after terminal result

### DIFF
--- a/core/src/main/java/bisq/core/trade/txproof/AssetTxProofResult.java
+++ b/core/src/main/java/bisq/core/trade/txproof/AssetTxProofResult.java
@@ -40,6 +40,11 @@ public enum AssetTxProofResult {
     // Any service failed. Might be that the tx is invalid.
     FAILED;
 
+    // If isTerminal is set it means that we stop the service
+    @Getter
+    private final boolean isTerminal;
+    @Getter
+    private String details = "";
     @Getter
     private int numSuccessResults;
     @Getter
@@ -48,11 +53,7 @@ public enum AssetTxProofResult {
     private int numConfirmations;
     @Getter
     private int numRequiredConfirmations;
-    @Getter
-    private String details = "";
-    // If isTerminal is set it means that we stop the service
-    @Getter
-    private final boolean isTerminal;
+
 
     AssetTxProofResult() {
         this(true);
@@ -91,11 +92,12 @@ public enum AssetTxProofResult {
     @Override
     public String toString() {
         return "AssetTxProofResult{" +
-                "\n     numSuccessResults=" + numSuccessResults +
-                ",\n     requiredSuccessResults=" + numRequiredSuccessResults +
+                "\n     details='" + details + '\'' +
+                ",\n     isTerminal=" + isTerminal +
+                ",\n     numSuccessResults=" + numSuccessResults +
+                ",\n     numRequiredSuccessResults=" + numRequiredSuccessResults +
                 ",\n     numConfirmations=" + numConfirmations +
                 ",\n     numRequiredConfirmations=" + numRequiredConfirmations +
-                ",\n     details='" + details + '\'' +
                 "\n} " + super.toString();
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -596,9 +596,9 @@ portfolio.pending.autoConf.state.PENDING=Success results: {0}/{1}; {2}
 # suppress inspection "UnusedProperty"
 portfolio.pending.autoConf.state.COMPLETED=Proof at all services succeeded
 # suppress inspection "UnusedProperty"
-portfolio.pending.autoConf.state.ERROR=An error at a service request occurred.
+portfolio.pending.autoConf.state.ERROR=An error at a service request occurred. No auto-confirm possible.
 # suppress inspection "UnusedProperty"
-portfolio.pending.autoConf.state.FAILED=A service returned with a failure.
+portfolio.pending.autoConf.state.FAILED=A service returned with a failure. No auto-confirm possible.
 
 portfolio.pending.step1.info=Deposit transaction has been published.\n{0} need to wait for at least one blockchain confirmation before starting the payment.
 portfolio.pending.step1.warn=The deposit transaction is still not confirmed. This sometimes happens in rare cases when the funding fee of one trader from an external wallet was too low.


### PR DESCRIPTION
Ignore future results in case we had a terminal result already.
Avoid that a success result overwrites an earlier failed/error result.