### PR TITLE
Add Amazon eGift Card payment method

### DIFF
--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -319,6 +319,24 @@ public class CurrencyUtil {
         return currencies;
     }
 
+    public static List<TradeCurrency> getAllAmazonGiftCardCurrencies() {
+        List<TradeCurrency> currencies = new ArrayList<>(Arrays.asList(
+                new FiatCurrency("AUD"),
+                new FiatCurrency("CAD"),
+                new FiatCurrency("EUR"),
+                new FiatCurrency("GBP"),
+                new FiatCurrency("INR"),
+                new FiatCurrency("JPY"),
+                new FiatCurrency("SAR"),
+                new FiatCurrency("SEK"),
+                new FiatCurrency("SGD"),
+                new FiatCurrency("TRY"),
+                new FiatCurrency("USD")
+        ));
+        currencies.sort(Comparator.comparing(TradeCurrency::getCode));
+        return currencies;
+    }
+
     // https://www.revolut.com/help/getting-started/exchanging-currencies/what-fiat-currencies-are-supported-for-holding-and-exchange
     public static List<TradeCurrency> getAllRevolutCurrencies() {
         ArrayList<TradeCurrency> currencies = new ArrayList<>(Arrays.asList(

--- a/core/src/main/java/bisq/core/payment/AmazonGiftCardAccount.java
+++ b/core/src/main/java/bisq/core/payment/AmazonGiftCardAccount.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment;
+
+import bisq.core.payment.payload.AmazonGiftCardAccountPayload;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.payment.payload.PaymentMethod;
+
+public final class AmazonGiftCardAccount extends PaymentAccount {
+
+    public AmazonGiftCardAccount() {
+        super(PaymentMethod.AMAZON_GIFT_CARD);
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new AmazonGiftCardAccountPayload(paymentMethod.getId(), id);
+    }
+
+    public String getEmailOrMobileNr() {
+        return getAmazonGiftCardAccountPayload().getEmailOrMobileNr();
+    }
+
+    public void setEmailOrMobileNr(String emailOrMobileNr) {
+        getAmazonGiftCardAccountPayload().setEmailOrMobileNr(emailOrMobileNr);
+    }
+
+    private AmazonGiftCardAccountPayload getAmazonGiftCardAccountPayload() {
+        return (AmazonGiftCardAccountPayload) paymentAccountPayload;
+    }
+}

--- a/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
@@ -80,6 +80,8 @@ public class PaymentAccountFactory {
                 return new AdvancedCashAccount();
             case PaymentMethod.TRANSFERWISE_ID:
                 return new TransferwiseAccount();
+            case PaymentMethod.AMAZON_GIFT_CARD_ID:
+                return new AmazonGiftCardAccount();
             case PaymentMethod.BLOCK_CHAINS_INSTANT_ID:
                 return new InstantCryptoCurrencyAccount();
 

--- a/core/src/main/java/bisq/core/payment/payload/AmazonGiftCardAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AmazonGiftCardAccountPayload.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import bisq.core.locale.Res;
+
+import com.google.protobuf.Message;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Setter
+@Getter
+@Slf4j
+public class AmazonGiftCardAccountPayload extends PaymentAccountPayload {
+    private String emailOrMobileNr;
+
+    public AmazonGiftCardAccountPayload(String paymentMethod, String id) {
+        super(paymentMethod, id);
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private AmazonGiftCardAccountPayload(String paymentMethodName,
+                                         String id,
+                                         String emailOrMobileNr,
+                                         long maxTradePeriod,
+                                         Map<String, String> excludeFromJsonDataMap) {
+        super(paymentMethodName,
+                id,
+                maxTradePeriod,
+                excludeFromJsonDataMap);
+        this.emailOrMobileNr = emailOrMobileNr;
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        protobuf.AmazonGiftCardAccountPayload.Builder builder =
+                protobuf.AmazonGiftCardAccountPayload.newBuilder()
+                        .setEmailOrMobileNr(emailOrMobileNr);
+        return getPaymentAccountPayloadBuilder()
+                .setAmazonGiftCardAccountPayload(builder)
+                .build();
+    }
+
+    public static PaymentAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
+        protobuf.AmazonGiftCardAccountPayload amazonGiftCardAccountPayload = proto.getAmazonGiftCardAccountPayload();
+        return new AmazonGiftCardAccountPayload(proto.getPaymentMethodId(),
+                proto.getId(),
+                amazonGiftCardAccountPayload.getEmailOrMobileNr(),
+                proto.getMaxTradePeriod(),
+                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public String getPaymentDetails() {
+        return Res.get(paymentMethodId) + " - " + getPaymentDetailsForTradePopup().replace("\n", ", ");
+    }
+
+    @Override
+    public String getPaymentDetailsForTradePopup() {
+        return Res.getWithCol("payment.email.mobile") + " " + emailOrMobileNr;
+    }
+
+    @Override
+    public byte[] getAgeWitnessInputData() {
+        String data = "AmazonGiftCard" + emailOrMobileNr;
+        return super.getAgeWitnessInputData(data.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -93,6 +93,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static final String PROMPT_PAY_ID = "PROMPT_PAY";
     public static final String ADVANCED_CASH_ID = "ADVANCED_CASH";
     public static final String TRANSFERWISE_ID = "TRANSFERWISE";
+    public static final String AMAZON_GIFT_CARD_ID = "AMAZON_GIFT_CARD";
     public static final String BLOCK_CHAINS_INSTANT_ID = "BLOCK_CHAINS_INSTANT";
 
     // Cannot be deleted as it would break old trade history entries
@@ -132,6 +133,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static PaymentMethod PROMPT_PAY;
     public static PaymentMethod ADVANCED_CASH;
     public static PaymentMethod TRANSFERWISE;
+    public static PaymentMethod AMAZON_GIFT_CARD;
     public static PaymentMethod BLOCK_CHAINS_INSTANT;
 
     // Cannot be deleted as it would break old trade history entries
@@ -176,6 +178,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
             SPECIFIC_BANKS = new PaymentMethod(SPECIFIC_BANKS_ID, 4 * DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
             HAL_CASH = new PaymentMethod(HAL_CASH_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),
             F2F = new PaymentMethod(F2F_ID, 4 * DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),
+            AMAZON_GIFT_CARD = new PaymentMethod(AMAZON_GIFT_CARD_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
 
             // Trans national
             UPHOLD = new PaymentMethod(UPHOLD_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),

--- a/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -23,6 +23,7 @@ import bisq.core.dao.governance.blindvote.storage.BlindVotePayload;
 import bisq.core.dao.governance.proposal.storage.appendonly.ProposalPayload;
 import bisq.core.payment.payload.AdvancedCashAccountPayload;
 import bisq.core.payment.payload.AliPayAccountPayload;
+import bisq.core.payment.payload.AmazonGiftCardAccountPayload;
 import bisq.core.payment.payload.AustraliaPayidPayload;
 import bisq.core.payment.payload.CashAppAccountPayload;
 import bisq.core.payment.payload.CashDepositAccountPayload;
@@ -151,6 +152,8 @@ public class CoreProtoResolver implements ProtoResolver {
                     return AdvancedCashAccountPayload.fromProto(proto);
                 case TRANSFERWISE_ACCOUNT_PAYLOAD:
                     return TransferwiseAccountPayload.fromProto(proto);
+                case AMAZON_GIFT_CARD_ACCOUNT_PAYLOAD:
+                    return AmazonGiftCardAccountPayload.fromProto(proto);
                 case INSTANT_CRYPTO_CURRENCY_ACCOUNT_PAYLOAD:
                     return InstantCryptoCurrencyPayload.fromProto(proto);
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -145,7 +145,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         PROMPT_PAY,
         ADVANCED_CASH,
         BLOCK_CHAINS_INSTANT,
-        TRANSFERWISE
+        TRANSFERWISE,
+        AMAZON_GIFT_CARD
     }
 
     @Getter

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -629,6 +629,10 @@ portfolio.pending.step2_buyer.moneyGram.extra=IMPORTANT REQUIREMENT:\nAfter you 
 portfolio.pending.step2_buyer.westernUnion=Please pay {0} to the BTC seller by using Western Union.\n\n
 portfolio.pending.step2_buyer.westernUnion.extra=IMPORTANT REQUIREMENT:\nAfter you have done the payment send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller.\n\
   The receipt must clearly show the seller''s full name, city, country and the amount. The seller''s email is: {0}.
+# suppress inspection "TrailingSpacesInProperty"
+portfolio.pending.step2_buyer.amazonGiftCard=Please purchase an Amazon eGift Card for {0} at your Amazon account and \
+  use the BTC seller''s email or mobile number as receiver. \
+  In case the trade amount exceeds the permitted amount send multiple cards.\n\n
 
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.postal=Please send {0} by \"US Postal Money Order\" to the BTC seller.\n\n
@@ -742,6 +746,9 @@ portfolio.pending.step3_seller.westernUnion=The buyer has to send you the MTCN (
   Only confirm receipt after you have successfully picked up the money!
 portfolio.pending.step3_seller.halCash=The buyer has to send you the HalCash code as text message. Beside that you will receive a message from HalCash with the required information to withdraw the EUR from a HalCash supporting ATM.\n\n\
   After you have picked up the money from the ATM please confirm here the receipt of the payment!
+portfolio.pending.step3_seller.amazonGiftCard=The buyer has sent you an Amazon eGift Card by email or by text \
+  message to your mobile phone. Please redeem now the Amazon eGift Card at your Amazon account and once accepted \
+  confirm the payment receipt.
 
 portfolio.pending.step3_seller.bankCheck=\n\nPlease also verify that the name of the sender specified on the trade contract matches the name that appears on your bank statement:\nSender''s name, per trade contract: {0}\n\n\
   If the names are not exactly the same, {1}
@@ -3278,6 +3285,11 @@ payment.payid=PayID linked to financial institution. Like email address or mobil
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your \
   bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. \
   Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and \
+  use the BTC seller''s email or mobile nr. as receiver. Amazon send then an email or text message to the receiver. \
+  Use the trade ID for the message field.\n\n\
+  Amazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\n\
+  For more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ
@@ -3355,6 +3367,8 @@ ADVANCED_CASH=Advanced Cash
 # suppress inspection "UnusedProperty"
 TRANSFERWISE=TransferWise
 # suppress inspection "UnusedProperty"
+AMAZON_GIFT_CARD=Amazon eGift Card
+# suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Altcoins Instant
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
@@ -3404,6 +3418,8 @@ PROMPT_PAY_SHORT=PromptPay
 ADVANCED_CASH_SHORT=Advanced Cash
 # suppress inspection "UnusedProperty"
 TRANSFERWISE_SHORT=TransferWise
+# suppress inspection "UnusedProperty"
+AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Altcoins Instant
 

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AmazonGiftCardForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AmazonGiftCardForm.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.paymentmethods;
+
+import bisq.desktop.components.InputTextField;
+import bisq.desktop.util.FormBuilder;
+import bisq.desktop.util.Layout;
+
+import bisq.core.account.witness.AccountAgeWitnessService;
+import bisq.core.locale.CurrencyUtil;
+import bisq.core.locale.Res;
+import bisq.core.locale.TradeCurrency;
+import bisq.core.payment.AmazonGiftCardAccount;
+import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.payload.AmazonGiftCardAccountPayload;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.util.coin.CoinFormatter;
+import bisq.core.util.validation.InputValidator;
+
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+
+import javafx.collections.FXCollections;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextField;
+import static bisq.desktop.util.FormBuilder.addInputTextField;
+import static bisq.desktop.util.FormBuilder.addTopLabelTextField;
+
+@Slf4j
+public class AmazonGiftCardForm extends PaymentMethodForm {
+    private InputTextField accountNrInputTextField;
+    private final AmazonGiftCardAccount amazonGiftCardAccount;
+
+    public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
+        FormBuilder.addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.email.mobile"),
+                ((AmazonGiftCardAccountPayload) paymentAccountPayload).getEmailOrMobileNr());
+        return gridRow;
+    }
+
+    public AmazonGiftCardForm(PaymentAccount paymentAccount,
+                              AccountAgeWitnessService accountAgeWitnessService,
+                              InputValidator inputValidator,
+                              GridPane gridPane,
+                              int gridRow,
+                              CoinFormatter formatter) {
+        super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
+
+        this.amazonGiftCardAccount = (AmazonGiftCardAccount) paymentAccount;
+    }
+
+    public void addTradeCurrency() {
+        addTradeCurrencyComboBox();
+        currencyComboBox.setItems(FXCollections.observableArrayList(CurrencyUtil.getAllAmazonGiftCardCurrencies()));
+        currencyComboBox.getSelectionModel().select(0);
+    }
+
+    @Override
+    public void addFormForAddAccount() {
+        gridRowFrom = gridRow + 1;
+
+        accountNrInputTextField = addInputTextField(gridPane, ++gridRow, Res.get("payment.email.mobile"));
+        accountNrInputTextField.setValidator(inputValidator);
+        accountNrInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            amazonGiftCardAccount.setEmailOrMobileNr(newValue);
+            updateFromInputs();
+        });
+
+        addTradeCurrency();
+
+        addLimitations(false);
+        addAccountNameTextFieldWithAutoFillToggleButton();
+    }
+
+
+    @Override
+    protected void autoFillNameTextField() {
+        setAccountNameWithString(accountNrInputTextField.getText());
+    }
+
+    @Override
+    public void addFormForDisplayAccount() {
+        addFormForAccountNumberDisplayAccount(paymentAccount.getAccountName(), paymentAccount.getPaymentMethod(),
+                amazonGiftCardAccount.getEmailOrMobileNr(),
+                paymentAccount.getSingleTradeCurrency());
+    }
+
+    @Override
+    public void updateAllInputsValid() {
+        allInputsValid.set(isAccountNameValid()
+                && inputValidator.validate(amazonGiftCardAccount.getEmailOrMobileNr()).isValid
+                && paymentAccount.getTradeCurrencies().size() > 0);
+    }
+
+    private void addFormForAccountNumberDisplayAccount(String accountName,
+                                                       PaymentMethod paymentMethod,
+                                                       String accountNr,
+                                                       TradeCurrency singleTradeCurrency) {
+        gridRowFrom = gridRow;
+        addTopLabelTextField(gridPane, gridRow, Res.get("payment.account.name"), accountName,
+                Layout.FIRST_ROW_AND_GROUP_DISTANCE);
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"),
+                Res.get(paymentMethod.getId()));
+        TextField field = addCompactTopLabelTextField(gridPane, ++gridRow,
+                Res.get("payment.email.mobile"), accountNr).second;
+        field.setMouseTransparent(false);
+
+        String nameAndCode = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "";
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.currency"), nameAndCode);
+
+        addLimitations(true);
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -21,6 +21,7 @@ import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.TitledGroupBg;
 import bisq.desktop.components.paymentmethods.AdvancedCashForm;
 import bisq.desktop.components.paymentmethods.AliPayForm;
+import bisq.desktop.components.paymentmethods.AmazonGiftCardForm;
 import bisq.desktop.components.paymentmethods.AustraliaPayidForm;
 import bisq.desktop.components.paymentmethods.CashDepositForm;
 import bisq.desktop.components.paymentmethods.ChaseQuickPayForm;
@@ -78,6 +79,7 @@ import bisq.desktop.util.validation.WeChatPayValidator;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.locale.Res;
 import bisq.core.offer.OfferRestrictions;
+import bisq.core.payment.AmazonGiftCardAccount;
 import bisq.core.payment.AustraliaPayid;
 import bisq.core.payment.CashDepositAccount;
 import bisq.core.payment.ClearXchangeAccount;
@@ -317,6 +319,13 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                                     .actionButtonText(Res.get("shared.iConfirm"))
                                     .onAction(() -> doSaveNewAccount(paymentAccount))
                                     .show();
+                        } else if (paymentAccount instanceof AmazonGiftCardAccount) {
+                            new Popup().information(Res.get("payment.amazonGiftCard.info", currencyName, currencyName))
+                                    .width(900)
+                                    .closeButtonText(Res.get("shared.cancel"))
+                                    .actionButtonText(Res.get("shared.iUnderstand"))
+                                    .onAction(() -> doSaveNewAccount(paymentAccount))
+                                    .show();
                         } else {
                             doSaveNewAccount(paymentAccount);
                         }
@@ -502,6 +511,8 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
                 return new AdvancedCashForm(paymentAccount, accountAgeWitnessService, advancedCashValidator, inputValidator, root, gridRow, formatter);
             case PaymentMethod.TRANSFERWISE_ID:
                 return new TransferwiseForm(paymentAccount, accountAgeWitnessService, transferwiseValidator, inputValidator, root, gridRow, formatter);
+            case PaymentMethod.AMAZON_GIFT_CARD_ID:
+                return new AmazonGiftCardForm(paymentAccount, accountAgeWitnessService, inputValidator, root, gridRow, formatter);
             default:
                 log.error("Not supported PaymentMethod: " + paymentMethod);
                 return null;

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -22,6 +22,7 @@ import bisq.desktop.components.TextFieldWithCopyIcon;
 import bisq.desktop.components.TitledGroupBg;
 import bisq.desktop.components.paymentmethods.AdvancedCashForm;
 import bisq.desktop.components.paymentmethods.AliPayForm;
+import bisq.desktop.components.paymentmethods.AmazonGiftCardForm;
 import bisq.desktop.components.paymentmethods.AssetsForm;
 import bisq.desktop.components.paymentmethods.CashDepositForm;
 import bisq.desktop.components.paymentmethods.ChaseQuickPayForm;
@@ -61,6 +62,7 @@ import bisq.core.network.MessageState;
 import bisq.core.offer.Offer;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.PaymentAccountUtil;
+import bisq.core.payment.payload.AmazonGiftCardAccountPayload;
 import bisq.core.payment.payload.AssetsAccountPayload;
 import bisq.core.payment.payload.CashDepositAccountPayload;
 import bisq.core.payment.payload.F2FAccountPayload;
@@ -217,10 +219,11 @@ public class BuyerStep2View extends TradeStepView {
         field.setCopyWithoutCurrencyPostFix(true);
 
         if (!(paymentAccountPayload instanceof AssetsAccountPayload) &&
-                !(paymentAccountPayload instanceof F2FAccountPayload))
+                !(paymentAccountPayload instanceof F2FAccountPayload)) {
             addTopLabelTextFieldWithCopyIcon(gridPane, gridRow, 1,
                     Res.get("shared.reasonForPayment"), model.dataModel.getReference(),
                     Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE);
+        }
 
         switch (paymentMethodId) {
             case PaymentMethod.UPHOLD_ID:
@@ -293,6 +296,7 @@ public class BuyerStep2View extends TradeStepView {
                 gridRow = HalCashForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
                 break;
             case PaymentMethod.F2F_ID:
+                checkNotNull(model.dataModel.getTrade(), "model.dataModel.getTrade() must not be null");
                 checkNotNull(model.dataModel.getTrade().getOffer(), "model.dataModel.getTrade().getOffer() must not be null");
                 gridRow = F2FForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload, model.dataModel.getTrade().getOffer(), 0);
                 break;
@@ -309,6 +313,9 @@ public class BuyerStep2View extends TradeStepView {
                 break;
             case PaymentMethod.TRANSFERWISE_ID:
                 gridRow = TransferwiseForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
+                break;
+            case PaymentMethod.AMAZON_GIFT_CARD_ID:
+                gridRow = AmazonGiftCardForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
                 break;
             default:
                 log.error("Not supported PaymentMethod: " + paymentMethodId);
@@ -599,6 +606,12 @@ public class BuyerStep2View extends TradeStepView {
                         assign +
                         refTextWarn + "\n\n" +
                         fees;
+            } else if (paymentAccountPayload instanceof AmazonGiftCardAccountPayload) {
+                message += Res.get("portfolio.pending.step2_buyer.amazonGiftCard",
+                        amount) +
+                        accountDetails +
+                        paymentDetailsForTradePopup + ".\n\n" +
+                        copyPaste;
             } else {
                 message += Res.get("portfolio.pending.step2_buyer.bank", amount) +
                         accountDetails +
@@ -609,6 +622,7 @@ public class BuyerStep2View extends TradeStepView {
                         refTextWarn + "\n\n" +
                         fees;
             }
+
             String key = "startPayment" + trade.getId();
             if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
                 DontShowAgainLookup.dontShowAgain(key, true);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -32,6 +32,7 @@ import bisq.desktop.util.Layout;
 import bisq.core.locale.Res;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.PaymentAccountUtil;
+import bisq.core.payment.payload.AmazonGiftCardAccountPayload;
 import bisq.core.payment.payload.AssetsAccountPayload;
 import bisq.core.payment.payload.BankAccountPayload;
 import bisq.core.payment.payload.CashDepositAccountPayload;
@@ -378,6 +379,7 @@ public class SellerStep3View extends TradeStepView {
                         message += Res.get("portfolio.pending.step3_seller.onPaymentReceived.name", optionalHolderName.get());
                     }
                 }
+
                 message += Res.get("portfolio.pending.step3_seller.onPaymentReceived.note");
                 if (model.dataModel.isSignWitnessTrade()) {
                     message += Res.get("portfolio.pending.step3_seller.onPaymentReceived.signer");
@@ -415,7 +417,8 @@ public class SellerStep3View extends TradeStepView {
                 message = Res.get("portfolio.pending.step3_seller.postal", part1, tradeVolumeWithCode, id);
             } else if (!(paymentAccountPayload instanceof WesternUnionAccountPayload) &&
                     !(paymentAccountPayload instanceof HalCashAccountPayload) &&
-                    !(paymentAccountPayload instanceof F2FAccountPayload)) {
+                    !(paymentAccountPayload instanceof F2FAccountPayload) &&
+                    !(paymentAccountPayload instanceof AmazonGiftCardAccountPayload)) {
                 message = Res.get("portfolio.pending.step3_seller.bank", currencyName, tradeVolumeWithCode, id);
             }
 
@@ -430,6 +433,8 @@ public class SellerStep3View extends TradeStepView {
                 message = message + Res.get("portfolio.pending.step3_seller.halCash");
             else if (paymentAccountPayload instanceof F2FAccountPayload)
                 message = part1;
+            else if (paymentAccountPayload instanceof AmazonGiftCardAccountPayload)
+                message = Res.get("portfolio.pending.step3_seller.amazonGiftCard");
 
             Optional<String> optionalHolderName = getOptionalHolderName();
             if (optionalHolderName.isPresent()) {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -948,6 +948,7 @@ message PaymentAccountPayload {
         JapanBankAccountPayload japan_bank_account_payload = 28;
         TransferwiseAccountPayload Transferwise_account_payload = 29;
         AustraliaPayidPayload australia_payid_payload = 30;
+        AmazonGiftCardAccountPayload amazon_gift_card_account_payload = 31;
     }
     map<string, string> exclude_from_json_data = 15;
 }
@@ -1053,6 +1054,10 @@ message WesternUnionAccountPayload {
     string city = 2;
     string state = 3;
     string email = 4;
+}
+
+message AmazonGiftCardAccountPayload {
+    string email_or_mobile_nr = 1;
 }
 
 message SepaAccountPayload {


### PR DESCRIPTION
Implements: https://github.com/bisq-network/bisq/issues/1866

@ripcurlx Would be cool if we could get it in 1.5.0. I think its not very risky and might be a interesting payment option.

@m52go Could you have a look at the popup text?

```
portfolio.pending.step2_buyer.amazonGiftCard=Please purchase an Amazon eGift Card for {0} at your Amazon account and \
  use the BTC seller''s email or mobile number as receiver. \
  In case the trade amount exceeds the permitted amount send multiple cards.\n\n

portfolio.pending.step3_seller.amazonGiftCard=The buyer has sent you an Amazon eGift Card by email or by text \
  message to your mobile phone. Please redeem now the Amazon eGift Card at your Amazon account and once accepted \
  confirm the payment receipt.
  
payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and \
  use the BTC seller''s email or mobile nr. as receiver. Amazon send then an email or text message to the receiver. \
  Use the trade ID for the message field.\n\n\
  Amazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\n\
  For more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
```


