### PR TITLE
Add new getoffer(id) api method

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -20,9 +20,11 @@ package bisq.apitest.method;
 import bisq.proto.grpc.CreatePaymentAccountRequest;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesRequest;
+import bisq.proto.grpc.GetOfferRequest;
 import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.LockWalletRequest;
 import bisq.proto.grpc.MarketPriceRequest;
+import bisq.proto.grpc.OfferInfo;
 import bisq.proto.grpc.RegisterDisputeAgentRequest;
 import bisq.proto.grpc.RemoveWalletPasswordRequest;
 import bisq.proto.grpc.SetWalletPasswordRequest;
@@ -80,6 +82,10 @@ public class MethodTest extends ApiTestCase {
         return MarketPriceRequest.newBuilder().setCurrencyCode(currencyCode).build();
     }
 
+    protected final GetOfferRequest createGetOfferRequest(String offerId) {
+        return GetOfferRequest.newBuilder().setId(offerId).build();
+    }
+
     // Convenience methods for calling frequently used & thoroughly tested gRPC services.
 
     protected final long getBalance(BisqAppConfig bisqAppConfig) {
@@ -134,6 +140,11 @@ public class MethodTest extends ApiTestCase {
     protected final double getMarketPrice(BisqAppConfig bisqAppConfig, String currencyCode) {
         var req = createMarketPriceRequest(currencyCode);
         return grpcStubs(bisqAppConfig).priceService.getMarketPrice(req).getPrice();
+    }
+
+    protected final OfferInfo getOffer(BisqAppConfig bisqAppConfig, String offerId) {
+        var req = createGetOfferRequest(offerId);
+        return grpcStubs(bisqAppConfig).offersService.getOffer(req).getOffer();
     }
 
     // Static conveniences for test methods and test case fixture setups.

--- a/apitest/src/test/java/bisq/apitest/method/offer/AbstractCreateOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/AbstractCreateOfferTest.java
@@ -77,6 +77,10 @@ abstract class AbstractCreateOfferTest extends MethodTest {
         }
     }
 
+    protected final OfferInfo getOffer(String offerId) {
+        return aliceStubs.offersService.getOffer(createGetOfferRequest(offerId)).getOffer();
+    }
+
     protected final OfferInfo getMostRecentOffer(String direction, String currencyCode) {
         List<OfferInfo> offerInfoList = getOffersSortedByDate(direction, currencyCode);
         if (offerInfoList.isEmpty())

--- a/apitest/src/test/java/bisq/apitest/method/offer/CreateOfferUsingFixedPriceTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/CreateOfferUsingFixedPriceTest.java
@@ -20,7 +20,6 @@ package bisq.apitest.method.offer;
 import bisq.core.btc.wallet.Restrictions;
 
 import bisq.proto.grpc.CreateOfferRequest;
-import bisq.proto.grpc.OfferInfo;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,17 +65,17 @@ public class CreateOfferUsingFixedPriceTest extends AbstractCreateOfferTest {
         assertEquals("BTC", newOffer.getBaseCurrencyCode());
         assertEquals("AUD", newOffer.getCounterCurrencyCode());
 
-        OfferInfo offer = getMostRecentOffer("buy", "aud");
-        assertEquals(newOfferId, offer.getId());
-        assertEquals("BUY", offer.getDirection());
-        assertFalse(offer.getUseMarketBasedPrice());
-        assertEquals(160000000, offer.getPrice());
-        assertEquals(10000000, offer.getAmount());
-        assertEquals(10000000, offer.getMinAmount());
-        assertEquals(1500000, offer.getBuyerSecurityDeposit());
-        assertEquals(paymentAccount.getId(), offer.getPaymentAccountId());
-        assertEquals("BTC", offer.getBaseCurrencyCode());
-        assertEquals("AUD", offer.getCounterCurrencyCode());
+        newOffer = getOffer(newOfferId);
+        assertEquals(newOfferId, newOffer.getId());
+        assertEquals("BUY", newOffer.getDirection());
+        assertFalse(newOffer.getUseMarketBasedPrice());
+        assertEquals(160000000, newOffer.getPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("AUD", newOffer.getCounterCurrencyCode());
     }
 
     @Test
@@ -107,17 +106,17 @@ public class CreateOfferUsingFixedPriceTest extends AbstractCreateOfferTest {
         assertEquals("BTC", newOffer.getBaseCurrencyCode());
         assertEquals("USD", newOffer.getCounterCurrencyCode());
 
-        OfferInfo offer = getMostRecentOffer("buy", "usd");
-        assertEquals(newOfferId, offer.getId());
-        assertEquals("BUY", offer.getDirection());
-        assertFalse(offer.getUseMarketBasedPrice());
-        assertEquals(100001234, offer.getPrice());
-        assertEquals(10000000, offer.getAmount());
-        assertEquals(10000000, offer.getMinAmount());
-        assertEquals(1500000, offer.getBuyerSecurityDeposit());
-        assertEquals(paymentAccount.getId(), offer.getPaymentAccountId());
-        assertEquals("BTC", offer.getBaseCurrencyCode());
-        assertEquals("USD", offer.getCounterCurrencyCode());
+        newOffer = getOffer(newOfferId);
+        assertEquals(newOfferId, newOffer.getId());
+        assertEquals("BUY", newOffer.getDirection());
+        assertFalse(newOffer.getUseMarketBasedPrice());
+        assertEquals(100001234, newOffer.getPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("USD", newOffer.getCounterCurrencyCode());
     }
 
     @Test
@@ -148,16 +147,16 @@ public class CreateOfferUsingFixedPriceTest extends AbstractCreateOfferTest {
         assertEquals("BTC", newOffer.getBaseCurrencyCode());
         assertEquals("EUR", newOffer.getCounterCurrencyCode());
 
-        OfferInfo offer = getMostRecentOffer("sell", "eur");
-        assertEquals(newOfferId, offer.getId());
-        assertEquals("SELL", offer.getDirection());
-        assertFalse(offer.getUseMarketBasedPrice());
-        assertEquals(95001234, offer.getPrice());
-        assertEquals(10000000, offer.getAmount());
-        assertEquals(10000000, offer.getMinAmount());
-        assertEquals(1500000, offer.getBuyerSecurityDeposit());
-        assertEquals(paymentAccount.getId(), offer.getPaymentAccountId());
-        assertEquals("BTC", offer.getBaseCurrencyCode());
-        assertEquals("EUR", offer.getCounterCurrencyCode());
+        newOffer = getOffer(newOfferId);
+        assertEquals(newOfferId, newOffer.getId());
+        assertEquals("SELL", newOffer.getDirection());
+        assertFalse(newOffer.getUseMarketBasedPrice());
+        assertEquals(95001234, newOffer.getPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("EUR", newOffer.getCounterCurrencyCode());
     }
 }

--- a/apitest/src/test/java/bisq/apitest/method/offer/CreateOfferUsingMarketPriceMarginTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/CreateOfferUsingMarketPriceMarginTest.java
@@ -77,18 +77,18 @@ public class CreateOfferUsingMarketPriceMarginTest extends AbstractCreateOfferTe
         assertEquals("BTC", newOffer.getBaseCurrencyCode());
         assertEquals("USD", newOffer.getCounterCurrencyCode());
 
-        OfferInfo offer = getMostRecentOffer("buy", "usd");
-        assertEquals(newOfferId, offer.getId());
-        assertEquals("BUY", offer.getDirection());
-        assertTrue(offer.getUseMarketBasedPrice());
-        assertEquals(10000000, offer.getAmount());
-        assertEquals(10000000, offer.getMinAmount());
-        assertEquals(1500000, offer.getBuyerSecurityDeposit());
-        assertEquals(paymentAccount.getId(), offer.getPaymentAccountId());
-        assertEquals("BTC", offer.getBaseCurrencyCode());
-        assertEquals("USD", offer.getCounterCurrencyCode());
+        newOffer = getOffer(newOfferId);
+        assertEquals(newOfferId, newOffer.getId());
+        assertEquals("BUY", newOffer.getDirection());
+        assertTrue(newOffer.getUseMarketBasedPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("USD", newOffer.getCounterCurrencyCode());
 
-        assertCalculatedPriceIsCorrect(offer, priceMarginPctInput);
+        assertCalculatedPriceIsCorrect(newOffer, priceMarginPctInput);
     }
 
     @Test
@@ -119,18 +119,18 @@ public class CreateOfferUsingMarketPriceMarginTest extends AbstractCreateOfferTe
         assertEquals("BTC", newOffer.getBaseCurrencyCode());
         assertEquals("NZD", newOffer.getCounterCurrencyCode());
 
-        OfferInfo offer = getMostRecentOffer("buy", "nzd");
-        assertEquals(newOfferId, offer.getId());
-        assertEquals("BUY", offer.getDirection());
-        assertTrue(offer.getUseMarketBasedPrice());
-        assertEquals(10000000, offer.getAmount());
-        assertEquals(10000000, offer.getMinAmount());
-        assertEquals(1500000, offer.getBuyerSecurityDeposit());
-        assertEquals(paymentAccount.getId(), offer.getPaymentAccountId());
-        assertEquals("BTC", offer.getBaseCurrencyCode());
-        assertEquals("NZD", offer.getCounterCurrencyCode());
+        newOffer = getOffer(newOfferId);
+        assertEquals(newOfferId, newOffer.getId());
+        assertEquals("BUY", newOffer.getDirection());
+        assertTrue(newOffer.getUseMarketBasedPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("NZD", newOffer.getCounterCurrencyCode());
 
-        assertCalculatedPriceIsCorrect(offer, priceMarginPctInput);
+        assertCalculatedPriceIsCorrect(newOffer, priceMarginPctInput);
     }
 
     @Test
@@ -162,18 +162,18 @@ public class CreateOfferUsingMarketPriceMarginTest extends AbstractCreateOfferTe
         assertEquals("BTC", newOffer.getBaseCurrencyCode());
         assertEquals("GBP", newOffer.getCounterCurrencyCode());
 
-        OfferInfo offer = getMostRecentOffer("sell", "gbp");
-        assertEquals(newOfferId, offer.getId());
-        assertEquals("SELL", offer.getDirection());
-        assertTrue(offer.getUseMarketBasedPrice());
-        assertEquals(10000000, offer.getAmount());
-        assertEquals(10000000, offer.getMinAmount());
-        assertEquals(1500000, offer.getBuyerSecurityDeposit());
-        assertEquals(paymentAccount.getId(), offer.getPaymentAccountId());
-        assertEquals("BTC", offer.getBaseCurrencyCode());
-        assertEquals("GBP", offer.getCounterCurrencyCode());
+        newOffer = getOffer(newOfferId);
+        assertEquals(newOfferId, newOffer.getId());
+        assertEquals("SELL", newOffer.getDirection());
+        assertTrue(newOffer.getUseMarketBasedPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("GBP", newOffer.getCounterCurrencyCode());
 
-        assertCalculatedPriceIsCorrect(offer, priceMarginPctInput);
+        assertCalculatedPriceIsCorrect(newOffer, priceMarginPctInput);
     }
 
     @Test
@@ -205,18 +205,18 @@ public class CreateOfferUsingMarketPriceMarginTest extends AbstractCreateOfferTe
         assertEquals("BTC", newOffer.getBaseCurrencyCode());
         assertEquals("BRL", newOffer.getCounterCurrencyCode());
 
-        OfferInfo offer = getMostRecentOffer("sell", "brl");
-        assertEquals(newOfferId, offer.getId());
-        assertEquals("SELL", offer.getDirection());
-        assertTrue(offer.getUseMarketBasedPrice());
-        assertEquals(10000000, offer.getAmount());
-        assertEquals(10000000, offer.getMinAmount());
-        assertEquals(1500000, offer.getBuyerSecurityDeposit());
-        assertEquals(paymentAccount.getId(), offer.getPaymentAccountId());
-        assertEquals("BTC", offer.getBaseCurrencyCode());
-        assertEquals("BRL", offer.getCounterCurrencyCode());
+        newOffer = getOffer(newOfferId);
+        assertEquals(newOfferId, newOffer.getId());
+        assertEquals("SELL", newOffer.getDirection());
+        assertTrue(newOffer.getUseMarketBasedPrice());
+        assertEquals(10000000, newOffer.getAmount());
+        assertEquals(10000000, newOffer.getMinAmount());
+        assertEquals(1500000, newOffer.getBuyerSecurityDeposit());
+        assertEquals(paymentAccount.getId(), newOffer.getPaymentAccountId());
+        assertEquals("BTC", newOffer.getBaseCurrencyCode());
+        assertEquals("BRL", newOffer.getCounterCurrencyCode());
 
-        assertCalculatedPriceIsCorrect(offer, priceMarginPctInput);
+        assertCalculatedPriceIsCorrect(newOffer, priceMarginPctInput);
     }
 
     private void assertCalculatedPriceIsCorrect(OfferInfo offer, double priceMarginPctInput) {

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -22,6 +22,7 @@ import bisq.proto.grpc.CreatePaymentAccountRequest;
 import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesRequest;
+import bisq.proto.grpc.GetOfferRequest;
 import bisq.proto.grpc.GetOffersRequest;
 import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.GetVersionRequest;
@@ -67,6 +68,7 @@ public class CliMain {
 
     private enum Method {
         createoffer,
+        getoffer,
         getoffers,
         createpaymentacct,
         getpaymentaccts,
@@ -223,6 +225,20 @@ public class CliMain {
                     out.println(formatOfferTable(singletonList(reply.getOffer()), currencyCode));
                     return;
                 }
+                case getoffer: {
+                    if (nonOptionArgs.size() < 2)
+                        throw new IllegalArgumentException("incorrect parameter count,"
+                                + " expecting offer id");
+
+                    var offerId = nonOptionArgs.get(1);
+                    var request = GetOfferRequest.newBuilder()
+                            .setId(offerId)
+                            .build();
+                    var reply = offersService.getOffer(request);
+                    out.println(formatOfferTable(singletonList(reply.getOffer()),
+                            reply.getOffer().getCounterCurrencyCode()));
+                    return;
+                }
                 case getoffers: {
                     if (nonOptionArgs.size() < 3)
                         throw new IllegalArgumentException("incorrect parameter count,"
@@ -364,6 +380,7 @@ public class CliMain {
             stream.format(rowFormat, "", "amount (btc), min amount, use mkt based price, \\", "");
             stream.format(rowFormat, "", "fixed price (btc) | mkt price margin (%), \\", "");
             stream.format(rowFormat, "", "security deposit (%)", "");
+            stream.format(rowFormat, "getoffer", "offer id", "Get current offer with id");
             stream.format(rowFormat, "getoffers", "buy | sell, currency code", "Get current offers");
             stream.format(rowFormat, "createpaymentacct", "account name, account number, currency code", "Create PerfectMoney dummy account");
             stream.format(rowFormat, "getpaymentaccts", "", "Get user payment accounts");

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -22,7 +22,6 @@ import bisq.core.monetary.Price;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.payment.PaymentAccount;
-import bisq.core.trade.handlers.TransactionResultHandler;
 import bisq.core.trade.statistics.TradeStatistics2;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 
@@ -110,17 +109,16 @@ public class CoreApi {
                 paymentAccountId);
     }
 
-    // Not used yet, should be renamed for a new placeoffer api method.
-    public Offer createOffer(String offerId,
-                             String currencyCode,
-                             OfferPayload.Direction direction,
-                             Price price,
-                             boolean useMarketBasedPrice,
-                             double marketPriceMargin,
-                             Coin amount,
-                             Coin minAmount,
-                             double buyerSecurityDeposit,
-                             PaymentAccount paymentAccount) {
+    public Offer editOffer(String offerId,
+                           String currencyCode,
+                           OfferPayload.Direction direction,
+                           Price price,
+                           boolean useMarketBasedPrice,
+                           double marketPriceMargin,
+                           Coin amount,
+                           Coin minAmount,
+                           double buyerSecurityDeposit,
+                           PaymentAccount paymentAccount) {
         return coreOffersService.createOffer(offerId,
                 currencyCode,
                 direction,
@@ -131,17 +129,6 @@ public class CoreApi {
                 minAmount,
                 buyerSecurityDeposit,
                 paymentAccount);
-    }
-
-    public Offer placeOffer(Offer offer,
-                            double buyerSecurityDeposit,
-                            boolean useSavingsWallet,
-                            TransactionResultHandler resultHandler) {
-        coreOffersService.placeOffer(offer,
-                buyerSecurityDeposit,
-                useSavingsWallet,
-                resultHandler);
-        return offer;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -119,7 +119,7 @@ public class CoreApi {
                            Coin minAmount,
                            double buyerSecurityDeposit,
                            PaymentAccount paymentAccount) {
-        return coreOffersService.createOffer(offerId,
+        return coreOffersService.editOffer(offerId,
                 currencyCode,
                 direction,
                 price,

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -86,6 +86,10 @@ public class CoreApi {
     // Offers
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    public Offer getOffer(String id) {
+        return coreOffersService.getOffer(id);
+    }
+
     public List<Offer> getOffers(String direction, String currencyCode) {
         return coreOffersService.getOffers(direction, currencyCode);
     }

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -35,6 +35,7 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -89,16 +90,17 @@ public class CoreApi {
         return coreOffersService.getOffers(direction, currencyCode);
     }
 
-    public Offer createOffer(String currencyCode,
-                             String directionAsString,
-                             String priceAsString,
-                             boolean useMarketBasedPrice,
-                             double marketPriceMargin,
-                             long amountAsLong,
-                             long minAmountAsLong,
-                             double buyerSecurityDeposit,
-                             String paymentAccountId) {
-        return coreOffersService.createOffer(currencyCode,
+    public Offer createAnPlaceOffer(String currencyCode,
+                                    String directionAsString,
+                                    String priceAsString,
+                                    boolean useMarketBasedPrice,
+                                    double marketPriceMargin,
+                                    long amountAsLong,
+                                    long minAmountAsLong,
+                                    double buyerSecurityDeposit,
+                                    String paymentAccountId,
+                                    Consumer<Offer> resultHandler) {
+        return coreOffersService.createAndPlaceOffer(currencyCode,
                 directionAsString,
                 priceAsString,
                 useMarketBasedPrice,
@@ -106,7 +108,8 @@ public class CoreApi {
                 amountAsLong,
                 minAmountAsLong,
                 buyerSecurityDeposit,
-                paymentAccountId);
+                paymentAccountId,
+                resultHandler);
     }
 
     public Offer editOffer(String offerId,

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -125,7 +125,7 @@ class CoreOffersService {
     }
 
     // Edit a placed offer.
-    Offer createOffer(String offerId,
+    Offer editOffer(String offerId,
                       String currencyCode,
                       Direction direction,
                       Price price,

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -47,6 +47,7 @@ import static bisq.common.util.MathUtils.scaleUpByPowerOf10;
 import static bisq.core.locale.CurrencyUtil.isCryptoCurrency;
 import static bisq.core.offer.OfferPayload.Direction;
 import static bisq.core.offer.OfferPayload.Direction.BUY;
+import static java.lang.String.format;
 
 @Slf4j
 class CoreOffersService {
@@ -65,6 +66,16 @@ class CoreOffersService {
         this.offerBookService = offerBookService;
         this.openOfferManager = openOfferManager;
         this.user = user;
+    }
+
+    Offer getOffer(String id) {
+        List<Offer> offers = offerBookService.getOffers().stream()
+                .filter(o -> o.getId().equals(id))
+                .collect(Collectors.toList());
+        if (offers.isEmpty())
+            throw new IllegalArgumentException(format("offer with id '%s' not found", id));
+        else
+            return offers.get(0);
     }
 
     List<Offer> getOffers(String direction, String currencyCode) {

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -23,6 +23,8 @@ import bisq.core.offer.Offer;
 
 import bisq.proto.grpc.CreateOfferReply;
 import bisq.proto.grpc.CreateOfferRequest;
+import bisq.proto.grpc.GetOfferReply;
+import bisq.proto.grpc.GetOfferRequest;
 import bisq.proto.grpc.GetOffersReply;
 import bisq.proto.grpc.GetOffersRequest;
 import bisq.proto.grpc.OffersGrpc;
@@ -47,6 +49,17 @@ class GrpcOffersService extends OffersGrpc.OffersImplBase {
     @Inject
     public GrpcOffersService(CoreApi coreApi) {
         this.coreApi = coreApi;
+    }
+
+    @Override
+    public void getOffer(GetOfferRequest req,
+                         StreamObserver<GetOfferReply> responseObserver) {
+        Offer offer = coreApi.getOffer(req.getId());
+        var reply = GetOfferReply.newBuilder()
+                .setOffer(toOfferInfo(offer).toProtoMessage())
+                .build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
     }
 
     @Override

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -78,21 +78,12 @@ class GrpcOffersService extends OffersGrpc.OffersImplBase {
                     req.getMinAmount(),
                     req.getBuyerSecurityDeposit(),
                     req.getPaymentAccountId());
-
-            // We don't support atm funding from external wallet to keep it simple.
-            boolean useSavingsWallet = true;
-            //noinspection ConstantConditions
-            coreApi.placeOffer(offer,
-                    req.getBuyerSecurityDeposit(),
-                    useSavingsWallet,
-                    transaction -> {
-                        OfferInfo offerInfo = toOfferInfo(offer);
-                        CreateOfferReply reply = CreateOfferReply.newBuilder()
-                                .setOffer(offerInfo.toProtoMessage())
-                                .build();
-                        responseObserver.onNext(reply);
-                        responseObserver.onCompleted();
-                    });
+            OfferInfo offerInfo = toOfferInfo(offer);
+            CreateOfferReply reply = CreateOfferReply.newBuilder()
+                    .setOffer(offerInfo.toProtoMessage())
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
         } catch (IllegalStateException | IllegalArgumentException cause) {
             var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
             responseObserver.onError(ex);

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -45,10 +45,20 @@ message RegisterDisputeAgentReply {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 service Offers {
+    rpc GetOffer (GetOfferRequest) returns (GetOfferReply) {
+    }
     rpc GetOffers (GetOffersRequest) returns (GetOffersReply) {
     }
     rpc CreateOffer (CreateOfferRequest) returns (CreateOfferReply) {
     }
+}
+
+message GetOfferRequest {
+    string id = 1;
+}
+
+message GetOfferReply {
+    OfferInfo offer = 1;
 }
 
 message GetOffersRequest {


### PR DESCRIPTION
There are a number of use cases where a CLI user may want to see a single offer instead of every offer for a currency pair on the buy or sell side.  The changes are:

- Add `getoffer` to `grpc.proto`
- Add new method to `GrpcOffersService`, `CoreApi`, `CoreOffersService`
- Add new method to CLI
- Adjust create offer tests to use this new convenience method