### PR TITLE
Redesign mailbox msg

### DIFF
--- a/core/src/main/java/bisq/core/alert/PrivateNotificationManager.java
+++ b/core/src/main/java/bisq/core/alert/PrivateNotificationManager.java
@@ -133,7 +133,7 @@ public class PrivateNotificationManager {
     }
 
     public void removePrivateNotification() {
-        p2PService.removeEntryFromMailbox(decryptedMessageWithPubKey);
+        p2PService.removeMailboxMsg(decryptedMessageWithPubKey);
     }
 
     private boolean isKeyValid(String privKeyString) {

--- a/core/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
@@ -43,6 +43,7 @@ import bisq.core.trade.statistics.TradeStatistics3Store;
 import bisq.core.user.PreferencesPayload;
 import bisq.core.user.UserPayload;
 
+import bisq.network.p2p.MailboxMessageList;
 import bisq.network.p2p.peers.peerexchange.PeerList;
 import bisq.network.p2p.storage.persistence.SequenceNumberMap;
 
@@ -129,6 +130,8 @@ public class CorePersistenceProtoResolver extends CoreProtoResolver implements P
                     return SignedWitnessStore.fromProto(proto.getSignedWitnessStore());
                 case TRADE_STATISTICS3_STORE:
                     return TradeStatistics3Store.fromProto(proto.getTradeStatistics3Store());
+                case MAILBOX_MESSAGE_LIST:
+                    return MailboxMessageList.fromProto(proto.getMailboxMessageList(), networkProtoResolver);
 
                 default:
                     throw new ProtobufferRuntimeException("Unknown proto message case(PB.PersistableEnvelope). " +

--- a/core/src/main/java/bisq/core/setup/CorePersistedDataHost.java
+++ b/core/src/main/java/bisq/core/setup/CorePersistedDataHost.java
@@ -35,6 +35,7 @@ import bisq.core.trade.failed.FailedTradesManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
+import bisq.network.p2p.P2PService;
 import bisq.network.p2p.peers.PeerManager;
 import bisq.network.p2p.storage.P2PDataStorage;
 
@@ -66,6 +67,7 @@ public class CorePersistedDataHost {
         persistedDataHosts.add(injector.getInstance(RefundDisputeListService.class));
         persistedDataHosts.add(injector.getInstance(P2PDataStorage.class));
         persistedDataHosts.add(injector.getInstance(PeerManager.class));
+        persistedDataHosts.add(injector.getInstance(P2PService.class));
 
         if (injector.getInstance(Config.class).daoActivated) {
             persistedDataHosts.add(injector.getInstance(BallotListService.class));

--- a/core/src/main/java/bisq/core/support/SupportManager.java
+++ b/core/src/main/java/bisq/core/support/SupportManager.java
@@ -177,7 +177,7 @@ public abstract class SupportManager {
             requestPersistence();
 
             if (decryptedMessageWithPubKey != null)
-                p2PService.removeEntryFromMailbox(decryptedMessageWithPubKey);
+                p2PService.removeMailboxMsg(decryptedMessageWithPubKey);
         }
     }
 
@@ -314,7 +314,7 @@ public abstract class SupportManager {
             log.debug("decryptedMessageWithPubKey.message " + networkEnvelope);
             if (networkEnvelope instanceof SupportMessage) {
                 dispatchMessage((SupportMessage) networkEnvelope);
-                p2PService.removeEntryFromMailbox(decryptedMessageWithPubKey);
+                p2PService.removeMailboxMsg(decryptedMessageWithPubKey);
             } else if (networkEnvelope instanceof AckMessage) {
                 onAckMessage((AckMessage) networkEnvelope, decryptedMessageWithPubKey);
             }

--- a/core/src/main/java/bisq/core/trade/closed/CleanupMailboxMessages.java
+++ b/core/src/main/java/bisq/core/trade/closed/CleanupMailboxMessages.java
@@ -35,6 +35,9 @@ import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 
+//TODO with the redesign of mailbox messages that is not required anymore. We leave it for now as we want to minimize
+// changes for the 1.5.0 release but we should clean up afterwards...
+
 /**
  * Util for removing pending mailbox messages in case the trade has been closed by the seller after confirming receipt
  * and a AckMessage as mailbox message will be sent by the buyer once they go online. In that case the seller's trade
@@ -73,8 +76,7 @@ public class CleanupMailboxMessages {
     }
 
     private void cleanupMailboxMessages(List<Trade> trades) {
-        p2PService.getMailboxItemsByUid().values()
-                .stream().map(P2PService.MailboxItem::getDecryptedMessageWithPubKey)
+        p2PService.getMailBoxMessages()
                 .forEach(message -> handleDecryptedMessageWithPubKey(message, trades));
     }
 
@@ -102,7 +104,7 @@ public class CleanupMailboxMessages {
     private void removeEntryFromMailbox(DecryptedMessageWithPubKey decryptedMessageWithPubKey, Trade trade) {
         log.info("We found a pending mailbox message ({}) for trade {}. As the trade is closed we remove the mailbox message.",
                 decryptedMessageWithPubKey.getNetworkEnvelope().getClass().getSimpleName(), trade.getId());
-        p2PService.removeEntryFromMailbox(decryptedMessageWithPubKey);
+        p2PService.removeMailboxMsg(decryptedMessageWithPubKey);
     }
 
     private boolean isMyMessage(TradeMessage message, Trade trade) {

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -30,7 +30,6 @@ import bisq.network.p2p.DecryptedDirectMessageListener;
 import bisq.network.p2p.DecryptedMessageWithPubKey;
 import bisq.network.p2p.MailboxMessage;
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.P2PService;
 import bisq.network.p2p.SendMailboxMessageListener;
 import bisq.network.p2p.messaging.DecryptedMailboxListener;
 
@@ -78,8 +77,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             processModel.getP2PService().addDecryptedDirectMessageListener(this);
         }
         processModel.getP2PService().addDecryptedMailboxListener(this);
-        processModel.getP2PService().getMailboxItemsByUid().values()
-                .stream().map(P2PService.MailboxItem::getDecryptedMessageWithPubKey)
+        processModel.getP2PService().getMailBoxMessages()
                 .forEach(this::handleDecryptedMessageWithPubKey);
     }
 
@@ -138,7 +136,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             // We only remove here if we have already completed the trade.
             // Otherwise removal is done after successfully applied the task runner.
             if (trade.isWithdrawn()) {
-                processModel.getP2PService().removeEntryFromMailbox(decryptedMessageWithPubKey);
+                processModel.getP2PService().removeMailboxMsg(decryptedMessageWithPubKey);
                 log.info("Remove {} from the P2P network.", tradeMessage.getClass().getSimpleName());
                 return;
             }
@@ -152,7 +150,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                 onAckMessage((AckMessage) networkEnvelope, peer);
             }
             // In any case we remove the msg
-            processModel.getP2PService().removeEntryFromMailbox(decryptedMessageWithPubKey);
+            processModel.getP2PService().removeMailboxMsg(decryptedMessageWithPubKey);
             log.info("Remove {} from the P2P network.", networkEnvelope.getClass().getSimpleName());
         }
     }
@@ -165,7 +163,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             PublicKey sigPubKey = processModel.getTradingPeer().getPubKeyRing().getSignaturePubKey();
             // We reconstruct the DecryptedMessageWithPubKey from the message and the peers signature pubKey
             DecryptedMessageWithPubKey decryptedMessageWithPubKey = new DecryptedMessageWithPubKey(tradeMessage, sigPubKey);
-            processModel.getP2PService().removeEntryFromMailbox(decryptedMessageWithPubKey);
+            processModel.getP2PService().removeMailboxMsg(decryptedMessageWithPubKey);
             log.info("Remove {} from the P2P network.", tradeMessage.getClass().getSimpleName());
         }
     }

--- a/p2p/src/main/java/bisq/network/p2p/DecryptedMessageWithPubKey.java
+++ b/p2p/src/main/java/bisq/network/p2p/DecryptedMessageWithPubKey.java
@@ -17,19 +17,48 @@
 
 package bisq.network.p2p;
 
+import bisq.common.crypto.Sig;
+import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.network.NetworkEnvelope;
+import bisq.common.proto.network.NetworkProtoResolver;
+import bisq.common.proto.persistable.PersistablePayload;
+
+import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
 import lombok.Value;
 
 @Value
-public final class DecryptedMessageWithPubKey {
+public final class DecryptedMessageWithPubKey implements PersistablePayload {
     private final NetworkEnvelope networkEnvelope;
-    private final PublicKey signaturePubKey;
+    private final byte[] signaturePubKeyBytes;
+    transient private final PublicKey signaturePubKey;
 
     public DecryptedMessageWithPubKey(NetworkEnvelope networkEnvelope, PublicKey signaturePubKey) {
         this.networkEnvelope = networkEnvelope;
         this.signaturePubKey = signaturePubKey;
+        this.signaturePubKeyBytes = Sig.getPublicKeyBytes(signaturePubKey);
+    }
+
+    private DecryptedMessageWithPubKey(NetworkEnvelope networkEnvelope, byte[] signaturePubKeyBytes) {
+        this.networkEnvelope = networkEnvelope;
+        this.signaturePubKeyBytes = signaturePubKeyBytes;
+        this.signaturePubKey = Sig.getPublicKeyFromBytes(signaturePubKeyBytes);
+    }
+
+    @Override
+    public protobuf.DecryptedMessageWithPubKey toProtoMessage() {
+        return protobuf.DecryptedMessageWithPubKey.newBuilder()
+                .setNetworkEnvelope(networkEnvelope.toProtoNetworkEnvelope())
+                .setSignaturePubKeyBytes(ByteString.copyFrom(signaturePubKeyBytes))
+                .build();
+    }
+
+    public static DecryptedMessageWithPubKey fromProto(protobuf.DecryptedMessageWithPubKey proto,
+                                                       NetworkProtoResolver networkProtoResolver)
+            throws ProtobufferException {
+        return new DecryptedMessageWithPubKey(networkProtoResolver.fromProto(proto.getNetworkEnvelope()),
+                proto.getSignaturePubKeyBytes().toByteArray());
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/MailboxItem.java
+++ b/p2p/src/main/java/bisq/network/p2p/MailboxItem.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p;
+
+import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
+
+import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.network.NetworkProtoResolver;
+import bisq.common.proto.persistable.PersistablePayload;
+
+import lombok.Value;
+
+@Value
+public class MailboxItem implements PersistablePayload {
+    private final ProtectedMailboxStorageEntry protectedMailboxStorageEntry;
+    private final DecryptedMessageWithPubKey decryptedMessageWithPubKey;
+
+    public MailboxItem(ProtectedMailboxStorageEntry protectedMailboxStorageEntry,
+                       DecryptedMessageWithPubKey decryptedMessageWithPubKey) {
+        this.protectedMailboxStorageEntry = protectedMailboxStorageEntry;
+        this.decryptedMessageWithPubKey = decryptedMessageWithPubKey;
+    }
+
+    @Override
+    public protobuf.MailboxItem toProtoMessage() {
+        return protobuf.MailboxItem.newBuilder()
+                .setProtectedMailboxStorageEntry(protectedMailboxStorageEntry.toProtoMessage())
+                .setDecryptedMessageWithPubKey(decryptedMessageWithPubKey.toProtoMessage())
+                .build();
+    }
+
+    public static MailboxItem fromProto(protobuf.MailboxItem proto, NetworkProtoResolver networkProtoResolver)
+            throws ProtobufferException {
+        return new MailboxItem(ProtectedMailboxStorageEntry.fromProto(proto.getProtectedMailboxStorageEntry(),
+                networkProtoResolver),
+                DecryptedMessageWithPubKey.fromProto(proto.getDecryptedMessageWithPubKey(), networkProtoResolver));
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/MailboxMessageList.java
+++ b/p2p/src/main/java/bisq/network/p2p/MailboxMessageList.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p;
+
+import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.network.NetworkProtoResolver;
+import bisq.common.proto.persistable.PersistableList;
+
+import com.google.protobuf.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@EqualsAndHashCode(callSuper = true)
+public class MailboxMessageList extends PersistableList<MailboxItem> {
+
+    MailboxMessageList() {
+        super();
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public MailboxMessageList(List<MailboxItem> list) {
+        super(list);
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        return protobuf.PersistableEnvelope.newBuilder()
+                .setMailboxMessageList(protobuf.MailboxMessageList.newBuilder()
+                        .addAllMailboxItem(getList().stream()
+                                .map(MailboxItem::toProtoMessage)
+                                .collect(Collectors.toList())))
+                .build();
+    }
+
+    public static MailboxMessageList fromProto(protobuf.MailboxMessageList proto,
+                                               NetworkProtoResolver networkProtoResolver) {
+        return new MailboxMessageList(new ArrayList<>(proto.getMailboxItemList().stream()
+                .map(e -> {
+                    try {
+                        return MailboxItem.fromProto(e, networkProtoResolver);
+                    } catch (ProtobufferException protobufferException) {
+                        protobufferException.printStackTrace();
+                        log.error("Error at MailboxItem.fromProto: {}", protobufferException.toString());
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList())));
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -931,8 +931,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         removeFromMapAndDataStore(Collections.singletonList(Maps.immutableEntry(hashOfPayload, protectedStorageEntry)));
     }
 
-    private void removeFromMapAndDataStore(
-            Collection<Map.Entry<ByteArray, ProtectedStorageEntry>> entriesToRemoveWithPayloadHash) {
+    private void removeFromMapAndDataStore(Collection<Map.Entry<ByteArray,
+            ProtectedStorageEntry>> entriesToRemoveWithPayloadHash) {
 
         if (entriesToRemoveWithPayloadHash.isEmpty())
             return;

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -180,6 +180,11 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         this.persistenceManager.initialize(sequenceNumberMap, PersistenceManager.Source.PRIVATE);
     }
 
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PersistedDataHost
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
     @Override
     public void readPersisted(Runnable completeHandler) {
         persistenceManager.readPersisted(persisted -> {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -570,6 +570,20 @@ message DataAndSeqNrPair {
     int32 sequence_number = 2;
 }
 
+message MailboxMessageList {
+    repeated MailboxItem mailbox_item = 1;
+}
+
+message MailboxItem {
+    ProtectedMailboxStorageEntry protected_mailbox_storage_entry = 1;
+    DecryptedMessageWithPubKey decrypted_message_with_pub_key = 2;
+}
+
+message DecryptedMessageWithPubKey {
+    NetworkEnvelope network_envelope = 1;
+    bytes signature_pub_key_bytes = 2;
+}
+
 // misc
 
 message PrivateNotificationPayload {
@@ -1188,6 +1202,7 @@ message PersistableEnvelope {
         MediationDisputeList mediation_dispute_list = 29;
         RefundDisputeList refund_dispute_list = 30;
         TradeStatistics3Store trade_statistics3_store = 31;
+        MailboxMessageList mailbox_message_list = 32;
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue with not removed mailbox messages from the trade process.
I redesigned the way how we remove the messages. Instead of removing it from the network after successful processing we remove it immediately when we received it after the listeners are called. We keep it locally stored so in case the client was not ready to process it at that moment it  requests the data later. We also persist the messages for the edge case that the user shuts down the app before the client was ready for processing. In that case the message wuld be lost if not persisted as it was removed from the network but only kept in RAM for later access which is lost at restart. By persisting the data we get them again at restart.
After processing we also try to remove the data if still in the P2PDataStorage to be sure that the message got removed from the network if the initial removal failed because we have not been bootstrapped.

By removing the messages at receipt we can expect that the number of messages will go down quite a lot. Currently its about 1000, normally it was about 400-600. I guess after that release and when old messages have been cleaned from TTL we might have only about 200-300 messages in the network.

This PR did only the minimum of changes to limit risks for this release. We should clean up later a bit more and continue refactoring the mailbox message handling so it gets more robust and uniform. 