### PR TITLE
Fix revolut accountID bug 

### DIFF
--- a/core/src/main/java/bisq/core/payment/PaymentAccount.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccount.java
@@ -173,4 +173,9 @@ public abstract class PaymentAccount implements PersistablePayload {
     public String getOwnerId() {
         return paymentAccountPayload.getOwnerId();
     }
+
+    public void onAddToUser() {
+        // We are in the process to get added to the user. This is called just before saving the account and the
+        // last moment we could apply some special handling if needed (e.g. as it happens for Revolut)
+    }
 }

--- a/core/src/main/java/bisq/core/payment/RevolutAccount.java
+++ b/core/src/main/java/bisq/core/payment/RevolutAccount.java
@@ -37,22 +37,34 @@ public final class RevolutAccount extends PaymentAccount {
     }
 
     public void setUserName(String userName) {
-        ((RevolutAccountPayload) paymentAccountPayload).setUserName(userName);
+        revolutAccountPayload().setUserName(userName);
     }
 
     public String getUserName() {
-        return ((RevolutAccountPayload) paymentAccountPayload).getUserName();
+        return (revolutAccountPayload()).getUserName();
     }
 
     public String getAccountId() {
-        return ((RevolutAccountPayload) paymentAccountPayload).getAccountId();
+        return (revolutAccountPayload()).getAccountId();
     }
 
     public boolean userNameNotSet() {
-        return ((RevolutAccountPayload) paymentAccountPayload).userNameNotSet();
+        return (revolutAccountPayload()).userNameNotSet();
     }
 
     public boolean hasOldAccountId() {
-        return ((RevolutAccountPayload) paymentAccountPayload).hasOldAccountId();
+        return (revolutAccountPayload()).hasOldAccountId();
+    }
+
+    private RevolutAccountPayload revolutAccountPayload() {
+        return (RevolutAccountPayload) paymentAccountPayload;
+    }
+
+    @Override
+    public void onAddToUser() {
+        super.onAddToUser();
+
+        // At save we apply the userName to accountId in case it is empty for backward compatibility
+        revolutAccountPayload().maybeApplyUserNameToAccountId();
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
@@ -81,7 +81,7 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
                 excludeFromJsonDataMap);
 
         this.accountId = accountId;
-        setUserName(userName);
+        this.userName = userName;
     }
 
     @Override
@@ -169,7 +169,11 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
 
     public void setUserName(String userName) {
         this.userName = userName;
-        // We need to set accountId as pre v1.3.8 clients expect the accountId field
+    }
+
+    // In case it is a new account we need to fill the accountId field to support not-updated traders who are not
+    // aware of the new userName field
+    public void maybeApplyUserNameToAccountId() {
         if (accountId.isEmpty()) {
             accountId = userName;
         }

--- a/core/src/main/java/bisq/core/user/User.java
+++ b/core/src/main/java/bisq/core/user/User.java
@@ -190,6 +190,8 @@ public class User implements PersistedDataHost {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void addPaymentAccount(PaymentAccount paymentAccount) {
+        paymentAccount.onAddToUser();
+
         boolean changed = paymentAccountsAsObservable.add(paymentAccount);
         setCurrentPaymentAccount(paymentAccount);
         if (changed)


### PR DESCRIPTION
Remove side effect in setUserName method and add extra handling for the moment we save the account. Only at that moment we check if we need to
set the accountId with the value of the userName.
We do that in the domain layer to avoid more domain logic code in the UI
layer.

Fixes bug found at:
https://github.com/bisq-network/bisq/pull/4481#pullrequestreview-485066342
