### PR TITLE
Add new api method 'sendbtc'

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -52,6 +52,7 @@ import bisq.proto.grpc.SetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.TakeOfferRequest;
 import bisq.proto.grpc.TradeInfo;
+import bisq.proto.grpc.TxInfo;
 import bisq.proto.grpc.UnlockWalletRequest;
 import bisq.proto.grpc.UnsetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.WithdrawFundsRequest;
@@ -160,8 +161,14 @@ public class MethodTest extends ApiTestCase {
         return GetUnusedBsqAddressRequest.newBuilder().build();
     }
 
-    protected final SendBsqRequest createSendBsqRequest(String address, String amount) {
-        return SendBsqRequest.newBuilder().setAddress(address).setAmount(amount).build();
+    protected final SendBsqRequest createSendBsqRequest(String address,
+                                                        String amount,
+                                                        String txFeeRate) {
+        return SendBsqRequest.newBuilder()
+                .setAddress(address)
+                .setAmount(amount)
+                .setTxFeeRate(txFeeRate)
+                .build();
     }
 
     protected final GetFundingAddressesRequest createGetFundingAddressesRequest() {
@@ -247,9 +254,21 @@ public class MethodTest extends ApiTestCase {
         return grpcStubs(bisqAppConfig).walletsService.getUnusedBsqAddress(createGetUnusedBsqAddressRequest()).getAddress();
     }
 
-    protected final void sendBsq(BisqAppConfig bisqAppConfig, String address, String amount) {
+    protected final TxInfo sendBsq(BisqAppConfig bisqAppConfig,
+                                   String address,
+                                   String amount) {
+        return sendBsq(bisqAppConfig, address, amount, "");
+    }
+
+    protected final TxInfo sendBsq(BisqAppConfig bisqAppConfig,
+                                   String address,
+                                   String amount,
+                                   String txFeeRate) {
         //noinspection ResultOfMethodCallIgnored
-        grpcStubs(bisqAppConfig).walletsService.sendBsq(createSendBsqRequest(address, amount));
+        return grpcStubs(bisqAppConfig).walletsService.sendBsq(createSendBsqRequest(address,
+                amount,
+                txFeeRate))
+                .getTxInfo();
     }
 
     protected final String getUnusedBtcAddress(BisqAppConfig bisqAppConfig) {

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -48,6 +48,7 @@ import bisq.proto.grpc.OfferInfo;
 import bisq.proto.grpc.RegisterDisputeAgentRequest;
 import bisq.proto.grpc.RemoveWalletPasswordRequest;
 import bisq.proto.grpc.SendBsqRequest;
+import bisq.proto.grpc.SendBtcRequest;
 import bisq.proto.grpc.SetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.SetWalletPasswordRequest;
 import bisq.proto.grpc.TakeOfferRequest;
@@ -171,6 +172,16 @@ public class MethodTest extends ApiTestCase {
                 .build();
     }
 
+    protected final SendBtcRequest createSendBtcRequest(String address,
+                                                        String amount,
+                                                        String txFeeRate) {
+        return SendBtcRequest.newBuilder()
+                .setAddress(address)
+                .setAmount(amount)
+                .setTxFeeRate(txFeeRate)
+                .build();
+    }
+
     protected final GetFundingAddressesRequest createGetFundingAddressesRequest() {
         return GetFundingAddressesRequest.newBuilder().build();
     }
@@ -266,6 +277,21 @@ public class MethodTest extends ApiTestCase {
                                    String txFeeRate) {
         //noinspection ResultOfMethodCallIgnored
         return grpcStubs(bisqAppConfig).walletsService.sendBsq(createSendBsqRequest(address,
+                amount,
+                txFeeRate))
+                .getTxInfo();
+    }
+
+    protected final TxInfo sendBtc(BisqAppConfig bisqAppConfig, String address, String amount) {
+        return sendBtc(bisqAppConfig, address, amount, "");
+    }
+
+    protected final TxInfo sendBtc(BisqAppConfig bisqAppConfig,
+                                   String address,
+                                   String amount,
+                                   String txFeeRate) {
+        //noinspection ResultOfMethodCallIgnored
+        return grpcStubs(bisqAppConfig).walletsService.sendBtc(createSendBtcRequest(address,
                 amount,
                 txFeeRate))
                 .getTxInfo();

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
@@ -108,7 +108,7 @@ public class BsqWalletTest extends MethodTest {
     @Order(3)
     public void testSendBsqAndCheckBalancesBeforeGeneratingBtcBlock(final TestInfo testInfo) {
         String bobsBsqAddress = getUnusedBsqAddress(bobdaemon);
-        sendBsq(alicedaemon, bobsBsqAddress, SEND_BSQ_AMOUNT);
+        sendBsq(alicedaemon, bobsBsqAddress, SEND_BSQ_AMOUNT, "100");
         sleep(2000);
 
         BsqBalanceInfo alicesBsqBalances = getBsqBalances(alicedaemon);

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BtcWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BtcWalletTest.java
@@ -20,6 +20,7 @@ import static bisq.cli.TableFormat.formatAddressBalanceTbl;
 import static bisq.cli.TableFormat.formatBtcBalanceInfoTbl;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
 
@@ -55,10 +56,10 @@ public class BtcWalletTest extends MethodTest {
         // Bob & Alice's regtest Bisq wallets were initialized with 10 BTC.
 
         BtcBalanceInfo alicesBalances = getBtcBalances(alicedaemon);
-        log.info("{} Alice's BTC Balances:\n{}", testName(testInfo), formatBtcBalanceInfoTbl(alicesBalances));
+        log.debug("{} Alice's BTC Balances:\n{}", testName(testInfo), formatBtcBalanceInfoTbl(alicesBalances));
 
         BtcBalanceInfo bobsBalances = getBtcBalances(bobdaemon);
-        log.info("{} Bob's BTC Balances:\n{}", testName(testInfo), formatBtcBalanceInfoTbl(bobsBalances));
+        log.debug("{} Bob's BTC Balances:\n{}", testName(testInfo), formatBtcBalanceInfoTbl(bobsBalances));
 
         assertEquals(INITIAL_BTC_BALANCES.getAvailableBalance(), alicesBalances.getAvailableBalance());
         assertEquals(INITIAL_BTC_BALANCES.getAvailableBalance(), bobsBalances.getAvailableBalance());
@@ -75,7 +76,7 @@ public class BtcWalletTest extends MethodTest {
         // New balance is 12.5 BTC
         assertEquals(1250000000, btcBalanceInfo.getAvailableBalance());
 
-        log.info("{} -> Alice's Funded Address Balance -> \n{}",
+        log.debug("{} -> Alice's Funded Address Balance -> \n{}",
                 testName(testInfo),
                 formatAddressBalanceTbl(singletonList(getAddressBalance(alicedaemon, newAddress))));
 
@@ -87,9 +88,41 @@ public class BtcWalletTest extends MethodTest {
                         1250000000,
                         0);
         verifyBtcBalances(alicesExpectedBalances, btcBalanceInfo);
-        log.info("{} -> Alice's BTC Balances After Sending 2.5 BTC -> \n{}",
+        log.debug("{} -> Alice's BTC Balances After Sending 2.5 BTC -> \n{}",
                 testName(testInfo),
                 formatBtcBalanceInfoTbl(btcBalanceInfo));
+    }
+
+    @Test
+    @Order(3)
+    public void testAliceSendBTCToBob(TestInfo testInfo) {
+        String bobsBtcAddress = getUnusedBtcAddress(bobdaemon);
+        log.debug("Sending most of Alice's BTC to Bob @ {}", bobsBtcAddress);
+
+        sendBtc(alicedaemon, bobsBtcAddress, "5.50", "100");
+        genBtcBlocksThenWait(1, 3000);
+
+        BtcBalanceInfo alicesBalances = getBtcBalances(alicedaemon);
+
+        log.debug("{} Alice's BTC Balances:\n{}",
+                testName(testInfo),
+                formatBtcBalanceInfoTbl(alicesBalances));
+        bisq.core.api.model.BtcBalanceInfo alicesExpectedBalances =
+                bisq.core.api.model.BtcBalanceInfo.valueOf(700000000,
+                        0,
+                        700000000,
+                        0);
+        verifyBtcBalances(alicesExpectedBalances, alicesBalances);
+
+        BtcBalanceInfo bobsBalances = getBtcBalances(bobdaemon);
+        log.debug("{} Bob's BTC Balances:\n{}",
+                testName(testInfo),
+                formatBtcBalanceInfoTbl(bobsBalances));
+        // We cannot (?) predict the exact tx size and calculate how much in tx fees were
+        // deducted from the 5.5 BTC sent to Bob, but we do know Bob should have something
+        // between 15.49978000 and 15.49978100 BTC.
+        assertTrue(bobsBalances.getAvailableBalance() >= 1549978000);
+        assertTrue(bobsBalances.getAvailableBalance() <= 1549978100);
     }
 
     @AfterAll

--- a/apitest/src/test/java/bisq/apitest/scenario/WalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/WalletTest.java
@@ -67,6 +67,7 @@ public class WalletTest extends MethodTest {
 
         btcWalletTest.testInitialBtcBalances(testInfo);
         btcWalletTest.testFundAlicesBtcWallet(testInfo);
+        btcWalletTest.testAliceSendBTCToBob(testInfo);
     }
 
     @Test

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -244,8 +244,11 @@ public class CoreApi {
         return walletsService.getUnusedBsqAddress();
     }
 
-    public void sendBsq(String address, String amount, TxBroadcaster.Callback callback) {
-        walletsService.sendBsq(address, amount, callback);
+    public void sendBsq(String address,
+                        String amount,
+                        String txFeeRate,
+                        TxBroadcaster.Callback callback) {
+        walletsService.sendBsq(address, amount, txFeeRate, callback);
     }
 
     public void getTxFeeRate(ResultHandler resultHandler) {

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -34,9 +34,12 @@ import bisq.common.app.Version;
 import bisq.common.handlers.ResultHandler;
 
 import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import com.google.common.util.concurrent.FutureCallback;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -249,6 +252,13 @@ public class CoreApi {
                         String txFeeRate,
                         TxBroadcaster.Callback callback) {
         walletsService.sendBsq(address, amount, txFeeRate, callback);
+    }
+
+    public void sendBtc(String address,
+                        String amount,
+                        String txFeeRate,
+                        FutureCallback<Transaction> callback) {
+        walletsService.sendBtc(address, amount, txFeeRate, callback);
     }
 
     public void getTxFeeRate(ResultHandler resultHandler) {

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -23,7 +23,9 @@ import bisq.core.api.model.BsqBalanceInfo;
 import bisq.core.api.model.BtcBalanceInfo;
 import bisq.core.api.model.TxFeeRateInfo;
 import bisq.core.btc.Balances;
+import bisq.core.btc.exceptions.AddressEntryException;
 import bisq.core.btc.exceptions.BsqChangeBelowDustException;
+import bisq.core.btc.exceptions.InsufficientFundsException;
 import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.exceptions.WalletException;
 import bisq.core.btc.model.AddressEntry;
@@ -35,7 +37,9 @@ import bisq.core.btc.wallet.TxBroadcaster;
 import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
+import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.BsqFormatter;
+import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
@@ -46,10 +50,12 @@ import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -64,6 +70,7 @@ import org.bouncycastle.crypto.params.KeyParameter;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -85,6 +92,7 @@ class CoreWalletsService {
     private final BsqTransferService bsqTransferService;
     private final BsqFormatter bsqFormatter;
     private final BtcWalletService btcWalletService;
+    private final CoinFormatter btcFormatter;
     private final FeeService feeService;
     private final Preferences preferences;
 
@@ -103,6 +111,7 @@ class CoreWalletsService {
                               BsqTransferService bsqTransferService,
                               BsqFormatter bsqFormatter,
                               BtcWalletService btcWalletService,
+                              @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter,
                               FeeService feeService,
                               Preferences preferences) {
         this.balances = balances;
@@ -111,6 +120,7 @@ class CoreWalletsService {
         this.bsqTransferService = bsqTransferService;
         this.bsqFormatter = bsqFormatter;
         this.btcWalletService = btcWalletService;
+        this.btcFormatter = btcFormatter;
         this.feeService = feeService;
         this.preferences = preferences;
     }
@@ -191,30 +201,83 @@ class CoreWalletsService {
                  String amount,
                  String txFeeRate,
                  TxBroadcaster.Callback callback) {
+        verifyWalletsAreAvailable();
+        verifyEncryptedWalletIsUnlocked();
+
         try {
             LegacyAddress legacyAddress = getValidBsqLegacyAddress(address);
-            Coin receiverAmount = getValidBsqTransferAmount(amount);
-
-            // A non txFeeRate String value overrides the fee service and custom fee.
-            Coin txFeePerVbyte = txFeeRate.isEmpty()
-                    ? btcWalletService.getTxFeeForWithdrawalPerVbyte()
-                    : Coin.valueOf(Long.parseLong(txFeeRate));
-
+            Coin receiverAmount = getValidTransferAmount(amount, bsqFormatter);
+            Coin txFeePerVbyte = getTxFeeRateFromParamOrPreferenceOrFeeService(txFeeRate);
             BsqTransferModel model = bsqTransferService.getBsqTransferModel(legacyAddress,
                     receiverAmount,
                     txFeePerVbyte);
-            log.info("Sending {} BSQ to {} with tx fee rate {} sats/byte).",
+            log.info("Sending {} BSQ to {} with tx fee rate {} sats/byte.",
                     amount,
                     address,
                     txFeePerVbyte.value);
             bsqTransferService.sendFunds(model, callback);
+        } catch (InsufficientMoneyException ex) {
+            log.error("", ex);
+            throw new IllegalStateException("cannot send bsq due to insufficient funds", ex);
         } catch (NumberFormatException
-                | InsufficientMoneyException
                 | BsqChangeBelowDustException
                 | TransactionVerificationException
                 | WalletException ex) {
             log.error("", ex);
             throw new IllegalStateException(ex);
+        }
+    }
+
+    void sendBtc(String address,
+                 String amount,
+                 String txFeeRate,
+                 FutureCallback<Transaction> callback) {
+        verifyWalletsAreAvailable();
+        verifyEncryptedWalletIsUnlocked();
+
+        try {
+            Set<String> fromAddresses = btcWalletService.getAddressEntriesForAvailableBalanceStream()
+                    .map(AddressEntry::getAddressString)
+                    .collect(Collectors.toSet());
+            Coin receiverAmount = getValidTransferAmount(amount, btcFormatter);
+            Coin txFeePerVbyte = getTxFeeRateFromParamOrPreferenceOrFeeService(txFeeRate);
+
+            // TODO Support feeExcluded (or included), default is fee included.
+            //  See WithdrawalView # onWithdraw (and refactor).
+            Transaction feeEstimationTransaction =
+                    btcWalletService.getFeeEstimationTransactionForMultipleAddresses(fromAddresses,
+                            receiverAmount,
+                            txFeePerVbyte);
+            if (feeEstimationTransaction == null)
+                throw new IllegalStateException("could not estimate the transaction fee");
+
+            Coin dust = btcWalletService.getDust(feeEstimationTransaction);
+            Coin fee = feeEstimationTransaction.getFee().add(dust);
+            if (dust.isPositive()) {
+                fee = feeEstimationTransaction.getFee().add(dust);
+                log.info("Dust txo ({} sats) was detected, the dust amount has been added to the fee (was {}, now {})",
+                        dust.value,
+                        feeEstimationTransaction.getFee(),
+                        fee.value);
+            }
+            log.info("Sending {} BTC to {} with tx fee of {} sats (fee rate {} sats/byte).",
+                    amount,
+                    address,
+                    fee.value,
+                    txFeePerVbyte.value);
+            btcWalletService.sendFundsForMultipleAddresses(fromAddresses,
+                    address,
+                    receiverAmount,
+                    fee,
+                    null,
+                    tempAesKey,
+                    callback);
+        } catch (AddressEntryException ex) {
+            log.error("", ex);
+            throw new IllegalStateException("cannot send btc from any addresses in wallet", ex);
+        } catch (InsufficientFundsException | InsufficientMoneyException ex) {
+            log.error("", ex);
+            throw new IllegalStateException("cannot send btc due to insufficient funds", ex);
         }
     }
 
@@ -437,13 +500,20 @@ class CoreWalletsService {
         }
     }
 
-    // Returns a Coin for the amount string, or a RuntimeException if invalid.
-    private Coin getValidBsqTransferAmount(String amount) {
-        Coin amountAsCoin = parseToCoin(amount, bsqFormatter);
+    // Returns a Coin for the transfer amount string, or a RuntimeException if invalid.
+    private Coin getValidTransferAmount(String amount, CoinFormatter coinFormatter) {
+        Coin amountAsCoin = parseToCoin(amount, coinFormatter);
         if (amountAsCoin.isLessThan(getMinNonDustOutput()))
-            throw new IllegalStateException(format("%s bsq is an invalid send amount", amount));
+            throw new IllegalStateException(format("%s is an invalid transfer amount", amount));
 
         return amountAsCoin;
+    }
+
+    private Coin getTxFeeRateFromParamOrPreferenceOrFeeService(String txFeeRate) {
+        // A non txFeeRate String value overrides the fee service and custom fee.
+        return txFeeRate.isEmpty()
+                ? btcWalletService.getTxFeeForWithdrawalPerVbyte()
+                : Coin.valueOf(Long.parseLong(txFeeRate));
     }
 
     private KeyCrypterScrypt getKeyCrypterScrypt() {

--- a/core/src/main/java/bisq/core/api/model/TxInfo.java
+++ b/core/src/main/java/bisq/core/api/model/TxInfo.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.api.model;
+
+import bisq.common.Payload;
+
+import org.bitcoinj.core.Transaction;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public class TxInfo implements Payload {
+
+    private final String id;
+    private final long outputSum;
+    private final long fee;
+    private final int size;
+
+    public TxInfo(String id, long outputSum, long fee, int size) {
+        this.id = id;
+        this.outputSum = outputSum;
+        this.fee = fee;
+        this.size = size;
+    }
+
+    public static TxInfo toTxInfo(Transaction transaction) {
+        if (transaction == null)
+            throw new IllegalStateException("server created a null transaction");
+
+        return new TxInfo(transaction.getTxId().toString(),
+                transaction.getOutputSum().value,
+                transaction.getFee().value,
+                transaction.getMessageSize());
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    //////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.TxInfo toProtoMessage() {
+        return bisq.proto.grpc.TxInfo.newBuilder()
+                .setId(id)
+                .setOutputSum(outputSum)
+                .setFee(fee)
+                .setSize(size)
+                .build();
+    }
+
+    @SuppressWarnings("unused")
+    public static TxInfo fromProto(bisq.proto.grpc.TxInfo proto) {
+        return new TxInfo(proto.getId(),
+                proto.getOutputSum(),
+                proto.getFee(),
+                proto.getSize());
+    }
+
+    @Override
+    public String toString() {
+        return "TxInfo{" + "\n" +
+                "  id='" + id + '\'' + "\n" +
+                ", outputSum=" + outputSum + " sats" + "\n" +
+                ", fee=" + fee + " sats" + "\n" +
+                ", size=" + size + " bytes" + "\n" +
+                '}';
+    }
+}

--- a/core/src/main/java/bisq/core/btc/wallet/BsqTransferService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqTransferService.java
@@ -40,7 +40,7 @@ public class BsqTransferService {
             InsufficientMoneyException {
 
         Transaction preparedSendTx = bsqWalletService.getPreparedSendBsqTx(address.toString(), receiverAmount);
-        Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx, true);
+        Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx);
         Transaction signedTx = bsqWalletService.signTx(txWithBtcFee);
 
         return new BsqTransferModel(address,

--- a/core/src/main/java/bisq/core/btc/wallet/BsqTransferService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqTransferService.java
@@ -33,14 +33,15 @@ public class BsqTransferService {
     }
 
     public BsqTransferModel getBsqTransferModel(LegacyAddress address,
-                                                Coin receiverAmount)
+                                                Coin receiverAmount,
+                                                Coin txFeePerVbyte)
             throws TransactionVerificationException,
             WalletException,
             BsqChangeBelowDustException,
             InsufficientMoneyException {
 
         Transaction preparedSendTx = bsqWalletService.getPreparedSendBsqTx(address.toString(), receiverAmount);
-        Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx);
+        Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx, txFeePerVbyte);
         Transaction signedTx = bsqWalletService.signTx(txWithBtcFee);
 
         return new BsqTransferModel(address,

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -991,7 +991,7 @@ public class BtcWalletService extends WalletService {
         if (!addressEntry.isPresent())
             throw new AddressEntryException("WithdrawFromAddress is not found in our wallet.");
 
-        checkNotNull(addressEntry.get().getAddress(), "addressEntry.get().getAddress() must nto be null");
+        checkNotNull(addressEntry.get().getAddress(), "addressEntry.get().getAddress() must not be null");
 
         try {
             Coin fee;
@@ -1023,6 +1023,14 @@ public class BtcWalletService extends WalletService {
     public Transaction getFeeEstimationTransactionForMultipleAddresses(Set<String> fromAddresses,
                                                                        Coin amount)
             throws AddressFormatException, AddressEntryException, InsufficientFundsException {
+        Coin txFeeForWithdrawalPerVbyte = getTxFeeForWithdrawalPerVbyte();
+        return getFeeEstimationTransactionForMultipleAddresses(fromAddresses, amount, txFeeForWithdrawalPerVbyte);
+    }
+
+    public Transaction getFeeEstimationTransactionForMultipleAddresses(Set<String> fromAddresses,
+                                                                       Coin amount,
+                                                                       Coin txFeeForWithdrawalPerVbyte)
+            throws AddressFormatException, AddressEntryException, InsufficientFundsException {
         Set<AddressEntry> addressEntries = fromAddresses.stream()
                 .map(address -> {
                     Optional<AddressEntry> addressEntryOptional = findAddressEntry(address, AddressEntry.Context.AVAILABLE);
@@ -1045,7 +1053,6 @@ public class BtcWalletService extends WalletService {
             int counter = 0;
             int txVsize = 0;
             Transaction tx;
-            Coin txFeeForWithdrawalPerVbyte = getTxFeeForWithdrawalPerVbyte();
             do {
                 counter++;
                 fee = txFeeForWithdrawalPerVbyte.multiply(txVsize);
@@ -1059,7 +1066,7 @@ public class BtcWalletService extends WalletService {
                 txVsize = tx.getVsize();
                 printTx("FeeEstimationTransactionForMultipleAddresses", tx);
             }
-            while (feeEstimationNotSatisfied(counter, tx));
+            while (feeEstimationNotSatisfied(counter, tx, txFeeForWithdrawalPerVbyte));
             if (counter == 10)
                 log.error("Could not calculate the fee. Tx=" + tx);
 
@@ -1072,7 +1079,11 @@ public class BtcWalletService extends WalletService {
     }
 
     private boolean feeEstimationNotSatisfied(int counter, Transaction tx) {
-        long targetFee = getTxFeeForWithdrawalPerVbyte().multiply(tx.getVsize()).value;
+        return feeEstimationNotSatisfied(counter, tx, getTxFeeForWithdrawalPerVbyte());
+    }
+
+    private boolean feeEstimationNotSatisfied(int counter, Transaction tx, Coin txFeeForWithdrawalPerVbyte) {
+        long targetFee = txFeeForWithdrawalPerVbyte.multiply(tx.getVsize()).value;
         return counter < 10 &&
                 (tx.getFee().value < targetFee ||
                         tx.getFee().value - targetFee > 1000);

--- a/core/src/main/java/bisq/core/dao/governance/bond/lockup/LockupTxService.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/lockup/LockupTxService.java
@@ -103,7 +103,7 @@ public class LockupTxService {
             throws InsufficientMoneyException, WalletException, TransactionVerificationException, IOException {
         byte[] opReturnData = BondConsensus.getLockupOpReturnData(lockTime, lockupReason, hash);
         Transaction preparedTx = bsqWalletService.getPreparedLockupTx(lockupAmount);
-        Transaction txWithBtcFee = btcWalletService.completePreparedBsqTx(preparedTx, true, opReturnData);
+        Transaction txWithBtcFee = btcWalletService.completePreparedBsqTx(preparedTx, opReturnData);
         Transaction transaction = bsqWalletService.signTx(txWithBtcFee);
         log.info("Lockup tx: " + transaction);
         return transaction;

--- a/core/src/main/java/bisq/core/dao/governance/bond/unlock/UnlockTxService.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/unlock/UnlockTxService.java
@@ -103,7 +103,7 @@ public class UnlockTxService {
         checkArgument(optionalLockupTxOutput.isPresent(), "lockupTxOutput must be present");
         TxOutput lockupTxOutput = optionalLockupTxOutput.get();
         Transaction preparedTx = bsqWalletService.getPreparedUnlockTx(lockupTxOutput);
-        Transaction txWithBtcFee = btcWalletService.completePreparedBsqTx(preparedTx, true, null);
+        Transaction txWithBtcFee = btcWalletService.completePreparedBsqTx(preparedTx, null);
         Transaction transaction = bsqWalletService.signTx(txWithBtcFee);
         log.info("Unlock tx: " + transaction);
         return transaction;

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -39,6 +39,8 @@ import bisq.proto.grpc.RemoveWalletPasswordReply;
 import bisq.proto.grpc.RemoveWalletPasswordRequest;
 import bisq.proto.grpc.SendBsqReply;
 import bisq.proto.grpc.SendBsqRequest;
+import bisq.proto.grpc.SendBtcReply;
+import bisq.proto.grpc.SendBtcRequest;
 import bisq.proto.grpc.SetTxFeeRatePreferenceReply;
 import bisq.proto.grpc.SetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.SetWalletPasswordReply;
@@ -57,10 +59,14 @@ import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 
+import com.google.common.util.concurrent.FutureCallback;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+
+import org.jetbrains.annotations.NotNull;
 
 import static bisq.core.api.model.TxInfo.toTxInfo;
 
@@ -167,10 +173,50 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
 
                         @Override
                         public void onFailure(TxBroadcastException ex) {
+                            log.error("", ex);
                             throw new IllegalStateException(ex);
                         }
                     });
         } catch (IllegalStateException cause) {
+            var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
+            responseObserver.onError(ex);
+            throw ex;
+        }
+    }
+
+    @Override
+    public void sendBtc(SendBtcRequest req,
+                        StreamObserver<SendBtcReply> responseObserver) {
+        try {
+            coreApi.sendBtc(req.getAddress(),
+                    req.getAmount(),
+                    req.getTxFeeRate(),
+                    new FutureCallback<>() {
+                        @Override
+                        public void onSuccess(Transaction tx) {
+                            if (tx != null) {
+                                log.info("Successfully published BTC tx: id {}, output sum {} sats, fee {} sats, size {} bytes",
+                                        tx.getTxId().toString(),
+                                        tx.getOutputSum(),
+                                        tx.getFee(),
+                                        tx.getMessageSize());
+                                var reply = SendBtcReply.newBuilder()
+                                        .setTxInfo(toTxInfo(tx).toProtoMessage())
+                                        .build();
+                                responseObserver.onNext(reply);
+                                responseObserver.onCompleted();
+                            } else {
+                                throw new IllegalStateException("btc transaction is null");
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(@NotNull Throwable t) {
+                            log.error("", t);
+                            throw new IllegalStateException(t);
+                        }
+                    });
+        } catch (IllegalStateException | IllegalArgumentException cause) {
             var ex = new StatusRuntimeException(Status.UNKNOWN.withDescription(cause.getMessage()));
             responseObserver.onError(ex);
             throw ex;

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -247,7 +247,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                 Coin receiverAmount = ParsingUtils.parseToCoin(amountInputTextField.getText(), bsqFormatter);
                 try {
                     Transaction preparedSendTx = bsqWalletService.getPreparedSendBsqTx(receiversAddressString, receiverAmount);
-                    Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx, true);
+                    Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx);
                     Transaction signedTx = bsqWalletService.signTx(txWithBtcFee);
                     Coin miningFee = signedTx.getFee();
                     int txVsize = signedTx.getVsize();
@@ -305,7 +305,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                 Coin receiverAmount = bsqFormatter.parseToBTC(btcAmountInputTextField.getText());
                 try {
                     Transaction preparedSendTx = bsqWalletService.getPreparedSendBtcTx(receiversAddressString, receiverAmount);
-                    Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx, true);
+                    Transaction txWithBtcFee = btcWalletService.completePreparedSendBsqTx(preparedSendTx);
                     Transaction signedTx = bsqWalletService.signTx(txWithBtcFee);
                     Coin miningFee = signedTx.getFee();
 

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -318,6 +318,8 @@ service Wallets {
     }
     rpc SendBsq (SendBsqRequest) returns (SendBsqReply) {
     }
+    rpc SendBtc (SendBtcRequest) returns (SendBtcReply) {
+    }
     rpc GetTxFeeRate (GetTxFeeRateRequest) returns (GetTxFeeRateReply) {
     }
     rpc SetTxFeeRatePreference (SetTxFeeRatePreferenceRequest) returns (SetTxFeeRatePreferenceReply) {
@@ -366,6 +368,16 @@ message SendBsqRequest {
 }
 
 message SendBsqReply {
+    TxInfo txInfo = 1;
+}
+
+message SendBtcRequest {
+    string address = 1;
+    string amount = 2;
+    string txFeeRate = 3;
+}
+
+message SendBtcReply {
     TxInfo txInfo = 1;
 }
 

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -288,6 +288,24 @@ message TradeInfo {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
+// Transactions
+///////////////////////////////////////////////////////////////////////////////////////////
+
+message TxFeeRateInfo {
+    bool useCustomTxFeeRate = 1;
+    uint64 customTxFeeRate = 2;
+    uint64 feeServiceRate = 3;
+    uint64 lastFeeServiceRequestTs = 4;
+}
+
+message TxInfo {
+    string id = 1;
+    uint64 outputSum = 2;
+    uint64 fee = 3;
+    int32 size = 4;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
 // Wallets
 ///////////////////////////////////////////////////////////////////////////////////////////
 
@@ -344,9 +362,11 @@ message GetUnusedBsqAddressReply {
 message SendBsqRequest {
     string address = 1;
     string amount = 2;
+    string txFeeRate = 3;
 }
 
 message SendBsqReply {
+    TxInfo txInfo = 1;
 }
 
 message GetTxFeeRateRequest {
@@ -435,13 +455,6 @@ message AddressBalanceInfo {
     string address = 1;
     int64 balance = 2;
     int64 numConfirmations = 3;
-}
-
-message TxFeeRateInfo {
-    bool useCustomTxFeeRate = 1;
-    uint64 customTxFeeRate = 2;
-    uint64 feeServiceRate = 3;
-    uint64 lastFeeServiceRequestTs = 4;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Takes an address, amount, and optional txfeerate param, returns a lightweight `TxInfo` proto.

Also overloaded two `BtcWalletService` methods to allow sendbtc to pass in the tx fee rate -- overriding the fee service and custom fee rate setting.


This is the 4th in a chain of PRs beginning with https://github.com/bisq-network/bisq/pull/4884.
PR https://github.com/bisq-network/bisq/pull/4900 should be reviewed before this one.