### PR TITLE
Refactor: move getDust(Transaction transaction)

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -505,6 +505,20 @@ public abstract class WalletService {
         return getNumTxOutputsForAddress(address) == 0;
     }
 
+    // BISQ issue #4039: Prevent dust outputs from being created.
+    // Check the outputs of a proposed transaction.  If any are below the dust threshold,
+    // add up the dust, log the details, and return the cumulative dust amount.
+    public Coin getDust(Transaction proposedTransaction) {
+        Coin dust = Coin.ZERO;
+        for (TransactionOutput transactionOutput : proposedTransaction.getOutputs()) {
+            if (transactionOutput.getValue().isLessThan(Restrictions.getMinNonDustOutput())) {
+                dust = dust.add(transactionOutput.getValue());
+                log.info("Dust TXO = {}", transactionOutput.toString());
+            }
+        }
+        return dust;
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Empty complete Wallet

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -56,7 +56,6 @@ import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.wallet.Wallet;
 
 import javax.inject.Inject;
@@ -334,9 +333,9 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                 }
                 checkNotNull(feeEstimationTransaction, "feeEstimationTransaction must not be null");
 
-                Coin dust = getDust(feeEstimationTransaction);
+                Coin dust = btcWalletService.getDust(feeEstimationTransaction);
                 Coin fee = feeEstimationTransaction.getFee().add(dust);
-                Coin receiverAmount = Coin.ZERO;
+                Coin receiverAmount;
                 // amountAsCoin is what the user typed into the withdrawal field.
                 // this can be interpreted as either the senders amount or receivers amount depending
                 // on a radio button "fee excluded / fee included".
@@ -668,21 +667,6 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                         };
                     }
                 });
-    }
-
-    // BISQ issue #4039: prevent dust outputs from being created.
-    // check the outputs of a proposed transaction, if any are below the dust threshold
-    // add up the dust, noting the details in the log.
-    // returns the 'dust amount' to indicate if any dust was detected.
-    private Coin getDust(Transaction transaction) {
-        Coin dust = Coin.ZERO;
-        for (TransactionOutput transactionOutput : transaction.getOutputs()) {
-            if (transactionOutput.getValue().isLessThan(Restrictions.getMinNonDustOutput())) {
-                dust = dust.add(transactionOutput.getValue());
-                log.info("dust TXO = {}", transactionOutput.toString());
-            }
-        }
-        return dust;
     }
 }
 


### PR DESCRIPTION
The api is going to need this method, so it was moved from desktop to core.

- Moved the method from `WithdrawalView` to `WalletService`.

- Removed an unused initializer in `WithdrawalView`.
