### PR TITLE
Replace use of Collections to FXCollections in desktop.

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/indicator/skin/StaticProgressIndicatorSkin.java
+++ b/desktop/src/main/java/bisq/desktop/components/indicator/skin/StaticProgressIndicatorSkin.java
@@ -75,8 +75,10 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 
+import javafx.collections.ObservableList;
+import javafx.collections.FXCollections;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 // TODO Copied form OpenJFX, check license issues and way how we integrated it
@@ -261,7 +263,7 @@ public class StaticProgressIndicatorSkin extends SkinBase<TxConfidenceIndicator>
      * CssMetaData of its super classes.
      */
     @SuppressWarnings("SameReturnValue")
-    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+    public static ObservableList<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
         return StyleableProperties.STYLEABLES;
     }
 
@@ -316,7 +318,7 @@ public class StaticProgressIndicatorSkin extends SkinBase<TxConfidenceIndicator>
      * {@inheritDoc}
      */
     @Override
-    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+    public ObservableList<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
         return getClassCssMetaData();
     }
 
@@ -691,7 +693,7 @@ public class StaticProgressIndicatorSkin extends SkinBase<TxConfidenceIndicator>
      */
     @SuppressWarnings({"deprecation", "unchecked", "ConstantConditions"})
     private static class StyleableProperties {
-        static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
+        static final ObservableList<CssMetaData<? extends Styleable, ?>> STYLEABLES;
 
         private static final CssMetaData<TxConfidenceIndicator, Paint> PROGRESS_COLOR =
                 new CssMetaData<>(
@@ -746,7 +748,6 @@ public class StaticProgressIndicatorSkin extends SkinBase<TxConfidenceIndicator>
                         return skin.spinEnabled == null || !skin.spinEnabled.isBound();
                     }
 
-
                     @Override
                     public StyleableProperty<Boolean> getStyleableProperty(TxConfidenceIndicator node) {
                         final StaticProgressIndicatorSkin skin = (StaticProgressIndicatorSkin) node.getSkin();
@@ -755,13 +756,12 @@ public class StaticProgressIndicatorSkin extends SkinBase<TxConfidenceIndicator>
                 };
 
         static {
-            final List<CssMetaData<? extends Styleable, ?>> styleables =
-                    new ArrayList<>(SkinBase.getClassCssMetaData());
+            final ObservableList<CssMetaData<? extends Styleable, ?>> styleables =
+                FXCollections.observableArrayList(SkinBase.getClassCssMetaData());
             styleables.add(PROGRESS_COLOR);
             styleables.add(INDETERMINATE_SEGMENT_COUNT);
             styleables.add(SPIN_ENABLED);
-            STYLEABLES = Collections.unmodifiableList(styleables);
+            STYLEABLES = FXCollections.unmodifiableObservableList(styleables);
         }
     }
-
 }

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -93,7 +93,6 @@ import java.text.DecimalFormat;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -668,12 +667,12 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     private void reverseTableColumns() {
         ObservableList<TableColumn<OfferListItem, ?>> columns = FXCollections.observableArrayList(buyOfferTableView.getColumns());
         buyOfferTableView.getColumns().clear();
-        Collections.reverse(columns);
+        FXCollections.reverse(columns);
         buyOfferTableView.getColumns().addAll(columns);
 
         columns = FXCollections.observableArrayList(sellOfferTableView.getColumns());
         sellOfferTableView.getColumns().clear();
-        Collections.reverse(columns);
+        FXCollections.reverse(columns);
         sellOfferTableView.getColumns().addAll(columns);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -65,7 +65,6 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -292,7 +291,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
         long accumulatedVolume = 0;
         long accumulatedAmount = 0;
         long numTrades = set.size();
-        List<Long> tradePrices = new ArrayList<>(set.size());
+        ObservableList<Long> tradePrices = FXCollections.observableArrayList();
 
         for (TradeStatistics3 item : set) {
             long tradePriceAsLong = item.getTradePrice().getValue();
@@ -304,13 +303,14 @@ class TradesChartsViewModel extends ActivatableViewModel {
             accumulatedAmount += item.getTradeAmount().getValue();
             tradePrices.add(item.getTradePrice().getValue());
         }
-        Collections.sort(tradePrices);
+        FXCollections.sort(tradePrices);
 
         List<TradeStatistics3> list = new ArrayList<>(set);
-        list.sort(Comparator.comparingLong(TradeStatistics3::getDateAsLong));
-        if (list.size() > 0) {
-            open = list.get(0).getTradePrice().getValue();
-            close = list.get(list.size() - 1).getTradePrice().getValue();
+        ObservableList<TradeStatistics3> obsList = FXCollections.observableArrayList(list);
+        obsList.sort(Comparator.comparingLong(TradeStatistics3::getDateAsLong));
+        if (obsList.size() > 0) {
+            open = obsList.get(0).getTradePrice().getValue();
+            close = obsList.get(obsList.size() - 1).getTradePrice().getValue();
         }
 
         long averagePrice;

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -37,6 +37,8 @@ import javax.inject.Named;
 
 import org.apache.commons.lang3.StringUtils;
 
+import javafx.collections.FXCollections;
+
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -50,7 +52,6 @@ import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -294,7 +295,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
 
     private List<String> readAsList(InputTextField field) {
         if (field.getText().isEmpty()) {
-            return Collections.emptyList();
+            return FXCollections.emptyObservableList();
         } else {
             return Arrays.asList(StringUtils.deleteWhitespace(field.getText()).split(","));
         }

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -99,7 +99,6 @@ import java.io.File;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -416,9 +415,9 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         });
 
         preferredTradeCurrencyComboBox.setButtonCell(GUIUtil.getTradeCurrencyButtonCell("", "",
-                Collections.emptyMap()));
+                FXCollections.emptyObservableMap()));
         preferredTradeCurrencyComboBox.setCellFactory(GUIUtil.getTradeCurrencyCellFactory("", "",
-                Collections.emptyMap()));
+                FXCollections.emptyObservableMap()));
 
         Tuple3<Label, ListView<FiatCurrency>, VBox> fiatTuple = addTopLabelListView(root, displayCurrenciesGridRowIndex,
                 Res.get("setting.preferences.displayFiat"));

--- a/desktop/src/main/java/bisq/desktop/util/AxisInlierUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/AxisInlierUtils.java
@@ -25,8 +25,8 @@ import javafx.scene.chart.XYChart;
 
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.FXCollections;
 
-import java.util.Collections;
 import java.util.DoubleSummaryStatistics;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -171,7 +171,7 @@ public class AxisInlierUtils {
             return numbers;
         }
         if (totalPercentTrim == 100) {
-            return Collections.emptyList();
+            return FXCollections.emptyObservableList();
         }
 
         if (numbers.isEmpty()) {

--- a/desktop/src/test/java/bisq/desktop/main/funds/transactions/DisplayedTransactionsTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/funds/transactions/DisplayedTransactionsTest.java
@@ -23,6 +23,8 @@ import org.bitcoinj.core.Transaction;
 
 import com.google.common.collect.Sets;
 
+import javafx.collections.FXCollections;
+
 import java.util.Collections;
 import java.util.Set;
 
@@ -61,7 +63,7 @@ public class DisplayedTransactionsTest {
                 .thenReturn(Collections.singleton(mock(Transaction.class)));
 
         TradableRepository tradableRepository = mock(TradableRepository.class);
-        when(tradableRepository.getAll()).thenReturn(Collections.emptySet());
+        when(tradableRepository.getAll()).thenReturn(FXCollections.emptyObservableSet());
 
         TransactionListItemFactory transactionListItemFactory = mock(TransactionListItemFactory.class);
 

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -57,7 +57,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +93,7 @@ public class OfferBookViewModelTest {
     @Ignore("PaymentAccountPayload needs to be set (has been changed with PB changes)")
     public void testIsAnyPaymentAccountValidForOffer() {
         Collection<PaymentAccount> paymentAccounts;
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSepaAccount("EUR", "DE", "1212324",
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSepaAccount("EUR", "DE", "1212324",
                 new ArrayList<>(Arrays.asList("AT", "DE")))));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSEPAPaymentMethod("EUR", "AT", new ArrayList<>(Arrays.asList("AT", "DE")), "PSK"), paymentAccounts));
@@ -108,33 +107,33 @@ public class OfferBookViewModelTest {
         // simple cases: same payment methods
 
         // offer: alipay paymentAccount: alipay - same country, same currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getAliPayAccount("CNY")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getAliPayAccount("CNY")));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getAliPayPaymentMethod("EUR"), paymentAccounts));
 
         // offer: ether paymentAccount: ether - same country, same currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getCryptoAccount("ETH")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getCryptoAccount("ETH")));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getBlockChainsPaymentMethod("ETH"), paymentAccounts));
 
         // offer: sepa paymentAccount: sepa - same country, same currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSepaAccount("EUR", "AT", "1212324",
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSepaAccount("EUR", "AT", "1212324",
                 new ArrayList<>(Arrays.asList("AT", "DE")))));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSEPAPaymentMethod("EUR", "AT", new ArrayList<>(Arrays.asList("AT", "DE")), "PSK"), paymentAccounts));
 
         // offer: nationalBank paymentAccount: nationalBank - same country, same currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getNationalBankAccount("EUR", "AT", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getNationalBankAccount("EUR", "AT", "PSK")));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // offer: SameBank paymentAccount: SameBank - same country, same currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSameBankAccount("EUR", "AT", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSameBankAccount("EUR", "AT", "PSK")));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSameBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // offer: sepa paymentAccount: sepa - diff. country, same currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSepaAccount("EUR", "DE", "1212324", new ArrayList<>(Arrays.asList("AT", "DE")))));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSepaAccount("EUR", "DE", "1212324", new ArrayList<>(Arrays.asList("AT", "DE")))));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSEPAPaymentMethod("EUR", "AT", new ArrayList<>(Arrays.asList("AT", "DE")), "PSK"), paymentAccounts));
 
@@ -142,78 +141,78 @@ public class OfferBookViewModelTest {
         //////
 
         // offer: sepa paymentAccount: sepa - same country, same currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSepaAccount("EUR", "AT", "1212324", new ArrayList<>(Arrays.asList("AT", "DE")))));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSepaAccount("EUR", "AT", "1212324", new ArrayList<>(Arrays.asList("AT", "DE")))));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSEPAPaymentMethod("EUR", "AT", new ArrayList<>(Arrays.asList("AT", "DE")), "PSK"), paymentAccounts));
 
 
         // offer: sepa paymentAccount: nationalBank - same country, same currency
         // wrong method
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getNationalBankAccount("EUR", "AT", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getNationalBankAccount("EUR", "AT", "PSK")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSEPAPaymentMethod("EUR", "AT", new ArrayList<>(Arrays.asList("AT", "DE")), "PSK"), paymentAccounts));
 
         // wrong currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getNationalBankAccount("USD", "US", "XXX")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getNationalBankAccount("USD", "US", "XXX")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // wrong country
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getNationalBankAccount("EUR", "FR", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getNationalBankAccount("EUR", "FR", "PSK")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // sepa wrong country
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getNationalBankAccount("EUR", "CH", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getNationalBankAccount("EUR", "CH", "PSK")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSEPAPaymentMethod("EUR", "AT", new ArrayList<>(Arrays.asList("AT", "DE")), "PSK"), paymentAccounts));
 
         // sepa wrong currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getNationalBankAccount("CHF", "DE", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getNationalBankAccount("CHF", "DE", "PSK")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getSEPAPaymentMethod("EUR", "AT", new ArrayList<>(Arrays.asList("AT", "DE")), "PSK"), paymentAccounts));
 
 
         // same bank
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSameBankAccount("EUR", "AT", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSameBankAccount("EUR", "AT", "PSK")));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // not same bank
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSameBankAccount("EUR", "AT", "Raika")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSameBankAccount("EUR", "AT", "Raika")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // same bank, wrong country
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSameBankAccount("EUR", "DE", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSameBankAccount("EUR", "DE", "PSK")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // same bank, wrong currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSameBankAccount("USD", "AT", "PSK")));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSameBankAccount("USD", "AT", "PSK")));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // spec. bank
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSpecificBanksAccount("EUR", "AT", "PSK",
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSpecificBanksAccount("EUR", "AT", "PSK",
                 new ArrayList<>(Arrays.asList("PSK", "Raika")))));
         assertTrue(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // spec. bank, missing bank
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSpecificBanksAccount("EUR", "AT", "PSK",
-                new ArrayList<>(Collections.singletonList("Raika")))));
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSpecificBanksAccount("EUR", "AT", "PSK",
+                new ArrayList<>(FXCollections.singletonObservableList("Raika")))));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // spec. bank, wrong country
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSpecificBanksAccount("EUR", "FR", "PSK",
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSpecificBanksAccount("EUR", "FR", "PSK",
                 new ArrayList<>(Arrays.asList("PSK", "Raika")))));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
 
         // spec. bank, wrong currency
-        paymentAccounts = new ArrayList<>(Collections.singletonList(getSpecificBanksAccount("USD", "AT", "PSK",
+        paymentAccounts = new ArrayList<>(FXCollections.singletonObservableList(getSpecificBanksAccount("USD", "AT", "PSK",
                 new ArrayList<>(Arrays.asList("PSK", "Raika")))));
         assertFalse(PaymentAccountUtil.isAnyTakerPaymentAccountValidForOffer(
                 getNationalBankPaymentMethod("EUR", "AT", "PSK"), paymentAccounts));
@@ -526,7 +525,7 @@ public class OfferBookViewModelTest {
         return getPaymentMethod(currencyCode,
                 PaymentMethod.NATIONAL_BANK_ID,
                 countryCode,
-                new ArrayList<>(Collections.singletonList(countryCode)),
+                new ArrayList<>(FXCollections.singletonObservableList(countryCode)),
                 bankId,
                 null);
     }
@@ -535,9 +534,9 @@ public class OfferBookViewModelTest {
         return getPaymentMethod(currencyCode,
                 PaymentMethod.SAME_BANK_ID,
                 countryCode,
-                new ArrayList<>(Collections.singletonList(countryCode)),
+                new ArrayList<>(FXCollections.singletonObservableList(countryCode)),
                 bankId,
-                new ArrayList<>(Collections.singletonList(bankId)));
+                new ArrayList<>(FXCollections.singletonObservableList(bankId)));
     }
 
     private Offer getSpecificBanksPaymentMethod(String currencyCode,
@@ -547,7 +546,7 @@ public class OfferBookViewModelTest {
         return getPaymentMethod(currencyCode,
                 PaymentMethod.SPECIFIC_BANKS_ID,
                 countryCode,
-                new ArrayList<>(Collections.singletonList(countryCode)),
+                new ArrayList<>(FXCollections.singletonObservableList(countryCode)),
                 bankId,
                 bankIds);
     }


### PR DESCRIPTION
#\Replace use of java library java.util.Collections with
javafx.collections.FXCollections instead.
Fixes #4388 

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Replace use of java.util.Collections, except for a few places that use Collections.singleton and Collections.nCopies which do not have direct replacements in FXCollections.
Run code and did not notice any issues.
