### PR TITLE
Improve offer publishing

### DIFF
--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -900,12 +900,10 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         offerBookService.addOffer(openOffer.getOffer(),
                 () -> {
                     if (!stopped) {
-                        log.debug("Successfully added offer to P2P network.");
                         // Refresh means we send only the data needed to refresh the TTL (hash, signature and sequence no.)
-                        if (periodicRefreshOffersTimer == null)
+                        if (periodicRefreshOffersTimer == null) {
                             startPeriodicRefreshOffersTimer();
-                    } else {
-                        log.debug("We have stopped already. We ignore that offerBookService.republishOffers.onSuccess call.");
+                        }
                     }
                 },
                 errorMessage -> {
@@ -914,26 +912,21 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                         stopRetryRepublishOffersTimer();
                         retryRepublishOffersTimer = UserThread.runAfter(OpenOfferManager.this::republishOffers,
                                 RETRY_REPUBLISH_DELAY_SEC);
-                    } else {
-                        log.debug("We have stopped already. We ignore that offerBookService.republishOffers.onFault call.");
                     }
                 });
     }
 
     private void startPeriodicRepublishOffersTimer() {
         stopped = false;
-        if (periodicRepublishOffersTimer == null)
+        if (periodicRepublishOffersTimer == null) {
             periodicRepublishOffersTimer = UserThread.runPeriodically(() -> {
                         if (!stopped) {
                             republishOffers();
-                        } else {
-                            log.debug("We have stopped already. We ignore that periodicRepublishOffersTimer.run call.");
                         }
                     },
                     REPUBLISH_INTERVAL_MS,
                     TimeUnit.MILLISECONDS);
-        else
-            log.trace("periodicRepublishOffersTimer already stated");
+        }
     }
 
     private void startPeriodicRefreshOffersTimer() {

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -880,10 +880,10 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
             return;
         }
 
+        stopPeriodicRefreshOffersTimer();
+
         List<OpenOffer> openOffersList = new ArrayList<>(openOffers.getList());
         processListForRepublishOffers(openOffersList);
-
-        stopPeriodicRefreshOffersTimer();
     }
 
     private void processListForRepublishOffers(List<OpenOffer> list) {

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -893,9 +893,14 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
         OpenOffer openOffer = list.remove(0);
         if (openOffers.contains(openOffer) && !openOffer.isDeactivated()) {
-            republishOffer(openOffer,
+            // TODO It is not clear yet if it is better for the node and the network to send out all add offer
+            //  messages in one go or to spread it over a delay. With power users who have 100-200 offers that can have
+            //  some significant impact to user experience and the network
+            republishOffer(openOffer, () -> processListForRepublishOffers(list));
+
+           /* republishOffer(openOffer,
                     () -> UserThread.runAfter(() -> processListForRepublishOffers(list),
-                            30, TimeUnit.MILLISECONDS));
+                            30, TimeUnit.MILLISECONDS));*/
         } else {
             // If the offer was removed in the meantime or if its deactivated we skip and call
             // processListForRepublishOffers again with the list where we removed the offer already.

--- a/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
@@ -49,7 +49,7 @@ public class OpenOfferManagerTest {
         final OpenOfferManager manager = new OpenOfferManager(null, null, null, p2PService,
                 null, null, null, offerBookService,
                 null, null, null,
-                null, null, null, null, null, null,
+                null, null, null, null, null, null, null,
                 persistenceManager);
 
         AtomicBoolean startEditOfferSuccessful = new AtomicBoolean(false);
@@ -81,7 +81,7 @@ public class OpenOfferManagerTest {
         final OpenOfferManager manager = new OpenOfferManager(null, null, null, p2PService,
                 null, null, null, offerBookService,
                 null, null, null,
-                null, null, null, null, null, null,
+                null, null, null, null, null, null, null,
                 persistenceManager);
 
         AtomicBoolean startEditOfferSuccessful = new AtomicBoolean(false);
@@ -106,7 +106,7 @@ public class OpenOfferManagerTest {
         final OpenOfferManager manager = new OpenOfferManager(null, null, null, p2PService,
                 null, null, null, offerBookService,
                 null, null, null,
-                null, null, null, null, null, null,
+                null, null, null, null, null, null, null,
                 persistenceManager);
 
         AtomicBoolean startEditOfferSuccessful = new AtomicBoolean(false);

--- a/p2p/src/main/java/bisq/network/p2p/peers/Broadcaster.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/Broadcaster.java
@@ -73,6 +73,10 @@ public class Broadcaster implements BroadcastHandler.ResultHandler {
         }
     }
 
+    public void flush() {
+        maybeBroadcastBundle();
+    }
+
     private void doShutDown() {
         broadcastHandlers.forEach(BroadcastHandler::cancel);
         if (timer != null) {


### PR DESCRIPTION
 Change handling of delay at republishing

The delay was too long. Some users have 100 - 200
offers and with the 700 ms delay it takes 70-140 sec.
This causes more stress for the network and UI due
permanent adding of offers. We decreased delay to 30 ms per offer.
So with 200 offers it would be about 6 sec. Maybe we could reduce
it even further but as it is hard to test in the live network with
so many offers it is better to not be too radical with the change.