### PR TITLE
Revert "Deactive confirm buttons once mediation started"

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
@@ -55,8 +55,6 @@ import bisq.common.handlers.ResultHandler;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 @Slf4j
 public class BuyerAsMakerProtocol extends TradeProtocol implements BuyerProtocol, MakerProtocol {
     private final BuyerAsMakerTrade buyerAsMakerTrade;
@@ -214,9 +212,6 @@ public class BuyerAsMakerProtocol extends TradeProtocol implements BuyerProtocol
     // User clicked the "bank transfer started" button
     @Override
     public void onFiatPaymentStarted(ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
-        checkArgument(!wasDisputed(), "A call to onFiatPaymentStarted is not permitted once a " +
-                "dispute has been opened.");
-
         if (trade.isDepositConfirmed() && !trade.isFiatSent()) {
             buyerAsMakerTrade.setState(Trade.State.BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED);
             TradeTaskRunner taskRunner = new TradeTaskRunner(buyerAsMakerTrade,

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -59,7 +59,6 @@ import bisq.common.handlers.ResultHandler;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -238,9 +237,6 @@ public class BuyerAsTakerProtocol extends TradeProtocol implements BuyerProtocol
     // User clicked the "bank transfer started" button
     @Override
     public void onFiatPaymentStarted(ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
-        checkArgument(!wasDisputed(), "A call to onFiatPaymentStarted is not permitted once a " +
-                "dispute has been opened.");
-
         if (!trade.isFiatSent()) {
             buyerAsTakerTrade.setState(Trade.State.BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED);
 

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
@@ -57,8 +57,6 @@ import bisq.common.handlers.ResultHandler;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 @Slf4j
 public class SellerAsMakerProtocol extends TradeProtocol implements SellerProtocol, MakerProtocol {
     private final SellerAsMakerTrade sellerAsMakerTrade;
@@ -206,9 +204,6 @@ public class SellerAsMakerProtocol extends TradeProtocol implements SellerProtoc
     // User clicked the "bank transfer received" button, so we release the funds for payout
     @Override
     public void onFiatPaymentReceived(ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
-        checkArgument(!wasDisputed(), "A call to onFiatPaymentReceived is not permitted once a " +
-                "dispute has been opened.");
-
         if (trade.getPayoutTx() == null) {
             sellerAsMakerTrade.setState(Trade.State.SELLER_CONFIRMED_IN_UI_FIAT_PAYMENT_RECEIPT);
             TradeTaskRunner taskRunner = new TradeTaskRunner(sellerAsMakerTrade,

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -56,7 +56,6 @@ import bisq.common.handlers.ResultHandler;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -197,9 +196,6 @@ public class SellerAsTakerProtocol extends TradeProtocol implements SellerProtoc
     // User clicked the "bank transfer received" button, so we release the funds for payout
     @Override
     public void onFiatPaymentReceived(ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
-        checkArgument(!wasDisputed(), "A call to onFiatPaymentReceived is not permitted once a " +
-                "dispute has been opened.");
-
         if (trade.getPayoutTx() == null) {
             sellerAsTakerTrade.setState(Trade.State.SELLER_CONFIRMED_IN_UI_FIAT_PAYMENT_RECEIPT);
             TradeTaskRunner taskRunner = new TradeTaskRunner(sellerAsTakerTrade,

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -344,10 +344,6 @@ public abstract class TradeProtocol {
         cleanup();
     }
 
-    protected boolean wasDisputed() {
-        return trade.getDisputeState() != Trade.DisputeState.NO_DISPUTE;
-    }
-
     private void sendAckMessage(@Nullable TradeMessage tradeMessage, boolean result, @Nullable String errorMessage) {
         // We complete at initial protocol setup with the setup listener tasks.
         // Other cases are if we start from an UI event the task runner (payment started, confirmed).

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -185,7 +185,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
     }
 
     public void onPaymentStarted(ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
-        Trade trade = getTrade();
+        final Trade trade = getTrade();
         checkNotNull(trade, "trade must not be null");
         checkArgument(trade instanceof BuyerTrade, "Check failed: trade instanceof BuyerTrade");
         ((BuyerTrade) trade).onFiatPaymentStarted(resultHandler, errorMessageHandler);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -391,6 +391,7 @@ public abstract class TradeStepView extends AnchorPane {
     }
 
     private void updateDisputeState(Trade.DisputeState disputeState) {
+        deactivatePaymentButtons(false);
         Optional<Dispute> ownDispute;
         switch (disputeState) {
             case NO_DISPUTE:
@@ -406,6 +407,7 @@ public abstract class TradeStepView extends AnchorPane {
                     if (tradeStepInfo != null)
                         tradeStepInfo.setState(TradeStepInfo.State.IN_MEDIATION_SELF_REQUESTED);
                 });
+
                 break;
             case MEDIATION_STARTED_BY_PEER:
                 if (tradeStepInfo != null) {
@@ -434,6 +436,7 @@ public abstract class TradeStepView extends AnchorPane {
                 updateMediationResultState(true);
                 break;
             case REFUND_REQUESTED:
+                deactivatePaymentButtons(true);
                 if (tradeStepInfo != null) {
                     tradeStepInfo.setFirstHalfOverWarnTextSupplier(this::getFirstHalfOverWarnText);
                 }
@@ -447,6 +450,7 @@ public abstract class TradeStepView extends AnchorPane {
 
                 break;
             case REFUND_REQUEST_STARTED_BY_PEER:
+                deactivatePaymentButtons(true);
                 if (tradeStepInfo != null) {
                     tradeStepInfo.setFirstHalfOverWarnTextSupplier(this::getFirstHalfOverWarnText);
                 }
@@ -459,12 +463,9 @@ public abstract class TradeStepView extends AnchorPane {
                 });
                 break;
             case REFUND_REQUEST_CLOSED:
-                break;
-            default:
+                deactivatePaymentButtons(true);
                 break;
         }
-
-        updateConfirmButtonDisableState(isDisputed());
     }
 
     private void updateMediationResultState(boolean blockOpeningOfResultAcceptedPopup) {
@@ -604,8 +605,7 @@ public abstract class TradeStepView extends AnchorPane {
         acceptMediationResultPopup.show();
     }
 
-    protected void updateConfirmButtonDisableState(boolean isDisabled) {
-        // By default do nothing. Only overwritten in certain trade steps
+    protected void deactivatePaymentButtons(boolean isDisabled) {
     }
 
     protected String getCurrencyName(Trade trade) {
@@ -651,11 +651,6 @@ public abstract class TradeStepView extends AnchorPane {
             }
         }
     }
-
-    protected boolean isDisputed() {
-        return trade.getDisputeState() != Trade.DisputeState.NO_DISPUTE;
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // TradeDurationLimitInfo

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -192,8 +192,6 @@ public class BuyerStep2View extends TradeStepView {
                 }
             });
         }
-
-        confirmButton.setDisable(isDisputed());
     }
 
     @Override
@@ -387,10 +385,6 @@ public class BuyerStep2View extends TradeStepView {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void onPaymentStarted() {
-        if (isDisputed()) {
-            return;
-        }
-
         if (!model.dataModel.isBootstrappedOrShowPopup()) {
             return;
         }
@@ -633,7 +627,7 @@ public class BuyerStep2View extends TradeStepView {
     }
 
     @Override
-    protected void updateConfirmButtonDisableState(boolean isDisabled) {
+    protected void deactivatePaymentButtons(boolean isDisabled) {
         confirmButton.setDisable(isDisabled);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -310,7 +310,7 @@ public class SellerStep3View extends TradeStepView {
     }
 
     @Override
-    protected void updateConfirmButtonDisableState(boolean isDisabled) {
+    protected void deactivatePaymentButtons(boolean isDisabled) {
         confirmButton.setDisable(isDisabled);
     }
 
@@ -361,10 +361,6 @@ public class SellerStep3View extends TradeStepView {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void onPaymentReceived() {
-        if (isDisputed()) {
-            return;
-        }
-
         // The confirmPaymentReceived call will trigger the trade protocol to do the payout tx. We want to be sure that we
         // are well connected to the Bitcoin network before triggering the broadcast.
         if (model.dataModel.isReadyForTxBroadcast()) {


### PR DESCRIPTION
Reverts bisq-network/bisq#4493

This change should have been discussed more before merging. Obviously disabling a UI button does not prevent a malicious person from abusing the trade protocol, and it only serves to degrade the UX of Bisq for honest traders who open a support ticket.

In the past week, about 50% of my mediation cases have traders who are complaining they can no longer resolve trades on their own because the mediation case is ongoing. As a mediator, it is my goal to mediate the trade so that the traders can complete the trade on their own, but now traders can no longer do so :sweat: