### PR TITLE
Fix bug with reading historical data

### DIFF
--- a/common/src/main/java/bisq/common/setup/CommonSetup.java
+++ b/common/src/main/java/bisq/common/setup/CommonSetup.java
@@ -102,11 +102,13 @@ public class CommonSetup {
 
     protected static void setupSigIntHandlers(GracefulShutDownHandler gracefulShutDownHandler) {
         Signal.handle(new Signal("INT"), signal -> {
+            log.info("Received {}", signal);
             UserThread.execute(() -> gracefulShutDownHandler.gracefulShutDown(() -> {
             }));
         });
 
         Signal.handle(new Signal("TERM"), signal -> {
+            log.info("Received {}", signal);
             UserThread.execute(() -> gracefulShutDownHandler.gracefulShutDown(() -> {
             }));
         });

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -168,8 +168,8 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
         }
 
         AtomicInteger remaining = new AtomicInteger(hosts.size());
-        hosts.forEach(e -> {
-            e.readPersisted(() -> {
+        hosts.forEach(host -> {
+            host.readPersisted(() -> {
                 if (remaining.decrementAndGet() == 0) {
                     UserThread.execute(completeHandler);
                 }

--- a/core/src/main/java/bisq/core/app/misc/AppSetupWithP2PAndDAO.java
+++ b/core/src/main/java/bisq/core/app/misc/AppSetupWithP2PAndDAO.java
@@ -19,7 +19,6 @@ package bisq.core.app.misc;
 
 import bisq.core.account.sign.SignedWitnessService;
 import bisq.core.account.witness.AccountAgeWitnessService;
-import bisq.core.app.TorSetup;
 import bisq.core.dao.DaoSetup;
 import bisq.core.dao.governance.ballot.BallotListService;
 import bisq.core.dao.governance.blindvote.MyBlindVoteListService;
@@ -31,6 +30,8 @@ import bisq.core.filter.FilterManager;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 
 import bisq.network.p2p.P2PService;
+import bisq.network.p2p.peers.PeerManager;
+import bisq.network.p2p.storage.P2PDataStorage;
 
 import bisq.common.config.Config;
 
@@ -44,6 +45,8 @@ public class AppSetupWithP2PAndDAO extends AppSetupWithP2P {
 
     @Inject
     public AppSetupWithP2PAndDAO(P2PService p2PService,
+                                 P2PDataStorage p2PDataStorage,
+                                 PeerManager peerManager,
                                  TradeStatisticsManager tradeStatisticsManager,
                                  AccountAgeWitnessService accountAgeWitnessService,
                                  SignedWitnessService signedWitnessService,
@@ -55,14 +58,14 @@ public class AppSetupWithP2PAndDAO extends AppSetupWithP2P {
                                  MyProposalListService myProposalListService,
                                  MyReputationListService myReputationListService,
                                  MyProofOfBurnListService myProofOfBurnListService,
-                                 TorSetup torSetup,
                                  Config config) {
         super(p2PService,
+                p2PDataStorage,
+                peerManager,
                 tradeStatisticsManager,
                 accountAgeWitnessService,
                 signedWitnessService,
                 filterManager,
-                torSetup,
                 config);
 
         this.daoSetup = daoSetup;

--- a/core/src/main/java/bisq/core/setup/CorePersistedDataHost.java
+++ b/core/src/main/java/bisq/core/setup/CorePersistedDataHost.java
@@ -35,7 +35,8 @@ import bisq.core.trade.failed.FailedTradesManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
-import bisq.network.p2p.P2PService;
+import bisq.network.p2p.peers.PeerManager;
+import bisq.network.p2p.storage.P2PDataStorage;
 
 import bisq.common.config.Config;
 import bisq.common.proto.persistable.PersistedDataHost;
@@ -63,7 +64,8 @@ public class CorePersistedDataHost {
         persistedDataHosts.add(injector.getInstance(ArbitrationDisputeListService.class));
         persistedDataHosts.add(injector.getInstance(MediationDisputeListService.class));
         persistedDataHosts.add(injector.getInstance(RefundDisputeListService.class));
-        persistedDataHosts.add(injector.getInstance(P2PService.class));
+        persistedDataHosts.add(injector.getInstance(P2PDataStorage.class));
+        persistedDataHosts.add(injector.getInstance(PeerManager.class));
 
         if (injector.getInstance(Config.class).daoActivated) {
             persistedDataHosts.add(injector.getInstance(BallotListService.class));

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
@@ -114,7 +114,6 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
 
     private Coin availableAmount;
     private int gridRow = 0;
-    double percentToTrim = 5;
     double howManyStdDevsConstituteOutlier = 10;
 
 

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -52,7 +52,6 @@ import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.network.NetworkEnvelope;
-import bisq.common.proto.persistable.PersistedDataHost;
 import bisq.common.util.Utilities;
 
 import com.google.inject.Inject;
@@ -105,7 +104,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class P2PService implements SetupListener, MessageListener, ConnectionListener, RequestDataManager.Listener,
-        HashMapChangedListener, PersistedDataHost {
+        HashMapChangedListener {
     private static final Logger log = LoggerFactory.getLogger(P2PService.class);
 
     private final SeedNodeRepository seedNodeRepository;
@@ -182,12 +181,6 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             if (newValue)
                 onNetworkReady();
         });
-    }
-
-    @Override
-    public void readPersisted(Runnable completeHandler) {
-        p2PDataStorage.readPersisted(completeHandler);
-        peerManager.readPersisted(completeHandler);
     }
 
 


### PR DESCRIPTION
Fix bugs with reading historical data:
- Use fileName not getFileName() in readHistoricalStoreFromResources
- use complete handler once reading of all historical data is completed where we
   build the ImmutableMaps and complete the readFromResources method

Fixes https://github.com/bisq-network/bisq/pull/4706#issuecomment-721156401

