### PR TITLE
Replace deprecated bitcoinj methods

### DIFF
--- a/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
@@ -211,7 +211,7 @@ public final class AddressEntryList implements UserThreadMappedPersistableEnvelo
     private void maybeAddNewAddressEntry(Transaction tx) {
         tx.getOutputs().stream()
                 .filter(output -> output.isMine(wallet))
-                .map(output -> output.getAddressFromP2PKHScript(wallet.getNetworkParameters()))
+                .map(output -> output.getScriptPubKey().getToAddress(wallet.getNetworkParameters()))
                 .filter(Objects::nonNull)
                 .filter(this::isAddressNotInEntries)
                 .map(address -> (DeterministicKey) wallet.findKeyFromPubKeyHash(address.getHash(),

--- a/core/src/main/java/bisq/core/trade/DelayedPayoutTxValidation.java
+++ b/core/src/main/java/bisq/core/trade/DelayedPayoutTxValidation.java
@@ -146,16 +146,12 @@ public class DelayedPayoutTxValidation {
 
 
         NetworkParameters params = btcWalletService.getParams();
-        Address address = output.getAddressFromP2PKHScript(params);
+        Address address = output.getScriptPubKey().getToAddress(params);
         if (address == null) {
-            // The donation address can be as well be a multisig address.
-            address = output.getAddressFromP2SH(params);
-            if (address == null) {
-                errorMsg = "Donation address cannot be resolved (not of type P2PKHScript or P2SH). Output: " + output;
-                log.error(errorMsg);
-                log.error(delayedPayoutTx.toString());
-                throw new DonationAddressException(errorMsg);
-            }
+            errorMsg = "Donation address cannot be resolved (not of type P2PK nor P2SH nor P2WH). Output: " + output;
+            log.error(errorMsg);
+            log.error(delayedPayoutTx.toString());
+            throw new DonationAddressException(errorMsg);
         }
 
         String addressAsString = address.toString();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupDepositTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupDepositTxListener.java
@@ -59,7 +59,7 @@ public class BuyerSetupDepositTxListener extends TradeTask {
                 final NetworkParameters params = walletService.getParams();
                 Transaction preparedDepositTx = new Transaction(params, processModel.getPreparedDepositTx());
                 checkArgument(!preparedDepositTx.getOutputs().isEmpty(), "preparedDepositTx.getOutputs() must not be empty");
-                Address depositTxAddress = preparedDepositTx.getOutput(0).getAddressFromP2SH(params);
+                Address depositTxAddress = preparedDepositTx.getOutput(0).getScriptPubKey().getToAddress(params);
                 final TransactionConfidence confidence = walletService.getConfidenceForAddress(depositTxAddress);
                 if (isInNetwork(confidence)) {
                     applyConfidence(confidence);

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareTrade.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareTrade.java
@@ -157,7 +157,7 @@ class TransactionAwareTrade implements TransactionAwareTradable {
                     tx.getOutputs().forEach(txo -> {
                         if (btcWalletService.isTransactionOutputMine(txo)) {
                             try {
-                                Address receiverAddress = txo.getAddressFromP2PKHScript(btcWalletService.getParams());
+                                Address receiverAddress = txo.getScriptPubKey().getToAddress(btcWalletService.getParams());
                                 Contract contract = checkNotNull(trade.getContract());
                                 String myPayoutAddressString = contract.isMyRoleBuyer(pubKeyRing) ?
                                         contract.getBuyerPayoutAddressString() :


### PR DESCRIPTION
Replace output.getAddressFromP2PKHScript() and
output.getAddressFromP2SH() with
output.getScriptPubKey().getToAddress()

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.
