### PR TITLE
Avoid that buyer switches back to trade step 2 at startup after payment confirmed

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessage.java
@@ -82,7 +82,9 @@ public class BuyerSendCounterCurrencyTransferStartedMessage extends SendMailboxM
 
     @Override
     protected void setStateSent() {
-        trade.setStateIfValidTransitionTo(Trade.State.BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG);
+        if (trade.getState().ordinal() < Trade.State.BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG.ordinal()) {
+            trade.setStateIfValidTransitionTo(Trade.State.BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG);
+        }
 
         processModel.getTradeManager().requestPersistence();
     }


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/4864

When seller if offline we resend the CounterCurrencyTransferStartedMessage at startup.
That caused the trade state set to BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG and then after
the msg was stored in mailbox to BUYER_STORED_IN_MAILBOX_FIAT_PAYMENT_INITIATED_MSG.
Those 2 msg trigger diff. UI states which led to the UI glitch that the UI moved to
step 2 and then to step 3 which was correct but confusing to the user.

Now we only apply BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG is trade state ordinal is
smaller avoiding that UI glitch.

This is not a critical bug fix so open to maintainers to add it to 1.5.1. But I think its also very low risk and easy to review and test.