### PR TITLE
Set memo to tx after tx creation and not on broadcast success

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -614,10 +614,10 @@ public class BtcWalletService extends WalletService {
                 .filter(e -> context == e.getContext())
                 .filter(e -> isAddressUnused(e.getAddress()))
                 .filter(e -> {
-                        boolean isSegwitOutputScriptType = Script.ScriptType.P2WPKH.equals(e.getAddress().getOutputScriptType());
-                        // We need to ensure that we take only addressEntries which matches our segWit flag
-                        boolean isMatchingOutputScriptType = isSegwitOutputScriptType == segwit;
-                        return isMatchingOutputScriptType;
+                    boolean isSegwitOutputScriptType = Script.ScriptType.P2WPKH.equals(e.getAddress().getOutputScriptType());
+                    // We need to ensure that we take only addressEntries which matches our segWit flag
+                    boolean isMatchingOutputScriptType = isSegwitOutputScriptType == segwit;
+                    return isMatchingOutputScriptType;
                 })
                 .findAny();
         return getOrCreateAddressEntry(context, addressEntry, segwit);
@@ -628,7 +628,9 @@ public class BtcWalletService extends WalletService {
                 addressEntryList.swapAvailableToAddressEntryWithOfferId(addressEntry, context, offerId));
     }
 
-    private AddressEntry getOrCreateAddressEntry(AddressEntry.Context context, Optional<AddressEntry> addressEntry, boolean segwit) {
+    private AddressEntry getOrCreateAddressEntry(AddressEntry.Context context,
+                                                 Optional<AddressEntry> addressEntry,
+                                                 boolean segwit) {
         if (addressEntry.isPresent()) {
             return addressEntry.get();
         } else {
@@ -1056,13 +1058,13 @@ public class BtcWalletService extends WalletService {
         return sendResult.tx.getTxId().toString();
     }
 
-    public String sendFundsForMultipleAddresses(Set<String> fromAddresses,
-                                                String toAddress,
-                                                Coin receiverAmount,
-                                                Coin fee,
-                                                @Nullable String changeAddress,
-                                                @Nullable KeyParameter aesKey,
-                                                FutureCallback<Transaction> callback) throws AddressFormatException,
+    public Transaction sendFundsForMultipleAddresses(Set<String> fromAddresses,
+                                                     String toAddress,
+                                                     Coin receiverAmount,
+                                                     Coin fee,
+                                                     @Nullable String changeAddress,
+                                                     @Nullable KeyParameter aesKey,
+                                                     FutureCallback<Transaction> callback) throws AddressFormatException,
             AddressEntryException, InsufficientMoneyException {
 
         SendRequest request = getSendRequestForMultipleAddresses(fromAddresses, toAddress, receiverAmount, fee, changeAddress, aesKey);
@@ -1070,7 +1072,7 @@ public class BtcWalletService extends WalletService {
         Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor());
 
         printTx("sendFunds", sendResult.tx);
-        return sendResult.tx.getTxId().toString();
+        return sendResult.tx;
     }
 
     private SendRequest getSendRequest(String fromAddress,

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -366,17 +366,17 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                         double kb = txSize / 1000d;
 
                         String messageText = Res.get("shared.sendFundsDetailsWithFee",
-                            formatter.formatCoinWithCode(sendersAmount),
-                            withdrawFromTextField.getText(),
-                            withdrawToTextField.getText(),
-                            formatter.formatCoinWithCode(fee),
-                            feePerByte,
-                            kb,
-                            formatter.formatCoinWithCode(receiverAmount));
+                                formatter.formatCoinWithCode(sendersAmount),
+                                withdrawFromTextField.getText(),
+                                withdrawToTextField.getText(),
+                                formatter.formatCoinWithCode(fee),
+                                feePerByte,
+                                kb,
+                                formatter.formatCoinWithCode(receiverAmount));
                         if (dust.isPositive()) {
                             messageText = Res.get("shared.sendFundsDetailsDust",
-                                dust.value, dust.value > 1 ? "s" : "")
-                                + messageText;
+                                    dust.value, dust.value > 1 ? "s" : "")
+                                    + messageText;
                         }
 
                         new Popup().headLine(Res.get("funds.withdrawal.confirmWithdrawalRequest"))
@@ -386,7 +386,6 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                                     @Override
                                     public void onSuccess(@javax.annotation.Nullable Transaction transaction) {
                                         if (transaction != null) {
-                                            transaction.setMemo(withdrawMemoTextField.getText());
                                             log.debug("onWithdraw onSuccess tx ID:{}", transaction.getTxId().toString());
                                         } else {
                                             log.error("onWithdraw transaction is null");
@@ -498,7 +497,14 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
 
     private void sendFunds(Coin amount, Coin fee, KeyParameter aesKey, FutureCallback<Transaction> callback) {
         try {
-            btcWalletService.sendFundsForMultipleAddresses(fromAddresses, withdrawToTextField.getText(), amount, fee, null, aesKey, callback);
+            Transaction transaction = btcWalletService.sendFundsForMultipleAddresses(fromAddresses,
+                    withdrawToTextField.getText(),
+                    amount,
+                    fee,
+                    null,
+                    aesKey,
+                    callback);
+            transaction.setMemo(withdrawMemoTextField.getText());
             reset();
             updateList();
         } catch (AddressFormatException e) {
@@ -672,7 +678,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
     // returns the 'dust amount' to indicate if any dust was detected.
     private Coin getDust(Transaction transaction) {
         Coin dust = Coin.ZERO;
-        for (TransactionOutput transactionOutput: transaction.getOutputs()) {
+        for (TransactionOutput transactionOutput : transaction.getOutputs()) {
             if (transactionOutput.getValue().isLessThan(Restrictions.getMinNonDustOutput())) {
                 dust = dust.add(transactionOutput.getValue());
                 log.info("dust TXO = {}", transactionOutput.toString());


### PR DESCRIPTION
Fixes #4616

Set memo to tx after tx creation and not on broadcast success, as broadcast success might not get called (even it is broadcast -> pending btcj bug)

