### PR TITLE
Show info popup if Bisq started under Qubes OS

### DIFF
--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -161,6 +161,19 @@ public class Utilities {
         return getOSName().contains("win");
     }
 
+    /**
+     * @return True, if Bisq is running on a virtualized OS within Qubes, false otherwise
+     */
+    public static boolean isQubesOS() {
+        // For Linux qubes, "os.version" looks like "4.19.132-1.pvops.qubes.x86_64"
+        // The presence of the "qubes" substring indicates this Linux is running as a qube
+        // This is the case for all 3 virtualization modes (PV, PVH, HVM)
+        // In addition, this works for both simple AppVMs, as well as for StandaloneVMs
+        // TODO This might not work for detecting Qubes virtualization for other OSes
+        // like Windows
+        return getOSVersion().contains("qubes");
+    }
+
     public static boolean isOSX() {
         return getOSName().contains("mac") || getOSName().contains("darwin");
     }

--- a/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
@@ -98,6 +98,7 @@ public class BisqHeadlessApp implements HeadlessApp {
         bisqSetup.setShowPopupIfInvalidBtcConfigHandler(() -> log.error("onShowPopupIfInvalidBtcConfigHandler"));
         bisqSetup.setRevolutAccountsUpdateHandler(revolutAccountList -> log.info("setRevolutAccountsUpdateHandler: revolutAccountList={}", revolutAccountList));
         bisqSetup.setOsxKeyLoggerWarningHandler(() -> log.info("setOsxKeyLoggerWarningHandler"));
+        bisqSetup.setQubesOSInfoHandler(() -> log.info("setQubesOSInfoHandler"));
 
         //TODO move to bisqSetup
         corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> log.warn("getCorruptedDatabaseFiles. files={}", files));

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -232,6 +232,9 @@ public class BisqSetup {
     @Setter
     @Nullable
     private Runnable osxKeyLoggerWarningHandler;
+    @Setter
+    @Nullable
+    private Runnable qubesOSInfoHandler;
 
     @Getter
     final BooleanProperty newVersionAvailableProperty = new SimpleBooleanProperty(false);
@@ -357,6 +360,7 @@ public class BisqSetup {
         checkCryptoSetup();
         checkForCorrectOSArchitecture();
         checkOSXVersion();
+        checkIfRunningOnQubesOS();
     }
 
     private void step3() {
@@ -675,6 +679,17 @@ public class BisqSetup {
             } catch (InvalidVersionException | NumberFormatException e) {
                 log.warn(e.getMessage());
             }
+        }
+    }
+
+    /**
+     * If Bisq is running on an OS that is virtualized under Qubes, show info popup with
+     * link to the Setup Guide. The guide documents what other steps are needed, in
+     * addition to installing the Linux package (qube sizing, etc)
+     */
+    private void checkIfRunningOnQubesOS() {
+        if (Utilities.isQubesOS() && qubesOSInfoHandler != null) {
+            qubesOSInfoHandler.run();
         }
     }
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2759,6 +2759,9 @@ popup.info.shutDownWithOpenOffers=Bisq is being shut down, but there are open of
   they will be re-published to the P2P network the next time you start Bisq.\n\n\
   To keep your offers online, keep Bisq running and make sure this computer remains online too \
   (i.e., make sure it doesn't go into standby mode...monitor standby is not a problem).
+popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\n\
+  Please make sure your Bisq qube is setup according to our Setup Guide at \
+  https://bisq.wiki/Running_Bisq_on_Qubes
 
 popup.privateNotification.headline=Important private notification!
 

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -397,6 +397,15 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                         .show();
             }
         });
+        bisqSetup.setQubesOSInfoHandler(() -> {
+            String key = "qubesOSSetupInfo";
+            if (preferences.showAgain(key)) {
+                new Popup().information(Res.get("popup.info.qubesOSSetupInfo"))
+                        .closeButtonText(Res.get("shared.iUnderstand"))
+                        .dontShowAgainId(key)
+                        .show();
+            }
+        });
 
         corruptedDatabaseFilesHandler.getCorruptedDatabaseFiles().ifPresent(files -> new Popup()
                 .warning(Res.get("popup.warning.incompatibleDB", files.toString(), config.appDataDir))


### PR DESCRIPTION
If Bisq is started under Qubes, show popup informing the user about the OS-specific setup guide.

Implements suggestion from https://github.com/bisq-network/bisq/issues/4386#issuecomment-691240207

---

Screenshot of the popup shown on startup:

![Screenshot from 2020-09-13 13-30-54](https://user-images.githubusercontent.com/15956136/93017004-c161dc80-f5c5-11ea-88bc-967ab4b37951.png)
