### PR TITLE
Property fields must not be set from non JavaFX threads.

### DIFF
--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -242,14 +242,16 @@ public class WalletsSetup {
                     return message;
                 });
 
-                chainHeight.set(chain.getBestChainHeight());
                 chain.addNewBestBlockListener(block -> {
-                    connectedPeers.set(peerGroup.getConnectedPeers());
-                    chainHeight.set(block.getHeight());
+                    UserThread.execute(() -> {
+                        connectedPeers.set(peerGroup.getConnectedPeers());
+                        chainHeight.set(block.getHeight());
+                    });
                 });
 
                 // Map to user thread
                 UserThread.execute(() -> {
+                    chainHeight.set(chain.getBestChainHeight());
                     addressEntryList.onWalletReady(walletConfig.btcWallet());
                     timeoutTimer.stop();
                     setupCompletedHandlers.forEach(Runnable::run);


### PR DESCRIPTION
So we map those setters to our UserThread.

How to reproduce issue?
Restore from seed triggered following exception:

Dec-08 13:20:04.547 [ STARTING] ERROR bisq.common.setup.CommonSetup: Stack trace:
java.lang.IllegalStateException: Not on FX application thread; currentThread =  STARTING
	at com.sun.javafx.tk.Toolkit.checkFxUserThread(Toolkit.java:291)
	at com.sun.javafx.tk.quantum.QuantumToolkit.checkFxUserThread(QuantumToolkit.java:424)
	at javafx.scene.Parent$3.onProposedChange(Parent.java:471)
	at com.sun.javafx.collections.VetoableListDecorator.setAll(VetoableListDecorator.java:113)
	at com.sun.javafx.collections.VetoableListDecorator.setAll(VetoableListDecorator.java:108)
	at javafx.scene.control.skin.LabeledSkinBase.updateChildren(LabeledSkinBase.java:272)
	at javafx.scene.control.skin.LabeledSkinBase.lambda$new$11(LabeledSkinBase.java:220)
	at com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler.lambda$new$1(LambdaMultiplePropertyChangeListenerHandler.java:49)
	at javafx.beans.value.WeakChangeListener.changed(WeakChangeListener.java:86)
	at com.sun.javafx.binding.ExpressionHelper$SingleChange.fireValueChangedEvent(ExpressionHelper.java:181)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:80)
	at javafx.beans.property.StringPropertyBase.fireValueChangedEvent(StringPropertyBase.java:104)
	at javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:111)
	at javafx.beans.property.StringPropertyBase.access$000(StringPropertyBase.java:50)
	at javafx.beans.property.StringPropertyBase$Listener.invalidated(StringPropertyBase.java:231)
	at com.sun.javafx.binding.ExpressionHelper$SingleInvalidation.fireValueChangedEvent(ExpressionHelper.java:136)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:80)
	at javafx.beans.property.StringPropertyBase.fireValueChangedEvent(StringPropertyBase.java:104)
	at javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:111)
	at javafx.beans.property.StringPropertyBase.access$000(StringPropertyBase.java:50)
	at javafx.beans.property.StringPropertyBase$Listener.invalidated(StringPropertyBase.java:231)
	at com.sun.javafx.binding.ExpressionHelper$Generic.fireValueChangedEvent(ExpressionHelper.java:348)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:80)
	at javafx.beans.property.StringPropertyBase.fireValueChangedEvent(StringPropertyBase.java:104)
	at javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:111)
	at javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:145)
	at javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:50)
	at bisq.core.app.WalletAppSetup.lambda$init$1(WalletAppSetup.java:170)
	at com.sun.javafx.binding.ExpressionHelper$SingleChange.fireValueChangedEvent(ExpressionHelper.java:181)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:80)
	at javafx.beans.binding.ObjectBinding.invalidate(ObjectBinding.java:170)
	at com.sun.javafx.binding.BindingHelperObserver.invalidated(BindingHelperObserver.java:52)
	at com.sun.javafx.binding.ExpressionHelper$SingleInvalidation.fireValueChangedEvent(ExpressionHelper.java:136)
	at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:80)
	at javafx.beans.property.IntegerPropertyBase.fireValueChangedEvent(IntegerPropertyBase.java:107)
	at javafx.beans.property.IntegerPropertyBase.markInvalid(IntegerPropertyBase.java:114)
	at javafx.beans.property.IntegerPropertyBase.set(IntegerPropertyBase.java:148)
	at bisq.core.btc.setup.WalletsSetup$1.onSetupCompleted(WalletsSetup.java:245)

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.
