### PR TITLE
Only remove offer locally when necessary

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
@@ -267,14 +267,16 @@ class TakeOfferDataModel extends OfferDataModel {
             priceFeedService.setCurrencyCode(offer.getCurrencyCode());
     }
 
-    public void onClose() {
+    public void onClose(boolean removeOffer) {
         // We do not wait until the offer got removed by a network remove message but remove it
         // directly from the offer book. The broadcast gets now bundled and has 2 sec. delay so the
         // removal from the network is a bit slower as it has been before. To avoid that the taker gets
         // confused to see the same offer still in the offerbook we remove it manually. This removal has
         // only local effect. Other trader might see the offer for a few seconds
         // still (but cannot take it).
-        offerBook.removeOffer(checkNotNull(offer), tradeManager);
+        if (removeOffer) {
+            offerBook.removeOffer(checkNotNull(offer), tradeManager);
+        }
 
         btcWalletService.resetAddressEntriesForOpenOffer(offer.getId());
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -388,7 +388,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         if (offer.getPrice() == null)
             new Popup().warning(Res.get("takeOffer.noPriceFeedAvailable"))
-                    .onClose(this::close)
+                    .onClose(() -> close(false))
                     .show();
     }
 
@@ -595,7 +595,11 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void close() {
-        model.dataModel.onClose();
+        close(true);
+    }
+
+    private void close(boolean removeOffer) {
+        model.dataModel.onClose(removeOffer);
         if (closeHandler != null)
             closeHandler.close();
     }
@@ -893,7 +897,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         cancelButton1.setDefaultButton(false);
         cancelButton1.setOnAction(e -> {
             model.dataModel.swapTradeToSavings();
-            close();
+            close(false);
         });
     }
 
@@ -1040,7 +1044,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
                         })
                         .show();
             } else {
-                close();
+                close(false);
                 model.dataModel.swapTradeToSavings();
             }
         });


### PR DESCRIPTION
Based on @stejbac findings an offer shouldn't be removed locally when the trade is cancelled before any fees were paid.
Currently this causes following warning messages when cancelling the taking of an offer.
![Screenshot from 2020-10-14 18-49-59](https://user-images.githubusercontent.com/170962/96093605-a5a36c00-0ecc-11eb-9d2e-0812be562694.png)
