### PR TITLE
Add taker check for deposit amount

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
@@ -20,6 +20,7 @@ package bisq.core.trade.protocol.tasks.buyer_as_taker;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.offer.Offer;
 import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.TradingPeer;
 import bisq.core.trade.protocol.tasks.TradeTask;
@@ -71,6 +72,10 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
             buyerMultiSigAddressEntry.setCoinLockedInMultiSig(buyerInput.subtract(trade.getTxFee().multiply(2)));
             walletService.saveAddressEntryList();
 
+            Offer offer = trade.getOffer();
+            Coin msOutputAmount = offer.getBuyerSecurityDeposit().add(offer.getSellerSecurityDeposit()).add(trade.getTxFee())
+                    .add(checkNotNull(trade.getTradeAmount()));
+
             TradingPeer tradingPeer = processModel.getTradingPeer();
             byte[] buyerMultiSigPubKey = processModel.getMyMultiSigPubKey();
             checkArgument(Arrays.equals(buyerMultiSigPubKey, buyerMultiSigAddressEntry.getPubKey()),
@@ -82,6 +87,7 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
                     false,
                     contractHash,
                     processModel.getPreparedDepositTx(),
+                    msOutputAmount,
                     buyerInputs,
                     sellerInputs,
                     buyerMultiSigPubKey,

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
@@ -20,6 +20,7 @@ package bisq.core.trade.protocol.tasks.seller_as_taker;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.offer.Offer;
 import bisq.core.trade.Contract;
 import bisq.core.trade.Trade;
 import bisq.core.trade.protocol.TradingPeer;
@@ -69,12 +70,17 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
             sellerMultiSigAddressEntry.setCoinLockedInMultiSig(sellerInput.subtract(totalFee));
             walletService.saveAddressEntryList();
 
+            Offer offer = trade.getOffer();
+            Coin msOutputAmount = offer.getBuyerSecurityDeposit().add(offer.getSellerSecurityDeposit()).add(trade.getTxFee())
+                    .add(checkNotNull(trade.getTradeAmount()));
+
             TradingPeer tradingPeer = processModel.getTradingPeer();
 
             Transaction depositTx = processModel.getTradeWalletService().takerSignsDepositTx(
                     true,
                     trade.getContractHash(),
                     processModel.getPreparedDepositTx(),
+                    msOutputAmount,
                     checkNotNull(tradingPeer.getRawTransactionInputs()),
                     sellerInputs,
                     tradingPeer.getMultiSigPubKey(),


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Make sure the taker checks the value of the 2-of-2 multisig output of the deposit tx created by the maker, before signing it. This avoids a potential security hole, where the maker attempts to steal most of the deposit by using the wrong output value and adding an extra 'change' output to himself.

Note that there's no actual vulnerability at present, as the output value is indirectly checked via the validation of the delayed payout tx. In particular, the extra checks added in 345426f as part of #4789 (Fix remaining blackmail vulnerabilities) place a lower bound on the delayed payout tx input value and with it the deposit tx output value. However, explicitly checking the amount is more robust.

--

This PR is mainly to provide a more robust solution than that already included in the 1.5.0 release.
