### PR TITLE
[WIP] Redesign persistence save to file task

### DIFF
--- a/common/src/main/java/bisq/common/storage/FileManager.java
+++ b/common/src/main/java/bisq/common/storage/FileManager.java
@@ -149,11 +149,7 @@ public class FileManager<T extends PersistableEnvelope> {
         }
     }
 
-
-    /**
-     * Shut down auto-saving.
-     */
-    private void shutDown() {
+    public void shutDown() {
         executor.shutdown();
         try {
             executor.awaitTermination(5, TimeUnit.SECONDS);

--- a/common/src/main/java/bisq/common/storage/Storage.java
+++ b/common/src/main/java/bisq/common/storage/Storage.java
@@ -103,14 +103,6 @@ public class Storage<T extends PersistableEnvelope> {
         queueUpForSave(persistable);
     }
 
-    public void queueUpForSave(long delayInMilli) {
-        queueUpForSave(persistable, delayInMilli);
-    }
-
-    public void setNumMaxBackupFiles(int numMaxBackupFiles) {
-        this.numMaxBackupFiles = numMaxBackupFiles;
-    }
-
     // Save delayed and on a background thread
     public void queueUpForSave(T persistable) {
         if (persistable != null) {
@@ -122,11 +114,11 @@ public class Storage<T extends PersistableEnvelope> {
         }
     }
 
-    public void queueUpForSave(T persistable, long delayInMilli) {
+    public void saveNow(T persistable) {
         if (persistable != null) {
             checkNotNull(storageFile, "storageFile = null. Call setupFileStorage before using read/write.");
 
-            fileManager.saveLater(persistable, delayInMilli);
+            fileManager.saveLater(persistable, 1);
         } else {
             log.trace("queueUpForSave called but no persistable set");
         }
@@ -134,6 +126,14 @@ public class Storage<T extends PersistableEnvelope> {
 
     public void remove(String fileName) {
         fileManager.removeFile(fileName);
+    }
+
+    public void shutDown() {
+        fileManager.shutDown();
+    }
+
+    public void setNumMaxBackupFiles(int numMaxBackupFiles) {
+        this.numMaxBackupFiles = numMaxBackupFiles;
     }
 
 

--- a/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
@@ -60,7 +60,7 @@ public final class AddressEntryList implements UserThreadMappedPersistableEnvelo
 
     @Override
     public void readPersisted() {
-        AddressEntryList persisted = storage.initAndGetPersisted(this, 50);
+        AddressEntryList persisted = storage.initAndGetPersisted(this, 200);
         if (persisted != null) {
             entrySet.clear();
             entrySet.addAll(persisted.entrySet);
@@ -194,7 +194,7 @@ public final class AddressEntryList implements UserThreadMappedPersistableEnvelo
     }
 
     public void persist() {
-        storage.queueUpForSave(50);
+        storage.queueUpForSave();
     }
 
 

--- a/core/src/main/java/bisq/core/dao/governance/ballot/BallotListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/ballot/BallotListService.java
@@ -129,7 +129,7 @@ public class BallotListService implements PersistedDataHost, DaoSetupService {
     @Override
     public void readPersisted() {
         if (DevEnv.isDaoActivated()) {
-            BallotList persisted = storage.initAndGetPersisted(ballotList, 100);
+            BallotList persisted = storage.initAndGetPersisted(ballotList, 500);
             if (persisted != null) {
                 ballotList.clear();
                 ballotList.addAll(persisted.getList());

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
@@ -162,7 +162,7 @@ public class MyBlindVoteListService implements PersistedDataHost, DaoStateListen
     @Override
     public void readPersisted() {
         if (DevEnv.isDaoActivated()) {
-            MyBlindVoteList persisted = storage.initAndGetPersisted(myBlindVoteList, 100);
+            MyBlindVoteList persisted = storage.initAndGetPersisted(myBlindVoteList, 500);
             if (persisted != null) {
                 myBlindVoteList.clear();
                 myBlindVoteList.addAll(persisted.getList());

--- a/core/src/main/java/bisq/core/dao/governance/bond/reputation/MyReputationListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/reputation/MyReputationListService.java
@@ -56,7 +56,7 @@ public class MyReputationListService implements PersistedDataHost, DaoSetupServi
     @Override
     public void readPersisted() {
         if (DevEnv.isDaoActivated()) {
-            MyReputationList persisted = storage.initAndGetPersisted(myReputationList, 100);
+            MyReputationList persisted = storage.initAndGetPersisted(myReputationList, 500);
             if (persisted != null) {
                 myReputationList.clear();
                 myReputationList.addAll(persisted.getList());
@@ -98,6 +98,6 @@ public class MyReputationListService implements PersistedDataHost, DaoSetupServi
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void persist() {
-        storage.queueUpForSave(20);
+        storage.queueUpForSave();
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/myvote/MyVoteListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/myvote/MyVoteListService.java
@@ -69,7 +69,7 @@ public class MyVoteListService implements PersistedDataHost {
     @Override
     public void readPersisted() {
         if (DevEnv.isDaoActivated()) {
-            MyVoteList persisted = storage.initAndGetPersisted(myVoteList, 100);
+            MyVoteList persisted = storage.initAndGetPersisted(myVoteList, 500);
             if (persisted != null) {
                 this.myVoteList.clear();
                 this.myVoteList.addAll(persisted.getList());

--- a/core/src/main/java/bisq/core/dao/governance/proofofburn/MyProofOfBurnListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proofofburn/MyProofOfBurnListService.java
@@ -56,7 +56,7 @@ public class MyProofOfBurnListService implements PersistedDataHost, DaoSetupServ
     @Override
     public void readPersisted() {
         if (DevEnv.isDaoActivated()) {
-            MyProofOfBurnList persisted = storage.initAndGetPersisted(myProofOfBurnList, 100);
+            MyProofOfBurnList persisted = storage.initAndGetPersisted(myProofOfBurnList, 500);
             if (persisted != null) {
                 myProofOfBurnList.clear();
                 myProofOfBurnList.addAll(persisted.getList());
@@ -99,6 +99,6 @@ public class MyProofOfBurnListService implements PersistedDataHost, DaoSetupServ
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void persist() {
-        storage.queueUpForSave(20);
+        storage.queueUpForSave();
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/MyProposalListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/MyProposalListService.java
@@ -107,7 +107,7 @@ public class MyProposalListService implements PersistedDataHost, DaoStateListene
     @Override
     public void readPersisted() {
         if (DevEnv.isDaoActivated()) {
-            MyProposalList persisted = storage.initAndGetPersisted(myProposalList, 100);
+            MyProposalList persisted = storage.initAndGetPersisted(myProposalList, 500);
             if (persisted != null) {
                 myProposalList.clear();
                 myProposalList.addAll(persisted.getList());

--- a/core/src/main/java/bisq/core/dao/state/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateStorageService.java
@@ -24,7 +24,6 @@ import bisq.core.dao.state.model.DaoState;
 import bisq.network.p2p.storage.persistence.ResourceDataStoreService;
 import bisq.network.p2p.storage.persistence.StoreService;
 
-import bisq.common.UserThread;
 import bisq.common.config.Config;
 import bisq.common.storage.FileManager;
 import bisq.common.storage.Storage;
@@ -36,7 +35,6 @@ import java.io.File;
 import java.io.IOException;
 
 import java.util.LinkedList;
-import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -104,8 +102,7 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
             store.setDaoState(new DaoState());
             store.setDaoStateHashChain(new LinkedList<>());
         });
-        storage.saveNow(store);
-        UserThread.runAfter(resultHandler, 300, TimeUnit.MILLISECONDS);
+        storage.saveAsync(store, resultHandler);
     }
 
     public void resyncDaoStateFromResources(File storageDir) throws IOException {

--- a/core/src/main/java/bisq/core/dao/state/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateStorageService.java
@@ -84,15 +84,11 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
     }
 
     public void persist(DaoState daoState, LinkedList<DaoStateHash> daoStateHashChain) {
-        persist(daoState, daoStateHashChain, 200);
-    }
-
-    private void persist(DaoState daoState, LinkedList<DaoStateHash> daoStateHashChain, long delayInMilli) {
         store.modifySynchronized(() -> {
             store.setDaoState(daoState);
             store.setDaoStateHashChain(daoStateHashChain);
         });
-        storage.queueUpForSave(store, delayInMilli);
+        storage.queueUpForSave(store);
     }
 
     public DaoState getPersistedBsqState() {
@@ -104,7 +100,11 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
     }
 
     public void resyncDaoStateFromGenesis(Runnable resultHandler) {
-        persist(new DaoState(), new LinkedList<>(), 1);
+        store.modifySynchronized(() -> {
+            store.setDaoState(new DaoState());
+            store.setDaoStateHashChain(new LinkedList<>());
+        });
+        storage.saveNow(store);
         UserThread.runAfter(resultHandler, 300, TimeUnit.MILLISECONDS);
     }
 

--- a/core/src/main/java/bisq/core/dao/state/unconfirmed/UnconfirmedBsqChangeOutputListService.java
+++ b/core/src/main/java/bisq/core/dao/state/unconfirmed/UnconfirmedBsqChangeOutputListService.java
@@ -55,7 +55,7 @@ public class UnconfirmedBsqChangeOutputListService implements PersistedDataHost 
     @Override
     public void readPersisted() {
         if (DevEnv.isDaoActivated()) {
-            UnconfirmedBsqChangeOutputList persisted = storage.initAndGetPersisted(unconfirmedBsqChangeOutputList, 100);
+            UnconfirmedBsqChangeOutputList persisted = storage.initAndGetPersisted(unconfirmedBsqChangeOutputList, 500);
             if (persisted != null) {
                 unconfirmedBsqChangeOutputList.clear();
                 unconfirmedBsqChangeOutputList.addAll(persisted.getList());

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationDisputeList.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationDisputeList.java
@@ -53,7 +53,7 @@ public final class ArbitrationDisputeList extends DisputeList<ArbitrationDispute
     @Override
     public void readPersisted() {
         // We need to use DisputeList as file name to not lose existing disputes which are stored in the DisputeList file
-        ArbitrationDisputeList persisted = storage.initAndGetPersisted(this, "DisputeList", 50);
+        ArbitrationDisputeList persisted = storage.initAndGetPersisted(this, "DisputeList", 500);
         if (persisted != null) {
             list.addAll(persisted.getList());
         }

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationDisputeList.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationDisputeList.java
@@ -49,7 +49,7 @@ public final class MediationDisputeList extends DisputeList<MediationDisputeList
 
     @Override
     public void readPersisted() {
-        MediationDisputeList persisted = storage.initAndGetPersisted(this, "MediationDisputeList", 0);
+        MediationDisputeList persisted = storage.initAndGetPersisted(this, "MediationDisputeList", 500);
         if (persisted != null) {
             list.addAll(persisted.getList());
         }

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundDisputeList.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundDisputeList.java
@@ -53,7 +53,7 @@ public final class RefundDisputeList extends DisputeList<RefundDisputeList> {
     @Override
     public void readPersisted() {
         // We need to use DisputeList as file name to not lose existing disputes which are stored in the DisputeList file
-        RefundDisputeList persisted = storage.initAndGetPersisted(this, "RefundDisputeList", 50);
+        RefundDisputeList persisted = storage.initAndGetPersisted(this, "RefundDisputeList", 500);
         if (persisted != null) {
             list.addAll(persisted.getList());
         }

--- a/core/src/main/java/bisq/core/trade/TradableList.java
+++ b/core/src/main/java/bisq/core/trade/TradableList.java
@@ -54,7 +54,7 @@ public final class TradableList<T extends Tradable> implements UserThreadMappedP
     public TradableList(Storage<TradableList<T>> storage, String fileName) {
         this.storage = storage;
 
-        TradableList<T> persisted = storage.initAndGetPersisted(this, fileName, 50);
+        TradableList<T> persisted = storage.initAndGetPersisted(this, fileName, 500);
         if (persisted != null)
             list.addAll(persisted.getList());
     }

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -787,7 +787,7 @@ public abstract class Trade implements Tradable, Model {
     // Get called from taskRunner after each completed task
     @Override
     public void persist() {
-        if (storage != null)
+        if (storage != null && storage.isInitialized())
             storage.queueUpForSave();
     }
 

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -226,7 +226,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     @Override
     public void readPersisted() {
-        PreferencesPayload persisted = storage.initAndGetPersistedWithFileName("PreferencesPayload", 100);
+        PreferencesPayload persisted = storage.initAndGetPersistedWithFileName("PreferencesPayload", 500);
         BaseCurrencyNetwork baseCurrencyNetwork = Config.baseCurrencyNetwork();
         TradeCurrency preferredTradeCurrency;
         if (persisted != null) {
@@ -614,14 +614,16 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     public void setResyncSpvRequested(boolean resyncSpvRequested) {
         prefPayload.setResyncSpvRequested(resyncSpvRequested);
-        // We call that before shutdown so we dont want a delay here
-        storage.queueUpForSave(prefPayload, 1);
+        // We call that before shutdown so we don't want a delay here,
+        // still it is threaded so we cannot shut down immediately
+        storage.saveNow(prefPayload);
     }
 
     public void setBridgeAddresses(List<String> bridgeAddresses) {
         prefPayload.setBridgeAddresses(bridgeAddresses);
-        // We call that before shutdown so we dont want a delay here
-        storage.queueUpForSave(prefPayload, 1);
+        // We call that before shutdown so we don't want a delay here,
+        // still it is threaded so we cannot shut down immediately
+        storage.saveNow(prefPayload);
     }
 
     // Only used from PB but keep it explicit as it may be used from the client and then we want to persist

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -612,18 +612,14 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         persist();
     }
 
-    public void setResyncSpvRequested(boolean resyncSpvRequested) {
+    public void applyResyncSpvRequested(boolean resyncSpvRequested, @Nullable Runnable completeHandler) {
         prefPayload.setResyncSpvRequested(resyncSpvRequested);
-        // We call that before shutdown so we don't want a delay here,
-        // still it is threaded so we cannot shut down immediately
-        storage.saveNow(prefPayload);
+        storage.saveAsync(prefPayload, completeHandler);
     }
 
     public void setBridgeAddresses(List<String> bridgeAddresses) {
         prefPayload.setBridgeAddresses(bridgeAddresses);
-        // We call that before shutdown so we don't want a delay here,
-        // still it is threaded so we cannot shut down immediately
-        storage.saveNow(prefPayload);
+        storage.saveSync(prefPayload);
     }
 
     // Only used from PB but keep it explicit as it may be used from the client and then we want to persist

--- a/core/src/main/java/bisq/core/user/User.java
+++ b/core/src/main/java/bisq/core/user/User.java
@@ -90,7 +90,7 @@ public class User implements PersistedDataHost {
 
     @Override
     public void readPersisted() {
-        UserPayload persisted = storage.initAndGetPersistedWithFileName("UserPayload", 100);
+        UserPayload persisted = storage.initAndGetPersistedWithFileName("UserPayload", 500);
         userPayload = persisted != null ? persisted : new UserPayload();
 
         checkNotNull(userPayload.getPaymentAccounts(), "userPayload.getPaymentAccounts() must not be null");

--- a/core/src/main/java/bisq/core/user/User.java
+++ b/core/src/main/java/bisq/core/user/User.java
@@ -90,14 +90,14 @@ public class User implements PersistedDataHost {
 
     @Override
     public void readPersisted() {
-        UserPayload persisted = storage.initAndGetPersistedWithFileName("UserPayload", 500);
+        UserPayload persisted = checkNotNull(storage).initAndGetPersistedWithFileName("UserPayload", 500);
         userPayload = persisted != null ? persisted : new UserPayload();
 
         checkNotNull(userPayload.getPaymentAccounts(), "userPayload.getPaymentAccounts() must not be null");
         checkNotNull(userPayload.getAcceptedLanguageLocaleCodes(), "userPayload.getAcceptedLanguageLocaleCodes() must not be null");
         paymentAccountsAsObservable = FXCollections.observableSet(userPayload.getPaymentAccounts());
         currentPaymentAccountProperty = new SimpleObjectProperty<>(userPayload.getCurrentPaymentAccount());
-        userPayload.setAccountId(String.valueOf(Math.abs(keyRing.getPubKeyRing().hashCode())));
+        userPayload.setAccountId(String.valueOf(Math.abs(checkNotNull(keyRing).getPubKeyRing().hashCode())));
 
         // language setup
         if (!userPayload.getAcceptedLanguageLocaleCodes().contains(LanguageUtil.getDefaultLanguageLocaleAsCode()))
@@ -117,7 +117,7 @@ public class User implements PersistedDataHost {
     }
 
     public void persist() {
-        if (storage != null)
+        if (storage != null && storage.isInitialized())
             storage.queueUpForSave(userPayload);
     }
 

--- a/desktop/src/main/java/bisq/desktop/Navigation.java
+++ b/desktop/src/main/java/bisq/desktop/Navigation.java
@@ -79,7 +79,7 @@ public final class Navigation implements PersistedDataHost {
 
     @Override
     public void readPersisted() {
-        NavigationPath persisted = storage.initAndGetPersisted(navigationPath, "NavigationPath", 300);
+        NavigationPath persisted = storage.initAndGetPersisted(navigationPath, "NavigationPath", 1000);
         if (persisted != null) {
             List<Class<? extends View>> viewClasses = persisted.getPath().stream()
                     .map(className -> {
@@ -143,7 +143,7 @@ public final class Navigation implements PersistedDataHost {
         if (currentPath.tip() != null) {
             navigationPath.setPath(currentPath.stream().map(Class::getName).collect(Collectors.toUnmodifiableList()));
         }
-        storage.queueUpForSave(navigationPath, 1000);
+        storage.queueUpForSave(navigationPath);
     }
 
     public void navigateToPreviousVisitedView() {

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -511,11 +511,13 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
 
     private void showSecondPopupIfResyncSPVRequested(Popup firstPopup) {
         firstPopup.hide();
-        preferences.setResyncSpvRequested(false);
-        new Popup().information(Res.get("settings.net.reSyncSPVAfterRestartCompleted"))
-                .hideCloseButton()
-                .useShutDownButton()
-                .show();
+        preferences.applyResyncSpvRequested(false,
+                () -> {
+                    new Popup().information(Res.get("settings.net.reSyncSPVAfterRestartCompleted"))
+                            .hideCloseButton()
+                            .useShutDownButton()
+                            .show();
+                });
     }
 
     private void showPopupIfInvalidBtcConfig() {

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -134,7 +134,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -793,8 +792,7 @@ public class GUIUtil {
                     .useShutDownButton()
                     .actionButtonText(Res.get("shared.shutDown"))
                     .onAction(() -> {
-                        preferences.setResyncSpvRequested(true);
-                        UserThread.runAfter(BisqApp.getShutDownHandler(), 100, TimeUnit.MILLISECONDS);
+                        preferences.applyResyncSpvRequested(true, BisqApp.getShutDownHandler());
                     })
                     .hideCloseButton()
                     .show();
@@ -1162,9 +1160,9 @@ public class GUIUtil {
         // match 127/8 (127.0.0.0 ~ 127.255.255.255)
         String localhostIpv4RegexPattern = String.format(
                 "(?:127\\.)" +
-                "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){2}" +
-                "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
-                "(?:\\:%1$s)?",
+                        "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){2}" +
+                        "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
+                        "(?:\\:%1$s)?",
                 portRegexPattern);
 
         // match ::/64 with optional port at the end, i.e. ::1 or [::1]:8081
@@ -1190,36 +1188,36 @@ public class GUIUtil {
         // match 10/8 (10.0.0.0 ~ 10.255.255.255)
         String localnetIpv4RegexPatternA = String.format(
                 "(?:10\\.)" +
-                "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){2}" +
-                "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
-                "(?:\\:%1$s)?",
+                        "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){2}" +
+                        "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
+                        "(?:\\:%1$s)?",
                 portRegexPattern);
 
         // match 172.16/12 (172.16.0.0 ~ 172.31.255.255)
         String localnetIpv4RegexPatternB = String.format(
                 "(?:172\\.)" +
-                "(?:(?:1[6-9]|2[0-9]|[3][0-1])\\.)" +
-                "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.)" +
-                "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
-                "(?:\\:%1$s)?",
+                        "(?:(?:1[6-9]|2[0-9]|[3][0-1])\\.)" +
+                        "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.)" +
+                        "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
+                        "(?:\\:%1$s)?",
                 portRegexPattern);
 
         // match 192.168/16 (192.168.0.0 ~ 192.168.255.255)
         String localnetIpv4RegexPatternC = String.format(
                 "(?:192\\.)" +
-                "(?:168\\.)" +
-                "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.)" +
-                "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
-                "(?:\\:%1$s)?",
+                        "(?:168\\.)" +
+                        "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.)" +
+                        "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
+                        "(?:\\:%1$s)?",
                 portRegexPattern);
 
         // match 169.254/15 (169.254.0.0 ~ 169.255.255.255)
         String autolocalIpv4RegexPattern = String.format(
                 "(?:169\\.)" +
-                "(?:(?:254|255)\\.)" +
-                "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.)" +
-                "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
-                "(?:\\:%1$s)?",
+                        "(?:(?:254|255)\\.)" +
+                        "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.)" +
+                        "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
+                        "(?:\\:%1$s)?",
                 portRegexPattern);
 
         // match fc00::/7  (fc00:: ~ fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff)

--- a/monitor/src/main/java/bisq/monitor/metric/P2PMarketStats.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PMarketStats.java
@@ -21,7 +21,6 @@ import bisq.monitor.OnionParser;
 import bisq.monitor.Reporter;
 
 import bisq.core.account.witness.AccountAgeWitnessStore;
-import bisq.common.config.BaseCurrencyNetwork;
 import bisq.core.offer.OfferPayload;
 import bisq.core.proto.persistable.CorePersistenceProtoResolver;
 import bisq.core.trade.statistics.TradeStatistics2Store;
@@ -30,11 +29,11 @@ import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.Connection;
 import bisq.network.p2p.peers.getdata.messages.GetDataResponse;
 import bisq.network.p2p.peers.getdata.messages.PreliminaryGetDataRequest;
-import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.app.Version;
+import bisq.common.config.BaseCurrencyNetwork;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.storage.Storage;
@@ -164,10 +163,10 @@ public class P2PMarketStats extends P2PSeedNodeSnapshotBase {
             String networkPostfix = "_" + BaseCurrencyNetwork.values()[Version.getBaseCurrencyNetwork()].toString();
             try {
                 Storage<PersistableEnvelope> storage = new Storage<>(dir, new CorePersistenceProtoResolver(null, null, null, null), null);
-                TradeStatistics2Store tradeStatistics2Store = (TradeStatistics2Store) storage.initAndGetPersistedWithFileName(TradeStatistics2Store.class.getSimpleName() + networkPostfix, 0);
+                TradeStatistics2Store tradeStatistics2Store = (TradeStatistics2Store) storage.initAndGetPersistedWithFileName(TradeStatistics2Store.class.getSimpleName() + networkPostfix, 100);
                 hashes.addAll(tradeStatistics2Store.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
 
-                AccountAgeWitnessStore accountAgeWitnessStore = (AccountAgeWitnessStore) storage.initAndGetPersistedWithFileName(AccountAgeWitnessStore.class.getSimpleName() + networkPostfix, 0);
+                AccountAgeWitnessStore accountAgeWitnessStore = (AccountAgeWitnessStore) storage.initAndGetPersistedWithFileName(AccountAgeWitnessStore.class.getSimpleName() + networkPostfix, 100);
                 hashes.addAll(accountAgeWitnessStore.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
             } catch (NullPointerException e) {
                 // in case there is no store file

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
@@ -21,7 +21,6 @@ import bisq.monitor.OnionParser;
 import bisq.monitor.Reporter;
 
 import bisq.core.account.witness.AccountAgeWitnessStore;
-import bisq.common.config.BaseCurrencyNetwork;
 import bisq.core.dao.monitoring.model.StateHash;
 import bisq.core.dao.monitoring.network.messages.GetBlindVoteStateHashesRequest;
 import bisq.core.dao.monitoring.network.messages.GetDaoStateHashesRequest;
@@ -34,11 +33,11 @@ import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.Connection;
 import bisq.network.p2p.peers.getdata.messages.GetDataResponse;
 import bisq.network.p2p.peers.getdata.messages.PreliminaryGetDataRequest;
-import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.app.Version;
+import bisq.common.config.BaseCurrencyNetwork;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.storage.Storage;
@@ -138,10 +137,10 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
             String networkPostfix = "_" + BaseCurrencyNetwork.values()[Version.getBaseCurrencyNetwork()].toString();
             try {
                 Storage<PersistableEnvelope> storage = new Storage<>(dir, new CorePersistenceProtoResolver(null, null, null, null), null);
-                TradeStatistics2Store tradeStatistics2Store = (TradeStatistics2Store) storage.initAndGetPersistedWithFileName(TradeStatistics2Store.class.getSimpleName() + networkPostfix, 0);
+                TradeStatistics2Store tradeStatistics2Store = (TradeStatistics2Store) storage.initAndGetPersistedWithFileName(TradeStatistics2Store.class.getSimpleName() + networkPostfix, 100);
                 hashes.addAll(tradeStatistics2Store.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
 
-                AccountAgeWitnessStore accountAgeWitnessStore = (AccountAgeWitnessStore) storage.initAndGetPersistedWithFileName(AccountAgeWitnessStore.class.getSimpleName() + networkPostfix, 0);
+                AccountAgeWitnessStore accountAgeWitnessStore = (AccountAgeWitnessStore) storage.initAndGetPersistedWithFileName(AccountAgeWitnessStore.class.getSimpleName() + networkPostfix, 100);
                 hashes.addAll(accountAgeWitnessStore.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
             } catch (NullPointerException e) {
                 // in case there is no store file

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -36,9 +36,8 @@ import bisq.common.config.Config;
 import bisq.common.proto.persistable.PersistedDataHost;
 import bisq.common.storage.Storage;
 
-import javax.inject.Named;
-
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -175,7 +174,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
 
     @Override
     public void readPersisted() {
-        PeerList persistedPeerList = storage.initAndGetPersistedWithFileName("PeerList", 1000);
+        PeerList persistedPeerList = storage.initAndGetPersistedWithFileName("PeerList", 2000);
         if (persistedPeerList != null) {
             long peersWithNoCapabilitiesSet = persistedPeerList.getList().stream()
                     .filter(e -> e.getCapabilities().isEmpty())
@@ -465,7 +464,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
 
             persistedPeers.addAll(reportedPeersToAdd);
             purgePersistedPeersIfExceeds();
-            storage.queueUpForSave(new PeerList(new ArrayList<>(persistedPeers)), 2000);
+            storage.queueUpForSave(new PeerList(new ArrayList<>(persistedPeers)));
 
             printReportedPeers();
         } else {
@@ -529,7 +528,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     private boolean removePersistedPeer(Peer persistedPeer) {
         if (persistedPeers.contains(persistedPeer)) {
             persistedPeers.remove(persistedPeer);
-            storage.queueUpForSave(new PeerList(new ArrayList<>(persistedPeers)), 2000);
+            storage.queueUpForSave(new PeerList(new ArrayList<>(persistedPeers)));
             return true;
         } else {
             return false;

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -171,7 +171,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
     @Override
     public void readPersisted() {
-        SequenceNumberMap persistedSequenceNumberMap = sequenceNumberMapStorage.initAndGetPersisted(sequenceNumberMap, 300);
+        SequenceNumberMap persistedSequenceNumberMap = sequenceNumberMapStorage.initAndGetPersisted(sequenceNumberMap, 2000);
         if (persistedSequenceNumberMap != null)
             sequenceNumberMap.setMap(getPurgedSequenceNumberMap(persistedSequenceNumberMap.getMap()));
     }
@@ -618,7 +618,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         // Record the updated sequence number and persist it. Higher delay so we can batch more items.
         sequenceNumberMap.put(hashOfPayload, new MapValue(protectedStorageEntry.getSequenceNumber(), this.clock.millis()));
-        sequenceNumberMapStorage.queueUpForSave(SequenceNumberMap.clone(sequenceNumberMap), 2000);
+        sequenceNumberMapStorage.queueUpForSave(SequenceNumberMap.clone(sequenceNumberMap));
 
         // Optionally, broadcast the add/update depending on the calling environment
         if (allowBroadcast)
@@ -672,7 +672,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         // Record the latest sequence number and persist it
         sequenceNumberMap.put(hashOfPayload, new MapValue(updatedEntry.getSequenceNumber(), this.clock.millis()));
-        sequenceNumberMapStorage.queueUpForSave(SequenceNumberMap.clone(sequenceNumberMap), 1000);
+        sequenceNumberMapStorage.queueUpForSave(SequenceNumberMap.clone(sequenceNumberMap));
 
         // Always broadcast refreshes
         broadcaster.broadcast(refreshTTLMessage, sender);
@@ -708,7 +708,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         // Record the latest sequence number and persist it
         sequenceNumberMap.put(hashOfPayload, new MapValue(protectedStorageEntry.getSequenceNumber(), this.clock.millis()));
-        sequenceNumberMapStorage.queueUpForSave(SequenceNumberMap.clone(sequenceNumberMap), 300);
+        sequenceNumberMapStorage.queueUpForSave(SequenceNumberMap.clone(sequenceNumberMap));
 
         // Update that we have seen this AddOncePayload so the next time it is seen it fails verification
         if (protectedStoragePayload instanceof AddOncePayload)

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
@@ -66,7 +66,7 @@ public abstract class StoreService<T extends PersistableEnvelope> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     protected void persist() {
-        storage.queueUpForSave(store, 200);
+        storage.queueUpForSave(store);
     }
 
     protected T getStore() {
@@ -123,7 +123,7 @@ public abstract class StoreService<T extends PersistableEnvelope> {
 
     protected void readStore() {
         final String fileName = getFileName();
-        store = storage.initAndGetPersistedWithFileName(fileName, 100);
+        store = storage.initAndGetPersistedWithFileName(fileName, 500);
         if (store != null) {
             int length = store.toProtoMessage().toByteArray().length;
             double size = length > 1_000_000D ? length / 1_000_000D : length / 1_000D;

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
@@ -125,9 +125,11 @@ public abstract class StoreService<T extends PersistableEnvelope> {
         final String fileName = getFileName();
         store = storage.initAndGetPersistedWithFileName(fileName, 100);
         if (store != null) {
-            log.info("{}: size of {}: {} MB", this.getClass().getSimpleName(),
-                    storage.getClass().getSimpleName(),
-                    store.toProtoMessage().toByteArray().length / 1_000_000D);
+            int length = store.toProtoMessage().toByteArray().length;
+            double size = length > 1_000_000D ? length / 1_000_000D : length / 1_000D;
+            String unit = length > 1_000_000D ? "MB" : "KB";
+            log.info("{}: size of {}: {} {}", this.getClass().getSimpleName(),
+                    storage.getClass().getSimpleName(), size, unit);
         } else {
             store = createStore();
         }

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -161,7 +161,7 @@ public class TestState {
      */
     private void verifySequenceNumberMapWriteContains(P2PDataStorage.ByteArray payloadHash, int sequenceNumber) {
         final ArgumentCaptor<SequenceNumberMap> captor = ArgumentCaptor.forClass(SequenceNumberMap.class);
-        verify(this.mockSeqNrStorage).queueUpForSave(captor.capture(), anyLong());
+        verify(this.mockSeqNrStorage).queueUpForSave(captor.capture());
 
         SequenceNumberMap savedMap = captor.getValue();
         Assert.assertEquals(sequenceNumber, savedMap.get(payloadHash).sequenceNr);
@@ -232,7 +232,7 @@ public class TestState {
         if (expectedSequenceNrMapWrite) {
             this.verifySequenceNumberMapWriteContains(P2PDataStorage.get32ByteHashAsByteArray(protectedStorageEntry.getProtectedStoragePayload()), protectedStorageEntry.getSequenceNumber());
         } else {
-            verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class), anyLong());
+            verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class));
         }
     }
 
@@ -273,7 +273,7 @@ public class TestState {
         }
 
         if (!expectedSeqNrWrite)
-            verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class), anyLong());
+            verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class));
 
         if (!expectedBroadcast)
             verify(this.mockBroadcaster, never()).broadcast(any(BroadcastMessage.class), nullable(NodeAddress.class));
@@ -338,7 +338,7 @@ public class TestState {
             }
 
             verify(this.mockBroadcaster, never()).broadcast(any(BroadcastMessage.class), nullable(NodeAddress.class));
-            verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class), anyLong());
+            verify(this.mockSeqNrStorage, never()).queueUpForSave(any(SequenceNumberMap.class));
         }
     }
 


### PR DESCRIPTION
The model we borrowed from BitcoinJ wallet persistence comes with some complexity and performance costs if the queueUpForSave was called frequently (which is the case). We started for each queueUpForSave call a new thread and most returned without doing work if the persitable data was written by a concurrent task already.

A periodic timer task is a much more simple model. The costs for creating a new task is higher than a runnable execute without doing work in case that there was no new queueUpForSave call.
It also simplifies the usage for clients as the period for persiting is set at intitialisation and cannot be changed anymore (was a bit messy with many different delay values). The period for persistence should reflect the frequency of data changes and the importance that the data is the latest version if the user shuts down quickly. 

There is now also a saveNow method in case immediate write is needed. This comes as sync or async with completeHandler so we dont need to add a safety delay before continuing (e.g. shutdown).


