### PR TITLE
Make it easier to translate trade roles

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3039,8 +3039,8 @@ navigation.dao.wallet.receive=\"DAO/BSQ Wallet/Receive\"
 
 formatter.formatVolumeLabel={0} amount{1}
 formatter.makerTaker=Maker as {0} {1} / Taker as {2} {3}
-formatter.youAreAsMaker=You are {0} {1} as maker / Taker is {2} {3}
-formatter.youAreAsTaker=You are {0} {1} as taker / Maker is {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=You are {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=You are creating an offer to {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=You are creating an offer to {0} {1} ({2} {3})

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -8,9 +8,9 @@ import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
-import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
+import bisq.core.util.coin.CoinFormatter;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
@@ -81,7 +81,7 @@ public class DisplayUtils {
         durationMillis = Math.max(0, durationMillis);
         String day = Res.get("time.day").toLowerCase();
         String days = Res.get("time.days");
-        String format = " d\' " + days + "\'";
+        String format = " d' " + days + "'";
         return StringUtils.strip(StringUtils.replaceOnce(DurationFormatUtils.formatDuration(durationMillis, format), " 1 " + days, " 1 " + day));
     }
 
@@ -167,12 +167,12 @@ public class DisplayUtils {
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String code = Res.getBaseCurrencyCode();
             return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.buying"), code, Res.get("shared.selling"), code) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.buying"), code, Res.get("shared.selling"), code);
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code);
         } else {
             return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.selling"), currencyCode, Res.get("shared.buying"), currencyCode) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.selling"), currencyCode, Res.get("shared.buying"), currencyCode);
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"), currencyCode) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"), currencyCode);
         }
     }
 
@@ -180,12 +180,12 @@ public class DisplayUtils {
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String code = Res.getBaseCurrencyCode();
             return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.selling"), code, Res.get("shared.buying"), code) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.selling"), code, Res.get("shared.buying"), code);
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code);
         } else {
             return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.buying"), currencyCode, Res.get("shared.selling"), currencyCode) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.buying"), currencyCode, Res.get("shared.selling"), currencyCode);
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), currencyCode, Res.get("shared.seller"), currencyCode) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), currencyCode, Res.get("shared.seller"), currencyCode);
         }
     }
 


### PR DESCRIPTION
As the German translation was quite embarrassing I think it might be similar in other languages (see `Angebotstyp`). 
**Before**
![Bildschirmfoto 2020-12-18 um 16 24 23](https://user-images.githubusercontent.com/170962/102635475-a61de480-4153-11eb-84b6-c83ba6568a97.png)
**After**
<img width="1268" alt="Bildschirmfoto 2020-12-18 um 17 08 35" src="https://user-images.githubusercontent.com/170962/102635503-b03fe300-4153-11eb-8fe8-aeefdbc1b8a2.png">

I changed the source to make it easier to translate (at least I hope so)
