### PR TITLE
Bugfix: Set username when saving the account not on every text change

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -359,6 +359,10 @@ public abstract class PaymentMethodForm {
         return gridRow - gridRowFrom + 2;
     }
 
+    public PaymentAccount getPaymentAccountForAccountCreation() {
+        return getPaymentAccount();
+    }
+
     public PaymentAccount getPaymentAccount() {
         return paymentAccount;
     }

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/RevolutForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/RevolutForm.java
@@ -40,6 +40,8 @@ import javafx.scene.layout.GridPane;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.jetbrains.annotations.NotNull;
+
 import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextField;
 import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
 import static bisq.desktop.util.FormBuilder.addTopLabelFlowPane;
@@ -73,7 +75,6 @@ public class RevolutForm extends PaymentMethodForm {
         userNameInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, Res.get("payment.account.userName"));
         userNameInputTextField.setValidator(validator);
         userNameInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
-            account.setUserName(newValue.trim());
             updateFromInputs();
         });
 
@@ -125,8 +126,23 @@ public class RevolutForm extends PaymentMethodForm {
 
     @Override
     public void updateAllInputsValid() {
-        allInputsValid.set(isAccountNameValid()
-                && validator.validate(account.getUserName()).isValid
+        String userName = getUserName();
+        allInputsValid.set(inputValidator.validate(userName).isValid
+                && validator.validate(userName).isValid
                 && account.getTradeCurrencies().size() > 0);
+    }
+
+    @Override
+    public PaymentAccount getPaymentAccountForAccountCreation() {
+        String userName = getUserName();
+        if (!userName.isEmpty()) {
+            account.setUserName(userName);
+        }
+        return super.getPaymentAccount();
+    }
+
+    @NotNull
+    private String getUserName() {
+        return userNameInputTextField.getText().trim();
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -382,7 +382,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                 gridRow = paymentMethodForm.getGridRow();
                 Tuple2<Button, Button> tuple2 = add2ButtonsAfterGroup(root, ++gridRow, Res.get("shared.saveNewAccount"), Res.get("shared.cancel"));
                 saveNewAccountButton = tuple2.first;
-                saveNewAccountButton.setOnAction(event -> onSaveNewAccount(paymentMethodForm.getPaymentAccount()));
+                saveNewAccountButton.setOnAction(event -> onSaveNewAccount(paymentMethodForm.getPaymentAccountForAccountCreation()));
                 saveNewAccountButton.disableProperty().bind(paymentMethodForm.allInputsValidProperty().not());
                 Button cancelButton = tuple2.second;
                 cancelButton.setOnAction(event -> onCancelNewAccount());


### PR DESCRIPTION
There is no elegant solution to do this, as we didn't have a input normalization for e-mail, phone numbers in Revolut before and I don't know what is possible to enter as a username as well.
So the workaround is to set the user name only when the account is saved and not on every text change which cause that only the first character will be added as account id in the payload.

See https://github.com/bisq-network/bisq/pull/4481#pullrequestreview-485066342