### PR TITLE
Reduce mempool fee estimation back to "medium" priority

### DIFF
--- a/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
+++ b/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
@@ -91,7 +91,7 @@ abstract class MempoolFeeRateProvider extends FeeRateProvider {
 
     private long getEstimatedFeeRate() {
         return getFeeRatePredictions()
-            .filter(p -> p.getKey().equalsIgnoreCase("fastestFee"))
+            .filter(p -> p.getKey().equalsIgnoreCase("halfHourFee"))
             .map(Map.Entry::getValue)
             .findFirst()
             .map(r -> {


### PR DESCRIPTION
Now that we've recently optimized the "medium" fee estimation algorithm
in mempool/mempool@15bb5a9, we can move Bisq back to "medium", since
always using "high" will be a bit wasteful on the weekends when the
mempool is empty.

Simulation:
![new-mempool-fees](https://user-images.githubusercontent.com/232186/95107085-61012d80-0774-11eb-918c-0b22522f2db3.gif)

Currently:
<img width="641" alt="Screen Shot 2020-10-06 at 1 37 20" src="https://user-images.githubusercontent.com/232186/95107170-7f672900-0774-11eb-978a-1b6ae0c82c56.png">
