### PR TITLE
Update monitor with last version from freimairs repo

### DIFF
--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessStore.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessStore.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AccountAgeWitnessStore extends PersistableNetworkPayloadStore<AccountAgeWitness> {
 
-    AccountAgeWitnessStore() {
+    public AccountAgeWitnessStore() {
     }
 
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3Store.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3Store.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TradeStatistics3Store extends PersistableNetworkPayloadStore<TradeStatistics3> {
 
-    TradeStatistics3Store() {
+    public TradeStatistics3Store() {
     }
 
 

--- a/monitor/src/main/java/bisq/monitor/AvailableTor.java
+++ b/monitor/src/main/java/bisq/monitor/AvailableTor.java
@@ -17,13 +17,15 @@
 
 package bisq.monitor;
 
-import java.io.File;
-import org.berndpruenster.netlayer.tor.Tor;
 import bisq.network.p2p.network.TorMode;
+
+import org.berndpruenster.netlayer.tor.Tor;
+
+import java.io.File;
 
 /**
  * This class uses an already defined Tor via <code>Tor.getDefault()</code>
- * 
+ *
  * @author Florian Reimair
  *
  */

--- a/monitor/src/main/java/bisq/monitor/Metric.java
+++ b/monitor/src/main/java/bisq/monitor/Metric.java
@@ -122,11 +122,11 @@ public abstract class Metric extends Configurable implements Runnable {
 
             // execute all the things
             synchronized (this) {
-                    log.info("{} started", getName());
-                    execute();
-                    log.info("{} done", getName());
+                log.info("{} started", getName());
+                execute();
+                log.info("{} done", getName());
             }
-        } catch(Throwable e) {
+        } catch (Throwable e) {
             log.error("A metric misbehaved!", e);
         }
     }

--- a/monitor/src/main/java/bisq/monitor/OnionParser.java
+++ b/monitor/src/main/java/bisq/monitor/OnionParser.java
@@ -17,10 +17,10 @@
 
 package bisq.monitor;
 
+import bisq.network.p2p.NodeAddress;
+
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import bisq.network.p2p.NodeAddress;
 
 /**
  * Helper for parsing and pretty printing onion addresses.

--- a/monitor/src/main/java/bisq/monitor/StatisticsHelper.java
+++ b/monitor/src/main/java/bisq/monitor/StatisticsHelper.java
@@ -17,11 +17,13 @@
 
 package bisq.monitor;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Calculates average, max, min, p25, p50, p75 off of a list of samples and
@@ -31,7 +33,9 @@ import java.util.Map;
  */
 public class StatisticsHelper {
 
-    public static Map<String, String> process(List<Long> samples) {
+    public static Map<String, String> process(Collection<Long> input) {
+
+        List<Long> samples = input.stream().collect(Collectors.toList());
 
         // aftermath
         Collections.sort(samples);

--- a/monitor/src/main/java/bisq/monitor/ThreadGate.java
+++ b/monitor/src/main/java/bisq/monitor/ThreadGate.java
@@ -41,7 +41,7 @@ public class ThreadGate {
 
     /**
      * Make everyone wait until the gate is open again.
-     * 
+     *
      * @param numberOfLocks how often the gate has to be unlocked until the gate
      *                      opens.
      */

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -156,7 +156,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
         // report
         Map<String, String> report = new HashMap<>();
 
-        if(lastRun != 0 && System.currentTimeMillis() - lastRun != 0) {
+        if (lastRun != 0 && System.currentTimeMillis() - lastRun != 0) {
             // - normalize to data/minute
             double perMinuteFactor = 60000.0 / (System.currentTimeMillis() - lastRun);
 
@@ -219,7 +219,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
     public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
         if (networkEnvelope instanceof BroadcastMessage) {
             try {
-                if(history.get(networkEnvelope.hashCode()) == null) {
+                if (history.get(networkEnvelope.hashCode()) == null) {
                     history.put(networkEnvelope.hashCode(), null);
                     buckets.get(networkEnvelope.getClass().getSimpleName()).increment();
                 }

--- a/monitor/src/main/java/bisq/monitor/metric/P2PRoundTripTime.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PRoundTripTime.java
@@ -57,7 +57,7 @@ public class P2PRoundTripTime extends P2PSeedNodeSnapshotBase {
         public synchronized void log(Object message) {
             Pong pong = (Pong) message;
             Long start = sentAt.get(pong.getRequestNonce());
-            if(start != null)
+            if (start != null)
                 samples.add(System.currentTimeMillis() - start);
         }
 

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshot.java
@@ -21,26 +21,27 @@ import bisq.monitor.OnionParser;
 import bisq.monitor.Reporter;
 
 import bisq.core.account.witness.AccountAgeWitnessStore;
+import bisq.common.config.BaseCurrencyNetwork;
 import bisq.core.dao.monitoring.model.StateHash;
 import bisq.core.dao.monitoring.network.messages.GetBlindVoteStateHashesRequest;
 import bisq.core.dao.monitoring.network.messages.GetDaoStateHashesRequest;
 import bisq.core.dao.monitoring.network.messages.GetProposalStateHashesRequest;
 import bisq.core.dao.monitoring.network.messages.GetStateHashesResponse;
 import bisq.core.proto.persistable.CorePersistenceProtoResolver;
-import bisq.core.trade.statistics.TradeStatistics3Store;
+import bisq.core.trade.statistics.TradeStatistics2Store;
 
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.Connection;
 import bisq.network.p2p.peers.getdata.messages.GetDataResponse;
 import bisq.network.p2p.peers.getdata.messages.PreliminaryGetDataRequest;
+import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.app.Version;
-import bisq.common.config.BaseCurrencyNetwork;
-import bisq.common.persistence.PersistenceManager;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.persistable.PersistableEnvelope;
+import bisq.common.storage.Storage;
 
 import java.net.MalformedURLException;
 
@@ -80,11 +81,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @Slf4j
 public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
-    private static final String DATABASE_DIR = "run.dbDir";
 
-    Statistics statistics;
     final Map<NodeAddress, Statistics<Set<Integer>>> bucketsPerHost = new ConcurrentHashMap<>();
-    protected final Set<byte[]> hashes = new TreeSet<>(Arrays::compare);
     private int daostateheight = 594000;
     private int proposalheight = daostateheight;
     private int blindvoteheight = daostateheight;
@@ -92,14 +90,7 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
     /**
      * Use a counter to do statistics.
      */
-    private class MyStatistics implements Statistics<Set<Integer>> {
-
-        private final Map<String, Set<Integer>> buckets = new HashMap<>();
-
-        @Override
-        public Statistics create() {
-            return new MyStatistics();
-        }
+    private class MyStatistics extends Statistics<Set<Integer>> {
 
         @Override
         public synchronized void log(Object message) {
@@ -110,43 +101,10 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
             buckets.putIfAbsent(className, new HashSet<>());
             buckets.get(className).add(message.hashCode());
         }
-
-        @Override
-        public Map<String, Set<Integer>> values() {
-            return buckets;
-        }
-
-        @Override
-        public synchronized void reset() {
-            buckets.clear();
-        }
     }
 
     public P2PSeedNodeSnapshot(Reporter reporter) {
         super(reporter);
-
-        statistics = new MyStatistics();
-    }
-
-    @Override
-    public void configure(Properties properties) {
-        super.configure(properties);
-
-        if (hashes.isEmpty() && configuration.getProperty(DATABASE_DIR) != null) {
-            File dir = new File(configuration.getProperty(DATABASE_DIR));
-            String networkPostfix = "_" + BaseCurrencyNetwork.values()[Version.getBaseCurrencyNetwork()].toString();
-            try {
-                PersistenceManager<PersistableEnvelope> persistenceManager = new PersistenceManager<>(dir, new CorePersistenceProtoResolver(null, null), null);
-                TradeStatistics3Store tradeStatistics3Store = (TradeStatistics3Store) persistenceManager.getPersisted(TradeStatistics3Store.class.getSimpleName() + networkPostfix);
-                hashes.addAll(tradeStatistics3Store.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
-
-                AccountAgeWitnessStore accountAgeWitnessStore = (AccountAgeWitnessStore) persistenceManager.getPersisted(AccountAgeWitnessStore.class.getSimpleName() + networkPostfix);
-                hashes.addAll(accountAgeWitnessStore.getMap().keySet().stream().map(byteArray -> byteArray.bytes).collect(Collectors.toList()));
-            } catch (NullPointerException e) {
-                // in case there is no store file
-                log.error("There is no storage file where there should be one: {}", dir.getAbsolutePath());
-            }
-        }
     }
 
     protected List<NetworkEnvelope> getRequests() {
@@ -190,21 +148,21 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
 
         //   - calculate diffs
         messagesPerHost.forEach(
-                (host, statistics) -> {
-                    statistics.values().forEach((messageType, set) -> {
-                        try {
-                            report.put(OnionParser.prettyPrint(host) + ".relativeNumberOfMessages." + messageType,
-                                    String.valueOf(set.size() - referenceValues.get(messageType).size()));
-                        } catch (MalformedURLException | NullPointerException ignore) {
-                            log.error("we should never have gotten here", ignore);
-                        }
-                    });
+            (host, statistics) -> {
+                statistics.values().forEach((messageType, set) -> {
                     try {
-                        report.put(OnionParser.prettyPrint(host) + ".referenceHost", referenceHost);
-                    } catch (MalformedURLException ignore) {
-                        log.error("we should never got here");
+                        report.put(OnionParser.prettyPrint(host) + ".relativeNumberOfMessages." + messageType,
+                                String.valueOf(set.size() - referenceValues.get(messageType).size()));
+                    } catch (MalformedURLException | NullPointerException ignore) {
+                        log.error("we should never have gotten here", ignore);
                     }
                 });
+                try {
+                    report.put(OnionParser.prettyPrint(host) + ".referenceHost", referenceHost);
+                } catch (MalformedURLException ignore) {
+                    log.error("we should never got here");
+                }
+            });
 
         // cleanup for next run
         bucketsPerHost.forEach((host, statistics) -> statistics.reset());
@@ -233,9 +191,9 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
             int oldest = (int) nodeAddressTupleMap.values().stream().min(Comparator.comparingLong(Tuple::getHeight)).get().height;
 
             //   - update queried height
-            if (type.contains("DaoState"))
+            if(type.contains("DaoState"))
                 daostateheight = oldest - 20;
-            else if (type.contains("Proposal"))
+            else if(type.contains("Proposal"))
                 proposalheight = oldest - 20;
             else
                 blindvoteheight = oldest - 20;
@@ -255,6 +213,7 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
 
             List<ByteBuffer> states = hitcount.entrySet().stream().sorted((o1, o2) -> o2.getValue().compareTo(o1.getValue())).map(byteBufferIntegerEntry -> byteBufferIntegerEntry.getKey()).collect(Collectors.toList());
             hitcount.clear();
+
             nodeAddressTupleMap.forEach((nodeAddress, tuple) -> daoreport.put(type + "." + OnionParser.prettyPrint(nodeAddress) + ".hash", Integer.toString(Arrays.asList(states.toArray()).indexOf(ByteBuffer.wrap(tuple.hash)))));
 
             //   - report reference head
@@ -278,14 +237,7 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
         }
     }
 
-    private class DaoStatistics implements Statistics<Tuple> {
-
-        Map<String, Tuple> buckets = new ConcurrentHashMap<>();
-
-        @Override
-        public Statistics create() {
-            return new DaoStatistics();
-        }
+    private class DaoStatistics extends Statistics<Tuple> {
 
         @Override
         public void log(Object message) {
@@ -297,16 +249,6 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
 
             buckets.putIfAbsent(className, new Tuple(last.getHeight(), last.getHash()));
         }
-
-        @Override
-        public Map<String, Tuple> values() {
-            return buckets;
-        }
-
-        @Override
-        public void reset() {
-            buckets.clear();
-        }
     }
 
     private Map<NodeAddress, Statistics<Tuple>> daoData = new ConcurrentHashMap<>();
@@ -317,7 +259,7 @@ public class P2PSeedNodeSnapshot extends P2PSeedNodeSnapshotBase {
 
         if (networkEnvelope instanceof GetDataResponse) {
 
-            Statistics result = this.statistics.create();
+            Statistics result = new MyStatistics();
 
             GetDataResponse dataResponse = (GetDataResponse) networkEnvelope;
             final Set<ProtectedStorageEntry> dataSet = dataResponse.getDataSet();

--- a/monitor/src/main/java/bisq/monitor/reporter/ConsoleReporter.java
+++ b/monitor/src/main/java/bisq/monitor/reporter/ConsoleReporter.java
@@ -19,9 +19,8 @@ package bisq.monitor.reporter;
 
 import bisq.monitor.Reporter;
 
-import bisq.common.config.BaseCurrencyNetwork;
-
 import bisq.common.app.Version;
+import bisq.common.config.BaseCurrencyNetwork;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/monitor/src/main/java/bisq/monitor/reporter/GraphiteReporter.java
+++ b/monitor/src/main/java/bisq/monitor/reporter/GraphiteReporter.java
@@ -20,11 +20,10 @@ package bisq.monitor.reporter;
 import bisq.monitor.OnionParser;
 import bisq.monitor.Reporter;
 
-import bisq.common.config.BaseCurrencyNetwork;
-
 import bisq.network.p2p.NodeAddress;
 
 import bisq.common.app.Version;
+import bisq.common.config.BaseCurrencyNetwork;
 
 import org.berndpruenster.netlayer.tor.TorSocket;
 
@@ -81,7 +80,7 @@ public class GraphiteReporter extends Reporter {
         String report = "bisq" + (Version.getBaseCurrencyNetwork() != 0 ? "-" + BaseCurrencyNetwork.values()[Version.getBaseCurrencyNetwork()].getNetwork() : "")
                 + (prefix.isEmpty() ? "" : "." + prefix)
                 + (key.isEmpty() ? "" : "." + key)
-                + " " + value + " " + Long.valueOf(timeInMilliseconds)/1000 + "\n";
+                + " " + value + " " + Long.valueOf(timeInMilliseconds) / 1000 + "\n";
 
         try {
             NodeAddress nodeAddress = OnionParser.getNodeAddress(configuration.getProperty("serviceUrl"));

--- a/monitor/src/main/resources/logback.xml
+++ b/monitor/src/main/resources/logback.xml
@@ -1,12 +1,12 @@
 <configuration>
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
-  </appender>
- 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
-  </root>
-  <logger name="org.berndpruenster.netlayer.tor" level="INFO"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="org.berndpruenster.netlayer.tor" level="INFO"/>
 </configuration>

--- a/monitor/src/test/java/bisq/monitor/MonitorInfrastructureTests.java
+++ b/monitor/src/test/java/bisq/monitor/MonitorInfrastructureTests.java
@@ -58,7 +58,7 @@ public class MonitorInfrastructureTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "empty", "no interval", "typo" })
+    @ValueSource(strings = {"empty", "no interval", "typo"})
     public void basicConfigurationError(String configuration) {
         HashMap<String, Properties> lut = new HashMap<>();
         lut.put("empty", new Properties());

--- a/monitor/src/test/java/bisq/monitor/P2PNetworkLoadTests.java
+++ b/monitor/src/test/java/bisq/monitor/P2PNetworkLoadTests.java
@@ -20,19 +20,20 @@ package bisq.monitor;
 import bisq.monitor.metric.P2PNetworkLoad;
 import bisq.monitor.reporter.ConsoleReporter;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.berndpruenster.netlayer.tor.NativeTor;
+import org.berndpruenster.netlayer.tor.Tor;
+import org.berndpruenster.netlayer.tor.TorCtlException;
 
 import java.util.Map;
 import java.util.Properties;
 
-import org.berndpruenster.netlayer.tor.NativeTor;
-import org.berndpruenster.netlayer.tor.Tor;
-import org.berndpruenster.netlayer.tor.TorCtlException;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Test the round trip time metric against the hidden service of tor project.org.

--- a/monitor/src/test/java/bisq/monitor/P2PRoundTripTimeTests.java
+++ b/monitor/src/test/java/bisq/monitor/P2PRoundTripTimeTests.java
@@ -20,20 +20,21 @@ package bisq.monitor;
 import bisq.monitor.metric.P2PRoundTripTime;
 import bisq.monitor.reporter.ConsoleReporter;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.berndpruenster.netlayer.tor.NativeTor;
+import org.berndpruenster.netlayer.tor.Tor;
+import org.berndpruenster.netlayer.tor.TorCtlException;
 
 import java.util.Map;
 import java.util.Properties;
 
-import org.berndpruenster.netlayer.tor.NativeTor;
-import org.berndpruenster.netlayer.tor.Tor;
-import org.berndpruenster.netlayer.tor.TorCtlException;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Test the round trip time metric against the hidden service of tor project.org.

--- a/monitor/src/test/java/bisq/monitor/PriceNodeStatsTests.java
+++ b/monitor/src/test/java/bisq/monitor/PriceNodeStatsTests.java
@@ -25,7 +25,6 @@ import org.berndpruenster.netlayer.tor.TorCtlException;
 
 import java.io.File;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -186,6 +186,10 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
         addMessageListener(messageListener);
 
+        if (config == null) {
+            config = new Config();
+        }
+
         this.networkProtoResolver = networkProtoResolver;
         init(peersNodeAddress);
     }

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -186,10 +186,6 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
         addMessageListener(messageListener);
 
-        if (config == null) {
-            config = new Config();
-        }
-
         this.networkProtoResolver = networkProtoResolver;
         init(peersNodeAddress);
     }


### PR DESCRIPTION
Update monitor code base with latest version form @freimair [repo](https://github.com/freimair/bisq/commits/monitor). 
Current version does not work due a nullpointer in connection. This was solved in @freimair's repo, but we removed it in that PR as it will have a better solution in https://github.com/bisq-network/bisq/pull/4680. We will make another new PR where this PR will be based on https://github.com/bisq-network/bisq/pull/4680 so the monitor become valid again.