### PR TITLE
Refactor API & add registerdisputeagent method to CLI

### DIFF
--- a/apitest/scripts/mainnet-test.sh
+++ b/apitest/scripts/mainnet-test.sh
@@ -48,14 +48,14 @@
   run ./bisq-cli --password="xyz" getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.8" ]
+  [ "$output" = "1.3.9" ]
 }
 
 @test "test getversion" {
   run ./bisq-cli --password=xyz getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.8" ]
+  [ "$output" = "1.3.9" ]
 }
 
 @test "test setwalletpassword \"a b c\"" {
@@ -166,15 +166,15 @@
   [ "$output" = "Error: address bogus not found in wallet" ]
 }
 
-@test "test createpaymentacct PerfectMoneyDummy (missing nbr, ccy params)" {
-  run ./bisq-cli --password=xyz createpaymentacct PerfectMoneyDummy
+@test "test createpaymentacct PerfectMoneyDummy (missing name, nbr, ccy params)" {
+  run ./bisq-cli --password=xyz createpaymentacct PERFECT_MONEY
   [ "$status" -eq 1 ]
  echo "actual output:  $output" >&2
-  [ "$output" = "Error: incorrect parameter count, expecting account name, account number, currency code" ]
+  [ "$output" = "Error: incorrect parameter count, expecting payment method id, account name, account number, currency code" ]
 }
 
-@test "test createpaymentacct PerfectMoneyDummy 0123456789 USD" {
-  run ./bisq-cli --password=xyz createpaymentacct PerfectMoneyDummy 0123456789 USD
+@test "test createpaymentacct PERFECT_MONEY PerfectMoneyDummy 0123456789 USD" {
+  run ./bisq-cli --password=xyz createpaymentacct PERFECT_MONEY PerfectMoneyDummy 0123456789 USD
   [ "$status" -eq 0 ]
 }
 

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -139,8 +139,14 @@ public class CoreApi {
     // PaymentAccounts
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public void createPaymentAccount(String accountName, String accountNumber, String fiatCurrencyCode) {
-        paymentAccountsService.createPaymentAccount(accountName, accountNumber, fiatCurrencyCode);
+    public void createPaymentAccount(String paymentMethodId,
+                                     String accountName,
+                                     String accountNumber,
+                                     String currencyCode) {
+        paymentAccountsService.createPaymentAccount(paymentMethodId,
+                accountName,
+                accountNumber,
+                currencyCode);
     }
 
     public Set<PaymentAccount> getPaymentAccounts() {

--- a/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
+++ b/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
@@ -68,7 +68,7 @@ class CoreDisputeAgentsService {
         this.languageCodes = Arrays.asList("de", "en", "es", "fr");
     }
 
-    public void registerDisputeAgent(String disputeAgentType, String registrationKey) {
+    void registerDisputeAgent(String disputeAgentType, String registrationKey) {
         if (!p2PService.isBootstrapped())
             throw new IllegalStateException("p2p service is not bootstrapped yet");
 

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -58,7 +58,7 @@ class CoreOffersService {
         this.user = user;
     }
 
-    public List<Offer> getOffers(String direction, String fiatCurrencyCode) {
+    List<Offer> getOffers(String direction, String fiatCurrencyCode) {
         List<Offer> offers = offerBookService.getOffers().stream()
                 .filter(o -> {
                     var offerOfWantedDirection = o.getDirection().name().equalsIgnoreCase(direction);
@@ -77,16 +77,16 @@ class CoreOffersService {
         return offers;
     }
 
-    public void createOffer(String currencyCode,
-                            String directionAsString,
-                            long priceAsLong,
-                            boolean useMarketBasedPrice,
-                            double marketPriceMargin,
-                            long amountAsLong,
-                            long minAmountAsLong,
-                            double buyerSecurityDeposit,
-                            String paymentAccountId,
-                            TransactionResultHandler resultHandler) {
+    void createOffer(String currencyCode,
+                     String directionAsString,
+                     long priceAsLong,
+                     boolean useMarketBasedPrice,
+                     double marketPriceMargin,
+                     long amountAsLong,
+                     long minAmountAsLong,
+                     double buyerSecurityDeposit,
+                     String paymentAccountId,
+                     TransactionResultHandler resultHandler) {
         String offerId = createOfferService.getRandomOfferId();
         OfferPayload.Direction direction = OfferPayload.Direction.valueOf(directionAsString);
         Price price = Price.valueOf(currencyCode, priceAsLong);
@@ -111,18 +111,18 @@ class CoreOffersService {
                 resultHandler);
     }
 
-    public void createOffer(String offerId,
-                            String currencyCode,
-                            OfferPayload.Direction direction,
-                            Price price,
-                            boolean useMarketBasedPrice,
-                            double marketPriceMargin,
-                            Coin amount,
-                            Coin minAmount,
-                            double buyerSecurityDeposit,
-                            PaymentAccount paymentAccount,
-                            boolean useSavingsWallet,
-                            TransactionResultHandler resultHandler) {
+    void createOffer(String offerId,
+                     String currencyCode,
+                     OfferPayload.Direction direction,
+                     Price price,
+                     boolean useMarketBasedPrice,
+                     double marketPriceMargin,
+                     Coin amount,
+                     Coin minAmount,
+                     double buyerSecurityDeposit,
+                     PaymentAccount paymentAccount,
+                     boolean useSavingsWallet,
+                     TransactionResultHandler resultHandler) {
         Coin useDefaultTxFee = Coin.ZERO;
         Offer offer = createOfferService.createAndGetOffer(offerId,
                 direction,

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -734,6 +734,9 @@ public abstract class WalletService {
         return maybeAddTxToWallet(transaction.bitcoinSerialize(), wallet, source);
     }
 
+    public Address getAddress(String addressString) {
+        return Address.fromBase58(params, addressString);
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // bisqWalletEventListener

--- a/core/src/main/java/bisq/core/user/User.java
+++ b/core/src/main/java/bisq/core/user/User.java
@@ -189,6 +189,12 @@ public class User implements PersistedDataHost {
     // Collection operations
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    public void addPaymentAccountIfNotExists(PaymentAccount paymentAccount) {
+        if (!paymentAccountExists(paymentAccount)) {
+            addPaymentAccount(paymentAccount);
+        }
+    }
+
     public void addPaymentAccount(PaymentAccount paymentAccount) {
         paymentAccount.onAddToUser();
 
@@ -492,5 +498,9 @@ public class User implements PersistedDataHost {
 
     public boolean isPaymentAccountImport() {
         return isPaymentAccountImport;
+    }
+
+    private boolean paymentAccountExists(PaymentAccount paymentAccount) {
+        return getPaymentAccountsAsObservable().stream().anyMatch(e -> e.equals(paymentAccount));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcGetTradeStatisticsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcGetTradeStatisticsService.java
@@ -1,0 +1,37 @@
+package bisq.daemon.grpc;
+
+import bisq.core.api.CoreApi;
+import bisq.core.trade.statistics.TradeStatistics2;
+
+import bisq.proto.grpc.GetTradeStatisticsGrpc;
+import bisq.proto.grpc.GetTradeStatisticsReply;
+import bisq.proto.grpc.GetTradeStatisticsRequest;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.stream.Collectors;
+
+public class GrpcGetTradeStatisticsService extends GetTradeStatisticsGrpc.GetTradeStatisticsImplBase {
+
+    private final CoreApi coreApi;
+
+    @Inject
+    public GrpcGetTradeStatisticsService(CoreApi coreApi) {
+        this.coreApi = coreApi;
+    }
+
+    @Override
+    public void getTradeStatistics(GetTradeStatisticsRequest req,
+                                   StreamObserver<GetTradeStatisticsReply> responseObserver) {
+
+        var tradeStatistics = coreApi.getTradeStatistics().stream()
+                .map(TradeStatistics2::toProtoTradeStatistics2)
+                .collect(Collectors.toList());
+
+        var reply = GetTradeStatisticsReply.newBuilder().addAllTradeStatistics(tradeStatistics).build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+}

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcGetTradeStatisticsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcGetTradeStatisticsService.java
@@ -13,7 +13,7 @@ import javax.inject.Inject;
 
 import java.util.stream.Collectors;
 
-public class GrpcGetTradeStatisticsService extends GetTradeStatisticsGrpc.GetTradeStatisticsImplBase {
+class GrpcGetTradeStatisticsService extends GetTradeStatisticsGrpc.GetTradeStatisticsImplBase {
 
     private final CoreApi coreApi;
 

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -52,7 +52,7 @@ class GrpcOffersService extends OffersGrpc.OffersImplBase {
         // The client cannot see bisq.core.Offer or its fromProto method.
         // We use the lighter weight OfferInfo proto wrapper instead, containing just
         // enough fields to view and create offers.
-        List<OfferInfo> result = coreApi.getOffers(req.getDirection(), req.getFiatCurrencyCode())
+        List<OfferInfo> result = coreApi.getOffers(req.getDirection(), req.getCurrencyCode())
                 .stream().map(offer -> new OfferInfo.OfferInfoBuilder()
                         .withId(offer.getId())
                         .withDirection(offer.getDirection().name())

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
@@ -45,7 +45,10 @@ class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccountsImpl
     @Override
     public void createPaymentAccount(CreatePaymentAccountRequest req,
                                      StreamObserver<CreatePaymentAccountReply> responseObserver) {
-        coreApi.createPaymentAccount(req.getAccountName(), req.getAccountNumber(), req.getFiatCurrencyCode());
+        coreApi.createPaymentAccount(req.getPaymentMethodId(),
+                req.getAccountName(),
+                req.getAccountNumber(),
+                req.getCurrencyCode());
         var reply = CreatePaymentAccountReply.newBuilder().build();
         responseObserver.onNext(reply);
         responseObserver.onCompleted();
@@ -54,10 +57,11 @@ class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccountsImpl
     @Override
     public void getPaymentAccounts(GetPaymentAccountsRequest req,
                                    StreamObserver<GetPaymentAccountsReply> responseObserver) {
-        var tradeStatistics = coreApi.getPaymentAccounts().stream()
+        var paymentAccounts = coreApi.getPaymentAccounts().stream()
                 .map(PaymentAccount::toProtoMessage)
                 .collect(Collectors.toList());
-        var reply = GetPaymentAccountsReply.newBuilder().addAllPaymentAccounts(tradeStatistics).build();
+        var reply = GetPaymentAccountsReply.newBuilder()
+                .addAllPaymentAccounts(paymentAccounts).build();
         responseObserver.onNext(reply);
         responseObserver.onCompleted();
     }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
@@ -18,30 +18,21 @@
 package bisq.daemon.grpc;
 
 import bisq.core.api.CoreApi;
-import bisq.core.trade.statistics.TradeStatistics2;
 
 import bisq.common.config.Config;
 
-import bisq.proto.grpc.GetTradeStatisticsGrpc;
-import bisq.proto.grpc.GetTradeStatisticsReply;
-import bisq.proto.grpc.GetTradeStatisticsRequest;
-import bisq.proto.grpc.GetVersionGrpc;
-import bisq.proto.grpc.GetVersionReply;
-import bisq.proto.grpc.GetVersionRequest;
-
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
-import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 
+@Singleton
 @Slf4j
 public class GrpcServer {
 
@@ -51,19 +42,22 @@ public class GrpcServer {
     @Inject
     public GrpcServer(Config config,
                       CoreApi coreApi,
+                      PasswordAuthInterceptor passwordAuthInterceptor,
                       GrpcDisputeAgentsService disputeAgentsService,
                       GrpcOffersService offersService,
                       GrpcPaymentAccountsService paymentAccountsService,
+                      GrpcVersionService versionService,
+                      GrpcGetTradeStatisticsService tradeStatisticsService,
                       GrpcWalletsService walletsService) {
         this.coreApi = coreApi;
         this.server = ServerBuilder.forPort(config.apiPort)
                 .addService(disputeAgentsService)
-                .addService(new GetVersionService())
-                .addService(new GetTradeStatisticsService())
                 .addService(offersService)
                 .addService(paymentAccountsService)
+                .addService(tradeStatisticsService)
+                .addService(versionService)
                 .addService(walletsService)
-                .intercept(new PasswordAuthInterceptor(config.apiPassword))
+                .intercept(passwordAuthInterceptor)
                 .build();
     }
 
@@ -71,36 +65,14 @@ public class GrpcServer {
         try {
             server.start();
             log.info("listening on port {}", server.getPort());
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                server.shutdown();
-                log.info("shutdown complete");
-            }));
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
     }
 
-    class GetVersionService extends GetVersionGrpc.GetVersionImplBase {
-        @Override
-        public void getVersion(GetVersionRequest req, StreamObserver<GetVersionReply> responseObserver) {
-            var reply = GetVersionReply.newBuilder().setVersion(coreApi.getVersion()).build();
-            responseObserver.onNext(reply);
-            responseObserver.onCompleted();
-        }
-    }
-
-    class GetTradeStatisticsService extends GetTradeStatisticsGrpc.GetTradeStatisticsImplBase {
-        @Override
-        public void getTradeStatistics(GetTradeStatisticsRequest req,
-                                       StreamObserver<GetTradeStatisticsReply> responseObserver) {
-
-            var tradeStatistics = coreApi.getTradeStatistics().stream()
-                    .map(TradeStatistics2::toProtoTradeStatistics2)
-                    .collect(Collectors.toList());
-
-            var reply = GetTradeStatisticsReply.newBuilder().addAllTradeStatistics(tradeStatistics).build();
-            responseObserver.onNext(reply);
-            responseObserver.onCompleted();
-        }
+    public void shutdown() {
+        log.info("Server shutdown started");
+        server.shutdown();
+        log.info("Server shutdown complete");
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
@@ -10,7 +10,7 @@ import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
 
-public class GrpcVersionService extends GetVersionGrpc.GetVersionImplBase {
+class GrpcVersionService extends GetVersionGrpc.GetVersionImplBase {
 
     private final CoreApi coreApi;
 

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
@@ -1,0 +1,28 @@
+package bisq.daemon.grpc;
+
+import bisq.core.api.CoreApi;
+
+import bisq.proto.grpc.GetVersionGrpc;
+import bisq.proto.grpc.GetVersionReply;
+import bisq.proto.grpc.GetVersionRequest;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+public class GrpcVersionService extends GetVersionGrpc.GetVersionImplBase {
+
+    private final CoreApi coreApi;
+
+    @Inject
+    public GrpcVersionService(CoreApi coreApi) {
+        this.coreApi = coreApi;
+    }
+
+    @Override
+    public void getVersion(GetVersionRequest req, StreamObserver<GetVersionReply> responseObserver) {
+        var reply = GetVersionReply.newBuilder().setVersion(coreApi.getVersion()).build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+}

--- a/daemon/src/main/java/bisq/daemon/grpc/PasswordAuthInterceptor.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/PasswordAuthInterceptor.java
@@ -17,11 +17,15 @@
 
 package bisq.daemon.grpc;
 
+import bisq.common.config.Config;
+
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.StatusRuntimeException;
+
+import javax.inject.Inject;
 
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 import static io.grpc.Metadata.Key;
@@ -36,12 +40,13 @@ import static java.lang.String.format;
  */
 class PasswordAuthInterceptor implements ServerInterceptor {
 
-    public static final String PASSWORD_KEY = "password";
+    private static final String PASSWORD_KEY = "password";
 
     private final String expectedPasswordValue;
 
-    public PasswordAuthInterceptor(String expectedPasswordValue) {
-        this.expectedPasswordValue = expectedPasswordValue;
+    @Inject
+    public PasswordAuthInterceptor(Config config) {
+        this.expectedPasswordValue = config.apiPassword;
     }
 
     @Override

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -53,7 +53,7 @@ service Offers {
 
 message GetOffersRequest {
     string direction = 1;
-    string fiatCurrencyCode = 2;
+    string currencyCode = 2;
 }
 
 message GetOffersReply {
@@ -61,7 +61,7 @@ message GetOffersReply {
 }
 
 message CreateOfferRequest {
-    string currencyCode = 1; // TODO switch order w/ direction field in next PR
+    string currencyCode = 1;
     string direction = 2;
     uint64 price = 3;
     bool useMarketBasedPrice = 4;
@@ -107,9 +107,11 @@ service PaymentAccounts {
 }
 
 message CreatePaymentAccountRequest {
-    string accountName = 1;
-    string accountNumber = 2;
-    string fiatCurrencyCode = 3;
+string paymentMethodId = 1;
+    string accountName = 2;
+    string accountNumber = 3;
+    // TODO  Support all currencies. Maybe add a repeated and if only one is used its a singletonList.
+    string currencyCode = 4;
 }
 
 message CreatePaymentAccountReply {
@@ -123,7 +125,7 @@ message GetPaymentAccountsReply {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// TradeStatistics
+// GetTradeStatistics
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 service GetTradeStatistics {


### PR DESCRIPTION
This commit contains most of the changes suggested by @chimp1984 in his api-suggestions branch.  See https://github.com/bisq-network/bisq/commit/961703ecea62df62946ab001ec28205662688ccd

A new `registerdisputeagent` method was also added to `CliMain`, finishing the work to support registration of mediators and refund agents on arbitration daemons running in regtest mode.  This method cannot be used to register dispute agents on mainnet;  users will see an error msg if they try.  (The change was added to this PR to avoid likely `CliMain` file conflicts.)

This PR replaces [4526](https://github.com/bisq-network/bisq/pull/4526).