### PR TITLE
Remove address prefix for mailbox messages

### DIFF
--- a/common/src/main/java/bisq/common/app/Capabilities.java
+++ b/common/src/main/java/bisq/common/app/Capabilities.java
@@ -184,4 +184,18 @@ public class Capabilities {
     public int size() {
         return capabilities.size();
     }
+
+    // We return true if our capabilities have less capabilities than the parameter value
+    public boolean hasLess(Capabilities other) {
+        return findHighestCapability(this) < findHighestCapability(other);
+    }
+
+    // We use the sum of all capabilities. Alternatively we could use the highest entry.
+    // Neither would support removal of past capabilities, a use case we never had so far and which might have
+    // backward compatibility issues, so we should treat capabilities as an append-only data structure.
+    public int findHighestCapability(Capabilities capabilities) {
+        return (int) capabilities.capabilities.stream()
+                .mapToLong(e -> (long) e.ordinal())
+                .sum();
+    }
 }

--- a/common/src/main/java/bisq/common/app/Capabilities.java
+++ b/common/src/main/java/bisq/common/app/Capabilities.java
@@ -98,6 +98,10 @@ public class Capabilities {
         return this.capabilities.containsAll(Arrays.asList(capabilities));
     }
 
+    public boolean contains(Capability capability) {
+        return this.capabilities.contains(capability);
+    }
+
     public boolean isEmpty() {
         return capabilities.isEmpty();
     }

--- a/common/src/main/java/bisq/common/app/Capability.java
+++ b/common/src/main/java/bisq/common/app/Capability.java
@@ -41,5 +41,5 @@ public enum Capability {
     MEDIATION,                          // Supports mediation feature
     REFUND_AGENT,                       // Supports refund agents
     TRADE_STATISTICS_HASH_UPDATE,       // We changed the hash method in 1.2.0 and that requires update to 1.2.2 for handling it correctly, otherwise the seed nodes have to process too much data.
-    NO_ADDRESS_PRE_FIX                   // At 1.4.0 we removed the prefix filter for mailbox messages. If a peer has that capability we do not sent the prefix.
+    NO_ADDRESS_PRE_FIX                  // At 1.4.0 we removed the prefix filter for mailbox messages. If a peer has that capability we do not sent the prefix.
 }

--- a/common/src/main/java/bisq/common/app/Capability.java
+++ b/common/src/main/java/bisq/common/app/Capability.java
@@ -40,5 +40,6 @@ public enum Capability {
     SIGNED_ACCOUNT_AGE_WITNESS,         // Supports the signed account age witness feature
     MEDIATION,                          // Supports mediation feature
     REFUND_AGENT,                       // Supports refund agents
-    TRADE_STATISTICS_HASH_UPDATE        // We changed the hash method in 1.2.0 and that requires update to 1.2.2 for handling it correctly, otherwise the seed nodes have to process too much data.
+    TRADE_STATISTICS_HASH_UPDATE,       // We changed the hash method in 1.2.0 and that requires update to 1.2.2 for handling it correctly, otherwise the seed nodes have to process too much data.
+    NO_ADDRESS_PRE_FIX                   // At 1.4.0 we removed the prefix filter for mailbox messages. If a peer has that capability we do not sent the prefix.
 }

--- a/common/src/test/java/bisq/common/app/CapabilitiesTest.java
+++ b/common/src/test/java/bisq/common/app/CapabilitiesTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 
 import org.junit.Test;
 
+import static bisq.common.app.Capability.DAO_FULL_NODE;
 import static bisq.common.app.Capability.SEED_NODE;
 import static bisq.common.app.Capability.TRADE_STATISTICS;
 import static bisq.common.app.Capability.TRADE_STATISTICS_2;
@@ -38,6 +39,47 @@ public class CapabilitiesTest {
 
         assertTrue(DUT.containsAll(new HashSet<>()));
         assertFalse(DUT.containsAll(new Capabilities(SEED_NODE)));
+    }
+
+    @Test
+    public void testHasLess() {
+        assertTrue(new Capabilities().hasLess(new Capabilities(SEED_NODE)));
+        assertFalse(new Capabilities().hasLess(new Capabilities()));
+        assertFalse(new Capabilities(SEED_NODE).hasLess(new Capabilities()));
+        assertTrue(new Capabilities(SEED_NODE).hasLess(new Capabilities(DAO_FULL_NODE)));
+        assertFalse(new Capabilities(DAO_FULL_NODE).hasLess(new Capabilities(SEED_NODE)));
+
+        Capabilities all = new Capabilities(
+                Capability.TRADE_STATISTICS,
+                Capability.TRADE_STATISTICS_2,
+                Capability.ACCOUNT_AGE_WITNESS,
+                Capability.ACK_MSG,
+                Capability.PROPOSAL,
+                Capability.BLIND_VOTE,
+                Capability.DAO_STATE,
+                Capability.BUNDLE_OF_ENVELOPES,
+                Capability.MEDIATION,
+                Capability.SIGNED_ACCOUNT_AGE_WITNESS,
+                Capability.REFUND_AGENT,
+                Capability.TRADE_STATISTICS_HASH_UPDATE
+        );
+        Capabilities other = new Capabilities(
+                Capability.TRADE_STATISTICS,
+                Capability.TRADE_STATISTICS_2,
+                Capability.ACCOUNT_AGE_WITNESS,
+                Capability.ACK_MSG,
+                Capability.PROPOSAL,
+                Capability.BLIND_VOTE,
+                Capability.DAO_STATE,
+                Capability.BUNDLE_OF_ENVELOPES,
+                Capability.MEDIATION,
+                Capability.SIGNED_ACCOUNT_AGE_WITNESS,
+                Capability.REFUND_AGENT,
+                Capability.TRADE_STATISTICS_HASH_UPDATE,
+                Capability.NO_ADDRESS_PRE_FIX
+        );
+
+        assertTrue(all.hasLess(other));
     }
 
     @Test

--- a/common/src/test/java/bisq/common/app/CapabilitiesTest.java
+++ b/common/src/test/java/bisq/common/app/CapabilitiesTest.java
@@ -50,8 +50,8 @@ public class CapabilitiesTest {
         assertFalse(new Capabilities(DAO_FULL_NODE).hasLess(new Capabilities(SEED_NODE)));
 
         Capabilities all = new Capabilities(
-                Capability.TRADE_STATISTICS,
-                Capability.TRADE_STATISTICS_2,
+                TRADE_STATISTICS,
+                TRADE_STATISTICS_2,
                 Capability.ACCOUNT_AGE_WITNESS,
                 Capability.ACK_MSG,
                 Capability.PROPOSAL,
@@ -64,8 +64,8 @@ public class CapabilitiesTest {
                 Capability.TRADE_STATISTICS_HASH_UPDATE
         );
         Capabilities other = new Capabilities(
-                Capability.TRADE_STATISTICS,
-                Capability.TRADE_STATISTICS_2,
+                TRADE_STATISTICS,
+                TRADE_STATISTICS_2,
                 Capability.ACCOUNT_AGE_WITNESS,
                 Capability.ACK_MSG,
                 Capability.PROPOSAL,

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/network/RepublishGovernanceDataHandler.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/network/RepublishGovernanceDataHandler.java
@@ -170,7 +170,7 @@ public final class RepublishGovernanceDataHandler {
     private void connectToAnyFullNode() {
         Capabilities required = new Capabilities(Capability.DAO_FULL_NODE);
 
-        List<Peer> list = peerManager.getLivePeers(null).stream()
+        List<Peer> list = peerManager.getLivePeers().stream()
                 .filter(peer -> peer.getCapabilities().containsAll(required))
                 .collect(Collectors.toList());
 

--- a/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
@@ -180,7 +180,7 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
     public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
         closeHandler(connection);
 
-        if (peerManager.isNodeBanned(closeConnectionReason, connection)) {
+        if (peerManager.isPeerBanned(closeConnectionReason, connection)) {
             connection.getPeersNodeAddressOptional().ifPresent(nodeAddress -> {
                 seedNodeAddresses.remove(nodeAddress);
                 removeFromRequestBlocksHandlerMap(nodeAddress);

--- a/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
+++ b/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
@@ -39,7 +39,8 @@ public class CoreNetworkCapabilities {
                 Capability.MEDIATION,
                 Capability.SIGNED_ACCOUNT_AGE_WITNESS,
                 Capability.REFUND_AGENT,
-                Capability.TRADE_STATISTICS_HASH_UPDATE
+                Capability.TRADE_STATISTICS_HASH_UPDATE,
+                Capability.NO_ADDRESS_PRE_FIX
         );
 
         if (config.daoActivated) {

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentManager.java
@@ -214,8 +214,6 @@ public abstract class DisputeAgentManager<T extends DisputeAgent> {
 
         observableMap.putAll(filtered);
         observableMap.values().forEach(this::addAcceptedDisputeAgentToUser);
-
-        log.info("Available disputeAgents: {}", observableMap.keySet());
     }
 
 

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -30,6 +30,7 @@ import bisq.network.p2p.DecryptedDirectMessageListener;
 import bisq.network.p2p.DecryptedMessageWithPubKey;
 import bisq.network.p2p.MailboxMessage;
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
 import bisq.network.p2p.SendMailboxMessageListener;
 import bisq.network.p2p.messaging.DecryptedMailboxListener;
 
@@ -77,8 +78,8 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             processModel.getP2PService().addDecryptedDirectMessageListener(this);
         }
         processModel.getP2PService().addDecryptedMailboxListener(this);
-        processModel.getP2PService().getMailboxMap().values()
-                .stream().map(e -> e.second)
+        processModel.getP2PService().getMailboxItemsByUid().values()
+                .stream().map(P2PService.MailboxItem::getDecryptedMessageWithPubKey)
                 .forEach(this::handleDecryptedMessageWithPubKey);
     }
 

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -133,7 +133,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
                         networkProtoResolver);
                 DefaultSeedNodeRepository seedNodeRepository = new DefaultSeedNodeRepository(config);
                 PeerManager peerManager = new PeerManager(networkNode, seedNodeRepository, new ClockWatcher(),
-                        maxConnections, new PersistenceManager<>(storageDir, persistenceProtoResolver, corruptedStorageFileHandler));
+                        new PersistenceManager<>(storageDir, persistenceProtoResolver, corruptedStorageFileHandler), maxConnections);
 
                 // init file storage
                 peerManager.readPersisted();

--- a/p2p/src/main/java/bisq/network/p2p/DecryptedDirectMessageListener.java
+++ b/p2p/src/main/java/bisq/network/p2p/DecryptedDirectMessageListener.java
@@ -19,5 +19,5 @@ package bisq.network.p2p;
 
 public interface DecryptedDirectMessageListener {
 
-    void onDirectMessage(DecryptedMessageWithPubKey decryptedMessageWithPubKey, @SuppressWarnings("UnusedParameters") NodeAddress peerNodeAddress);
+    void onDirectMessage(DecryptedMessageWithPubKey decryptedMessageWithPubKey, NodeAddress peerNodeAddress);
 }

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -323,8 +323,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                 "seedNodeOfPreliminaryDataRequest must be present");
 
         requestDataManager.requestUpdateData();
-        /*if (Capabilities.app.containsAll(Capability.SEED_NODE))
-            UserThread.runPeriodically(() -> requestDataManager.requestUpdateData(), 1, TimeUnit.HOURS);*/
 
         // If we start up first time we don't have any peers so we need to request from seed node.
         // As well it can be that the persisted peer list is outdated with dead peers.

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -452,7 +452,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     private void processSingleMailboxEntry(Collection<ProtectedMailboxStorageEntry> protectedMailboxStorageEntries) {
         checkArgument(protectedMailboxStorageEntries.size() == 1);
         var decryptedEntries = new ArrayList<>(getDecryptedEntries(protectedMailboxStorageEntries));
-        if (protectedMailboxStorageEntries.size() == 1) {
+        if (decryptedEntries.size() == 1) {
             storeMailboxDataAndNotifyListeners(decryptedEntries.get(0));
         }
     }

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -450,9 +450,11 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     private void processSingleMailboxEntry(Collection<ProtectedMailboxStorageEntry> protectedMailboxStorageEntries) {
+        checkArgument(protectedMailboxStorageEntries.size() == 1);
         var decryptedEntries = new ArrayList<>(getDecryptedEntries(protectedMailboxStorageEntries));
-        checkArgument(decryptedEntries.size() == 1);
-        storeMailboxDataAndNotifyListeners(decryptedEntries.get(0));
+        if (protectedMailboxStorageEntries.size() == 1) {
+            storeMailboxDataAndNotifyListeners(decryptedEntries.get(0));
+        }
     }
 
     // We run the batch processing of all mailbox messages we have received at startup in a thread to not block the UI.

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -285,13 +285,13 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
         boolean seedNodesAvailable = requestDataManager.requestPreliminaryData();
 
         keepAliveManager.start();
-        p2pServiceListeners.stream().forEach(SetupListener::onTorNodeReady);
+        p2pServiceListeners.forEach(SetupListener::onTorNodeReady);
 
         if (!seedNodesAvailable) {
             isBootstrapped = true;
             // As we do not expect a updated data request response we start here with addHashMapChangedListenerAndApply
             addHashMapChangedListenerAndApply();
-            p2pServiceListeners.stream().forEach(P2PServiceListener::onNoSeedNodeAvailable);
+            p2pServiceListeners.forEach(P2PServiceListener::onNoSeedNodeAvailable);
         }
     }
 
@@ -301,17 +301,17 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
         hiddenServicePublished.set(true);
 
-        p2pServiceListeners.stream().forEach(SetupListener::onHiddenServicePublished);
+        p2pServiceListeners.forEach(SetupListener::onHiddenServicePublished);
     }
 
     @Override
     public void onSetupFailed(Throwable throwable) {
-        p2pServiceListeners.stream().forEach(e -> e.onSetupFailed(throwable));
+        p2pServiceListeners.forEach(e -> e.onSetupFailed(throwable));
     }
 
     @Override
     public void onRequestCustomBridges() {
-        p2pServiceListeners.stream().forEach(SetupListener::onRequestCustomBridges);
+        p2pServiceListeners.forEach(SetupListener::onRequestCustomBridges);
     }
 
     // Called from networkReadyBinding
@@ -353,24 +353,24 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             // Only now we start listening and processing. The p2PDataStorage is our cache for data we have received
             // after the hidden service was ready.
             addHashMapChangedListenerAndApply();
-            p2pServiceListeners.stream().forEach(P2PServiceListener::onUpdatedDataReceived);
+            p2pServiceListeners.forEach(P2PServiceListener::onUpdatedDataReceived);
             p2PDataStorage.onBootstrapComplete();
         }
     }
 
     @Override
     public void onNoSeedNodeAvailable() {
-        p2pServiceListeners.stream().forEach(P2PServiceListener::onNoSeedNodeAvailable);
+        p2pServiceListeners.forEach(P2PServiceListener::onNoSeedNodeAvailable);
     }
 
     @Override
     public void onNoPeersAvailable() {
-        p2pServiceListeners.stream().forEach(P2PServiceListener::onNoPeersAvailable);
+        p2pServiceListeners.forEach(P2PServiceListener::onNoPeersAvailable);
     }
 
     @Override
     public void onDataReceived() {
-        p2pServiceListeners.stream().forEach(P2PServiceListener::onDataReceived);
+        p2pServiceListeners.forEach(P2PServiceListener::onDataReceived);
     }
 
 
@@ -644,7 +644,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
             log.debug("sendEncryptedMailboxMessage msg={},  peersNodeAddress={}", message, peer);
             SettableFuture<Connection> future = networkNode.sendMessage(peer, prefixedSealedAndSignedMessage);
-            Futures.addCallback(future, new FutureCallback<Connection>() {
+            Futures.addCallback(future, new FutureCallback<>() {
                 @Override
                 public void onSuccess(@Nullable Connection connection) {
                     sendMailboxMessageListener.onArrived();
@@ -670,11 +670,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     private boolean capabilityRequiredAndCapabilityNotSupported(NodeAddress peersNodeAddress, NetworkEnvelope message) {
         if (!(message instanceof CapabilityRequiringPayload))
             return false;
-
-        // We only expect AckMessage so far
-        if (!(message instanceof AckMessage))
-            log.warn("We got a CapabilityRequiringPayload for the mailbox message which is not a AckMessage. " +
-                    "peersNodeAddress={}", peersNodeAddress);
 
         Set<Peer> allPeers = peerManager.getPersistedPeers();
         allPeers.addAll(peerManager.getReportedPeers());
@@ -878,8 +873,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     public void removeP2PServiceListener(P2PServiceListener listener) {
-        if (p2pServiceListeners.contains(listener))
-            p2pServiceListeners.remove(listener);
+        p2pServiceListeners.remove(listener);
     }
 
     public void addHashSetChangedListener(HashMapChangedListener hashMapChangedListener) {

--- a/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
@@ -34,8 +34,8 @@ public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implem
     private final NodeAddress senderNodeAddress;
     private final SealedAndSigned sealedAndSigned;
 
-    // From v1.4.0 on that can be an empty byte array. We cannot use null as not updated nodes would get a nullPointer
-    // at protobuf serialisation.
+    // From v1.4.0 on addressPrefixHash can be an empty byte array.
+    // We cannot make it nullable as not updated nodes would get a nullPointer exception at protobuf serialisation.
     private final byte[] addressPrefixHash;
 
     private final String uid;
@@ -75,7 +75,8 @@ public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implem
                 .build();
     }
 
-    public static PrefixedSealedAndSignedMessage fromProto(protobuf.PrefixedSealedAndSignedMessage proto, int messageVersion) {
+    public static PrefixedSealedAndSignedMessage fromProto(protobuf.PrefixedSealedAndSignedMessage proto,
+                                                           int messageVersion) {
         return new PrefixedSealedAndSignedMessage(NodeAddress.fromProto(proto.getNodeAddress()),
                 SealedAndSigned.fromProto(proto.getSealedAndSigned()),
                 proto.getAddressPrefixHash().toByteArray(),

--- a/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
@@ -33,7 +33,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implements MailboxMessage, SendersNodeAddressMessage {
     private final NodeAddress senderNodeAddress;
     private final SealedAndSigned sealedAndSigned;
+
+    // From v1.4.0 on that can be an empty byte array. We cannot use null as not updated nodes would get a nullPointer
+    // at protobuf serialisation.
     private final byte[] addressPrefixHash;
+
     private final String uid;
 
     public PrefixedSealedAndSignedMessage(NodeAddress senderNodeAddress,

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -900,11 +900,10 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
     @Nullable
     private NodeAddress getSenderNodeAddress(NetworkEnvelope networkEnvelope) {
-        return getPeersNodeAddressOptional().isPresent() ?
-                getPeersNodeAddressOptional().get() :
+        return getPeersNodeAddressOptional().orElse(
                 networkEnvelope instanceof SendersNodeAddressMessage ?
                         ((SendersNodeAddressMessage) networkEnvelope).getSenderNodeAddress() :
-                        null;
+                        null);
     }
 
     private String getSenderNodeAddressAsString(NetworkEnvelope networkEnvelope) {

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -159,6 +159,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
     private final List<Long> messageTimeStamps = new ArrayList<>();
     private final CopyOnWriteArraySet<MessageListener> messageListeners = new CopyOnWriteArraySet<>();
     private volatile long lastSendTimeStamp = 0;
+    // We use a weak reference here to ensure that no connection causes a memory leak in case it get closed without
+    // the shutDown being called.
     private final CopyOnWriteArraySet<WeakReference<SupportedCapabilitiesListener>> capabilitiesListeners = new CopyOnWriteArraySet<>();
 
     @Getter
@@ -514,6 +516,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         } finally {
             protoOutputStream.onConnectionShutdown();
 
+            capabilitiesListeners.clear();
+
             try {
                 protoInputStream.close();
             } catch (IOException e) {
@@ -559,7 +563,6 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                 '}';
     }
 
-    @SuppressWarnings("unused")
     public String printDetails() {
         String portInfo;
         if (socket.getLocalPort() == 0)
@@ -783,19 +786,26 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                     }
 
                     if (networkEnvelope instanceof SupportedCapabilitiesMessage) {
-                        Capabilities supportedCapabilities = ((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities();
-                        if (supportedCapabilities != null) {
-                            if (!capabilities.equals(supportedCapabilities)) {
-                                capabilities.set(supportedCapabilities);
+                        Capabilities capabilities = ((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities();
+                        if (capabilities != null) {
+                            if (!this.capabilities.equals(capabilities)) {
+                                this.capabilities.set(capabilities);
 
                                 // Capabilities can be empty. We only check for mandatory if we get some capabilities.
-                                if (!capabilities.isEmpty() && !Capabilities.hasMandatoryCapability(capabilities)) {
-                                    String senderNodeAddress = networkEnvelope instanceof SendersNodeAddressMessage ?
-                                            ((SendersNodeAddressMessage) networkEnvelope).getSenderNodeAddress().getFullAddress() :
-                                            "[unknown address]";
-                                    log.info("We close a connection to old node {}. " +
-                                                    "Capabilities of old node: {}, networkEnvelope class name={}",
-                                            senderNodeAddress, capabilities.prettyPrint(), networkEnvelope.getClass().getSimpleName());
+                                if (!this.capabilities.isEmpty() && !Capabilities.hasMandatoryCapability(this.capabilities)) {
+                                    String senderNodeAddress = getPeersNodeAddressOptional().isPresent() ?
+                                            getPeersNodeAddressOptional().get().getFullAddress() :
+                                            networkEnvelope instanceof SendersNodeAddressMessage ?
+                                                    ((SendersNodeAddressMessage) networkEnvelope).getSenderNodeAddress().getFullAddress() :
+                                                    "[unknown address]";
+
+                                    log.info("We close a connection because of " +
+                                                    "CloseConnectionReason.MANDATORY_CAPABILITIES_NOT_SUPPORTED " +
+                                                    "to node {}. Capabilities of old node: {}, " +
+                                                    "networkEnvelope class name={}",
+                                            senderNodeAddress,
+                                            this.capabilities.prettyPrint(),
+                                            networkEnvelope.getClass().getSimpleName());
                                     shutDown(CloseConnectionReason.MANDATORY_CAPABILITIES_NOT_SUPPORTED);
                                     return;
                                 }
@@ -803,7 +813,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                                 capabilitiesListeners.forEach(weakListener -> {
                                     SupportedCapabilitiesListener supportedCapabilitiesListener = weakListener.get();
                                     if (supportedCapabilitiesListener != null) {
-                                        UserThread.execute(() -> supportedCapabilitiesListener.onChanged(supportedCapabilities));
+                                        UserThread.execute(() -> supportedCapabilitiesListener.onChanged(capabilities));
                                     }
                                 });
                             }

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -911,5 +911,4 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         NodeAddress nodeAddress = getSenderNodeAddress(networkEnvelope);
         return nodeAddress == null ? "null" : nodeAddress.getFullAddress();
     }
-
 }

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -21,6 +21,7 @@ import bisq.network.p2p.NodeAddress;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
+import bisq.common.app.Capabilities;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.util.Utilities;
@@ -495,5 +496,13 @@ public abstract class NetworkNode implements MessageListener {
     @Nullable
     public NodeAddress getNodeAddress() {
         return nodeAddressProperty.get();
+    }
+
+    public Optional<Capabilities> findPeersCapabilities(NodeAddress nodeAddress) {
+        return getConfirmedConnections().stream()
+                .filter(c -> c.getPeersNodeAddressProperty().get() != null)
+                .filter(c -> c.getPeersNodeAddressProperty().get().equals(nodeAddress))
+                .map(Connection::getCapabilities)
+                .findAny();
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/SynchronizedProtoOutputStream.java
@@ -50,11 +50,11 @@ class SynchronizedProtoOutputStream extends ProtoOutputStream {
         } catch (InterruptedException e) {
             Thread currentThread = Thread.currentThread();
             currentThread.interrupt();
-            final String msg = "Thread " + currentThread + " was interrupted. InterruptedException=" + e;
+            String msg = "Thread " + currentThread + " was interrupted. InterruptedException=" + e;
             log.error(msg);
             throw new BisqRuntimeException(msg, e);
         } catch (ExecutionException e) {
-            final String msg = "Failed to write envelope. ExecutionException " + e;
+            String msg = "Failed to write envelope. ExecutionException " + e;
             log.error(msg);
             throw new BisqRuntimeException(msg, e);
         }
@@ -65,7 +65,7 @@ class SynchronizedProtoOutputStream extends ProtoOutputStream {
             executorService.shutdownNow();
             super.onConnectionShutdown();
         } catch (Throwable t) {
-            log.error("Failed to handle connection shutdown. Throwable={}", t);
+            log.error("Failed to handle connection shutdown. Throwable={}", t.toString());
         }
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -32,6 +32,7 @@ import bisq.common.ClockWatcher;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.Capabilities;
+import bisq.common.app.Capability;
 import bisq.common.config.Config;
 import bisq.common.persistence.PersistenceManager;
 import bisq.common.proto.persistable.PersistedDataHost;
@@ -205,6 +206,21 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
         maxConnectionsAbsolute = Math.max(12, (int) Math.round(maxConnections * 2.5));            // app node 30; seedNode 66
     }
 
+
+    public boolean peerHasCapability(NodeAddress peersNodeAddress, Capability capability) {
+        return findPeersCapabilities(peersNodeAddress)
+                .map(capabilities -> capabilities.contains(capability))
+                .orElse(false);
+    }
+
+    // TODO persist Capabilities
+    public Optional<Capabilities> findPeersCapabilities(NodeAddress peersNodeAddress) {
+        return networkNode.getConfirmedConnections().stream()
+                .filter(c -> c.getPeersNodeAddressProperty().get() != null)
+                .filter(c -> c.getPeersNodeAddressProperty().get().equals(peersNodeAddress))
+                .map(Connection::getCapabilities)
+                .findAny();
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // ConnectionListener implementation

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -401,7 +401,7 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
         // We look up first our connections as that is our own data. If not found there we look up the peers which
         // include reported peers.
         Optional<Capabilities> optionalCapabilities = networkNode.findPeersCapabilities(nodeAddress);
-        if (optionalCapabilities.isPresent()) {
+        if (optionalCapabilities.isPresent() && !optionalCapabilities.get().isEmpty()) {
             return optionalCapabilities;
         }
 
@@ -415,7 +415,8 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
         // attack all users have a strong incentive to update ;-).
         return getAllPeers().stream()
                 .filter(peer -> peer.getNodeAddress().equals(nodeAddress))
-                .findAny().map(Peer::getCapabilities);
+                .findAny()
+                .map(Peer::getCapabilities);
     }
 
     private void applyCapabilities(Connection connection, Capabilities capabilities) {
@@ -647,7 +648,7 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
 
     private boolean removePersistedPeer(Peer persistedPeer) {
         if (getPersistedPeers().contains(persistedPeer)) {
-            getPersistedPeers().remove(persistedPeer);
+            //getPersistedPeers().remove(persistedPeer);
             requestPersistence();
             return true;
         } else {

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -464,7 +464,12 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
         return reportedPeers;
     }
 
-    public void addToReportedPeers(Set<Peer> reportedPeersToAdd, Connection connection) {
+    public void addToReportedPeers(Set<Peer> reportedPeersToAdd,
+                                   Connection connection,
+                                   Capabilities supportedCapabilities) {
+
+        //TODO apply supportedCapabilities
+
         printNewReportedPeers(reportedPeersToAdd);
 
         // We check if the reported msg is not violating our rules

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -417,15 +417,16 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
                 .map(Peer::getCapabilities);
     }
 
-    private void applyCapabilities(Connection connection, Capabilities capabilities) {
-        if (capabilities == null || capabilities.isEmpty()) {
+    private void applyCapabilities(Connection connection, Capabilities newCapabilities) {
+        if (newCapabilities == null || newCapabilities.isEmpty()) {
             return;
         }
 
         connection.getPeersNodeAddressOptional().ifPresent(nodeAddress -> {
             getAllPeers().stream()
                     .filter(peer -> peer.getNodeAddress().equals(nodeAddress))
-                    .forEach(peer -> peer.setCapabilities(capabilities));
+                    .filter(peer -> peer.getCapabilities().hasLess(newCapabilities))
+                    .forEach(peer -> peer.setCapabilities(newCapabilities));
         });
         requestPersistence();
     }

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -186,7 +186,7 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
     public void readPersisted() {
         PeerList persisted = persistenceManager.getPersisted();
         if (persisted != null) {
-            peerList.setAll(persisted.getList());
+            peerList.setAll(persisted.getSet());
         }
     }
 
@@ -321,13 +321,17 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
     }
 
     public Collection<Peer> getPersistedPeers() {
-        return peerList.getList();
+        return peerList.getSet();
     }
 
     public void addToReportedPeers(Set<Peer> reportedPeersToAdd,
                                    Connection connection,
                                    Capabilities capabilities) {
         applyCapabilities(connection, capabilities);
+
+        reportedPeersToAdd = reportedPeersToAdd.stream()
+                .filter(peer -> !isSelf(peer.getNodeAddress()))
+                .collect(Collectors.toSet());
 
         printNewReportedPeers(reportedPeersToAdd);
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -524,14 +524,16 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
     }
 
     private void applyCapabilities(Connection connection, Capabilities capabilities) {
-        if (capabilities != null && !capabilities.isEmpty()) {
-            connection.getPeersNodeAddressOptional().ifPresent(nodeAddress -> {
-                getAllPeers().stream()
-                        .filter(peer -> peer.getNodeAddress().equals(nodeAddress))
-                        .forEach(peer -> peer.setCapabilities(capabilities));
-            });
-            requestPersistence();
+        if (capabilities == null || capabilities.isEmpty()) {
+            return;
         }
+
+        connection.getPeersNodeAddressOptional().ifPresent(nodeAddress -> {
+            getAllPeers().stream()
+                    .filter(peer -> peer.getNodeAddress().equals(nodeAddress))
+                    .forEach(peer -> peer.setCapabilities(capabilities));
+        });
+        requestPersistence();
     }
 
     private void purgeReportedPeersIfExceeds() {

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -271,8 +271,8 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
     }
 
     public boolean isSeedNode(Connection connection) {
-        //TODO
-        return connection.hasPeersNodeAddress() && seedNodeAddresses.contains(connection.getPeersNodeAddressOptional().get());
+        return connection.getPeersNodeAddressOptional().isPresent() &&
+                seedNodeAddresses.contains(connection.getPeersNodeAddressOptional().get());
     }
 
     public boolean isSelf(NodeAddress nodeAddress) {
@@ -306,6 +306,7 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
     // Peer
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    @SuppressWarnings("unused")
     public Optional<Peer> findPeer(NodeAddress peersNodeAddress) {
         return getAllPeers().stream()
                 .filter(peer -> peer.getNodeAddress().equals(peersNodeAddress))

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -213,7 +213,7 @@ public class PeerManager implements ConnectionListener, PersistedDataHost {
                 .orElse(false);
     }
 
-    // TODO persist Capabilities
+    // TODO get Capabilities from peers
     public Optional<Capabilities> findPeersCapabilities(NodeAddress peersNodeAddress) {
         return networkNode.getConfirmedConnections().stream()
                 .filter(c -> c.getPeersNodeAddressProperty().get() != null)

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -334,18 +334,18 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
                                    Capabilities capabilities) {
         applyCapabilities(connection, capabilities);
 
-        reportedPeersToAdd = reportedPeersToAdd.stream()
+        Set<Peer> peers = reportedPeersToAdd.stream()
                 .filter(peer -> !isSelf(peer.getNodeAddress()))
                 .collect(Collectors.toSet());
 
-        printNewReportedPeers(reportedPeersToAdd);
+        printNewReportedPeers(peers);
 
         // We check if the reported msg is not violating our rules
-        if (reportedPeersToAdd.size() <= (MAX_REPORTED_PEERS + maxConnectionsAbsolute + 10)) {
-            reportedPeers.addAll(reportedPeersToAdd);
+        if (peers.size() <= (MAX_REPORTED_PEERS + maxConnectionsAbsolute + 10)) {
+            reportedPeers.addAll(peers);
             purgeReportedPeersIfExceeds();
 
-            getPersistedPeers().addAll(reportedPeersToAdd);
+            getPersistedPeers().addAll(peers);
             purgePersistedPeersIfExceeds();
             requestPersistence();
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/PeerManager.java
@@ -287,14 +287,13 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
         return seedNodeAddresses.contains(nodeAddress);
     }
 
-    //TODO rename
-    public boolean isNodeBanned(CloseConnectionReason closeConnectionReason, Connection connection) {
+    public boolean isPeerBanned(CloseConnectionReason closeConnectionReason, Connection connection) {
         return closeConnectionReason == CloseConnectionReason.PEER_BANNED &&
                 connection.getPeersNodeAddressOptional().isPresent();
     }
 
     private void maybeRemoveBannedPeer(CloseConnectionReason closeConnectionReason, Connection connection) {
-        if (connection.getPeersNodeAddressOptional().isPresent() && isNodeBanned(closeConnectionReason, connection)) {
+        if (connection.getPeersNodeAddressOptional().isPresent() && isPeerBanned(closeConnectionReason, connection)) {
             NodeAddress nodeAddress = connection.getPeersNodeAddressOptional().get();
             seedNodeAddresses.remove(nodeAddress);
             removePersistedPeer(nodeAddress);

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -210,8 +210,8 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
         closeHandler(connection);
 
-        if (peerManager.isNodeBanned(closeConnectionReason, connection) && connection.getPeersNodeAddressOptional().isPresent()) {
-            final NodeAddress nodeAddress = connection.getPeersNodeAddressOptional().get();
+        if (peerManager.isPeerBanned(closeConnectionReason, connection) && connection.getPeersNodeAddressOptional().isPresent()) {
+            NodeAddress nodeAddress = connection.getPeersNodeAddressOptional().get();
             seedNodeAddresses.remove(nodeAddress);
             handlerMap.remove(nodeAddress);
         }

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/GetPeersRequestHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/GetPeersRequestHandler.java
@@ -32,6 +32,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 
+import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
@@ -83,11 +84,11 @@ class GetPeersRequestHandler {
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public void handle(GetPeersRequest getPeersRequest, final Connection connection) {
+    public void handle(GetPeersRequest getPeersRequest, Connection connection) {
         checkArgument(connection.getPeersNodeAddressOptional().isPresent(),
                 "The peers address must have been already set at the moment");
         GetPeersResponse getPeersResponse = new GetPeersResponse(getPeersRequest.getNonce(),
-                peerManager.getLivePeers(connection.getPeersNodeAddressOptional().get()));
+                new HashSet<>(peerManager.getLivePeers(connection.getPeersNodeAddressOptional().get())));
 
         checkArgument(timeoutTimer == null, "onGetPeersRequest must not be called twice.");
         timeoutTimer = UserThread.runAfter(() -> {  // setup before sending to avoid race conditions

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/GetPeersRequestHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/GetPeersRequestHandler.java
@@ -130,8 +130,9 @@ class GetPeersRequestHandler {
                 }
             }
         }, MoreExecutors.directExecutor());
-
-        peerManager.addToReportedPeers(getPeersRequest.getReportedPeers(), connection);
+        peerManager.addToReportedPeers(getPeersRequest.getReportedPeers(),
+                connection,
+                getPeersRequest.getSupportedCapabilities());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/Peer.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/Peer.java
@@ -42,7 +42,8 @@ public final class Peer implements HasCapabilities, NetworkPayload, PersistableP
     private final long date;
     @Setter
     transient private int failedConnectionAttempts = 0;
-    private final Capabilities capabilities = new Capabilities();
+    @Setter
+    private Capabilities capabilities = new Capabilities();
 
     public Peer(NodeAddress nodeAddress, @Nullable Capabilities supportedCapabilities) {
         this(nodeAddress, new Date().getTime(), supportedCapabilities);
@@ -89,6 +90,10 @@ public final class Peer implements HasCapabilities, NetworkPayload, PersistableP
 
     public Date getDate() {
         return new Date(date);
+    }
+
+    public long getDateAsLong() {
+        return date;
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/Peer.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/Peer.java
@@ -27,7 +27,6 @@ import bisq.common.proto.persistable.PersistablePayload;
 
 import java.util.Date;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -35,18 +34,15 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 @Getter
-@EqualsAndHashCode(exclude = {"date"}) // failedConnectionAttempts is transient and therefore excluded anyway
 @Slf4j
 public final class Peer implements HasCapabilities, NetworkPayload, PersistablePayload, SupportedCapabilitiesListener {
     private static final int MAX_FAILED_CONNECTION_ATTEMPTS = 5;
 
     private final NodeAddress nodeAddress;
     private final long date;
-    // Added in v. 0.7.1
-
     @Setter
     transient private int failedConnectionAttempts = 0;
-    private Capabilities capabilities = new Capabilities();
+    private final Capabilities capabilities = new Capabilities();
 
     public Peer(NodeAddress nodeAddress, @Nullable Capabilities supportedCapabilities) {
         this(nodeAddress, new Date().getTime(), supportedCapabilities);
@@ -102,14 +98,29 @@ public final class Peer implements HasCapabilities, NetworkPayload, PersistableP
         }
     }
 
+    // We use only node address for equals and hashcode
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Peer)) return false;
+
+        Peer peer = (Peer) o;
+
+        return nodeAddress != null ? nodeAddress.equals(peer.nodeAddress) : peer.nodeAddress == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return nodeAddress != null ? nodeAddress.hashCode() : 0;
+    }
 
     @Override
     public String toString() {
         return "Peer{" +
                 "\n     nodeAddress=" + nodeAddress +
-                ",\n     supportedCapabilities=" + capabilities +
-                ",\n     failedConnectionAttempts=" + failedConnectionAttempts +
                 ",\n     date=" + date +
+                ",\n     failedConnectionAttempts=" + failedConnectionAttempts +
+                ",\n     capabilities=" + capabilities +
                 "\n}";
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/Peer.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/Peer.java
@@ -80,8 +80,12 @@ public final class Peer implements HasCapabilities, NetworkPayload, PersistableP
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public void increaseFailedConnectionAttempts() {
+    public void onDisconnect() {
         this.failedConnectionAttempts++;
+    }
+
+    public void onConnection() {
+        this.failedConnectionAttempts--;
     }
 
     public boolean tooManyFailedConnectionAttempts() {

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
@@ -168,7 +168,9 @@ class PeerExchangeHandler implements MessageListener {
 
                 // Check if the response is for our request
                 if (getPeersResponse.getRequestNonce() == nonce) {
-                    peerManager.addToReportedPeers(getPeersResponse.getReportedPeers(), connection);
+                    peerManager.addToReportedPeers(getPeersResponse.getReportedPeers(),
+                            connection,
+                            getPeersResponse.getSupportedCapabilities());
                     cleanup();
                     listener.onComplete();
                 } else {

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeHandler.java
@@ -35,6 +35,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 
+import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -104,7 +105,9 @@ class PeerExchangeHandler implements MessageListener {
         log.debug("sendGetPeersRequest to nodeAddress={}", nodeAddress);
         if (!stopped) {
             if (networkNode.getNodeAddress() != null) {
-                GetPeersRequest getPeersRequest = new GetPeersRequest(networkNode.getNodeAddress(), nonce, peerManager.getLivePeers(nodeAddress));
+                GetPeersRequest getPeersRequest = new GetPeersRequest(networkNode.getNodeAddress(),
+                        nonce,
+                        new HashSet<>(peerManager.getLivePeers(nodeAddress)));
                 if (timeoutTimer == null) {
                     timeoutTimer = UserThread.runAfter(() -> {  // setup before sending to avoid race conditions
                                 if (!stopped) {

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -147,7 +147,7 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
             }, RETRY_DELAY_SEC);
         }
 
-        if (peerManager.isNodeBanned(closeConnectionReason, connection))
+        if (peerManager.isPeerBanned(closeConnectionReason, connection))
             seedNodeAddresses.remove(connection.getPeersNodeAddressOptional().get());
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -147,9 +147,9 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
             }, RETRY_DELAY_SEC);
         }
 
-        if (peerManager.isPeerBanned(closeConnectionReason, connection) &&
-                connection.getPeersNodeAddressOptional().isPresent())
-            seedNodeAddresses.remove(connection.getPeersNodeAddressOptional().get());
+        if (peerManager.isPeerBanned(closeConnectionReason, connection)) {
+            connection.getPeersNodeAddressOptional().ifPresent(seedNodeAddresses::remove);
+        }
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -224,7 +224,8 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void requestReportedPeers(NodeAddress nodeAddress, List<NodeAddress> remainingNodeAddresses) {
-        log.debug("requestReportedPeers nodeAddress={}; remainingNodeAddresses.size={}", nodeAddress, remainingNodeAddresses.size());
+        log.debug("requestReportedPeers nodeAddress={}; remainingNodeAddresses.size={}",
+                nodeAddress, remainingNodeAddresses.size());
         if (!stopped) {
             if (!handlerMap.containsKey(nodeAddress)) {
                 PeerExchangeHandler peerExchangeHandler = new PeerExchangeHandler(networkNode,

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -147,7 +147,8 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
             }, RETRY_DELAY_SEC);
         }
 
-        if (peerManager.isPeerBanned(closeConnectionReason, connection))
+        if (peerManager.isPeerBanned(closeConnectionReason, connection) &&
+                connection.getPeersNodeAddressOptional().isPresent())
             seedNodeAddresses.remove(connection.getPeersNodeAddressOptional().get());
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerList.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/PeerList.java
@@ -21,46 +21,55 @@ import bisq.common.proto.persistable.PersistableEnvelope;
 
 import com.google.protobuf.Message;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @EqualsAndHashCode
 public class PeerList implements PersistableEnvelope {
     @Getter
-    private final List<Peer> list = new ArrayList<>();
+    private final Set<Peer> set = new HashSet<>();
 
     public PeerList() {
     }
 
-    public PeerList(List<Peer> list) {
-        setAll(list);
+    public PeerList(Set<Peer> set) {
+        setAll(set);
     }
 
     public int size() {
-        return list.size();
+        return set.size();
     }
 
     @Override
     public Message toProtoMessage() {
         return protobuf.PersistableEnvelope.newBuilder()
                 .setPeerList(protobuf.PeerList.newBuilder()
-                        .addAllPeer(list.stream().map(Peer::toProtoMessage).collect(Collectors.toList())))
+                        .addAllPeer(set.stream().map(Peer::toProtoMessage).collect(Collectors.toList())))
                 .build();
     }
 
     public static PeerList fromProto(protobuf.PeerList proto) {
-        return new PeerList(new ArrayList<>(proto.getPeerList().stream()
+        return new PeerList(proto.getPeerList().stream()
                 .map(Peer::fromProto)
-                .collect(Collectors.toList())));
+                .collect(Collectors.toSet()));
     }
 
     public void setAll(Collection<Peer> collection) {
-        this.list.clear();
-        this.list.addAll(collection);
+        this.set.clear();
+        this.set.addAll(collection);
+    }
+
+    @Override
+    public String toString() {
+        return "PeerList{" +
+                "\n     set=" + set +
+                "\n}";
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersRequest.java
@@ -47,8 +47,14 @@ public final class GetPeersRequest extends NetworkEnvelope implements PeerExchan
     @Nullable
     private final Capabilities supportedCapabilities;
 
-    public GetPeersRequest(NodeAddress senderNodeAddress, int nonce, Set<Peer> reportedPeers) {
-        this(senderNodeAddress, nonce, reportedPeers, Capabilities.app, Version.getP2PMessageVersion());
+    public GetPeersRequest(NodeAddress senderNodeAddress,
+                           int nonce,
+                           Set<Peer> reportedPeers) {
+        this(senderNodeAddress,
+                nonce,
+                reportedPeers,
+                Capabilities.app,
+                Version.getP2PMessageVersion());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersResponse.java
@@ -43,8 +43,12 @@ public final class GetPeersResponse extends NetworkEnvelope implements PeerExcha
     @Nullable
     private final Capabilities supportedCapabilities;
 
-    public GetPeersResponse(int requestNonce, Set<Peer> reportedPeers) {
-        this(requestNonce, reportedPeers, Capabilities.app, Version.getP2PMessageVersion());
+    public GetPeersResponse(int requestNonce,
+                            Set<Peer> reportedPeers) {
+        this(requestNonce,
+                reportedPeers,
+                Capabilities.app,
+                Version.getP2PMessageVersion());
     }
 
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/HashMapChangedListener.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/HashMapChangedListener.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 public interface HashMapChangedListener {
     void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries);
 
-    @SuppressWarnings("UnusedParameters")
-    void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries);
+    default void onRemoved(Collection<ProtectedStorageEntry> protectedStorageEntries) {
+        // Often we are only interested in added data as there is no use case for remove
+    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -637,12 +637,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         // To avoid that expired data get stored and broadcast we check early for expire date.
         if (protectedStorageEntry.isExpired(clock)) {
             String peer = sender != null ? sender.getFullAddress() : "sender is null";
-            log.warn("We received an expired protectedStorageEntry from peer {}. ProtectedStoragePayload={}",
+            log.debug("We received an expired protectedStorageEntry from peer {}. ProtectedStoragePayload={}",
                     peer, protectedStorageEntry.getProtectedStoragePayload().getClass().getSimpleName());
-            log.debug("Expired protectedStorageEntry from peer {}. getCreationTimeStamp={}, protectedStorageEntry={}",
-                    peer,
-                    new Date(protectedStorageEntry.getCreationTimeStamp()),
-                    protectedStorageEntry);
             return false;
         }
 

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
@@ -117,12 +117,11 @@ public abstract class StoreService<T extends PersistableEnvelope> {
         T persisted = persistenceManager.getPersisted(fileName);
         if (persisted != null) {
             store = persisted;
-
-            int length = store.toProtoMessage().toByteArray().length;
+           /* int length = store.toProtoMessage().getSerializedSize();
             double size = length > 1_000_000D ? length / 1_000_000D : length / 1_000D;
             String unit = length > 1_000_000D ? "MB" : "KB";
             log.info("{}: size of {}: {} {}", this.getClass().getSimpleName(),
-                    persisted.getClass().getSimpleName(), size, unit);
+                    persisted.getClass().getSimpleName(), size, unit);*/
         } else {
             store = createStore();
         }

--- a/p2p/src/test/java/bisq/network/p2p/MockNode.java
+++ b/p2p/src/test/java/bisq/network/p2p/MockNode.java
@@ -60,7 +60,7 @@ public class MockNode {
         networkNode = mock(NetworkNode.class);
         File storageDir = Files.createTempDirectory("storage").toFile();
         PersistenceManager<PeerList> persistenceManager = new PersistenceManager<>(storageDir, mock(PersistenceProtoResolver.class), mock(CorruptedStorageFileHandler.class));
-        peerManager = new PeerManager(networkNode, mock(SeedNodeRepository.class), new ClockWatcher(), maxConnections, persistenceManager);
+        peerManager = new PeerManager(networkNode, mock(SeedNodeRepository.class), new ClockWatcher(), persistenceManager, maxConnections);
         connections = new HashSet<>();
         when(networkNode.getAllConnections()).thenReturn(connections);
     }


### PR DESCRIPTION
Remove address prefix in case the peer has updated vesion as well.
Processes all mailbox messages in a thread. (1000 msgs takes about 1 sec).

EDIT: Merged master and rebased
Capability handling is still WIP 