### PR TITLE
Touch-ups to the DAO BSQ Supply page

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -1700,7 +1700,9 @@ textfield */
     -fx-font-size: 0.880em;
 }
 
-#price-chart .axis-tick-mark-text-node, #volume-chart .axis-tick-mark-text-node {
+#price-chart  .axis-tick-mark-text-node,
+#volume-chart .axis-tick-mark-text-node,
+#charts-dao   .axis-tick-mark-text-node {
     -fx-text-alignment: center;
 }
 
@@ -1726,13 +1728,13 @@ textfield */
 
 /* The .chart-line-symbol rules change the color of the legend symbol */
 #charts-dao .default-color0.chart-series-line { -fx-stroke: -bs-chart-dao-line1; }
-#charts-dao .default-color0.chart-line-symbol { -fx-background-color: -bs-chart-dao-line1, -bs-background-color; }
+#charts-dao .default-color0.chart-line-symbol { -fx-background-color: -bs-chart-dao-line1, -bs-chart-dao-line1; }
 
 #charts-dao .default-color1.chart-series-line { -fx-stroke: -bs-chart-dao-line2; }
-#charts-dao .default-color1.chart-line-symbol { -fx-background-color: -bs-chart-dao-line2, -bs-background-color; }
+#charts-dao .default-color1.chart-line-symbol { -fx-background-color: -bs-chart-dao-line2, -bs-chart-dao-line2; }
 
 #charts-dao .chart-series-line {
-    -fx-stroke-width: 1px;
+    -fx-stroke-width: 3px;
 }
 
 #charts .default-color0.chart-series-area-fill {


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
## Intro

The BSQ supply page on the DAO GUI tab, provides 3 charts and some numerical data on the BSQ supply.
For simplicity, I will refer here to the charts as chart#1 (top), chart#2 (middle) and chart#3 (bottom) to avoid any confusion with the names.
The charts and the page itself seems a little confusing. This PR provides some touch-ups to improve it. It is not a redesign of the page.

## Current Status 

The DAO BSQ pages, as of version 1.4.2 is like this:
![Bisq-Dao-Page-BSQ_Supply_top-2020-11-08](https://user-images.githubusercontent.com/142019/98921446-fb723080-24d9-11eb-9454-20d8057e55fe.png)
![Bisq-Dao-Page-BSQ_Supply_bottom-2020-11-08](https://user-images.githubusercontent.com/142019/98921479-075df280-24da-11eb-8af6-09415f6323c5.png)

## Results
The result of this PR becomes:
![Bisq-Dao-Page-BSQ_Supply_NEW_top-2020-11-22](https://user-images.githubusercontent.com/142019/99905944-c7b6b800-2cdc-11eb-9329-578846263b5d.png)
![Bisq-Dao-Page-BSQ_Supply_NEW_bottom-2020-11-12](https://user-images.githubusercontent.com/142019/98923219-0e860000-24dc-11eb-8420-7418eee13dc7.png)

## Description of changes

1. Chart touch-ups affect the display of lines and axes.
2. Removed Chart#2. It has no new information from Chart#1, so it is not needed.
3. Did not:
    - Check or touch any of the calculations in the number sections.
    - <del>Removed chart#2 by commenting-out the relevant code and left as a placeholder. Easy to re-insert another chart in its place if/when needed.</del>

### Remaining issues 

1. Section **BSQ burnt** shows a negative number for _Burned BSQ (fees)_. **Q:** Is this by design ?
