### PR TITLE
Fix bug with seed restore and open offers

### DIFF
--- a/common/src/main/java/bisq/common/storage/FileUtil.java
+++ b/common/src/main/java/bisq/common/storage/FileUtil.java
@@ -102,7 +102,9 @@ public class FileUtil {
         deleteDirectory(file, null, true);
     }
 
-    public static void deleteDirectory(File file, @Nullable File exclude, boolean ignoreLockedFiles) throws IOException {
+    public static void deleteDirectory(File file,
+                                       @Nullable File exclude,
+                                       boolean ignoreLockedFiles) throws IOException {
         boolean excludeFileFound = false;
         if (file.isDirectory()) {
             File[] files = file.listFiles();
@@ -156,7 +158,8 @@ public class FileUtil {
         return !file.canWrite();
     }
 
-    public static void resourceToFile(String resourcePath, File destinationFile) throws ResourceNotFoundException, IOException {
+    public static void resourceToFile(String resourcePath,
+                                      File destinationFile) throws ResourceNotFoundException, IOException {
         try (InputStream inputStream = ClassLoader.getSystemClassLoader().getResourceAsStream(resourcePath)) {
             if (inputStream == null) {
                 throw new ResourceNotFoundException(resourcePath);
@@ -180,6 +183,20 @@ public class FileUtil {
         } else if (!oldFile.renameTo(newFile)) {
             throw new IOException("Failed to rename " + oldFile + " to " + newFile);
         }
+    }
+
+    public static void copyFile(File origin, File target) throws IOException {
+        if (!origin.exists()) {
+            return;
+        }
+
+        try {
+            Files.copy(origin, target);
+        } catch (IOException e) {
+            log.error("Copy file failed", e);
+            throw new IOException("Failed to copy " + origin + " to " + target);
+        }
+
     }
 
     public static void copyDirectory(File source, File destination) throws IOException {

--- a/core/src/main/java/bisq/core/btc/model/AddressEntry.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntry.java
@@ -197,9 +197,10 @@ public final class AddressEntry implements PersistablePayload {
     @Override
     public String toString() {
         return "AddressEntry{" +
-                "offerId='" + getOfferId() + '\'' +
+                "address=" + address +
                 ", context=" + context +
-                ", address=" + getAddressString() +
-                '}';
+                ", offerId='" + offerId + '\'' +
+                ", coinLockedInMultiSig=" + coinLockedInMultiSig +
+                "}";
     }
 }

--- a/core/src/main/java/bisq/core/btc/model/AddressEntry.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntry.java
@@ -186,10 +186,6 @@ public final class AddressEntry implements PersistablePayload {
         return context == Context.MULTI_SIG || context == Context.TRADE_PAYOUT;
     }
 
-    public boolean isTradable() {
-        return isOpenOffer() || isTrade();
-    }
-
     public Coin getCoinLockedInMultiSig() {
         return Coin.valueOf(coinLockedInMultiSig);
     }

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -59,7 +59,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Service;
 
 import org.apache.commons.lang3.StringUtils;
@@ -498,7 +497,7 @@ public class WalletsSetup {
     }
 
     public Set<Address> getAddressesByContext(@SuppressWarnings("SameParameterValue") AddressEntry.Context context) {
-        return ImmutableList.copyOf(addressEntryList.getList()).stream()
+        return addressEntryList.getAddressEntriesAsListImmutable().stream()
                 .filter(addressEntry -> addressEntry.getContext() == context)
                 .map(AddressEntry::getAddress)
                 .collect(Collectors.toSet());

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3036,6 +3036,8 @@ Ideally you should specify the date your wallet seed was created.\n\n\n\
 Are you sure you want to go ahead without specifying a wallet date?
 seed.restore.success=Wallets restored successfully with the new seed words.\n\nYou need to shut down and restart the application.
 seed.restore.error=An error occurred when restoring the wallets with seed words.{0}
+seed.restore.openOffers.warn=You have open offers which will be removed if you restore from seed words.\n\
+  Are you sure that you want to continue?
 
 
 ####################################################################

--- a/desktop/src/main/java/bisq/desktop/main/SharedPresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/SharedPresentation.java
@@ -41,10 +41,12 @@ import lombok.extern.slf4j.Slf4j;
 public class SharedPresentation {
     public static void restoreSeedWords(DeterministicSeed seed, WalletsManager walletsManager, File storageDir) {
         try {
-            FileUtil.renameFile(new File(storageDir, "AddressEntryList"), new File(storageDir, "AddressEntryList_wallet_restore_" + System.currentTimeMillis()));
+            File backup = new File(storageDir, "AddressEntryList_backup_pre_wallet_restore_" + System.currentTimeMillis());
+            FileUtil.copyFile(new File(storageDir, "AddressEntryList"), backup);
         } catch (Throwable t) {
             new Popup().error(Res.get("error.deleteAddressEntryListFailed", t)).show();
         }
+
         walletsManager.restoreSeedWords(
                 seed,
                 () -> UserThread.execute(() -> {

--- a/desktop/src/main/java/bisq/desktop/main/SharedPresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/SharedPresentation.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main;
+
+import bisq.desktop.app.BisqApp;
+import bisq.desktop.main.overlays.popups.Popup;
+
+import bisq.core.btc.wallet.WalletsManager;
+import bisq.core.locale.Res;
+
+import bisq.common.UserThread;
+import bisq.common.storage.FileUtil;
+
+import org.bitcoinj.wallet.DeterministicSeed;
+
+import java.io.File;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This serves as shared space for static methods used from different views where no common parent view would fit as
+ * owner of that code. We keep it strictly static. It should replace GUIUtil for those methods which are not utility
+ * methods.
+ */
+@Slf4j
+public class SharedPresentation {
+    public static void restoreSeedWords(DeterministicSeed seed, WalletsManager walletsManager, File storageDir) {
+        try {
+            FileUtil.renameFile(new File(storageDir, "AddressEntryList"), new File(storageDir, "AddressEntryList_wallet_restore_" + System.currentTimeMillis()));
+        } catch (Throwable t) {
+            new Popup().error(Res.get("error.deleteAddressEntryListFailed", t)).show();
+        }
+        walletsManager.restoreSeedWords(
+                seed,
+                () -> UserThread.execute(() -> {
+                    log.info("Wallets restored with seed words");
+                    new Popup().feedback(Res.get("seed.restore.success")).hideCloseButton().show();
+                    BisqApp.getShutDownHandler().run();
+                }),
+                throwable -> UserThread.execute(() -> {
+                    log.error(throwable.toString());
+                    new Popup().error(Res.get("seed.restore.error", Res.get("shared.errorMessageInline", throwable)))
+                            .show();
+                }));
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
@@ -27,6 +27,7 @@ import bisq.desktop.util.Layout;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.locale.Res;
+import bisq.core.offer.OpenOfferManager;
 import bisq.core.user.DontShowAgainLookup;
 
 import bisq.common.config.Config;
@@ -68,6 +69,7 @@ import static javafx.beans.binding.Bindings.createBooleanBinding;
 @FxmlView
 public class SeedWordsView extends ActivatableView<GridPane, Void> {
     private final WalletsManager walletsManager;
+    private final OpenOfferManager openOfferManager;
     private final BtcWalletService btcWalletService;
     private final WalletPasswordWindow walletPasswordWindow;
     private final File storageDir;
@@ -91,10 +93,12 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
 
     @Inject
     private SeedWordsView(WalletsManager walletsManager,
+                          OpenOfferManager openOfferManager,
                           BtcWalletService btcWalletService,
                           WalletPasswordWindow walletPasswordWindow,
                           @Named(Config.STORAGE_DIR) File storageDir) {
         this.walletsManager = walletsManager;
+        this.openOfferManager = openOfferManager;
         this.btcWalletService = btcWalletService;
         this.walletPasswordWindow = walletPasswordWindow;
         this.storageDir = storageDir;
@@ -166,20 +170,18 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
         String key = "showBackupWarningAtSeedPhrase";
         if (DontShowAgainLookup.showAgain(key)) {
             new Popup().warning(Res.get("account.seed.backup.warning"))
-                .onAction(() -> {
-                    showSeedPhrase();
-                })
-                .actionButtonText(Res.get("shared.iUnderstand"))
-                .useIUnderstandButton()
-                .dontShowAgainId(key)
-                .hideCloseButton()
-                .show();
+                    .onAction(this::showSeedPhrase)
+                    .actionButtonText(Res.get("shared.iUnderstand"))
+                    .useIUnderstandButton()
+                    .dontShowAgainId(key)
+                    .hideCloseButton()
+                    .show();
         } else {
             showSeedPhrase();
         }
     }
 
-    public void showSeedPhrase() {
+    private void showSeedPhrase() {
         DeterministicSeed keyChainSeed = btcWalletService.getKeyChainSeed();
         // wallet creation date is not encrypted
         walletCreationDate = Instant.ofEpochSecond(walletsManager.getChainSeedCreationTimeSeconds()).atZone(ZoneId.systemDefault()).toLocalDate();
@@ -305,6 +307,6 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
         long date = localDateTime.toEpochSecond(ZoneOffset.UTC);
 
         DeterministicSeed seed = new DeterministicSeed(Splitter.on(" ").splitToList(seedWordsTextArea.getText()), null, "", date);
-        SharedPresentation.restoreSeedWords(seed, walletsManager, storageDir);
+        SharedPresentation.restoreSeedWords(walletsManager, openOfferManager, seed, storageDir);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/seedwords/SeedWordsView.java
@@ -19,9 +19,9 @@ package bisq.desktop.main.account.content.seedwords;
 
 import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.FxmlView;
+import bisq.desktop.main.SharedPresentation;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.WalletPasswordWindow;
-import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
 
 import bisq.core.btc.wallet.BtcWalletService;
@@ -305,6 +305,6 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
         long date = localDateTime.toEpochSecond(ZoneOffset.UTC);
 
         DeterministicSeed seed = new DeterministicSeed(Splitter.on(" ").splitToList(seedWordsTextArea.getText()), null, "", date);
-        GUIUtil.restoreSeedWords(seed, walletsManager, storageDir);
+        SharedPresentation.restoreSeedWords(seed, walletsManager, storageDir);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
@@ -30,6 +30,7 @@ import bisq.desktop.util.Transitions;
 import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.crypto.ScryptUtil;
 import bisq.core.locale.Res;
+import bisq.core.offer.OpenOfferManager;
 
 import bisq.common.UserThread;
 import bisq.common.config.Config;
@@ -88,6 +89,7 @@ import static javafx.beans.binding.Bindings.createBooleanBinding;
 @Slf4j
 public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
     private final WalletsManager walletsManager;
+    private final OpenOfferManager openOfferManager;
     private File storageDir;
 
     private Button unlockButton;
@@ -115,8 +117,10 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
 
     @Inject
     private WalletPasswordWindow(WalletsManager walletsManager,
+                                 OpenOfferManager openOfferManager,
                                  @Named(Config.STORAGE_DIR) File storageDir) {
         this.walletsManager = walletsManager;
+        this.openOfferManager = openOfferManager;
         this.storageDir = storageDir;
         type = Type.Attention;
         width = 900;
@@ -277,7 +281,6 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         gridPane.getChildren().add(headLine2Label);
 
         seedWordsTextArea = addTextArea(gridPane, ++rowIndex, Res.get("seed.enterSeedWords"), 5);
-        ;
         seedWordsTextArea.setPrefHeight(60);
 
         Tuple2<Label, DatePicker> labelDatePickerTuple2 = addTopLabelDatePicker(gridPane, ++rowIndex,
@@ -356,6 +359,6 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         //TODO Is ZoneOffset correct?
         long date = value != null ? value.atStartOfDay().toEpochSecond(ZoneOffset.UTC) : 0;
         DeterministicSeed seed = new DeterministicSeed(Splitter.on(" ").splitToList(seedWordsTextArea.getText()), null, "", date);
-        SharedPresentation.restoreSeedWords(seed, walletsManager, storageDir);
+        SharedPresentation.restoreSeedWords(walletsManager, openOfferManager, seed, storageDir);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/WalletPasswordWindow.java
@@ -21,9 +21,9 @@ import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.BusyAnimation;
 import bisq.desktop.components.PasswordTextField;
+import bisq.desktop.main.SharedPresentation;
 import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.popups.Popup;
-import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
 import bisq.desktop.util.Transitions;
 
@@ -356,6 +356,6 @@ public class WalletPasswordWindow extends Overlay<WalletPasswordWindow> {
         //TODO Is ZoneOffset correct?
         long date = value != null ? value.atStartOfDay().toEpochSecond(ZoneOffset.UTC) : 0;
         DeterministicSeed seed = new DeterministicSeed(Splitter.on(" ").splitToList(seedWordsTextArea.getText()), null, "", date);
-        GUIUtil.restoreSeedWords(seed, walletsManager, storageDir);
+        SharedPresentation.restoreSeedWords(seed, walletsManager, storageDir);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -32,7 +32,6 @@ import bisq.desktop.util.validation.RegexValidator;
 import bisq.core.account.witness.AccountAgeWitness;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.btc.setup.WalletsSetup;
-import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.locale.Country;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.CurrencyUtil;
@@ -63,7 +62,6 @@ import bisq.common.config.Config;
 import bisq.common.proto.persistable.PersistableList;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
 import bisq.common.storage.CorruptedDatabaseFilesHandler;
-import bisq.common.storage.FileUtil;
 import bisq.common.storage.Storage;
 import bisq.common.util.MathUtils;
 import bisq.common.util.Tuple2;
@@ -75,7 +73,6 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.uri.BitcoinURI;
 import org.bitcoinj.utils.Fiat;
-import org.bitcoinj.wallet.DeterministicSeed;
 
 import com.googlecode.jcsv.CSVStrategy;
 import com.googlecode.jcsv.writer.CSVEntryConverter;
@@ -801,26 +798,6 @@ public class GUIUtil {
         } catch (Throwable t) {
             new Popup().error(Res.get("settings.net.reSyncSPVFailed", t)).show();
         }
-    }
-
-    public static void restoreSeedWords(DeterministicSeed seed, WalletsManager walletsManager, File storageDir) {
-        try {
-            FileUtil.renameFile(new File(storageDir, "AddressEntryList"), new File(storageDir, "AddressEntryList_wallet_restore_" + System.currentTimeMillis()));
-        } catch (Throwable t) {
-            new Popup().error(Res.get("error.deleteAddressEntryListFailed", t)).show();
-        }
-        walletsManager.restoreSeedWords(
-                seed,
-                () -> UserThread.execute(() -> {
-                    log.info("Wallets restored with seed words");
-                    new Popup().feedback(Res.get("seed.restore.success")).hideCloseButton().show();
-                    BisqApp.getShutDownHandler().run();
-                }),
-                throwable -> UserThread.execute(() -> {
-                    log.error(throwable.toString());
-                    new Popup().error(Res.get("seed.restore.error", Res.get("shared.errorMessageInline", throwable)))
-                            .show();
-                }));
     }
 
     public static void showSelectableTextModal(String title, String text) {


### PR DESCRIPTION
Fixes #4499

When restoring from same seeds and the user had open offers the reserved balance was not updated as the addressEntry list got created newly. It is not the normal use case that a user applies the same seed to a data directory containing open offers but we should handle such cases correctly as well.

We also check now for open offers and enforce that those get removed at restore from seeds.

There have been potential bugs as well in the addressEntryList class which are hopefully eliminated by that PR. Some might have been responsible for out-of-sync addressList with wallet data issues. Those cases are hard to reproduce and mostly happen at rather un-usual situations. 

Lots of refactoring as well...

I tested quite a bit but it will require good testing before deployment.