### PR TITLE
Improve TransferWise account

### DIFF
--- a/core/src/main/java/bisq/core/payment/TransferwiseAccount.java
+++ b/core/src/main/java/bisq/core/payment/TransferwiseAccount.java
@@ -17,7 +17,6 @@
 
 package bisq.core.payment;
 
-import bisq.core.locale.CurrencyUtil;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.payment.payload.TransferwiseAccountPayload;
@@ -28,8 +27,6 @@ import lombok.EqualsAndHashCode;
 public final class TransferwiseAccount extends PaymentAccount {
     public TransferwiseAccount() {
         super(PaymentMethod.TRANSFERWISE);
-
-        tradeCurrencies.addAll(CurrencyUtil.getAllTransferwiseCurrencies());
     }
 
     @Override

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3152,6 +3152,7 @@ payment.venmo.venmoUserName=Venmo username
 payment.popmoney.accountId=Email or phone no.
 payment.promptPay.promptPayId=Citizen ID/Tax ID or phone no.
 payment.supportedCurrencies=Supported currencies
+payment.supportedCurrenciesForReceiver=Currencies for receiving funds
 payment.limitations=Limitations
 payment.salt=Salt for account age verification
 payment.error.noHexSalt=The salt needs to be in HEX format.\n\

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/TransferwiseForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/TransferwiseForm.java
@@ -78,7 +78,7 @@ public class TransferwiseForm extends PaymentMethodForm {
 
     private void addCurrenciesGrid(boolean isEditable) {
         FlowPane flowPane = FormBuilder.addTopLabelFlowPane(gridPane, ++gridRow,
-                Res.get("payment.supportedCurrencies"), 20, 20).second;
+                Res.get("payment.supportedCurrenciesForReceiver"), 20, 20).second;
 
         if (isEditable) {
             flowPane.setId("flow-pane-checkboxes-bg");


### PR DESCRIPTION
Rename 'Supported currencies' to 'Currencies for receiving funds'
Do not autofill all currencies by default but keep all unselected. 