### PR TITLE
Return if setting not present

### DIFF
--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
@@ -166,6 +166,7 @@ public class XmrTxProofService implements AssetTxProofService {
 
         if (!preferences.findAutoConfirmSettings("XMR").isPresent()) {
             log.error("AutoConfirmSettings is not present");
+            return;
         }
         autoConfirmSettings = preferences.findAutoConfirmSettings("XMR").get();
 


### PR DESCRIPTION
Seems better to return instead of getting a certain exception
