### PR TITLE
Segwit fee estimation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ configure(subprojects) {
 
     ext { // in alphabetical order
         bcVersion = '1.63'
-        bitcoinjVersion = 'fcec3da'
+        bitcoinjVersion = '60b4f2f'
         btcdCli4jVersion = '27b94333'
         codecVersion = '1.13'
         easybindVersion = '1.0.3'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ configure(subprojects) {
 
     ext { // in alphabetical order
         bcVersion = '1.63'
-        bitcoinjVersion = 'a733034'
+        bitcoinjVersion = 'fcec3da'
         btcdCli4jVersion = '27b94333'
         codecVersion = '1.13'
         easybindVersion = '1.0.3'

--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -92,10 +92,13 @@ public class Version {
 
     // The version no. of the current protocol. The offer holds that version.
     // A taker will check the version of the offers to see if his version is compatible.
-    // Offers created with the old version will become invalid and have to be canceled.
+    // For the switch to version 2, offers created with the old version will become invalid and have to be canceled.
+    // For the switch to version 3, offers created with the old version can be migrated to version 3 just by opening
+    // the Bisq app.
     // VERSION = 0.5.0 -> TRADE_PROTOCOL_VERSION = 1
     // Version 1.2.2 -> TRADE_PROTOCOL_VERSION = 2
-    public static final int TRADE_PROTOCOL_VERSION = 2;
+    // Version 1.5.0 -> TRADE_PROTOCOL_VERSION = 3
+    public static final int TRADE_PROTOCOL_VERSION = 3;
     private static int p2pMessageVersion;
 
     public static final String BSQ_TX_VERSION = "1";

--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -107,7 +107,7 @@ public class WalletAppSetup {
               Runnable downloadCompleteHandler,
               Runnable walletInitializedHandler) {
         log.info("Initialize WalletAppSetup with BitcoinJ version {} and hash of BitcoinJ commit {}",
-                VersionMessage.BITCOINJ_VERSION, "fcec3da");
+                VersionMessage.BITCOINJ_VERSION, "60b4f2f");
 
         ObjectProperty<Throwable> walletServiceException = new SimpleObjectProperty<>();
         btcInfoBinding = EasyBind.combine(walletsSetup.downloadPercentageProperty(),

--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -107,7 +107,7 @@ public class WalletAppSetup {
               Runnable downloadCompleteHandler,
               Runnable walletInitializedHandler) {
         log.info("Initialize WalletAppSetup with BitcoinJ version {} and hash of BitcoinJ commit {}",
-                VersionMessage.BITCOINJ_VERSION, "a733034");
+                VersionMessage.BITCOINJ_VERSION, "fcec3da");
 
         ObjectProperty<Throwable> walletServiceException = new SimpleObjectProperty<>();
         btcInfoBinding = EasyBind.combine(walletsSetup.downloadPercentageProperty(),

--- a/core/src/main/java/bisq/core/btc/TxFeeEstimationService.java
+++ b/core/src/main/java/bisq/core/btc/TxFeeEstimationService.java
@@ -107,7 +107,7 @@ public class TxFeeEstimationService {
             estimatedTxSize = getEstimatedTxSize(List.of(tradeFee, amount), estimatedTxSize, txFeePerByte, btcWalletService);
         } catch (InsufficientMoneyException e) {
             if (isTaker) {
-                // if we cannot do the estimation we use the deposit tx size
+                // If we cannot do the estimation, we use the size o the largest of our txs which is the deposit tx.
                 estimatedTxSize = DEPOSIT_TX_SIZE;
             }
             log.info("We cannot do the fee estimation because there are not enough funds in the wallet. This is expected " +

--- a/core/src/main/java/bisq/core/btc/TxFeeEstimationService.java
+++ b/core/src/main/java/bisq/core/btc/TxFeeEstimationService.java
@@ -57,7 +57,6 @@ public class TxFeeEstimationService {
 //  segwit delayed payout tx vsize = 139
     public static int TYPICAL_TX_WITH_1_INPUT_SIZE = 175;
     private static int DEPOSIT_TX_SIZE = 233;
-    private static int PAYOUT_TX_SIZE = 169;
 
     private static int BSQ_INPUT_INCREASE = 150;
     private static int MAX_ITERATIONS = 10;

--- a/core/src/main/java/bisq/core/btc/model/AddressEntry.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntry.java
@@ -97,10 +97,6 @@ public final class AddressEntry implements PersistablePayload {
                         Context context,
                         @Nullable String offerId,
                         boolean segwit) {
-        if (segwit && (!Context.AVAILABLE.equals(context) || offerId != null)) {
-            throw new IllegalArgumentException("Segwit addresses are only allowed for " +
-                    "AVAILABLE entries without an offerId");
-        }
         this.keyPair = keyPair;
         this.context = context;
         this.offerId = offerId;

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -27,7 +27,6 @@ import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
 
-import bisq.common.config.Config;
 import bisq.common.handlers.ErrorMessageHandler;
 
 import org.bitcoinj.core.Address;

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -34,7 +34,7 @@ import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.InsufficientMoneyException;
-import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.SegwitAddress;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionInput;
@@ -992,7 +992,9 @@ public class BtcWalletService extends WalletService {
                 counter++;
                 fee = txFeeForWithdrawalPerByte.multiply(txSize);
                 // We use a dummy address for the output
-                final String dummyReceiver = LegacyAddress.fromKey(params, new ECKey()).toBase58();
+                // We don't know here whether the output is segwit or not but we don't care too much because the size of
+                // a segwit ouput is just 3 byte smaller than the size of a legacy ouput.
+                final String dummyReceiver = SegwitAddress.fromKey(params, new ECKey()).toString();
                 SendRequest sendRequest = getSendRequestForMultipleAddresses(fromAddresses, dummyReceiver, amount, fee, null, aesKey);
                 wallet.completeTx(sendRequest);
                 tx = sendRequest.tx;
@@ -1021,7 +1023,9 @@ public class BtcWalletService extends WalletService {
     public int getEstimatedFeeTxSize(List<Coin> outputValues, Coin txFee)
             throws InsufficientMoneyException, AddressFormatException {
         Transaction transaction = new Transaction(params);
-        Address dummyAddress = LegacyAddress.fromKey(params, new ECKey());
+        // In reality txs have a mix of segwit/legacy ouputs, but we don't care too much because the size of
+        // a segwit ouput is just 3 byte smaller than the size of a legacy ouput.
+        Address dummyAddress = SegwitAddress.fromKey(params, new ECKey());
         outputValues.forEach(outputValue -> transaction.addOutput(outputValue, dummyAddress));
 
         SendRequest sendRequest = SendRequest.forTx(transaction);

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -584,6 +584,8 @@ public class BtcWalletService extends WalletService {
             TransactionOutput connectedOutput = input.getConnectedOutput();
             if (connectedOutput == null || ScriptPattern.isP2PKH(connectedOutput.getScriptPubKey()) ||
                 ScriptPattern.isP2PK(connectedOutput.getScriptPubKey())) {
+                // If connectedOutput is null, we don't know here the input type. To avoid underpaying fees,
+                // we treat it as a legacy input which will result in a higher fee estimation.
                 numLegacyInputs++;
             } else if (ScriptPattern.isP2WPKH(connectedOutput.getScriptPubKey())) {
                 numSegwitInputs++;

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -27,6 +27,7 @@ import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
 
+import bisq.common.config.Config;
 import bisq.common.handlers.ErrorMessageHandler;
 
 import org.bitcoinj.core.Address;
@@ -579,18 +580,17 @@ public class BtcWalletService extends WalletService {
         if (addressEntry.isPresent()) {
             return addressEntry.get();
         } else {
-            // We still use non-segwit addresses for the trade protocol.
             // We try to use available and not yet used entries
             Optional<AddressEntry> emptyAvailableAddressEntry = getAddressEntryListAsImmutableList().stream()
                     .filter(e -> AddressEntry.Context.AVAILABLE == e.getContext())
                     .filter(e -> isAddressUnused(e.getAddress()))
-                    .filter(e -> Script.ScriptType.P2PKH.equals(e.getAddress().getOutputScriptType()))
+                    .filter(e -> Script.ScriptType.P2WPKH.equals(e.getAddress().getOutputScriptType()))
                     .findAny();
             if (emptyAvailableAddressEntry.isPresent()) {
                 return addressEntryList.swapAvailableToAddressEntryWithOfferId(emptyAvailableAddressEntry.get(), context, offerId);
             } else {
-                DeterministicKey key = (DeterministicKey) wallet.findKeyFromAddress(wallet.freshReceiveAddress(Script.ScriptType.P2PKH));
-                AddressEntry entry = new AddressEntry(key, context, offerId, false);
+                DeterministicKey key = (DeterministicKey) wallet.findKeyFromAddress(wallet.freshReceiveAddress(Script.ScriptType.P2WPKH));
+                AddressEntry entry = new AddressEntry(key, context, offerId, true);
                 addressEntryList.addAddressEntry(entry);
                 return entry;
             }

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -263,7 +263,7 @@ public class BtcWalletService extends WalletService {
             resultTx.addOutput(new TransactionOutput(params, resultTx, Coin.ZERO, ScriptBuilder.createOpReturnScript(opReturnData).getProgram()));
 
             numInputs = resultTx.getInputs().size();
-            txSizeWithUnsignedInputs = resultTx.bitcoinSerialize().length;
+            txSizeWithUnsignedInputs = resultTx.getVsize();
             long estimatedFeeAsLong = txFeePerByte.multiply(txSizeWithUnsignedInputs + sigSizePerInput * numInputs).value;
             // calculated fee must be inside of a tolerance range with tx fee
             isFeeOutsideTolerance = Math.abs(resultTx.getFee().value - estimatedFeeAsLong) > 1000;
@@ -373,7 +373,7 @@ public class BtcWalletService extends WalletService {
             resultTx.addOutput(new TransactionOutput(params, resultTx, Coin.ZERO, ScriptBuilder.createOpReturnScript(opReturnData).getProgram()));
 
             numInputs = resultTx.getInputs().size();
-            txSizeWithUnsignedInputs = resultTx.bitcoinSerialize().length;
+            txSizeWithUnsignedInputs = resultTx.getVsize();
             final long estimatedFeeAsLong = txFeePerByte.multiply(txSizeWithUnsignedInputs + sigSizePerInput * numInputs).value;
             // calculated fee must be inside of a tolerance range with tx fee
             isFeeOutsideTolerance = Math.abs(resultTx.getFee().value - estimatedFeeAsLong) > 1000;
@@ -529,14 +529,14 @@ public class BtcWalletService extends WalletService {
                 resultTx.addOutput(new TransactionOutput(params, resultTx, Coin.ZERO, ScriptBuilder.createOpReturnScript(opReturnData).getProgram()));
 
             numInputs = resultTx.getInputs().size();
-            txSizeWithUnsignedInputs = resultTx.bitcoinSerialize().length;
+            txSizeWithUnsignedInputs = resultTx.getVsize();
             final long estimatedFeeAsLong = txFeePerByte.multiply(txSizeWithUnsignedInputs + sigSizePerInput * numInputs).value;
             // calculated fee must be inside of a tolerance range with tx fee
             isFeeOutsideTolerance = Math.abs(resultTx.getFee().value - estimatedFeeAsLong) > 1000;
         }
         while (opReturnIsOnlyOutput ||
                 isFeeOutsideTolerance ||
-                resultTx.getFee().value < txFeePerByte.multiply(resultTx.bitcoinSerialize().length).value);
+                resultTx.getFee().value < txFeePerByte.multiply(resultTx.getVsize()).value);
 
         // Sign all BTC inputs
         signAllBtcInputs(preparedBsqTxInputs.size(), resultTx);
@@ -809,7 +809,7 @@ public class BtcWalletService extends WalletService {
                 );
 
                 log.info("newTransaction no. of inputs " + newTransaction.getInputs().size());
-                log.info("newTransaction size in kB " + newTransaction.bitcoinSerialize().length / 1024);
+                log.info("newTransaction size in kB " + newTransaction.getVsize() / 1024);
 
                 if (!newTransaction.getInputs().isEmpty()) {
                     Coin amount = Coin.valueOf(newTransaction.getInputs().stream()
@@ -839,7 +839,7 @@ public class BtcWalletService extends WalletService {
                             sendRequest.changeAddress = toAddress;
                             wallet.completeTx(sendRequest);
                             tx = sendRequest.tx;
-                            txSize = tx.bitcoinSerialize().length;
+                            txSize = tx.getVsize();
                             printTx("FeeEstimationTransaction", tx);
                             sendRequest.tx.getOutputs().forEach(o -> log.debug("Output value " + o.getValue().toFriendlyString()));
                         }
@@ -947,7 +947,7 @@ public class BtcWalletService extends WalletService {
                 SendRequest sendRequest = getSendRequest(fromAddress, toAddress, amount, fee, aesKey, context);
                 wallet.completeTx(sendRequest);
                 tx = sendRequest.tx;
-                txSize = tx.bitcoinSerialize().length;
+                txSize = tx.getVsize();
                 printTx("FeeEstimationTransaction", tx);
             }
             while (feeEstimationNotSatisfied(counter, tx));
@@ -996,7 +996,7 @@ public class BtcWalletService extends WalletService {
                 SendRequest sendRequest = getSendRequestForMultipleAddresses(fromAddresses, dummyReceiver, amount, fee, null, aesKey);
                 wallet.completeTx(sendRequest);
                 tx = sendRequest.tx;
-                txSize = tx.bitcoinSerialize().length;
+                txSize = tx.getVsize();
                 printTx("FeeEstimationTransactionForMultipleAddresses", tx);
             }
             while (feeEstimationNotSatisfied(counter, tx));
@@ -1012,7 +1012,7 @@ public class BtcWalletService extends WalletService {
     }
 
     private boolean feeEstimationNotSatisfied(int counter, Transaction tx) {
-        long targetFee = getTxFeeForWithdrawalPerByte().multiply(tx.bitcoinSerialize().length).value;
+        long targetFee = getTxFeeForWithdrawalPerByte().multiply(tx.getVsize()).value;
         return counter < 10 &&
                 (tx.getFee().value < targetFee ||
                         tx.getFee().value - targetFee > 1000);
@@ -1034,7 +1034,7 @@ public class BtcWalletService extends WalletService {
         sendRequest.ensureMinRequiredFee = false;
         sendRequest.changeAddress = dummyAddress;
         wallet.completeTx(sendRequest);
-        return transaction.bitcoinSerialize().length;
+        return transaction.getVsize();
     }
 
 

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -36,7 +36,6 @@ import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.InsufficientMoneyException;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.SegwitAddress;
 import org.bitcoinj.core.Sha256Hash;

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -1275,11 +1275,8 @@ public class TradeWalletService {
                 input.setScriptSig(ScriptBuilder.createInputScript(txSig, sigKey));
             }
         } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
-            // TODO: Consider using this alternative way to build the scriptCode (taken from bitcoinj master)
-            // Script scriptCode = ScriptBuilder.createP2PKHOutputScript(sigKey)
-            Script scriptCode = new ScriptBuilder().data(
-                    ScriptBuilder.createOutputScript(LegacyAddress.fromKey(transaction.getParams(), sigKey)).getProgram())
-                    .build();
+            // scriptCode is expected to have the format of a legacy P2PKH output script
+            Script scriptCode = ScriptBuilder.createP2PKHOutputScript(sigKey);
             Coin value = input.getValue();
             TransactionSignature txSig = transaction.calculateWitnessSignature(inputIndex, sigKey, scriptCode, value,
                     Transaction.SigHash.ALL, false);

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -38,6 +38,7 @@ import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.SegwitAddress;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.SignatureDecodeException;
 import org.bitcoinj.core.Transaction;
@@ -336,7 +337,7 @@ public class TradeWalletService {
         Transaction dummyTX = new Transaction(params);
         // The output is just used to get the right inputs and change outputs, so we use an anonymous ECKey, as it will never be used for anything.
         // We don't care about fee calculation differences between the real tx and that dummy tx as we use a static tx fee.
-        TransactionOutput dummyOutput = new TransactionOutput(params, dummyTX, dummyOutputAmount, LegacyAddress.fromKey(params, new ECKey()));
+        TransactionOutput dummyOutput = new TransactionOutput(params, dummyTX, dummyOutputAmount, SegwitAddress.fromKey(params, new ECKey()));
         dummyTX.addOutput(dummyOutput);
 
         // Find the needed inputs to pay the output, optionally add 1 change output.
@@ -455,7 +456,7 @@ public class TradeWalletService {
         // First we construct a dummy TX to get the inputs and outputs we want to use for the real deposit tx.
         // Similar to the way we did in the createTakerDepositTxInputs method.
         Transaction dummyTx = new Transaction(params);
-        TransactionOutput dummyOutput = new TransactionOutput(params, dummyTx, makerInputAmount, LegacyAddress.fromKey(params, new ECKey()));
+        TransactionOutput dummyOutput = new TransactionOutput(params, dummyTx, makerInputAmount, SegwitAddress.fromKey(params, new ECKey()));
         dummyTx.addOutput(dummyOutput);
         addAvailableInputsAndChangeOutputs(dummyTx, makerAddress, makerChangeAddress);
         // Normally we have only 1 input but we support multiple inputs if the user has paid in with several transactions.

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -1171,6 +1171,10 @@ public class TradeWalletService {
                 "input.getConnectedOutput().getParentTransaction() must not be null");
         checkNotNull(input.getValue(), "input.getValue() must not be null");
 
+        // bitcoinSerialize(false) is used just in case the serialized tx is parsed by a bisq node still using
+        // bitcoinj 0.14. This is not supposed to happen ever since Version.TRADE_PROTOCOL_VERSION was set to 3,
+        // but it costs nothing to be on the safe side.
+        // The serialized tx is just used to obtain its hash, so the witness data is not relevant.
         return new RawTransactionInput(input.getOutpoint().getIndex(),
                 input.getConnectedOutput().getParentTransaction().bitcoinSerialize(false),
                 input.getValue().value);

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -502,12 +502,12 @@ public class TradeWalletService {
 
 
         // Add MultiSig output
-        Script p2SHMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey);
+        Script hashedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey, false);
 
         // Tx fee for deposit tx will be paid by buyer.
-        TransactionOutput p2SHMultiSigOutput = new TransactionOutput(params, preparedDepositTx, msOutputAmount,
-                p2SHMultiSigOutputScript.getProgram());
-        preparedDepositTx.addOutput(p2SHMultiSigOutput);
+        TransactionOutput hashedMultiSigOutput = new TransactionOutput(params, preparedDepositTx, msOutputAmount,
+                hashedMultiSigOutputScript.getProgram());
+        preparedDepositTx.addOutput(hashedMultiSigOutput);
 
         // We add the hash ot OP_RETURN with a 0 amount output
         TransactionOutput contractHashOutput = new TransactionOutput(params, preparedDepositTx, Coin.ZERO,
@@ -587,9 +587,9 @@ public class TradeWalletService {
         checkArgument(!sellerInputs.isEmpty());
 
         // Check if maker's MultiSig script is identical to the takers
-        Script p2SHMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey);
-        if (!makersDepositTx.getOutput(0).getScriptPubKey().equals(p2SHMultiSigOutputScript)) {
-            throw new TransactionVerificationException("Maker's p2SHMultiSigOutputScript does not match to takers p2SHMultiSigOutputScript");
+        Script hashedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey, false);
+        if (!makersDepositTx.getOutput(0).getScriptPubKey().equals(hashedMultiSigOutputScript)) {
+            throw new TransactionVerificationException("Maker's hashedMultiSigOutputScript does not match to takers hashedMultiSigOutputScript");
         }
 
         // The outpoints are not available from the serialized makersDepositTx, so we cannot use that tx directly, but we use it to construct a new
@@ -692,11 +692,11 @@ public class TradeWalletService {
                                                      Coin minerFee,
                                                      long lockTime)
             throws AddressFormatException, TransactionVerificationException {
-        TransactionOutput p2SHMultiSigOutput = depositTx.getOutput(0);
+        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
         Transaction delayedPayoutTx = new Transaction(params);
-        delayedPayoutTx.addInput(p2SHMultiSigOutput);
+        delayedPayoutTx.addInput(hashedMultiSigOutput);
         applyLockTime(lockTime, delayedPayoutTx);
-        Coin outputAmount = p2SHMultiSigOutput.getValue().subtract(minerFee);
+        Coin outputAmount = hashedMultiSigOutput.getValue().subtract(minerFee);
         delayedPayoutTx.addOutput(outputAmount, Address.fromString(params, donationAddressString));
         WalletService.printTx("Unsigned delayedPayoutTx ToDonationAddress", delayedPayoutTx);
         WalletService.verifyTransaction(delayedPayoutTx);
@@ -704,13 +704,17 @@ public class TradeWalletService {
     }
 
     public byte[] signDelayedPayoutTx(Transaction delayedPayoutTx,
+                                      Transaction preparedDepositTx,
                                       DeterministicKey myMultiSigKeyPair,
                                       byte[] buyerPubKey,
                                       byte[] sellerPubKey)
             throws AddressFormatException, TransactionVerificationException {
 
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
-        Sha256Hash sigHash = delayedPayoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        Sha256Hash sigHash;
+        Coin delayedPayoutTxInputValue = preparedDepositTx.getOutput(0).getValue();
+        sigHash = delayedPayoutTx.hashForWitnessSignature(0, redeemScript,
+                                    delayedPayoutTxInputValue, Transaction.SigHash.ALL, false);
         checkNotNull(myMultiSigKeyPair, "myMultiSigKeyPair must not be null");
         if (myMultiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -733,9 +737,10 @@ public class TradeWalletService {
         ECKey.ECDSASignature sellerECDSASignature = ECKey.ECDSASignature.decodeFromDER(sellerSignature);
         TransactionSignature buyerTxSig = new TransactionSignature(buyerECDSASignature, Transaction.SigHash.ALL, false);
         TransactionSignature sellerTxSig = new TransactionSignature(sellerECDSASignature, Transaction.SigHash.ALL, false);
-        Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig), redeemScript);
         TransactionInput input = delayedPayoutTx.getInput(0);
-        input.setScriptSig(inputScript);
+        input.setScriptSig(ScriptBuilder.createEmpty());
+        TransactionWitness witness = TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig);
+        input.setWitness(witness);
         WalletService.printTx("finalizeDelayedPayoutTx", delayedPayoutTx);
         WalletService.verifyTransaction(delayedPayoutTx);
         WalletService.checkWalletConsistency(wallet);
@@ -779,7 +784,15 @@ public class TradeWalletService {
         // MS redeemScript
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
         // MS output from prev. tx is index 0
-        Sha256Hash sigHash = preparedPayoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        Sha256Hash sigHash;
+        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
+        if (ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey())) {
+            sigHash = preparedPayoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        } else {
+            Coin inputValue = hashedMultiSigOutput.getValue();
+            sigHash = preparedPayoutTx.hashForWitnessSignature(0, redeemScript,
+                    inputValue, Transaction.SigHash.ALL, false);
+        }
         checkNotNull(multiSigKeyPair, "multiSigKeyPair must not be null");
         if (multiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -822,7 +835,16 @@ public class TradeWalletService {
         // MS redeemScript
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
         // MS output from prev. tx is index 0
-        Sha256Hash sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
+        boolean hashedMultiSigOutputIsLegacy = ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
+        Sha256Hash sigHash;
+        if (hashedMultiSigOutputIsLegacy) {
+            sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        } else {
+            Coin inputValue = hashedMultiSigOutput.getValue();
+            sigHash = payoutTx.hashForWitnessSignature(0, redeemScript,
+                    inputValue, Transaction.SigHash.ALL, false);
+        }
         checkNotNull(multiSigKeyPair, "multiSigKeyPair must not be null");
         if (multiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -832,10 +854,16 @@ public class TradeWalletService {
                 Transaction.SigHash.ALL, false);
         TransactionSignature sellerTxSig = new TransactionSignature(sellerSignature, Transaction.SigHash.ALL, false);
         // Take care of order of signatures. Need to be reversed here. See comment below at getMultiSigRedeemScript (seller, buyer)
-        Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig),
-                redeemScript);
         TransactionInput input = payoutTx.getInput(0);
-        input.setScriptSig(inputScript);
+        if (hashedMultiSigOutputIsLegacy) {
+            Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig),
+                    redeemScript);
+            input.setScriptSig(inputScript);
+        } else {
+            input.setScriptSig(ScriptBuilder.createEmpty());
+            TransactionWitness witness = TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig);
+            input.setWitness(witness);
+        }
         WalletService.printTx("payoutTx", payoutTx);
         WalletService.verifyTransaction(payoutTx);
         WalletService.checkWalletConsistency(wallet);
@@ -863,7 +891,16 @@ public class TradeWalletService {
         // MS redeemScript
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
         // MS output from prev. tx is index 0
-        Sha256Hash sigHash = preparedPayoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
+        boolean hashedMultiSigOutputIsLegacy = ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
+        Sha256Hash sigHash;
+        if (hashedMultiSigOutputIsLegacy) {
+            sigHash = preparedPayoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        } else {
+            Coin inputValue = hashedMultiSigOutput.getValue();
+            sigHash = preparedPayoutTx.hashForWitnessSignature(0, redeemScript,
+                    inputValue, Transaction.SigHash.ALL, false);
+        }
         checkNotNull(myMultiSigKeyPair, "myMultiSigKeyPair must not be null");
         if (myMultiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -895,9 +932,18 @@ public class TradeWalletService {
         TransactionSignature sellerTxSig = new TransactionSignature(ECKey.ECDSASignature.decodeFromDER(sellerSignature),
                 Transaction.SigHash.ALL, false);
         // Take care of order of signatures. Need to be reversed here. See comment below at getMultiSigRedeemScript (seller, buyer)
-        Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig), redeemScript);
+        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
+        boolean hashedMultiSigOutputIsLegacy = ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
         TransactionInput input = payoutTx.getInput(0);
-        input.setScriptSig(inputScript);
+        if (hashedMultiSigOutputIsLegacy) {
+            Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig),
+                    redeemScript);
+            input.setScriptSig(inputScript);
+        } else {
+            input.setScriptSig(ScriptBuilder.createEmpty());
+            TransactionWitness witness = TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig);
+            input.setWitness(witness);
+        }
         WalletService.printTx("mediated payoutTx", payoutTx);
         WalletService.verifyTransaction(payoutTx);
         WalletService.checkWalletConsistency(wallet);
@@ -945,9 +991,9 @@ public class TradeWalletService {
                                                              byte[] arbitratorPubKey)
             throws AddressFormatException, TransactionVerificationException, WalletException, SignatureDecodeException {
         Transaction depositTx = new Transaction(params, depositTxSerialized);
-        TransactionOutput p2SHMultiSigOutput = depositTx.getOutput(0);
+        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
         Transaction payoutTx = new Transaction(params);
-        payoutTx.addInput(p2SHMultiSigOutput);
+        payoutTx.addInput(hashedMultiSigOutput);
         if (buyerPayoutAmount.isPositive()) {
             payoutTx.addOutput(buyerPayoutAmount, Address.fromString(params, buyerAddressString));
         }
@@ -957,7 +1003,15 @@ public class TradeWalletService {
 
         // take care of sorting!
         Script redeemScript = get2of3MultiSigRedeemScript(buyerPubKey, sellerPubKey, arbitratorPubKey);
-        Sha256Hash sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        Sha256Hash sigHash;
+        boolean hashedMultiSigOutputIsLegacy = !ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
+        if (hashedMultiSigOutputIsLegacy) {
+            sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        } else {
+            Coin inputValue = hashedMultiSigOutput.getValue();
+            sigHash = payoutTx.hashForWitnessSignature(0, redeemScript,
+                    inputValue, Transaction.SigHash.ALL, false);
+        }
         checkNotNull(tradersMultiSigKeyPair, "tradersMultiSigKeyPair must not be null");
         if (tradersMultiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -966,11 +1020,18 @@ public class TradeWalletService {
         TransactionSignature tradersTxSig = new TransactionSignature(tradersSignature, Transaction.SigHash.ALL, false);
         TransactionSignature arbitratorTxSig = new TransactionSignature(ECKey.ECDSASignature.decodeFromDER(arbitratorSignature),
                 Transaction.SigHash.ALL, false);
-        // Take care of order of signatures. See comment below at getMultiSigRedeemScript (sort order needed here: arbitrator, seller, buyer)
-        Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(arbitratorTxSig, tradersTxSig),
-                redeemScript);
         TransactionInput input = payoutTx.getInput(0);
-        input.setScriptSig(inputScript);
+        // Take care of order of signatures. See comment below at getMultiSigRedeemScript (sort order needed here: arbitrator, seller, buyer)
+        if (hashedMultiSigOutputIsLegacy) {
+            Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(
+                                                        ImmutableList.of(arbitratorTxSig, tradersTxSig),
+                                                        redeemScript);
+            input.setScriptSig(inputScript);
+        } else {
+            input.setScriptSig(ScriptBuilder.createEmpty());
+            TransactionWitness witness = TransactionWitness.redeemP2WSH(redeemScript, arbitratorTxSig, tradersTxSig);
+            input.setWitness(witness);
+        }
         WalletService.printTx("disputed payoutTx", payoutTx);
         WalletService.verifyTransaction(payoutTx);
         WalletService.checkWalletConsistency(wallet);
@@ -995,21 +1056,23 @@ public class TradeWalletService {
                                                                 String sellerPrivateKeyAsHex,
                                                                 String buyerPubKeyAsHex,
                                                                 String sellerPubKeyAsHex,
+                                                                boolean hashedMultiSigOutputIsLegacy,
                                                                 TxBroadcaster.Callback callback)
             throws AddressFormatException, TransactionVerificationException, WalletException {
         byte[] buyerPubKey = ECKey.fromPublicOnly(Utils.HEX.decode(buyerPubKeyAsHex)).getPubKey();
         byte[] sellerPubKey = ECKey.fromPublicOnly(Utils.HEX.decode(sellerPubKeyAsHex)).getPubKey();
 
-        Script p2SHMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey);
+        Script hashedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey,
+                                                                        hashedMultiSigOutputIsLegacy);
 
-        Coin msOutput = buyerPayoutAmount.add(sellerPayoutAmount).add(txFee);
-        TransactionOutput p2SHMultiSigOutput = new TransactionOutput(params, null, msOutput, p2SHMultiSigOutputScript.getProgram());
+        Coin msOutputValue = buyerPayoutAmount.add(sellerPayoutAmount).add(txFee);
+        TransactionOutput hashedMultiSigOutput = new TransactionOutput(params, null, msOutputValue, hashedMultiSigOutputScript.getProgram());
         Transaction depositTx = new Transaction(params);
-        depositTx.addOutput(p2SHMultiSigOutput);
+        depositTx.addOutput(hashedMultiSigOutput);
 
         Transaction payoutTx = new Transaction(params);
         Sha256Hash spendTxHash = Sha256Hash.wrap(depositTxHex);
-        payoutTx.addInput(new TransactionInput(params, depositTx, p2SHMultiSigOutputScript.getProgram(), new TransactionOutPoint(params, 0, spendTxHash), msOutput));
+        payoutTx.addInput(new TransactionInput(params, depositTx, null, new TransactionOutPoint(params, 0, spendTxHash), msOutputValue));
 
         if (buyerPayoutAmount.isPositive()) {
             payoutTx.addOutput(buyerPayoutAmount, Address.fromString(params, buyerAddressString));
@@ -1020,7 +1083,14 @@ public class TradeWalletService {
 
         // take care of sorting!
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
-        Sha256Hash sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        Sha256Hash sigHash;
+        if (hashedMultiSigOutputIsLegacy) {
+            sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
+        } else {
+            Coin inputValue = msOutputValue;
+            sigHash = payoutTx.hashForWitnessSignature(0, redeemScript,
+                    inputValue, Transaction.SigHash.ALL, false);
+        }
 
         ECKey buyerPrivateKey = ECKey.fromPrivate(Utils.HEX.decode(buyerPrivateKeyAsHex));
         checkNotNull(buyerPrivateKey, "key must not be null");
@@ -1032,10 +1102,18 @@ public class TradeWalletService {
 
         TransactionSignature buyerTxSig = new TransactionSignature(buyerECDSASignature, Transaction.SigHash.ALL, false);
         TransactionSignature sellerTxSig = new TransactionSignature(sellerECDSASignature, Transaction.SigHash.ALL, false);
-        Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig), redeemScript);
 
         TransactionInput input = payoutTx.getInput(0);
-        input.setScriptSig(inputScript);
+        if (hashedMultiSigOutputIsLegacy) {
+            Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig),
+                                                                             redeemScript);
+            input.setScriptSig(inputScript);
+        } else {
+            input.setScriptSig(ScriptBuilder.createEmpty());
+            TransactionWitness witness = TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig);
+            input.setWitness(witness);
+        }
+
         WalletService.printTx("payoutTx", payoutTx);
         WalletService.verifyTransaction(payoutTx);
         WalletService.checkWalletConsistency(wallet);
@@ -1144,8 +1222,13 @@ public class TradeWalletService {
         return ScriptBuilder.createMultiSigOutputScript(2, keys);
     }
 
-    private Script get2of2MultiSigOutputScript(byte[] buyerPubKey, byte[] sellerPubKey) {
-        return ScriptBuilder.createP2SHOutputScript(get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey));
+    private Script get2of2MultiSigOutputScript(byte[] buyerPubKey, byte[] sellerPubKey, boolean legacy) {
+        Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
+        if (legacy) {
+            return ScriptBuilder.createP2SHOutputScript(redeemScript);
+        } else {
+            return ScriptBuilder.createP2WSHOutputScript(redeemScript);
+        }
     }
 
     private Transaction createPayoutTx(Transaction depositTx,
@@ -1153,9 +1236,9 @@ public class TradeWalletService {
                                        Coin sellerPayoutAmount,
                                        String buyerAddressString,
                                        String sellerAddressString) throws AddressFormatException {
-        TransactionOutput p2SHMultiSigOutput = depositTx.getOutput(0);
+        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
         Transaction transaction = new Transaction(params);
-        transaction.addInput(p2SHMultiSigOutput);
+        transaction.addInput(hashedMultiSigOutput);
         if (buyerPayoutAmount.isPositive()) {
             transaction.addOutput(buyerPayoutAmount, Address.fromString(params, buyerAddressString));
         }

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -37,7 +37,6 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.InsufficientMoneyException;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -325,11 +325,8 @@ public abstract class WalletService {
                     }
                 } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
                     try {
-                        // TODO: Consider using this alternative way to build the scriptCode (taken from bitcoinj master)
-                        // Script scriptCode = ScriptBuilder.createP2PKHOutputScript(key);
-                        Script scriptCode = new ScriptBuilder().data(
-                                ScriptBuilder.createOutputScript(LegacyAddress.fromKey(tx.getParams(), key)).getProgram())
-                                .build();
+                        // scriptCode is expected to have the format of a legacy P2PKH output script
+                        Script scriptCode = ScriptBuilder.createP2PKHOutputScript(key);
                         Coin value = txIn.getValue();
                         TransactionSignature txSig = tx.calculateWitnessSignature(index, key, scriptCode, value,
                                 Transaction.SigHash.ALL, false);

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
@@ -195,7 +195,7 @@ public class MyBlindVoteListService implements PersistedDataHost, DaoStateListen
         Coin blindVoteFee = BlindVoteConsensus.getFee(daoStateService, daoStateService.getChainHeight());
         Transaction dummyTx = getBlindVoteTx(stake, blindVoteFee, new byte[22]);
         Coin miningFee = dummyTx.getFee();
-        int txSize = dummyTx.bitcoinSerialize().length;
+        int txSize = dummyTx.getVsize();
         return new Tuple2<>(miningFee, txSize);
     }
 

--- a/core/src/main/java/bisq/core/dao/governance/bond/lockup/LockupTxService.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/lockup/LockupTxService.java
@@ -95,7 +95,7 @@ public class LockupTxService {
             throws InsufficientMoneyException, WalletException, TransactionVerificationException, IOException {
         Transaction tx = getLockupTx(lockupAmount, lockTime, lockupReason, hash);
         Coin miningFee = tx.getFee();
-        int txSize = tx.bitcoinSerialize().length;
+        int txSize = tx.getVsize();
         return new Tuple2<>(miningFee, txSize);
     }
 

--- a/core/src/main/java/bisq/core/dao/governance/bond/unlock/UnlockTxService.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/unlock/UnlockTxService.java
@@ -93,7 +93,7 @@ public class UnlockTxService {
             throws InsufficientMoneyException, WalletException, TransactionVerificationException {
         Transaction tx = getUnlockTx(lockupTxId);
         Coin miningFee = tx.getFee();
-        int txSize = tx.bitcoinSerialize().length;
+        int txSize = tx.getVsize();
         return new Tuple2<>(miningFee, txSize);
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignsDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignsDelayedPayoutTx.java
@@ -24,7 +24,6 @@ import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
 
-import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.crypto.DeterministicKey;

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignsDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignsDelayedPayoutTx.java
@@ -24,6 +24,8 @@ import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
 
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.crypto.DeterministicKey;
 
@@ -46,7 +48,11 @@ public class BuyerSignsDelayedPayoutTx extends TradeTask {
             runInterceptHook();
 
             Transaction preparedDelayedPayoutTx = checkNotNull(processModel.getPreparedDelayedPayoutTx());
+
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            NetworkParameters params = btcWalletService.getParams();
+            Transaction preparedDepositTx = new Transaction(params, processModel.getPreparedDepositTx());
+
             String id = processModel.getOffer().getId();
 
             byte[] buyerMultiSigPubKey = processModel.getMyMultiSigPubKey();
@@ -58,6 +64,7 @@ public class BuyerSignsDelayedPayoutTx extends TradeTask {
             byte[] sellerMultiSigPubKey = processModel.getTradingPeer().getMultiSigPubKey();
             byte[] delayedPayoutTxSignature = processModel.getTradeWalletService().signDelayedPayoutTx(
                     preparedDelayedPayoutTx,
+                    preparedDepositTx,
                     myMultiSigKeyPair,
                     buyerMultiSigPubKey,
                     sellerMultiSigPubKey);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignsDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignsDelayedPayoutTx.java
@@ -24,7 +24,6 @@ import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
 
-import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.crypto.DeterministicKey;

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignsDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignsDelayedPayoutTx.java
@@ -24,6 +24,8 @@ import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
 
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.crypto.DeterministicKey;
 
@@ -47,6 +49,9 @@ public class SellerSignsDelayedPayoutTx extends TradeTask {
 
             Transaction preparedDelayedPayoutTx = checkNotNull(processModel.getPreparedDelayedPayoutTx());
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            NetworkParameters params = btcWalletService.getParams();
+            Transaction preparedDepositTx = new Transaction(params, processModel.getPreparedDepositTx());
+
             String id = processModel.getOffer().getId();
 
             byte[] sellerMultiSigPubKey = processModel.getMyMultiSigPubKey();
@@ -59,6 +64,7 @@ public class SellerSignsDelayedPayoutTx extends TradeTask {
 
             byte[] delayedPayoutTxSignature = processModel.getTradeWalletService().signDelayedPayoutTx(
                     preparedDelayedPayoutTx,
+                    preparedDepositTx,
                     myMultiSigKeyPair,
                     buyerMultiSigPubKey,
                     sellerMultiSigPubKey);

--- a/core/src/test/java/bisq/core/btc/TxFeeEstimationServiceTest.java
+++ b/core/src/test/java/bisq/core/btc/TxFeeEstimationServiceTest.java
@@ -45,14 +45,14 @@ public class TxFeeEstimationServiceTest {
         int realTxSize;
         Coin txFee;
 
-        initialEstimatedTxSize = 260;
+        initialEstimatedTxSize = 175;
         txFeePerByte = Coin.valueOf(10);
-        realTxSize = 260;
+        realTxSize = 175;
 
         txFee = txFeePerByte.multiply(initialEstimatedTxSize);
         when(btcWalletService.getEstimatedFeeTxSize(outputValues, txFee)).thenReturn(realTxSize);
         result = TxFeeEstimationService.getEstimatedTxSize(outputValues, initialEstimatedTxSize, txFeePerByte, btcWalletService);
-        assertEquals(260, result);
+        assertEquals(175, result);
     }
 
     // FIXME @Bernard could you have a look?
@@ -67,16 +67,16 @@ public class TxFeeEstimationServiceTest {
         int realTxSize;
         Coin txFee;
 
-        initialEstimatedTxSize = 260;
+        initialEstimatedTxSize = 175;
         txFeePerByte = Coin.valueOf(10);
-        realTxSize = 2600;
+        realTxSize = 1750;
 
         txFee = txFeePerByte.multiply(initialEstimatedTxSize);
         when(btcWalletService.getEstimatedFeeTxSize(outputValues, txFee)).thenReturn(realTxSize);
 
         // repeated calls to getEstimatedFeeTxSize do not work (returns 0 at second call in loop which cause test to fail)
         result = TxFeeEstimationService.getEstimatedTxSize(outputValues, initialEstimatedTxSize, txFeePerByte, btcWalletService);
-        assertEquals(2600, result);
+        assertEquals(1750, result);
     }
 
     // FIXME @Bernard could you have a look?
@@ -91,14 +91,14 @@ public class TxFeeEstimationServiceTest {
         int realTxSize;
         Coin txFee;
 
-        initialEstimatedTxSize = 2600;
+        initialEstimatedTxSize = 1750;
         txFeePerByte = Coin.valueOf(10);
-        realTxSize = 260;
+        realTxSize = 175;
 
         txFee = txFeePerByte.multiply(initialEstimatedTxSize);
         when(btcWalletService.getEstimatedFeeTxSize(outputValues, txFee)).thenReturn(realTxSize);
         result = TxFeeEstimationService.getEstimatedTxSize(outputValues, initialEstimatedTxSize, txFeePerByte, btcWalletService);
-        assertEquals(260, result);
+        assertEquals(175, result);
     }
 
     @Test

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/assetfee/AssetFeeView.java
@@ -189,7 +189,7 @@ public class AssetFeeView extends ActivatableView<GridPane, Void> implements Bsq
                 try {
                     Transaction transaction = assetService.payFee(selectedAsset, listingFee.value);
                     Coin miningFee = transaction.getFee();
-                    int txSize = transaction.bitcoinSerialize().length;
+                    int txSize = transaction.getVsize();
 
                     if (!DevEnv.isDevMode()) {
                         GUIUtil.showBsqFeeInfoPopup(listingFee, miningFee, txSize, bsqFormatter, btcFormatter,

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
@@ -172,7 +172,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                 String preImageAsString = preImageTextField.getText();
                 Transaction transaction = proofOfBurnService.burn(preImageAsString, amount.value);
                 Coin miningFee = transaction.getFee();
-                int txSize = transaction.bitcoinSerialize().length;
+                int txSize = transaction.getVsize();
 
                 if (!DevEnv.isDevMode()) {
                     GUIUtil.showBsqFeeInfoPopup(amount, miningFee, txSize, bsqFormatter, btcFormatter,

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -283,7 +283,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
             Proposal proposal = proposalWithTransaction.getProposal();
             Transaction transaction = proposalWithTransaction.getTransaction();
             Coin miningFee = transaction.getFee();
-            int txSize = transaction.bitcoinSerialize().length;
+            int txSize = transaction.getVsize();
             Coin fee = daoFacade.getProposalFee(daoFacade.getChainHeight());
 
             if (type.equals(ProposalType.BONDED_ROLE)) {

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -243,7 +243,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                     Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx, true);
                     Transaction signedTx = bsqWalletService.signTx(txWithBtcFee);
                     Coin miningFee = signedTx.getFee();
-                    int txSize = signedTx.bitcoinSerialize().length;
+                    int txSize = signedTx.getVsize();
                     showPublishTxPopup(receiverAmount,
                             txWithBtcFee,
                             TxType.TRANSFER_BSQ,
@@ -305,7 +305,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                     if (miningFee.getValue() >= receiverAmount.getValue())
                         GUIUtil.showWantToBurnBTCPopup(miningFee, receiverAmount, btcFormatter);
                     else {
-                        int txSize = signedTx.bitcoinSerialize().length;
+                        int txSize = signedTx.getVsize();
                         showPublishTxPopup(receiverAmount,
                                 txWithBtcFee,
                                 TxType.INVALID,

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -356,7 +356,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                 }
 
                 if (areInputsValid()) {
-                    int txSize = feeEstimationTransaction.bitcoinSerialize().length;
+                    int txSize = feeEstimationTransaction.getVsize();
                     log.info("Fee for tx with size {}: {} " + Res.getBaseCurrencyCode() + "", txSize, fee.toPlainString());
 
                     if (receiverAmount.isPositive()) {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
@@ -40,6 +40,7 @@ import org.bitcoinj.core.Transaction;
 import javax.inject.Inject;
 
 import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
 import javafx.scene.input.KeyCode;
 
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import static bisq.desktop.util.FormBuilder.addCheckBox;
 import static bisq.desktop.util.FormBuilder.addInputTextField;
 
 // We don't translate here as it is for dev only purpose
@@ -116,6 +118,8 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
         InputTextField buyerPubKeyAsHex = addInputTextField(gridPane, ++rowIndex, "buyerPubKeyAsHex");
         InputTextField sellerPubKeyAsHex = addInputTextField(gridPane, ++rowIndex, "sellerPubKeyAsHex");
 
+        CheckBox depositTxLegacy = addCheckBox(gridPane, ++rowIndex, "depositTxLegacy");
+
         // Notes:
         // Open with alt+g
         // Priv key is only visible if pw protection is removed (wallet details data (alt+j))
@@ -135,6 +139,9 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
         sellerAddressString.setText("");
         sellerPubKeyAsHex.setText("");
         sellerPrivateKeyAsHex.setText("");
+
+        depositTxLegacy.setAllowIndeterminate(false);
+        depositTxLegacy.setSelected(false);
 
         actionButtonText("Sign and publish transaction");
 
@@ -167,6 +174,7 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
                             sellerPrivateKeyAsHex.getText(),
                             buyerPubKeyAsHex.getText(),
                             sellerPubKeyAsHex.getText(),
+                            depositTxLegacy.isSelected(),
                             callback);
                 } catch (AddressFormatException | WalletException | TransactionVerificationException e) {
                     log.error(e.toString());

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep4View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep4View.java
@@ -205,7 +205,7 @@ public class BuyerStep4View extends TradeStepView {
                         validateWithdrawAddress();
                     } else if (Restrictions.isAboveDust(receiverAmount)) {
                         CoinFormatter formatter = model.btcFormatter;
-                        int txSize = feeEstimationTransaction.bitcoinSerialize().length;
+                        int txSize = feeEstimationTransaction.getVsize();
                         double feePerByte = CoinUtil.getFeePerByte(fee, txSize);
                         double kb = txSize / 1000d;
                         String recAmount = formatter.formatCoinWithCode(receiverAmount);

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -23,7 +23,7 @@ dependencyVerification {
         'com.github.bisq-network.netlayer:tor.external:a3606a592d6b6caa6a2fb7db224eaf43c6874c6730da4815bd37ad686b283dcb',
         'com.github.bisq-network.netlayer:tor.native:b15aba7fe987185037791c7ec7c529cb001b90d723d047d54aab87aceb3b3d45',
         'com.github.bisq-network.netlayer:tor:a974190aa3a031067ccd1dda28a3ae58cad14060792299d86ea38a05fb21afc5',
-        'com.github.bisq-network:bitcoinj:b8b6e4b8010f2b8d4aac7141c0809dea6d102c3ff3c06ceba78c2626d531b0af',
+        'com.github.bisq-network.bitcoinj:bitcoinj-core:8af7faa2155feff5afd1fa0fcea6fe7f7fa0d7ee977bdc648d1e73f3dcf2c754',
         'com.github.cd2357.tor-binary:tor-binary-geoip:ae27b6aca1a3a50a046eb11e38202b6d21c2fcd2b8643bbeb5ea85e065fbc1be',
         'com.github.cd2357.tor-binary:tor-binary-linux32:7b5d6770aa442ef6d235e8a9bfbaa7c62560690f9fe69ff03c7a752eae84f7dc',
         'com.github.cd2357.tor-binary:tor-binary-linux64:24111fa35027599a750b0176392dc1e9417d919414396d1b221ac2e707eaba76',

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -23,7 +23,7 @@ dependencyVerification {
         'com.github.bisq-network.netlayer:tor.external:a3606a592d6b6caa6a2fb7db224eaf43c6874c6730da4815bd37ad686b283dcb',
         'com.github.bisq-network.netlayer:tor.native:b15aba7fe987185037791c7ec7c529cb001b90d723d047d54aab87aceb3b3d45',
         'com.github.bisq-network.netlayer:tor:a974190aa3a031067ccd1dda28a3ae58cad14060792299d86ea38a05fb21afc5',
-        'com.github.bisq-network.bitcoinj:bitcoinj-core:8af7faa2155feff5afd1fa0fcea6fe7f7fa0d7ee977bdc648d1e73f3dcf2c754',
+        'com.github.bisq-network:bitcoinj:804f587a44b1ce9cd9b8dd1848fc911329634163b7905bafb86f502a3d08264c',
         'com.github.cd2357.tor-binary:tor-binary-geoip:ae27b6aca1a3a50a046eb11e38202b6d21c2fcd2b8643bbeb5ea85e065fbc1be',
         'com.github.cd2357.tor-binary:tor-binary-linux32:7b5d6770aa442ef6d235e8a9bfbaa7c62560690f9fe69ff03c7a752eae84f7dc',
         'com.github.cd2357.tor-binary:tor-binary-linux64:24111fa35027599a750b0176392dc1e9417d919414396d1b221ac2e707eaba76',


### PR DESCRIPTION
Users reduce btc miner fees for segwit txs.

Pre-segwit miners used to evaluate tx fee and tx size. Txs were selected by their fee/byte.
Segwit brought the concept of "virtual size".
virtual size of a tx = tx serialized without witness data size + witness size (i.e. pub keys and signatures) / 4.
The virtual size of a legacy tx is the same as its size.
Segwit txs have similar sizes compared to legacy txs, but their virtual size is smaller.
New terms are now used such as vsize, vbyte, fee/vbyte, etc.
Miners now compare txs by its fee/vbyte (This is not entirely true, since they use tx weight, but we can do our math using fee/vbyte which is roughly equivalent)
See https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#additional-definitions for more info.

This PR does not include renaming size to vsize, feePerByte to feePerVbyte, etc.
I expect this PR won't be merged to master for quite some time.
The renames will introduce hundreds of changes all over the code, leading to merging hell.
I plan to do the renames either when merging date is closer or as an independent PR.

I suggest to use this link https://github.com/oscarguindzberg/bisq/compare/segwit...oscarguindzberg:fee-estimation to understand the content of this PR until https://github.com/bisq-network/bisq/pull/4612 is merged. Otherwise you will find here the content for both PRs making understanding this PR more difficult