### PR TITLE
Allow sending private notifications from avatar icon at trade

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -104,7 +104,7 @@ public class PeerInfoIcon extends Group {
                 role,
                 numTrades,
                 privateNotificationManager,
-                null,
+                trade.getOffer(),
                 trade,
                 preferences,
                 accountAgeWitnessService,
@@ -246,7 +246,7 @@ public class PeerInfoIcon extends Group {
 
         getChildren().addAll(outerBackground, innerBackground, avatarImageView, tagPane, numTradesPane);
 
-        addMouseListener(numTrades, privateNotificationManager, offer, preferences, useDevPrivilegeKeys,
+        addMouseListener(numTrades, privateNotificationManager, trade, offer, preferences, useDevPrivilegeKeys,
                 isFiatCurrency, accountAge, signAge, peersAccount.third, peersAccount.fourth, peersAccount.fifth);
     }
 
@@ -297,6 +297,7 @@ public class PeerInfoIcon extends Group {
 
     protected void addMouseListener(int numTrades,
                                     PrivateNotificationManager privateNotificationManager,
+                                    @Nullable Trade trade,
                                     Offer offer,
                                     Preferences preferences,
                                     boolean useDevPrivilegeKeys,
@@ -319,7 +320,7 @@ public class PeerInfoIcon extends Group {
                         Res.get("peerInfo.unknownAge") :
                 null;
 
-        setOnMouseClicked(e -> new PeerInfoWithTagEditor(privateNotificationManager, offer, preferences, useDevPrivilegeKeys)
+        setOnMouseClicked(e -> new PeerInfoWithTagEditor(privateNotificationManager, trade, offer, preferences, useDevPrivilegeKeys)
                 .fullAddress(fullAddress)
                 .numTrades(numTrades)
                 .accountAge(accountAgeFormatted)

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIconSmall.java
@@ -3,13 +3,17 @@ package bisq.desktop.components;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.offer.Offer;
+import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
 
 import bisq.network.p2p.NodeAddress;
 
+import javax.annotation.Nullable;
+
 public class PeerInfoIconSmall extends PeerInfoIcon {
     public PeerInfoIconSmall(NodeAddress nodeAddress,
-                             String role, Offer offer,
+                             String role,
+                             Offer offer,
                              Preferences preferences,
                              AccountAgeWitnessService accountAgeWitnessService,
                              boolean useDevPrivilegeKeys) {
@@ -32,6 +36,7 @@ public class PeerInfoIconSmall extends PeerInfoIcon {
     @Override
     protected void addMouseListener(int numTrades,
                                     PrivateNotificationManager privateNotificationManager,
+                                    @Nullable Trade trade,
                                     Offer offer,
                                     Preferences preferences,
                                     boolean useDevPrivilegeKeys,


### PR DESCRIPTION
Allow sending private notifications from avatar icon at trade.
Before it was using the makers pubKeyRing from the offer and that fails if the user was the maker as he cannot send to himself a private notofication.