### PR TITLE
Add 1 sec delay before calling exit

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -239,7 +239,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
                         PersistenceManager.flushAllDataToDisk(() -> {
                             log.info("Graceful shutdown completed. Exiting now.");
                             resultHandler.handleResult();
-                            System.exit(EXIT_SUCCESS);
+                            UserThread.runAfter(() -> System.exit(EXIT_SUCCESS), 1);
                         });
                     });
                 });
@@ -253,7 +253,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
                 PersistenceManager.flushAllDataToDisk(() -> {
                     log.info("Graceful shutdown resulted in a timeout. Exiting now.");
                     resultHandler.handleResult();
-                    System.exit(EXIT_SUCCESS);
+                    UserThread.runAfter(() -> System.exit(EXIT_SUCCESS), 1);
                 });
             }, 20);
         } catch (Throwable t) {
@@ -262,7 +262,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
             PersistenceManager.flushAllDataToDisk(() -> {
                 log.info("Graceful shutdown resulted in an error. Exiting now.");
                 resultHandler.handleResult();
-                System.exit(EXIT_FAILURE);
+                UserThread.runAfter(() -> System.exit(EXIT_FAILURE), 1);
             });
         }
     }

--- a/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
@@ -95,7 +95,7 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable {
                         PersistenceManager.flushAllDataToDisk(() -> {
                             resultHandler.handleResult();
                             log.info("Graceful shutdown completed. Exiting now.");
-                            System.exit(BisqExecutable.EXIT_SUCCESS);
+                            UserThread.runAfter(() -> System.exit(BisqExecutable.EXIT_SUCCESS), 1);
                         });
                     });
                     injector.getInstance(WalletsSetup.class).shutDown();
@@ -107,7 +107,7 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable {
                     PersistenceManager.flushAllDataToDisk(() -> {
                         resultHandler.handleResult();
                         log.info("Graceful shutdown caused a timeout. Exiting now.");
-                        System.exit(BisqExecutable.EXIT_SUCCESS);
+                        UserThread.runAfter(() -> System.exit(BisqExecutable.EXIT_SUCCESS), 1);
                     });
                 }, 5);
             } else {
@@ -122,7 +122,7 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable {
             PersistenceManager.flushAllDataToDisk(() -> {
                 resultHandler.handleResult();
                 log.info("Graceful shutdown resulted in an error. Exiting now.");
-                System.exit(BisqExecutable.EXIT_FAILURE);
+                UserThread.runAfter(() -> System.exit(BisqExecutable.EXIT_FAILURE), 1);
             });
 
         }


### PR DESCRIPTION
To persist in the very last moment before exit might cause problems on some OS.
We do not have confirmed that this might be an issue but to be on the safe side
we add a 1 sec. delay between persistence completed and exit.
