### PR TITLE
Increase max number of log files to 20.

### DIFF
--- a/common/src/main/java/bisq/common/app/Log.java
+++ b/common/src/main/java/bisq/common/app/Log.java
@@ -48,7 +48,7 @@ public class Log {
         rollingPolicy.setParent(appender);
         rollingPolicy.setFileNamePattern(fileName + "_%i.log");
         rollingPolicy.setMinIndex(1);
-        rollingPolicy.setMaxIndex(10);
+        rollingPolicy.setMaxIndex(20);
         rollingPolicy.start();
 
         SizeBasedTriggeringPolicy<ILoggingEvent> triggeringPolicy = new SizeBasedTriggeringPolicy<>();


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/4856

This is a quick fix for the request at https://github.com/bisq-network/bisq/issues/4856.
I only increases statically the numbe rof log files from 10 to 20. As we have too many bugs atm I think that helps to find the issues and can be reverted later once not needed anymore, and/or implemented with a setting in the preferences. As log is setup very early in the setup I am not sure that will be that easy... the propery file need to be used probably. 
We should use a high value as default, as otherwise once a bug happen it might not help if it is older and already removed.

No hard need to get into 1.5.1 but as its that low risk and have be helpful for future debugging I recommend to get it in as well. 
