### PR TITLE
In seednode installer, don't run random shell script to install git lfs

### DIFF
--- a/seednode/install_seednode_debian.sh
+++ b/seednode/install_seednode_debian.sh
@@ -61,7 +61,6 @@ echo "[*] Installing base packages"
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ${ROOT_PKG}
 
 echo "[*] Installing Git LFS"
-sudo -H -i -u "${ROOT_USER}" curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
 sudo -H -i -u "${ROOT_USER}" apt-get install git-lfs
 sudo -H -i -u "${ROOT_USER}" git lfs install
 


### PR DESCRIPTION
This was only needed on very old versions of ubuntu, and in any case we shouldn't call some random shell script from the internet hosted by a TTP