### PR TITLE
Fix trade protocol check for refund agent ticket close

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -474,8 +474,6 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
 
     protected abstract void handleOnSelectDispute(Dispute dispute);
 
-    protected abstract void onCloseDispute(Dispute dispute);
-
     protected void reOpenDispute() {
         if (selectedDispute != null) {
             selectedDispute.setIsClosed(false);

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -55,7 +55,6 @@ import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
 
-import bisq.common.app.Version;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.util.Utilities;
@@ -475,15 +474,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
 
     protected abstract void handleOnSelectDispute(Dispute dispute);
 
-    protected void onCloseDispute(Dispute dispute) {
-        long protocolVersion = dispute.getContract().getOfferPayload().getProtocolVersion();
-        if (protocolVersion == Version.TRADE_PROTOCOL_VERSION) {
-            disputeSummaryWindow.onFinalizeDispute(() -> chatView.removeInputBox())
-                    .show(dispute);
-        } else {
-            new Popup().warning(Res.get("support.wrongVersion", protocolVersion)).show();
-        }
-    }
+    protected abstract void onCloseDispute(Dispute dispute);
 
     protected void reOpenDispute() {
         if (selectedDispute != null) {

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/DisputeAgentView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/DisputeAgentView.java
@@ -215,6 +215,8 @@ public abstract class DisputeAgentView extends DisputeView implements MultipleHo
         tableView.getColumns().add(getAlertColumn());
     }
 
+    protected abstract void onCloseDispute(Dispute dispute);
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.support.dispute.agent.arbitration;
 
 import bisq.desktop.common.view.FxmlView;
+import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.ContractWindow;
 import bisq.desktop.main.overlays.windows.DisputeSummaryWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
@@ -26,6 +27,7 @@ import bisq.desktop.main.support.dispute.agent.DisputeAgentView;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.dao.DaoFacade;
+import bisq.core.locale.Res;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.DisputeSession;
@@ -83,5 +85,18 @@ public class ArbitratorView extends DisputeAgentView {
     @Override
     protected DisputeSession getConcreteDisputeChatSession(Dispute dispute) {
         return new ArbitrationSession(dispute, disputeManager.isTrader(dispute));
+    }
+
+    @Override
+    protected void onCloseDispute(Dispute dispute) {
+        long protocolVersion = dispute.getContract().getOfferPayload().getProtocolVersion();
+        // Only cases with protocolVersion 1 are candidates for legacy arbitration.
+        // This code path is not tested and it is not assumed that it is still be used as old arbitrators would use
+        // their old Bisq version if sill cases are pending.
+        if (protocolVersion == 1) {
+            disputeSummaryWindow.onFinalizeDispute(() -> chatView.removeInputBox()).show(dispute);
+        } else {
+            new Popup().warning(Res.get("support.wrongVersion", protocolVersion)).show();
+        }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
@@ -92,7 +92,7 @@ public class ArbitratorView extends DisputeAgentView {
         long protocolVersion = dispute.getContract().getOfferPayload().getProtocolVersion();
         // Only cases with protocolVersion 1 are candidates for legacy arbitration.
         // This code path is not tested and it is not assumed that it is still be used as old arbitrators would use
-        // their old Bisq version if sill cases are pending.
+        // their old Bisq version if still cases are pending.
         if (protocolVersion == 1) {
             disputeSummaryWindow.onFinalizeDispute(() -> chatView.removeInputBox()).show(dispute);
         } else {

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/mediation/MediatorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/mediation/MediatorView.java
@@ -112,7 +112,6 @@ public class MediatorView extends DisputeAgentView {
 
     @Override
     protected void onCloseDispute(Dispute dispute) {
-        disputeSummaryWindow.onFinalizeDispute(() -> chatView.removeInputBox())
-                .show(dispute);
+        disputeSummaryWindow.onFinalizeDispute(() -> chatView.removeInputBox()).show(dispute);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/refund/RefundAgentView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/refund/RefundAgentView.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.support.dispute.agent.refund;
 
 import bisq.desktop.common.view.FxmlView;
+import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.ContractWindow;
 import bisq.desktop.main.overlays.windows.DisputeSummaryWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
@@ -26,6 +27,7 @@ import bisq.desktop.main.support.dispute.agent.DisputeAgentView;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.dao.DaoFacade;
+import bisq.core.locale.Res;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.DisputeSession;
@@ -83,5 +85,16 @@ public class RefundAgentView extends DisputeAgentView {
     @Override
     protected DisputeSession getConcreteDisputeChatSession(Dispute dispute) {
         return new RefundSession(dispute, disputeManager.isTrader(dispute));
+    }
+
+    @Override
+    protected void onCloseDispute(Dispute dispute) {
+        long protocolVersion = dispute.getContract().getOfferPayload().getProtocolVersion();
+        // Refund agent was introduced with protocolVersion version 2. We do not support old trade protocol cases.
+        if (protocolVersion >= 2) {
+            disputeSummaryWindow.onFinalizeDispute(() -> chatView.removeInputBox()).show(dispute);
+        } else {
+            new Popup().warning(Res.get("support.wrongVersion", protocolVersion)).show();
+        }
     }
 }


### PR DESCRIPTION
When a refund agent closes a case we have checked that the trade protocol is the same between offer and refund agent.

This would fail once we update trade protocol version when we release segwit. So this fixes that as it only checks if the version is not the old version (1) where refund agents have not been part of the system.
Also checks for legacy arbitrator that it only can be used for version 1 cases. Not tested and not assumed that this code will be executed as old arbitrators would use the old app in case they need to still work on a old case.
