### PR TITLE
Fix register dipute agent test assert

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/RegisterDisputeAgentsTest.java
@@ -71,7 +71,7 @@ public class RegisterDisputeAgentsTest extends MethodTest {
                 createRegisterDisputeAgentRequest("badagent");
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 grpcStubs(arbdaemon).disputeAgentsService.registerDisputeAgent(req));
-        assertEquals("INVALID_ARGUMENT: unknown dispute agent type badagent",
+        assertEquals("INVALID_ARGUMENT: unknown dispute agent type 'badagent'",
                 exception.getMessage());
     }
 


### PR DESCRIPTION
This should have been included in commit 5f9b1e6, PR [4595](https://github.com/bisq-network/bisq/pull/4595).
