### PR TITLE
Fix remaining blackmail vulnerabilities

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -76,6 +76,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TradeWalletService {
     private static final Logger log = LoggerFactory.getLogger(TradeWalletService.class);
+    private static final Coin MIN_DELAYED_PAYOUT_TX_FEE = Coin.valueOf(1000);
 
     private final WalletsSetup walletsSetup;
     private final Preferences preferences;
@@ -766,6 +767,9 @@ public class TradeWalletService {
         WalletService.printTx("finalizeDelayedPayoutTx", delayedPayoutTx);
         WalletService.verifyTransaction(delayedPayoutTx);
 
+        if (checkNotNull(inputValue).isLessThan(delayedPayoutTx.getOutputSum().add(MIN_DELAYED_PAYOUT_TX_FEE))) {
+            throw new TransactionVerificationException("Delayed payout tx is paying less than the minimum allowed tx fee");
+        }
         Script scriptPubKey = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey, false);
         input.getScriptSig().correctlySpends(delayedPayoutTx, 0, witness, inputValue, scriptPubKey, Script.ALL_VERIFY_FLAGS);
         return delayedPayoutTx;

--- a/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureRequest.java
@@ -33,16 +33,19 @@ import lombok.Value;
 public final class DelayedPayoutTxSignatureRequest extends TradeMessage implements DirectMessage {
     private final NodeAddress senderNodeAddress;
     private final byte[] delayedPayoutTx;
+    private final byte[] delayedPayoutTxSellerSignature;
 
     public DelayedPayoutTxSignatureRequest(String uid,
                                            String tradeId,
                                            NodeAddress senderNodeAddress,
-                                           byte[] delayedPayoutTx) {
+                                           byte[] delayedPayoutTx,
+                                           byte[] delayedPayoutTxSellerSignature) {
         this(Version.getP2PMessageVersion(),
                 uid,
                 tradeId,
                 senderNodeAddress,
-                delayedPayoutTx);
+                delayedPayoutTx,
+                delayedPayoutTxSellerSignature);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -53,10 +56,12 @@ public final class DelayedPayoutTxSignatureRequest extends TradeMessage implemen
                                             String uid,
                                             String tradeId,
                                             NodeAddress senderNodeAddress,
-                                            byte[] delayedPayoutTx) {
+                                            byte[] delayedPayoutTx,
+                                            byte[] delayedPayoutTxSellerSignature) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
         this.delayedPayoutTx = delayedPayoutTx;
+        this.delayedPayoutTxSellerSignature = delayedPayoutTxSellerSignature;
     }
 
 
@@ -67,16 +72,19 @@ public final class DelayedPayoutTxSignatureRequest extends TradeMessage implemen
                         .setUid(uid)
                         .setTradeId(tradeId)
                         .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
-                        .setDelayedPayoutTx(ByteString.copyFrom(delayedPayoutTx)))
+                        .setDelayedPayoutTx(ByteString.copyFrom(delayedPayoutTx))
+                        .setDelayedPayoutTxSellerSignature(ByteString.copyFrom(delayedPayoutTxSellerSignature)))
                 .build();
     }
 
-    public static DelayedPayoutTxSignatureRequest fromProto(protobuf.DelayedPayoutTxSignatureRequest proto, int messageVersion) {
+    public static DelayedPayoutTxSignatureRequest fromProto(protobuf.DelayedPayoutTxSignatureRequest proto,
+                                                            int messageVersion) {
         return new DelayedPayoutTxSignatureRequest(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
-                proto.getDelayedPayoutTx().toByteArray());
+                proto.getDelayedPayoutTx().toByteArray(),
+                proto.getDelayedPayoutTxSellerSignature().toByteArray());
     }
 
     @Override
@@ -84,6 +92,7 @@ public final class DelayedPayoutTxSignatureRequest extends TradeMessage implemen
         return "DelayedPayoutTxSignatureRequest{" +
                 "\n     senderNodeAddress=" + senderNodeAddress +
                 ",\n     delayedPayoutTx=" + Utilities.bytesAsHexString(delayedPayoutTx) +
+                ",\n     delayedPayoutTxSellerSignature=" + Utilities.bytesAsHexString(delayedPayoutTxSellerSignature) +
                 "\n} " + super.toString();
     }
 }

--- a/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureResponse.java
@@ -32,17 +32,17 @@ import lombok.Value;
 @Value
 public final class DelayedPayoutTxSignatureResponse extends TradeMessage implements DirectMessage {
     private final NodeAddress senderNodeAddress;
-    private final byte[] delayedPayoutTxSignature;
+    private final byte[] delayedPayoutTxBuyerSignature;
 
     public DelayedPayoutTxSignatureResponse(String uid,
                                             String tradeId,
                                             NodeAddress senderNodeAddress,
-                                            byte[] delayedPayoutTxSignature) {
+                                            byte[] delayedPayoutTxBuyerSignature) {
         this(Version.getP2PMessageVersion(),
                 uid,
                 tradeId,
                 senderNodeAddress,
-                delayedPayoutTxSignature);
+                delayedPayoutTxBuyerSignature);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -53,10 +53,10 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
                                              String uid,
                                              String tradeId,
                                              NodeAddress senderNodeAddress,
-                                             byte[] delayedPayoutTxSignature) {
+                                             byte[] delayedPayoutTxBuyerSignature) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
-        this.delayedPayoutTxSignature = delayedPayoutTxSignature;
+        this.delayedPayoutTxBuyerSignature = delayedPayoutTxBuyerSignature;
     }
 
 
@@ -67,24 +67,25 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
                         .setUid(uid)
                         .setTradeId(tradeId)
                         .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
-                        .setDelayedPayoutTxSignature(ByteString.copyFrom(delayedPayoutTxSignature))
+                        .setDelayedPayoutTxBuyerSignature(ByteString.copyFrom(delayedPayoutTxBuyerSignature))
                 )
                 .build();
     }
 
-    public static DelayedPayoutTxSignatureResponse fromProto(protobuf.DelayedPayoutTxSignatureResponse proto, int messageVersion) {
+    public static DelayedPayoutTxSignatureResponse fromProto(protobuf.DelayedPayoutTxSignatureResponse proto,
+                                                             int messageVersion) {
         return new DelayedPayoutTxSignatureResponse(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
-                proto.getDelayedPayoutTxSignature().toByteArray());
+                proto.getDelayedPayoutTxBuyerSignature().toByteArray());
     }
 
     @Override
     public String toString() {
         return "DelayedPayoutTxSignatureResponse{" +
                 "\n     senderNodeAddress=" + senderNodeAddress +
-                ",\n     delayedPayoutTxSignature=" + Utilities.bytesAsHexString(delayedPayoutTxSignature) +
+                ",\n     delayedPayoutTxBuyerSignature=" + Utilities.bytesAsHexString(delayedPayoutTxBuyerSignature) +
                 "\n} " + super.toString();
     }
 }

--- a/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureResponse.java
@@ -33,16 +33,19 @@ import lombok.Value;
 public final class DelayedPayoutTxSignatureResponse extends TradeMessage implements DirectMessage {
     private final NodeAddress senderNodeAddress;
     private final byte[] delayedPayoutTxBuyerSignature;
+    private final byte[] depositTx;
 
     public DelayedPayoutTxSignatureResponse(String uid,
                                             String tradeId,
                                             NodeAddress senderNodeAddress,
-                                            byte[] delayedPayoutTxBuyerSignature) {
+                                            byte[] delayedPayoutTxBuyerSignature,
+                                            byte[] depositTx) {
         this(Version.getP2PMessageVersion(),
                 uid,
                 tradeId,
                 senderNodeAddress,
-                delayedPayoutTxBuyerSignature);
+                delayedPayoutTxBuyerSignature,
+                depositTx);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -53,10 +56,12 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
                                              String uid,
                                              String tradeId,
                                              NodeAddress senderNodeAddress,
-                                             byte[] delayedPayoutTxBuyerSignature) {
+                                             byte[] delayedPayoutTxBuyerSignature,
+                                             byte[] depositTx) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
         this.delayedPayoutTxBuyerSignature = delayedPayoutTxBuyerSignature;
+        this.depositTx = depositTx;
     }
 
 
@@ -68,6 +73,7 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
                         .setTradeId(tradeId)
                         .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
                         .setDelayedPayoutTxBuyerSignature(ByteString.copyFrom(delayedPayoutTxBuyerSignature))
+                        .setDepositTx(ByteString.copyFrom(depositTx))
                 )
                 .build();
     }
@@ -78,7 +84,8 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
                 proto.getUid(),
                 proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
-                proto.getDelayedPayoutTxBuyerSignature().toByteArray());
+                proto.getDelayedPayoutTxBuyerSignature().toByteArray(),
+                proto.getDepositTx().toByteArray());
     }
 
     @Override
@@ -86,6 +93,7 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
         return "DelayedPayoutTxSignatureResponse{" +
                 "\n     senderNodeAddress=" + senderNodeAddress +
                 ",\n     delayedPayoutTxBuyerSignature=" + Utilities.bytesAsHexString(delayedPayoutTxBuyerSignature) +
+                ",\n     depositTx=" + Utilities.bytesAsHexString(depositTx) +
                 "\n} " + super.toString();
     }
 }

--- a/core/src/main/java/bisq/core/trade/messages/DepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/DepositTxMessage.java
@@ -34,17 +34,17 @@ import lombok.Value;
 @Value
 public final class DepositTxMessage extends TradeMessage implements DirectMessage {
     private final NodeAddress senderNodeAddress;
-    private final byte[] depositTx;
+    private final byte[] depositTxWithoutWitnesses;
 
     public DepositTxMessage(String uid,
                             String tradeId,
                             NodeAddress senderNodeAddress,
-                            byte[] depositTx) {
+                            byte[] depositTxWithoutWitnesses) {
         this(Version.getP2PMessageVersion(),
                 uid,
                 tradeId,
                 senderNodeAddress,
-                depositTx);
+                depositTxWithoutWitnesses);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -55,10 +55,10 @@ public final class DepositTxMessage extends TradeMessage implements DirectMessag
                              String uid,
                              String tradeId,
                              NodeAddress senderNodeAddress,
-                             byte[] depositTx) {
+                             byte[] depositTxWithoutWitnesses) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
-        this.depositTx = depositTx;
+        this.depositTxWithoutWitnesses = depositTxWithoutWitnesses;
     }
 
     @Override
@@ -68,7 +68,7 @@ public final class DepositTxMessage extends TradeMessage implements DirectMessag
                         .setUid(uid)
                         .setTradeId(tradeId)
                         .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
-                        .setDepositTx(ByteString.copyFrom(depositTx)))
+                        .setDepositTxWithoutWitnesses(ByteString.copyFrom(depositTxWithoutWitnesses)))
                 .build();
     }
 
@@ -77,14 +77,14 @@ public final class DepositTxMessage extends TradeMessage implements DirectMessag
                 proto.getUid(),
                 proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
-                proto.getDepositTx().toByteArray());
+                proto.getDepositTxWithoutWitnesses().toByteArray());
     }
 
     @Override
     public String toString() {
         return "DepositTxMessage{" +
                 "\n     senderNodeAddress=" + senderNodeAddress +
-                ",\n     depositTx=" + Utilities.bytesAsHexString(depositTx) +
+                ",\n     depositTxWithoutWitnesses=" + Utilities.bytesAsHexString(depositTxWithoutWitnesses) +
                 "\n} " + super.toString();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
@@ -26,6 +26,7 @@ import bisq.core.trade.messages.PayoutTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.ApplyFilter;
 import bisq.core.trade.protocol.tasks.TradeTask;
 import bisq.core.trade.protocol.tasks.VerifyPeersAccountAgeWitness;
+import bisq.core.trade.protocol.tasks.buyer.BuyerFinalizesDelayedPayoutTx;
 import bisq.core.trade.protocol.tasks.buyer.BuyerProcessDelayedPayoutTxSignatureRequest;
 import bisq.core.trade.protocol.tasks.buyer.BuyerSendsDelayedPayoutTxSignatureResponse;
 import bisq.core.trade.protocol.tasks.buyer.BuyerSetupDepositTxListener;
@@ -103,6 +104,7 @@ public class BuyerAsMakerProtocol extends BuyerProtocol implements MakerProtocol
                         MakerRemovesOpenOffer.class,
                         BuyerVerifiesPreparedDelayedPayoutTx.class,
                         BuyerSignsDelayedPayoutTx.class,
+                        BuyerFinalizesDelayedPayoutTx.class,
                         BuyerSendsDelayedPayoutTxSignatureResponse.class)
                         .withTimeout(30))
                 .executeTasks();

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -29,6 +29,7 @@ import bisq.core.trade.messages.TradeMessage;
 import bisq.core.trade.protocol.tasks.ApplyFilter;
 import bisq.core.trade.protocol.tasks.TradeTask;
 import bisq.core.trade.protocol.tasks.VerifyPeersAccountAgeWitness;
+import bisq.core.trade.protocol.tasks.buyer.BuyerFinalizesDelayedPayoutTx;
 import bisq.core.trade.protocol.tasks.buyer.BuyerProcessDelayedPayoutTxSignatureRequest;
 import bisq.core.trade.protocol.tasks.buyer.BuyerSendsDelayedPayoutTxSignatureResponse;
 import bisq.core.trade.protocol.tasks.buyer.BuyerSetupDepositTxListener;
@@ -119,6 +120,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         BuyerProcessDelayedPayoutTxSignatureRequest.class,
                         BuyerVerifiesPreparedDelayedPayoutTx.class,
                         BuyerSignsDelayedPayoutTx.class,
+                        BuyerFinalizesDelayedPayoutTx.class,
                         BuyerSendsDelayedPayoutTxSignatureResponse.class)
                         .withTimeout(30))
                 .executeTasks();

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
@@ -35,6 +35,7 @@ import bisq.core.trade.protocol.tasks.maker.MakerSetsLockTime;
 import bisq.core.trade.protocol.tasks.maker.MakerVerifyTakerFeePayment;
 import bisq.core.trade.protocol.tasks.seller.SellerCreatesDelayedPayoutTx;
 import bisq.core.trade.protocol.tasks.seller.SellerSendDelayedPayoutTxSignatureRequest;
+import bisq.core.trade.protocol.tasks.seller.SellerSignsDelayedPayoutTx;
 import bisq.core.trade.protocol.tasks.seller_as_maker.SellerAsMakerCreatesUnsignedDepositTx;
 import bisq.core.trade.protocol.tasks.seller_as_maker.SellerAsMakerFinalizesDepositTx;
 import bisq.core.trade.protocol.tasks.seller_as_maker.SellerAsMakerProcessDepositTxMessage;
@@ -103,6 +104,7 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
                         MakerRemovesOpenOffer.class,
                         SellerAsMakerFinalizesDepositTx.class,
                         SellerCreatesDelayedPayoutTx.class,
+                        SellerSignsDelayedPayoutTx.class,
                         SellerSendDelayedPayoutTxSignatureRequest.class)
                         .withTimeout(30))
                 .executeTasks();

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -30,6 +30,7 @@ import bisq.core.trade.protocol.tasks.TradeTask;
 import bisq.core.trade.protocol.tasks.VerifyPeersAccountAgeWitness;
 import bisq.core.trade.protocol.tasks.seller.SellerCreatesDelayedPayoutTx;
 import bisq.core.trade.protocol.tasks.seller.SellerSendDelayedPayoutTxSignatureRequest;
+import bisq.core.trade.protocol.tasks.seller.SellerSignsDelayedPayoutTx;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerCreatesDepositTxInputs;
 import bisq.core.trade.protocol.tasks.seller_as_taker.SellerAsTakerSignsDepositTx;
 import bisq.core.trade.protocol.tasks.taker.CreateTakerFeeTx;
@@ -98,6 +99,7 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
                         TakerPublishFeeTx.class,
                         SellerAsTakerSignsDepositTx.class,
                         SellerCreatesDelayedPayoutTx.class,
+                        SellerSignsDelayedPayoutTx.class,
                         SellerSendDelayedPayoutTxSignatureRequest.class)
                         .withTimeout(30))
                 .executeTasks();

--- a/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
@@ -33,7 +33,6 @@ import bisq.core.trade.protocol.tasks.seller.SellerPublishesTradeStatistics;
 import bisq.core.trade.protocol.tasks.seller.SellerSendPayoutTxPublishedMessage;
 import bisq.core.trade.protocol.tasks.seller.SellerSendsDepositTxAndDelayedPayoutTxMessage;
 import bisq.core.trade.protocol.tasks.seller.SellerSignAndFinalizePayoutTx;
-import bisq.core.trade.protocol.tasks.seller.SellerSignsDelayedPayoutTx;
 
 import bisq.network.p2p.NodeAddress;
 
@@ -77,7 +76,6 @@ public abstract class SellerProtocol extends DisputeProtocol {
                 .with(message)
                 .from(peer))
                 .setup(tasks(SellerProcessDelayedPayoutTxSignatureResponse.class,
-                        SellerSignsDelayedPayoutTx.class,
                         SellerFinalizesDelayedPayoutTx.class,
                         SellerSendsDepositTxAndDelayedPayoutTxMessage.class,
                         SellerPublishesDepositTx.class,

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerFinalizesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerFinalizesDelayedPayoutTx.java
@@ -1,0 +1,60 @@
+package bisq.core.trade.protocol.tasks.buyer;
+
+import bisq.core.btc.model.AddressEntry;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.trade.Trade;
+import bisq.core.trade.protocol.tasks.TradeTask;
+
+import bisq.common.taskrunner.TaskRunner;
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.Transaction;
+
+import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Slf4j
+public class BuyerFinalizesDelayedPayoutTx extends TradeTask {
+    public BuyerFinalizesDelayedPayoutTx(TaskRunner<Trade> taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        try {
+            runInterceptHook();
+
+            Transaction preparedDelayedPayoutTx = checkNotNull(processModel.getPreparedDelayedPayoutTx());
+            BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            String id = processModel.getOffer().getId();
+
+            byte[] buyerMultiSigPubKey = processModel.getMyMultiSigPubKey();
+            checkArgument(Arrays.equals(buyerMultiSigPubKey,
+                    btcWalletService.getOrCreateAddressEntry(id, AddressEntry.Context.MULTI_SIG).getPubKey()),
+                    "buyerMultiSigPubKey from AddressEntry must match the one from the trade data. trade id =" + id);
+            byte[] sellerMultiSigPubKey = processModel.getTradingPeer().getMultiSigPubKey();
+
+            byte[] buyerSignature = processModel.getDelayedPayoutTxSignature();
+            byte[] sellerSignature = processModel.getTradingPeer().getDelayedPayoutTxSignature();
+
+            Transaction signedDelayedPayoutTx = processModel.getTradeWalletService().finalizeDelayedPayoutTx(
+                    preparedDelayedPayoutTx,
+                    buyerMultiSigPubKey,
+                    sellerMultiSigPubKey,
+                    buyerSignature,
+                    sellerSignature,
+                    false);
+
+            trade.applyDelayedPayoutTxBytes(signedDelayedPayoutTx.bitcoinSerialize());
+            log.info("DelayedPayoutTxBytes = {}", Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()));
+
+            complete();
+        } catch (Throwable t) {
+            failed(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
@@ -46,6 +46,7 @@ public class BuyerProcessDelayedPayoutTxSignatureRequest extends TradeTask {
             byte[] delayedPayoutTxAsBytes = checkNotNull(request.getDelayedPayoutTx());
             Transaction preparedDelayedPayoutTx = processModel.getBtcWalletService().getTxFromSerializedTx(delayedPayoutTxAsBytes);
             processModel.setPreparedDelayedPayoutTx(preparedDelayedPayoutTx);
+            processModel.getTradingPeer().setDelayedPayoutTxSignature(checkNotNull(request.getDelayedPayoutTxSellerSignature()));
 
             // When we receive that message the taker has published the taker fee, so we apply it to the trade.
             // The takerFeeTx was sent in the first message. It should be part of DelayedPayoutTxSignatureRequest

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -26,12 +26,16 @@ import bisq.core.trade.protocol.tasks.TradeTask;
 import bisq.core.util.Validator;
 
 import bisq.common.taskrunner.TaskRunner;
+import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.wallet.Wallet;
 
+import java.util.Arrays;
+
 import lombok.extern.slf4j.Slf4j;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -59,9 +63,11 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
 
             // To access tx confidence we need to add that tx into our wallet.
             byte[] delayedPayoutTxBytes = checkNotNull(message.getDelayedPayoutTx());
+            checkArgument(Arrays.equals(delayedPayoutTxBytes, trade.getDelayedPayoutTxBytes()),
+                    "mismatch between delayedPayoutTx received from peer and our one." +
+                            "\n Expected: " + Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()) +
+                            "\n Received: " + Utilities.bytesAsHexString(delayedPayoutTxBytes));
             trade.applyDelayedPayoutTxBytes(delayedPayoutTxBytes);
-            BtcWalletService.printTx("delayedPayoutTx received from peer",
-                    checkNotNull(trade.getDelayedPayoutTx()));
 
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSendsDelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSendsDelayedPayoutTxSignatureResponse.java
@@ -44,10 +44,15 @@ public class BuyerSendsDelayedPayoutTxSignatureResponse extends TradeTask {
             runInterceptHook();
 
             byte[] delayedPayoutTxSignature = checkNotNull(processModel.getDelayedPayoutTxSignature());
+            byte[] depositTxBytes = processModel.getDepositTx() != null
+                    ? processModel.getDepositTx().bitcoinSerialize() // set in BuyerAsTakerSignsDepositTx task
+                    : processModel.getPreparedDepositTx();           // set in BuyerAsMakerCreatesAndSignsDepositTx task
+
             DelayedPayoutTxSignatureResponse message = new DelayedPayoutTxSignatureResponse(UUID.randomUUID().toString(),
                     processModel.getOfferId(),
                     processModel.getMyNodeAddress(),
-                    delayedPayoutTxSignature);
+                    delayedPayoutTxSignature,
+                    depositTxBytes);
 
             NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
             log.info("Send {} to peer {}. tradeId={}, uid={}",

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
@@ -72,6 +72,8 @@ public class BuyerAsMakerCreatesAndSignsDepositTx extends TradeTask {
                     .add(tradeAmount);
 
             List<RawTransactionInput> takerRawTransactionInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
+            checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
+                    "all takerRawTransactionInputs must be P2WH");
             long takerChangeOutputValue = tradingPeer.getChangeOutputValue();
             @Nullable String takerChangeAddressString = tradingPeer.getChangeOutputAddress();
             Address makerAddress = walletService.getOrCreateAddressEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE).getAddress();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerSendsInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerSendsInputsForDepositTxResponse.java
@@ -22,6 +22,8 @@ import bisq.core.trade.protocol.tasks.maker.MakerSendsInputsForDepositTxResponse
 
 import bisq.common.taskrunner.TaskRunner;
 
+import org.bitcoinj.core.Transaction;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -32,6 +34,9 @@ public class BuyerAsMakerSendsInputsForDepositTxResponse extends MakerSendsInput
 
     @Override
     protected byte[] getPreparedDepositTx() {
-        return processModel.getPreparedDepositTx();
+        Transaction preparedDepositTx = processModel.getBtcWalletService().getTxFromSerializedTx(processModel.getPreparedDepositTx());
+        // Remove witnesses from preparedDepositTx, so that the seller can still compute the final
+        // tx id, but cannot publish it before providing the buyer with a signed delayed payout tx.
+        return preparedDepositTx.bitcoinSerialize(false);
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSendsDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSendsDepositTxMessage.java
@@ -41,10 +41,12 @@ public class BuyerAsTakerSendsDepositTxMessage extends TradeTask {
         try {
             runInterceptHook();
             if (processModel.getDepositTx() != null) {
+                // Remove witnesses from the sent depositTx, so that the seller can still compute the final
+                // tx id, but cannot publish it before providing the buyer with a signed delayed payout tx.
                 DepositTxMessage message = new DepositTxMessage(UUID.randomUUID().toString(),
                         processModel.getOfferId(),
                         processModel.getMyNodeAddress(),
-                        processModel.getDepositTx().bitcoinSerialize());
+                        processModel.getDepositTx().bitcoinSerialize(false));
 
                 NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
                 log.info("Send {} to peer {}. tradeId={}, uid={}",

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerCreatesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerCreatesDelayedPayoutTx.java
@@ -20,6 +20,7 @@ package bisq.core.trade.protocol.tasks.seller;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.dao.governance.param.Param;
 import bisq.core.trade.Trade;
+import bisq.core.trade.TradeDataValidation;
 import bisq.core.trade.protocol.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
@@ -53,6 +54,10 @@ public class SellerCreatesDelayedPayoutTx extends TradeTask {
                     donationAddressString,
                     minerFee,
                     lockTime);
+            TradeDataValidation.validateDelayedPayoutTx(trade,
+                    preparedDelayedPayoutTx,
+                    processModel.getDaoFacade(),
+                    processModel.getBtcWalletService());
 
             processModel.setPreparedDelayedPayoutTx(preparedDelayedPayoutTx);
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
@@ -63,7 +63,8 @@ public class SellerFinalizesDelayedPayoutTx extends TradeTask {
                     buyerMultiSigPubKey,
                     sellerMultiSigPubKey,
                     buyerSignature,
-                    sellerSignature);
+                    sellerSignature,
+                    true);
 
             trade.applyDelayedPayoutTx(signedDelayedPayoutTx);
             log.info("DelayedPayoutTxBytes = {}", Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()));

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
@@ -63,8 +63,7 @@ public class SellerFinalizesDelayedPayoutTx extends TradeTask {
                     buyerMultiSigPubKey,
                     sellerMultiSigPubKey,
                     buyerSignature,
-                    sellerSignature,
-                    true);
+                    sellerSignature);
 
             trade.applyDelayedPayoutTx(signedDelayedPayoutTx);
             log.info("DelayedPayoutTxBytes = {}", Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()));

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
@@ -44,6 +44,11 @@ public class SellerProcessDelayedPayoutTxSignatureResponse extends TradeTask {
 
             processModel.getTradingPeer().setDelayedPayoutTxSignature(checkNotNull(response.getDelayedPayoutTxBuyerSignature()));
 
+            processModel.getTradeWalletService().sellerAddsBuyerWitnessesToDepositTx(
+                    processModel.getDepositTx(),
+                    processModel.getBtcWalletService().getTxFromSerializedTx(response.getDepositTx())
+            );
+
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
@@ -42,7 +42,7 @@ public class SellerProcessDelayedPayoutTxSignatureResponse extends TradeTask {
             checkNotNull(response);
             checkTradeId(processModel.getOfferId(), response);
 
-            processModel.getTradingPeer().setDelayedPayoutTxSignature(checkNotNull(response.getDelayedPayoutTxSignature()));
+            processModel.getTradingPeer().setDelayedPayoutTxSignature(checkNotNull(response.getDelayedPayoutTxBuyerSignature()));
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSendDelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSendDelayedPayoutTxSignatureRequest.java
@@ -47,10 +47,13 @@ public class SellerSendDelayedPayoutTxSignatureRequest extends TradeTask {
 
             Transaction preparedDelayedPayoutTx = checkNotNull(processModel.getPreparedDelayedPayoutTx(),
                     "processModel.getPreparedDelayedPayoutTx() must not be null");
+            byte[] delayedPayoutTxSignature = checkNotNull(processModel.getDelayedPayoutTxSignature(),
+                    "processModel.getDelayedPayoutTxSignature() must not be null");
             DelayedPayoutTxSignatureRequest message = new DelayedPayoutTxSignatureRequest(UUID.randomUUID().toString(),
                     processModel.getOfferId(),
                     processModel.getMyNodeAddress(),
-                    preparedDelayedPayoutTx.bitcoinSerialize());
+                    preparedDelayedPayoutTx.bitcoinSerialize(),
+                    delayedPayoutTxSignature);
 
             NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
             log.info("Send {} to peer {}. tradeId={}, uid={}",

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
@@ -78,6 +78,8 @@ public class SellerAsMakerCreatesUnsignedDepositTx extends TradeTask {
                     .add(offer.getBuyerSecurityDeposit());
 
             List<RawTransactionInput> takerRawTransactionInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
+            checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
+                    "all takerRawTransactionInputs must be P2WH");
             long takerChangeOutputValue = tradingPeer.getChangeOutputValue();
             String takerChangeAddressString = tradingPeer.getChangeOutputAddress();
             Address makerAddress = walletService.getOrCreateAddressEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE).getAddress();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerProcessDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerProcessDepositTxMessage.java
@@ -43,7 +43,7 @@ public class SellerAsMakerProcessDepositTxMessage extends TradeTask {
             Validator.checkTradeId(processModel.getOfferId(), message);
             checkNotNull(message);
 
-            processModel.getTradingPeer().setPreparedDepositTx(checkNotNull(message.getDepositTx()));
+            processModel.getTradingPeer().setPreparedDepositTx(checkNotNull(message.getDepositTxWithoutWitnesses()));
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
             // When we receive that message the taker has published the taker fee, so we apply it to the trade.

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerSendsInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerSendsInputsForDepositTxResponse.java
@@ -44,6 +44,7 @@ public class SellerAsMakerSendsInputsForDepositTxResponse extends MakerSendsInpu
 
         processModel.getTradeManager().requestPersistence();
 
-        return preparedDepositTx.bitcoinSerialize();
+        // Make sure witnesses are removed as well before sending, to cover the segwit case.
+        return preparedDepositTx.bitcoinSerialize(false);
     }
 }

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -271,13 +271,14 @@ message DelayedPayoutTxSignatureRequest {
     string trade_id = 2;
     NodeAddress sender_node_address = 3;
     bytes delayed_payout_tx = 4;
+    bytes delayed_payout_tx_seller_signature = 5;
 }
 
 message DelayedPayoutTxSignatureResponse {
     string uid = 1;
     string trade_id = 2;
     NodeAddress sender_node_address = 3;
-    bytes delayed_payout_tx_signature = 4;
+    bytes delayed_payout_tx_buyer_signature = 4;
 }
 
 message DepositTxAndDelayedPayoutTxMessage {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -279,6 +279,7 @@ message DelayedPayoutTxSignatureResponse {
     string trade_id = 2;
     NodeAddress sender_node_address = 3;
     bytes delayed_payout_tx_buyer_signature = 4;
+    bytes deposit_tx = 5;
 }
 
 message DepositTxAndDelayedPayoutTxMessage {
@@ -293,7 +294,7 @@ message DepositTxMessage {
     string uid = 1;
     string trade_id = 2;
     NodeAddress sender_node_address = 3;
-    bytes deposit_tx = 4;
+    bytes deposit_tx_without_witnesses = 4;
 }
 
 message PeerPublishedDelayedPayoutTxMessage {


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This PR attempts to take advantage of the SegWit trade protocol upgrade (hard fork), to fix all the remaining cases where a buyer or seller can publish a deposit tx without their peer having a valid delayed payout tx (at least in the fully SegWit case, when taking an offer created in v1.5.0+). When taking pre-1.5.0 offers, the deposit tx inputs will be of mixed type, which makes it malleable and thus impossible to completely prevent either trader from altering its ID and thus rendering their peer's delayed payout tx invalid. In that case, the buyer should still fully validate their delayed payout tx anyway, against the agreed deposit tx, so that if the latter changes before confirming, the trade hopefully fails before the buyer makes payment. The PR additionally fixes a bug where (it appears) the buyer fails to check the signature of the final delayed payout tx.

These changes are intended to prevent blackmail attacks (or reduce the risk of them in not-fully-SegWit cases where the deposit tx is malleable).
