### PR TITLE
Use AES key for signing when wallet is encrypted

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -1271,7 +1271,7 @@ public class TradeWalletService {
             // scriptCode is expected to have the format of a legacy P2PKH output script
             Script scriptCode = ScriptBuilder.createP2PKHOutputScript(sigKey);
             Coin value = input.getValue();
-            TransactionSignature txSig = transaction.calculateWitnessSignature(inputIndex, sigKey, scriptCode, value,
+            TransactionSignature txSig = transaction.calculateWitnessSignature(inputIndex, sigKey, aesKey, scriptCode, value,
                     Transaction.SigHash.ALL, false);
             input.setScriptSig(ScriptBuilder.createEmpty());
             input.setWitness(TransactionWitness.redeemP2WPKH(txSig, sigKey));

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -327,7 +327,7 @@ public abstract class WalletService {
                         // scriptCode is expected to have the format of a legacy P2PKH output script
                         Script scriptCode = ScriptBuilder.createP2PKHOutputScript(key);
                         Coin value = txIn.getValue();
-                        TransactionSignature txSig = tx.calculateWitnessSignature(index, key, scriptCode, value,
+                        TransactionSignature txSig = tx.calculateWitnessSignature(index, key, aesKey, scriptCode, value,
                                 Transaction.SigHash.ALL, false);
                         txIn.setScriptSig(ScriptBuilder.createEmpty());
                         txIn.setWitness(TransactionWitness.redeemP2WPKH(txSig, key));


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

I forgot to pass the AES key as a parameter. Without this change, encrypted wallets can not sign transactions
