### PR TITLE
Use 30 days average USD/BSQ price for market cap

### DIFF
--- a/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
@@ -21,7 +21,7 @@ import bisq.core.dao.governance.param.Param;
 import bisq.core.dao.governance.proposal.ProposalValidationException;
 import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.Res;
-import bisq.core.provider.price.MarketPrice;
+import bisq.core.monetary.Price;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
 import bisq.core.util.validation.BtcAddressValidator;
@@ -121,10 +121,10 @@ public class BsqFormatter implements CoinFormatter {
         return amountFormat.format(MathUtils.scaleDownByPowerOf10(amount.value, 2)) + " BSQ";
     }
 
-    public String formatMarketCap(MarketPrice bsqPriceMarketPrice, MarketPrice fiatMarketPrice, Coin issuedAmount) {
-        if (bsqPriceMarketPrice != null && fiatMarketPrice != null) {
-            double marketCap = bsqPriceMarketPrice.getPrice() * fiatMarketPrice.getPrice() * (MathUtils.scaleDownByPowerOf10(issuedAmount.value, 2));
-            return marketCapFormat.format(MathUtils.doubleToLong(marketCap)) + " " + fiatMarketPrice.getCurrencyCode();
+    public String formatMarketCap(Price usdBsqPrice, Coin issuedAmount) {
+        if (usdBsqPrice != null && issuedAmount != null) {
+            double marketCap = usdBsqPrice.getValue() * (MathUtils.scaleDownByPowerOf10(issuedAmount.value, 6));
+            return marketCapFormat.format(MathUtils.doubleToLong(marketCap)) + " USD";
         } else {
             return "";
         }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2418,13 +2418,11 @@ dao.monitor.blindVote.table.numBlindVotes=No. blind votes
 dao.factsAndFigures.menuItem.supply=BSQ Supply
 dao.factsAndFigures.menuItem.transactions=BSQ Transactions
 
-dao.factsAndFigures.dashboard.marketPrice=Market data
-dao.factsAndFigures.dashboard.price=Latest BSQ/BTC trade price (in Bisq)
 dao.factsAndFigures.dashboard.avgPrice90=90 days average BSQ/BTC trade price
 dao.factsAndFigures.dashboard.avgPrice30=30 days average BSQ/BTC trade price
-dao.factsAndFigures.dashboard.avgUSDPrice90=90 days volume weighted average USD/BSQ trade price
-dao.factsAndFigures.dashboard.avgUSDPrice30=30 days volume weighted average USD/BSQ trade price
-dao.factsAndFigures.dashboard.marketCap=Market capitalisation (based on trade price)
+dao.factsAndFigures.dashboard.avgUSDPrice90=90 days volume weighted average USD/BSQ price
+dao.factsAndFigures.dashboard.avgUSDPrice30=30 days volume weighted average USD/BSQ price
+dao.factsAndFigures.dashboard.marketCap=Market capitalisation (based on 30 days average USD/BSQ price)
 dao.factsAndFigures.dashboard.availableAmount=Total available BSQ
 
 dao.factsAndFigures.supply.issuedVsBurnt=BSQ issued v. BSQ burnt

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
@@ -115,6 +115,7 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
     private Coin availableAmount;
     private int gridRow = 0;
     double howManyStdDevsConstituteOutlier = 10;
+    private Price avg30DayUSDPrice;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -145,6 +146,7 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
             updatePrice();
             updateAveragePriceFields(avgPrice90TextField, avgPrice30TextField, false);
             updateAveragePriceFields(avgUSDPrice90TextField, avgUSDPrice30TextField, true);
+            updateMarketCap();
         };
     }
 
@@ -188,6 +190,7 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
         updateChartData();
         updateAveragePriceFields(avgPrice90TextField, avgPrice30TextField, false);
         updateAveragePriceFields(avgUSDPrice90TextField, avgUSDPrice30TextField, true);
+        updateMarketCap();
     }
 
 
@@ -333,14 +336,16 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
             Price bsqPrice = optionalBsqPrice.get();
             marketPriceLabel.setText(FormattingUtils.formatPrice(bsqPrice) + " BSQ/BTC");
 
-            marketCapTextField.setText(bsqFormatter.formatMarketCap(priceFeedService.getMarketPrice("BSQ"),
-                    priceFeedService.getMarketPrice(preferences.getPreferredTradeCurrency().getCode()),
-                    availableAmount));
-
             updateChartData();
-
         } else {
             marketPriceLabel.setText(Res.get("shared.na"));
+        }
+    }
+
+    private void updateMarketCap() {
+        if (avg30DayUSDPrice != null) {
+            marketCapTextField.setText(bsqFormatter.formatMarketCap(avg30DayUSDPrice, availableAmount));
+        } else {
             marketCapTextField.setText(Res.get("shared.na"));
         }
     }
@@ -394,6 +399,9 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
         String avg = FormattingUtils.formatPrice(avgPrice);
         if (isUSDField) {
             textField.setText(avg + " USD/BSQ");
+            if (days == 30) {
+                avg30DayUSDPrice = avgPrice;
+            }
         } else {
             textField.setText(avg + " BSQ/BTC");
         }


### PR DESCRIPTION
We used latest trade price to calculate the market cap which is confusing and volatile. Better to use the 30 day average.