### PR TITLE
Implement and test api method 'getunusedbsqaddress'

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/BsqWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/BsqWalletTest.java
@@ -1,0 +1,61 @@
+package bisq.apitest.method;
+
+import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.NetworkParameters;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.apitest.config.BisqAppConfig.alicedaemon;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_MAINNET;
+import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_REGTEST;
+import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_TESTNET;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+
+// @Disabled
+@Slf4j
+@TestMethodOrder(OrderAnnotation.class)
+public class BsqWalletTest extends MethodTest {
+
+    @BeforeAll
+    public static void setUp() {
+        try {
+            setUpScaffold(alicedaemon);
+            MILLISECONDS.sleep(2000);
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    @Test
+    @Order(1)
+    public void testGetUnusedBsqAddress() {
+        var request = createGetUnusedBsqAddressRequest();
+
+        String address = grpcStubs(alicedaemon).walletsService.getUnusedBsqAddress(request).getAddress();
+        assertFalse(address.isEmpty());
+        assertTrue(address.startsWith("B"));
+
+        NetworkParameters networkParameters = LegacyAddress.getParametersFromAddress(address.substring(1));
+        String addressNetwork = networkParameters.getPaymentProtocolId();
+        assertNotEquals(PAYMENT_PROTOCOL_ID_MAINNET, addressNetwork);
+        // TODO Fix bug causing the regtest bsq address network to be evaluated as 'testnet' here.
+        assertTrue(addressNetwork.equals(PAYMENT_PROTOCOL_ID_TESTNET)
+                || addressNetwork.equals(PAYMENT_PROTOCOL_ID_REGTEST));
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        tearDownScaffold();
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -26,6 +26,7 @@ import bisq.proto.grpc.GetFundingAddressesRequest;
 import bisq.proto.grpc.GetOfferRequest;
 import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.GetTradeRequest;
+import bisq.proto.grpc.GetUnusedBsqAddressRequest;
 import bisq.proto.grpc.KeepFundsRequest;
 import bisq.proto.grpc.LockWalletRequest;
 import bisq.proto.grpc.MarketPriceRequest;
@@ -127,6 +128,10 @@ public class MethodTest extends ApiTestCase {
         return LockWalletRequest.newBuilder().build();
     }
 
+    protected final GetUnusedBsqAddressRequest createGetUnusedBsqAddressRequest() {
+        return GetUnusedBsqAddressRequest.newBuilder().build();
+    }
+
     protected final GetFundingAddressesRequest createGetFundingAddressesRequest() {
         return GetFundingAddressesRequest.newBuilder().build();
     }
@@ -186,6 +191,10 @@ public class MethodTest extends ApiTestCase {
     protected final void lockWallet(BisqAppConfig bisqAppConfig) {
         //noinspection ResultOfMethodCallIgnored
         grpcStubs(bisqAppConfig).walletsService.lockWallet(createLockWalletRequest());
+    }
+
+    protected final String getUnusedBsqAddress(BisqAppConfig bisqAppConfig) {
+        return grpcStubs(bisqAppConfig).walletsService.getUnusedBsqAddress(createGetUnusedBsqAddressRequest()).getAddress();
     }
 
     protected final String getUnusedBtcAddress(BisqAppConfig bisqAppConfig) {

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -29,6 +29,7 @@ import bisq.proto.grpc.GetOfferRequest;
 import bisq.proto.grpc.GetOffersRequest;
 import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.GetTradeRequest;
+import bisq.proto.grpc.GetUnusedBsqAddressRequest;
 import bisq.proto.grpc.GetVersionRequest;
 import bisq.proto.grpc.KeepFundsRequest;
 import bisq.proto.grpc.LockWalletRequest;
@@ -90,6 +91,7 @@ public class CliMain {
         getbalance,
         getaddressbalance,
         getfundingaddresses,
+        getunusedbsqaddress,
         lockwallet,
         unlockwallet,
         removewalletpassword,
@@ -197,6 +199,12 @@ public class CliMain {
                             .setAddress(nonOptionArgs.get(1)).build();
                     var reply = walletsService.getAddressBalance(request);
                     out.println(formatAddressBalanceTbl(singletonList(reply.getAddressBalanceInfo())));
+                    return;
+                }
+                case getunusedbsqaddress: {
+                    var request = GetUnusedBsqAddressRequest.newBuilder().build();
+                    var reply = walletsService.getUnusedBsqAddress(request);
+                    out.println(reply.getAddress());
                     return;
                 }
                 case getfundingaddresses: {
@@ -484,6 +492,7 @@ public class CliMain {
             stream.format(rowFormat, "getversion", "", "Get server version");
             stream.format(rowFormat, "getbalance", "", "Get server wallet balance");
             stream.format(rowFormat, "getaddressbalance", "address", "Get server wallet address balance");
+            stream.format(rowFormat, "getunusedbsqaddress", "", "Get unused BSQ address");
             stream.format(rowFormat, "getfundingaddresses", "", "Get BTC funding addresses");
             stream.format(rowFormat, "createoffer", "payment acct id, buy | sell, currency code, \\", "Create and place an offer");
             stream.format(rowFormat, "", "amount (btc), min amount, use mkt based price, \\", "");

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -225,6 +225,10 @@ public class CoreApi {
         return walletsService.getAddressBalanceInfo(addressString);
     }
 
+    public String getUnusedBsqAddress() {
+        return walletsService.getUnusedBsqAddress();
+    }
+
     public List<AddressBalanceInfo> getFundingAddresses() {
         return walletsService.getFundingAddresses();
     }

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -20,6 +20,7 @@ package bisq.core.api;
 import bisq.core.api.model.AddressBalanceInfo;
 import bisq.core.btc.Balances;
 import bisq.core.btc.model.AddressEntry;
+import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletsManager;
 
@@ -55,6 +56,7 @@ class CoreWalletsService {
 
     private final Balances balances;
     private final WalletsManager walletsManager;
+    private final BsqWalletService bsqWalletService;
     private final BtcWalletService btcWalletService;
 
     @Nullable
@@ -66,9 +68,11 @@ class CoreWalletsService {
     @Inject
     public CoreWalletsService(Balances balances,
                               WalletsManager walletsManager,
+                              BsqWalletService bsqWalletService,
                               BtcWalletService btcWalletService) {
         this.balances = balances;
         this.walletsManager = walletsManager;
+        this.bsqWalletService = bsqWalletService;
         this.btcWalletService = btcWalletService;
     }
 
@@ -98,6 +102,10 @@ class CoreWalletsService {
         var satoshiBalance = getAddressBalance(addressString);
         var numConfirmations = getNumConfirmationsForMostRecentTransaction(addressString);
         return new AddressBalanceInfo(addressString, satoshiBalance, numConfirmations);
+    }
+
+    String getUnusedBsqAddress() {
+        return "TODO";
     }
 
     List<AddressBalanceInfo> getFundingAddresses() {

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -28,6 +28,7 @@ import bisq.common.Timer;
 import bisq.common.UserThread;
 
 import org.bitcoinj.core.Address;
+import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 
@@ -105,7 +106,7 @@ class CoreWalletsService {
     }
 
     String getUnusedBsqAddress() {
-        return "TODO";
+        return bsqWalletService.getUnusedBsqAddressAsString();
     }
 
     List<AddressBalanceInfo> getFundingAddresses() {

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -28,7 +28,6 @@ import bisq.common.Timer;
 import bisq.common.UserThread;
 
 import org.bitcoinj.core.Address;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -26,6 +26,8 @@ import bisq.proto.grpc.GetBalanceReply;
 import bisq.proto.grpc.GetBalanceRequest;
 import bisq.proto.grpc.GetFundingAddressesReply;
 import bisq.proto.grpc.GetFundingAddressesRequest;
+import bisq.proto.grpc.GetUnusedBsqAddressReply;
+import bisq.proto.grpc.GetUnusedBsqAddressRequest;
 import bisq.proto.grpc.LockWalletReply;
 import bisq.proto.grpc.LockWalletRequest;
 import bisq.proto.grpc.RemoveWalletPasswordReply;
@@ -81,6 +83,23 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
             AddressBalanceInfo balanceInfo = coreApi.getAddressBalanceInfo(req.getAddress());
             var reply = GetAddressBalanceReply.newBuilder()
                     .setAddressBalanceInfo(balanceInfo.toProtoMessage()).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (IllegalStateException cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
+    }
+
+    @Override
+    public void getUnusedBsqAddress(GetUnusedBsqAddressRequest req,
+                                    StreamObserver<GetUnusedBsqAddressReply> responseObserver) {
+        try {
+            String address = coreApi.getUnusedBsqAddress();
+            var reply = GetUnusedBsqAddressReply.newBuilder()
+                    .setAddress(address)
+                    .build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (IllegalStateException cause) {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -275,6 +275,8 @@ message TradeInfo {
 service Wallets {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
+    rpc GetUnusedBsqAddress (GetUnusedBsqAddressRequest) returns (GetUnusedBsqAddressReply) {
+    }
     rpc GetAddressBalance (GetAddressBalanceRequest) returns (GetAddressBalanceReply) {
     }
     rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
@@ -302,6 +304,13 @@ message GetAddressBalanceRequest {
 
 message GetAddressBalanceReply {
     AddressBalanceInfo addressBalanceInfo = 1;
+}
+
+message GetUnusedBsqAddressRequest {
+}
+
+message GetUnusedBsqAddressReply {
+     string address = 1;
 }
 
 message GetFundingAddressesRequest {


### PR DESCRIPTION
This method returns one unused BSQ address.  It takes no arguments and returns a String.

PR https://github.com/bisq-network/bisq/pull/4772 should be reviewd & merged before this PR.
