### PR TITLE
Setting jvm option  `-Djdk.module.illegalAccess=deny`

### DIFF
--- a/desktop/package/linux/package.sh
+++ b/desktop/package/linux/package.sh
@@ -111,6 +111,7 @@ $JAVA_HOME/bin/javapackager \
     -BjvmOptions=-Xss1280k \
     -BjvmOptions=-XX:MaxRAM=4g \
     -BjvmOptions=-Djava.net.preferIPv4Stack=true \
+    -BjvmOptions=-Djdk.module.illegalAccess=deny \
     -outfile Bisq-$version \
     -v
 

--- a/desktop/package/macosx/create_app.sh
+++ b/desktop/package/macosx/create_app.sh
@@ -91,6 +91,7 @@ $JAVA_HOME/bin/javapackager \
     -srcfiles "Bisq-$version.jar" \
     -appclass bisq.desktop.app.BisqAppMain \
     -outfile Bisq \
+    -BjvmOptions=-Djdk.module.illegalAccess=deny \
     -v
 
 open deploy

--- a/desktop/package/windows/package.bat
+++ b/desktop/package/windows/package.bat
@@ -111,6 +111,7 @@ call "%JAVA_HOME%\bin\javapackager.exe" -deploy ^
 -srcdir "%package_dir%" ^
 -srcfiles %jar_filename% ^
 -outfile Bisq ^
+-BjvmOptions=-Djdk.module.illegalAccess=deny ^
 -v
 
 if not exist "%package_dir%\windows\Bisq-%version%.exe" (


### PR DESCRIPTION
Setting jvm option  `-Djdk.module.illegalAccess=deny` avoids the warning logs at startup

Not sure how to add it to gradle so its set at normal compilation as well...

User get confused by the warning as it sounds somehow alerting.

`WARNING: An illegal reflective access operation has occurred
 WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/Users/dev/.gradle/caches/modules-2/files-2.1/com.google.inject/guice/4.2.2/6dacbe18e5eaa7f6c9c36db33b42e7985e94ce77/guice-4.2.2.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
 WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
 WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
 WARNING: All illegal access operations will be denied in a future release`
