### PR TITLE
Rename history field in version

### DIFF
--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -35,7 +35,7 @@ public class Version {
     /**
      * Holds a list of the versions of tagged resource files for optimizing the getData requests.
      */
-    public static final List<String> HISTORY = Arrays.asList("1.4.1");
+    public static final List<String> HISTORY = Arrays.asList("1.4.0");
 
     public static int getMajorVersion(String version) {
         return getSubVersion(version, 0);

--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -33,9 +33,11 @@ public class Version {
     public static final String VERSION = "1.4.1";
 
     /**
-     * Holds a list of the versions of tagged resource files for optimizing the getData requests.
+     * Holds a list of the tagged resource files for optimizing the getData requests.
+     * This must not contain each version but only those where we add new version-tagged resource files for
+     * historical data stores.
      */
-    public static final List<String> HISTORY = Arrays.asList("1.4.0");
+    public static final List<String> HISTORICAL_RESOURCE_FILE_VERSION_TAGS = Arrays.asList("1.4.0");
 
     public static int getMajorVersion(String version) {
         return getSubVersion(version, 0);

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
@@ -154,7 +154,7 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
         ImmutableMap.Builder<P2PDataStorage.ByteArray, PersistableNetworkPayload> allHistoricalPayloadsBuilder = ImmutableMap.builder();
         ImmutableMap.Builder<String, PersistableNetworkPayloadStore<? extends PersistableNetworkPayload>> storesByVersionBuilder = ImmutableMap.builder();
 
-        Version.HISTORY.forEach(version -> readHistoricalStoreFromResources(version, postFix, allHistoricalPayloadsBuilder, storesByVersionBuilder));
+        Version.HISTORICAL_RESOURCE_FILE_VERSION_TAGS.forEach(version -> readHistoricalStoreFromResources(version, postFix, allHistoricalPayloadsBuilder, storesByVersionBuilder));
 
         allHistoricalPayloads = allHistoricalPayloadsBuilder.build();
         storesByVersion = storesByVersionBuilder.build();


### PR DESCRIPTION
This field contains the versions where we have tagged a resource file.
It does not need to be the latest version in case we have not added a new resource file.

Additional to the fix in #4677 this comes with a renaming to make usage more clear.

I leave it to maintainers which PR to pick for the release fix...