### PR TITLE
Improve filter

### DIFF
--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -261,6 +261,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
         } else {
             ownerPubKey = null;
         }
+
+        log.error("Filter");
     }
 
     @Override
@@ -348,6 +350,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
         return "Filter{" +
                 "\n     bannedOfferIds=" + bannedOfferIds +
                 ",\n     bannedNodeAddress=" + bannedNodeAddress +
+                ",\n     bannedAutoConfExplorers=" + bannedAutoConfExplorers +
                 ",\n     bannedPaymentAccounts=" + bannedPaymentAccounts +
                 ",\n     bannedCurrencies=" + bannedCurrencies +
                 ",\n     bannedPaymentMethods=" + bannedPaymentMethods +
@@ -365,12 +368,12 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                 ",\n     mediators=" + mediators +
                 ",\n     refundAgents=" + refundAgents +
                 ",\n     bannedAccountWitnessSignerPubKeys=" + bannedAccountWitnessSignerPubKeys +
-                ",\n     bannedPrivilegedDevPubKeys=" + bannedPrivilegedDevPubKeys +
                 ",\n     btcFeeReceiverAddresses=" + btcFeeReceiverAddresses +
                 ",\n     creationDate=" + creationDate +
+                ",\n     bannedPrivilegedDevPubKeys=" + bannedPrivilegedDevPubKeys +
                 ",\n     extraDataMap=" + extraDataMap +
+                ",\n     ownerPubKey=" + ownerPubKey +
                 ",\n     disableAutoConf=" + disableAutoConf +
-                ",\n     bannedAutoConfExplorers=" + bannedAutoConfExplorers +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -261,8 +261,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
         } else {
             ownerPubKey = null;
         }
-
-        log.error("Filter");
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -27,6 +27,7 @@ import bisq.core.filter.FilterManager;
 import bisq.core.filter.PaymentAccountFilter;
 import bisq.core.locale.Res;
 
+import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
 import bisq.common.config.Config;
 
@@ -223,12 +224,16 @@ public class FilterWindow extends Overlay<FilterWindow> {
                 );
 
                 // We remove first the old filter
+                // We delay a bit with adding as it seems that the instant add/remove calls lead to issues that the
+                // remove msg was rejected (P2P storage should handle it but seems there are edge cases where its not
+                // working as expected)
                 if (filterManager.canRemoveDevFilter(privKeyString)) {
                     filterManager.removeDevFilter(privKeyString);
+                    UserThread.runAfter(() -> addDevFilter(removeFilterMessageButton, privKeyString, newFilter),
+                            5);
+                } else {
+                    addDevFilter(removeFilterMessageButton, privKeyString, newFilter);
                 }
-                filterManager.addDevFilter(newFilter, privKeyString);
-                removeFilterMessageButton.setDisable(filterManager.getDevFilter() == null);
-                hide();
             } else {
                 new Popup().warning(Res.get("shared.invalidKey")).onClose(this::blurAgain).show();
             }
@@ -256,6 +261,12 @@ public class FilterWindow extends Overlay<FilterWindow> {
         hBox.getChildren().addAll(sendButton, removeFilterMessageButton, closeButton);
         gridPane.getChildren().add(hBox);
         GridPane.setMargin(hBox, new Insets(10, 0, 0, 0));
+    }
+
+    private void addDevFilter(Button removeFilterMessageButton, String privKeyString, Filter newFilter) {
+        filterManager.addDevFilter(newFilter, privKeyString);
+        removeFilterMessageButton.setDisable(filterManager.getDevFilter() == null);
+        hide();
     }
 
     private void setupFieldFromList(InputTextField field, List<String> values) {


### PR DESCRIPTION
Add delay between remove and add new filter

We saw that some seed nodes have 2 filters after filter update.
This should not be the case as the remove is broadcast before the
add but seems there is some issue in the P2P storage which does
not cover that correctly.
By adding a 5 sec delay between the remove and add we mitigate
that issue, though should be fixes in the P2P layer but that
will be a more complex and larger effort.