### PR TITLE
[1.5.2] Remove NGN (Nigerian Naira) as their central bank blocked Transferwise

### DIFF
--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -301,7 +301,6 @@ public class CurrencyUtil {
                 new FiatCurrency("MAD"),
                 new FiatCurrency("NPR"),
                 new FiatCurrency("NZD"),
-                new FiatCurrency("NGN"),
                 new FiatCurrency("NOK"),
                 new FiatCurrency("PKR"),
                 new FiatCurrency("PEN"),


### PR DESCRIPTION
Remove NGN (Nigerian Naira) as their central bank blocked Transferwise

See: https://twitter.com/cenbank/status/1339196770774093825

I tested it with setting that currency, doing offers and trades,
then remove it and continue the trades.
Offers with NGN cannot be taken anymore.
