### PR TITLE
Fix issues with missing persistence for trade state

### DIFF
--- a/common/src/main/java/bisq/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/bisq/common/persistence/PersistenceManager.java
@@ -143,25 +143,25 @@ public class PersistenceManager<T extends PersistableEnvelope> {
 
     public enum Source {
         // For data stores we received from the network and which could be rebuilt. We store only for avoiding too much network traffic.
-        NETWORK(1, TimeUnit.HOURS.toSeconds(1), false),
+        NETWORK(1, TimeUnit.MINUTES.toMillis(5), false),
 
         // For data stores which are created from private local data. This data could only be rebuilt from backup files.
-        PRIVATE(10, TimeUnit.SECONDS.toSeconds(30), true),
+        PRIVATE(10, 200, true),
 
-        // For data stores which are created from private local data. Loss of that data would not have any critical consequences.
-        PRIVATE_LOW_PRIO(4, TimeUnit.HOURS.toSeconds(2), false);
+        // For data stores which are created from private local data. Loss of that data would not have critical consequences.
+        PRIVATE_LOW_PRIO(4, TimeUnit.MINUTES.toMillis(1), false);
 
 
         @Getter
         private final int numMaxBackupFiles;
         @Getter
-        private final long delayInSec;
+        private final long delay;
         @Getter
         private final boolean flushAtShutDown;
 
-        Source(int numMaxBackupFiles, long delayInSec, boolean flushAtShutDown) {
+        Source(int numMaxBackupFiles, long delay, boolean flushAtShutDown) {
             this.numMaxBackupFiles = numMaxBackupFiles;
-            this.delayInSec = delayInSec;
+            this.delay = delay;
             this.flushAtShutDown = flushAtShutDown;
         }
     }
@@ -352,7 +352,7 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             timer = UserThread.runAfter(() -> {
                 persistNow(null);
                 UserThread.execute(() -> timer = null);
-            }, source.delayInSec, TimeUnit.SECONDS);
+            }, source.delay, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -454,7 +454,7 @@ public class PersistenceManager<T extends PersistableEnvelope> {
                 ",\n     dir=" + dir +
                 ",\n     storageFile=" + storageFile +
                 ",\n     persistable=" + persistable +
-                ",\n     priority=" + source +
+                ",\n     source=" + source +
                 ",\n     usedTempFilePath=" + usedTempFilePath +
                 ",\n     persistenceRequested=" + persistenceRequested +
                 "\n}";

--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -247,6 +247,7 @@ public class WalletAppSetup {
                                         String finalDetails = details;
                                         UserThread.runAfter(() -> {
                                             trade.setErrorMessage(newValue.getMessage());
+                                            tradeManager.requestPersistence();
                                             if (rejectedTxErrorMessageHandler != null) {
                                                 rejectedTxErrorMessageHandler.accept(Res.get("popup.warning.trade.txRejected",
                                                         finalDetails, trade.getShortId(), txId));

--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -395,6 +395,7 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
                 if (!storedDisputeOptional.isPresent()) {
                     disputeList.add(dispute);
                     trade.setDisputeState(getDisputeStateStartedByPeer());
+                    tradeManager.requestPersistence();
                     errorMessage = null;
                 } else {
                     // valid case if both have opened a dispute and agent was not online.

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -207,6 +207,7 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
                 tradeManager.requestPersistence();
 
                 trade.setDisputeState(Trade.DisputeState.MEDIATION_CLOSED);
+                tradeManager.requestPersistence();
             }
         } else {
             Optional<OpenOffer> openOfferOptional = openOfferManager.getOpenOfferById(tradeId);
@@ -243,6 +244,7 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
         DisputeProtocol tradeProtocol = (DisputeProtocol) tradeManager.getTradeProtocol(trade);
 
         trade.setMediationResultState(MediationResultState.MEDIATION_RESULT_ACCEPTED);
+        tradeManager.requestPersistence();
 
         // If we have not got yet the peers signature we sign and send to the peer our signature.
         // Otherwise we sign and complete with the peers signature the payout tx.
@@ -265,5 +267,6 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
 
     public void rejectMediationResult(Trade trade) {
         trade.setMediationResultState(MediationResultState.MEDIATION_RESULT_REJECTED);
+        tradeManager.requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -204,9 +204,9 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
                     trade.getDisputeState() == Trade.DisputeState.MEDIATION_STARTED_BY_PEER) {
                 trade.getProcessModel().setBuyerPayoutAmountFromMediation(disputeResult.getBuyerPayoutAmount().value);
                 trade.getProcessModel().setSellerPayoutAmountFromMediation(disputeResult.getSellerPayoutAmount().value);
-                tradeManager.requestPersistence();
 
                 trade.setDisputeState(Trade.DisputeState.MEDIATION_CLOSED);
+
                 tradeManager.requestPersistence();
             }
         } else {

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -205,6 +205,7 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
             if (trade.getDisputeState() == Trade.DisputeState.REFUND_REQUESTED ||
                     trade.getDisputeState() == Trade.DisputeState.REFUND_REQUEST_STARTED_BY_PEER) {
                 trade.setDisputeState(Trade.DisputeState.REFUND_REQUEST_CLOSED);
+                tradeManager.requestPersistence();
             }
         } else {
             Optional<OpenOffer> openOfferOptional = openOfferManager.getOpenOfferById(tradeId);

--- a/core/src/main/java/bisq/core/support/traderchat/TraderChatManager.java
+++ b/core/src/main/java/bisq/core/support/traderchat/TraderChatManager.java
@@ -164,5 +164,7 @@ public class TraderChatManager extends SupportManager {
                 trade.getDate().getTime());
         chatMessage.setSystemMessage(true);
         trade.getChatMessages().add(chatMessage);
+
+        requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -700,10 +700,6 @@ public abstract class Trade implements Tradable, Model {
         }
     }
 
-    public void appendErrorMessage(String msg) {
-        errorMessage = errorMessage == null ? msg : errorMessage + "\n" + msg;
-    }
-
     public boolean mediationResultAppliedPenaltyToSeller() {
         // If mediated payout is same or more then normal payout we enable otherwise a penalty was applied
         // by mediators and we keep the confirm disabled to avoid that the seller can complete the trade
@@ -1099,6 +1095,9 @@ public abstract class Trade implements Tradable, Model {
     private void setConfirmedState() {
         // we only apply the state if we are not already further in the process
         if (!isDepositConfirmed()) {
+            // As setState is called here from the trade itself we cannot trigger a requestPersistence call.
+            // But as we get setupConfidenceListener called at startup anyway there is no issue if it would not be
+            // persisted in case the shutdown routine did not persist the trade.
             setState(State.DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN);
         }
     }

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -342,11 +342,13 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     private void initPersistedTrade(Trade trade) {
         initTradeAndProtocol(trade, getTradeProtocol(trade));
         trade.updateDepositTxFromWallet();
+        requestPersistence();
     }
 
     private void initTradeAndProtocol(Trade trade, TradeProtocol tradeProtocol) {
         tradeProtocol.initialize(processModelServiceProvider, this, trade.getOffer());
         trade.initialize(processModelServiceProvider);
+        requestPersistence();
     }
 
     public void requestPersistence() {
@@ -544,10 +546,13 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                 Date halfTradePeriodDate = trade.getHalfTradePeriodDate();
                 if (maxTradePeriodDate != null && halfTradePeriodDate != null) {
                     Date now = new Date();
-                    if (now.after(maxTradePeriodDate))
+                    if (now.after(maxTradePeriodDate)) {
                         trade.setTradePeriodState(Trade.TradePeriodState.TRADE_PERIOD_OVER);
-                    else if (now.after(halfTradePeriodDate))
+                        requestPersistence();
+                    } else if (now.after(halfTradePeriodDate)) {
                         trade.setTradePeriodState(Trade.TradePeriodState.SECOND_HALF);
+                        requestPersistence();
+                    }
                 }
             }
         });

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -433,6 +433,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
 
                         ((TakerProtocol) tradeProtocol).onTakeOffer();
                         tradeResultHandler.handleResult(trade);
+                        requestPersistence();
                     }
                 },
                 errorMessageHandler);

--- a/core/src/main/java/bisq/core/trade/closed/ClosedTradableManager.java
+++ b/core/src/main/java/bisq/core/trade/closed/ClosedTradableManager.java
@@ -84,13 +84,13 @@ public class ClosedTradableManager implements PersistedDataHost {
 
     public void add(Tradable tradable) {
         if (closedTradables.add(tradable)) {
-            persistenceManager.requestPersistence();
+            requestPersistence();
         }
     }
 
     public void remove(Tradable tradable) {
         if (closedTradables.remove(tradable)) {
-            persistenceManager.requestPersistence();
+            requestPersistence();
         }
     }
 
@@ -116,5 +116,9 @@ public class ClosedTradableManager implements PersistedDataHost {
     public Stream<Trade> getTradesStreamWithFundsLockedIn() {
         return getClosedTrades().stream()
                 .filter(Trade::isFundsLockedIn);
+    }
+
+    private void requestPersistence() {
+        persistenceManager.requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
+++ b/core/src/main/java/bisq/core/trade/failed/FailedTradesManager.java
@@ -95,13 +95,13 @@ public class FailedTradesManager implements PersistedDataHost {
 
     public void add(Trade trade) {
         if (failedTrades.add(trade)) {
-            persistenceManager.requestPersistence();
+            requestPersistence();
         }
     }
 
     public void removeTrade(Trade trade) {
         if (failedTrades.remove(trade)) {
-            persistenceManager.requestPersistence();
+            requestPersistence();
         }
     }
 
@@ -129,7 +129,7 @@ public class FailedTradesManager implements PersistedDataHost {
         if (unFailTradeCallback.apply(trade)) {
             log.info("Unfailing trade {}", trade.getId());
             if (failedTrades.remove(trade)) {
-                persistenceManager.requestPersistence();
+                requestPersistence();
             }
         }
     }
@@ -150,5 +150,9 @@ public class FailedTradesManager implements PersistedDataHost {
             }
         }
         return blockingTrades.toString();
+    }
+
+    private void requestPersistence() {
+        persistenceManager.requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -65,7 +65,6 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
 
         Offer offer = checkNotNull(trade.getOffer());
         processModel.getTradingPeer().setPubKeyRing(offer.getPubKeyRing());
-        processModel.getTradeManager().requestPersistence();
     }
 
 

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -65,6 +65,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
 
         Offer offer = checkNotNull(trade.getOffer());
         processModel.getTradingPeer().setPubKeyRing(offer.getPubKeyRing());
+        processModel.getTradeManager().requestPersistence();
     }
 
 
@@ -83,7 +84,10 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         BuyerAsTakerCreatesDepositTxInputs.class,
                         TakerSendInputsForDepositTxRequest.class)
                         .withTimeout(30))
-                .run(() -> processModel.setTempTradingPeerNodeAddress(trade.getTradingPeerNodeAddress()))
+                .run(() -> {
+                    processModel.setTempTradingPeerNodeAddress(trade.getTradingPeerNodeAddress());
+                    processModel.getTradeManager().requestPersistence();
+                })
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerProtocol.java
@@ -147,7 +147,10 @@ public abstract class BuyerProtocol extends DisputeProtocol {
                                     errorMessageHandler.handleErrorMessage(errorMessage);
                                     handleTaskRunnerFault(event, errorMessage);
                                 })))
-                .run(() -> trade.setState(Trade.State.BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED))
+                .run(() -> {
+                    trade.setState(Trade.State.BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED);
+                    processModel.getTradeManager().requestPersistence();
+                })
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/FluentProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/FluentProtocol.java
@@ -99,11 +99,13 @@ public class FluentProtocol {
         NodeAddress peer = condition.getPeer();
         if (peer != null) {
             tradeProtocol.processModel.setTempTradingPeerNodeAddress(peer);
+            tradeProtocol.processModel.getTradeManager().requestPersistence();
         }
 
         TradeMessage message = condition.getMessage();
         if (message != null) {
             tradeProtocol.processModel.setTradeMessage(message);
+            tradeProtocol.processModel.getTradeManager().requestPersistence();
         }
 
         TradeTaskRunner taskRunner = setup.getTaskRunner(message, condition.getEvent());

--- a/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
@@ -294,6 +294,7 @@ public class ProcessModel implements Model, PersistablePayload {
 
     public void setPaymentStartedMessageState(MessageState paymentStartedMessageStateProperty) {
         this.paymentStartedMessageStateProperty.set(paymentStartedMessageStateProperty);
+        tradeManager.requestPersistence();
     }
 
     void setDepositTxSentAckMessage(AckMessage ackMessage) {
@@ -305,6 +306,7 @@ public class ProcessModel implements Model, PersistablePayload {
 
     public void setDepositTxMessageState(MessageState messageState) {
         this.depositTxMessageStateProperty.set(messageState);
+        tradeManager.requestPersistence();
     }
 
     void witnessDebugLog(Trade trade) {

--- a/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/ProcessModel.java
@@ -294,7 +294,9 @@ public class ProcessModel implements Model, PersistablePayload {
 
     public void setPaymentStartedMessageState(MessageState paymentStartedMessageStateProperty) {
         this.paymentStartedMessageStateProperty.set(paymentStartedMessageStateProperty);
-        tradeManager.requestPersistence();
+        if (tradeManager != null) {
+            tradeManager.requestPersistence();
+        }
     }
 
     void setDepositTxSentAckMessage(AckMessage ackMessage) {
@@ -306,7 +308,9 @@ public class ProcessModel implements Model, PersistablePayload {
 
     public void setDepositTxMessageState(MessageState messageState) {
         this.depositTxMessageStateProperty.set(messageState);
-        tradeManager.requestPersistence();
+        if (tradeManager != null) {
+            tradeManager.requestPersistence();
+        }
     }
 
     void witnessDebugLog(Trade trade) {

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -59,7 +59,6 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
         super(trade);
         Offer offer = checkNotNull(trade.getOffer());
         processModel.getTradingPeer().setPubKeyRing(offer.getPubKeyRing());
-        processModel.getTradeManager().requestPersistence();
     }
 
 

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -59,6 +59,7 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
         super(trade);
         Offer offer = checkNotNull(trade.getOffer());
         processModel.getTradingPeer().setPubKeyRing(offer.getPubKeyRing());
+        processModel.getTradeManager().requestPersistence();
     }
 
 

--- a/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
@@ -141,7 +141,10 @@ public abstract class SellerProtocol extends DisputeProtocol {
                                     errorMessageHandler.handleErrorMessage(errorMessage);
                                     handleTaskRunnerFault(event, errorMessage);
                                 })))
-                .run(() -> trade.setState(Trade.State.SELLER_CONFIRMED_IN_UI_FIAT_PAYMENT_RECEIPT))
+                .run(() -> {
+                    trade.setState(Trade.State.SELLER_CONFIRMED_IN_UI_FIAT_PAYMENT_RECEIPT);
+                    processModel.getTradeManager().requestPersistence();
+                })
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerProtocol.java
@@ -99,7 +99,12 @@ public abstract class SellerProtocol extends DisputeProtocol {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     protected void handle(CounterCurrencyTransferStartedMessage message, NodeAddress peer) {
-        expect(phase(Trade.Phase.DEPOSIT_CONFIRMED)
+        // We are more tolerant with expected phase and allow also DEPOSIT_PUBLISHED as it can be the case
+        // that the wallet is still syncing and so the DEPOSIT_CONFIRMED state to yet triggered when we received
+        // a mailbox message with CounterCurrencyTransferStartedMessage.
+        // TODO A better fix would be to add a listener for the wallet sync state and process
+        // the mailbox msg once wallet is ready and trade state set.
+        expect(anyPhase(Trade.Phase.DEPOSIT_CONFIRMED, Trade.Phase.DEPOSIT_PUBLISHED)
                 .with(message)
                 .from(peer)
                 .preCondition(trade.getPayoutTx() == null,

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -41,6 +41,8 @@ import bisq.common.taskrunner.Task;
 
 import java.security.PublicKey;
 
+import java.util.concurrent.TimeUnit;
+
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -69,7 +71,13 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
 
     public void initialize(ProcessModelServiceProvider serviceProvider, TradeManager tradeManager, Offer offer) {
         processModel.applyTransient(serviceProvider, tradeManager, offer);
-        onInitialized();
+
+        // We delay a bit here as the trade gets updated from the wallet to update the trade
+        // state (deposit confirmed) and that happens after our method is called.
+        // TODO To fix that in a better way we would need to change the order of some routines
+        // from the TradeManager, but as we are close to a release I dont want to risk a bigger
+        // change and leave that for a later PR
+        UserThread.runAfter(this::onInitialized, 100, TimeUnit.MILLISECONDS);
     }
 
     protected void onInitialized() {

--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -297,6 +297,8 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             log.error("Timeout reached. TradeID={}, state={}, timeoutSec={}",
                     trade.getId(), trade.stateProperty().get(), timeoutSec);
             trade.setErrorMessage("Timeout reached. Protocol did not complete in " + timeoutSec + " sec.");
+
+            processModel.getTradeManager().requestPersistence();
             cleanup();
         }, timeoutSec);
     }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessPeerPublishedDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessPeerPublishedDelayedPayoutTxMessage.java
@@ -52,6 +52,8 @@ public class ProcessPeerPublishedDelayedPayoutTxMessage extends TradeTask {
             Transaction delayedPayoutTx = checkNotNull(trade.getDelayedPayoutTx());
             WalletService.maybeAddSelfTxToWallet(delayedPayoutTx, processModel.getBtcWalletService().getWallet());
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/SetupPayoutTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/SetupPayoutTxListener.java
@@ -91,6 +91,7 @@ public abstract class SetupPayoutTxListener extends TradeTask {
         if (trade.getPayoutTx() == null) {
             Transaction walletTx = processModel.getTradeWalletService().getWalletTx(confidence.getTransactionHash());
             trade.setPayoutTx(walletTx);
+            processModel.getTradeManager().requestPersistence();
             BtcWalletService.printTx("payoutTx received from network", walletTx);
             setState();
         } else {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/TradeTask.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/TradeTask.java
@@ -40,6 +40,8 @@ public abstract class TradeTask extends Task<Trade> {
     @Override
     protected void failed() {
         trade.setErrorMessage(errorMessage);
+        processModel.getTradeManager().requestPersistence();
+
         super.failed();
     }
 
@@ -47,6 +49,8 @@ public abstract class TradeTask extends Task<Trade> {
     protected void failed(String message) {
         appendToErrorMessage(message);
         trade.setErrorMessage(errorMessage);
+        processModel.getTradeManager().requestPersistence();
+
         super.failed();
     }
 
@@ -55,6 +59,8 @@ public abstract class TradeTask extends Task<Trade> {
         t.printStackTrace();
         appendExceptionToErrorMessage(t);
         trade.setErrorMessage(errorMessage);
+        processModel.getTradeManager().requestPersistence();
+
         super.failed();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/TradeTask.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/TradeTask.java
@@ -38,6 +38,13 @@ public abstract class TradeTask extends Task<Trade> {
     }
 
     @Override
+    protected void complete() {
+        processModel.getTradeManager().requestPersistence();
+
+        super.complete();
+    }
+
+    @Override
     protected void failed() {
         trade.setErrorMessage(errorMessage);
         processModel.getTradeManager().requestPersistence();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
@@ -54,6 +54,8 @@ public class BuyerProcessDelayedPayoutTxSignatureRequest extends TradeTask {
 
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -73,6 +73,8 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(trade.getId(),
                     AddressEntry.Context.RESERVED_FOR_TRADE);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessPayoutTxPublishedMessage.java
@@ -73,6 +73,8 @@ public class BuyerProcessPayoutTxPublishedMessage extends TradeTask {
                 processModel.getAccountAgeWitnessService().publishOwnSignedWitness(signedWitness);
             }
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessage.java
@@ -83,11 +83,15 @@ public class BuyerSendCounterCurrencyTransferStartedMessage extends SendMailboxM
     @Override
     protected void setStateSent() {
         trade.setStateIfValidTransitionTo(Trade.State.BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG);
+
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
     protected void setStateArrived() {
         trade.setStateIfValidTransitionTo(Trade.State.BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG);
+
+        processModel.getTradeManager().requestPersistence();
         cleanup();
         // Complete is called in base class
     }
@@ -104,6 +108,7 @@ public class BuyerSendCounterCurrencyTransferStartedMessage extends SendMailboxM
         if (!trade.isPayoutPublished()) {
             tryToSendAgainLater();
         }
+        processModel.getTradeManager().requestPersistence();
     }
 
     // We override the default behaviour for onFault and do not call appendToErrorMessage and failed
@@ -118,6 +123,7 @@ public class BuyerSendCounterCurrencyTransferStartedMessage extends SendMailboxM
         if (!trade.isPayoutPublished()) {
             tryToSendAgainLater();
         }
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
@@ -173,6 +179,9 @@ public class BuyerSendCounterCurrencyTransferStartedMessage extends SendMailboxM
         if (newValue == MessageState.ACKNOWLEDGED) {
             // We treat a ACK like BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG
             trade.setStateIfValidTransitionTo(Trade.State.BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG);
+
+            processModel.getTradeManager().requestPersistence();
+
             cleanup();
             complete();
         }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupDepositTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupDepositTxListener.java
@@ -100,6 +100,8 @@ public class BuyerSetupDepositTxListener extends TradeTask {
             // We don't want to trigger the tradeStateSubscription when setting the state, so we unsubscribe before
             unSubscribeAndRemoveListener();
             trade.setState(Trade.State.BUYER_SAW_DEPOSIT_TX_IN_NETWORK);
+
+            processModel.getTradeManager().requestPersistence();
         } else {
             unSubscribeAndRemoveListener();
         }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupPayoutTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupPayoutTxListener.java
@@ -45,5 +45,7 @@ public class BuyerSetupPayoutTxListener extends SetupPayoutTxListener {
     @Override
     protected void setState() {
         trade.setStateIfValidTransitionTo(Trade.State.BUYER_SAW_PAYOUT_TX_IN_NETWORK);
+
+        processModel.getTradeManager().requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignPayoutTx.java
@@ -81,6 +81,8 @@ public class BuyerSignPayoutTx extends TradeTask {
                     sellerMultiSigPubKey);
             processModel.setPayoutTxSignature(payoutTxSignature);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignsDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSignsDelayedPayoutTx.java
@@ -69,6 +69,8 @@ public class BuyerSignsDelayedPayoutTx extends TradeTask {
                     sellerMultiSigPubKey);
             processModel.setDelayedPayoutTxSignature(delayedPayoutTxSignature);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
@@ -97,6 +97,8 @@ public class BuyerAsMakerCreatesAndSignsDepositTx extends TradeTask {
             processModel.setPreparedDepositTx(result.depositTransaction);
             processModel.setRawTransactionInputs(result.rawMakerInputs);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerCreatesDepositTxInputs.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerCreatesDepositTxInputs.java
@@ -53,6 +53,8 @@ public class BuyerAsTakerCreatesDepositTxInputs extends TradeTask {
             processModel.setChangeOutputValue(result.changeOutputValue);
             processModel.setChangeOutputAddress(result.changeOutputAddress);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSendsDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSendsDepositTxMessage.java
@@ -72,7 +72,7 @@ public class BuyerAsTakerSendsDepositTxMessage extends TradeTask {
                         }
                 );
             } else {
-                log.error("processModel.getDepositTx() = " + processModel.getDepositTx());
+                log.error("processModel.getDepositTx() = {}", processModel.getDepositTx());
                 failed("DepositTx is null");
             }
         } catch (Throwable t) {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
@@ -88,6 +88,8 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
                     sellerMultiSigPubKey);
             processModel.setDepositTx(depositTx);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerCreateAndSignContract.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerCreateAndSignContract.java
@@ -95,6 +95,8 @@ public class MakerCreateAndSignContract extends TradeTask {
 
             processModel.setMyMultiSigPubKey(makerMultiSigPubKey);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSendsInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSendsInputsForDepositTxResponse.java
@@ -89,7 +89,7 @@ public abstract class MakerSendsInputsForDepositTxResponse extends TradeTask {
                     trade.getLockTime());
 
             trade.setState(Trade.State.MAKER_SENT_PUBLISH_DEPOSIT_TX_REQUEST);
-
+            processModel.getTradeManager().requestPersistence();
             NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
             log.info("Send {} to peer {}. tradeId={}, uid={}",
                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
@@ -103,6 +103,7 @@ public abstract class MakerSendsInputsForDepositTxResponse extends TradeTask {
                             log.info("{} arrived at peer {}. tradeId={}, uid={}",
                                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
                             trade.setState(Trade.State.MAKER_SAW_ARRIVED_PUBLISH_DEPOSIT_TX_REQUEST);
+                            processModel.getTradeManager().requestPersistence();
                             complete();
                         }
 
@@ -112,6 +113,7 @@ public abstract class MakerSendsInputsForDepositTxResponse extends TradeTask {
                                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid(), errorMessage);
                             trade.setState(Trade.State.MAKER_SEND_FAILED_PUBLISH_DEPOSIT_TX_REQUEST);
                             appendToErrorMessage("Sending message failed: message=" + message + "\nerrorMessage=" + errorMessage);
+                            processModel.getTradeManager().requestPersistence();
                             failed(errorMessage);
                         }
                     }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSetsLockTime.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/maker/MakerSetsLockTime.java
@@ -47,6 +47,8 @@ public class MakerSetsLockTime extends TradeTask {
             log.info("lockTime={}, delay={}", lockTime, delay);
             trade.setLockTime(lockTime);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/BroadcastMediatedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/BroadcastMediatedPayoutTx.java
@@ -45,5 +45,6 @@ public class BroadcastMediatedPayoutTx extends BroadcastPayoutTx {
     @Override
     protected void setState() {
         trade.setMediationResultState(MediationResultState.PAYOUT_TX_PUBLISHED);
+        processModel.getTradeManager().requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/FinalizeMediatedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/FinalizeMediatedPayoutTx.java
@@ -108,6 +108,8 @@ public class FinalizeMediatedPayoutTx extends TradeTask {
 
             trade.setPayoutTx(transaction);
 
+            processModel.getTradeManager().requestPersistence();
+
             walletService.swapTradeEntryToAvailableEntry(tradeId, AddressEntry.Context.MULTI_SIG);
 
             complete();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutSignatureMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutSignatureMessage.java
@@ -51,6 +51,8 @@ public class ProcessMediatedPayoutSignatureMessage extends TradeTask {
 
             trade.setMediationResultState(MediationResultState.RECEIVED_SIG_MSG);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
@@ -74,6 +74,9 @@ public class ProcessMediatedPayoutTxPublishedMessage extends TradeTask {
             } else {
                 log.info("We got the payout tx already set from BuyerSetupPayoutTxListener and do nothing here. trade ID={}", trade.getId());
             }
+
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SendMediatedPayoutSignatureMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SendMediatedPayoutSignatureMessage.java
@@ -60,6 +60,7 @@ public class SendMediatedPayoutSignatureMessage extends TradeTask {
                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
 
             trade.setMediationResultState(MediationResultState.SIG_MSG_SENT);
+            processModel.getTradeManager().requestPersistence();
             p2PService.sendEncryptedMailboxMessage(peersNodeAddress,
                     peersPubKeyRing,
                     message,
@@ -70,6 +71,7 @@ public class SendMediatedPayoutSignatureMessage extends TradeTask {
                                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
 
                             trade.setMediationResultState(MediationResultState.SIG_MSG_ARRIVED);
+                            processModel.getTradeManager().requestPersistence();
                             complete();
                         }
 
@@ -79,6 +81,7 @@ public class SendMediatedPayoutSignatureMessage extends TradeTask {
                                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid());
 
                             trade.setMediationResultState(MediationResultState.SIG_MSG_IN_MAILBOX);
+                            processModel.getTradeManager().requestPersistence();
                             complete();
                         }
 
@@ -88,6 +91,7 @@ public class SendMediatedPayoutSignatureMessage extends TradeTask {
                                     message.getClass().getSimpleName(), peersNodeAddress, message.getTradeId(), message.getUid(), errorMessage);
                             trade.setMediationResultState(MediationResultState.SIG_MSG_SEND_FAILED);
                             appendToErrorMessage("Sending message failed: message=" + message + "\nerrorMessage=" + errorMessage);
+                            processModel.getTradeManager().requestPersistence();
                             failed(errorMessage);
                         }
                     }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SendMediatedPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SendMediatedPayoutTxPublishedMessage.java
@@ -54,21 +54,25 @@ public class SendMediatedPayoutTxPublishedMessage extends SendMailboxMessageTask
     @Override
     protected void setStateSent() {
         trade.setMediationResultState(MediationResultState.PAYOUT_TX_PUBLISHED_MSG_SENT);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
     protected void setStateArrived() {
         trade.setMediationResultState(MediationResultState.PAYOUT_TX_PUBLISHED_MSG_ARRIVED);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
     protected void setStateStoredInMailbox() {
         trade.setMediationResultState(MediationResultState.PAYOUT_TX_PUBLISHED_MSG_IN_MAILBOX);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
     protected void setStateFault() {
         trade.setMediationResultState(MediationResultState.PAYOUT_TX_PUBLISHED_MSG_SEND_FAILED);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SetupMediatedPayoutTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SetupMediatedPayoutTxListener.java
@@ -49,5 +49,6 @@ public class SetupMediatedPayoutTxListener extends SetupPayoutTxListener {
         if (trade.getPayoutTx() != null) {
             processModel.getTradeManager().closeDisputedTrade(trade.getId(), Trade.DisputeState.MEDIATION_CLOSED);
         }
+        processModel.getTradeManager().requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SignMediatedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/SignMediatedPayoutTx.java
@@ -99,6 +99,8 @@ public class SignMediatedPayoutTx extends TradeTask {
                     sellerMultiSigPubKey);
             processModel.setMediatedPayoutTxSignature(mediatedPayoutTxSignature);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerBroadcastPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerBroadcastPayoutTx.java
@@ -44,5 +44,6 @@ public class SellerBroadcastPayoutTx extends BroadcastPayoutTx {
     @Override
     protected void setState() {
         trade.setState(Trade.State.SELLER_PUBLISHED_PAYOUT_TX);
+        processModel.getTradeManager().requestPersistence();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerCreatesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerCreatesDelayedPayoutTx.java
@@ -56,6 +56,8 @@ public class SellerCreatesDelayedPayoutTx extends TradeTask {
 
             processModel.setPreparedDelayedPayoutTx(preparedDelayedPayoutTx);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerFinalizesDelayedPayoutTx.java
@@ -68,6 +68,8 @@ public class SellerFinalizesDelayedPayoutTx extends TradeTask {
             trade.applyDelayedPayoutTx(signedDelayedPayoutTx);
             log.info("DelayedPayoutTxBytes = {}", Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()));
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessCounterCurrencyTransferStartedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessCounterCurrencyTransferStartedMessage.java
@@ -61,6 +61,8 @@ public class SellerProcessCounterCurrencyTransferStartedMessage extends TradeTas
 
             trade.setState(Trade.State.SELLER_RECEIVED_FIAT_PAYMENT_INITIATED_MSG);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
@@ -47,6 +47,8 @@ public class SellerProcessDelayedPayoutTxSignatureResponse extends TradeTask {
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerPublishesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerPublishesDepositTx.java
@@ -54,6 +54,8 @@ public class SellerPublishesDepositTx extends TradeTask {
                                 processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(processModel.getOffer().getId(),
                                         AddressEntry.Context.RESERVED_FOR_TRADE);
 
+                                processModel.getTradeManager().requestPersistence();
+
                                 complete();
                             } else {
                                 log.warn("We got the onSuccess callback called after the timeout has been triggered a complete().");

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSendPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSendPayoutTxPublishedMessage.java
@@ -65,6 +65,7 @@ public class SellerSendPayoutTxPublishedMessage extends SendMailboxMessageTask {
         trade.setState(Trade.State.SELLER_SENT_PAYOUT_TX_PUBLISHED_MSG);
         log.info("Sent PayoutTxPublishedMessage: tradeId={} at peer {} SignedWitness {}",
                 trade.getId(), trade.getTradingPeerNodeAddress(), signedWitness);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
@@ -72,6 +73,7 @@ public class SellerSendPayoutTxPublishedMessage extends SendMailboxMessageTask {
         trade.setState(Trade.State.SELLER_SAW_ARRIVED_PAYOUT_TX_PUBLISHED_MSG);
         log.info("PayoutTxPublishedMessage arrived: tradeId={} at peer {} SignedWitness {}",
                 trade.getId(), trade.getTradingPeerNodeAddress(), signedWitness);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
@@ -79,6 +81,7 @@ public class SellerSendPayoutTxPublishedMessage extends SendMailboxMessageTask {
         trade.setState(Trade.State.SELLER_STORED_IN_MAILBOX_PAYOUT_TX_PUBLISHED_MSG);
         log.info("PayoutTxPublishedMessage storedInMailbox: tradeId={} at peer {} SignedWitness {}",
                 trade.getId(), trade.getTradingPeerNodeAddress(), signedWitness);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
@@ -86,6 +89,7 @@ public class SellerSendPayoutTxPublishedMessage extends SendMailboxMessageTask {
         trade.setState(Trade.State.SELLER_SEND_FAILED_PAYOUT_TX_PUBLISHED_MSG);
         log.error("PayoutTxPublishedMessage failed: tradeId={} at peer {} SignedWitness {}",
                 trade.getId(), trade.getTradingPeerNodeAddress(), signedWitness);
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSendsDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSendsDepositTxAndDelayedPayoutTxMessage.java
@@ -76,11 +76,15 @@ public class SellerSendsDepositTxAndDelayedPayoutTxMessage extends SendMailboxMe
     @Override
     protected void setStateSent() {
         trade.setStateIfValidTransitionTo(Trade.State.SELLER_SENT_DEPOSIT_TX_PUBLISHED_MSG);
+
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
     protected void setStateArrived() {
         trade.setStateIfValidTransitionTo(Trade.State.SELLER_SAW_ARRIVED_DEPOSIT_TX_PUBLISHED_MSG);
+
+        processModel.getTradeManager().requestPersistence();
         cleanup();
         // Complete is called in base class
     }
@@ -94,6 +98,8 @@ public class SellerSendsDepositTxAndDelayedPayoutTxMessage extends SendMailboxMe
     @Override
     protected void setStateStoredInMailbox() {
         trade.setStateIfValidTransitionTo(Trade.State.SELLER_STORED_IN_MAILBOX_DEPOSIT_TX_PUBLISHED_MSG);
+
+        processModel.getTradeManager().requestPersistence();
         // The DepositTxAndDelayedPayoutTxMessage is a mailbox message as earlier we use only the deposit tx which can
         // be also received from the network once published.
         // Now we send the delayed payout tx as well and with that this message is mandatory for continuing the protocol.
@@ -119,6 +125,8 @@ public class SellerSendsDepositTxAndDelayedPayoutTxMessage extends SendMailboxMe
         if (!trade.isDepositConfirmed()) {
             tryToSendAgainLater();
         }
+
+        processModel.getTradeManager().requestPersistence();
     }
 
     @Override
@@ -173,6 +181,8 @@ public class SellerSendsDepositTxAndDelayedPayoutTxMessage extends SendMailboxMe
         if (newValue == MessageState.ACKNOWLEDGED) {
             // We treat a ACK like SELLER_SAW_ARRIVED_DEPOSIT_TX_PUBLISHED_MSG
             trade.setStateIfValidTransitionTo(Trade.State.SELLER_SAW_ARRIVED_DEPOSIT_TX_PUBLISHED_MSG);
+
+            processModel.getTradeManager().requestPersistence();
             cleanup();
             complete();
         }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignAndFinalizePayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignAndFinalizePayoutTx.java
@@ -100,6 +100,8 @@ public class SellerSignAndFinalizePayoutTx extends TradeTask {
 
             trade.setPayoutTx(transaction);
 
+            processModel.getTradeManager().requestPersistence();
+
             walletService.swapTradeEntryToAvailableEntry(id, AddressEntry.Context.MULTI_SIG);
 
             complete();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignsDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignsDelayedPayoutTx.java
@@ -70,6 +70,8 @@ public class SellerSignsDelayedPayoutTx extends TradeTask {
 
             processModel.setDelayedPayoutTxSignature(delayedPayoutTxSignature);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
@@ -103,6 +103,8 @@ public class SellerAsMakerCreatesUnsignedDepositTx extends TradeTask {
             processModel.setPreparedDepositTx(result.depositTransaction);
             processModel.setRawTransactionInputs(result.rawMakerInputs);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerFinalizesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerFinalizesDepositTx.java
@@ -48,6 +48,8 @@ public class SellerAsMakerFinalizesDepositTx extends TradeTask {
 
             processModel.setDepositTx(myDepositTx);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerProcessDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerProcessDepositTxMessage.java
@@ -51,6 +51,8 @@ public class SellerAsMakerProcessDepositTxMessage extends TradeTask {
             // but that cannot be changed due backward compatibility issues. It is a left over from the old trade protocol.
             trade.setTakerFeeTxId(processModel.getTakeOfferFeeTxId());
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerSendsInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerSendsInputsForDepositTxResponse.java
@@ -41,6 +41,9 @@ public class SellerAsMakerSendsInputsForDepositTxResponse extends MakerSendsInpu
             // before we have received his signature for the delayed payout tx.
             input.setScriptSig(new Script(new byte[]{}));
         });
+
+        processModel.getTradeManager().requestPersistence();
+
         return preparedDepositTx.bitcoinSerialize();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCreatesDepositTxInputs.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerCreatesDepositTxInputs.java
@@ -57,6 +57,8 @@ public class SellerAsTakerCreatesDepositTxInputs extends TradeTask {
             processModel.setChangeOutputValue(result.changeOutputValue);
             processModel.setChangeOutputAddress(result.changeOutputAddress);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
@@ -83,6 +83,8 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
             // We set the deposit tx to trade once we have it published
             processModel.setDepositTx(depositTx);
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             Contract contract = trade.getContract();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/CreateTakerFeeTx.java
@@ -100,6 +100,9 @@ public class CreateTakerFeeTx extends TradeTask {
 
             processModel.setTakeOfferFeeTx(transaction);
             walletService.swapTradeEntryToAvailableEntry(id, AddressEntry.Context.OFFER_FUNDING);
+
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             if (t instanceof DaoDisabledException) {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
@@ -83,6 +83,8 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
+            processModel.getTradeManager().requestPersistence();
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerPublishFeeTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerPublishFeeTx.java
@@ -110,6 +110,9 @@ public class TakerPublishFeeTx extends TradeTask {
             if (transaction != null) {
                 trade.setTakerFeeTxId(transaction.getTxId().toString());
                 trade.setState(Trade.State.TAKER_PUBLISHED_TAKER_FEE_TX);
+
+                processModel.getTradeManager().requestPersistence();
+
                 complete();
             }
         } else {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerSendInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerSendInputsForDepositTxRequest.java
@@ -129,6 +129,9 @@ public class TakerSendInputsForDepositTxRequest extends TradeTask {
             log.info("Send {} with offerId {} and uid {} to peer {}",
                     request.getClass().getSimpleName(), request.getTradeId(),
                     request.getUid(), trade.getTradingPeerNodeAddress());
+
+            processModel.getTradeManager().requestPersistence();
+
             processModel.getP2PService().sendEncryptedDirectMessage(
                     trade.getTradingPeerNodeAddress(),
                     processModel.getTradingPeer().getPubKeyRing(),

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerVerifyAndSignContract.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/taker/TakerVerifyAndSignContract.java
@@ -114,6 +114,8 @@ public class TakerVerifyAndSignContract extends TradeTask {
             trade.setContractHash(contractHash);
 
             trade.setTakerContractSignature(signature);
+
+            processModel.getTradeManager().requestPersistence();
             try {
                 checkNotNull(maker.getPubKeyRing(), "maker.getPubKeyRing() must nto be null");
                 Sig.verify(maker.getPubKeyRing().getSignaturePubKey(),

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -555,6 +555,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
 
             trade.setDisputeState(Trade.DisputeState.MEDIATION_REQUESTED);
             sendOpenDisputeMessage(disputeManager, resultHandler, dispute);
+            tradeManager.requestPersistence();
         } else if (useRefundAgent) {
             resultHandler = () -> navigation.navigateTo(MainView.class, SupportView.class, RefundClientView.class);
 
@@ -630,7 +631,6 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                         sendOpenDisputeMessage(disputeManager, resultHandler, dispute);
                     },
                     errorMessage -> new Popup().error(errorMessage).show());
-
         } else {
             log.warn("Invalid dispute state {}", disputeState.name());
         }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -471,6 +471,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
             trade.stateProperty().removeListener(tradeStateListener);
             trade.disputeStateProperty().addListener(disputeStateListener);
             trade.mediationResultStateProperty().addListener(mediationResultStateListener);
+            traderChatManager.requestPersistence();
         });
 
         Scene scene = new Scene(pane);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -472,6 +472,8 @@ public class BuyerStep2View extends TradeStepView {
 
                         trade.setCounterCurrencyExtraData(txKey);
                         trade.setCounterCurrencyTxId(txHash);
+
+                        model.dataModel.getTradeManager().requestPersistence();
                         showConfirmPaymentStartedPopup();
                     })
                     .closeButtonText(Res.get("shared.cancel"))
@@ -519,6 +521,7 @@ public class BuyerStep2View extends TradeStepView {
         //TODO seems this was a hack to enable repeated confirm???
         if (trade.isFiatSent()) {
             trade.setState(Trade.State.DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN);
+            model.dataModel.getTradeManager().requestPersistence();
         }
 
         model.dataModel.onPaymentStarted(() -> {

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -536,7 +536,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
         mailboxItemsByUid.putIfAbsent(uid, new ArrayList<>());
         mailboxItemsByUid.get(uid).add(mailboxItem);
         mailboxMessageList.add(mailboxItem);
-        persistenceManager.requestPersistence();
+        requestPersistence();
 
         NodeAddress sender = mailboxMessage.getSenderNodeAddress();
         log.info("Received a {} mailbox message with uid {} and senderAddress {}",
@@ -818,13 +818,17 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                         mailboxMessageList.remove(mailboxItem);
                     });
                     mailboxItemsByUid.remove(uid);
-                    persistenceManager.requestPersistence();
+                    requestPersistence();
                 }
             });
         } else {
             // In case the network was not ready yet we try again later
             UserThread.runAfter(() -> removeMailboxMsg(decryptedMessageWithPubKey), 30);
         }
+    }
+
+    private void requestPersistence() {
+        persistenceManager.requestPersistence();
     }
 
 


### PR DESCRIPTION
There are some bug reports which suggest that the persistence at shutdown is not working reliable (hard kill, crash,...).
We reduce the persistence interval radically to ensure important data is written immediately (200 ms delay).
Further the `requestPersistence` has been missing in most trade tasks. I guess that happened when merging the large refactoring projects (trade protocol, persistence). If shutdown routine gets executed it did not had any effect as we wrote then the trade state, but if that was missing we might miss important trade state/data changes.
 
Fixes https://github.com/bisq-network/bisq/issues/4806
Fixes https://github.com/bisq-network/bisq/issues/4762