### PR TITLE
Change data response behaviour

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
+++ b/core/src/main/java/bisq/core/dao/governance/asset/AssetService.java
@@ -157,7 +157,7 @@ public class AssetService implements DaoSetupService, DaoStateListener {
                 .filter(e -> CurrencyUtil.isCryptoCurrency(e.getCurrency()))
                 .forEach(e -> {
                     lookupMap.putIfAbsent(e.getCurrency(), new ArrayList<>());
-                    lookupMap.get(e.getCurrency()).add(new TradeAmountDateTuple(e.getAmount(), e.getDate()));
+                    lookupMap.get(e.getCurrency()).add(new TradeAmountDateTuple(e.getAmount(), e.getDateAsLong()));
                 });
 
         getStatefulAssets().stream()

--- a/core/src/main/java/bisq/core/offer/availability/DisputeAgentSelection.java
+++ b/core/src/main/java/bisq/core/offer/availability/DisputeAgentSelection.java
@@ -63,7 +63,7 @@ public class DisputeAgentSelection {
                                                                        boolean isMediator) {
         // We take last 100 entries from trade statistics
         List<TradeStatistics3> list = new ArrayList<>(tradeStatisticsManager.getObservableTradeStatisticsSet());
-        list.sort(Comparator.comparing(TradeStatistics3::getDate));
+        list.sort(Comparator.comparing(TradeStatistics3::getDateAsLong));
         Collections.reverse(list);
         if (!list.isEmpty()) {
             int max = Math.min(list.size(), LOOK_BACK_RANGE);

--- a/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
@@ -307,7 +307,7 @@ public class PriceFeedService {
         mapByCurrencyCode.values().stream()
                 .filter(list -> !list.isEmpty())
                 .forEach(list -> {
-                    list.sort(Comparator.comparing(TradeStatistics3::getTradeDate));
+                    list.sort(Comparator.comparing(TradeStatistics3::getDate));
                     TradeStatistics3 tradeStatistics = list.get(list.size() - 1);
                     setBisqMarketPrice(tradeStatistics.getCurrency(), tradeStatistics.getTradePrice());
                 });

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -24,6 +24,7 @@ import bisq.core.monetary.Volume;
 import bisq.core.offer.OfferUtil;
 
 import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
+import bisq.network.p2p.storage.payload.DateSortedTruncatablePayload;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
 
@@ -64,7 +65,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 @Getter
 public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayload, PersistableNetworkPayload,
-        CapabilityRequiringPayload {
+        CapabilityRequiringPayload, DateSortedTruncatablePayload {
 
     // This enum must not change the order as we use the ordinal for storage to reduce data size.
     // The payment method string can be quite long and would consume 15% more space.
@@ -265,6 +266,16 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     @Override
     public Capabilities getRequiredCapabilities() {
         return new Capabilities(Capability.TRADE_STATISTICS_3);
+    }
+
+    @Override
+    public Date getDate() {
+        return getTradeDate();
+    }
+
+    @Override
+    public int maxItems() {
+        return 3000;
     }
 
     public void pruneOptionalData() {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -63,7 +63,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Data size is about 50 bytes in average
  */
 @Slf4j
-@Getter
 public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayload, PersistableNetworkPayload,
         CapabilityRequiringPayload, DateSortedTruncatablePayload {
 
@@ -106,8 +105,11 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         BLOCK_CHAINS_INSTANT
     }
 
+    @Getter
     private final String currency;
+    @Getter
     private final long price;
+    @Getter
     private final long amount;
     private final String paymentMethod;
     // As only seller is publishing it is the sellers trade date
@@ -116,9 +118,11 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     // Old converted trade stat objects might not have it set
     @Nullable
     @JsonExclude
+    @Getter
     private String mediator;
     @Nullable
     @JsonExclude
+    @Getter
     private String refundAgent;
 
     // todo should we add referrerId as well? get added to extra map atm but not used so far
@@ -131,6 +135,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     // field in a class would break that hash and therefore break the storage mechanism.
     @Nullable
     @JsonExclude
+    @Getter
     private final Map<String, String> extraDataMap;
 
     public TradeStatistics3(String currency,
@@ -270,7 +275,11 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
 
     @Override
     public Date getDate() {
-        return getTradeDate();
+        return new Date(date);
+    }
+
+    public long getDateAsLong() {
+        return date;
     }
 
     @Override
@@ -289,10 +298,6 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         } catch (Throwable ignore) {
             return paymentMethod;
         }
-    }
-
-    public Date getTradeDate() {
-        return new Date(date);
     }
 
     public Price getTradePrice() {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsConverter.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsConverter.java
@@ -143,7 +143,7 @@ public class TradeStatisticsConverter {
 
         // We prune mediator and refundAgent data from all objects but the last 100 as we only use the
         // last 100 entries (DisputeAgentSelection.LOOK_BACK_RANGE).
-        list.sort(Comparator.comparing(TradeStatistics3::getDate));
+        list.sort(Comparator.comparing(TradeStatistics3::getDateAsLong));
         if (size > DisputeAgentSelection.LOOK_BACK_RANGE) {
             int start = size - DisputeAgentSelection.LOOK_BACK_RANGE;
             for (int i = start; i < size; i++) {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsForJson.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsForJson.java
@@ -55,7 +55,7 @@ public final class TradeStatisticsForJson {
         this.paymentMethod = tradeStatistics.getPaymentMethod();
         this.tradePrice = tradeStatistics.getPrice();
         this.tradeAmount = tradeStatistics.getAmount();
-        this.tradeDate = tradeStatistics.getDate();
+        this.tradeDate = tradeStatistics.getDateAsLong();
 
         try {
             Price tradePrice = getTradePrice();

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -188,7 +188,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                 .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap().get(OfferPayload.REFERRAL_ID) != null)
                 .map(tradeStatistics3 -> {
                     StringBuilder sb = new StringBuilder();
-                    sb.append("Date: ").append(DisplayUtils.formatDateTime(tradeStatistics3.getTradeDate())).append("\n")
+                    sb.append("Date: ").append(DisplayUtils.formatDateTime(tradeStatistics3.getDate())).append("\n")
                             .append("Market: ").append(CurrencyUtil.getCurrencyPair(tradeStatistics3.getCurrency())).append("\n")
                             .append("Price: ").append(FormattingUtils.formatPrice(tradeStatistics3.getTradePrice())).append("\n")
                             .append("Amount: ").append(formatter.formatCoin(tradeStatistics3.getTradeAmount())).append("\n")

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -567,14 +567,14 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                             public void updateItem(final TradeStatistics3 item, boolean empty) {
                                 super.updateItem(item, empty);
                                 if (item != null)
-                                    setText(DisplayUtils.formatDateTime(item.getTradeDate()));
+                                    setText(DisplayUtils.formatDateTime(item.getDate()));
                                 else
                                     setText("");
                             }
                         };
                     }
                 });
-        dateColumn.setComparator(Comparator.comparing(TradeStatistics3::getTradeDate));
+        dateColumn.setComparator(Comparator.comparing(TradeStatistics3::getDate));
         tableView.getColumns().add(dateColumn);
 
         // market
@@ -603,7 +603,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                         };
                     }
                 });
-        marketColumn.setComparator(Comparator.comparing(TradeStatistics3::getTradeDate));
+        marketColumn.setComparator(Comparator.comparing(TradeStatistics3::getDate));
         tableView.getColumns().add(marketColumn);
 
         // price

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -260,7 +260,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
         tradeStatisticsByCurrency.forEach(e -> {
             for (long i = maxTicks; i > 0; --i) {
                 Pair<Date, Set<TradeStatistics3>> p = itemsPerInterval.get(i);
-                if (e.getTradeDate().after(p.getKey())) {
+                if (e.getDate().after(p.getKey())) {
                     p.getValue().add(e);
                     break;
                 }
@@ -307,7 +307,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
         Collections.sort(tradePrices);
 
         List<TradeStatistics3> list = new ArrayList<>(set);
-        list.sort(Comparator.comparingLong(TradeStatistics3::getDate));
+        list.sort(Comparator.comparingLong(TradeStatistics3::getDateAsLong));
         if (list.size() > 0) {
             open = list.get(0).getTradePrice().getValue();
             close = list.get(list.size() - 1).getTradePrice().getValue();

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -345,8 +345,8 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
             var startDate = new Date(System.currentTimeMillis() - blocksRange * 10 * 60000);
             var sortedRangeData = tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
                     .filter(e -> e.getCurrency().equals(getTradeCurrency().getCode()))
-                    .filter(e -> e.getTradeDate().compareTo(startDate) >= 0)
-                    .sorted(Comparator.comparing(TradeStatistics3::getTradeDate))
+                    .filter(e -> e.getDate().compareTo(startDate) >= 0)
+                    .sorted(Comparator.comparing(TradeStatistics3::getDate))
                     .collect(Collectors.toList());
             var movingAverage = new MathUtils.MovingAverage(10, 0.2);
             double[] extremes = {Double.MAX_VALUE, Double.MIN_VALUE};

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -37,6 +37,7 @@ import bisq.network.p2p.storage.messages.RefreshOfferMessage;
 import bisq.network.p2p.storage.messages.RemoveDataMessage;
 import bisq.network.p2p.storage.messages.RemoveMailboxDataMessage;
 import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
+import bisq.network.p2p.storage.payload.DateSortedTruncatablePayload;
 import bisq.network.p2p.storage.payload.DateTolerantPayload;
 import bisq.network.p2p.storage.payload.MailboxStoragePayload;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
@@ -96,7 +97,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -317,29 +317,57 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
      * by a given set of keys and peer capabilities.
      */
     static private <T extends NetworkPayload> Set<T> filterKnownHashes(
-            Map<ByteArray, T> mapToFilter,
-            Function<T, ? extends NetworkPayload> objToPayloadFunction,
+            Map<ByteArray, T> toFilter,
+            Function<T, ? extends NetworkPayload> objToPayload,
             Set<ByteArray> knownHashes,
             Capabilities peerCapabilities,
             int maxEntries,
-            AtomicBoolean wasTruncated) {
+            AtomicBoolean outTruncated) {
 
-        AtomicInteger limit = new AtomicInteger(maxEntries);
+        log.info("Num knownHashes {}", knownHashes.size());
 
-        Set<T> filteredResults = mapToFilter.entrySet().stream()
-                .filter(e -> !knownHashes.contains(e.getKey()))
-                .filter(e -> limit.decrementAndGet() >= 0)
+        Set<Map.Entry<ByteArray, T>> entries = toFilter.entrySet();
+        List<T> dateSortedTruncatablePayloads = entries.stream()
+                .filter(entry -> entry.getValue() instanceof DateSortedTruncatablePayload)
+                .filter(entry -> !knownHashes.contains(entry.getKey()))
                 .map(Map.Entry::getValue)
-                .filter(networkPayload -> shouldTransmitPayloadToPeer(peerCapabilities,
-                        objToPayloadFunction.apply(networkPayload)))
-                .collect(Collectors.toSet());
-
-        if (limit.get() < 0) {
-            wasTruncated.set(true);
+                .filter(payload -> shouldTransmitPayloadToPeer(peerCapabilities, objToPayload.apply(payload)))
+                .sorted(Comparator.comparing(payload -> ((DateSortedTruncatablePayload) payload).getDate()))
+                .collect(Collectors.toList());
+        log.info("Num filtered dateSortedTruncatablePayloads {}", dateSortedTruncatablePayloads.size());
+        if (!dateSortedTruncatablePayloads.isEmpty()) {
+            int maxItems = ((DateSortedTruncatablePayload) dateSortedTruncatablePayloads.get(0)).maxItems();
+            if (dateSortedTruncatablePayloads.size() > maxItems) {
+                int fromIndex = dateSortedTruncatablePayloads.size() - maxItems;
+                int toIndex = dateSortedTruncatablePayloads.size();
+                dateSortedTruncatablePayloads = dateSortedTruncatablePayloads.subList(fromIndex, toIndex);
+                log.info("Num truncated dateSortedTruncatablePayloads {}", dateSortedTruncatablePayloads.size());
+            }
         }
 
-        return filteredResults;
+        List<T> filteredResults = entries.stream()
+                .filter(entry -> !(entry.getValue() instanceof DateSortedTruncatablePayload))
+                .filter(entry -> !knownHashes.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .filter(payload -> shouldTransmitPayloadToPeer(peerCapabilities, objToPayload.apply(payload)))
+                .collect(Collectors.toList());
+        log.info("Num filtered non-dateSortedTruncatablePayloads {}", filteredResults.size());
+
+        // The non-dateSortedTruncatablePayloads have higher prio, so we added dateSortedTruncatablePayloads
+        // after those so in case we need to truncate we first truncate the dateSortedTruncatablePayloads.
+        filteredResults.addAll(dateSortedTruncatablePayloads);
+
+        if (filteredResults.size() > maxEntries) {
+            filteredResults = filteredResults.subList(0, maxEntries);
+            outTruncated.set(true);
+            log.info("Num truncated filteredResults {}", filteredResults.size());
+        } else {
+            log.info("Num filteredResults {}", filteredResults.size());
+        }
+
+        return new HashSet<>(filteredResults);
     }
+
 
     private Set<byte[]> getKeysAsByteSet(Map<ByteArray, ? extends PersistablePayload> map) {
         return map.keySet().stream()

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/DateSortedTruncatablePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/DateSortedTruncatablePayload.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.payload;
+
+import java.util.Date;
+
+/**
+ * Marker interface for PersistableNetworkPayloads which get truncated at initial data response in case we exceed
+ * the max items defined for that type of object. The truncation happens on a sorted list where we use the date for
+ * sorting so in case of truncation we prefer to receive the most recent data.
+ */
+public interface DateSortedTruncatablePayload extends PersistableNetworkPayload {
+    Date getDate();
+
+    int maxItems();
+}


### PR DESCRIPTION
Add DateSortedTruncatablePayload interface for TradeStatistics2

We check first if we need to truncate dateSortedTruncatablePayloads, if so we have sorted by date and truncate in the way that we receive the most recent data. We define the maxItems in the class implementing the interface (3000 for trade stats).
Later we apply the maxEntries check the combined list and if we need to truncate here as well (10 000) we have added the dateSortedTruncatablePayloads at the end so those will get truncated with higher prio.

This code change is only relevant for seed nodes (data response). It needs to get into 1.4.0.
Old nodes send hashes for trade stats which are different to the new ones, so the seed would send all 10k trade stat objects and other important data like account age witness might get dropped as we hit the 10 000 item limit. 