### PR TITLE
Fix BTC address tbl output formatting

### DIFF
--- a/cli/src/main/java/bisq/cli/ColumnHeaderConstants.java
+++ b/cli/src/main/java/bisq/cli/ColumnHeaderConstants.java
@@ -29,7 +29,7 @@ class ColumnHeaderConstants {
     // such as COL_HEADER_CREATION_DATE, COL_HEADER_VOLUME and COL_HEADER_UUID, the
     // expected max data string length is accounted for.  In others, the column header length
     // are expected to be greater than any column value length.
-    static final String COL_HEADER_ADDRESS = padEnd("Address", 34, ' ');
+    static final String COL_HEADER_ADDRESS = padEnd("%-3s Address", 52, ' ');
     static final String COL_HEADER_AMOUNT = padEnd("BTC(min - max)", 24, ' ');
     static final String COL_HEADER_BALANCE = padStart("Balance", 12, ' ');
     static final String COL_HEADER_CONFIRMATIONS = "Confirmations";

--- a/cli/src/main/java/bisq/cli/TableFormat.java
+++ b/cli/src/main/java/bisq/cli/TableFormat.java
@@ -45,13 +45,15 @@ class TableFormat {
     static final TimeZone TZ_UTC = getTimeZone("UTC");
     static final SimpleDateFormat DATE_FORMAT_ISO_8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    static String formatAddressBalanceTbl(List<AddressBalanceInfo> addressBalanceInfo) {
-        String headerLine = (COL_HEADER_ADDRESS + COL_HEADER_DELIMITER
+    public static String formatAddressBalanceTbl(List<AddressBalanceInfo> addressBalanceInfo) {
+        String headerFormatString = COL_HEADER_ADDRESS + COL_HEADER_DELIMITER
                 + COL_HEADER_BALANCE + COL_HEADER_DELIMITER
-                + COL_HEADER_CONFIRMATIONS + COL_HEADER_DELIMITER + "\n");
-        String colDataFormat = "%-" + COL_HEADER_ADDRESS.length() + "s" // left justify
-                + "  %" + COL_HEADER_BALANCE.length() + "s" // right justify
-                + "  %" + COL_HEADER_CONFIRMATIONS.length() + "d"; // right justify
+                + COL_HEADER_CONFIRMATIONS + COL_HEADER_DELIMITER + "\n";
+        String headerLine = format(headerFormatString, "BTC");
+
+        String colDataFormat = "%-" + COL_HEADER_ADDRESS.length() + "s" // lt justify
+                + "  %" + (COL_HEADER_BALANCE.length() - 1) + "s" // rt justify
+                + "  %" + COL_HEADER_CONFIRMATIONS.length() + "d"; // lt justify
         return headerLine
                 + addressBalanceInfo.stream()
                 .map(info -> format(colDataFormat,


### PR DESCRIPTION
- Adjusts the CLI's output formatting for segwit address lengths.

- Anticipates possibility this formatting method will be used  to display other types of crypto addresses.
