### PR TITLE
Remove outliers when calculating BSQ rate

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -416,6 +416,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         requestPersistence();
     }
 
+    public void setBsqAverageTrimThreshold(double bsqAverageTrimThreshold) {
+        prefPayload.setBsqAverageTrimThreshold(bsqAverageTrimThreshold);
+        requestPersistence();
+    }
+
     public Optional<AutoConfirmSettings> findAutoConfirmSettings(String currencyCode) {
         return prefPayload.getAutoConfirmSettingsList().stream()
                 .filter(e -> e.getCurrencyCode().equals(currencyCode))
@@ -1033,6 +1038,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         int getBlockNotifyPort();
 
         void setTacAcceptedV120(boolean tacAccepted);
+
+        void setBsqAverageTrimThreshold(double bsqAverageTrimThreshold);
 
         void setAutoConfirmSettings(AutoConfirmSettings autoConfirmSettings);
     }

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -124,6 +124,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
     private double buyerSecurityDepositAsPercentForCrypto = getDefaultBuyerSecurityDepositAsPercent();
     private int blockNotifyPort;
     private boolean tacAcceptedV120;
+    private double bsqAverageTrimThreshold = 0.05;
 
     // Added at 1.3.8
     private List<AutoConfirmSettings> autoConfirmSettingsList = new ArrayList<>();
@@ -188,9 +189,10 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .setBuyerSecurityDepositAsPercentForCrypto(buyerSecurityDepositAsPercentForCrypto)
                 .setBlockNotifyPort(blockNotifyPort)
                 .setTacAcceptedV120(tacAcceptedV120)
+                .setBsqAverageTrimThreshold(bsqAverageTrimThreshold)
                 .addAllAutoConfirmSettings(autoConfirmSettingsList.stream()
-                    .map(autoConfirmSettings -> ((protobuf.AutoConfirmSettings) autoConfirmSettings.toProtoMessage()))
-                    .collect(Collectors.toList()));
+                        .map(autoConfirmSettings -> ((protobuf.AutoConfirmSettings) autoConfirmSettings.toProtoMessage()))
+                        .collect(Collectors.toList()));
 
         Optional.ofNullable(backupDirectory).ifPresent(builder::setBackupDirectory);
         Optional.ofNullable(preferredTradeCurrency).ifPresent(e -> builder.setPreferredTradeCurrency((protobuf.TradeCurrency) e.toProtoMessage()));
@@ -280,6 +282,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.getBuyerSecurityDepositAsPercentForCrypto(),
                 proto.getBlockNotifyPort(),
                 proto.getTacAcceptedV120(),
+                proto.getBsqAverageTrimThreshold(),
                 proto.getAutoConfirmSettingsList().isEmpty() ? new ArrayList<>() :
                         new ArrayList<>(proto.getAutoConfirmSettingsList().stream()
                                 .map(AutoConfirmSettings::fromProto)

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1184,6 +1184,7 @@ setting.preferences.general=General preferences
 setting.preferences.explorer=Bitcoin Explorer
 setting.preferences.explorer.bsq=Bisq Explorer
 setting.preferences.deviation=Max. deviation from market price
+setting.preferences.bsqAverageTrimThreshold=Outlier threshold for BSQ rate
 setting.preferences.avoidStandbyMode=Avoid standby mode
 setting.preferences.autoConfirmXMR=XMR auto-confirm
 setting.preferences.autoConfirmEnabled=Enabled

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.dao.economy.dashboard;
 import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.TextFieldWithIcon;
+import bisq.desktop.util.AxisInlierUtils;
 
 import bisq.core.dao.DaoFacade;
 import bisq.core.dao.state.DaoStateListener;
@@ -112,8 +113,10 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
     private Label marketPriceLabel;
 
     private Coin availableAmount;
-
     private int gridRow = 0;
+    double percentToTrim = 5;
+    double howManyStdDevsConstituteOutlier = 10;
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor, lifecycle
@@ -121,10 +124,10 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
 
     @Inject
     public BsqDashboardView(DaoFacade daoFacade,
-                             TradeStatisticsManager tradeStatisticsManager,
-                             PriceFeedService priceFeedService,
-                             Preferences preferences,
-                             BsqFormatter bsqFormatter) {
+                            TradeStatisticsManager tradeStatisticsManager,
+                            PriceFeedService priceFeedService,
+                            Preferences preferences,
+                            BsqFormatter bsqFormatter) {
         this.daoFacade = daoFacade;
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.priceFeedService = priceFeedService;
@@ -134,7 +137,6 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
 
     @Override
     public void initialize() {
-
         ADJUSTERS.put(DAY, TemporalAdjusters.ofDateAdjuster(d -> d));
 
         createKPIs();
@@ -368,15 +370,24 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
     }
 
     private long updateAveragePriceField(TextField textField, int days, boolean isUSDField) {
+        double percentToTrim = Math.max(0, Math.min(49, preferences.getBsqAverageTrimThreshold() * 100));
         Date pastXDays = getPastDate(days);
-        List<TradeStatistics3> bsqTradePastXDays = tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
+        List<TradeStatistics3> bsqAllTradePastXDays = tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
                 .filter(e -> e.getCurrency().equals("BSQ"))
                 .filter(e -> e.getDate().after(pastXDays))
                 .collect(Collectors.toList());
-        List<TradeStatistics3> usdTradePastXDays = tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
+        List<TradeStatistics3> bsqTradePastXDays = percentToTrim > 0 ?
+                removeOutliers(bsqAllTradePastXDays, percentToTrim) :
+                bsqAllTradePastXDays;
+
+        List<TradeStatistics3> usdAllTradePastXDays = tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
                 .filter(e -> e.getCurrency().equals("USD"))
                 .filter(e -> e.getDate().after(pastXDays))
                 .collect(Collectors.toList());
+        List<TradeStatistics3> usdTradePastXDays = percentToTrim > 0 ?
+                removeOutliers(usdAllTradePastXDays, percentToTrim) :
+                usdAllTradePastXDays;
+
         long average = isUSDField ? getUSDAverage(bsqTradePastXDays, usdTradePastXDays) :
                 getBTCAverage(bsqTradePastXDays);
         Price avgPrice = isUSDField ? Price.valueOf("USD", average) :
@@ -390,11 +401,26 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
         return average;
     }
 
-    private long getBTCAverage(List<TradeStatistics3> bsqList) {
+    private List<TradeStatistics3> removeOutliers(List<TradeStatistics3> list, double percentToTrim) {
+        List<Double> yValues = list.stream()
+                .filter(TradeStatistics3::isValid)
+                .map(e -> (double) e.getPrice())
+                .collect(Collectors.toList());
+
+        Tuple2<Double, Double> tuple = AxisInlierUtils.findInlierRange(yValues, percentToTrim, howManyStdDevsConstituteOutlier);
+        double lowerBound = tuple.first;
+        double upperBound = tuple.second;
+        return list.stream()
+                .filter(e -> e.getPrice() > lowerBound)
+                .filter(e -> e.getPrice() < upperBound)
+                .collect(Collectors.toList());
+    }
+
+    private long getBTCAverage(List<TradeStatistics3> list) {
         long accumulatedVolume = 0;
         long accumulatedAmount = 0;
 
-        for (TradeStatistics3 item : bsqList) {
+        for (TradeStatistics3 item : list) {
             accumulatedVolume += item.getTradeVolume().getValue();
             accumulatedAmount += item.getTradeAmount().getValue(); // Amount of BTC traded
         }

--- a/desktop/src/main/java/bisq/desktop/util/AxisInlierUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/AxisInlierUtils.java
@@ -91,7 +91,7 @@ public class AxisInlierUtils {
     /* Finds the minimum and maximum inlier values. The returned values may be NaN.
      * See `computeInlierThreshold` for the definition of inlier.
      */
-    private static Tuple2<Double, Double> findInlierRange(
+    public static Tuple2<Double, Double> findInlierRange(
             List<Double> yValues,
             double percentToTrim,
             double howManyStdDevsConstituteOutlier

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1576,6 +1576,7 @@ message PreferencesPayload {
     int32 css_theme = 54;
     bool tac_accepted_v120 = 55;
     repeated AutoConfirmSettings auto_confirm_settings = 56;
+    double bsq_average_trim_threshold = 57;
 }
 
 message AutoConfirmSettings {


### PR DESCRIPTION
Remove outliers when calculating BSQ rate.
Add percentage for upper and lower threshold for outlier detection.
It filters outliers in the BSQ and in the USD market.

Settings:
<img width="322" alt="settings" src="https://user-images.githubusercontent.com/54558767/97122115-4b3ab480-16f1-11eb-9ae5-640e22ab1cbb.png">

As one can see below even a small % threshold removes the few outliers we had recently: 5 % is default value.

With 0%:
<img width="1187" alt="0perc" src="https://user-images.githubusercontent.com/54558767/97122092-2a725f00-16f1-11eb-8157-7f015d625b7a.png">

With 1%:
<img width="1194" alt="1perc" src="https://user-images.githubusercontent.com/54558767/97122095-2e05e600-16f1-11eb-8bf6-c9472c7e948f.png">

With 5%:
<img width="1185" alt="5perc" src="https://user-images.githubusercontent.com/54558767/97122098-33fbc700-16f1-11eb-9c24-162e0a0effaf.png">

With 10%:
<img width="1194" alt="10perc" src="https://user-images.githubusercontent.com/54558767/97122104-378f4e00-16f1-11eb-85eb-56d917693a33.png">

With 20%:
<img width="1195" alt="20perc" src="https://user-images.githubusercontent.com/54558767/97122106-39591180-16f1-11eb-8981-b316c43a3859.png">

With 49% (max):
<img width="1188" alt="Screen Shot 2020-10-25 at 18 39 56" src="https://user-images.githubusercontent.com/54558767/97122141-8937d880-16f1-11eb-939c-fd567aa340df.png">



