### PR TITLE
Remove redundant DisputeAgentType enum

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -34,8 +34,6 @@ import java.util.stream.Collectors;
 
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
 import static bisq.core.payment.payload.PaymentMethod.PERFECT_MONEY;
-import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.MEDIATOR;
-import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.REFUND_AGENT;
 import static java.util.Comparator.comparing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -45,6 +43,10 @@ import bisq.apitest.ApiTestCase;
 import bisq.apitest.config.BisqAppConfig;
 
 public class MethodTest extends ApiTestCase {
+
+    protected static final String ARBITRATOR = "arbitrator";
+    protected static final String MEDIATOR = "mediator";
+    protected static final String REFUND_AGENT = "refundagent";
 
     // Convenience methods for building gRPC request objects
 
@@ -147,7 +149,7 @@ public class MethodTest extends ApiTestCase {
     @SuppressWarnings("ResultOfMethodCallIgnored")
     protected static void registerDisputeAgents(BisqAppConfig bisqAppConfig) {
         var disputeAgentsService = grpcStubs(bisqAppConfig).disputeAgentsService;
-        disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(MEDIATOR.name()));
-        disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(REFUND_AGENT.name()));
+        disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(MEDIATOR));
+        disputeAgentsService.registerDisputeAgent(createRegisterDisputeAgentRequest(REFUND_AGENT));
     }
 }

--- a/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
@@ -33,9 +33,6 @@ import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
 import static bisq.apitest.config.BisqAppConfig.arbdaemon;
 import static bisq.apitest.config.BisqAppConfig.seednode;
 import static bisq.common.app.DevEnv.DEV_PRIVILEGE_PRIV_KEY;
-import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.ARBITRATOR;
-import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.MEDIATOR;
-import static bisq.core.support.dispute.agent.DisputeAgent.DisputeAgentType.REFUND_AGENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -60,7 +57,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(1)
     public void testRegisterArbitratorShouldThrowException() {
         var req =
-                createRegisterDisputeAgentRequest(ARBITRATOR.name());
+                createRegisterDisputeAgentRequest(ARBITRATOR);
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req));
         assertEquals("INVALID_ARGUMENT: arbitrators must be registered in a Bisq UI",
@@ -82,7 +79,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(3)
     public void testInvalidRegistrationKeyArgShouldThrowException() {
         var req = RegisterDisputeAgentRequest.newBuilder()
-                .setDisputeAgentType(REFUND_AGENT.name().toLowerCase())
+                .setDisputeAgentType(REFUND_AGENT)
                 .setRegistrationKey("invalid" + DEV_PRIVILEGE_PRIV_KEY).build();
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req));
@@ -94,7 +91,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(4)
     public void testRegisterMediator() {
         var req =
-                createRegisterDisputeAgentRequest(MEDIATOR.name());
+                createRegisterDisputeAgentRequest(MEDIATOR);
         grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req);
     }
 
@@ -102,7 +99,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
     @Order(5)
     public void testRegisterRefundAgent() {
         var req =
-                createRegisterDisputeAgentRequest(REFUND_AGENT.name());
+                createRegisterDisputeAgentRequest(REFUND_AGENT);
         grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req);
     }
 

--- a/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
+++ b/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
@@ -45,6 +45,7 @@ import static bisq.core.support.SupportType.ARBITRATION;
 import static bisq.core.support.SupportType.MEDIATION;
 import static bisq.core.support.SupportType.REFUND;
 import static bisq.core.support.SupportType.TRADE;
+import static java.lang.String.format;
 import static java.net.InetAddress.getLoopbackAddress;
 import static java.util.Arrays.asList;
 
@@ -107,7 +108,7 @@ class CoreDisputeAgentsService {
                     throw new IllegalArgumentException("trade agent registration not supported");
             }
         } else {
-            throw new IllegalArgumentException("unknown dispute agent type " + disputeAgentType);
+            throw new IllegalArgumentException(format("unknown dispute agent type '%s'", disputeAgentType));
         }
     }
 

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -43,18 +43,6 @@ import javax.annotation.Nullable;
 public abstract class DisputeAgent implements ProtectedStoragePayload, ExpirablePayload {
     public static final long TTL = TimeUnit.DAYS.toMillis(10);
 
-    public enum DisputeAgentType {
-        ARBITRATOR,
-        MEDIATOR,
-        REFUND_AGENT;
-
-        public String alternateName() {
-            return this.equals(REFUND_AGENT)
-                    ? REFUND_AGENT.name().replace("_", "")
-                    : this.name();
-        }
-    }
-
     protected final NodeAddress nodeAddress;
     protected final PubKeyRing pubKeyRing;
     protected final List<String> languageCodes;


### PR DESCRIPTION
Use existing `SupportType` enum instead, and map the valid CLI `registerdisputeagent` method's dispute-agent-type parameter names to SupportType.

Adjusted affected tests.
