### PR TITLE
Center align tick marks text for trading charts

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -1700,6 +1700,10 @@ textfield */
     -fx-font-size: 0.880em;
 }
 
+#price-chart .axis-tick-mark-text-node, #volume-chart .axis-tick-mark-text-node {
+    -fx-text-alignment: center;
+}
+
 #charts .chart-plot-background, #charts-dao .chart-plot-background {
     -fx-background-color: -bs-background-color;
 }
@@ -2169,4 +2173,3 @@ textfield */
     -fx-stroke: linear-gradient(to bottom, -bs-text-color-transparent, -bs-text-color-transparent-dark) !important;
     -fx-fill: -bs-background-color !important;
 }
-

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -67,6 +67,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.scene.Node;
+import javafx.scene.text.Text;
 
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -337,6 +339,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         priceAxisX.setMinorTickVisible(true);
         priceAxisX.setForceZeroInRange(false);
         priceAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
+        addTickMarkLabelCssClass(priceAxisX, "axis-tick-mark-text-node");
 
         priceAxisY = new NumberAxis();
         priceAxisY.setForceZeroInRange(false);
@@ -402,6 +405,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         volumeAxisX.setMinorTickVisible(true);
         volumeAxisX.setForceZeroInRange(false);
         volumeAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
+        addTickMarkLabelCssClass(volumeAxisX, "axis-tick-mark-text-node");
 
         volumeAxisY = new NumberAxis();
         volumeAxisY.setForceZeroInRange(true);
@@ -513,6 +517,20 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         };
     }
 
+    private void addTickMarkLabelCssClass(NumberAxis axis, String cssClass) {
+        // grab the axis tick mark label (text object) and add a CSS class.
+        axis.getChildrenUnmodifiable().addListener((ListChangeListener<Node>) c -> {
+                while (c.next()) {
+                    if (c.wasAdded()) {
+                        for (Node mark : c.getAddedSubList()) {
+                            if (mark instanceof Text) {
+                                mark.getStyleClass().add(cssClass);
+                            }
+                        }
+                    }
+                }
+            });
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // CurrencyComboBox


### PR DESCRIPTION
New method addTickMarkLabelCssClass to grab the axis tick label and add a CSS class to it.

Signed-off-by: Deus Max <deusmax@gmx.com>
Acked-by: Deus Max <deusmax@gmx.com>

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Your PR description here.
@ghubstan  as discussed in PR#4175. to center-align tick mark text.
Add a CSS class to the axis tick marks text. The CSS class can be used to add any css command, such as `-fx-text-align: center` to the labels.
Here is a screenshot of the results:
![Bisq-chartaxes-day_centeralign-2020-11-02](https://user-images.githubusercontent.com/142019/97916540-c9cfcb80-1d5b-11eb-9003-286aee9983c4.png)

