### PR TITLE
Reduce apitest harness' dependency on string matching

### DIFF
--- a/apitest/src/main/java/bisq/apitest/Scaffold.java
+++ b/apitest/src/main/java/bisq/apitest/Scaffold.java
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
 import static bisq.apitest.config.BisqAppConfig.*;
 import static java.lang.String.format;
 import static java.lang.System.exit;
@@ -63,6 +64,10 @@ public class Scaffold {
 
     public static final int EXIT_SUCCESS = 0;
     public static final int EXIT_FAILURE = 1;
+
+    public enum BitcoinCoreApp {
+        bitcoind
+    }
 
     public final ApiTestConfig config;
 
@@ -295,7 +300,7 @@ public class Scaffold {
 
         log.info("Starting supporting apps {}", config.supportingApps.toString());
 
-        if (config.hasSupportingApp("bitcoind")) {
+        if (config.hasSupportingApp(bitcoind.name())) {
             BitcoinDaemon bitcoinDaemon = new BitcoinDaemon(config);
             bitcoinDaemon.verifyBitcoinPathsExist(true);
             bitcoindTask = new SetupTask(bitcoinDaemon, countdownLatch);

--- a/apitest/src/test/java/bisq/apitest/ApiTestCase.java
+++ b/apitest/src/test/java/bisq/apitest/ApiTestCase.java
@@ -24,7 +24,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
+import static java.util.Arrays.stream;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 
@@ -68,15 +70,21 @@ public class ApiTestCase {
     // gRPC service stubs are used by method & scenario tests, but not e2e tests.
     private static final Map<BisqAppConfig, GrpcStubs> grpcStubsCache = new HashMap<>();
 
-    public static void setUpScaffold(String supportingApps)
+    public static void setUpScaffold(Enum<?>... supportingApps)
             throws InterruptedException, ExecutionException, IOException {
-        scaffold = new Scaffold(supportingApps).setUp();
+        scaffold = new Scaffold(stream(supportingApps).map(Enum::name)
+                .collect(Collectors.joining(",")))
+                .setUp();
         config = scaffold.config;
         bitcoinCli = new BitcoinCliHelper((config));
     }
 
     public static void setUpScaffold(String[] params)
             throws InterruptedException, ExecutionException, IOException {
+        // Test cases needing to pass more than just an ApiTestConfig
+        // --supportingApps option will use this setup method, but the
+        // --supportingApps option will need to be passed too, with its comma
+        // delimited app list value, e.g., "bitcoind,seednode,arbdaemon".
         scaffold = new Scaffold(params).setUp();
         config = scaffold.config;
     }

--- a/apitest/src/test/java/bisq/apitest/method/GetBalanceTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/GetBalanceTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
 import static bisq.apitest.config.BisqAppConfig.alicedaemon;
+import static bisq.apitest.config.BisqAppConfig.seednode;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -41,7 +43,7 @@ public class GetBalanceTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         try {
-            setUpScaffold("bitcoind,seednode,alicedaemon");
+            setUpScaffold(bitcoind, seednode, alicedaemon);
 
             // Have to generate 1 regtest block for alice's wallet to show 10 BTC balance.
             bitcoinCli.generateBlocks(1);

--- a/apitest/src/test/java/bisq/apitest/method/GetVersionTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/GetVersionTest.java
@@ -41,7 +41,7 @@ public class GetVersionTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         try {
-            setUpScaffold(alicedaemon.name());
+            setUpScaffold(alicedaemon);
         } catch (Exception ex) {
             fail(ex);
         }

--- a/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
 import static bisq.apitest.config.BisqAppConfig.arbdaemon;
+import static bisq.apitest.config.BisqAppConfig.seednode;
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,10 +44,14 @@ import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 @TestMethodOrder(OrderAnnotation.class)
 public class RegisterDisputeAgentsTest extends MethodTest {
 
+    private static final String ARBITRATOR = "arbitrator";
+    private static final String MEDIATOR = "mediator";
+    private static final String REFUNDAGENT = "refundagent";
+
     @BeforeAll
     public static void setUp() {
         try {
-            setUpScaffold("bitcoind,seednode,arbdaemon");
+            setUpScaffold(bitcoind, seednode, arbdaemon);
         } catch (Exception ex) {
             fail(ex);
         }
@@ -55,7 +61,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(1)
     public void testRegisterArbitratorShouldThrowException() {
         var req =
-                createRegisterDisputeAgentRequest("arbitrator");
+                createRegisterDisputeAgentRequest(ARBITRATOR);
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req));
         assertEquals("INVALID_ARGUMENT: arbitrators must be registered in a Bisq UI",
@@ -77,7 +83,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(3)
     public void testInvalidRegistrationKeyArgShouldThrowException() {
         var req = RegisterDisputeAgentRequest.newBuilder()
-                .setDisputeAgentType("refundagent")
+                .setDisputeAgentType(REFUNDAGENT)
                 .setRegistrationKey("invalid" + DEV_PRIVILEGE_PRIV_KEY).build();
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req));
@@ -89,7 +95,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(4)
     public void testRegisterMediator() {
         var req =
-                createRegisterDisputeAgentRequest("mediator");
+                createRegisterDisputeAgentRequest(MEDIATOR);
         grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req);
     }
 
@@ -97,7 +103,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(5)
     public void testRegisterRefundAgent() {
         var req =
-                createRegisterDisputeAgentRequest("refundagent");
+                createRegisterDisputeAgentRequest(REFUNDAGENT);
         grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req);
     }
 

--- a/apitest/src/test/java/bisq/apitest/method/WalletProtectionTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/WalletProtectionTest.java
@@ -25,7 +25,7 @@ public class WalletProtectionTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         try {
-            setUpScaffold(alicedaemon.name());
+            setUpScaffold(alicedaemon);
             MILLISECONDS.sleep(2000);
         } catch (Exception ex) {
             fail(ex);

--- a/apitest/src/test/java/bisq/apitest/scenario/FundWalletScenarioTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/FundWalletScenarioTest.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
 import static bisq.apitest.config.BisqAppConfig.alicedaemon;
+import static bisq.apitest.config.BisqAppConfig.seednode;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -38,7 +40,7 @@ public class FundWalletScenarioTest extends ScenarioTest {
     @BeforeAll
     public static void setUp() {
         try {
-            setUpScaffold("bitcoind,seednode,alicedaemon");
+            setUpScaffold(bitcoind, seednode, alicedaemon);
             bitcoinCli.generateBlocks(1);
             MILLISECONDS.sleep(1500);
         } catch (Exception ex) {


### PR DESCRIPTION
- Pass list of supporting app names as enum vararg to scaffold setup.
- Use dispute agent type constants in RegisterDisputeAgentsTest case.
