### PR TITLE
UI improvements

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/F2FForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/F2FForm.java
@@ -65,7 +65,7 @@ public class F2FForm extends PaymentMethodForm {
         addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.f2f.contact"),
                 f2fAccountPayload.getContact());
         TextArea textArea = addTopLabelTextArea(gridPane, gridRow, 1, Res.get("payment.f2f.extra"), "").second;
-        textArea.setPrefHeight(60);
+        textArea.setMinHeight(70);
         textArea.setEditable(false);
         textArea.setId("text-area-disabled");
         textArea.setText(offer.getF2FExtraInfo());
@@ -110,7 +110,7 @@ public class F2FForm extends PaymentMethodForm {
 
         TextArea extraTextArea = addTopLabelTextArea(gridPane, ++gridRow,
                 Res.get("payment.f2f.optionalExtra"), Res.get("payment.f2f.extra.prompt")).second;
-        extraTextArea.setPrefHeight(60);
+        extraTextArea.setMinHeight(70);
         ((JFXTextArea) extraTextArea).setLabelFloat(false);
         //extraTextArea.setValidator(f2fValidator);
         extraTextArea.textProperty().addListener((ov, oldValue, newValue) -> {
@@ -165,7 +165,7 @@ public class F2FForm extends PaymentMethodForm {
                 f2fAccount.getCity());
         TextArea textArea = addCompactTopLabelTextArea(gridPane, ++gridRow, Res.get("payment.f2f.extra"), "").second;
         textArea.setText(f2fAccount.getExtraInfo());
-        textArea.setPrefHeight(60);
+        textArea.setMinHeight(70);
         textArea.setEditable(false);
 
         addLimitations(true);

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/USPostalMoneyOrderForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/USPostalMoneyOrderForm.java
@@ -47,7 +47,7 @@ public class USPostalMoneyOrderForm extends PaymentMethodForm {
         addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.account.owner"),
                 ((USPostalMoneyOrderAccountPayload) paymentAccountPayload).getHolderName());
         TextArea textArea = addCompactTopLabelTextArea(gridPane, ++gridRow, Res.get("payment.postal.address"), "").second;
-        textArea.setPrefHeight(70);
+        textArea.setMinHeight(70);
         textArea.setEditable(false);
         textArea.setId("text-area-disabled");
         textArea.setText(((USPostalMoneyOrderAccountPayload) paymentAccountPayload).getPostalAddress());
@@ -76,7 +76,7 @@ public class USPostalMoneyOrderForm extends PaymentMethodForm {
 
         postalAddressTextArea = addTopLabelTextArea(gridPane, ++gridRow,
                 Res.get("payment.postal.address"), "").second;
-        postalAddressTextArea.setPrefHeight(70);
+        postalAddressTextArea.setMinHeight(70);
         //postalAddressTextArea.setValidator(usPostalMoneyOrderValidator);
         postalAddressTextArea.textProperty().addListener((ov, oldValue, newValue) -> {
             usPostalMoneyOrderAccount.setPostalAddress(newValue);
@@ -108,7 +108,7 @@ public class USPostalMoneyOrderForm extends PaymentMethodForm {
                 usPostalMoneyOrderAccount.getHolderName());
         TextArea textArea = addCompactTopLabelTextArea(gridPane, ++gridRow, Res.get("payment.postal.address"), "").second;
         textArea.setText(usPostalMoneyOrderAccount.getPostalAddress());
-        textArea.setPrefHeight(70);
+        textArea.setMinHeight(70);
         textArea.setEditable(false);
         TradeCurrency singleTradeCurrency = usPostalMoneyOrderAccount.getSingleTradeCurrency();
         String nameAndCode = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "null";

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
@@ -157,4 +157,8 @@ class AltCoinAccountsDataModel extends ActivatableDataModel {
     public void importAccounts(Stage stage) {
         GUIUtil.importAccounts(user, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler);
     }
+
+    public int getNumPaymentAccounts() {
+        return user.getPaymentAccounts() != null ? user.getPaymentAccounts().size() : 0;
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.fxml
@@ -31,6 +31,6 @@
         <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
     </padding>
     <columnConstraints>
-        <ColumnConstraints hgrow="NEVER" minWidth="300.0"/>
+        <ColumnConstraints hgrow="ALWAYS" minWidth="300.0"/>
     </columnConstraints>
 </GridPane>

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
@@ -177,7 +177,8 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
 
         Tuple3<Label, ListView<PaymentAccount>, VBox> tuple = addTopLabelListView(root, gridRow, Res.get("account.altcoin.yourAltcoinAccounts"), Layout.FIRST_ROW_DISTANCE);
         paymentAccountsListView = tuple.second;
-        paymentAccountsListView.setMinHeight(2 * Layout.LIST_ROW_HEIGHT + 14);
+        int prefNumRows = Math.min(4, Math.max(2, model.dataModel.getNumPaymentAccounts()));
+        paymentAccountsListView.setMinHeight(prefNumRows * Layout.LIST_ROW_HEIGHT + 28);
         setPaymentAccountsCellFactory();
 
         Tuple3<Button, Button, Button> tuple3 = add3ButtonsAfterGroup(root, ++gridRow, Res.get("shared.addNewAccount"),

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
@@ -160,4 +160,8 @@ class FiatAccountsDataModel extends ActivatableDataModel {
     public void importAccounts(Stage stage) {
         GUIUtil.importAccounts(user, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler);
     }
+
+    public int getNumPaymentAccounts() {
+        return user.getPaymentAccounts() != null ? user.getPaymentAccounts().size() : 0;
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -362,7 +362,8 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
 
         Tuple3<Label, ListView<PaymentAccount>, VBox> tuple = addTopLabelListView(root, gridRow, Res.get("account.fiat.yourFiatAccounts"), Layout.FIRST_ROW_DISTANCE);
         paymentAccountsListView = tuple.second;
-        paymentAccountsListView.setMinHeight(2 * Layout.LIST_ROW_HEIGHT + 14);
+        int prefNumRows = Math.min(4, Math.max(2, model.dataModel.getNumPaymentAccounts()));
+        paymentAccountsListView.setMinHeight(prefNumRows * Layout.LIST_ROW_HEIGHT + 28);
         setPaymentAccountsCellFactory();
 
         Tuple3<Button, Button, Button> tuple3 = add3ButtonsAfterGroup(root, ++gridRow, Res.get("shared.addNewAccount"),

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -135,8 +135,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private BusyAnimation waitingForFundsSpinner;
     private AutoTooltipButton nextButton, cancelButton1, cancelButton2, placeOfferButton;
     private Button priceTypeToggleButton;
-    private InputTextField fixedPriceTextField;
-    private InputTextField marketBasedPriceTextField;
+    private InputTextField fixedPriceTextField, marketBasedPriceTextField;
     protected InputTextField amountTextField, minAmountTextField, volumeTextField, buyerSecurityDepositInputTextField;
     private TextField currencyTextField;
     private AddressTextField addressTextField;
@@ -154,7 +153,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             currencyTextFieldBox;
     private HBox fundingHBox, firstRowHBox, secondRowHBox, placeOfferBox, amountValueCurrencyBox,
             priceAsPercentageValueCurrencyBox, volumeValueCurrencyBox, priceValueCurrencyBox,
-            minAmountValueCurrencyBox, advancedOptionsBox, paymentGroupBox;
+            minAmountValueCurrencyBox, advancedOptionsBox;
 
     private Subscription isWaitingForFundsSubscription, balanceSubscription;
     private ChangeListener<Boolean> amountFocusedListener, minAmountFocusedListener, volumeFocusedListener,
@@ -988,7 +987,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         paymentTitledGroupBg = addTitledGroupBg(gridPane, gridRow, 1, Res.get("shared.selectTradingAccount"));
         GridPane.setColumnSpan(paymentTitledGroupBg, 2);
 
-        paymentGroupBox = new HBox();
+        HBox paymentGroupBox = new HBox();
         paymentGroupBox.setAlignment(Pos.CENTER_LEFT);
         paymentGroupBox.setSpacing(12);
         paymentGroupBox.setPadding(new Insets(10, 0, 18, 0));

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -122,7 +122,6 @@ import static bisq.desktop.util.FormBuilder.*;
 import static javafx.beans.binding.Bindings.createStringBinding;
 
 public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> extends ActivatableViewAndModel<AnchorPane, M> {
-    public static final String BUYER_SECURITY_DEPOSIT_NEWS = "buyerSecurityDepositNews0.9.5";
     protected final Navigation navigation;
     private final Preferences preferences;
     private final OfferDetailsWindow offerDetailsWindow;

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -1037,12 +1037,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         paymentGroupBox.getChildren().add(currencyTextFieldBox);
     }
 
-    protected void hidePaymentGroup() {
-        paymentTitledGroupBg.setVisible(false);
-        paymentGroupBox.setManaged(false);
-        paymentGroupBox.setVisible(false);
-    }
-
     private void addAmountPriceGroup() {
         amountTitledGroupBg = addTitledGroupBg(gridPane, ++gridRow, 2,
                 Res.get("createOffer.setAmountPrice"), Layout.COMPACT_GROUP_DISTANCE);

--- a/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
@@ -53,8 +53,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static bisq.desktop.main.offer.MutableOfferView.BUYER_SECURITY_DEPOSIT_NEWS;
-
 public abstract class OfferView extends ActivatableView<TabPane, Void> {
 
     private OfferBookView offerBookView;
@@ -273,8 +271,6 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
         offerBookView.enableCreateOfferButton();
 
         navigation.navigateTo(MainView.class, this.getClass(), OfferBookView.class);
-
-        preferences.dontShowAgain(BUYER_SECURITY_DEPOSIT_NEWS, true);
     }
 
     private void onTakeOfferViewRemoved() {


### PR DESCRIPTION
Small UI improvements
- Make altcoin account screen 2 colums wide (same as fiat accounts)
- Increase text area height
- increase number of visible rows in accounts for better scolling

Cleanups
- Remove old `buyerSecurityDepositNews0.9.5` flag
- Remove unused method
- Make field local