### PR TITLE
Change 'createoffer' api method return type

### DIFF
--- a/apitest/scripts/mainnet-test.sh
+++ b/apitest/scripts/mainnet-test.sh
@@ -16,6 +16,8 @@
 #
 #     ./cli/test.sh
 
+# load 'mainnet-test-helper'
+
 @test "test unsupported method error" {
   run ./bisq-cli --password=xyz bogus
   [ "$status" -eq 1 ]
@@ -45,17 +47,19 @@
 }
 
 @test "test getversion call with quoted password" {
+  load 'version-parser'
   run ./bisq-cli --password="xyz" getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.9" ]
+  [ "$output" = "$CURRENT_VERSION" ]
 }
 
 @test "test getversion" {
+  load 'version-parser'
   run ./bisq-cli --password=xyz getversion
   [ "$status" -eq 0 ]
   echo "actual output:  $output" >&2
-  [ "$output" = "1.3.9" ]
+  [ "$output" = "$CURRENT_VERSION" ]
 }
 
 @test "test setwalletpassword \"a b c\"" {

--- a/apitest/scripts/mainnet-test.sh
+++ b/apitest/scripts/mainnet-test.sh
@@ -16,8 +16,6 @@
 #
 #     ./cli/test.sh
 
-# load 'mainnet-test-helper'
-
 @test "test unsupported method error" {
   run ./bisq-cli --password=xyz bogus
   [ "$status" -eq 1 ]

--- a/apitest/scripts/version-parser.bash
+++ b/apitest/scripts/version-parser.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Bats helper script for parsing current version from Version.java.
+
+export CURRENT_VERSION=$(grep "String VERSION =" common/src/main/java/bisq/common/app/Version.java | sed 's/[^0-9.]*//g')

--- a/apitest/src/test/java/bisq/apitest/method/CreateOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/CreateOfferTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.apitest.method;
+
+import bisq.core.btc.wallet.Restrictions;
+
+import bisq.proto.grpc.CreateOfferRequest;
+import bisq.proto.grpc.GetOffersRequest;
+import bisq.proto.grpc.OfferInfo;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
+import static bisq.apitest.config.BisqAppConfig.alicedaemon;
+import static bisq.apitest.config.BisqAppConfig.arbdaemon;
+import static bisq.apitest.config.BisqAppConfig.seednode;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+
+
+@Slf4j
+@TestMethodOrder(OrderAnnotation.class)
+public class CreateOfferTest extends MethodTest {
+
+    @BeforeAll
+    public static void setUp() {
+        try {
+            // setUpScaffold(new String[]{"--supportingApps", "bitcoind,seednode,arbdaemon,alicedaemon", "--enableBisqDebugging", "true"});
+            setUpScaffold(bitcoind, seednode, arbdaemon, alicedaemon);
+
+            // Generate 1 regtest block for alice's wallet to show 10 BTC balance,
+            // and give alicedaemon time to parse the new block.
+            bitcoinCli.generateBlocks(1);
+            MILLISECONDS.sleep(1500);
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    @Test
+    @Order(1)
+    public void testCreateBuyOffer() {
+        var paymentAccount = getDefaultPerfectDummyPaymentAccount(alicedaemon);
+        var req = CreateOfferRequest.newBuilder()
+                .setCurrencyCode("USD")
+                .setDirection("BUY")
+                .setPrice(0)
+                .setUseMarketBasedPrice(true)
+                .setMarketPriceMargin(0.00)
+                .setAmount(10000000)
+                .setMinAmount(10000000)
+                .setBuyerSecurityDeposit(Restrictions.getDefaultBuyerSecurityDepositAsPercent())
+                .setPaymentAccountId(paymentAccount.getId())
+                .build();
+        var newOffer = grpcStubs(alicedaemon).offersService.createOffer(req).getOffer();
+        assertEquals("BUY", newOffer.getDirection());
+        assertTrue(newOffer.getUseMarketBasedPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("USD", newOffer.getCounterCurrencyCode());
+    }
+
+    @Test
+    @Order(2)
+    public void testGetNewBuyOffer() {
+        var req = GetOffersRequest.newBuilder().setDirection("BUY").setCurrencyCode("USD").build();
+        var reply = grpcStubs(alicedaemon).offersService.getOffers(req);
+
+        assertEquals(1, reply.getOffersCount());
+        OfferInfo offer = reply.getOffersList().get(0);
+        assertEquals("BUY", offer.getDirection());
+        assertTrue(offer.getUseMarketBasedPrice());
+        assertEquals(10000000, offer.getAmount());
+        assertEquals(10000000, offer.getMinAmount());
+        assertEquals(1500000, offer.getBuyerSecurityDeposit());
+        assertEquals("", offer.getPaymentAccountId());
+        assertEquals("BTC", offer.getBaseCurrencyCode());
+        assertEquals("USD", offer.getCounterCurrencyCode());
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        tearDownScaffold();
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/method/CreatePaymentAccountTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/CreatePaymentAccountTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.apitest.method;
+
+import bisq.proto.grpc.GetPaymentAccountsRequest;
+
+import protobuf.PaymentAccount;
+import protobuf.PerfectMoneyAccountPayload;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
+import static bisq.apitest.config.BisqAppConfig.alicedaemon;
+import static java.util.Comparator.comparing;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+
+
+@Slf4j
+@TestMethodOrder(OrderAnnotation.class)
+public class CreatePaymentAccountTest extends MethodTest {
+
+    static final String PERFECT_MONEY_ACCT_NAME = "Perfect Money USD";
+    static final String PERFECT_MONEY_ACCT_NUMBER = "0123456789";
+
+    @BeforeAll
+    public static void setUp() {
+        try {
+            setUpScaffold(bitcoind, alicedaemon);
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    @Test
+    @Order(1)
+    public void testCreatePerfectMoneyUSDPaymentAccount() {
+        var perfectMoneyPaymentAccountRequest = createCreatePerfectMoneyPaymentAccountRequest(
+                PERFECT_MONEY_ACCT_NAME,
+                PERFECT_MONEY_ACCT_NUMBER,
+                "USD");
+        //noinspection ResultOfMethodCallIgnored
+        grpcStubs(alicedaemon).paymentAccountsService.createPaymentAccount(perfectMoneyPaymentAccountRequest);
+
+        var getPaymentAccountsRequest = GetPaymentAccountsRequest.newBuilder().build();
+        var reply = grpcStubs(alicedaemon).paymentAccountsService.getPaymentAccounts(getPaymentAccountsRequest);
+
+        // The daemon is running against the regtest/dao setup files, and was set up with
+        // two dummy accounts ("PerfectMoney dummy", "ETH dummy") before any tests ran.
+        // We just added 1 test account, making 3 total.
+        assertEquals(3, reply.getPaymentAccountsCount());
+
+        // Sort the returned list by creation date; the last item in the sorted
+        // list will be the payment acct we just created.
+        List<PaymentAccount> paymentAccountList = reply.getPaymentAccountsList().stream()
+                .sorted(comparing(PaymentAccount::getCreationDate))
+                .collect(Collectors.toList());
+        PaymentAccount paymentAccount = paymentAccountList.get(2);
+        PerfectMoneyAccountPayload perfectMoneyAccount = paymentAccount
+                .getPaymentAccountPayload()
+                .getPerfectMoneyAccountPayload();
+
+        assertEquals(PERFECT_MONEY_ACCT_NAME, paymentAccount.getAccountName());
+        assertEquals("USD",
+                paymentAccount.getSelectedTradeCurrency().getFiatCurrency().getCurrency().getCurrencyCode());
+        assertEquals(PERFECT_MONEY_ACCT_NUMBER, perfectMoneyAccount.getAccountNr());
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        tearDownScaffold();
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -20,16 +20,25 @@ package bisq.apitest.method;
 import bisq.proto.grpc.CreatePaymentAccountRequest;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesRequest;
+import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.LockWalletRequest;
 import bisq.proto.grpc.RegisterDisputeAgentRequest;
 import bisq.proto.grpc.RemoveWalletPasswordRequest;
 import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.UnlockWalletRequest;
 
+import protobuf.PaymentAccount;
+
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
 import static bisq.core.payment.payload.PaymentMethod.PERFECT_MONEY;
 import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.MEDIATOR;
 import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.REFUNDAGENT;
+import static java.util.Comparator.comparing;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 
@@ -105,6 +114,18 @@ public class MethodTest extends ApiTestCase {
                 .setAccountNumber(accountNumber)
                 .setCurrencyCode(currencyCode)
                 .build();
+    }
+
+    protected final PaymentAccount getDefaultPerfectDummyPaymentAccount(BisqAppConfig bisqAppConfig) {
+        var getPaymentAccountsRequest = GetPaymentAccountsRequest.newBuilder().build();
+        var paymentAccountsService = grpcStubs(bisqAppConfig).paymentAccountsService;
+        PaymentAccount paymentAccount = paymentAccountsService.getPaymentAccounts(getPaymentAccountsRequest)
+                .getPaymentAccountsList()
+                .stream()
+                .sorted(comparing(protobuf.PaymentAccount::getCreationDate))
+                .collect(Collectors.toList()).get(0);
+        assertEquals("PerfectMoney dummy", paymentAccount.getAccountName());
+        return paymentAccount;
     }
 
     // Static conveniences for test methods and test case fixture setups.

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -95,6 +95,18 @@ public class MethodTest extends ApiTestCase {
                 .getAddress();
     }
 
+    protected final CreatePaymentAccountRequest createCreatePerfectMoneyPaymentAccountRequest(
+            String accountName,
+            String accountNumber,
+            String currencyCode) {
+        return CreatePaymentAccountRequest.newBuilder()
+                .setPaymentMethodId(PERFECT_MONEY.getId())
+                .setAccountName(accountName)
+                .setAccountNumber(accountNumber)
+                .setCurrencyCode(currencyCode)
+                .build();
+    }
+
     // Static conveniences for test methods and test case fixture setups.
 
     protected static RegisterDisputeAgentRequest createRegisterDisputeAgentRequest(String disputeAgentType) {
@@ -108,17 +120,5 @@ public class MethodTest extends ApiTestCase {
         var disputeAgentsService = grpcStubs(bisqAppConfig).disputeAgentsService;
         disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(MEDIATOR.name()));
         disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(REFUNDAGENT.name()));
-    }
-
-    protected static CreatePaymentAccountRequest createCreatePerfectMoneyPaymentAccountRequest(
-            String accountName,
-            String accountNumber,
-            String currencyCode) {
-        return CreatePaymentAccountRequest.newBuilder()
-                .setPaymentMethodId(PERFECT_MONEY.getId())
-                .setAccountName(accountName)
-                .setAccountNumber(accountNumber)
-                .setCurrencyCode(currencyCode)
-                .build();
     }
 }

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -17,6 +17,7 @@
 
 package bisq.apitest.method;
 
+import bisq.proto.grpc.CreatePaymentAccountRequest;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.LockWalletRequest;
@@ -26,6 +27,7 @@ import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.UnlockWalletRequest;
 
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
+import static bisq.core.payment.payload.PaymentMethod.PERFECT_MONEY;
 import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.MEDIATOR;
 import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.REFUNDAGENT;
 
@@ -66,12 +68,6 @@ public class MethodTest extends ApiTestCase {
         return GetFundingAddressesRequest.newBuilder().build();
     }
 
-    protected final RegisterDisputeAgentRequest createRegisterDisputeAgentRequest(String disputeAgentType) {
-        return RegisterDisputeAgentRequest.newBuilder()
-                .setDisputeAgentType(disputeAgentType.toLowerCase())
-                .setRegistrationKey(DEV_PRIVILEGE_PRIV_KEY).build();
-    }
-
     // Convenience methods for calling frequently used & thoroughly tested gRPC services.
 
     protected final long getBalance(BisqAppConfig bisqAppConfig) {
@@ -99,10 +95,30 @@ public class MethodTest extends ApiTestCase {
                 .getAddress();
     }
 
+    // Static conveniences for test methods and test case fixture setups.
+
+    protected static final RegisterDisputeAgentRequest createRegisterDisputeAgentRequest(String disputeAgentType) {
+        return RegisterDisputeAgentRequest.newBuilder()
+                .setDisputeAgentType(disputeAgentType.toLowerCase())
+                .setRegistrationKey(DEV_PRIVILEGE_PRIV_KEY).build();
+    }
+
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    protected final void registerDisputeAgents(BisqAppConfig bisqAppConfig) {
+    protected static final void registerDisputeAgents(BisqAppConfig bisqAppConfig) {
         var disputeAgentsService = grpcStubs(bisqAppConfig).disputeAgentsService;
         disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(MEDIATOR.name()));
         disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(REFUNDAGENT.name()));
+    }
+
+    protected static final CreatePaymentAccountRequest createCreatePerfectMoneyPaymentAccountRequest(
+            String accountName,
+            String accountNumber,
+            String currencyCode) {
+        return CreatePaymentAccountRequest.newBuilder()
+                .setPaymentMethodId(PERFECT_MONEY.getId())
+                .setAccountName(accountName)
+                .setAccountNumber(accountNumber)
+                .setCurrencyCode(currencyCode)
+                .build();
     }
 }

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -97,20 +97,20 @@ public class MethodTest extends ApiTestCase {
 
     // Static conveniences for test methods and test case fixture setups.
 
-    protected static final RegisterDisputeAgentRequest createRegisterDisputeAgentRequest(String disputeAgentType) {
+    protected static RegisterDisputeAgentRequest createRegisterDisputeAgentRequest(String disputeAgentType) {
         return RegisterDisputeAgentRequest.newBuilder()
                 .setDisputeAgentType(disputeAgentType.toLowerCase())
                 .setRegistrationKey(DEV_PRIVILEGE_PRIV_KEY).build();
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    protected static final void registerDisputeAgents(BisqAppConfig bisqAppConfig) {
+    protected static void registerDisputeAgents(BisqAppConfig bisqAppConfig) {
         var disputeAgentsService = grpcStubs(bisqAppConfig).disputeAgentsService;
         disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(MEDIATOR.name()));
         disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(REFUNDAGENT.name()));
     }
 
-    protected static final CreatePaymentAccountRequest createCreatePerfectMoneyPaymentAccountRequest(
+    protected static CreatePaymentAccountRequest createCreatePerfectMoneyPaymentAccountRequest(
             String accountName,
             String accountNumber,
             String currencyCode) {

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -31,14 +31,12 @@ import protobuf.PaymentAccount;
 
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Assertions;
-
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
 import static bisq.core.payment.payload.PaymentMethod.PERFECT_MONEY;
 import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.MEDIATOR;
 import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.REFUNDAGENT;
 import static java.util.Comparator.comparing;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -26,6 +26,8 @@ import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.UnlockWalletRequest;
 
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
+import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.MEDIATOR;
+import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.REFUNDAGENT;
 
 
 
@@ -66,7 +68,7 @@ public class MethodTest extends ApiTestCase {
 
     protected final RegisterDisputeAgentRequest createRegisterDisputeAgentRequest(String disputeAgentType) {
         return RegisterDisputeAgentRequest.newBuilder()
-                .setDisputeAgentType(disputeAgentType)
+                .setDisputeAgentType(disputeAgentType.toLowerCase())
                 .setRegistrationKey(DEV_PRIVILEGE_PRIV_KEY).build();
     }
 
@@ -95,5 +97,12 @@ public class MethodTest extends ApiTestCase {
                 .findFirst()
                 .get()
                 .getAddress();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    protected final void registerDisputeAgents(BisqAppConfig bisqAppConfig) {
+        var disputeAgentsService = grpcStubs(bisqAppConfig).disputeAgentsService;
+        disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(MEDIATOR.name()));
+        disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(REFUNDAGENT.name()));
     }
 }

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -120,7 +120,7 @@ public class MethodTest extends ApiTestCase {
         PaymentAccount paymentAccount = paymentAccountsService.getPaymentAccounts(getPaymentAccountsRequest)
                 .getPaymentAccountsList()
                 .stream()
-                .sorted(comparing(protobuf.PaymentAccount::getCreationDate))
+                .sorted(comparing(PaymentAccount::getCreationDate))
                 .collect(Collectors.toList()).get(0);
         assertEquals("PerfectMoney dummy", paymentAccount.getAccountName());
         return paymentAccount;

--- a/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
@@ -33,6 +33,9 @@ import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
 import static bisq.apitest.config.BisqAppConfig.arbdaemon;
 import static bisq.apitest.config.BisqAppConfig.seednode;
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
+import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.ARBITRATOR;
+import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.MEDIATOR;
+import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.REFUNDAGENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -43,10 +46,6 @@ import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 @Slf4j
 @TestMethodOrder(OrderAnnotation.class)
 public class RegisterDisputeAgentsTest extends MethodTest {
-
-    private static final String ARBITRATOR = "arbitrator";
-    private static final String MEDIATOR = "mediator";
-    private static final String REFUNDAGENT = "refundagent";
 
     @BeforeAll
     public static void setUp() {
@@ -61,7 +60,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(1)
     public void testRegisterArbitratorShouldThrowException() {
         var req =
-                createRegisterDisputeAgentRequest(ARBITRATOR);
+                createRegisterDisputeAgentRequest(ARBITRATOR.name());
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req));
         assertEquals("INVALID_ARGUMENT: arbitrators must be registered in a Bisq UI",
@@ -83,7 +82,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(3)
     public void testInvalidRegistrationKeyArgShouldThrowException() {
         var req = RegisterDisputeAgentRequest.newBuilder()
-                .setDisputeAgentType(REFUNDAGENT)
+                .setDisputeAgentType(REFUNDAGENT.name().toLowerCase())
                 .setRegistrationKey("invalid" + DEV_PRIVILEGE_PRIV_KEY).build();
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req));
@@ -95,7 +94,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(4)
     public void testRegisterMediator() {
         var req =
-                createRegisterDisputeAgentRequest(MEDIATOR);
+                createRegisterDisputeAgentRequest(MEDIATOR.name());
         grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req);
     }
 
@@ -103,7 +102,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(5)
     public void testRegisterRefundAgent() {
         var req =
-                createRegisterDisputeAgentRequest(REFUNDAGENT);
+                createRegisterDisputeAgentRequest(REFUNDAGENT.name());
         grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req);
     }
 

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -60,6 +60,7 @@ import static java.util.Collections.singletonList;
 public class CliMain {
 
     private enum Method {
+        createoffer,
         getoffers,
         createpaymentacct,
         getpaymentaccts,
@@ -165,6 +166,11 @@ public class CliMain {
                     var request = GetFundingAddressesRequest.newBuilder().build();
                     var reply = walletsService.getFundingAddresses(request);
                     out.println(formatAddressBalanceTbl(reply.getAddressBalanceInfoList()));
+                    return;
+                }
+                case createoffer: {
+                    // TODO
+                    out.println("offer created");
                     return;
                 }
                 case getoffers: {
@@ -303,6 +309,7 @@ public class CliMain {
             stream.format("%-22s%-50s%s%n", "getbalance", "", "Get server wallet balance");
             stream.format("%-22s%-50s%s%n", "getaddressbalance", "address", "Get server wallet address balance");
             stream.format("%-22s%-50s%s%n", "getfundingaddresses", "", "Get BTC funding addresses");
+            stream.format("%-22s%-50s%s%n", "createoffer", "", "Create and place an offer");
             stream.format("%-22s%-50s%s%n", "getoffers", "buy | sell, fiat currency code", "Get current offers");
             stream.format("%-22s%-50s%s%n", "createpaymentacct", "account name, account number, currency code", "Create PerfectMoney dummy account");
             stream.format("%-22s%-50s%s%n", "getpaymentaccts", "", "Get user payment accounts");

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -87,17 +87,17 @@ public class CoreApi {
         return coreOffersService.getOffers(direction, fiatCurrencyCode);
     }
 
-    public void createOffer(String currencyCode,
-                            String directionAsString,
-                            long priceAsLong,
-                            boolean useMarketBasedPrice,
-                            double marketPriceMargin,
-                            long amountAsLong,
-                            long minAmountAsLong,
-                            double buyerSecurityDeposit,
-                            String paymentAccountId,
-                            TransactionResultHandler resultHandler) {
-        coreOffersService.createOffer(currencyCode,
+    public Offer createOffer(String currencyCode,
+                             String directionAsString,
+                             long priceAsLong,
+                             boolean useMarketBasedPrice,
+                             double marketPriceMargin,
+                             long amountAsLong,
+                             long minAmountAsLong,
+                             double buyerSecurityDeposit,
+                             String paymentAccountId,
+                             TransactionResultHandler resultHandler) {
+        return coreOffersService.createOffer(currencyCode,
                 directionAsString,
                 priceAsLong,
                 useMarketBasedPrice,
@@ -109,19 +109,19 @@ public class CoreApi {
                 resultHandler);
     }
 
-    public void createOffer(String offerId,
-                            String currencyCode,
-                            OfferPayload.Direction direction,
-                            Price price,
-                            boolean useMarketBasedPrice,
-                            double marketPriceMargin,
-                            Coin amount,
-                            Coin minAmount,
-                            double buyerSecurityDeposit,
-                            PaymentAccount paymentAccount,
-                            boolean useSavingsWallet,
-                            TransactionResultHandler resultHandler) {
-        coreOffersService.createOffer(offerId,
+    public Offer createOffer(String offerId,
+                             String currencyCode,
+                             OfferPayload.Direction direction,
+                             Price price,
+                             boolean useMarketBasedPrice,
+                             double marketPriceMargin,
+                             Coin amount,
+                             Coin minAmount,
+                             double buyerSecurityDeposit,
+                             PaymentAccount paymentAccount,
+                             boolean useSavingsWallet,
+                             TransactionResultHandler resultHandler) {
+        return coreOffersService.createOffer(offerId,
                 currencyCode,
                 direction,
                 price,

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -77,16 +77,16 @@ class CoreOffersService {
         return offers;
     }
 
-    void createOffer(String currencyCode,
-                     String directionAsString,
-                     long priceAsLong,
-                     boolean useMarketBasedPrice,
-                     double marketPriceMargin,
-                     long amountAsLong,
-                     long minAmountAsLong,
-                     double buyerSecurityDeposit,
-                     String paymentAccountId,
-                     TransactionResultHandler resultHandler) {
+    Offer createOffer(String currencyCode,
+                      String directionAsString,
+                      long priceAsLong,
+                      boolean useMarketBasedPrice,
+                      double marketPriceMargin,
+                      long amountAsLong,
+                      long minAmountAsLong,
+                      double buyerSecurityDeposit,
+                      String paymentAccountId,
+                      TransactionResultHandler resultHandler) {
         String offerId = createOfferService.getRandomOfferId();
         OfferPayload.Direction direction = OfferPayload.Direction.valueOf(directionAsString);
         Price price = Price.valueOf(currencyCode, priceAsLong);
@@ -97,7 +97,7 @@ class CoreOffersService {
         boolean useSavingsWallet = true;
 
         //noinspection ConstantConditions
-        createOffer(offerId,
+        return createAndPlaceOffer(offerId,
                 currencyCode,
                 direction,
                 price,
@@ -111,19 +111,56 @@ class CoreOffersService {
                 resultHandler);
     }
 
-    void createOffer(String offerId,
-                     String currencyCode,
-                     OfferPayload.Direction direction,
-                     Price price,
-                     boolean useMarketBasedPrice,
-                     double marketPriceMargin,
-                     Coin amount,
-                     Coin minAmount,
-                     double buyerSecurityDeposit,
-                     PaymentAccount paymentAccount,
-                     boolean useSavingsWallet,
-                     TransactionResultHandler resultHandler) {
+    Offer createAndPlaceOffer(String offerId,
+                              String currencyCode,
+                              OfferPayload.Direction direction,
+                              Price price,
+                              boolean useMarketBasedPrice,
+                              double marketPriceMargin,
+                              Coin amount,
+                              Coin minAmount,
+                              double buyerSecurityDeposit,
+                              PaymentAccount paymentAccount,
+                              boolean useSavingsWallet,
+                              TransactionResultHandler resultHandler) {
         Coin useDefaultTxFee = Coin.ZERO;
+
+        Offer offer = createOfferService.createAndGetOffer(offerId,
+                direction,
+                currencyCode,
+                amount,
+                minAmount,
+                price,
+                useDefaultTxFee,
+                useMarketBasedPrice,
+                marketPriceMargin,
+                buyerSecurityDeposit,
+                paymentAccount);
+
+        // TODO give user chance to examine offer before placing it (placeoffer)
+        openOfferManager.placeOffer(offer,
+                buyerSecurityDeposit,
+                useSavingsWallet,
+                resultHandler,
+                log::error);
+
+        return offer;
+    }
+
+    Offer createOffer(String offerId,
+                      String currencyCode,
+                      OfferPayload.Direction direction,
+                      Price price,
+                      boolean useMarketBasedPrice,
+                      double marketPriceMargin,
+                      Coin amount,
+                      Coin minAmount,
+                      double buyerSecurityDeposit,
+                      PaymentAccount paymentAccount,
+                      boolean useSavingsWallet,
+                      TransactionResultHandler resultHandler) {
+        Coin useDefaultTxFee = Coin.ZERO;
+
         Offer offer = createOfferService.createAndGetOffer(offerId,
                 direction,
                 currencyCode,
@@ -141,5 +178,7 @@ class CoreOffersService {
                 useSavingsWallet,
                 resultHandler,
                 log::error);
+
+        return offer;
     }
 }

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -62,8 +62,6 @@ class CorePaymentAccountsService {
                 accountNumber,
                 currencyCode);
 
-        // TODO not sure if there is more to do at account creation.
-        //  Need to check all the flow when its created from UI.
         user.addPaymentAccountIfNotExists(paymentAccount);
 
         // Don't do this on mainnet until thoroughly tested.

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -43,6 +43,12 @@ import javax.annotation.Nullable;
 public abstract class DisputeAgent implements ProtectedStoragePayload, ExpirablePayload {
     public static final long TTL = TimeUnit.DAYS.toMillis(10);
 
+    public enum DisputeAgentType {
+        ARBITRATOR,
+        MEDIATOR,
+        REFUNDAGENT
+    }
+
     protected final NodeAddress nodeAddress;
     protected final PubKeyRing pubKeyRing;
     protected final List<String> languageCodes;

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -107,7 +107,7 @@ service PaymentAccounts {
 }
 
 message CreatePaymentAccountRequest {
-string paymentMethodId = 1;
+    string paymentMethodId = 1;
     string accountName = 2;
     string accountNumber = 3;
     // TODO  Support all currencies. Maybe add a repeated and if only one is used its a singletonList.

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -73,7 +73,7 @@ message CreateOfferRequest {
 }
 
 message CreateOfferReply {
-    bool result = 1;
+    OfferInfo offer = 1;
 }
 
 message OfferInfo {


### PR DESCRIPTION
This updates the existing gRPC `createoffer` method to return the new Offer instead of a boolean.  Although `createoffer` still places the offer, it might be changed to give the user a chance to examine a newly created (and cached) offer before it is placed in a separate `confirmoffer offer-id`  or  `placeoffer offer-id` method.  

An api test case was added and the CLI's `createoffer` method was stubbed out -- to be implemented in another PR.

Several unrelated, minor changes were pushed before the most relevant ones.

(This PR should be reviewed/merged before [4558](https://github.com/bisq-network/bisq/pull/4558) and [4559](https://github.com/bisq-network/bisq/pull/4559).)
