### PR TITLE
Set initial value for bsqAverageTrimThreshold at update to 5%

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -245,6 +245,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         setCryptoCurrencies(prefPayload.getCryptoCurrencies());
         setBsqBlockChainExplorer(prefPayload.getBsqBlockChainExplorer());
         GlobalSettings.setDefaultTradeCurrency(preferredTradeCurrency);
+        prefPayload.setBsqAverageTrimThreshold(0.05);
         setupPreferences();
     }
 

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -245,7 +245,16 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         setCryptoCurrencies(prefPayload.getCryptoCurrencies());
         setBsqBlockChainExplorer(prefPayload.getBsqBlockChainExplorer());
         GlobalSettings.setDefaultTradeCurrency(preferredTradeCurrency);
-        prefPayload.setBsqAverageTrimThreshold(0.05);
+
+        // If a user has updated and the field was not set and get set to 0 by protobuf
+        // As there is no way to detect that a primitive value field was set we cannot apply
+        // a "marker" value like -1 to it. We also do not want to wrap the value in a new
+        // proto message as thats too much for that feature... So we accept that if the user
+        // sets the value to 0 it will be overwritten by the default at next startup.
+        if (prefPayload.getBsqAverageTrimThreshold() == 0) {
+            prefPayload.setBsqAverageTrimThreshold(0.05);
+        }
+
         setupPreferences();
     }
 


### PR DESCRIPTION
 Set initial value for bsqAverageTrimThreshold to 5% in case of an update (using persisted preferences which would
have value set to 0 as it was not existing in old version)

Fixes https://github.com/bisq-network/bisq/pull/4706#issuecomment-721833394
