### PR TITLE
Handle Capabilities for encrypted messages (offer availibility request/response)

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -419,6 +419,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             connection.setPeerType(Connection.PeerType.DIRECT_MSG_PEER);
             try {
                 DecryptedMessageWithPubKey decryptedMsg = encryptionService.decryptAndVerify(sealedMsg.getSealedAndSigned());
+                connection.maybeHandleSupportedCapabilitiesMessage(decryptedMsg.getNetworkEnvelope());
                 connection.getPeersNodeAddressOptional().ifPresentOrElse(nodeAddress ->
                                 decryptedDirectMessageListeners.forEach(e -> e.onDirectMessage(decryptedMsg, nodeAddress)),
                         () -> {

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -785,11 +785,9 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         return;
                     }
 
-                    if (networkEnvelope instanceof SupportedCapabilitiesMessage) {
-                        boolean causedShutDown = handleSupportedCapabilitiesMessage(networkEnvelope);
-                        if (causedShutDown) {
-                            return;
-                        }
+                    boolean causedShutDown = maybeHandleSupportedCapabilitiesMessage(networkEnvelope);
+                    if (causedShutDown) {
+                        return;
                     }
 
                     if (networkEnvelope instanceof CloseConnectionMessage) {
@@ -865,7 +863,11 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         }
     }
 
-    protected boolean handleSupportedCapabilitiesMessage(NetworkEnvelope networkEnvelope) {
+    public boolean maybeHandleSupportedCapabilitiesMessage(NetworkEnvelope networkEnvelope) {
+        if (!(networkEnvelope instanceof SupportedCapabilitiesMessage)) {
+            return false;
+        }
+
         Capabilities supportedCapabilities = ((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities();
         if (supportedCapabilities == null || supportedCapabilities.isEmpty()) {
             return false;


### PR DESCRIPTION
We did check in Connection for SupportedCapabilitiesMessage and if a message is of that type we set the capability.
But encrypted messages are wrapped in a PrefixedSealedAndSignedMessage so the payload is not visible as SupportedCapabilitiesMessage without decrypting it.
We need to call maybeHandleSupportedCapabilitiesMessage at decrypting the message. We do that only for direct messages not for mailbox messages as we likely do not have a connection open to the peer in that case (otherwise it would not be a mailbox msg) and as we don't have the connection available (we get is as AddDataMessage broadcast from an peer, so could could not apply it to the Connection of the sender.