### PR TITLE
Show price deviation in % for fixed price offers and BSQ

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -1010,12 +1010,12 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                             }
 
                             @Override
-                            public void updateItem(final OfferBookListItem newItem, boolean empty) {
-                                super.updateItem(newItem, empty);
+                            public void updateItem(final OfferBookListItem item, boolean empty) {
+                                super.updateItem(item, empty);
 
                                 TableRow<OfferBookListItem> tableRow = getTableRow();
-                                if (newItem != null && !empty) {
-                                    final Offer offer = newItem.getOffer();
+                                if (item != null && !empty) {
+                                    final Offer offer = item.getOffer();
                                     boolean myOffer = model.isMyOffer(offer);
                                     if (tableRow != null) {
                                         isPaymentAccountValidForOffer = model.isAnyPaymentAccountValidForOffer(offer);

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -49,6 +49,7 @@ import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.FiatCurrency;
 import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
+import bisq.core.monetary.Price;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.offer.OfferRestrictions;
@@ -86,6 +87,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.scene.text.TextAlignment;
 
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
@@ -107,8 +109,6 @@ import javafx.util.StringConverter;
 
 import java.util.Comparator;
 import java.util.Optional;
-
-import org.jetbrains.annotations.NotNull;
 
 import static bisq.desktop.util.FormBuilder.addTitledGroupBg;
 
@@ -241,7 +241,31 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 o -> CurrencyUtil.getCurrencyPair(o.getOffer().getCurrencyCode()),
                 Comparator.nullsFirst(Comparator.naturalOrder())
         ));
-        priceColumn.setComparator(Comparator.comparing(o -> o.getOffer().getPrice(), Comparator.nullsFirst(Comparator.naturalOrder())));
+
+        // We sort by % so we can also sort if SHOW ALL is selected
+        Comparator<OfferBookListItem> marketBasedPriceComparator = (o1, o2) -> {
+            Optional<Double> marketBasedPrice1 = model.getMarketBasedPrice(o1.getOffer());
+            Optional<Double> marketBasedPrice2 = model.getMarketBasedPrice(o2.getOffer());
+            if (marketBasedPrice1.isPresent() && marketBasedPrice2.isPresent()) {
+                return Double.compare(marketBasedPrice1.get(), marketBasedPrice2.get());
+            } else {
+                return 0;
+            }
+        };
+        // If we do not have a % price we use only fix price and sort by that
+        priceColumn.setComparator(marketBasedPriceComparator.thenComparing((o1, o2) -> {
+            Price price2 = o2.getOffer().getPrice();
+            Price price1 = o1.getOffer().getPrice();
+            if (price2 == null || price1 == null) {
+                return 0;
+            }
+            if (model.getDirection() == OfferPayload.Direction.SELL) {
+                return price1.compareTo(price2);
+            } else {
+                return price2.compareTo(price1);
+            }
+        }));
+
         amountColumn.setComparator(Comparator.comparing(o -> o.getOffer().getMinAmount()));
         volumeColumn.setComparator(Comparator.comparing(o -> o.getOffer().getMinVolume(), Comparator.nullsFirst(Comparator.naturalOrder())));
         paymentMethodColumn.setComparator(Comparator.comparing(o -> Res.get(o.getOffer().getPaymentMethod().getId())));
@@ -308,10 +332,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         currencyComboBox.getEditor().setText(new CurrencyStringConverter(currencyComboBox).toString(currencyComboBox.getSelectionModel().getSelectedItem()));
 
         volumeColumn.sortableProperty().bind(model.showAllTradeCurrenciesProperty.not());
-        priceColumn.sortableProperty().bind(model.showAllTradeCurrenciesProperty.not());
         model.getOfferList().comparatorProperty().bind(tableView.comparatorProperty());
-        model.priceSortTypeProperty.addListener((observable, oldValue, newValue) -> priceColumn.setSortType(newValue));
-        priceColumn.setSortType(model.priceSortTypeProperty.get());
 
         amountColumn.sortTypeProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue == TableColumn.SortType.DESCENDING) {
@@ -751,7 +772,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
     private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> getPriceColumn() {
         AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> column = new AutoTooltipTableColumn<>("") {
             {
-                setMinWidth(100);
+                setMinWidth(130);
             }
         };
         column.getStyleClass().add("number-column");
@@ -767,37 +788,40 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
-                                    setGraphic(getPriceLabel(model.getPrice(item), item));
+                                    setGraphic(getPriceAndPercentage(item));
                                 } else {
                                     setGraphic(null);
                                 }
                             }
 
-                            @NotNull
-                            private AutoTooltipLabel getPriceLabel(String priceString, OfferBookListItem item) {
-                                final Offer offer = item.getOffer();
-                                final MaterialDesignIcon icon = offer.isUseMarketBasedPrice() ? MaterialDesignIcon.CHART_LINE : MaterialDesignIcon.LOCK;
-
+                            private HBox getPriceAndPercentage(OfferBookListItem item) {
+                                Offer offer = item.getOffer();
+                                boolean useMarketBasedPrice = offer.isUseMarketBasedPrice();
+                                MaterialDesignIcon icon = useMarketBasedPrice ? MaterialDesignIcon.CHART_LINE : MaterialDesignIcon.LOCK;
                                 String info;
 
-                                if (offer.isUseMarketBasedPrice()) {
-                                    if (offer.getMarketPriceMargin() == 0) {
+                                if (useMarketBasedPrice) {
+                                    double marketPriceMargin = offer.getMarketPriceMargin();
+                                    if (marketPriceMargin == 0) {
                                         if (offer.isBuyOffer()) {
                                             info = Res.get("offerbook.info.sellAtMarketPrice");
                                         } else {
                                             info = Res.get("offerbook.info.buyAtMarketPrice");
                                         }
-                                    } else if (offer.getMarketPriceMargin() > 0) {
-                                        if (offer.isBuyOffer()) {
-                                            info = Res.get("offerbook.info.sellBelowMarketPrice", model.getAbsolutePriceMargin(offer));
-                                        } else {
-                                            info = Res.get("offerbook.info.buyAboveMarketPrice", model.getAbsolutePriceMargin(offer));
-                                        }
                                     } else {
-                                        if (offer.isBuyOffer()) {
-                                            info = Res.get("offerbook.info.sellAboveMarketPrice", model.getAbsolutePriceMargin(offer));
+                                        String absolutePriceMargin = model.getAbsolutePriceMargin(offer);
+                                        if (marketPriceMargin > 0) {
+                                            if (offer.isBuyOffer()) {
+                                                info = Res.get("offerbook.info.sellBelowMarketPrice", absolutePriceMargin);
+                                            } else {
+                                                info = Res.get("offerbook.info.buyAboveMarketPrice", absolutePriceMargin);
+                                            }
                                         } else {
-                                            info = Res.get("offerbook.info.buyBelowMarketPrice", model.getAbsolutePriceMargin(offer));
+                                            if (offer.isBuyOffer()) {
+                                                info = Res.get("offerbook.info.sellAboveMarketPrice", absolutePriceMargin);
+                                            } else {
+                                                info = Res.get("offerbook.info.buyBelowMarketPrice", absolutePriceMargin);
+                                            }
                                         }
                                     }
                                 } else {
@@ -807,8 +831,17 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                                         info = Res.get("offerbook.info.buyAtFixedPrice");
                                     }
                                 }
+                                InfoAutoTooltipLabel priceLabel = new InfoAutoTooltipLabel(model.getPrice(item),
+                                        icon, ContentDisplay.RIGHT, info);
+                                priceLabel.setTextAlignment(TextAlignment.RIGHT);
+                                AutoTooltipLabel percentageLabel = new AutoTooltipLabel(model.getPriceAsPercentage(item));
+                                percentageLabel.setOpacity(useMarketBasedPrice ? 1 : 0.4);
 
-                                return new InfoAutoTooltipLabel(priceString, icon, ContentDisplay.RIGHT, info);
+                                HBox hBox = new HBox();
+                                hBox.setSpacing(5);
+                                hBox.getChildren().addAll(priceLabel, percentageLabel);
+                                hBox.setPadding(new Insets(7, 0, 0, 0));
+                                return hBox;
                             }
                         };
                     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -239,9 +239,12 @@ class OfferBookViewModel extends ActivatableViewModel {
         applyFilterPredicate();
         setMarketPriceFeedCurrency();
 
-        bsq30DayAveragePrice = AveragePriceUtil.getAveragePriceTuple(preferences,
-                tradeStatisticsManager,
-                30).second;
+        // Null check needed for tests passing null for tradeStatisticsManager
+        if (tradeStatisticsManager != null) {
+            bsq30DayAveragePrice = AveragePriceUtil.getAveragePriceTuple(preferences,
+                    tradeStatisticsManager,
+                    30).second;
+        }
     }
 
     @Override

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -41,9 +41,9 @@ import bisq.core.payment.payload.SepaAccountPayload;
 import bisq.core.payment.payload.SpecificBanksAccountPayload;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.coin.ImmutableCoinFormatter;
-import bisq.core.util.coin.BsqFormatter;
 
 import bisq.common.config.Config;
 
@@ -229,7 +229,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         assertEquals(0, model.maxPlacesForAmount.intValue());
     }
 
@@ -243,7 +243,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         model.activate();
 
         assertEquals(6, model.maxPlacesForAmount.intValue());
@@ -261,7 +261,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         model.activate();
 
         assertEquals(15, model.maxPlacesForAmount.intValue());
@@ -280,7 +280,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         assertEquals(0, model.maxPlacesForVolume.intValue());
     }
 
@@ -294,7 +294,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         model.activate();
 
         assertEquals(5, model.maxPlacesForVolume.intValue());
@@ -312,7 +312,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         model.activate();
 
         assertEquals(9, model.maxPlacesForVolume.intValue());
@@ -331,7 +331,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         assertEquals(0, model.maxPlacesForPrice.intValue());
     }
 
@@ -345,7 +345,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         model.activate();
 
         assertEquals(7, model.maxPlacesForPrice.intValue());
@@ -363,7 +363,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         assertEquals(0, model.maxPlacesForMarketPriceMargin.intValue());
     }
 
@@ -391,7 +391,7 @@ public class OfferBookViewModelTest {
         offerBookListItems.addAll(item1, item2);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, priceFeedService,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
         model.activate();
 
         assertEquals(8, model.maxPlacesForMarketPriceMargin.intValue()); //" (1.97%)"
@@ -412,7 +412,7 @@ public class OfferBookViewModelTest {
         when(priceFeedService.getMarketPrice(anyString())).thenReturn(new MarketPrice("USD", 12684.0450, Instant.now().getEpochSecond(), true));
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, null, coinFormatter, new BsqFormatter());
+                null, null, null, null, null, coinFormatter, new BsqFormatter());
 
         final OfferBookListItem item = make(btcBuyItem.but(
                 with(useMarketBasedPrice, true),
@@ -429,13 +429,15 @@ public class OfferBookViewModelTest {
         offerBookListItems.addAll(lowItem, fixedItem);
         model.activate();
 
-        assertEquals("12557.2046 (1.00%)", model.getPrice(lowItem));
+
+        assertEquals("12557.2046", model.getPrice(lowItem));
+        assertEquals("(1.00%)", model.getPriceAsPercentage(lowItem));
         assertEquals("10.0000", model.getPrice(fixedItem));
         offerBookListItems.addAll(item);
-        assertEquals("14206.1304 (-12.00%)", model.getPrice(item));
-        assertEquals("12557.2046 (1.00%)", model.getPrice(lowItem));
-
-
+        assertEquals("14206.1304", model.getPrice(item));
+        assertEquals("(-12.00%)", model.getPriceAsPercentage(item));
+        assertEquals("12557.2046", model.getPrice(lowItem));
+        assertEquals("(1.00%)", model.getPriceAsPercentage(lowItem));
     }
 
     private PaymentAccount getAliPayAccount(String currencyCode) {


### PR DESCRIPTION
Add price deviation in % to fix price offers and BSQ (using 30 day average)
Allow sorting by % price in "show all" mode.

There are performance issues in the offer book as we use the view model for the item value calculations and do not cache the values. With those changes here it got worse. So we need to refactor the handling of the ListItem so that the ListItem caches the data and only updates when needed (e.g. when a market price feed update arrives). There will be follow up commits for that.

UPDATE:
The issue was the 30 day average BSQ price which was calculated too frequently. This is fixed now and the table behaves similar like the master version. Still need for performance improvement in that area, but seems that PR does not make things worse.