### PR TITLE
Use HistoricalDataStoreService for AccountAgeWitnessStorageService 

### DIFF
--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessStorageService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessStorageService.java
@@ -17,9 +17,8 @@
 
 package bisq.core.account.witness;
 
-import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
-import bisq.network.p2p.storage.persistence.MapStoreService;
+import bisq.network.p2p.storage.persistence.HistoricalDataStoreService;
 
 import bisq.common.config.Config;
 import bisq.common.persistence.PersistenceManager;
@@ -29,12 +28,10 @@ import javax.inject.Named;
 
 import java.io.File;
 
-import java.util.Map;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class AccountAgeWitnessStorageService extends MapStoreService<AccountAgeWitnessStore, PersistableNetworkPayload> {
+public class AccountAgeWitnessStorageService extends HistoricalDataStoreService<AccountAgeWitnessStore> {
     private static final String FILE_NAME = "AccountAgeWitnessStore";
 
 
@@ -48,14 +45,10 @@ public class AccountAgeWitnessStorageService extends MapStoreService<AccountAgeW
         super(storageDir, persistenceManager);
     }
 
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
-
-    @Override
-    protected void initializePersistenceManager() {
-        persistenceManager.initialize(store, PersistenceManager.Source.NETWORK);
-    }
 
     @Override
     public String getFileName() {
@@ -63,8 +56,8 @@ public class AccountAgeWitnessStorageService extends MapStoreService<AccountAgeW
     }
 
     @Override
-    public Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> getMap() {
-        return store.getMap();
+    protected void initializePersistenceManager() {
+        persistenceManager.initialize(store, PersistenceManager.Source.NETWORK);
     }
 
     @Override

--- a/desktop/package/macosx/copy_dbs.sh
+++ b/desktop/package/macosx/copy_dbs.sh
@@ -12,6 +12,6 @@ resDir=p2p/src/main/resources
 # Only commit new TradeStatistics3Store if you plan to add it to
 # https://github.com/bisq-network/bisq/blob/0345c795e2c227d827a1f239a323dda1250f4e69/common/src/main/java/bisq/common/app/Version.java#L40 as well.
 cp "$dbDir/TradeStatistics3Store" "$resDir/TradeStatistics3Store_${version}_BTC_MAINNET"
-cp "$dbDir/AccountAgeWitnessStore" "$resDir/AccountAgeWitnessStore_BTC_MAINNET"
+cp "$dbDir/AccountAgeWitnessStore" "$resDir/AccountAgeWitnessStore_${version}_BTC_MAINNET"
 cp "$dbDir/DaoStateStore" "$resDir/DaoStateStore_BTC_MAINNET"
 cp "$dbDir/SignedWitnessStore" "$resDir/SignedWitnessStore_BTC_MAINNET"

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
@@ -192,10 +192,7 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
                     pruneStore(persisted, version);
                     completeHandler.run();
                 },
-                () -> {
-                    log.warn("Resource file with file name {} does not exits.", fileName);
-                    completeHandler.run();
-                });
+                completeHandler::run);
     }
 
     private void pruneStore(PersistableNetworkPayloadStore<? extends PersistableNetworkPayload> historicalStore,


### PR DESCRIPTION
Use HistoricalDataStoreService for AccountAgeWitnessStorageService 

@ripcurlx We need to deploy the resource file with the version number and add the version to Version.HISTORICAL_RESOURCE_FILE_VERSION_TAGS. It is not required that we update all HistoricalDataStores (e.g. we can deploay the AccountAgeWitnessStore_1.5.2 but no new TradeStatistics2Store...