### PR TITLE
Hide proposal delete button

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsListItem.java
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
 //TODO merge with vote result ProposalListItem
 public class ProposalsListItem {
 
-    enum IconButtonTypes {
+    enum IconButtonType {
         REMOVE_PROPOSAL(Res.get("dao.proposal.table.icon.tooltip.removeProposal")),
         ACCEPT(Res.get("dao.proposal.display.myVote.accepted")),
         REJECT(Res.get("dao.proposal.display.myVote.rejected")),
@@ -57,7 +57,7 @@ public class ProposalsListItem {
         @Getter
         private String title;
 
-        IconButtonTypes(String title) {
+        IconButtonType(String title) {
             this.title = title;
         }
     }
@@ -128,7 +128,7 @@ public class ProposalsListItem {
             iconButton = new JFXButton("", icon);
             boolean isMyProposal = daoFacade.isMyProposal(proposal);
             if (isMyProposal) {
-                iconButton.setUserData(IconButtonTypes.REMOVE_PROPOSAL);
+                iconButton.setUserData(IconButtonType.REMOVE_PROPOSAL);
             }
             iconButton.setVisible(isMyProposal);
             iconButton.setManaged(isMyProposal);
@@ -148,36 +148,36 @@ public class ProposalsListItem {
                     icon = FormBuilder.getIcon(AwesomeIcon.THUMBS_UP);
                     icon.getStyleClass().addAll("icon", "dao-accepted-icon");
                     iconButton = new JFXButton("", icon);
-                    iconButton.setUserData(IconButtonTypes.ACCEPT);
+                    iconButton.setUserData(IconButtonType.ACCEPT);
                 } else {
                     icon = FormBuilder.getIcon(AwesomeIcon.THUMBS_DOWN);
                     icon.getStyleClass().addAll("icon", "dao-rejected-icon");
                     iconButton = new JFXButton("", icon);
-                    iconButton.setUserData(IconButtonTypes.REJECT);
+                    iconButton.setUserData(IconButtonType.REJECT);
                 }
             } else {
                 icon = FormBuilder.getIcon(AwesomeIcon.MINUS);
                 icon.getStyleClass().addAll("icon", "dao-ignored-icon");
                 iconButton = new JFXButton("", icon);
-                iconButton.setUserData(IconButtonTypes.IGNORE);
+                iconButton.setUserData(IconButtonType.IGNORE);
             }
             iconButton.setTooltip(new Tooltip(Res.get("dao.proposal.table.icon.tooltip.changeVote",
-                    ((IconButtonTypes) iconButton.getUserData()).getTitle(),
-                    getNext(((IconButtonTypes) iconButton.getUserData()))
+                    ((IconButtonType) iconButton.getUserData()).getTitle(),
+                    getNext(((IconButtonType) iconButton.getUserData()))
             )));
             iconButton.getStyleClass().add("hidden-icon-button");
             iconButton.layout();
         }
     }
 
-    private String getNext(IconButtonTypes iconButtonTypes) {
-        switch (iconButtonTypes) {
+    private String getNext(IconButtonType iconButtonType) {
+        switch (iconButtonType) {
             case ACCEPT:
-                return IconButtonTypes.REJECT.getTitle();
+                return IconButtonType.REJECT.getTitle();
             case REJECT:
-                return IconButtonTypes.IGNORE.getTitle();
+                return IconButtonType.IGNORE.getTitle();
             default:
-                return IconButtonTypes.ACCEPT.getTitle();
+                return IconButtonType.ACCEPT.getTitle();
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsListItem.java
@@ -127,8 +127,9 @@ public class ProposalsListItem {
             icon.getStyleClass().addAll("icon", "dao-remove-proposal-icon");
             iconButton = new JFXButton("", icon);
             boolean isMyProposal = daoFacade.isMyProposal(proposal);
-            if (isMyProposal)
+            if (isMyProposal) {
                 iconButton.setUserData(IconButtonTypes.REMOVE_PROPOSAL);
+            }
             iconButton.setVisible(isMyProposal);
             iconButton.setManaged(isMyProposal);
             iconButton.getStyleClass().add("hidden-icon-button");

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -590,7 +590,11 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
 
         switch (daoFacade.phaseProperty().get()) {
             case PROPOSAL:
-                lastColumn.setText(Res.get("dao.proposal.table.header.remove"));
+                // We have a bug in removing a proposal which is not trivial to fix (p2p network layer). Until that bug is fixed
+                // it is better to not show the remove button as it confused users and a removed proposal will reappear with a
+                // high probability at the vote phase.
+                //lastColumn.setText(Res.get("dao.proposal.table.header.remove"));
+                lastColumn.setText("");
                 break;
             case BLIND_VOTE:
                 lastColumn.setText(Res.get("dao.proposal.table.header.myVote"));
@@ -841,25 +845,36 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                             item.onPhaseChanged(currentPhase);
                             JFXButton iconButton = item.getIconButton();
                             if (iconButton != null) {
+                                ProposalsListItem.IconButtonTypes iconButtonType = (ProposalsListItem.IconButtonTypes) iconButton.getUserData();
                                 iconButton.setOnAction(e -> {
                                     selectedItem = item;
                                     if (areVoteButtonsVisible) {
-                                        if (iconButton.getUserData() == ProposalsListItem.IconButtonTypes.ACCEPT)
+                                        if (iconButtonType == ProposalsListItem.IconButtonTypes.ACCEPT)
                                             onReject();
-                                        else if (iconButton.getUserData() == ProposalsListItem.IconButtonTypes.REJECT)
+                                        else if (iconButtonType == ProposalsListItem.IconButtonTypes.REJECT)
                                             onIgnore();
-                                        else if (iconButton.getUserData() == ProposalsListItem.IconButtonTypes.IGNORE)
+                                        else if (iconButtonType == ProposalsListItem.IconButtonTypes.IGNORE)
                                             onAccept();
                                     } else {
-                                        if (iconButton.getUserData() == ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL)
+                                        if (iconButtonType == ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL)
                                             onRemoveProposal();
                                     }
                                 });
 
-                                if (!areVoteButtonsVisible && iconButton.getUserData() != ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL) {
+                                if (!areVoteButtonsVisible && iconButtonType != ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL) {
                                     iconButton.setMouseTransparent(true);
                                     iconButton.setStyle("-fx-cursor: default;");
                                 }
+
+                                // We have a bug in removing a proposal which is not trivial to fix (p2p network layer).
+                                // Until that bug is fixed
+                                // it is better to not show the remove button as it confused users and a removed proposal will reappear with a
+                                // high probability at the vote phase. The following lines can be removed once the bug is fixed.
+                                boolean showIcon = iconButtonType != null &&
+                                        iconButtonType != ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL;
+                                iconButton.setVisible(showIcon);
+                                iconButton.setManaged(showIcon);
+
                                 setGraphic(iconButton);
                             } else {
                                 setGraphic(null);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -845,23 +845,23 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                             item.onPhaseChanged(currentPhase);
                             JFXButton iconButton = item.getIconButton();
                             if (iconButton != null) {
-                                ProposalsListItem.IconButtonTypes iconButtonType = (ProposalsListItem.IconButtonTypes) iconButton.getUserData();
+                                ProposalsListItem.IconButtonType iconButtonType = (ProposalsListItem.IconButtonType) iconButton.getUserData();
                                 iconButton.setOnAction(e -> {
                                     selectedItem = item;
                                     if (areVoteButtonsVisible) {
-                                        if (iconButtonType == ProposalsListItem.IconButtonTypes.ACCEPT)
+                                        if (iconButtonType == ProposalsListItem.IconButtonType.ACCEPT)
                                             onReject();
-                                        else if (iconButtonType == ProposalsListItem.IconButtonTypes.REJECT)
+                                        else if (iconButtonType == ProposalsListItem.IconButtonType.REJECT)
                                             onIgnore();
-                                        else if (iconButtonType == ProposalsListItem.IconButtonTypes.IGNORE)
+                                        else if (iconButtonType == ProposalsListItem.IconButtonType.IGNORE)
                                             onAccept();
                                     } else {
-                                        if (iconButtonType == ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL)
+                                        if (iconButtonType == ProposalsListItem.IconButtonType.REMOVE_PROPOSAL)
                                             onRemoveProposal();
                                     }
                                 });
 
-                                if (!areVoteButtonsVisible && iconButtonType != ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL) {
+                                if (!areVoteButtonsVisible && iconButtonType != ProposalsListItem.IconButtonType.REMOVE_PROPOSAL) {
                                     iconButton.setMouseTransparent(true);
                                     iconButton.setStyle("-fx-cursor: default;");
                                 }
@@ -871,7 +871,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
                                 // it is better to not show the remove button as it confused users and a removed proposal will reappear with a
                                 // high probability at the vote phase. The following lines can be removed once the bug is fixed.
                                 boolean showIcon = iconButtonType != null &&
-                                        iconButtonType != ProposalsListItem.IconButtonTypes.REMOVE_PROPOSAL;
+                                        iconButtonType != ProposalsListItem.IconButtonType.REMOVE_PROPOSAL;
                                 iconButton.setVisible(showIcon);
                                 iconButton.setManaged(showIcon);
 


### PR DESCRIPTION
We have a bug in removing a proposal which is not trivial to fix
(p2p network layer). Until that bug is fixed
it is better to not show the remove button as it
confused users and a removed proposal will reappear with a
high probability at the vote phase.