### PR TITLE
Detect missing deposit tx to allow moving to failed trades

### DIFF
--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -1030,6 +1030,7 @@ public abstract class Trade implements Tradable, Model {
         return offer.getOfferFeePaymentTxId() == null ||
                 getTakerFeeTxId() == null ||
                 getDepositTxId() == null ||
+                getDepositTx() == null ||
                 getDelayedPayoutTxBytes() == null;
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.overlays.windows;
 
 import bisq.desktop.components.BisqTextArea;
 import bisq.desktop.components.TextFieldWithCopyIcon;
+import bisq.desktop.components.TxIdTextField;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.util.DisplayUtils;
@@ -285,9 +286,17 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         addLabelTxIdTextField(gridPane, ++rowIndex, Res.get("shared.makerFeeTxId"), offer.getOfferFeePaymentTxId());
         addLabelTxIdTextField(gridPane, ++rowIndex, Res.get("shared.takerFeeTxId"), trade.getTakerFeeTxId());
 
+        String depositTxId = trade.getDepositTxId();
         Transaction depositTx = trade.getDepositTx();
-        String depositTxString = depositTx != null ? depositTx.getTxId().toString() : null;
-        addLabelTxIdTextField(gridPane, ++rowIndex, Res.get("shared.depositTransactionId"), depositTxString);
+        String depositTxIdFromTx = depositTx != null ? depositTx.getTxId().toString() : null;
+        TxIdTextField depositTxIdTextField = addLabelTxIdTextField(gridPane, ++rowIndex,
+                Res.get("shared.depositTransactionId"), depositTxId).second;
+        if (depositTxId == null || !depositTxId.equals(depositTxIdFromTx)) {
+            depositTxIdTextField.getTextField().setId("address-text-field-error");
+            log.error("trade.getDepositTxId() and trade.getDepositTx().getTxId().toString() are not the same. " +
+                            "trade.getDepositTxId()={}, trade.getDepositTx().getTxId().toString()={}, depositTx={}",
+                    depositTxId, depositTxIdFromTx, depositTx);
+        }
 
         Transaction delayedPayoutTx = trade.getDelayedPayoutTx(btcWalletService);
         String delayedPayoutTxString = delayedPayoutTx != null ? delayedPayoutTx.getTxId().toString() : null;


### PR DESCRIPTION
We got some reports where users have no deposit tx displayed in the
trade after spv resync but cannot move the trade to failed trades.
It seems the invalid txId is still stored in the trade but the tx itself
got removed from the wallet after reysnc. We check not that both the tx
and the txId need to be present.

Fixes https://github.com/bisq-network/bisq/issues/4905
