### PR TITLE
Fix warning about rejected transaction

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2803,7 +2803,7 @@ popup.warning.openOffer.makerFeeTxRejected=The maker fee transaction for offer w
 popup.warning.trade.txRejected.tradeFee=trade fee
 popup.warning.trade.txRejected.deposit=deposit
 popup.warning.trade.txRejected=The {0} transaction for trade with ID {1} was rejected by the Bitcoin network.\n\
-  Transaction ID={2}}\n\
+  Transaction ID={2}\n\
   The trade has been moved to failed trades.\n\
   Please go to \"Settings/Network info\" and do a SPV resync.\n\
   For further help please contact the Bisq support channel at the Bisq Keybase team.


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #4876 

My first PR here, so I'm starting small. I'm just fixing the English string `popup.warning.trade.txRejected` which contains an extra curly brace: `... Transaction ID={2}} ...`.

Most translations have inherited this error.