### PR TITLE
Remove unused, broken accessor

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -38,8 +38,6 @@ import org.bitcoinj.core.Context;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
-import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
@@ -47,12 +45,14 @@ import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.core.listeners.NewBestBlockListener;
+import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptChunk;
+import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.signers.TransactionSigner;
 import org.bitcoinj.utils.Threading;
@@ -791,10 +791,6 @@ public abstract class WalletService {
                                                  Wallet wallet,
                                                  TransactionConfidence.Source source) throws VerificationException {
         return maybeAddTxToWallet(transaction.bitcoinSerialize(), wallet, source);
-    }
-
-    public Address getAddress(String addressString) {
-        return Address.fromBase58(params, addressString);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The accessor added in commit e2bd89f broke the build, and was not used as originally intended -- by CoreWalletsService -- because the the api's wallet methods need addresses from the wallet, not just a valid address.
