### PR TITLE
[1.5.2] Add extra note for amazon gift cards

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3315,10 +3315,14 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
   bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. \
   Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
 payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and \
-  use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. \
-  Use the trade ID for the message field.\n\n\
-  Amazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\n\
-  For more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+  use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver.\n\
+  Amazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\
+  For more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]\n\n\
+  It is recommended to not send more than 100 USD per gift card as it seems that Amazon is considering higher amounts as \
+  risky and often flags such transactions as fraudulent.\n\
+  Split the amount up to several smaller amounts and use some creative reference text instead of the trade ID (e.g. 'Happy birthday Susan').\n\
+  Exchange in the trade chat with the peer which reference text you have used so they are able to \
+  assign the payment to the trade.
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3314,15 +3314,15 @@ payment.payid=PayID linked to financial institution. Like email address or mobil
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your \
   bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. \
   Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and \
-  use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver.\n\
-  Amazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\
-  For more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]\n\n\
-  It is recommended to not send more than 100 USD per gift card as it seems that Amazon is considering higher amounts as \
-  risky and often flags such transactions as fraudulent.\n\
-  Split the amount up to several smaller amounts and use some creative reference text instead of the trade ID (e.g. 'Happy birthday Susan').\n\
-  Exchange in the trade chat with the peer which reference text you have used so they are able to \
-  assign the payment to the trade.
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\n\
+  Bisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift \
+  card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\n\
+  Three important notes:\n\
+  - try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n\
+  - try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat \
+  to tell your trading peer the reference text you picked so they can verify your payment)\n\
+  - Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AmazonGiftCardForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AmazonGiftCardForm.java
@@ -69,7 +69,6 @@ public class AmazonGiftCardForm extends PaymentMethodForm {
     public void addTradeCurrency() {
         addTradeCurrencyComboBox();
         currencyComboBox.setItems(FXCollections.observableArrayList(CurrencyUtil.getAllAmazonGiftCardCurrencies()));
-        currencyComboBox.getSelectionModel().select(0);
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PerfectMoneyForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PerfectMoneyForm.java
@@ -54,7 +54,6 @@ public class PerfectMoneyForm extends GeneralAccountNumberForm {
     public void addTradeCurrency() {
         addTradeCurrencyComboBox();
         currencyComboBox.setItems(FXCollections.observableArrayList(new FiatCurrency("USD"), new FiatCurrency("EUR")));
-        currencyComboBox.getSelectionModel().select(0);
     }
 
     @Override


### PR DESCRIPTION
Add extra note for amazon gift cards

There have been many reports with account block with AGC payments. It seems they block amounts > 100 USD. The cryptic trade ID as message might be another factor to get flagged. The change in the text should help to avoid those issues.