### PR TITLE
Replace TradeUtils with singleton TradeUtil

### DIFF
--- a/core/src/main/java/bisq/core/api/model/OfferInfo.java
+++ b/core/src/main/java/bisq/core/api/model/OfferInfo.java
@@ -125,13 +125,9 @@ public class OfferInfo implements Payload {
                 .build();
     }
 
+    @SuppressWarnings({"unused", "SameReturnValue"})
     public static OfferInfo fromProto(bisq.proto.grpc.OfferInfo proto) {
-        /*
-        TODO?
-        return new OfferInfo(proto.getOfferPayload().getId(),
-                proto.getOfferPayload().getDate());
-        */
-        return null;
+        return null; // TODO
     }
 
     /*

--- a/core/src/main/java/bisq/core/api/model/TradeInfo.java
+++ b/core/src/main/java/bisq/core/api/model/TradeInfo.java
@@ -21,6 +21,8 @@ import bisq.core.trade.Trade;
 
 import bisq.common.Payload;
 
+import java.util.Objects;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -37,6 +39,16 @@ public class TradeInfo implements Payload {
     private final OfferInfo offer;
     private final String tradeId;
     private final String shortId;
+    private final long date;
+    private final boolean isCurrencyForTakerFeeBtc;
+    private final long txFeeAsLong;
+    private final long takerFeeAsLong;
+    private final String takerFeeTxId;
+    private final String depositTxId;
+    private final String payoutTxId;
+    private final long tradeAmountAsLong;
+    private final long tradePrice;
+    private final String tradingPeerNodeAddress;
     private final String state;
     private final String phase;
     private final String tradePeriodState;
@@ -46,11 +58,22 @@ public class TradeInfo implements Payload {
     private final boolean isFiatReceived;
     private final boolean isPayoutPublished;
     private final boolean isWithdrawn;
+    private final String contractAsJson;
 
     public TradeInfo(TradeInfoBuilder builder) {
         this.offer = builder.offer;
         this.tradeId = builder.tradeId;
         this.shortId = builder.shortId;
+        this.date = builder.date;
+        this.isCurrencyForTakerFeeBtc = builder.isCurrencyForTakerFeeBtc;
+        this.txFeeAsLong = builder.txFeeAsLong;
+        this.takerFeeAsLong = builder.takerFeeAsLong;
+        this.takerFeeTxId = builder.takerFeeTxId;
+        this.depositTxId = builder.depositTxId;
+        this.payoutTxId = builder.payoutTxId;
+        this.tradeAmountAsLong = builder.tradeAmountAsLong;
+        this.tradePrice = builder.tradePrice;
+        this.tradingPeerNodeAddress = builder.tradingPeerNodeAddress;
         this.state = builder.state;
         this.phase = builder.phase;
         this.tradePeriodState = builder.tradePeriodState;
@@ -60,6 +83,7 @@ public class TradeInfo implements Payload {
         this.isFiatReceived = builder.isFiatReceived;
         this.isPayoutPublished = builder.isPayoutPublished;
         this.isWithdrawn = builder.isWithdrawn;
+        this.contractAsJson = builder.contractAsJson;
     }
 
     public static TradeInfo toTradeInfo(Trade trade) {
@@ -67,6 +91,18 @@ public class TradeInfo implements Payload {
                 .withOffer(toOfferInfo(trade.getOffer()))
                 .withTradeId(trade.getId())
                 .withShortId(trade.getShortId())
+                .withDate(trade.getDate().getTime())
+                .withIsCurrencyForTakerFeeBtc(trade.isCurrencyForTakerFeeBtc())
+                .withTxFeeAsLong(trade.getTxFeeAsLong())
+                .withTakerFeeAsLong(trade.getTakerFeeAsLong())
+                .withTakerFeeAsLong(trade.getTakerFeeAsLong())
+                .withTakerFeeTxId(trade.getTakerFeeTxId())
+                .withDepositTxId(trade.getDepositTxId())
+                .withPayoutTxId(trade.getPayoutTxId())
+                .withTradeAmountAsLong(trade.getTradeAmountAsLong())
+                .withTradePrice(trade.getTradePrice().getValue())
+                .withTradingPeerNodeAddress(Objects.requireNonNull(
+                        trade.getTradingPeerNodeAddress()).getHostNameWithoutPostFix())
                 .withState(trade.getState().name())
                 .withPhase(trade.getPhase().name())
                 .withTradePeriodState(trade.getTradePeriodState().name())
@@ -76,6 +112,7 @@ public class TradeInfo implements Payload {
                 .withIsFiatReceived(trade.isFiatReceived())
                 .withIsPayoutPublished(trade.isPayoutPublished())
                 .withIsWithdrawn(trade.isWithdrawn())
+                .withContractAsJson(trade.getContractAsJson())
                 .build();
     }
 
@@ -89,6 +126,16 @@ public class TradeInfo implements Payload {
                 .setOffer(offer.toProtoMessage())
                 .setTradeId(tradeId)
                 .setShortId(shortId)
+                .setDate(date)
+                .setIsCurrencyForTakerFeeBtc(isCurrencyForTakerFeeBtc)
+                .setTxFeeAsLong(txFeeAsLong)
+                .setTakerFeeAsLong(takerFeeAsLong)
+                .setTakerFeeTxId(takerFeeTxId == null ? "" : takerFeeTxId)
+                .setDepositTxId(depositTxId == null ? "" : depositTxId)
+                .setPayoutTxId(payoutTxId == null ? "" : payoutTxId)
+                .setTradeAmountAsLong(tradeAmountAsLong)
+                .setTradePrice(tradePrice)
+                .setTradingPeerNodeAddress(tradingPeerNodeAddress)
                 .setState(state)
                 .setPhase(phase)
                 .setTradePeriodState(tradePeriodState)
@@ -98,12 +145,13 @@ public class TradeInfo implements Payload {
                 .setIsFiatReceived(isFiatReceived)
                 .setIsPayoutPublished(isPayoutPublished)
                 .setIsWithdrawn(isWithdrawn)
+                .setContractAsJson(contractAsJson == null ? "" : contractAsJson)
                 .build();
     }
 
+    @SuppressWarnings({"unused", "SameReturnValue"})
     public static TradeInfo fromProto(bisq.proto.grpc.TradeInfo proto) {
-        // TODO
-        return null;
+        return null;  // TODO
     }
 
     /*
@@ -116,6 +164,16 @@ public class TradeInfo implements Payload {
         private OfferInfo offer;
         private String tradeId;
         private String shortId;
+        private long date;
+        private boolean isCurrencyForTakerFeeBtc;
+        private long txFeeAsLong;
+        private long takerFeeAsLong;
+        private String takerFeeTxId;
+        private String depositTxId;
+        private String payoutTxId;
+        private long tradeAmountAsLong;
+        private long tradePrice;
+        private String tradingPeerNodeAddress;
         private String state;
         private String phase;
         private String tradePeriodState;
@@ -125,6 +183,7 @@ public class TradeInfo implements Payload {
         private boolean isFiatReceived;
         private boolean isPayoutPublished;
         private boolean isWithdrawn;
+        private String contractAsJson;
 
         public TradeInfoBuilder withOffer(OfferInfo offer) {
             this.offer = offer;
@@ -141,6 +200,56 @@ public class TradeInfo implements Payload {
             return this;
         }
 
+        public TradeInfoBuilder withDate(long date) {
+            this.date = date;
+            return this;
+        }
+
+        public TradeInfoBuilder withIsCurrencyForTakerFeeBtc(boolean isCurrencyForTakerFeeBtc) {
+            this.isCurrencyForTakerFeeBtc = isCurrencyForTakerFeeBtc;
+            return this;
+        }
+
+        public TradeInfoBuilder withTxFeeAsLong(long txFeeAsLong) {
+            this.txFeeAsLong = txFeeAsLong;
+            return this;
+        }
+
+        public TradeInfoBuilder withTakerFeeAsLong(long takerFeeAsLong) {
+            this.takerFeeAsLong = takerFeeAsLong;
+            return this;
+        }
+
+        public TradeInfoBuilder withTakerFeeTxId(String takerFeeTxId) {
+            this.takerFeeTxId = takerFeeTxId;
+            return this;
+        }
+
+        public TradeInfoBuilder withDepositTxId(String depositTxId) {
+            this.depositTxId = depositTxId;
+            return this;
+        }
+
+        public TradeInfoBuilder withPayoutTxId(String payoutTxId) {
+            this.payoutTxId = payoutTxId;
+            return this;
+        }
+
+        public TradeInfoBuilder withTradeAmountAsLong(long tradeAmountAsLong) {
+            this.tradeAmountAsLong = tradeAmountAsLong;
+            return this;
+        }
+
+        public TradeInfoBuilder withTradePrice(long tradePrice) {
+            this.tradePrice = tradePrice;
+            return this;
+        }
+
+        public TradeInfoBuilder withTradePeriodState(String tradePeriodState) {
+            this.tradePeriodState = tradePeriodState;
+            return this;
+        }
+
         public TradeInfoBuilder withState(String state) {
             this.state = state;
             return this;
@@ -151,8 +260,8 @@ public class TradeInfo implements Payload {
             return this;
         }
 
-        public TradeInfoBuilder withTradePeriodState(String tradePeriodState) {
-            this.tradePeriodState = tradePeriodState;
+        public TradeInfoBuilder withTradingPeerNodeAddress(String tradingPeerNodeAddress) {
+            this.tradingPeerNodeAddress = tradingPeerNodeAddress;
             return this;
         }
 
@@ -186,6 +295,11 @@ public class TradeInfo implements Payload {
             return this;
         }
 
+        public TradeInfoBuilder withContractAsJson(String contractAsJson) {
+            this.contractAsJson = contractAsJson;
+            return this;
+        }
+
         public TradeInfo build() {
             return new TradeInfo(this);
         }
@@ -196,6 +310,16 @@ public class TradeInfo implements Payload {
         return "TradeInfo{" +
                 "  tradeId='" + tradeId + '\'' + "\n" +
                 ", shortId='" + shortId + '\'' + "\n" +
+                ", date='" + date + '\'' + "\n" +
+                ", isCurrencyForTakerFeeBtc='" + isCurrencyForTakerFeeBtc + '\'' + "\n" +
+                ", txFeeAsLong='" + txFeeAsLong + '\'' + "\n" +
+                ", takerFeeAsLong='" + takerFeeAsLong + '\'' + "\n" +
+                ", takerFeeTxId='" + takerFeeTxId + '\'' + "\n" +
+                ", depositTxId='" + depositTxId + '\'' + "\n" +
+                ", payoutTxId='" + payoutTxId + '\'' + "\n" +
+                ", tradeAmountAsLong='" + tradeAmountAsLong + '\'' + "\n" +
+                ", tradePrice='" + tradePrice + '\'' + "\n" +
+                ", tradingPeerNodeAddress='" + tradingPeerNodeAddress + '\'' + "\n" +
                 ", state='" + state + '\'' + "\n" +
                 ", phase='" + phase + '\'' + "\n" +
                 ", tradePeriodState='" + tradePeriodState + '\'' + "\n" +
@@ -206,6 +330,7 @@ public class TradeInfo implements Payload {
                 ", isPayoutPublished=" + isPayoutPublished + "\n" +
                 ", isWithdrawn=" + isWithdrawn + "\n" +
                 ", offer=" + offer + "\n" +
+                ", contractAsJson=" + contractAsJson + "\n" +
                 '}';
     }
 }

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -120,6 +120,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     private final P2PService p2PService;
     private final PriceFeedService priceFeedService;
     private final TradeStatisticsManager tradeStatisticsManager;
+    private final TradeUtil tradeUtil;
     @Getter
     private final ArbitratorManager arbitratorManager;
     private final MediatorManager mediatorManager;
@@ -157,6 +158,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                         P2PService p2PService,
                         PriceFeedService priceFeedService,
                         TradeStatisticsManager tradeStatisticsManager,
+                        TradeUtil tradeUtil,
                         ArbitratorManager arbitratorManager,
                         MediatorManager mediatorManager,
                         ProcessModelServiceProvider processModelServiceProvider,
@@ -175,6 +177,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         this.p2PService = p2PService;
         this.priceFeedService = priceFeedService;
         this.tradeStatisticsManager = tradeStatisticsManager;
+        this.tradeUtil = tradeUtil;
         this.arbitratorManager = arbitratorManager;
         this.mediatorManager = mediatorManager;
         this.processModelServiceProvider = processModelServiceProvider;
@@ -634,7 +637,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     // the relevant entries are changed, otherwise it's not added and no address entries are changed
     private boolean recoverAddresses(Trade trade) {
         // Find addresses associated with this trade.
-        var entries = TradeUtils.getAvailableAddresses(trade, btcWalletService, keyRing);
+        var entries = tradeUtil.getAvailableAddresses(trade);
         if (entries == null)
             return false;
 

--- a/core/src/main/java/bisq/core/trade/TradeUtil.java
+++ b/core/src/main/java/bisq/core/trade/TradeUtil.java
@@ -1,18 +1,18 @@
 /*
  * This file is part of Bisq.
  *
- * bisq is free software: you can redistribute it and/or modify it
+ * Bisq is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
  *
- * bisq is distributed in the hope that it will be useful, but WITHOUT
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with bisq. If not, see <http://www.gnu.org/licenses/>.
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package bisq.core.trade;

--- a/core/src/main/java/bisq/core/trade/TradeUtil.java
+++ b/core/src/main/java/bisq/core/trade/TradeUtil.java
@@ -1,18 +1,18 @@
 /*
  * This file is part of Bisq.
  *
- * Bisq is free software: you can redistribute it and/or modify it
+ * bisq is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
  *
- * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * bisq is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ * along with bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package bisq.core.trade;
@@ -23,20 +23,44 @@ import bisq.common.crypto.KeyRing;
 import bisq.common.util.Tuple2;
 import bisq.common.util.Utilities;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import java.util.Objects;
 
-public class TradeUtils {
+import lombok.extern.slf4j.Slf4j;
 
-    // Returns <MULTI_SIG, TRADE_PAYOUT> if both are AVAILABLE, otherwise null
-    static Tuple2<String, String> getAvailableAddresses(Trade trade, BtcWalletService btcWalletService,
-                                                        KeyRing keyRing) {
-        var addresses = getTradeAddresses(trade, btcWalletService, keyRing);
+/**
+ * This class contains trade utility methods.
+ */
+@Slf4j
+@Singleton
+public class TradeUtil {
+
+    private final BtcWalletService btcWalletService;
+    private final KeyRing keyRing;
+
+    @Inject
+    public TradeUtil(BtcWalletService btcWalletService, KeyRing keyRing) {
+        this.btcWalletService = btcWalletService;
+        this.keyRing = keyRing;
+    }
+
+    /**
+     * Returns <MULTI_SIG, TRADE_PAYOUT> if and only if both are AVAILABLE,
+     * otherwise null.
+     * @param trade the trade being queried for MULTI_SIG, TRADE_PAYOUT addresses
+     * @return Tuple2 tuple containing MULTI_SIG, TRADE_PAYOUT addresses for trade
+     */
+    public Tuple2<String, String> getAvailableAddresses(Trade trade) {
+        var addresses = getTradeAddresses(trade);
         if (addresses == null)
             return null;
 
         if (btcWalletService.getAvailableAddressEntries().stream()
                 .noneMatch(e -> Objects.equals(e.getAddressString(), addresses.first)))
             return null;
+
         if (btcWalletService.getAvailableAddressEntries().stream()
                 .noneMatch(e -> Objects.equals(e.getAddressString(), addresses.second)))
             return null;
@@ -44,18 +68,25 @@ public class TradeUtils {
         return new Tuple2<>(addresses.first, addresses.second);
     }
 
-    // Returns <MULTI_SIG, TRADE_PAYOUT> addresses as strings if they're known by the wallet
-    public static Tuple2<String, String> getTradeAddresses(Trade trade, BtcWalletService btcWalletService,
-                                                           KeyRing keyRing) {
+    /**
+     * Returns <MULTI_SIG, TRADE_PAYOUT> addresses as strings if they're known by the
+     * wallet.
+     * @param trade the trade being queried for MULTI_SIG, TRADE_PAYOUT addresses
+     * @return Tuple2 tuple containing MULTI_SIG, TRADE_PAYOUT addresses for trade
+     */
+    public Tuple2<String, String> getTradeAddresses(Trade trade) {
         var contract = trade.getContract();
         if (contract == null)
             return null;
 
         // Get multisig address
         var isMyRoleBuyer = contract.isMyRoleBuyer(keyRing.getPubKeyRing());
-        var multiSigPubKey = isMyRoleBuyer ? contract.getBuyerMultiSigPubKey() : contract.getSellerMultiSigPubKey();
+        var multiSigPubKey = isMyRoleBuyer
+                ? contract.getBuyerMultiSigPubKey()
+                : contract.getSellerMultiSigPubKey();
         if (multiSigPubKey == null)
             return null;
+
         var multiSigPubKeyString = Utilities.bytesAsHexString(multiSigPubKey);
         var multiSigAddress = btcWalletService.getAddressEntryListAsImmutableList().stream()
                 .filter(e -> e.getKeyPair().getPublicKeyAsHex().equals(multiSigPubKeyString))
@@ -65,8 +96,9 @@ public class TradeUtils {
             return null;
 
         // Get payout address
-        var payoutAddress = isMyRoleBuyer ?
-                contract.getBuyerPayoutAddressString() : contract.getSellerPayoutAddressString();
+        var payoutAddress = isMyRoleBuyer
+                ? contract.getBuyerPayoutAddressString()
+                : contract.getSellerPayoutAddressString();
         var payoutAddressEntry = btcWalletService.getAddressEntryListAsImmutableList().stream()
                 .filter(e -> Objects.equals(e.getAddressString(), payoutAddress))
                 .findAny()

--- a/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
+++ b/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
@@ -24,7 +24,7 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.DumpDelayedPayoutTx;
 import bisq.core.trade.TradableList;
 import bisq.core.trade.Trade;
-import bisq.core.trade.TradeUtils;
+import bisq.core.trade.TradeUtil;
 
 import bisq.common.crypto.KeyRing;
 import bisq.common.persistence.PersistenceManager;
@@ -50,6 +50,7 @@ public class FailedTradesManager implements PersistedDataHost {
     private final PriceFeedService priceFeedService;
     private final BtcWalletService btcWalletService;
     private final PersistenceManager<TradableList<Trade>> persistenceManager;
+    private final TradeUtil tradeUtil;
     private final DumpDelayedPayoutTx dumpDelayedPayoutTx;
     @Setter
     private Function<Trade, Boolean> unFailTradeCallback;
@@ -59,12 +60,14 @@ public class FailedTradesManager implements PersistedDataHost {
                                PriceFeedService priceFeedService,
                                BtcWalletService btcWalletService,
                                PersistenceManager<TradableList<Trade>> persistenceManager,
+                               TradeUtil tradeUtil,
                                DumpDelayedPayoutTx dumpDelayedPayoutTx) {
         this.keyRing = keyRing;
         this.priceFeedService = priceFeedService;
         this.btcWalletService = btcWalletService;
         this.dumpDelayedPayoutTx = dumpDelayedPayoutTx;
         this.persistenceManager = persistenceManager;
+        this.tradeUtil = tradeUtil;
 
         this.persistenceManager.initialize(failedTrades, "FailedTrades", PersistenceManager.Source.PRIVATE);
     }
@@ -127,7 +130,7 @@ public class FailedTradesManager implements PersistedDataHost {
     }
 
     public String checkUnFail(Trade trade) {
-        var addresses = TradeUtils.getTradeAddresses(trade, btcWalletService, keyRing);
+        var addresses = tradeUtil.getTradeAddresses(trade);
         if (addresses == null) {
             return "Addresses not found";
         }

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -217,15 +217,26 @@ message TradeInfo {
     OfferInfo offer = 1;
     string tradeId = 2;
     string shortId = 3;
-    string state = 4;
-    string phase = 5;
-    string tradePeriodState = 6;
-    bool isDepositPublished = 7;
-    bool isDepositConfirmed = 8;
-    bool isFiatSent = 9;
-    bool isFiatReceived = 10;
-    bool isPayoutPublished = 11;
-    bool isWithdrawn = 12;
+    uint64 date = 4;
+    bool isCurrencyForTakerFeeBtc = 5;
+    uint64 txFeeAsLong = 6;
+    uint64 takerFeeAsLong = 7;
+    string takerFeeTxId = 8;
+    string depositTxId = 9;
+    string payoutTxId = 10;
+    uint64 tradeAmountAsLong = 11;
+    uint64 tradePrice = 12;
+    string tradingPeerNodeAddress = 13;
+    string state = 14;
+    string phase = 15;
+    string tradePeriodState = 16;
+    bool isDepositPublished = 17;
+    bool isDepositConfirmed = 18;
+    bool isFiatSent = 19;
+    bool isFiatReceived = 20;
+    bool isPayoutPublished = 21;
+    bool isWithdrawn = 22;
+    string contractAsJson = 23;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The API is going to need some desktop trade utilities, which should be shared between `:desktop` and `:core.api`.   


The next PR in this chain will move trade related utilities in desktop model classes into this new singleton.

https://github.com/bisq-network/bisq/pull/4696 should be reviewed and merged before this one.
