### PR TITLE
Check if user has downgraded to an older version

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -68,6 +68,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
     protected AppModule module;
     protected Config config;
     private boolean isShutdownInProgress;
+    private boolean hasDowngraded;
 
     public BisqExecutable(String fullName, String scriptName, String appName, String version) {
         this.fullName = fullName;
@@ -133,9 +134,17 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
         CommonSetup.setupUncaughtExceptionHandler(this);
         setupGuice();
         setupAvoidStandbyMode();
-        readAllPersisted(this::startApplication);
-    }
 
+        hasDowngraded = BisqSetup.hasDowngraded();
+        if (hasDowngraded) {
+            // If user tried to downgrade we do not read the persisted data to avoid data corruption
+            // We call startApplication to enable UI to show popup. We prevent in BisqSetup to go further
+            // in the process and require a shut down.
+            startApplication();
+        } else {
+            readAllPersisted(this::startApplication);
+        }
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // We continue with a series of synchronous execution tasks
@@ -236,11 +245,16 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
                     injector.getInstance(P2PService.class).shutDown(() -> {
                         log.info("P2PService shutdown completed");
                         module.close(injector);
-                        PersistenceManager.flushAllDataToDisk(() -> {
-                            log.info("Graceful shutdown completed. Exiting now.");
-                            resultHandler.handleResult();
+                        if (!hasDowngraded) {
+                            // If user tried to downgrade we do not write the persistable data to avoid data corruption
+                            PersistenceManager.flushAllDataToDisk(() -> {
+                                log.info("Graceful shutdown completed. Exiting now.");
+                                resultHandler.handleResult();
+                                System.exit(EXIT_SUCCESS);
+                            });
+                        } else {
                             System.exit(EXIT_SUCCESS);
-                        });
+                        }
                     });
                 });
                 walletsSetup.shutDown();
@@ -250,20 +264,31 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
             // Wait max 20 sec.
             UserThread.runAfter(() -> {
                 log.warn("Timeout triggered resultHandler");
-                PersistenceManager.flushAllDataToDisk(() -> {
-                    log.info("Graceful shutdown resulted in a timeout. Exiting now.");
-                    resultHandler.handleResult();
+                if (!hasDowngraded) {
+                    // If user tried to downgrade we do not write the persistable data to avoid data corruption
+                    PersistenceManager.flushAllDataToDisk(() -> {
+                        log.info("Graceful shutdown resulted in a timeout. Exiting now.");
+                        resultHandler.handleResult();
+                        System.exit(EXIT_SUCCESS);
+                    });
+                } else {
                     System.exit(EXIT_SUCCESS);
-                });
+                }
+
             }, 20);
         } catch (Throwable t) {
             log.error("App shutdown failed with exception {}", t.toString());
             t.printStackTrace();
-            PersistenceManager.flushAllDataToDisk(() -> {
-                log.info("Graceful shutdown resulted in an error. Exiting now.");
-                resultHandler.handleResult();
+            if (!hasDowngraded) {
+                // If user tried to downgrade we do not write the persistable data to avoid data corruption
+                PersistenceManager.flushAllDataToDisk(() -> {
+                    log.info("Graceful shutdown resulted in an error. Exiting now.");
+                    resultHandler.handleResult();
+                    System.exit(EXIT_FAILURE);
+                });
+            } else {
                 System.exit(EXIT_FAILURE);
-            });
+            }
         }
     }
 

--- a/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
@@ -20,6 +20,7 @@ package bisq.core.app;
 import bisq.core.trade.TradeManager;
 
 import bisq.common.UserThread;
+import bisq.common.app.Version;
 import bisq.common.file.CorruptedStorageFileHandler;
 import bisq.common.setup.GracefulShutDownHandler;
 
@@ -94,6 +95,8 @@ public class BisqHeadlessApp implements HeadlessApp {
         bisqSetup.setRevolutAccountsUpdateHandler(revolutAccountList -> log.info("setRevolutAccountsUpdateHandler: revolutAccountList={}", revolutAccountList));
         bisqSetup.setOsxKeyLoggerWarningHandler(() -> log.info("setOsxKeyLoggerWarningHandler"));
         bisqSetup.setQubesOSInfoHandler(() -> log.info("setQubesOSInfoHandler"));
+        bisqSetup.setDownGradePreventionHandler(lastVersion -> log.info("Downgrade from version {} to version {} is not supported",
+                lastVersion, Version.VERSION));
 
         corruptedStorageFileHandler.getFiles().ifPresent(files -> log.warn("getCorruptedDatabaseFiles. files={}", files));
         tradeManager.setTakeOfferRequestErrorMessageHandler(errorMessage -> log.error("onTakeOfferRequestErrorMessageHandler"));

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2819,6 +2819,7 @@ popup.info.shutDownWithOpenOffers=Bisq is being shut down, but there are open of
   (i.e., make sure it doesn't go into standby mode...monitor standby is not a problem).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\n\
   Please make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
+popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
 
 popup.privateNotification.headline=Important private notification!
 

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -809,7 +809,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             this.setToggleGroup(navButtons);
             this.getStyleClass().add("nav-button");
             // Japanese fonts are dense, increase top nav button text size
-            if (model.getPreferences().getUserLanguage().equals("ja")) {
+            if (model.getPreferences() != null && "ja".equals(model.getPreferences().getUserLanguage())) {
                 this.getStyleClass().add("nav-button-japanese");
             }
 

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -403,6 +403,13 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
             }
         });
 
+        bisqSetup.setDownGradePreventionHandler(lastVersion -> {
+            new Popup().warning(Res.get("popup.warn.downGradePrevention", lastVersion, Version.VERSION))
+                    .useShutDownButton()
+                    .hideCloseButton()
+                    .show();
+        });
+
         corruptedStorageFileHandler.getFiles().ifPresent(files -> new Popup()
                 .warning(Res.get("popup.warning.incompatibleDB", files.toString(), config.appDataDir))
                 .useShutDownButton()


### PR DESCRIPTION
Check if user has downgraded to an older version. If so require shutdown 
and do not read or write persisted data.

We had recently a case where a user downgraded from 1.4.2 to 1.3.9 and
this caused failed trades and the wallet funds have been missing due to
some complexities of the wallet wegwit upgrade. The fund could be recovered
but it took quite some effort.
As downgrade is never tested and can lead to all kind of weird bugs we
should prevent that users accidentally can do it.
If there is valid reason to downgrade they can remove the version file.

I would suggest that we add that to 1.5.0 as it is a critical update which would likely cause major issues if users downgrade. But up to maintainers if they consider risk/benefit ration in favor to add it to the release.