### PR TITLE
Allow take offer in case account age witness is not found and trade amount is small

### DIFF
--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -533,10 +533,18 @@ public class AccountAgeWitnessService {
                                           Coin tradeAmount,
                                           ErrorMessageHandler errorMessageHandler) {
         checkNotNull(offer);
+
+        // In case we don't find the witness we check if the trade amount is above the
+        // TOLERATED_SMALL_TRADE_AMOUNT (0.01 BTC) and only in that case return false.
         return findWitness(offer)
                 .map(witness -> verifyPeersTradeLimit(offer, tradeAmount, witness, new Date(), errorMessageHandler))
-                .orElse(false);
+                .orElse(isToleratedSmalleAmount(tradeAmount));
     }
+
+    private boolean isToleratedSmalleAmount(Coin tradeAmount) {
+        return tradeAmount.value <= OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.value;
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Package scope verification subroutines


### PR DESCRIPTION
In case the peers witness is not found and the trade amount 
is not exceeding TOLERATED_SMALL_TRADE_AMOUNT (0.01 BTC) we
return true for verifyPeersTradeAmount.
Before such offers could not be taken even the witness
check would be irrelevant as the trade amount is below the
threshold where we require account age witness.