### PR TITLE
Avoid resync from genesis in case of dao state issues

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
@@ -97,6 +97,12 @@ public class BisqHeadlessApp implements HeadlessApp {
         bisqSetup.setQubesOSInfoHandler(() -> log.info("setQubesOSInfoHandler"));
         bisqSetup.setDownGradePreventionHandler(lastVersion -> log.info("Downgrade from version {} to version {} is not supported",
                 lastVersion, Version.VERSION));
+        bisqSetup.setDaoRequiresRestartHandler(() -> {
+            log.info("There was a problem with synchronizing the DAO state. " +
+                    "A restart of the application is required to fix the issue.");
+            gracefulShutDownHandler.gracefulShutDown(() -> {
+            });
+        });
 
         corruptedStorageFileHandler.getFiles().ifPresent(files -> log.warn("getCorruptedDatabaseFiles. files={}", files));
         tradeManager.setTakeOfferRequestErrorMessageHandler(errorMessage -> log.error("onTakeOfferRequestErrorMessageHandler"));

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -182,6 +182,9 @@ public class BisqSetup {
     private Runnable qubesOSInfoHandler;
     @Setter
     @Nullable
+    private Runnable daoRequiresRestartHandler;
+    @Setter
+    @Nullable
     private Consumer<String> downGradePreventionHandler;
 
     @Getter
@@ -443,7 +446,8 @@ public class BisqSetup {
                 daoWarnMessageHandler,
                 filterWarningHandler,
                 voteResultExceptionHandler,
-                revolutAccountsUpdateHandler);
+                revolutAccountsUpdateHandler,
+                daoRequiresRestartHandler);
 
         if (walletsSetup.downloadPercentageProperty().get() == 1) {
             checkForLockedUpFunds();

--- a/core/src/main/java/bisq/core/app/DomainInitialisation.java
+++ b/core/src/main/java/bisq/core/app/DomainInitialisation.java
@@ -25,6 +25,7 @@ import bisq.core.btc.Balances;
 import bisq.core.dao.DaoSetup;
 import bisq.core.dao.governance.voteresult.VoteResultException;
 import bisq.core.dao.governance.voteresult.VoteResultService;
+import bisq.core.dao.state.DaoStateSnapshotService;
 import bisq.core.filter.FilterManager;
 import bisq.core.notifications.MobileNotificationService;
 import bisq.core.notifications.alerts.DisputeMsgEvents;
@@ -104,6 +105,7 @@ public class DomainInitialisation {
     private final PriceAlert priceAlert;
     private final MarketAlerts marketAlerts;
     private final User user;
+    private final DaoStateSnapshotService daoStateSnapshotService;
 
     @Inject
     public DomainInitialisation(ClockWatcher clockWatcher,
@@ -138,7 +140,8 @@ public class DomainInitialisation {
                                 DisputeMsgEvents disputeMsgEvents,
                                 PriceAlert priceAlert,
                                 MarketAlerts marketAlerts,
-                                User user) {
+                                User user,
+                                DaoStateSnapshotService daoStateSnapshotService) {
         this.clockWatcher = clockWatcher;
         this.tradeLimits = tradeLimits;
         this.arbitrationManager = arbitrationManager;
@@ -172,6 +175,7 @@ public class DomainInitialisation {
         this.priceAlert = priceAlert;
         this.marketAlerts = marketAlerts;
         this.user = user;
+        this.daoStateSnapshotService = daoStateSnapshotService;
     }
 
     public void initDomainServices(Consumer<String> rejectedTxErrorMessageHandler,
@@ -180,7 +184,8 @@ public class DomainInitialisation {
                                    Consumer<String> daoWarnMessageHandler,
                                    Consumer<String> filterWarningHandler,
                                    Consumer<VoteResultException> voteResultExceptionHandler,
-                                   Consumer<List<RevolutAccount>> revolutAccountsUpdateHandler) {
+                                   Consumer<List<RevolutAccount>> revolutAccountsUpdateHandler,
+                                   Runnable daoRequiresRestartHandler) {
         clockWatcher.start();
 
         tradeLimits.onAllServicesInitialized();
@@ -222,6 +227,8 @@ public class DomainInitialisation {
                 if (daoWarnMessageHandler != null)
                     daoWarnMessageHandler.accept(warningMessage);
             });
+
+            daoStateSnapshotService.setDaoRequiresRestartHandler(daoRequiresRestartHandler);
         }
 
         tradeStatisticsManager.onAllServicesInitialized();

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2850,6 +2850,7 @@ popup.info.shutDownWithOpenOffers=Bisq is being shut down, but there are open of
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\n\
   Please make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Important private notification!
 

--- a/core/src/test/java/bisq/core/dao/state/DaoStateSnapshotServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/state/DaoStateSnapshotServiceTest.java
@@ -17,7 +17,6 @@
 
 package bisq.core.dao.state;
 
-import bisq.core.dao.governance.period.CycleService;
 import bisq.core.dao.monitoring.DaoStateMonitoringService;
 import bisq.core.dao.state.storage.DaoStateStorageService;
 
@@ -37,9 +36,9 @@ public class DaoStateSnapshotServiceTest {
     public void setup() {
         daoStateSnapshotService = new DaoStateSnapshotService(mock(DaoStateService.class),
                 mock(GenesisTxInfo.class),
-                mock(CycleService.class),
                 mock(DaoStateStorageService.class),
-                mock(DaoStateMonitoringService.class));
+                mock(DaoStateMonitoringService.class),
+                null);
     }
 
     @Test

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -417,6 +417,11 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                     .show();
         });
 
+        bisqSetup.setDaoRequiresRestartHandler(() -> new Popup().warning("popup.warn.daoRequiresRestart")
+                .useShutDownButton()
+                .hideCloseButton()
+                .show());
+
         corruptedStorageFileHandler.getFiles().ifPresent(files -> new Popup()
                 .warning(Res.get("popup.warning.incompatibleDB", files.toString(), config.appDataDir))
                 .useShutDownButton()

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -20,6 +20,7 @@ package bisq.seednode;
 import bisq.core.app.TorSetup;
 import bisq.core.app.misc.ExecutableForAppWithP2p;
 import bisq.core.app.misc.ModuleForAppWithP2p;
+import bisq.core.dao.state.DaoStateSnapshotService;
 
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.P2PServiceListener;
@@ -30,6 +31,7 @@ import bisq.common.UserThread;
 import bisq.common.app.AppModule;
 import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
+import bisq.common.app.DevEnv;
 import bisq.common.config.BaseCurrencyNetwork;
 import bisq.common.config.Config;
 import bisq.common.handlers.ResultHandler;
@@ -98,6 +100,11 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
         super.applyInjector();
 
         seedNode.setInjector(injector);
+
+        if (DevEnv.isDaoActivated()) {
+            injector.getInstance(DaoStateSnapshotService.class).setDaoRequiresRestartHandler(() -> gracefulShutDown(() -> {
+            }));
+        }
     }
 
     @Override


### PR DESCRIPTION
In case a reset of the dao state was triggered we delete now all dao store files and request a shut down of the app.

After a restart the resource files are used. This avoids cases where a resync from
genesis got triggered (observed on seed nodes, not on desktop apps).

Seed nodes and headless apps get shut down automatically.
In case of the desktop app we show a warn popup with shutdown
button and no close button, so we enforce a shutdown to avoid
complications in case the user would continue.