### PR TITLE
Rename getsAll payout option string

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2484,7 +2484,7 @@ disputeSummaryWindow.openDate=Ticket opening date
 disputeSummaryWindow.role=Trader's role
 disputeSummaryWindow.payout=Trade amount payout
 disputeSummaryWindow.payout.getsTradeAmount=BTC {0} gets trade amount payout
-disputeSummaryWindow.payout.getsAll=BTC {0} gets all
+disputeSummaryWindow.payout.getsAll=Max. payout to BTC {0}
 disputeSummaryWindow.payout.custom=Custom payout
 disputeSummaryWindow.payout.adjustAmount=Amount entered exceeds available amount of {0}.\n\
 We adjust this input field to the max possible value.


### PR DESCRIPTION
Renamed it to better represent the outcome of this option since
the winning party doesn't in fact get all the funds in escrow.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

To replace https://github.com/bisq-network/bisq/pull/4629 as I was unable to properly squash all commits.
