### PR TITLE
Market Offers chart modifications

### DIFF
--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -543,4 +543,8 @@ public class CurrencyUtil {
         else
             return Res.get(translationKey, currencyCode, Res.getBaseCurrencyCode());
     }
+
+    public static String getOfferVolumeCode(String currencyCode) {
+        return Res.get("shared.offerVolumeCode", currencyCode);
+    }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -52,6 +52,7 @@ shared.P2P=P2P
 shared.oneOffer=offer
 shared.multipleOffers=offers
 shared.Offer=Offer
+shared.offerVolumeCode={0} Offer Volume
 shared.openOffers=open offers
 shared.trade=trade
 shared.trades=trades

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -1751,6 +1751,10 @@ textfield */
     -fx-alignment: center-left;
 }
 
+#charts .axisy .axis-label {
+    -fx-alignment: center;
+}
+
 /********************************************************************************************************************
  *                                                                                                                  *
  * Highlight buttons                                                                                                  *


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
## Intro
This is an attempt to simplify the Market Offers chart, to provide a better  (I think) visual "feeling". 
In particular, the scientific precision of the X-axis values is confusing to the user: 

For example, for EUR this:
![Bisq-MarketOfferBook-EURold-2020-11-09](https://user-images.githubusercontent.com/142019/98598945-e469ed80-22e3-11eb-9929-703b192189b5.png)
becomes:
![Bisq-MarketOfferBook-EURnew-2020-11-09](https://user-images.githubusercontent.com/142019/98599008-fb104480-22e3-11eb-8c79-576f895c15c0.png)

For XMR:
![Bisq-MarketOfferBook-default-XMR-2020-11-08](https://user-images.githubusercontent.com/142019/98600419-3449b400-22e6-11eb-9f8f-7877b79d03c3.png)
becomes:
![Bisq-MarketOfferBook-new-XMR-2020-11-08](https://user-images.githubusercontent.com/142019/98600531-5fcc9e80-22e6-11eb-97b5-9dafa3d0ac89.png)

For GBP:
![Bisq-MarketOfferBook-GBPold-2020-11-09](https://user-images.githubusercontent.com/142019/98600994-10d33900-22e7-11eb-937b-2e77292cd82e.png)
becomes:
![Bisq-MarketOfferBook-GBPnew-2020-11-09](https://user-images.githubusercontent.com/142019/98601027-1fb9eb80-22e7-11eb-9de4-d1b1a3b6fa69.png)

## The BSQ problem
The above works well (my opinion of course) for the remaining currencies (including USD, which I forgot to capture a pic - sorry), except for BSQ.
BSQ offers have some crazy values. The current charts implementation, filters-out values that have a factor 3 difference, the outliers are removed.
In the current PR, the filtering-out has been removed. I believe if there is a problem, the data should show it, not hide it. Hiding bad data creates a false sense of OKness. Better to see it:
Current BSQ chart:
![Bisq-MarketOfferBook-BSQold-2020-11-09](https://user-images.githubusercontent.com/142019/98604344-2ac34a80-22ec-11eb-8d22-703d5a88d547.png)
becomes:
![Bisq-MarketOfferBook-BSQnew-2020-11-09](https://user-images.githubusercontent.com/142019/98604387-3ca4ed80-22ec-11eb-90e2-0312ccc5cc83.png)

Looking at the Sell BTC (red) table, we see the last few values represent orders of magnitude jumps from the main core.
Putting back the filtering is easy, as is taking it off. I hope a discussion on how to best handle this issue follows. Is there one ongoing, already ?

Perhaps an outliers-toggle switch like in that other DAO chart on BSQs.

## The translations
The Y-axis label is "BTC Offer Volume". As a multi-lingual configuration is used on this chart, a translation web service was used to provide stock translations, which probably sometimes fail miserably. I don't know the Bisq policy on this, please advice. 
