### PR TITLE
Define proto for api method 'getunusedbsqaddress'

### DIFF
--- a/core/src/main/java/bisq/core/api/model/BalancesInfo.java
+++ b/core/src/main/java/bisq/core/api/model/BalancesInfo.java
@@ -1,0 +1,42 @@
+package bisq.core.api.model;
+
+import bisq.common.Payload;
+
+import lombok.Getter;
+
+@Getter
+public class BalancesInfo implements Payload {
+
+    private final BsqBalanceInfo bsqBalanceInfo;
+    private final BtcBalanceInfo btcBalanceInfo;
+
+    public BalancesInfo(BsqBalanceInfo bsqBalanceInfo, BtcBalanceInfo btcBalanceInfo) {
+        this.bsqBalanceInfo = bsqBalanceInfo;
+        this.btcBalanceInfo = btcBalanceInfo;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.BalancesInfo toProtoMessage() {
+        return bisq.proto.grpc.BalancesInfo.newBuilder()
+                .setBsqBalanceInfo(bsqBalanceInfo.toProtoMessage())
+                .setBtcBalanceInfo(btcBalanceInfo.toProtoMessage())
+                .build();
+    }
+
+    public static BalancesInfo fromProto(bisq.proto.grpc.BalancesInfo proto) {
+        return new BalancesInfo(BsqBalanceInfo.fromProto(proto.getBsqBalanceInfo()),
+                BtcBalanceInfo.fromProto(proto.getBtcBalanceInfo()));
+    }
+
+    @Override
+    public String toString() {
+        return "BalancesInfo{" + "\n" +
+                "  " + bsqBalanceInfo.toString() + "\n" +
+                ", " + btcBalanceInfo.toString() + "\n" +
+                '}';
+    }
+}

--- a/core/src/main/java/bisq/core/api/model/BsqBalanceInfo.java
+++ b/core/src/main/java/bisq/core/api/model/BsqBalanceInfo.java
@@ -1,0 +1,87 @@
+package bisq.core.api.model;
+
+import bisq.common.Payload;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.Getter;
+
+@Getter
+public class BsqBalanceInfo implements Payload {
+
+    // All balances are in BSQ satoshis.
+    private final long availableConfirmedBalance;
+    private final long unverifiedBalance;
+    private final long unconfirmedChangeBalance;
+    private final long lockedForVotingBalance;
+    private final long lockupBondsBalance;
+    private final long unlockingBondsBalance;
+
+    public BsqBalanceInfo(long availableConfirmedBalance,
+                          long unverifiedBalance,
+                          long unconfirmedChangeBalance,
+                          long lockedForVotingBalance,
+                          long lockupBondsBalance,
+                          long unlockingBondsBalance) {
+        this.availableConfirmedBalance = availableConfirmedBalance;
+        this.unverifiedBalance = unverifiedBalance;
+        this.unconfirmedChangeBalance = unconfirmedChangeBalance;
+        this.lockedForVotingBalance = lockedForVotingBalance;
+        this.lockupBondsBalance = lockupBondsBalance;
+        this.unlockingBondsBalance = unlockingBondsBalance;
+    }
+
+    @VisibleForTesting
+    public static BsqBalanceInfo valueOf(long availableConfirmedBalance,
+                                         long unverifiedBalance,
+                                         long unconfirmedChangeBalance,
+                                         long lockedForVotingBalance,
+                                         long lockupBondsBalance,
+                                         long unlockingBondsBalance) {
+        // Convenience for creating a model instance instead of a proto.
+        return new BsqBalanceInfo(availableConfirmedBalance,
+                unverifiedBalance,
+                unconfirmedChangeBalance,
+                lockedForVotingBalance,
+                lockupBondsBalance,
+                unlockingBondsBalance);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.BsqBalanceInfo toProtoMessage() {
+        return bisq.proto.grpc.BsqBalanceInfo.newBuilder()
+                .setAvailableConfirmedBalance(availableConfirmedBalance)
+                .setUnverifiedBalance(unverifiedBalance)
+                .setUnconfirmedChangeBalance(unconfirmedChangeBalance)
+                .setLockedForVotingBalance(lockedForVotingBalance)
+                .setLockupBondsBalance(lockupBondsBalance)
+                .setUnlockingBondsBalance(unlockingBondsBalance)
+                .build();
+
+    }
+
+    public static BsqBalanceInfo fromProto(bisq.proto.grpc.BsqBalanceInfo proto) {
+        return new BsqBalanceInfo(proto.getAvailableConfirmedBalance(),
+                proto.getUnverifiedBalance(),
+                proto.getUnconfirmedChangeBalance(),
+                proto.getLockedForVotingBalance(),
+                proto.getLockupBondsBalance(),
+                proto.getUnlockingBondsBalance());
+    }
+
+    @Override
+    public String toString() {
+        return "BsqBalanceInfo{" +
+                "availableConfirmedBalance=" + availableConfirmedBalance +
+                ", unverifiedBalance=" + unverifiedBalance +
+                ", unconfirmedChangeBalance=" + unconfirmedChangeBalance +
+                ", lockedForVotingBalance=" + lockedForVotingBalance +
+                ", lockupBondsBalance=" + lockupBondsBalance +
+                ", unlockingBondsBalance=" + unlockingBondsBalance +
+                '}';
+    }
+}

--- a/core/src/main/java/bisq/core/api/model/BtcBalanceInfo.java
+++ b/core/src/main/java/bisq/core/api/model/BtcBalanceInfo.java
@@ -1,0 +1,70 @@
+package bisq.core.api.model;
+
+import bisq.common.Payload;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.Getter;
+
+@Getter
+public class BtcBalanceInfo implements Payload {
+
+    // All balances are in BTC satoshis.
+    private final long availableBalance;
+    private final long reservedBalance;
+    private final long totalAvailableBalance; // available + reserved
+    private final long lockedBalance;
+
+    public BtcBalanceInfo(long availableBalance,
+                          long reservedBalance,
+                          long totalAvailableBalance,
+                          long lockedBalance) {
+        this.availableBalance = availableBalance;
+        this.reservedBalance = reservedBalance;
+        this.totalAvailableBalance = totalAvailableBalance;
+        this.lockedBalance = lockedBalance;
+    }
+
+    @VisibleForTesting
+    public static BtcBalanceInfo valueOf(long availableBalance,
+                                         long reservedBalance,
+                                         long totalAvailableBalance,
+                                         long lockedBalance) {
+        // Convenience for creating a model instance instead of a proto.
+        return new BtcBalanceInfo(availableBalance,
+                reservedBalance,
+                totalAvailableBalance,
+                lockedBalance);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.BtcBalanceInfo toProtoMessage() {
+        return bisq.proto.grpc.BtcBalanceInfo.newBuilder()
+                .setAvailableBalance(availableBalance)
+                .setReservedBalance(reservedBalance)
+                .setTotalAvailableBalance(totalAvailableBalance)
+                .setLockedBalance(lockedBalance)
+                .build();
+    }
+
+    public static BtcBalanceInfo fromProto(bisq.proto.grpc.BtcBalanceInfo proto) {
+        return new BtcBalanceInfo(proto.getAvailableBalance(),
+                proto.getReservedBalance(),
+                proto.getTotalAvailableBalance(),
+                proto.getLockedBalance());
+    }
+
+    @Override
+    public String toString() {
+        return "BtcBalanceInfo{" +
+                "availableBalance=" + availableBalance +
+                ", reservedBalance=" + reservedBalance +
+                ", totalAvailableBalance=" + totalAvailableBalance +
+                ", lockedBalance=" + lockedBalance +
+                '}';
+    }
+}

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -275,6 +275,12 @@ message TradeInfo {
 service Wallets {
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceReply) {
     }
+    rpc GetBalances (GetBalancesRequest) returns (GetBalancesReply) {
+    }
+    rpc GetBsqBalances (GetBsqBalancesRequest) returns (GetBsqBalancesReply) {
+    }
+    rpc GetBtcBalances (GetBtcBalancesRequest) returns (GetBtcBalancesReply) {
+    }
     rpc GetAddressBalance (GetAddressBalanceRequest) returns (GetAddressBalanceReply) {
     }
     rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
@@ -294,6 +300,27 @@ message GetBalanceRequest {
 
 message GetBalanceReply {
     uint64 balance = 1;
+}
+
+message GetBalancesRequest {
+}
+
+message GetBalancesReply {
+    BalancesInfo balances = 1;
+}
+
+message GetBsqBalancesRequest {
+}
+
+message GetBsqBalancesReply {
+    BsqBalanceInfo bsqBalanceInfo = 1;
+}
+
+message GetBtcBalancesRequest {
+}
+
+message GetBtcBalancesReply {
+    BtcBalanceInfo btcBalanceInfo = 1;
 }
 
 message GetAddressBalanceRequest {
@@ -338,6 +365,27 @@ message UnlockWalletRequest {
 }
 
 message UnlockWalletReply {
+}
+
+message BalancesInfo {
+    BsqBalanceInfo bsqBalanceInfo = 1;
+    BtcBalanceInfo btcBalanceInfo = 2;
+}
+
+message BsqBalanceInfo {
+    uint64 availableConfirmedBalance = 1;
+    uint64 unverifiedBalance = 2;
+    uint64 unconfirmedChangeBalance = 3;
+    uint64 lockedForVotingBalance = 4;
+    uint64 lockupBondsBalance = 5;
+    uint64 unlockingBondsBalance = 6;
+}
+
+message BtcBalanceInfo {
+    uint64 availableBalance = 1;
+    uint64 reservedBalance = 2;
+    uint64 totalAvailableBalance = 3;
+    uint64 lockedBalance = 4;
 }
 
 message AddressBalanceInfo {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -283,6 +283,8 @@ service Wallets {
     }
     rpc GetAddressBalance (GetAddressBalanceRequest) returns (GetAddressBalanceReply) {
     }
+    rpc GetUnusedBsqAddress (GetUnusedBsqAddressRequest) returns (GetUnusedBsqAddressReply) {
+    }
     rpc GetFundingAddresses (GetFundingAddressesRequest) returns (GetFundingAddressesReply) {
     }
     rpc SetWalletPassword (SetWalletPasswordRequest) returns (SetWalletPasswordReply) {
@@ -329,6 +331,13 @@ message GetAddressBalanceRequest {
 
 message GetAddressBalanceReply {
     AddressBalanceInfo addressBalanceInfo = 1;
+}
+
+message GetUnusedBsqAddressRequest {
+}
+
+message GetUnusedBsqAddressReply {
+     string address = 1;
 }
 
 message GetFundingAddressesRequest {


### PR DESCRIPTION
This change adds a proto to support a future api implementation for  getting an unused, bsq funding address.

This is the third in a chain of PRs beginning with https://github.com/bisq-network/bisq/pull/4793.  

PR https://github.com/bisq-network/bisq/pull/4794 should be reviewed before this one.