### PR TITLE
Re activate confirm buttons again

### DIFF
--- a/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
@@ -109,13 +109,13 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
     @Getter
     private boolean isInConflictWithSeedNode;
     @Getter
-    private ObservableList<UtxoMismatch> utxoMismatches = FXCollections.observableArrayList();
+    private final ObservableList<UtxoMismatch> utxoMismatches = FXCollections.observableArrayList();
 
-    private List<Checkpoint> checkpoints = Arrays.asList(
+    private final List<Checkpoint> checkpoints = Arrays.asList(
             new Checkpoint(586920, Utilities.decodeFromHex("523aaad4e760f6ac6196fec1b3ec9a2f42e5b272"))
     );
     private boolean checkpointFailed;
-    private boolean ignoreDevMsg;
+    private final boolean ignoreDevMsg;
     private int numCalls;
     private long accumulatedDuration;
 

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -202,6 +202,10 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
             Trade trade = tradeOptional.get();
             if (trade.getDisputeState() == Trade.DisputeState.MEDIATION_REQUESTED ||
                     trade.getDisputeState() == Trade.DisputeState.MEDIATION_STARTED_BY_PEER) {
+                trade.getProcessModel().setBuyerPayoutAmountFromMediation(disputeResult.getBuyerPayoutAmount().value);
+                trade.getProcessModel().setSellerPayoutAmountFromMediation(disputeResult.getSellerPayoutAmount().value);
+                tradeManager.requestPersistence();
+
                 trade.setDisputeState(Trade.DisputeState.MEDIATION_CLOSED);
             }
         } else {

--- a/core/src/main/java/bisq/core/trade/BuyerTrade.java
+++ b/core/src/main/java/bisq/core/trade/BuyerTrade.java
@@ -85,4 +85,8 @@ public abstract class BuyerTrade extends Trade {
         return checkNotNull(getOffer()).getBuyerSecurityDeposit().add(getTradeAmount());
     }
 
+    @Override
+    public boolean confirmPermitted() {
+        return !getDisputeState().isArbitrated();
+    }
 }

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -245,23 +245,23 @@ public abstract class Trade implements Tradable, Model {
             return protobuf.Trade.DisputeState.valueOf(disputeState.name());
         }
 
-        public static boolean isNotDisputed(DisputeState disputeState) {
-            return disputeState == Trade.DisputeState.NO_DISPUTE;
+        public boolean isNotDisputed() {
+            return this == Trade.DisputeState.NO_DISPUTE;
         }
 
-        public static boolean isMediated(DisputeState disputeState) {
-            return disputeState == Trade.DisputeState.MEDIATION_REQUESTED ||
-                    disputeState == Trade.DisputeState.MEDIATION_STARTED_BY_PEER ||
-                    disputeState == Trade.DisputeState.MEDIATION_CLOSED;
+        public boolean isMediated() {
+            return this == Trade.DisputeState.MEDIATION_REQUESTED ||
+                    this == Trade.DisputeState.MEDIATION_STARTED_BY_PEER ||
+                    this == Trade.DisputeState.MEDIATION_CLOSED;
         }
 
-        public static boolean isArbitrated(DisputeState disputeState) {
-            return disputeState == Trade.DisputeState.DISPUTE_REQUESTED ||
-                    disputeState == Trade.DisputeState.DISPUTE_STARTED_BY_PEER ||
-                    disputeState == Trade.DisputeState.DISPUTE_CLOSED ||
-                    disputeState == Trade.DisputeState.REFUND_REQUESTED ||
-                    disputeState == Trade.DisputeState.REFUND_REQUEST_STARTED_BY_PEER ||
-                    disputeState == Trade.DisputeState.REFUND_REQUEST_CLOSED;
+        public boolean isArbitrated() {
+            return this == Trade.DisputeState.DISPUTE_REQUESTED ||
+                    this == Trade.DisputeState.DISPUTE_STARTED_BY_PEER ||
+                    this == Trade.DisputeState.DISPUTE_CLOSED ||
+                    this == Trade.DisputeState.REFUND_REQUESTED ||
+                    this == Trade.DisputeState.REFUND_REQUEST_STARTED_BY_PEER ||
+                    this == Trade.DisputeState.REFUND_REQUEST_CLOSED;
         }
     }
 
@@ -731,6 +731,7 @@ public abstract class Trade implements Tradable, Model {
 
     public abstract Coin getPayoutAmount();
 
+    public abstract boolean confirmPermitted();
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Setters

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerProtocol.java
@@ -134,7 +134,7 @@ public abstract class BuyerProtocol extends DisputeProtocol {
         BuyerEvent event = BuyerEvent.PAYMENT_SENT;
         expect(phase(Trade.Phase.DEPOSIT_CONFIRMED)
                 .with(event)
-                .preCondition(paymentStartedEnabled()))
+                .preCondition(trade.confirmPermitted()))
                 .setup(tasks(ApplyFilter.class,
                         getVerifyPeersFeePaymentClass(),
                         BuyerSignPayoutTx.class,
@@ -188,9 +188,4 @@ public abstract class BuyerProtocol extends DisputeProtocol {
     }
 
     abstract protected Class<? extends TradeTask> getVerifyPeersFeePaymentClass();
-
-    // Once arbitration is opened we disable confirmation of payment started
-    protected boolean paymentStartedEnabled() {
-        return !Trade.DisputeState.isArbitrated(trade.getDisputeState());
-    }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerProtocol.java
@@ -134,7 +134,7 @@ public abstract class BuyerProtocol extends DisputeProtocol {
         BuyerEvent event = BuyerEvent.PAYMENT_SENT;
         expect(phase(Trade.Phase.DEPOSIT_CONFIRMED)
                 .with(event)
-                .preCondition(notDisputed()))
+                .preCondition(paymentStartedEnabled()))
                 .setup(tasks(ApplyFilter.class,
                         getVerifyPeersFeePaymentClass(),
                         BuyerSignPayoutTx.class,
@@ -189,4 +189,8 @@ public abstract class BuyerProtocol extends DisputeProtocol {
 
     abstract protected Class<? extends TradeTask> getVerifyPeersFeePaymentClass();
 
+    // Once arbitration is opened we disable confirmation of payment started
+    protected boolean paymentStartedEnabled() {
+        return !Trade.DisputeState.isArbitrated(trade.getDisputeState());
+    }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/DisputeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/DisputeProtocol.java
@@ -55,10 +55,6 @@ public class DisputeProtocol extends TradeProtocol {
         super(trade);
     }
 
-    protected boolean notDisputed() {
-        return trade.getDisputeState() == Trade.DisputeState.NO_DISPUTE;
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // User interaction: Trader accepts mediation result

--- a/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade.protocol;
 
+import bisq.core.locale.CurrencyUtil;
 import bisq.core.trade.SellerTrade;
 import bisq.core.trade.Trade;
 import bisq.core.trade.messages.CounterCurrencyTransferStartedMessage;
@@ -123,7 +124,7 @@ public abstract class SellerProtocol extends DisputeProtocol {
         SellerEvent event = SellerEvent.PAYMENT_RECEIVED;
         expect(anyPhase(Trade.Phase.FIAT_SENT, Trade.Phase.PAYOUT_PUBLISHED)
                 .with(event)
-                .preCondition(notDisputed()))
+                .preCondition(paymentReceivedEnabled()))
                 .setup(tasks(
                         ApplyFilter.class,
                         getVerifyPeersFeePaymentClass(),
@@ -159,4 +160,32 @@ public abstract class SellerProtocol extends DisputeProtocol {
     }
 
     abstract protected Class<? extends TradeTask> getVerifyPeersFeePaymentClass();
+
+    protected boolean paymentReceivedEnabled() {
+        // For altcoin there is no reason to delay BTC release as no chargeback risk
+        if (CurrencyUtil.isCryptoCurrency(trade.getOffer().getCurrencyCode())) {
+            return true;
+        }
+
+        switch (trade.getDisputeState()) {
+            case NO_DISPUTE:
+                return true;
+
+            case DISPUTE_REQUESTED:
+            case DISPUTE_STARTED_BY_PEER:
+            case DISPUTE_CLOSED:
+            case MEDIATION_REQUESTED:
+            case MEDIATION_STARTED_BY_PEER:
+                return false;
+
+            case MEDIATION_CLOSED:
+                return !trade.mediationResultAppliedPenaltyToSeller();
+
+            case REFUND_REQUESTED:
+            case REFUND_REQUEST_STARTED_BY_PEER:
+            case REFUND_REQUEST_CLOSED:
+            default:
+                return false;
+        }
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -716,10 +716,6 @@ public abstract class TradeStepView extends AnchorPane {
         }
     }
 
-    protected boolean isDisputed() {
-        return trade.getDisputeState() != Trade.DisputeState.NO_DISPUTE;
-    }
-
     private void checkIfLockTimeIsOver() {
         if (trade.getDisputeState() == Trade.DisputeState.MEDIATION_CLOSED) {
             Transaction delayedPayoutTx = trade.getDelayedPayoutTx();

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -430,7 +430,7 @@ public abstract class TradeStepView extends AnchorPane {
     protected void applyOnDisputeOpened() {
     }
 
-    private void updateDisputeState(Trade.DisputeState disputeState) {
+    protected void updateDisputeState(Trade.DisputeState disputeState) {
         Optional<Dispute> ownDispute;
         switch (disputeState) {
             case NO_DISPUTE:
@@ -513,8 +513,6 @@ public abstract class TradeStepView extends AnchorPane {
             default:
                 break;
         }
-
-        updateConfirmButtonDisableState(isDisputed());
     }
 
     private void updateMediationResultState(boolean blockOpeningOfResultAcceptedPopup) {
@@ -672,10 +670,6 @@ public abstract class TradeStepView extends AnchorPane {
         }
 
         acceptMediationResultPopup.show();
-    }
-
-    protected void updateConfirmButtonDisableState(boolean isDisabled) {
-        // By default do nothing. Only overwritten in certain trade steps
     }
 
     protected String getCurrencyName(Trade trade) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -164,7 +164,7 @@ public class BuyerStep2View extends TradeStepView {
                                 break;
                         }
                     } else {
-                        log.warn("confirmButton gets disabled because trade contains error message {}", trade.getErrorMessage());
+                        log.warn("Trade contains error message {}", trade.getErrorMessage());
                         statusLabel.setText("");
                     }
                 }
@@ -191,13 +191,6 @@ public class BuyerStep2View extends TradeStepView {
     protected void onPendingTradesInitialized() {
         super.onPendingTradesInitialized();
         validatePayoutTx();
-    }
-
-    @Override
-    protected void updateDisputeState(Trade.DisputeState disputeState) {
-        super.updateDisputeState(disputeState);
-
-        confirmButton.setDisable(!trade.confirmPermitted());
     }
 
 
@@ -371,6 +364,14 @@ public class BuyerStep2View extends TradeStepView {
     @Override
     protected void applyOnDisputeOpened() {
     }
+
+    @Override
+    protected void updateDisputeState(Trade.DisputeState disputeState) {
+        super.updateDisputeState(disputeState);
+
+        confirmButton.setDisable(!trade.confirmPermitted());
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // UI Handlers

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -378,10 +378,6 @@ public class BuyerStep2View extends TradeStepView {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void onPaymentStarted() {
-        if (isDisputed()) {
-            return;
-        }
-
         if (!model.dataModel.isBootstrappedOrShowPopup()) {
             return;
         }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -134,12 +134,10 @@ public class BuyerStep2View extends TradeStepView {
                             case BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED:
                             case BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG:
                                 busyAnimation.play();
-                                // confirmButton.setDisable(true);
                                 statusLabel.setText(Res.get("shared.sendingConfirmation"));
                                 model.setMessageStateProperty(MessageState.SENT);
                                 timeoutTimer = UserThread.runAfter(() -> {
                                     busyAnimation.stop();
-                                    // confirmButton.setDisable(false);
                                     statusLabel.setText(Res.get("shared.sendingConfirmationAgain"));
                                 }, 10);
                                 break;
@@ -156,20 +154,17 @@ public class BuyerStep2View extends TradeStepView {
                             case BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG:
                                 // We get a popup and the trade closed, so we dont need to show anything here
                                 busyAnimation.stop();
-                                // confirmButton.setDisable(false);
                                 statusLabel.setText("");
                                 model.setMessageStateProperty(MessageState.FAILED);
                                 break;
                             default:
                                 log.warn("Unexpected case: State={}, tradeId={} " + state.name(), trade.getId());
                                 busyAnimation.stop();
-                                // confirmButton.setDisable(false);
                                 statusLabel.setText(Res.get("shared.sendingConfirmationAgain"));
                                 break;
                         }
                     } else {
                         log.warn("confirmButton gets disabled because trade contains error message {}", trade.getErrorMessage());
-                        // confirmButton.setDisable(true);
                         statusLabel.setText("");
                     }
                 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -170,8 +170,6 @@ public class BuyerStep2View extends TradeStepView {
                 }
             });
         }
-
-        confirmButton.setDisable(isDisputed());
     }
 
     @Override
@@ -193,6 +191,13 @@ public class BuyerStep2View extends TradeStepView {
     protected void onPendingTradesInitialized() {
         super.onPendingTradesInitialized();
         validatePayoutTx();
+    }
+
+    @Override
+    protected void updateDisputeState(Trade.DisputeState disputeState) {
+        super.updateDisputeState(disputeState);
+
+        confirmButton.setDisable(!trade.confirmPermitted());
     }
 
 
@@ -627,10 +632,5 @@ public class BuyerStep2View extends TradeStepView {
                 new Popup().warning(Res.get("portfolio.pending.invalidDelayedPayoutTx", e.getMessage())).show();
             }
         }
-    }
-
-    @Override
-    protected void updateConfirmButtonDisableState(boolean isDisabled) {
-        confirmButton.setDisable(isDisabled);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -359,10 +359,6 @@ public class SellerStep3View extends TradeStepView {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void onPaymentReceived() {
-        if (isDisputed()) {
-            return;
-        }
-
         // The confirmPaymentReceived call will trigger the trade protocol to do the payout tx. We want to be sure that we
         // are well connected to the Bitcoin network before triggering the broadcast.
         if (model.dataModel.isReadyForTxBroadcast()) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -45,6 +45,7 @@ import bisq.core.payment.payload.SepaInstantAccountPayload;
 import bisq.core.payment.payload.USPostalMoneyOrderAccountPayload;
 import bisq.core.payment.payload.WesternUnionAccountPayload;
 import bisq.core.trade.Contract;
+import bisq.core.trade.Trade;
 import bisq.core.trade.txproof.AssetTxProofResult;
 import bisq.core.user.DontShowAgainLookup;
 
@@ -304,8 +305,10 @@ public class SellerStep3View extends TradeStepView {
     }
 
     @Override
-    protected void updateConfirmButtonDisableState(boolean isDisabled) {
-        confirmButton.setDisable(isDisabled);
+    protected void updateDisputeState(Trade.DisputeState disputeState) {
+        super.updateDisputeState(disputeState);
+
+        confirmButton.setDisable(!trade.confirmPermitted());
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -304,13 +304,6 @@ public class SellerStep3View extends TradeStepView {
         statusLabel = tuple.third;
     }
 
-    @Override
-    protected void updateDisputeState(Trade.DisputeState disputeState) {
-        super.updateDisputeState(disputeState);
-
-        confirmButton.setDisable(!trade.confirmPermitted());
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Info
@@ -352,6 +345,14 @@ public class SellerStep3View extends TradeStepView {
     @Override
     protected void applyOnDisputeOpened() {
     }
+
+    @Override
+    protected void updateDisputeState(Trade.DisputeState disputeState) {
+        super.updateDisputeState(disputeState);
+
+        confirmButton.setDisable(!trade.confirmPermitted());
+    }
+
 
     ////////////////////////////////////////////////////////////////////////////////////////
     // UI Handlers

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -119,12 +119,10 @@ public class SellerStep3View extends TradeStepView {
                         case SELLER_PUBLISHED_PAYOUT_TX:
                         case SELLER_SENT_PAYOUT_TX_PUBLISHED_MSG:
                             busyAnimation.play();
-                            // confirmButton.setDisable(true);
                             statusLabel.setText(Res.get("shared.sendingConfirmation"));
 
                             timeoutTimer = UserThread.runAfter(() -> {
                                 busyAnimation.stop();
-                                // confirmButton.setDisable(false);
                                 statusLabel.setText(Res.get("shared.sendingConfirmationAgain"));
                             }, 10);
                             break;
@@ -139,19 +137,16 @@ public class SellerStep3View extends TradeStepView {
                         case SELLER_SEND_FAILED_PAYOUT_TX_PUBLISHED_MSG:
                             // We get a popup and the trade closed, so we dont need to show anything here
                             busyAnimation.stop();
-                            // confirmButton.setDisable(false);
                             statusLabel.setText("");
                             break;
                         default:
                             log.warn("Unexpected case: State={}, tradeId={} " + state.name(), trade.getId());
                             busyAnimation.stop();
-                            // confirmButton.setDisable(false);
                             statusLabel.setText(Res.get("shared.sendingConfirmationAgain"));
                             break;
                     }
                 } else {
-                    log.warn("confirmButton gets disabled because trade contains error message {}", trade.getErrorMessage());
-                    // confirmButton.setDisable(true);
+                    log.warn("Trade contains error message {}", trade.getErrorMessage());
                     statusLabel.setText("");
                 }
             }
@@ -459,13 +454,7 @@ public class SellerStep3View extends TradeStepView {
         statusLabel.setText(Res.get("shared.sendingConfirmation"));
 
         model.dataModel.onFiatPaymentReceived(() -> {
-            // In case the first send failed we got the support button displayed.
-            // If it succeeds at a second try we remove the support button again.
-            //TODO check for support. in case of a dispute we dont want to hide the button
-            //if (notificationGroup != null)
-            //   notificationGroup.setButtonVisible(false);
         }, errorMessage -> {
-            // confirmButton.setDisable(false);
             busyAnimation.stop();
             new Popup().warning(Res.get("popup.warning.sendMsgFailed")).show();
         });


### PR DESCRIPTION
Implements what we discussed in https://github.com/bisq-network/bisq/pull/4562

>     * Enable for buyer and altcoin seller at all times (only once arbitration is opened it is disabled as there is no way anyway to do a normal payout anymore.
> 
>     * Disable for fiat seller while mediation is open. Enable it at dispute result if no penalty was applied by mediators (derived from payout suggestion). So the mediator is the enabler for the confirm-button by his judgement expressed in the payout suggestion. This solves automatically point 2 as if the mediated payout suggestion is the same as the happy-path there is no avoid-penalty issue as no penalty was applied.
>       If seller confirms receipt in mediation the mediator can close anyway so there is only a bit of extra friction and delay due the communication but the dispute has to be closed anyway from the mediator. So I don't see that this creates any significant difference. If mediator has applied a penalty to the buyer the seller still gets his button activated (no penaly for seller - this is the only condition we check). So the seller has 2 options: accept mediated result and hope that buyer accept as well, or click confirm button and "forgive" buyer. The confirm button would stay active also after accept button has been clicked. So he can try mediated suggestion and before it goes to arbitration click the confirm button so we avoid arbitration cases.

