### PR TITLE
Remove unused translations

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -123,6 +123,7 @@ shared.noDetailsAvailable=No details available
 shared.notUsedYet=Not used yet
 shared.date=Date
 shared.sendFundsDetailsWithFee=Sending: {0}\nFrom address: {1}\nTo receiving address: {2}.\nRequired mining fee is: {3} ({4} satoshis/vbyte)\nTransaction vsize: {5} vKb\n\nThe recipient will receive: {6}\n\nAre you sure you want to withdraw this amount?
+# suppress inspection "TrailingSpacesInProperty"
 shared.sendFundsDetailsDust=Bisq detected that this transaction would create a change output which is below the minimum dust threshold (and therefore not allowed by Bitcoin consensus rules). Instead, this dust ({0} satoshi{1}) will be added to the mining fee.\n\n\n
 shared.copyToClipboard=Copy to clipboard
 shared.language=Language
@@ -188,7 +189,6 @@ shared.tradeWalletAddress=Trade wallet address
 shared.tradeWalletBalance=Trade wallet balance
 shared.makerTxFee=Maker: {0}
 shared.takerTxFee=Taker: {0}
-shared.securityDepositBox.description=Security deposit for BTC {0}
 shared.iConfirm=I confirm
 shared.tradingFeeInBsqInfo=equivalent to {0} used as trading fee
 shared.openURL=Open {0}
@@ -237,8 +237,6 @@ mainView.menu.settings=Settings
 mainView.menu.account=Account
 mainView.menu.dao=DAO
 
-mainView.marketPrice.provider=Price by
-mainView.marketPrice.label=Market price
 mainView.marketPriceWithProvider.label=Market price by {0}
 mainView.marketPrice.bisqInternalPrice=Price of latest Bisq trade
 mainView.marketPrice.tooltip.bisqInternalPrice=There is no market price from external price feed providers available.\n\
@@ -294,7 +292,6 @@ market.tabs.spread=Details
 market.tabs.trades=Trades
 
 # OfferBookChartView
-market.offerBook.chart.title=Offer book for {0}
 market.offerBook.buyAltcoin=Buy {0} (sell {1})
 market.offerBook.sellAltcoin=Sell {0} (buy {1})
 market.offerBook.buyWithFiat=Buy {0}
@@ -406,10 +403,6 @@ offerbook.warning.paymentMethodBanned=The payment method used in that offer was 
 offerbook.warning.nodeBlocked=The onion address of that trader was blocked by the Bisq developers.\nProbably there is an unhandled bug causing issues when taking offers from that trader.
 offerbook.warning.requireUpdateToNewVersion=Your version of Bisq is not compatible for trading anymore.\n\
   Please update to the latest Bisq version at [HYPERLINK:https://bisq.network/downloads].
-offerbook.warning.tradeLimitNotMatching=Your payment account has been created {0} ago. Your trade limit is based on the account age and is not sufficient for that offer.\n\n\
-  Your trade limit is: {1}\n\
-  The min. trade amount of the offer is: {2}.\n\n\
-  You cannot take that offer at the moment. Once your account is older than 2 months this restriction gets removed.
 offerbook.warning.offerWasAlreadyUsedInTrade=You cannot take this offer because you already took it earlier. \
   It could be that your previous take-offer attempt resulted in a failed trade.
 
@@ -461,7 +454,6 @@ createOffer.alreadyFunded=You had already funded that offer.\nYour funds have be
 createOffer.createOfferFundWalletInfo.headline=Fund your offer
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Trade amount: {0} \n
-createOffer.createOfferFundWalletInfo.feesWithBSQ={0} and {1}
 createOffer.createOfferFundWalletInfo.msg=You need to deposit {0} to this offer.\n\nThose funds are reserved in your local wallet and will get locked into the multisig deposit address once someone takes your offer.\n\nThe amount is the sum of:\n{1}- Your security deposit: {2}\n- Trading fee: {3}\n- Mining fee: {4}\n\nYou can choose between two options when funding your trade:\n- Use your Bisq wallet (convenient, but transactions may be linkable) OR\n- Transfer from an external wallet (potentially more private)\n\nYou will see all funding options and details after closing this popup.
 
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
@@ -536,6 +528,7 @@ takeOffer.failed.offererOffline=You cannot take that offer because the maker is 
 takeOffer.warning.connectionToPeerLost=You lost connection to the maker.\nThey might have gone offline or has closed the connection to you because of too many open connections.\n\nIf you can still see their offer in the offerbook you can try to take the offer again.
 
 takeOffer.error.noFundsLost=\n\nNo funds have left your wallet yet.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.
+# suppress inspection "TrailingSpacesInProperty"
 takeOffer.error.feePaid=\n\n
 takeOffer.error.depositPublished=\n\nThe deposit transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
 takeOffer.error.payoutPublished=\n\nThe payout transaction is already published.\nPlease try to restart your application and check your network connection to see if you can resolve the issue.\nIf the problem still remains please contact the developers for support.
@@ -685,9 +678,6 @@ portfolio.pending.step2_seller.f2fInfo.headline=Buyer's contact information
 portfolio.pending.step2_seller.waitPayment.msg=The deposit transaction has at least one blockchain confirmation.\nYou need to wait until the BTC buyer starts the {0} payment.
 portfolio.pending.step2_seller.warn=The BTC buyer still has not done the {0} payment.\nYou need to wait until they have started the payment.\nIf the trade has not been completed on {1} the arbitrator will investigate.
 portfolio.pending.step2_seller.openForDispute=The BTC buyer has not started their payment!\nThe max. allowed period for the trade has elapsed.\nYou can wait longer and give the trading peer more time or contact the mediator for assistance.
-portfolio.pending.step2_seller.refresh=Refresh Trade State
-portfolio.pending.step2_seller.refreshInfo=Sometimes P2P network messages acknowledging payment are not delivered, \
-  causing trades to get stuck. Hit the button below to make your peer resend the last message.
 tradeChat.chatWindowTitle=Chat window for trade with ID ''{0}''
 tradeChat.openChat=Open chat window
 tradeChat.rules=You can communicate with your trade peer to resolve potential problems with this trade.\n\
@@ -754,6 +744,7 @@ portfolio.pending.step3_seller.halCash=The buyer has to send you the HalCash cod
 
 portfolio.pending.step3_seller.bankCheck=\n\nPlease also verify that the name of the sender specified on the trade contract matches the name that appears on your bank statement:\nSender''s name, per trade contract: {0}\n\n\
   If the names are not exactly the same, {1}
+# suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.openDispute=don't confirm payment receipt. Instead, open a dispute by pressing \"alt + o\" or \"option + o\".\n\n
 portfolio.pending.step3_seller.confirmPaymentReceipt=Confirm payment receipt
 portfolio.pending.step3_seller.amountToReceive=Amount to receive
@@ -779,6 +770,7 @@ portfolio.pending.step3_seller.onPaymentReceived.part1=Have you received the {0}
 portfolio.pending.step3_seller.onPaymentReceived.fiat=The trade ID (\"reason for payment\" text) of the transaction is: \"{0}\"\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the name of the sender specified on the trade contract matches the name that appears on your bank statement:\nSender''s name, per trade contract: {0}\n\nIf the names are not exactly the same, don''t confirm payment receipt. Instead, open a dispute by pressing \"alt + o\" or \"option + o\".\n\n
+# suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.note=Please note, that as soon you have confirmed the receipt, the locked trade amount will be released to the BTC buyer and the security deposit will be refunded.\n\n
 portfolio.pending.step3_seller.onPaymentReceived.confirm.headline=Confirm that you have received the payment
 portfolio.pending.step3_seller.onPaymentReceived.confirm.yes=Yes, I have received the payment
@@ -843,20 +835,11 @@ portfolio.pending.error.depositTxNotConfirmed=The deposit transaction is not con
   with an unconfirmed deposit transaction. Please wait until it is confirmed or go to \"Settings/Network info\" and do a SPV resync.\n\n\
   For further help please contact the Bisq support channel at the Bisq Keybase team.
 
-portfolio.pending.notification=Notification
-
 portfolio.pending.support.headline.getHelp=Need help?
 portfolio.pending.support.text.getHelp=If you have any problems you can try to contact the trade peer in the trade \
   chat or ask the Bisq community at https://bisq.community. \
   If your issue still isn't resolved, you can request more help from a mediator.
-portfolio.pending.support.text.getHelp.arbitrator=If you have any problems you can try to contact the trade peer in the trade \
-  chat or ask the Bisq community at https://bisq.community. \
-  If your issue still isn't resolved, you can request more help from an arbitrator.
 portfolio.pending.support.button.getHelp=Open Trader Chat
-portfolio.pending.support.popup.info=If your issue with the trade remains unsolved, you can open a support \
-  ticket to request help from a mediator. If you have not received the payment, please wait until the trade period is over.\n\n\
-  Are you sure you want to open a support ticket?
-portfolio.pending.support.popup.button=Open support ticket
 portfolio.pending.support.headline.halfPeriodOver=Check payment
 portfolio.pending.support.headline.periodOver=Trade period is over
 
@@ -864,19 +847,11 @@ portfolio.pending.mediationRequested=Mediation requested
 portfolio.pending.refundRequested=Refund requested
 portfolio.pending.openSupport=Open support ticket
 portfolio.pending.supportTicketOpened=Support ticket opened
-portfolio.pending.requestSupport=Request support
-portfolio.pending.error.requestSupport=Please report the problem to your mediator or arbitrator.\n\nThey will forward the \
-  information to the developers to investigate the problem.\nAfter the problem has been analyzed you will \
-  get back all locked funds.
 portfolio.pending.communicateWithArbitrator=Please communicate in the \"Support\" screen with the arbitrator.
 portfolio.pending.communicateWithMediator=Please communicate in the \"Support\" screen with the mediator.
-portfolio.pending.supportTicketOpenedMyUser=You opened already a support ticket.\n{0}
 portfolio.pending.disputeOpenedMyUser=You opened already a dispute.\n{0}
 portfolio.pending.disputeOpenedByPeer=Your trading peer opened a dispute\n{0}
-portfolio.pending.supportTicketOpenedByPeer=Your trading peer opened a support ticket.\n{0}
 portfolio.pending.noReceiverAddressDefined=No receiver address defined
-portfolio.pending.removeFailedTrade=Is this a failed trade? If so, would you like to manually \
-  close it, so that it no longer shows as an open trade?
 
 portfolio.pending.mediationResult.headline=Suggested payout from mediation
 portfolio.pending.mediationResult.info.noneAccepted=Complete the trade by accepting the mediator's suggestion for the trade payout.
@@ -1197,9 +1172,7 @@ setting.preferences.useCustomValue=Use custom value
 setting.preferences.txFeeMin=Transaction fee must be at least {0} satoshis/vbyte
 setting.preferences.txFeeTooLarge=Your input is above any reasonable value (>5000 satoshis/vbyte). Transaction fee is usually in the range of 50-400 satoshis/vbyte.
 setting.preferences.ignorePeers=Ignored peers [onion address:port]
-setting.preferences.refererId=Referral ID
 setting.preferences.ignoreDustThreshold=Min. non-dust output value
-setting.preferences.refererId.prompt=Optional referral ID
 setting.preferences.currenciesInList=Currencies in market price feed list
 setting.preferences.prefCurrency=Preferred currency
 setting.preferences.displayFiat=Display national currencies
@@ -1215,10 +1188,8 @@ setting.preferences.useAnimations=Use animations
 setting.preferences.useDarkMode=Use dark mode
 setting.preferences.sortWithNumOffers=Sort market lists with no. of offers/trades
 setting.preferences.resetAllFlags=Reset all \"Don't show again\" flags
-setting.preferences.reset=Reset
 settings.preferences.languageChange=To apply the language change to all screens requires a restart.
 settings.preferences.supportLanguageWarning=In case of a dispute, please note that mediation is handled in {0} and arbitration in {1}.
-settings.preferences.selectCurrencyNetwork=Select network
 setting.preferences.daoOptions=DAO options
 setting.preferences.dao.resyncFromGenesis.label=Rebuild DAO state from genesis tx
 setting.preferences.dao.resyncFromResources.label=Rebuild DAO state from resources
@@ -1385,11 +1356,9 @@ setting.info.msg=When selling BTC for XMR you can use the auto-confirm feature t
 # Account
 ####################################################################
 
-account.tab.arbitratorRegistration=Arbitrator registration
 account.tab.mediatorRegistration=Mediator registration
 account.tab.refundAgentRegistration=Refund agent registration
 account.tab.signing=Signing
-account.tab.account=Account
 account.info.headline=Welcome to your Bisq Account
 account.info.msg=Here you can add trading accounts for national currencies & altcoins and create a backup of your wallet & account data.\n\n\
 A new Bitcoin wallet was created the first time you started Bisq.\n\n\
@@ -1427,6 +1396,7 @@ described on the {1} web page.\nUsing wallets from centralized exchanges where (
 (b) which don''t use compatible wallet software is risky: it can lead to loss of the traded funds!\nThe mediator or arbitrator is \
 not a {2} specialist and cannot help in such cases.
 account.altcoin.popup.wallet.confirm=I understand and confirm that I know which wallet I need to use.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.upx.msg=Trading UPX on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 For sending UPX, you need to use either the official uPlexa GUI wallet or uPlexa CLI wallet with the \
@@ -1445,6 +1415,7 @@ arbitrator in case of a dispute.\n\n\
 There is no payment ID required, just the normal public address.\n\
 If you are not sure about that process visit uPlexa discord channel (https://discord.gg/vhdNSrV) \
 or the uPlexa Telegram Chat (https://t.me/uplexaOfficial) to find more information.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.arq.msg=Trading ARQ on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 For sending ARQ, you need to use either the official ArQmA GUI wallet or ArQmA CLI wallet with the \
@@ -1463,6 +1434,7 @@ mediator or arbitrator in case of a dispute.\n\n\
 There is no payment ID required, just the normal public address.\n\
 If you are not sure about that process visit ArQmA discord channel (https://discord.gg/s9BQpJT) \
 or the ArQmA forum (https://labs.arqma.com) to find more information.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.xmr.msg=Trading XMR on Bisq requires that you understand the following requirement.\n\n\
 If selling XMR, you must be able to provide the following information to a mediator or arbitrator in case of a dispute:\n\
 - the transaction key (Tx Key, Tx Secret Key or Tx Private Key)\n\
@@ -1473,7 +1445,7 @@ Failure to provide the required transaction data will result in losing disputes.
 Also note that Bisq now offers automatic confirming for XMR transactions to make trades quicker, \
 but you need to enable it in Settings.\n\n\
 See the wiki for more information about the auto-confirm feature: [HYPERLINK:https://bisq.wiki/Trading_Monero#Auto-confirming_trades].
-# suppress inspection "TrailingSpacesInProperty"
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.msr.msg=Trading MSR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 For sending MSR, you need to use either the official Masari GUI wallet, Masari CLI wallet with the \
@@ -1497,6 +1469,7 @@ dispute case. The MSR sender is responsible for providing verification of the MS
 mediator or arbitrator in case of a dispute.\n\n\
 There is no payment ID required, just the normal public address.\n\
 If you are not sure about that process, ask for help on the Official Masari Discord (https://discord.gg/sMCwMqs).
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.blur.msg=Trading BLUR on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 To send BLUR you must use the Blur Network CLI or GUI Wallet. \n\n\
@@ -1512,6 +1485,7 @@ transfer using the Blur Transaction Viewer (https://blur.cash/#tx-viewer).\n\n\
 Failure to provide the required information to the mediator or arbitrator will result in losing the dispute case. In all cases of dispute, the \
 BLUR sender bears 100% of the burden of responsibility in verifying transactions to an mediator or arbitrator. \n\n\
 If you do not understand these requirements, do not trade on Bisq. First, seek help at the Blur Network Discord (https://discord.gg/dMWaqVW).
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.solo.msg=Trading Solo on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 To send Solo you must use the Solo Network CLI Wallet. \n\n\
@@ -1524,6 +1498,7 @@ transfer using the Solo Block Explorer by searching for the transaction and then
 failure to provide the required information to the mediator or arbitrator will result in losing the dispute case. In all cases of dispute, the \
 Solo sender bears 100% of the burden of responsibility in verifying transactions to an mediator or arbitrator. \n\n\
 If you do not understand these requirements, do not trade on Bisq. First, seek help at the Solo Network Discord (https://discord.minesolo.com/).
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.cash2.msg=Trading CASH2 on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 To send CASH2 you must use the Cash2 Wallet version 3 or higher. \n\n\
@@ -1536,6 +1511,7 @@ transfer using the Cash2 Block Explorer (https://blocks.cash2.org).\n\n\
 Failure to provide the required information to the mediator or arbitrator will result in losing the dispute case. In all cases of dispute, the \
 CASH2 sender bears 100% of the burden of responsibility in verifying transactions to an mediator or arbitrator. \n\n\
 If you do not understand these requirements, do not trade on Bisq. First, seek help at the Cash2 Discord (https://discord.gg/FGfXAYN).
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.qwertycoin.msg=Trading Qwertycoin on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 To send QWC you must use the official QWC Wallet version 5.1.3 or higher. \n\n\
@@ -1548,6 +1524,7 @@ transfer using the QWC Block Explorer (https://explorer.qwertycoin.org).\n\n\
 Failure to provide the required information to the mediator or arbitrator will result in losing the dispute case. In all cases of dispute, the \
 QWC sender bears 100% of the burden of responsibility in verifying transactions to an mediator or arbitrator. \n\n\
 If you do not understand these requirements, do not trade on Bisq. First, seek help at the QWC Discord (https://discord.gg/rUkfnpC).
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.drgl.msg=Trading Dragonglass on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 Because of the privacy Dragonglass provides, a transaction is not verifiable on the public blockchain. If required, you \
@@ -1565,10 +1542,13 @@ Failure to provide the above data, or if you used an incompatible wallet, will r
 dispute case. The Dragonglass sender is responsible for providing verification of the DRGL transfer to the \
 mediator or arbitrator in case of a dispute. Use of PaymentID is not required.\n\n\
 If you are unsure about any part of this process, visit Dragonglass on Discord (http://discord.drgl.info) for help.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.ZEC.msg=When using Zcash you can only use the transparent addresses (starting with t), not \
 the z-addresses (private), because the mediator or arbitrator would not be able to verify the transaction with z-addresses.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.XZC.msg=When using Zcoin you can only use the transparent (traceable) addresses, not \
 the untraceable addresses, because the mediator or arbitrator would not be able to verify the transaction with untraceable addresses at a block explorer.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.grin.msg=GRIN requires an interactive process between the sender and receiver to create the \
   transaction. Be sure to follow the instructions from the GRIN project web page to reliably send and receive GRIN \
   (the receiver needs to be online or at least be online during a certain time frame). \n\n\
@@ -1579,6 +1559,7 @@ account.altcoin.popup.grin.msg=GRIN requires an interactive process between the 
   receiving GRIN as well as how to create the proof. \n\n\
   See https://github.com/vault713/wallet713/blob/master/docs/usage.md#transaction-proofs-grinbox-only for more \
   information about the Grinbox proof tool.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.beam.msg=BEAM requires an interactive process between the sender and receiver to create the \
   transaction. \n\n\
   Be sure to follow the instructions from the BEAM project web page to reliably send and receive BEAM \
@@ -1586,6 +1567,7 @@ account.altcoin.popup.beam.msg=BEAM requires an interactive process between the 
   The BEAM sender is required to provide proof that they sent BEAM successfully. \
   Be sure to use wallet software which can produce such a proof. If the wallet cannot provide the proof a potential \
   dispute will be resolved in favor of the BEAM receiver.
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.pars.msg=Trading ParsiCoin on Bisq requires that you understand and fulfill \
 the following requirements:\n\n\
 To send PARS you must use the official ParsiCoin Wallet version 3.0.0 or higher. \n\n\
@@ -1598,6 +1580,7 @@ Failure to provide the required information to the mediator or arbitrator will r
 ParsiCoin sender bears 100% of the burden of responsibility in verifying transactions to an mediator or arbitrator. \n\n\
 If you do not understand these requirements, do not trade on Bisq. First, seek help at the ParsiCoin Discord (https://discord.gg/c7qmFNh).
 
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.blk-burnt.msg=To trade burnt blackcoins, you need to know the following:\n\n\
 Burnt blackcoins are unspendable. To trade them on Bisq, output scripts need to be in the form: \
 OP_RETURN OP_PUSHDATA, followed by associated data bytes which, after being hex-encoded, constitute addresses. \
@@ -1609,6 +1592,7 @@ As burnt blackcoins are unspendable, they can not be reselled. “Selling” bur
 burning ordinary blackcoins (with associated data equal to the destination address).\n\n\
 In case of a dispute, the BLK seller needs to provide the transaction hash.
 
+# suppress inspection "UnusedProperty"
 account.altcoin.popup.liquidbitcoin.msg=Trading L-BTC on Bisq requires that you understand the following:\n\n\
 When receiving L-BTC for a trade on Bisq, you cannot use the mobile Blockstream Green Wallet app or a \
 custodial/exchange wallet. You must only receive L-BTC into the Liquid Elements Core wallet, or another \
@@ -1628,7 +1612,6 @@ account.backup.location=Backup location
 account.backup.selectLocation=Select backup location
 account.backup.backupNow=Backup now (backup is not encrypted!)
 account.backup.appDir=Application data directory
-account.backup.logFile=Log file
 account.backup.openDirectory=Open directory
 account.backup.openLogFile=Open Log file
 account.backup.success=Backup successfully saved at:\n{0}
@@ -1674,14 +1657,11 @@ account.seed.restore.ok=Ok, do the restore and shut down Bisq
 
 account.notifications.setup.title=Setup
 account.notifications.download.label=Download mobile app
-account.notifications.download.button=Download
 account.notifications.waitingForWebCam=Waiting for webcam...
 account.notifications.webCamWindow.headline=Scan QR-code from phone
 account.notifications.webcam.label=Use webcam
 account.notifications.webcam.button=Scan QR code
 account.notifications.noWebcam.button=I don't have a webcam
-account.notifications.testMsg.label=Send test notification
-account.notifications.testMsg.title=Test
 account.notifications.erase.label=Clear notifications on phone
 account.notifications.erase.title=Clear notifications
 account.notifications.email.label=Pairing token
@@ -1720,8 +1700,6 @@ account.notifications.marketAlert.trigger.prompt=Percentage distance from market
 account.notifications.marketAlert.addButton=Add offer alert
 account.notifications.marketAlert.manageAlertsButton=Manage offer alerts
 account.notifications.marketAlert.manageAlerts.title=Manage offer alerts
-account.notifications.marketAlert.manageAlerts.label=Offer alerts
-account.notifications.marketAlert.manageAlerts.item=Offer alert for {0} offer with trigger price {1} and payment account {2}
 account.notifications.marketAlert.manageAlerts.header.paymentAccount=Payment account
 account.notifications.marketAlert.manageAlerts.header.trigger=Trigger price
 account.notifications.marketAlert.manageAlerts.header.offerType=Offer type
@@ -1761,7 +1739,6 @@ dao.unverifiedBsqBalance=Balance of all unverified transactions (awaiting block 
 dao.lockedForVoteBalance=Used for voting
 dao.lockedInBonds=Locked in bonds
 dao.availableNonBsqBalance=Available non-BSQ balance (BTC)
-dao.totalBsqBalance=Total BSQ balance
 dao.reputationBalance=Merit Value (not spendable)
 
 dao.tx.published.success=Your transaction has been successfully published.
@@ -1895,11 +1872,6 @@ dao.param.ISSUANCE_LIMIT=Issuance limit per cycle in BSQ
 dao.param.currentValue=Current value: {0}
 dao.param.currentAndPastValue=Current value: {0} (Value when proposal was made: {1})
 dao.param.blocks={0} blocks
-
-dao.results.cycle.duration.label=Duration of {0}
-dao.results.cycle.duration.value={0} block(s)
-dao.results.cycle.value.postFix.isDefaultValue=(default value)
-dao.results.cycle.value.postFix.hasChanged=(has been changed in voting)
 
 dao.results.invalidVotes=We had invalid votes in that voting cycle. That can happen if a vote was \
   not distributed well in the Bisq network.\n{0}
@@ -2092,7 +2064,6 @@ dao.proofOfBurn.sign=Sign
 dao.proofOfBurn.message=Message
 dao.proofOfBurn.sig=Signature
 dao.proofOfBurn.verify=Verify
-dao.proofOfBurn.verify.header=Verify message with key from proof of burn transaction
 dao.proofOfBurn.verificationResult.ok=Verification succeeded
 dao.proofOfBurn.verificationResult.failed=Verification failed
 
@@ -2189,19 +2160,18 @@ dao.proposal.display.name=Exact GitHub username
 dao.proposal.display.link=Link to detailed info
 dao.proposal.display.link.prompt=Link to proposal
 dao.proposal.display.requestedBsq=Requested amount in BSQ
-dao.proposal.display.bsqAddress=BSQ address
 dao.proposal.display.txId=Proposal transaction ID
 dao.proposal.display.proposalFee=Proposal fee
 dao.proposal.display.myVote=My vote
 dao.proposal.display.voteResult=Vote result summary
 dao.proposal.display.bondedRoleComboBox.label=Bonded role type
 dao.proposal.display.requiredBondForRole.label=Required bond for role
-dao.proposal.display.tickerSymbol.label=Ticker Symbol
 dao.proposal.display.option=Option
 
 dao.proposal.table.header.proposalType=Proposal type
 dao.proposal.table.header.link=Link
 dao.proposal.table.header.myVote=My vote
+# suppress inspection "UnusedProperty"
 dao.proposal.table.header.remove=Remove
 dao.proposal.table.icon.tooltip.removeProposal=Remove my proposal
 dao.proposal.table.icon.tooltip.changeVote=Current vote: ''{0}''. Change vote to: ''{1}''
@@ -2239,23 +2209,11 @@ dao.wallet.dashboard.myBalance=My wallet balance
 dao.wallet.receive.fundYourWallet=Your BSQ receive address
 dao.wallet.receive.bsqAddress=BSQ wallet address (Fresh unused address)
 
-dao.wallet.receive.dao.headline=The Bisq DAO
-dao.wallet.receive.daoInfo=Just as the Bisq exchange is decentralized and censorship-resistant, so is its governance \
-  model — and the Bisq DAO and BSQ token are the tools that make it possible.
-dao.wallet.receive.daoInfo.button=Learn more about the Bisq DAO
-dao.wallet.receive.daoTestnetInfo=The mainnet Bisq DAO is not launched yet but you can learn about the Bisq DAO by \
-  running it on testnet.
-dao.wallet.receive.daoTestnetInfo.button=How to run the Bisq DAO on our testnet
-dao.wallet.receive.daoContributorInfo=If you have contributed to Bisq please use the \
-  BSQ address below and make a request for taking part of the BSQ genesis distribution.
-dao.wallet.receive.daoContributorInfo.button=How to be part of the BSQ genesis distribution
-
 dao.wallet.send.sendFunds=Send funds
 dao.wallet.send.sendBtcFunds=Send non-BSQ funds (BTC)
 dao.wallet.send.amount=Amount in BSQ
 dao.wallet.send.btcAmount=Amount in BTC (non-BSQ funds)
 dao.wallet.send.setAmount=Set amount to withdraw (min. amount is {0})
-dao.wallet.send.setBtcAmount=Set amount in BTC to withdraw (min. amount is {0})
 dao.wallet.send.receiverAddress=Receiver's BSQ address
 dao.wallet.send.receiverBtcAddress=Receiver's BTC address
 dao.wallet.send.setDestinationAddress=Fill in your destination address
@@ -2418,8 +2376,6 @@ dao.monitor.blindVote.table.numBlindVotes=No. blind votes
 dao.factsAndFigures.menuItem.supply=BSQ Supply
 dao.factsAndFigures.menuItem.transactions=BSQ Transactions
 
-dao.factsAndFigures.dashboard.marketPrice=Market data
-dao.factsAndFigures.dashboard.price=Latest BSQ/BTC trade price (in Bisq)
 dao.factsAndFigures.dashboard.avgPrice90=90 days average BSQ/BTC trade price
 dao.factsAndFigures.dashboard.avgPrice30=30 days average BSQ/BTC trade price
 dao.factsAndFigures.dashboard.avgUSDPrice90=90 days volume weighted average USD/BSQ trade price
@@ -2500,8 +2456,6 @@ disputeSummaryWindow.payout=Trade amount payout
 disputeSummaryWindow.payout.getsTradeAmount=BTC {0} gets trade amount payout
 disputeSummaryWindow.payout.getsAll=BTC {0} gets all
 disputeSummaryWindow.payout.custom=Custom payout
-disputeSummaryWindow.payout.adjustAmount=Amount entered exceeds available amount of {0}.\n\
-We adjust this input field to the max possible value.
 disputeSummaryWindow.payoutAmount.buyer=Buyer's payout amount
 disputeSummaryWindow.payoutAmount.seller=Seller's payout amount
 disputeSummaryWindow.payoutAmount.invert=Use loser as publisher
@@ -2538,6 +2492,7 @@ disputeSummaryWindow.addSummaryNotes=Add summary notes
 disputeSummaryWindow.close.button=Close ticket
 
 # Do no change any line break or order of tokens as the structure is used for signature verification
+# suppress inspection "TrailingSpacesInProperty"
 disputeSummaryWindow.close.msg=Ticket closed on {0}\n\
   {1} node address: {2}\n\n\
   Summary:\n\
@@ -2558,7 +2513,9 @@ disputeSummaryWindow.close.nextStepsForRefundAgentArbitration=\nNext steps:\n\
 No further action is required from you. If the arbitrator decided in your favor, you'll see a "Refund from arbitration" transaction in Funds/Transactions
 disputeSummaryWindow.close.closePeer=You need to close also the trading peers ticket!
 disputeSummaryWindow.close.txDetails.headline=Publish refund transaction
+# suppress inspection "TrailingSpacesInProperty"
 disputeSummaryWindow.close.txDetails.buyer=Buyer receives {0} on address: {1}\n
+# suppress inspection "TrailingSpacesInProperty"
 disputeSummaryWindow.close.txDetails.seller=Seller receives {0} on address: {1}\n
 disputeSummaryWindow.close.txDetails=Spending: {0}\n\
   {1}{2}\
@@ -2641,12 +2598,6 @@ visible in the list presented here. Once you found the correct transaction selec
 Sorry for the inconvenience but that error case should happen very rarely and in future we will try \
 to find better ways to resolve it.
 selectDepositTxWindow.select=Select deposit transaction
-
-selectBaseCurrencyWindow.headline=Market selection
-selectBaseCurrencyWindow.msg=The selected default market is {0}.\n\n\
-If you want to change to another base currency please select one from the drop down box.\n\
-You can also change later the base currency at the \"Settings/Network\" screen.
-selectBaseCurrencyWindow.select=Select base currency
 
 sendAlertMessageWindow.headline=Send global notification
 sendAlertMessageWindow.alertMsg=Alert message
@@ -2769,7 +2720,6 @@ Please check if you have the latest version of Bisq installed.\n\
 You can download it at: [HYPERLINK:https://bisq.network/downloads].\n\n\
 Please restart the application.
 popup.warning.startupFailed.twoInstances=Bisq is already running. You cannot run two instances of Bisq.
-popup.warning.cryptoTestFailed=Seems that you use a self compiled binary and have not following the build instructions in https://github.com/bisq-network/exchange/blob/master/doc/build.md#7-enable-unlimited-strength-for-cryptographic-keys.\n\nIf that is not the case and you use the official Bisq binary, please file a bug report to the GitHub page.\nError={0}
 popup.warning.tradePeriod.halfReached=Your trade with ID {0} has reached the half of the max. allowed trading period and is still not completed.\n\nThe trade period ends on {1}\n\nPlease check your trade state at \"Portfolio/Open trades\" for further information.
 popup.warning.tradePeriod.ended=Your trade with ID {0} has reached the max. allowed trading period and is not completed.\n\n\
   The trade period ended on {1}\n\n\
@@ -2810,7 +2760,9 @@ popup.warning.lockedUpFunds=You have locked up funds from a failed trade.\n\
   Trade ID: {2}.\n\n\
   Please open a support ticket by selecting the trade in the open trades screen and pressing \"alt + o\" or \"option + o\"."
 
+# suppress inspection "UnusedProperty"
 popup.warning.nodeBanned=One of the {0} nodes got banned.
+# suppress inspection "UnusedProperty"
 popup.warning.priceRelay=price relay
 popup.warning.seed=seed
 popup.warning.mandatoryUpdate.trading=Please update to the latest Bisq version. \
@@ -2877,12 +2829,6 @@ popup.attention.forTradeWithId=Attention required for trade with ID {0}
 popup.info.multiplePaymentAccounts.headline=Multiple payment accounts available
 popup.info.multiplePaymentAccounts.msg=You have multiple payment accounts available for this offer. Please make sure you've picked the right one.
 
-popup.news.launch.headline=Two Major Updates
-popup.news.launch.accountSigning.headline=ACCOUNT SIGNING
-popup.news.launch.accountSigning.description=Lift 0.01 BTC fiat trading limits by buying BTC from a signed peer.
-popup.news.launch.ntp.headline=NEW TRADE PROTOCOL
-popup.news.launch.ntp.description=New 2-level dispute resolution system makes Bisq more secure, scalable, and censorship-resistant.
-
 popup.accountSigning.selectAccounts.headline=Select payment accounts
 popup.accountSigning.selectAccounts.description=Based on the payment method and point of time all payment accounts that are connected to a dispute where a payout to the buyer occurred will be selected for you to sign.
 popup.accountSigning.selectAccounts.signAll=Sign all payment methods
@@ -2920,7 +2866,6 @@ popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
 popup.accountSigning.unsignedPubKeys.signed=Pubkeys were signed
-popup.accountSigning.unsignedPubKeys.result.headline=Signing completed
 popup.accountSigning.unsignedPubKeys.result.signed=Signed pubkeys
 popup.accountSigning.unsignedPubKeys.result.failed=Failed to sign
 
@@ -3046,6 +2991,7 @@ navigation.portfolio.pending=\"Portfolio/Open trades\"
 navigation.portfolio.closedTrades=\"Portfolio/History\"
 navigation.funds.depositFunds=\"Funds/Receive funds\"
 navigation.settings.preferences=\"Settings/Preferences\"
+# suppress inspection "UnusedProperty"
 navigation.funds.transactions=\"Funds/Transactions\"
 navigation.support=\"Support\"
 navigation.dao.wallet.receive=\"DAO/BSQ Wallet/Receive\"
@@ -3181,7 +3127,6 @@ payment.secret=Secret question
 payment.answer=Answer
 payment.wallet=Wallet ID
 payment.uphold.accountId=Username or email or phone no.
-payment.cashApp.cashTag=$Cashtag
 payment.moneyBeam.accountId=Email or phone no.
 payment.venmo.venmoUserName=Venmo username
 payment.popmoney.accountId=Email or phone no.
@@ -3266,6 +3211,7 @@ payment.limits.info=Please be aware that all bank transfers carry a certain amou
   ● After the 2nd month, your per-trade limit will be {2}\n\
   \n\
   Please note: limits only apply to trade size. You can place as many trades as you like.
+# suppress inspection "UnusedProperty"
 payment.limits.info.withSigning=To limit chargeback risk, Bisq sets per-trade limits for this payment account type based \
   on the following 2 factors:\n\n\
   1. General chargeback risk for the payment method\n\
@@ -3488,7 +3434,6 @@ validation.fiat.toLarge=Input larger than maximum possible amount is not allowed
 validation.btc.fraction=Input will result in a bitcoin value of less than 1 satoshi
 validation.btc.toLarge=Input larger than {0} is not allowed.
 validation.btc.toSmall=Input smaller than {0} is not allowed.
-validation.securityDeposit.toSmall=Input smaller than {0} is not allowed.
 validation.passwordTooShort=The password you entered is too short. It needs to have a min. of 8 characters.
 validation.passwordTooLong=The password you entered is too long. It cannot be longer than 50 characters.
 validation.sortCodeNumber={0} must consist of {1} numbers.
@@ -3507,10 +3452,15 @@ validation.nationalAccountId={0} must consist of {1} numbers.
 #new
 validation.invalidInput=Invalid input: {0}
 validation.accountNrFormat=Account number must be of format: {0}
+# suppress inspection "UnusedProperty"
 validation.altcoin.wrongStructure=Address validation failed because it does not match the structure of a {0} address.
+# suppress inspection "UnusedProperty"
 validation.altcoin.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
+# suppress inspection "UnusedProperty"
 validation.altcoin.zAddressesNotSupported=ZEC addresses must start with t. Addresses starting with z are not supported.
+# suppress inspection "UnusedProperty"
 validation.altcoin.invalidAddress=Address is not a valid {0} address! {1}
+# suppress inspection "UnusedProperty"
 validation.altcoin.liquidBitcoin.invalidAddress=Native segwit addresses (those starting with 'lq') are not supported.
 validation.bic.invalidLength=Input length must be 8 or 11
 validation.bic.letters=Bank and Country code must be letters

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3281,7 +3281,7 @@ payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your \
   bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. \
-  Both sending and receiving financial institutions must support PayID. For more information please check https://payid.com.au/faqs/
+  Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3357,7 +3357,7 @@ PROMPT_PAY=PromptPay
 # suppress inspection "UnusedProperty"
 ADVANCED_CASH=Advanced Cash
 # suppress inspection "UnusedProperty"
-TRANSFERWISE=Transferwise
+TRANSFERWISE=TransferWise
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Altcoins Instant
 
@@ -3407,7 +3407,7 @@ PROMPT_PAY_SHORT=PromptPay
 # suppress inspection "UnusedProperty"
 ADVANCED_CASH_SHORT=Advanced Cash
 # suppress inspection "UnusedProperty"
-TRANSFERWISE_SHORT=Transferwise
+TRANSFERWISE_SHORT=TransferWise
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Altcoins Instant
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3197,20 +3197,15 @@ payment.halCash.info=When using HalCash the BTC buyer needs to send the BTC sell
   UI in the create-offer and take-offer screen will adjust the BTC amount so that the EUR amount is correct. You cannot use market \
   based price as the EUR amount would be changing with changing prices.\n\n\
   In case of a dispute the BTC buyer needs to provide the proof that they sent the EUR.
-payment.limits.info=Please be aware that all bank transfers carry a certain amount of chargeback risk.\n\
+# suppress inspection "UnusedMessageFormatParameter"
+payment.limits.info=Please be aware that all bank transfers carry a certain amount of chargeback risk. To mitigate this risk, \
+  Bisq sets per-trade limits based on the estimated level of chargeback risk for the payment method used.\n\
   \n\
-  To mitigate this risk, Bisq sets per-trade limits based on two factors:\n\
+  For this payment method, your per-trade limit for buying and selling is {2}.\n\
   \n\
-  1. The estimated level of chargeback risk for the payment method used\n\
-  2. The age of your account for that payment method\n\
+  This limit only applies to the size of a single trade—you can place as many trades as you like.\n\
   \n\
-  The account you are creating now is new and its age is zero. As your account ages, your per-trade limits will grow:\n\
-  \n\
-  ● During the 1st month, your per-trade limit will be {0}\n\
-  ● During the 2nd month, your per-trade limit will be {1}\n\
-  ● After the 2nd month, your per-trade limit will be {2}\n\
-  \n\
-  Please note: limits only apply to trade size. You can place as many trades as you like.
+  See more details on the wiki [HYPERLINK:https://bisq.wiki/Account_limits].
 # suppress inspection "UnusedProperty"
 payment.limits.info.withSigning=To limit chargeback risk, Bisq sets per-trade limits for this payment account type based \
   on the following 2 factors:\n\n\
@@ -3224,11 +3219,11 @@ payment.limits.info.withSigning=To limit chargeback risk, Bisq sets per-trade li
   ● 30 days after signing, your per-trade buy limit will be {1}\n\
   ● 60 days after signing, your per-trade buy limit will be {2}\n\
   \n\
-  Sell limits are not affected by account signing, and increase with account age.\n\
+  Sell limits are not affected by account signing. You can sell {2} in a single trade immediately.\n\
   \n\
-  See more: [HYPERLINK:https://bisq.wiki/Account_limits]\n\
+  These limits only apply to the size of a single trade—you can place as many trades as you like. \n\
   \n\
-  Please note: limits only apply to trade size. You can place as many trades as you like.
+  See more details on the wiki [HYPERLINK:https://bisq.wiki/Account_limits].
 
 payment.cashDeposit.info=Please confirm your bank allows you to send cash deposits into other peoples' accounts. \
   For example, Bank of America and Wells Fargo no longer allow such deposits.


### PR DESCRIPTION
While looking for translations that need to be changed because of our new simplified account restrictions I removed all unused translations and added suppress inspection annotations. This helps during development with Intellij to keep our translations file more clean by looking at the warnings within the file.