### PR TITLE
Avoid case of multi trades with same offer

### DIFF
--- a/core/src/main/java/bisq/core/trade/BuyerAsMakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/BuyerAsMakerTrade.java
@@ -24,7 +24,11 @@ import bisq.core.trade.protocol.ProcessModel;
 
 import bisq.network.p2p.NodeAddress;
 
+import bisq.common.proto.ProtoUtil;
+
 import org.bitcoinj.core.Coin;
+
+import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,7 +49,8 @@ public final class BuyerAsMakerTrade extends BuyerTrade implements MakerTrade {
                              @Nullable NodeAddress mediatorNodeAddress,
                              @Nullable NodeAddress refundAgentNodeAddress,
                              BtcWalletService btcWalletService,
-                             ProcessModel processModel) {
+                             ProcessModel processModel,
+                             String uid) {
         super(offer,
                 txFee,
                 takeOfferFee,
@@ -54,7 +59,8 @@ public final class BuyerAsMakerTrade extends BuyerTrade implements MakerTrade {
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -74,6 +80,10 @@ public final class BuyerAsMakerTrade extends BuyerTrade implements MakerTrade {
                                      CoreProtoResolver coreProtoResolver) {
         protobuf.Trade proto = buyerAsMakerTradeProto.getTrade();
         ProcessModel processModel = ProcessModel.fromProto(proto.getProcessModel(), coreProtoResolver);
+        String uid = ProtoUtil.stringOrNullFromProto(proto.getUid());
+        if (uid == null) {
+            uid = UUID.randomUUID().toString();
+        }
         BuyerAsMakerTrade trade = new BuyerAsMakerTrade(
                 Offer.fromProto(proto.getOffer()),
                 Coin.valueOf(proto.getTxFeeAsLong()),
@@ -83,7 +93,8 @@ public final class BuyerAsMakerTrade extends BuyerTrade implements MakerTrade {
                 proto.hasMediatorNodeAddress() ? NodeAddress.fromProto(proto.getMediatorNodeAddress()) : null,
                 proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
 
         trade.setTradeAmountAsLong(proto.getTradeAmountAsLong());
         trade.setTradePrice(proto.getTradePrice());

--- a/core/src/main/java/bisq/core/trade/BuyerAsTakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/BuyerAsTakerTrade.java
@@ -24,7 +24,11 @@ import bisq.core.trade.protocol.ProcessModel;
 
 import bisq.network.p2p.NodeAddress;
 
+import bisq.common.proto.ProtoUtil;
+
 import org.bitcoinj.core.Coin;
+
+import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,7 +52,8 @@ public final class BuyerAsTakerTrade extends BuyerTrade implements TakerTrade {
                              @Nullable NodeAddress mediatorNodeAddress,
                              @Nullable NodeAddress refundAgentNodeAddress,
                              BtcWalletService btcWalletService,
-                             ProcessModel processModel) {
+                             ProcessModel processModel,
+                             String uid) {
         super(offer,
                 tradeAmount,
                 txFee,
@@ -60,7 +65,8 @@ public final class BuyerAsTakerTrade extends BuyerTrade implements TakerTrade {
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
 
@@ -81,6 +87,10 @@ public final class BuyerAsTakerTrade extends BuyerTrade implements TakerTrade {
                                      CoreProtoResolver coreProtoResolver) {
         protobuf.Trade proto = buyerAsTakerTradeProto.getTrade();
         ProcessModel processModel = ProcessModel.fromProto(proto.getProcessModel(), coreProtoResolver);
+        String uid = ProtoUtil.stringOrNullFromProto(proto.getUid());
+        if (uid == null) {
+            uid = UUID.randomUUID().toString();
+        }
         return fromProto(new BuyerAsTakerTrade(
                         Offer.fromProto(proto.getOffer()),
                         Coin.valueOf(proto.getTradeAmountAsLong()),
@@ -93,7 +103,8 @@ public final class BuyerAsTakerTrade extends BuyerTrade implements TakerTrade {
                         proto.hasMediatorNodeAddress() ? NodeAddress.fromProto(proto.getMediatorNodeAddress()) : null,
                         proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                         btcWalletService,
-                        processModel),
+                        processModel,
+                        uid),
                 proto,
                 coreProtoResolver);
     }

--- a/core/src/main/java/bisq/core/trade/BuyerTrade.java
+++ b/core/src/main/java/bisq/core/trade/BuyerTrade.java
@@ -44,7 +44,8 @@ public abstract class BuyerTrade extends Trade {
                @Nullable NodeAddress mediatorNodeAddress,
                @Nullable NodeAddress refundAgentNodeAddress,
                BtcWalletService btcWalletService,
-               ProcessModel processModel) {
+               ProcessModel processModel,
+               String uid) {
         super(offer,
                 tradeAmount,
                 txFee,
@@ -56,7 +57,8 @@ public abstract class BuyerTrade extends Trade {
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
     BuyerTrade(Offer offer,
@@ -67,7 +69,8 @@ public abstract class BuyerTrade extends Trade {
                @Nullable NodeAddress mediatorNodeAddress,
                @Nullable NodeAddress refundAgentNodeAddress,
                BtcWalletService btcWalletService,
-               ProcessModel processModel) {
+               ProcessModel processModel,
+               String uid) {
         super(offer,
                 txFee,
                 takerFee,
@@ -76,7 +79,8 @@ public abstract class BuyerTrade extends Trade {
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/SellerAsMakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/SellerAsMakerTrade.java
@@ -24,7 +24,11 @@ import bisq.core.trade.protocol.ProcessModel;
 
 import bisq.network.p2p.NodeAddress;
 
+import bisq.common.proto.ProtoUtil;
+
 import org.bitcoinj.core.Coin;
+
+import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,7 +49,8 @@ public final class SellerAsMakerTrade extends SellerTrade implements MakerTrade 
                               @Nullable NodeAddress mediatorNodeAddress,
                               @Nullable NodeAddress refundAgentNodeAddress,
                               BtcWalletService btcWalletService,
-                              ProcessModel processModel) {
+                              ProcessModel processModel,
+                              String uid) {
         super(offer,
                 txFee,
                 takerFee,
@@ -54,7 +59,8 @@ public final class SellerAsMakerTrade extends SellerTrade implements MakerTrade 
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
 
@@ -75,6 +81,10 @@ public final class SellerAsMakerTrade extends SellerTrade implements MakerTrade 
                                      CoreProtoResolver coreProtoResolver) {
         protobuf.Trade proto = sellerAsMakerTradeProto.getTrade();
         ProcessModel processModel = ProcessModel.fromProto(proto.getProcessModel(), coreProtoResolver);
+        String uid = ProtoUtil.stringOrNullFromProto(proto.getUid());
+        if (uid == null) {
+            uid = UUID.randomUUID().toString();
+        }
         SellerAsMakerTrade trade = new SellerAsMakerTrade(
                 Offer.fromProto(proto.getOffer()),
                 Coin.valueOf(proto.getTxFeeAsLong()),
@@ -84,7 +94,8 @@ public final class SellerAsMakerTrade extends SellerTrade implements MakerTrade 
                 proto.hasMediatorNodeAddress() ? NodeAddress.fromProto(proto.getMediatorNodeAddress()) : null,
                 proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
 
         trade.setTradeAmountAsLong(proto.getTradeAmountAsLong());
         trade.setTradePrice(proto.getTradePrice());

--- a/core/src/main/java/bisq/core/trade/SellerAsTakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/SellerAsTakerTrade.java
@@ -24,7 +24,11 @@ import bisq.core.trade.protocol.ProcessModel;
 
 import bisq.network.p2p.NodeAddress;
 
+import bisq.common.proto.ProtoUtil;
+
 import org.bitcoinj.core.Coin;
+
+import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,7 +52,8 @@ public final class SellerAsTakerTrade extends SellerTrade implements TakerTrade 
                               @Nullable NodeAddress mediatorNodeAddress,
                               @Nullable NodeAddress refundAgentNodeAddress,
                               BtcWalletService btcWalletService,
-                              ProcessModel processModel) {
+                              ProcessModel processModel,
+                              String uid) {
         super(offer,
                 tradeAmount,
                 txFee,
@@ -60,7 +65,8 @@ public final class SellerAsTakerTrade extends SellerTrade implements TakerTrade 
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
 
@@ -81,6 +87,10 @@ public final class SellerAsTakerTrade extends SellerTrade implements TakerTrade 
                                      CoreProtoResolver coreProtoResolver) {
         protobuf.Trade proto = sellerAsTakerTradeProto.getTrade();
         ProcessModel processModel = ProcessModel.fromProto(proto.getProcessModel(), coreProtoResolver);
+        String uid = ProtoUtil.stringOrNullFromProto(proto.getUid());
+        if (uid == null) {
+            uid = UUID.randomUUID().toString();
+        }
         return fromProto(new SellerAsTakerTrade(
                         Offer.fromProto(proto.getOffer()),
                         Coin.valueOf(proto.getTradeAmountAsLong()),
@@ -93,7 +103,8 @@ public final class SellerAsTakerTrade extends SellerTrade implements TakerTrade 
                         proto.hasMediatorNodeAddress() ? NodeAddress.fromProto(proto.getMediatorNodeAddress()) : null,
                         proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                         btcWalletService,
-                        processModel),
+                        processModel,
+                        uid),
                 proto,
                 coreProtoResolver);
     }

--- a/core/src/main/java/bisq/core/trade/SellerTrade.java
+++ b/core/src/main/java/bisq/core/trade/SellerTrade.java
@@ -45,7 +45,8 @@ public abstract class SellerTrade extends Trade {
                 @Nullable NodeAddress mediatorNodeAddress,
                 @Nullable NodeAddress refundAgentNodeAddress,
                 BtcWalletService btcWalletService,
-                ProcessModel processModel) {
+                ProcessModel processModel,
+                String uid) {
         super(offer,
                 tradeAmount,
                 txFee,
@@ -57,7 +58,8 @@ public abstract class SellerTrade extends Trade {
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
     SellerTrade(Offer offer,
@@ -68,7 +70,8 @@ public abstract class SellerTrade extends Trade {
                 @Nullable NodeAddress mediatorNodeAddress,
                 @Nullable NodeAddress refundAgentNodeAddress,
                 BtcWalletService btcWalletService,
-                ProcessModel processModel) {
+                ProcessModel processModel,
+                String uid) {
         super(offer,
                 txFee,
                 takeOfferFee,
@@ -77,7 +80,8 @@ public abstract class SellerTrade extends Trade {
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -296,6 +296,11 @@ public abstract class Trade implements Tradable, Model {
     private final long txFeeAsLong;
     @Getter
     private final long takerFeeAsLong;
+
+    // Added in 1.5.1
+    @Getter
+    private final String uid;
+
     @Setter
     private long takeOfferDate;
 
@@ -470,7 +475,8 @@ public abstract class Trade implements Tradable, Model {
                     @Nullable NodeAddress mediatorNodeAddress,
                     @Nullable NodeAddress refundAgentNodeAddress,
                     BtcWalletService btcWalletService,
-                    ProcessModel processModel) {
+                    ProcessModel processModel,
+                    String uid) {
         this.offer = offer;
         this.txFee = txFee;
         this.takerFee = takerFee;
@@ -480,10 +486,13 @@ public abstract class Trade implements Tradable, Model {
         this.refundAgentNodeAddress = refundAgentNodeAddress;
         this.btcWalletService = btcWalletService;
         this.processModel = processModel;
+        this.uid = uid;
 
         txFeeAsLong = txFee.value;
         takerFeeAsLong = takerFee.value;
         takeOfferDate = new Date().getTime();
+
+        log.error("New trade created with offerId={} and Uid={}", offer.getId(), uid);
     }
 
 
@@ -500,7 +509,8 @@ public abstract class Trade implements Tradable, Model {
                     @Nullable NodeAddress mediatorNodeAddress,
                     @Nullable NodeAddress refundAgentNodeAddress,
                     BtcWalletService btcWalletService,
-                    ProcessModel processModel) {
+                    ProcessModel processModel,
+                    String uid) {
 
         this(offer,
                 txFee,
@@ -510,7 +520,8 @@ public abstract class Trade implements Tradable, Model {
                 mediatorNodeAddress,
                 refundAgentNodeAddress,
                 btcWalletService,
-                processModel);
+                processModel,
+                uid);
         this.tradePrice = tradePrice;
         this.tradingPeerNodeAddress = tradingPeerNodeAddress;
 
@@ -539,7 +550,8 @@ public abstract class Trade implements Tradable, Model {
                 .addAllChatMessage(chatMessages.stream()
                         .map(msg -> msg.toProtoNetworkEnvelope().getChatMessage())
                         .collect(Collectors.toList()))
-                .setLockTime(lockTime);
+                .setLockTime(lockTime)
+                .setUid(uid);
 
         Optional.ofNullable(takerFeeTxId).ifPresent(builder::setTakerFeeTxId);
         Optional.ofNullable(depositTxId).ifPresent(builder::setDepositTxId);

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
@@ -100,8 +100,8 @@ public class BuyerAsMakerProtocol extends BuyerProtocol implements MakerProtocol
                 .with(message)
                 .from(peer))
                 .setup(tasks(
-                        BuyerProcessDelayedPayoutTxSignatureRequest.class,
                         MakerRemovesOpenOffer.class,
+                        BuyerProcessDelayedPayoutTxSignatureRequest.class,
                         BuyerVerifiesPreparedDelayedPayoutTx.class,
                         BuyerSignsDelayedPayoutTx.class,
                         BuyerFinalizesDelayedPayoutTx.class,

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsMakerProtocol.java
@@ -86,7 +86,7 @@ public class BuyerAsMakerProtocol extends BuyerProtocol implements MakerProtocol
                                     errorMessageHandler.handleErrorMessage(errorMessage);
                                     handleTaskRunnerFault(message, errorMessage);
                                 }))
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 
@@ -106,7 +106,7 @@ public class BuyerAsMakerProtocol extends BuyerProtocol implements MakerProtocol
                         BuyerSignsDelayedPayoutTx.class,
                         BuyerFinalizesDelayedPayoutTx.class,
                         BuyerSendsDelayedPayoutTxSignatureResponse.class)
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/BuyerAsTakerProtocol.java
@@ -83,7 +83,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         CreateTakerFeeTx.class,
                         BuyerAsTakerCreatesDepositTxInputs.class,
                         TakerSendInputsForDepositTxRequest.class)
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .run(() -> {
                     processModel.setTempTradingPeerNodeAddress(trade.getTradingPeerNodeAddress());
                     processModel.getTradeManager().requestPersistence();
@@ -108,7 +108,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         BuyerAsTakerSignsDepositTx.class,
                         BuyerSetupDepositTxListener.class,
                         BuyerAsTakerSendsDepositTxMessage.class)
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 
@@ -122,7 +122,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         BuyerSignsDelayedPayoutTx.class,
                         BuyerFinalizesDelayedPayoutTx.class,
                         BuyerSendsDelayedPayoutTxSignatureResponse.class)
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
@@ -86,7 +86,7 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
                                     errorMessageHandler.handleErrorMessage(errorMessage);
                                     handleTaskRunnerFault(message, errorMessage);
                                 }))
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 
@@ -106,7 +106,7 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
                         SellerCreatesDelayedPayoutTx.class,
                         SellerSignsDelayedPayoutTx.class,
                         SellerSendDelayedPayoutTxSignatureRequest.class)
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
@@ -100,8 +100,8 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
                 .with(message)
                 .from(peer))
                 .setup(tasks(
-                        SellerAsMakerProcessDepositTxMessage.class,
                         MakerRemovesOpenOffer.class,
+                        SellerAsMakerProcessDepositTxMessage.class,
                         SellerAsMakerFinalizesDepositTx.class,
                         SellerCreatesDelayedPayoutTx.class,
                         SellerSignsDelayedPayoutTx.class,

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsTakerProtocol.java
@@ -78,7 +78,7 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
                         CreateTakerFeeTx.class,
                         SellerAsTakerCreatesDepositTxInputs.class,
                         TakerSendInputsForDepositTxRequest.class)
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 
@@ -101,7 +101,7 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
                         SellerCreatesDelayedPayoutTx.class,
                         SellerSignsDelayedPayoutTx.class,
                         SellerSendDelayedPayoutTxSignatureRequest.class)
-                        .withTimeout(30))
+                        .withTimeout(60))
                 .executeTasks();
     }
 

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1449,6 +1449,7 @@ message Trade {
     int64 last_refresh_request_date = 36 [deprecated = true];
     string counter_currency_extra_data = 37;
     string asset_tx_proof_result = 38; // name of AssetTxProofResult enum
+    string uid = 39;
 }
 
 message BuyerAsMakerTrade {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/4879

We had removed the offer after the first trade task. If it failed there the offer stayed online and could be taken by another user. This caused the issue that one failed trade was in the trade list and then later a valid trade entered as well. As we used the offerId as key for a map which was used for the processModel lookup, that caused a bug with a Nullpointer exception.

This PR fixes that problem by using a uid instead of the offerId to make the map lookup more solid.
It also moves the task to remove the offer as the very first task so it cannot happen anymore that a offer stays online and leads later to 2 trades with the same offer id.

It also increased the realtively short timeout of 30 seconds in the some trade protocol task runners. We saw some cases where those timeouts triggered errorMessages but the trade could complete without problem, so that should help to reduce such cases. We do not fail on those timeouts, they only trigger an error message. The general trade protocol timeout would cause a failure of the trade.

