### PR TITLE
Fix republish trade stats

### DIFF
--- a/common/src/main/java/bisq/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/bisq/common/persistence/PersistenceManager.java
@@ -305,7 +305,7 @@ public class PersistenceManager<T extends PersistableEnvelope> {
 
             tempFile = usedTempFilePath != null
                     ? FileUtil.createNewFile(usedTempFilePath)
-                    : File.createTempFile("temp", null, dir);
+                    : File.createTempFile("temp_" + fileName, null, dir);
             // Don't use a new temp file path each time, as that causes the delete-on-exit hook to leak memory:
             tempFile.deleteOnExit();
 

--- a/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
@@ -39,10 +39,6 @@ import bisq.network.p2p.NodeAddress;
 
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
-import bisq.common.util.Utilities;
-
-import java.util.Date;
-import java.util.GregorianCalendar;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,27 +51,6 @@ public abstract class SellerProtocol extends DisputeProtocol {
 
     public SellerProtocol(SellerTrade trade) {
         super(trade);
-    }
-
-    @Override
-    protected void onInitialized() {
-        super.onInitialized();
-
-        // We get called the constructor with any possible state and phase. As we don't want to log an error for such
-        // cases we use the alternative 'given' method instead of 'expect'.
-
-        // We only re-publish for about 2 weeks after 1.4.0 release until most nodes have updated to
-        // achieve sufficient resilience.
-        boolean currentDateBeforeCutOffDate = new Date().before(Utilities.getUTCDate(2020, GregorianCalendar.NOVEMBER, 1));
-        given(anyPhase(Trade.Phase.DEPOSIT_PUBLISHED,
-                Trade.Phase.DEPOSIT_CONFIRMED,
-                Trade.Phase.FIAT_SENT,
-                Trade.Phase.FIAT_RECEIVED,
-                Trade.Phase.PAYOUT_PUBLISHED)
-                .with(SellerEvent.STARTUP)
-                .preCondition(currentDateBeforeCutOffDate))
-                .setup(tasks(SellerPublishesTradeStatistics.class))
-                .executeTasks();
     }
 
 
@@ -91,6 +66,7 @@ public abstract class SellerProtocol extends DisputeProtocol {
             handle((CounterCurrencyTransferStartedMessage) message, peerNodeAddress);
         }
     }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Incoming messages

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -21,9 +21,12 @@ import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.AltcoinExchangeRate;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
+import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.offer.OfferUtil;
+import bisq.core.trade.Trade;
 
+import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
@@ -46,6 +49,7 @@ import org.bitcoinj.utils.Fiat;
 import com.google.common.base.Charsets;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -66,6 +70,36 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Value
 public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayload, PersistableNetworkPayload,
         CapabilityRequiringPayload, Comparable<TradeStatistics2> {
+
+    public static TradeStatistics2 from(Trade trade,
+                                        @Nullable String referralId,
+                                        boolean isTorNetworkNode) {
+        Map<String, String> extraDataMap = new HashMap<>();
+        if (referralId != null) {
+            extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
+        }
+
+        NodeAddress mediatorNodeAddress = trade.getMediatorNodeAddress();
+        if (mediatorNodeAddress != null) {
+            // The first 4 chars are sufficient to identify a mediator.
+            // For testing with regtest/localhost we use the full address as its localhost and would result in
+            // same values for multiple mediators.
+            String address = isTorNetworkNode ?
+                    mediatorNodeAddress.getFullAddress().substring(0, 4) :
+                    mediatorNodeAddress.getFullAddress();
+            extraDataMap.put(TradeStatistics2.MEDIATOR_ADDRESS, address);
+        }
+
+        Offer offer = trade.getOffer();
+        checkNotNull(offer, "offer must not ne null");
+        checkNotNull(trade.getTradeAmount(), "trade.getTradeAmount() must not ne null");
+        return new TradeStatistics2(offer.getOfferPayload(),
+                trade.getTradePrice(),
+                trade.getTradeAmount(),
+                trade.getDate(),
+                trade.getDepositTxId(),
+                extraDataMap);
+    }
 
     @SuppressWarnings("SpellCheckingInspection")
     public static final String MEDIATOR_ADDRESS = "medAddr";

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -544,7 +544,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     private void createTable() {
         tableView = new TableView<>();
-        tableView.setMinHeight(120);
+        tableView.setMinHeight(80);
         tableView.setPrefHeight(130);
         VBox.setVgrow(tableView, Priority.ALWAYS);
 

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -419,6 +419,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             connection.setPeerType(Connection.PeerType.DIRECT_MSG_PEER);
             try {
                 DecryptedMessageWithPubKey decryptedMsg = encryptionService.decryptAndVerify(sealedMsg.getSealedAndSigned());
+                connection.maybeHandleSupportedCapabilitiesMessage(decryptedMsg.getNetworkEnvelope());
                 connection.getPeersNodeAddressOptional().ifPresentOrElse(nodeAddress ->
                                 decryptedDirectMessageListeners.forEach(e -> e.onDirectMessage(decryptedMsg, nodeAddress)),
                         () -> {

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -785,11 +785,9 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         return;
                     }
 
-                    if (networkEnvelope instanceof SupportedCapabilitiesMessage) {
-                        boolean causedShutDown = handleSupportedCapabilitiesMessage(networkEnvelope);
-                        if (causedShutDown) {
-                            return;
-                        }
+                    boolean causedShutDown = maybeHandleSupportedCapabilitiesMessage(networkEnvelope);
+                    if (causedShutDown) {
+                        return;
                     }
 
                     if (networkEnvelope instanceof CloseConnectionMessage) {
@@ -865,7 +863,11 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         }
     }
 
-    protected boolean handleSupportedCapabilitiesMessage(NetworkEnvelope networkEnvelope) {
+    public boolean maybeHandleSupportedCapabilitiesMessage(NetworkEnvelope networkEnvelope) {
+        if (!(networkEnvelope instanceof SupportedCapabilitiesMessage)) {
+            return false;
+        }
+
         Capabilities supportedCapabilities = ((SupportedCapabilitiesMessage) networkEnvelope).getSupportedCapabilities();
         if (supportedCapabilities == null || supportedCapabilities.isEmpty()) {
             return false;


### PR DESCRIPTION
At init trades we iterate all trades (closed and pending) and check if the trade statistics contain a trade stat from that trade. First we check for the new TradeStatistics3, if not found we lookup for the hash of TradeStatistics2 created from that trade. If also not found and if it is valid data we republish the TradeStatistics3.

Remove republishing at SellerProtocol as we don't know the capability of the peer at that moment and as we also want to republish for completed trades.