### PR TITLE
Prevent that a wrong tx is set as deposit tx

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -467,7 +467,7 @@ public class BisqSetup {
                     .filter(e -> setOfAllTradeIds.contains(e.getOfferId()) &&
                             e.getContext() == AddressEntry.Context.MULTI_SIG)
                     .forEach(e -> {
-                        Coin balance = e.getCoinLockedInMultiSig();
+                        Coin balance = e.getCoinLockedInMultiSigAsCoin();
                         if (balance.isPositive()) {
                             String message = Res.get("popup.warning.lockedUpFunds",
                                     formatter.formatCoinWithCode(balance), e.getAddressString(), e.getOfferId());

--- a/core/src/main/java/bisq/core/btc/Balances.java
+++ b/core/src/main/java/bisq/core/btc/Balances.java
@@ -124,7 +124,7 @@ public class Balances {
         long sum = lockedTrades.map(trade -> btcWalletService.getAddressEntry(trade.getId(), AddressEntry.Context.MULTI_SIG)
                 .orElse(null))
                 .filter(Objects::nonNull)
-                .mapToLong(addressEntry -> addressEntry.getCoinLockedInMultiSig().getValue())
+                .mapToLong(AddressEntry::getCoinLockedInMultiSig)
                 .sum();
         lockedBalance.set(Coin.valueOf(sum));
     }

--- a/core/src/main/java/bisq/core/btc/model/AddressEntry.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntry.java
@@ -71,16 +71,19 @@ public final class AddressEntry implements PersistablePayload {
     private final byte[] pubKey;
     @Getter
     private final byte[] pubKeyHash;
-
-    private long coinLockedInMultiSig;
-
     @Getter
-    private boolean segwit;
+    private final long coinLockedInMultiSig;
+    @Getter
+    private final boolean segwit;
 
+    // Not an immutable field. Set at startup once wallet is ready and at encrypting/decrypting wallet.
     @Nullable
     transient private DeterministicKey keyPair;
+
+    // Only used as cache
     @Nullable
     transient private Address address;
+    // Only used as cache
     @Nullable
     transient private String addressString;
 
@@ -93,16 +96,29 @@ public final class AddressEntry implements PersistablePayload {
         this(keyPair, context, null, segwit);
     }
 
-    public AddressEntry(@NotNull DeterministicKey keyPair,
+    public AddressEntry(DeterministicKey keyPair,
                         Context context,
                         @Nullable String offerId,
                         boolean segwit) {
+        this(keyPair,
+                context,
+                offerId,
+                0,
+                segwit);
+    }
+
+    public AddressEntry(DeterministicKey keyPair,
+                        Context context,
+                        @Nullable String offerId,
+                        long coinLockedInMultiSig,
+                        boolean segwit) {
+        this(keyPair.getPubKey(),
+                keyPair.getPubKeyHash(),
+                context,
+                offerId,
+                coinLockedInMultiSig,
+                segwit);
         this.keyPair = keyPair;
-        this.context = context;
-        this.offerId = offerId;
-        pubKey = keyPair.getPubKey();
-        pubKeyHash = keyPair.getPubKeyHash();
-        this.segwit = segwit;
     }
 
 
@@ -114,13 +130,13 @@ public final class AddressEntry implements PersistablePayload {
                          byte[] pubKeyHash,
                          Context context,
                          @Nullable String offerId,
-                         Coin coinLockedInMultiSig,
+                         long coinLockedInMultiSig,
                          boolean segwit) {
         this.pubKey = pubKey;
         this.pubKeyHash = pubKeyHash;
         this.context = context;
         this.offerId = offerId;
-        this.coinLockedInMultiSig = coinLockedInMultiSig.value;
+        this.coinLockedInMultiSig = coinLockedInMultiSig;
         this.segwit = segwit;
     }
 
@@ -129,7 +145,7 @@ public final class AddressEntry implements PersistablePayload {
                 proto.getPubKeyHash().toByteArray(),
                 ProtoUtil.enumFromProto(AddressEntry.Context.class, proto.getContext().name()),
                 ProtoUtil.stringOrNullFromProto(proto.getOfferId()),
-                Coin.valueOf(proto.getCoinLockedInMultiSig()),
+                proto.getCoinLockedInMultiSig(),
                 proto.getSegwit());
     }
 
@@ -164,10 +180,6 @@ public final class AddressEntry implements PersistablePayload {
         return keyPair;
     }
 
-    public void setCoinLockedInMultiSig(@NotNull Coin coinLockedInMultiSig) {
-        this.coinLockedInMultiSig = coinLockedInMultiSig.value;
-    }
-
     // For display we usually only display the first 8 characters.
     @Nullable
     public String getShortOfferId() {
@@ -196,14 +208,14 @@ public final class AddressEntry implements PersistablePayload {
         return context == Context.MULTI_SIG || context == Context.TRADE_PAYOUT;
     }
 
-    public Coin getCoinLockedInMultiSig() {
+    public Coin getCoinLockedInMultiSigAsCoin() {
         return Coin.valueOf(coinLockedInMultiSig);
     }
 
     @Override
     public String toString() {
         return "AddressEntry{" +
-                "address=" + address +
+                "address=" + getAddress() +
                 ", context=" + context +
                 ", offerId='" + offerId + '\'' +
                 ", coinLockedInMultiSig=" + coinLockedInMultiSig +

--- a/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
@@ -196,6 +196,15 @@ public final class AddressEntryList implements PersistableEnvelope, PersistedDat
     }
 
     public void swapToAvailable(AddressEntry addressEntry) {
+        if (addressEntry.getContext() == AddressEntry.Context.MULTI_SIG) {
+            log.error("swapToAvailable called with an addressEntry with MULTI_SIG context. " +
+                    "This in not permitted as we must not reuse those address entries and there are " +
+                    "no redeemable funds on those addresses. " +
+                    "Only the keys are used for creating the Multisig address. " +
+                    "addressEntry={}", addressEntry);
+            return;
+        }
+
         boolean setChangedByRemove = entrySet.remove(addressEntry);
         boolean setChangedByAdd = entrySet.add(new AddressEntry(addressEntry.getKeyPair(),
                 AddressEntry.Context.AVAILABLE,

--- a/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
+++ b/core/src/main/java/bisq/core/btc/model/AddressEntryList.java
@@ -226,6 +226,24 @@ public final class AddressEntryList implements PersistableEnvelope, PersistedDat
         return newAddressEntry;
     }
 
+    public void setCoinLockedInMultiSigAddressEntry(AddressEntry addressEntry, long value) {
+        if (addressEntry.getContext() != AddressEntry.Context.MULTI_SIG) {
+            log.error("setCoinLockedInMultiSigAddressEntry must be called only on MULTI_SIG entries");
+            return;
+        }
+
+        boolean setChangedByRemove = entrySet.remove(addressEntry);
+        AddressEntry entry = new AddressEntry(addressEntry.getKeyPair(),
+                AddressEntry.Context.MULTI_SIG,
+                addressEntry.getOfferId(),
+                value,
+                addressEntry.isSegwit());
+        boolean setChangedByAdd = entrySet.add(entry);
+        if (setChangedByRemove || setChangedByAdd) {
+            requestPersistence();
+        }
+    }
+
     public void requestPersistence() {
         persistenceManager.requestPersistence();
     }

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -756,6 +756,23 @@ public class BtcWalletService extends WalletService {
                 });
     }
 
+    // When funds from MultiSig address is spent we reset the coinLockedInMultiSig value to 0.
+    public void resetCoinLockedInMultiSigAddressEntry(String offerId) {
+        setCoinLockedInMultiSigAddressEntry(offerId, 0);
+    }
+
+    public void setCoinLockedInMultiSigAddressEntry(String offerId, long value) {
+        getAddressEntryListAsImmutableList().stream()
+                .filter(e -> AddressEntry.Context.MULTI_SIG == e.getContext())
+                .filter(e -> offerId.equals(e.getOfferId()))
+                .forEach(addressEntry -> setCoinLockedInMultiSigAddressEntry(addressEntry, value));
+    }
+
+    public void setCoinLockedInMultiSigAddressEntry(AddressEntry addressEntry, long value) {
+        log.info("Set coinLockedInMultiSig for addressEntry {} to value {}", addressEntry, value);
+        addressEntryList.setCoinLockedInMultiSigAddressEntry(addressEntry, value);
+    }
+
     public void resetAddressEntriesForOpenOffer(String offerId) {
         log.info("resetAddressEntriesForOpenOffer offerId={}", offerId);
         swapTradeEntryToAvailableEntry(offerId, AddressEntry.Context.OFFER_FUNDING);

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -254,8 +254,8 @@ public class BtcWalletService extends WalletService {
             sendRequest.signInputs = false;
 
             sendRequest.fee = txFeePerVbyte.multiply(txVsizeWithUnsignedInputs +
-                                                    sigSizePerInput * numLegacyInputs +
-                                                    sigSizePerInput * numSegwitInputs / 4);
+                    sigSizePerInput * numLegacyInputs +
+                    sigSizePerInput * numSegwitInputs / 4);
 
             sendRequest.feePerKb = Coin.ZERO;
             sendRequest.ensureMinRequiredFee = false;
@@ -274,8 +274,8 @@ public class BtcWalletService extends WalletService {
             numSegwitInputs = numInputs.second;
             txVsizeWithUnsignedInputs = resultTx.getVsize();
             long estimatedFeeAsLong = txFeePerVbyte.multiply(txVsizeWithUnsignedInputs +
-                                                            sigSizePerInput * numLegacyInputs +
-                                                            sigSizePerInput * numSegwitInputs / 4).value;
+                    sigSizePerInput * numLegacyInputs +
+                    sigSizePerInput * numSegwitInputs / 4).value;
 
             // calculated fee must be inside of a tolerance range with tx fee
             isFeeOutsideTolerance = Math.abs(resultTx.getFee().value - estimatedFeeAsLong) > 1000;
@@ -374,8 +374,8 @@ public class BtcWalletService extends WalletService {
             sendRequest.signInputs = false;
 
             sendRequest.fee = txFeePerVbyte.multiply(txVsizeWithUnsignedInputs +
-                                                    sigSizePerInput * numLegacyInputs +
-                                                    sigSizePerInput * numSegwitInputs / 4);
+                    sigSizePerInput * numLegacyInputs +
+                    sigSizePerInput * numSegwitInputs / 4);
             sendRequest.feePerKb = Coin.ZERO;
             sendRequest.ensureMinRequiredFee = false;
 
@@ -393,8 +393,8 @@ public class BtcWalletService extends WalletService {
             numSegwitInputs = numInputs.second;
             txVsizeWithUnsignedInputs = resultTx.getVsize();
             final long estimatedFeeAsLong = txFeePerVbyte.multiply(txVsizeWithUnsignedInputs +
-                                                                  sigSizePerInput * numLegacyInputs +
-                                                                  sigSizePerInput * numSegwitInputs / 4).value;
+                    sigSizePerInput * numLegacyInputs +
+                    sigSizePerInput * numSegwitInputs / 4).value;
             // calculated fee must be inside of a tolerance range with tx fee
             isFeeOutsideTolerance = Math.abs(resultTx.getFee().value - estimatedFeeAsLong) > 1000;
         }
@@ -532,8 +532,8 @@ public class BtcWalletService extends WalletService {
             sendRequest.signInputs = false;
 
             sendRequest.fee = txFeePerVbyte.multiply(txVsizeWithUnsignedInputs +
-                                                    sigSizePerInput * numLegacyInputs +
-                                                    sigSizePerInput * numSegwitInputs / 4);
+                    sigSizePerInput * numLegacyInputs +
+                    sigSizePerInput * numSegwitInputs / 4);
             sendRequest.feePerKb = Coin.ZERO;
             sendRequest.ensureMinRequiredFee = false;
 
@@ -558,8 +558,8 @@ public class BtcWalletService extends WalletService {
             numSegwitInputs = numInputs.second;
             txVsizeWithUnsignedInputs = resultTx.getVsize();
             final long estimatedFeeAsLong = txFeePerVbyte.multiply(txVsizeWithUnsignedInputs +
-                                                                  sigSizePerInput * numLegacyInputs +
-                                                                  sigSizePerInput * numSegwitInputs / 4).value;
+                    sigSizePerInput * numLegacyInputs +
+                    sigSizePerInput * numSegwitInputs / 4).value;
             // calculated fee must be inside of a tolerance range with tx fee
             isFeeOutsideTolerance = Math.abs(resultTx.getFee().value - estimatedFeeAsLong) > 1000;
         }
@@ -583,7 +583,7 @@ public class BtcWalletService extends WalletService {
         for (TransactionInput input : tx.getInputs()) {
             TransactionOutput connectedOutput = input.getConnectedOutput();
             if (connectedOutput == null || ScriptPattern.isP2PKH(connectedOutput.getScriptPubKey()) ||
-                ScriptPattern.isP2PK(connectedOutput.getScriptPubKey())) {
+                    ScriptPattern.isP2PK(connectedOutput.getScriptPubKey())) {
                 // If connectedOutput is null, we don't know here the input type. To avoid underpaying fees,
                 // we treat it as a legacy input which will result in a higher fee estimation.
                 numLegacyInputs++;

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -742,7 +742,7 @@ public class BtcWalletService extends WalletService {
             log.error("swapTradeEntryToAvailableEntry called with MULTI_SIG context. " +
                     "This in not permitted as we must not reuse those address entries and there " +
                     "are no redeemable funds on that addresses. Only the keys are used for creating " +
-                    "the Multisig address");
+                    "the Multisig address. offerId={}, context={}", offerId, context);
             return;
         }
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/SetupPayoutTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/SetupPayoutTxListener.java
@@ -71,6 +71,8 @@ public abstract class SetupPayoutTxListener extends TradeTask {
 
                     tradeStateSubscription = EasyBind.subscribe(trade.stateProperty(), newValue -> {
                         if (trade.isPayoutPublished()) {
+                            processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(trade.getId());
+
                             // hack to remove tradeStateSubscription at callback
                             UserThread.execute(this::unSubscribe);
                         }
@@ -95,6 +97,8 @@ public abstract class SetupPayoutTxListener extends TradeTask {
         } else {
             log.info("We had the payout tx already set. tradeId={}, state={}", trade.getId(), trade.getState());
         }
+
+        processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(trade.getId());
 
         // need delay as it can be called inside the handler before the listener and tradeStateSubscription are actually set.
         UserThread.execute(this::unSubscribe);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/SetupPayoutTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/SetupPayoutTxListener.java
@@ -71,8 +71,6 @@ public abstract class SetupPayoutTxListener extends TradeTask {
 
                     tradeStateSubscription = EasyBind.subscribe(trade.stateProperty(), newValue -> {
                         if (trade.isPayoutPublished()) {
-                            swapMultiSigEntry();
-
                             // hack to remove tradeStateSubscription at callback
                             UserThread.execute(this::unSubscribe);
                         }
@@ -98,14 +96,8 @@ public abstract class SetupPayoutTxListener extends TradeTask {
             log.info("We had the payout tx already set. tradeId={}, state={}", trade.getId(), trade.getState());
         }
 
-        swapMultiSigEntry();
-
         // need delay as it can be called inside the handler before the listener and tradeStateSubscription are actually set.
         UserThread.execute(this::unSubscribe);
-    }
-
-    private void swapMultiSigEntry() {
-        processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(trade.getId(), AddressEntry.Context.MULTI_SIG);
     }
 
     private boolean isInNetwork(TransactionConfidence confidence) {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/arbitration/PublishedDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/arbitration/PublishedDelayedPayoutTx.java
@@ -18,7 +18,6 @@
 package bisq.core.trade.protocol.tasks.arbitration;
 
 import bisq.core.btc.exceptions.TxBroadcastException;
-import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TxBroadcaster;
 import bisq.core.btc.wallet.WalletService;
@@ -44,10 +43,6 @@ public class PublishedDelayedPayoutTx extends TradeTask {
 
             Transaction delayedPayoutTx = trade.getDelayedPayoutTx();
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
-
-            // We have spent the funds from the deposit tx with the delayedPayoutTx
-            btcWalletService.swapTradeEntryToAvailableEntry(trade.getId(), AddressEntry.Context.MULTI_SIG);
-            // We might receive funds on AddressEntry.Context.TRADE_PAYOUT so we don't swap that
 
             Transaction committedDelayedPayoutTx = WalletService.maybeAddSelfTxToWallet(delayedPayoutTx, btcWalletService.getWallet());
 

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/arbitration/PublishedDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/arbitration/PublishedDelayedPayoutTx.java
@@ -44,6 +44,10 @@ public class PublishedDelayedPayoutTx extends TradeTask {
             Transaction delayedPayoutTx = trade.getDelayedPayoutTx();
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
 
+            // We have spent the funds from the deposit tx with the delayedPayoutTx
+            btcWalletService.resetCoinLockedInMultiSigAddressEntry(trade.getId());
+            // We might receive funds on AddressEntry.Context.TRADE_PAYOUT so we don't swap that
+
             Transaction committedDelayedPayoutTx = WalletService.maybeAddSelfTxToWallet(delayedPayoutTx, btcWalletService.getWallet());
 
             processModel.getTradeWalletService().broadcastTx(committedDelayedPayoutTx, new TxBroadcaster.Callback() {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessPayoutTxPublishedMessage.java
@@ -59,6 +59,7 @@ public class BuyerProcessPayoutTxPublishedMessage extends TradeTask {
                 BtcWalletService.printTx("payoutTx received from peer", committedPayoutTx);
 
                 trade.setState(Trade.State.BUYER_RECEIVED_PAYOUT_TX_PUBLISHED_MSG);
+                processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(trade.getId());
             } else {
                 log.info("We got the payout tx already set from BuyerSetupPayoutTxListener and do nothing here. trade ID={}", trade.getId());
             }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerProcessPayoutTxPublishedMessage.java
@@ -18,7 +18,6 @@
 package bisq.core.trade.protocol.tasks.buyer;
 
 import bisq.core.account.sign.SignedWitness;
-import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletService;
 import bisq.core.trade.Trade;
@@ -60,7 +59,6 @@ public class BuyerProcessPayoutTxPublishedMessage extends TradeTask {
                 BtcWalletService.printTx("payoutTx received from peer", committedPayoutTx);
 
                 trade.setState(Trade.State.BUYER_RECEIVED_PAYOUT_TX_PUBLISHED_MSG);
-                processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(trade.getId(), AddressEntry.Context.MULTI_SIG);
             } else {
                 log.info("We got the payout tx already set from BuyerSetupPayoutTxListener and do nothing here. trade ID={}", trade.getId());
             }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupDepositTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSetupDepositTxListener.java
@@ -28,13 +28,20 @@ import bisq.common.taskrunner.TaskRunner;
 
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
 
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
+import java.util.Objects;
+
 import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -59,14 +66,20 @@ public class BuyerSetupDepositTxListener extends TradeTask {
                 Transaction preparedDepositTx = new Transaction(params, processModel.getPreparedDepositTx());
                 checkArgument(!preparedDepositTx.getOutputs().isEmpty(), "preparedDepositTx.getOutputs() must not be empty");
                 Address depositTxAddress = preparedDepositTx.getOutput(0).getScriptPubKey().getToAddress(params);
+
+                // For buyer as maker takerFeeTxId is null
+                @Nullable String takerFeeTxId = trade.getTakerFeeTxId();
+                String makerFeeTxId = trade.getOffer().getOfferFeePaymentTxId();
                 TransactionConfidence confidence = walletService.getConfidenceForAddress(depositTxAddress);
-                if (isVisibleInNetwork(confidence)) {
+                if (isConfTxDepositTx(confidence, params, depositTxAddress, takerFeeTxId, makerFeeTxId) &&
+                        isVisibleInNetwork(confidence)) {
                     applyConfidence(confidence);
                 } else {
                     confidenceListener = new AddressConfidenceListener(depositTxAddress) {
                         @Override
                         public void onTransactionConfidenceChanged(TransactionConfidence confidence) {
-                            if (isVisibleInNetwork(confidence)) {
+                            if (isConfTxDepositTx(confidence, params, depositTxAddress,
+                                    takerFeeTxId, makerFeeTxId) && isVisibleInNetwork(confidence)) {
                                 applyConfidence(confidence);
                             }
                         }
@@ -89,6 +102,56 @@ public class BuyerSetupDepositTxListener extends TradeTask {
         } catch (Throwable t) {
             failed(t);
         }
+    }
+
+    // We check if the txIds of the inputs matches our maker fee tx and taker fee tx and if the depositTxAddress we
+    // use for the confidence lookup is use as an output address.
+    // This prevents that past txs which have the our depositTxAddress as input or output (deposit or payout txs) could
+    // be interpreted as our deposit tx. This happened because if a bug which caused re-use of the Multisig address
+    // entries and if both traders use the same key for multiple trades the depositTxAddress would be the same.
+    // We fix that bug as well but we also need to avoid that past already used addresses might be taken again
+    // (the Multisig flag got reverted to available in the address entry).
+    private boolean isConfTxDepositTx(@Nullable TransactionConfidence confidence,
+                                      NetworkParameters params,
+                                      Address depositTxAddress,
+                                      @Nullable String takerFeeTxId,
+                                      String makerFeeTxId) {
+        if (confidence == null) {
+            return false;
+        }
+
+        Transaction walletTx = processModel.getTradeWalletService().getWalletTx(confidence.getTransactionHash());
+        long numInputMatches = walletTx.getInputs().stream()
+                .map(TransactionInput::getOutpoint)
+                .filter(Objects::nonNull)
+                .map(TransactionOutPoint::getHash)
+                .map(Sha256Hash::toString)
+                .filter(txId -> txId.equals(takerFeeTxId) || txId.equals(makerFeeTxId))
+                .count();
+        if (takerFeeTxId == null && numInputMatches != 1) {
+            log.warn("We  got a transactionConfidenceTx which does not match our inputs. " +
+                            "takerFeeTxId is null (valid if role is buyer as maker) and numInputMatches " +
+                            "is not 1 as expected (for makerFeeTxId). " +
+                            "numInputMatches={}, transactionConfidenceTx={}",
+                    numInputMatches, walletTx);
+            return false;
+        } else if (takerFeeTxId != null && numInputMatches != 2) {
+            log.warn("We  got a transactionConfidenceTx which does not match our inputs. " +
+                            "numInputMatches is not 2 as expected (for makerFeeTxId and takerFeeTxId). " +
+                            "numInputMatches={}, transactionConfidenceTx={}",
+                    numInputMatches, walletTx);
+            return false;
+        }
+
+        boolean isOutputMatching = walletTx.getOutputs().stream()
+                .map(transactionOutput -> transactionOutput.getScriptPubKey().getToAddress(params))
+                .anyMatch(address -> address.equals(depositTxAddress));
+        if (!isOutputMatching) {
+            log.warn("We got a transactionConfidenceTx which does not has the depositTxAddress " +
+                            "as output (but as input). depositTxAddress={}, transactionConfidenceTx={}",
+                    depositTxAddress, walletTx);
+        }
+        return isOutputMatching;
     }
 
     private void applyConfidence(TransactionConfidence confidence) {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
@@ -63,7 +63,8 @@ public class BuyerAsMakerCreatesAndSignsDepositTx extends TradeTask {
             Optional<AddressEntry> addressEntryOptional = walletService.getAddressEntry(id, AddressEntry.Context.MULTI_SIG);
             checkArgument(addressEntryOptional.isPresent(), "addressEntryOptional must be present");
             AddressEntry makerMultiSigAddressEntry = addressEntryOptional.get();
-            makerMultiSigAddressEntry.setCoinLockedInMultiSig(makerInputAmount);
+            processModel.getBtcWalletService().setCoinLockedInMultiSigAddressEntry(makerMultiSigAddressEntry, makerInputAmount.value);
+
             walletService.saveAddressEntryList();
 
             Coin msOutputAmount = makerInputAmount

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
@@ -68,7 +68,8 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
             AddressEntry buyerMultiSigAddressEntry = addressEntryOptional.get();
             Coin buyerInput = Coin.valueOf(buyerInputs.stream().mapToLong(input -> input.value).sum());
 
-            buyerMultiSigAddressEntry.setCoinLockedInMultiSig(buyerInput.subtract(trade.getTxFee().multiply(2)));
+            Coin multiSigValue = buyerInput.subtract(trade.getTxFee().multiply(2));
+            processModel.getBtcWalletService().setCoinLockedInMultiSigAddressEntry(buyerMultiSigAddressEntry, multiSigValue.value);
             walletService.saveAddressEntryList();
 
             TradingPeer tradingPeer = processModel.getTradingPeer();

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/FinalizeMediatedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/FinalizeMediatedPayoutTx.java
@@ -110,6 +110,8 @@ public class FinalizeMediatedPayoutTx extends TradeTask {
 
             processModel.getTradeManager().requestPersistence();
 
+            walletService.resetCoinLockedInMultiSigAddressEntry(tradeId);
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/FinalizeMediatedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/FinalizeMediatedPayoutTx.java
@@ -110,8 +110,6 @@ public class FinalizeMediatedPayoutTx extends TradeTask {
 
             processModel.getTradeManager().requestPersistence();
 
-            walletService.swapTradeEntryToAvailableEntry(tradeId, AddressEntry.Context.MULTI_SIG);
-
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
@@ -68,6 +68,8 @@ public class ProcessMediatedPayoutTxPublishedMessage extends TradeTask {
                     UserThread.execute(() -> processModel.getTradeManager()
                             .closeDisputedTrade(trade.getId(), Trade.DisputeState.MEDIATION_CLOSED));
                 }
+
+                processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(trade.getId());
             } else {
                 log.info("We got the payout tx already set from BuyerSetupPayoutTxListener and do nothing here. trade ID={}", trade.getId());
             }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/mediation/ProcessMediatedPayoutTxPublishedMessage.java
@@ -17,7 +17,6 @@
 
 package bisq.core.trade.protocol.tasks.mediation;
 
-import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletService;
 import bisq.core.support.dispute.mediation.MediationResultState;
@@ -69,8 +68,6 @@ public class ProcessMediatedPayoutTxPublishedMessage extends TradeTask {
                     UserThread.execute(() -> processModel.getTradeManager()
                             .closeDisputedTrade(trade.getId(), Trade.DisputeState.MEDIATION_CLOSED));
                 }
-
-                processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(trade.getId(), AddressEntry.Context.MULTI_SIG);
             } else {
                 log.info("We got the payout tx already set from BuyerSetupPayoutTxListener and do nothing here. trade ID={}", trade.getId());
             }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignAndFinalizePayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignAndFinalizePayoutTx.java
@@ -102,6 +102,8 @@ public class SellerSignAndFinalizePayoutTx extends TradeTask {
 
             processModel.getTradeManager().requestPersistence();
 
+            walletService.resetCoinLockedInMultiSigAddressEntry(id);
+
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignAndFinalizePayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller/SellerSignAndFinalizePayoutTx.java
@@ -102,8 +102,6 @@ public class SellerSignAndFinalizePayoutTx extends TradeTask {
 
             processModel.getTradeManager().requestPersistence();
 
-            walletService.swapTradeEntryToAvailableEntry(id, AddressEntry.Context.MULTI_SIG);
-
             complete();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
@@ -70,7 +70,8 @@ public class SellerAsMakerCreatesUnsignedDepositTx extends TradeTask {
             Optional<AddressEntry> addressEntryOptional = walletService.getAddressEntry(id, AddressEntry.Context.MULTI_SIG);
             checkArgument(addressEntryOptional.isPresent(), "addressEntryOptional must be present");
             AddressEntry makerMultiSigAddressEntry = addressEntryOptional.get();
-            makerMultiSigAddressEntry.setCoinLockedInMultiSig(makerInputAmount);
+            processModel.getBtcWalletService().setCoinLockedInMultiSigAddressEntry(makerMultiSigAddressEntry, makerInputAmount.value);
+
             walletService.saveAddressEntryList();
 
             Coin msOutputAmount = makerInputAmount

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
@@ -66,7 +66,8 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
             Coin sellerInput = Coin.valueOf(sellerInputs.stream().mapToLong(input -> input.value).sum());
 
             Coin totalFee = trade.getTxFee().multiply(2); // Fee for deposit and payout tx
-            sellerMultiSigAddressEntry.setCoinLockedInMultiSig(sellerInput.subtract(totalFee));
+            Coin multiSigValue = sellerInput.subtract(totalFee);
+            processModel.getBtcWalletService().setCoinLockedInMultiSigAddressEntry(sellerMultiSigAddressEntry, multiSigValue.value);
             walletService.saveAddressEntryList();
 
             TradingPeer tradingPeer = processModel.getTradingPeer();

--- a/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedListItem.java
@@ -78,7 +78,7 @@ class LockedListItem {
     }
 
     private void updateBalance() {
-        balance = addressEntry.getCoinLockedInMultiSig();
+        balance = addressEntry.getCoinLockedInMultiSigAsCoin();
         balanceLabel.setText(formatter.formatCoin(this.balance));
     }
 


### PR DESCRIPTION
Fixes #4873

Beside what is mentioned in #4873 I found another (minor) issue. We use an immutable list for address entries but the coinLockedInMultiSig value was set in the object via a setter. This change would be lost when accessed as when one open the wallet tool with cmd+j (after take offe the value was 0 there instead of the locked up funds). As the field is only used for lookup for locked funds from failed trades the bug was not very visible.
coinLockedInMultiSig is now a final field set by the constructor.

EDIT: used wrong issue before...