### PR TITLE
Apply limit after filtering for shouldTransmitPayloadToPeer

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -328,10 +328,10 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         Set<T> filteredResults = mapToFilter.entrySet().stream()
                 .filter(e -> !knownHashes.contains(e.getKey()))
-                .filter(e -> limit.decrementAndGet() >= 0)
                 .map(Map.Entry::getValue)
                 .filter(networkPayload -> shouldTransmitPayloadToPeer(peerCapabilities,
                         objToPayloadFunction.apply(networkPayload)))
+                .filter(e -> limit.decrementAndGet() >= 0)
                 .collect(Collectors.toSet());
 
         if (limit.get() < 0) {


### PR DESCRIPTION
We want to limit the output not in between the various filter operations.
shouldTransmitPayloadToPeer is a rather cheap operation so no need to protect that by applying the limit before that.

If maintainers prefer to not merge it into release let me know, then I will do the PR to master. 