### PR TITLE
Increase our mempool fee estimation from "medium" to "high" priority

### DIFF
--- a/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
+++ b/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
@@ -91,7 +91,7 @@ abstract class MempoolFeeRateProvider extends FeeRateProvider {
 
     private long getEstimatedFeeRate() {
         return getFeeRatePredictions()
-            .filter(p -> p.getKey().equalsIgnoreCase("halfHourFee"))
+            .filter(p -> p.getKey().equalsIgnoreCase("fastestFee"))
             .map(Map.Entry::getValue)
             .findFirst()
             .map(r -> {


### PR DESCRIPTION
<img width="554" alt="Screen Shot 2020-10-02 at 5 15 00" src="https://user-images.githubusercontent.com/232186/94858600-3fe7c680-046e-11eb-9120-ffd65a458c47.png">

Bisq currently uses the mempool.space API for fee estimation, selecting
the "medium" priority fee, which generally works very well. However, if
your timing is bad, sometimes the mempool can quickly fill up and your
TX can get stuck for several hours or even days, which degrades the UX
of Bisq.

This PR changes the Pricenode code to always use "high" priority fees,
which would at the time of writing use 99 sat/vB instead of 85 sat/vB,
and hopefully prevent the above-mentioned issue from occuring. Of
course if the mempool is empty the minimum fees would still be used, as
this only changes the "priority" from medium to high.

Fee estimates: https://mempool.space/
API endpoint: https://mempool.space/api/v1/fees/recommended