### PR TITLE
Cleaner formatting for trading charts date axes

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -479,11 +479,27 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             @Override
             public String toString(Number object) {
                 long index = MathUtils.doubleToLong((double) object);
+                // The last tick is on the chart edge, it is not well spaced with
+                // the previous tick and interferes with its label.
+                if (model.maxTicks + 1 == index) return "";
+
                 long time = model.getTimeFromTickIndex(index);
-                if (model.tickUnit.ordinal() <= TradesChartsViewModel.TickUnit.DAY.ordinal())
-                    return index % 4 == 0 ? DisplayUtils.formatDateAxis(new Date(time)) : "";
-                else
-                    return index % 3 == 0 ? DisplayUtils.formatTimeAxis(new Date(time)) : "";
+                String fmt = "";
+                switch (model.tickUnit) {
+                case YEAR  : fmt = "yyyy";
+                    break;
+                case MONTH : fmt = "MMMyy";
+                    break;
+                case WEEK  :
+                case DAY   : fmt = "dd/MMM\nyyyy";
+                    break;
+                case HOUR  :
+                case MINUTE_10: fmt = "HH:mm\ndd/MMM";
+                    break;
+                default:        // nothing here
+                }
+
+                return DisplayUtils.formatDateAxis(new Date(time), fmt);
             }
 
             @Override

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -332,8 +332,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         priceSeries = new XYChart.Series<>();
 
         priceAxisX = new NumberAxis(0, model.maxTicks + 1, 1);
-        priceAxisX.setTickUnit(1);
-        priceAxisX.setMinorTickCount(0);
+        priceAxisX.setTickUnit(4);
+        priceAxisX.setMinorTickCount(4);
+        priceAxisX.setMinorTickVisible(true);
         priceAxisX.setForceZeroInRange(false);
         priceAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
 
@@ -376,8 +377,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             }
         });
         priceChart.setId("price-chart");
-        priceChart.setMinHeight(178);
-        priceChart.setPrefHeight(178);
+        priceChart.setMinHeight(188);
+        priceChart.setPrefHeight(188);
         priceChart.setMaxHeight(300);
         priceChart.setLegendVisible(false);
         priceChart.setPadding(new Insets(0));
@@ -396,8 +397,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         volumeSeries = new XYChart.Series<>();
 
         volumeAxisX = new NumberAxis(0, model.maxTicks + 1, 1);
-        volumeAxisX.setTickUnit(1);
-        volumeAxisX.setMinorTickCount(0);
+        volumeAxisX.setTickUnit(4);
+        volumeAxisX.setMinorTickCount(4);
+        volumeAxisX.setMinorTickVisible(true);
         volumeAxisX.setForceZeroInRange(false);
         volumeAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
 
@@ -430,8 +432,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         });
         volumeChart.setId("volume-chart");
         volumeChart.setData(FXCollections.observableArrayList(List.of(volumeSeries)));
-        volumeChart.setMinHeight(128);
-        volumeChart.setPrefHeight(128);
+        volumeChart.setMinHeight(138);
+        volumeChart.setPrefHeight(138);
         volumeChart.setMaxHeight(200);
         volumeChart.setLegendVisible(false);
         volumeChart.setPadding(new Insets(0));
@@ -479,9 +481,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 long index = MathUtils.doubleToLong((double) object);
                 long time = model.getTimeFromTickIndex(index);
                 if (model.tickUnit.ordinal() <= TradesChartsViewModel.TickUnit.DAY.ordinal())
-                    return index % 4 == 0 ? DisplayUtils.formatDate(new Date(time)) : "";
+                    return index % 4 == 0 ? DisplayUtils.formatDateAxis(new Date(time)) : "";
                 else
-                    return index % 3 == 0 ? DisplayUtils.formatTime(new Date(time)) : "";
+                    return index % 3 == 0 ? DisplayUtils.formatTimeAxis(new Date(time)) : "";
             }
 
             @Override

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -486,15 +486,19 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 long time = model.getTimeFromTickIndex(index);
                 String fmt = "";
                 switch (model.tickUnit) {
-                case YEAR  : fmt = "yyyy";
+                case YEAR:
+                    fmt = "yyyy";
                     break;
-                case MONTH : fmt = "MMMyy";
+                case MONTH:
+                    fmt = "MMMyy";
                     break;
-                case WEEK  :
-                case DAY   : fmt = "dd/MMM\nyyyy";
+                case WEEK:
+                case DAY:
+                    fmt = "dd/MMM\nyyyy";
                     break;
-                case HOUR  :
-                case MINUTE_10: fmt = "HH:mm\ndd/MMM";
+                case HOUR :
+                case MINUTE_10:
+                    fmt = "HH:mm\ndd/MMM";
                     break;
                 default:        // nothing here
                 }

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/price/CandleStickChart.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/price/CandleStickChart.java
@@ -130,7 +130,7 @@ public class CandleStickChart extends XYChart<Number, Number> {
                     double candleWidth = -1;
                     if (getXAxis() instanceof NumberAxis) {
                         NumberAxis xa = (NumberAxis) getXAxis();
-                        candleWidth = xa.getDisplayPosition(xa.getTickUnit()) * 0.60; // use 90% width between ticks
+                        candleWidth = xa.getDisplayPosition(1) * 0.60; // use 60% width between units
                     }
                     // update candle
                     candle.update(close - y, high - y, low - y, candleWidth);

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeChart.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeChart.java
@@ -65,7 +65,7 @@ public class VolumeChart extends XYChart<Number, Number> {
                     double candleWidth = -1;
                     if (getXAxis() instanceof NumberAxis) {
                         NumberAxis xa = (NumberAxis) getXAxis();
-                        candleWidth = xa.getDisplayPosition(xa.getTickUnit()) * 0.60; // use 90% width between ticks
+                        candleWidth = xa.getDisplayPosition(1) * 0.60; // use 60% width between units
                     }
 
                     // 97 is visible chart data height if chart height is 140.

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -61,6 +62,24 @@ public class DisplayUtils {
     public static String formatDate(Date date) {
         if (date != null) {
             DateFormat dateFormatter = DateFormat.getDateInstance(DateFormat.DEFAULT, GlobalSettings.getLocale());
+            return dateFormatter.format(date);
+        } else {
+            return "";
+        }
+    }
+
+    public static String formatTimeAxis(Date date) {
+        if (date != null) {
+            SimpleDateFormat timeFormatter = new SimpleDateFormat(" HH:mm \n d/MMM ", GlobalSettings.getLocale());
+            return timeFormatter.format(date);
+        } else {
+            return "";
+        }
+    }
+
+    public static String formatDateAxis(Date date) {
+        if (date != null) {
+            SimpleDateFormat dateFormatter = new SimpleDateFormat("dd/MMM\nyyyy", GlobalSettings.getLocale());
             return dateFormatter.format(date);
         } else {
             return "";

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -68,18 +68,9 @@ public class DisplayUtils {
         }
     }
 
-    public static String formatTimeAxis(Date date) {
+    public static String formatDateAxis(Date date, String format) {
         if (date != null) {
-            SimpleDateFormat timeFormatter = new SimpleDateFormat(" HH:mm \n d/MMM ", GlobalSettings.getLocale());
-            return timeFormatter.format(date);
-        } else {
-            return "";
-        }
-    }
-
-    public static String formatDateAxis(Date date) {
-        if (date != null) {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("dd/MMM\nyyyy", GlobalSettings.getLocale());
+            SimpleDateFormat dateFormatter = new SimpleDateFormat(format, GlobalSettings.getLocale());
             return dateFormatter.format(date);
         } else {
             return "";


### PR DESCRIPTION
Clean up date axes style for easy reading. Made date labels shorter,
with clear visual correspondence to relevant axes tick mark.
Tick marks with labels are now larger than those without.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Currently, the X-axis for the Price and Volume charts is not well designed. The labels are large, all the tick marks are the same. It is difficult to estimate to which tick mark the date label corresponds.  Here is a typical example for the DAY interval:
![Bisq-chartaxes-day_orig-2020-10-27](https://user-images.githubusercontent.com/142019/97351164-0c942e00-189a-11eb-9d90-efb66982e7c0.png)


The fix proposed here draws the labels more compact and the respective ticks stand-out. The chart view becomes cleaner and more visually intuitive. Above example, becomes:
![Bisq-chartaxes-day_new-2020-10-27](https://user-images.githubusercontent.com/142019/97351201-187ff000-189a-11eb-8c87-4bee28332fb1.png)

The labels take less horizontal space by splitting into 2-levels, using 24-hour time instead of AM/PM. The examples here show English locale, though localization for the month names is maintained, as before.

Of course, further customization is possible, but the above, I feel, provides an acceptable improvement to chart display, without deviating from the current UI or introducing new features.

Similar results are obtained with the other chart interval  values. Examples (10min, HOUR, WEEK, MOTH):
![Bisq-chartaxes-10min_new-2020-10-27](https://user-images.githubusercontent.com/142019/97348987-955d9a80-1897-11eb-9991-7abe3213aff8.png)
![Bisq-chartaxes-hour_new-2020-10-27](https://user-images.githubusercontent.com/142019/97349048-a27a8980-1897-11eb-8ea7-d4ca27d58e41.png)
![Bisq-chartaxes-week_new-2020-10-27](https://user-images.githubusercontent.com/142019/97349073-adcdb500-1897-11eb-9610-854ae7685803.png)
![Bisq-chartaxes-month_new-2020-10-27](https://user-images.githubusercontent.com/142019/97349093-b625f000-1897-11eb-8779-d9694558ad6a.png)

Bisq is a unique tool. It deserves better charts.
Hope you find this a small improvement in the right direction.

