### PR TITLE
Translate checkArgument messages

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -25,6 +25,7 @@ import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.model.AddressEntryList;
 import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.btc.wallet.http.MemPoolSpaceTxBroadcaster;
+import bisq.core.locale.Res;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
 
@@ -1187,7 +1188,7 @@ public class BtcWalletService extends WalletService {
         Transaction tx = new Transaction(params);
         final Coin receiverAmount = amount.subtract(fee);
         Preconditions.checkArgument(Restrictions.isAboveDust(receiverAmount),
-                "The amount is too low (dust limit).");
+                Res.get("validation.amountBelowDust.short"));
         tx.addOutput(receiverAmount, Address.fromString(params, toAddress));
 
         SendRequest sendRequest = SendRequest.forTx(tx);
@@ -1217,7 +1218,7 @@ public class BtcWalletService extends WalletService {
         Transaction tx = new Transaction(params);
         final Coin netValue = amount.subtract(fee);
         checkArgument(Restrictions.isAboveDust(netValue),
-                "The amount is too low (dust limit).");
+                Res.get("validation.amountBelowDust.short"));
 
         tx.addOutput(netValue, Address.fromString(params, toAddress));
 
@@ -1278,18 +1279,18 @@ public class BtcWalletService extends WalletService {
             throws AddressFormatException, InsufficientMoneyException, WalletException, TransactionVerificationException {
         Transaction tx = new Transaction(params);
         Preconditions.checkArgument(buyerAmount.add(sellerAmount).isPositive(),
-                "The sellerAmount + buyerAmount must be positive.");
+                Res.get("validation.refundPayoutTx.buyerSellerNotPositive"));
         // buyerAmount can be 0
         if (buyerAmount.isPositive()) {
             Preconditions.checkArgument(Restrictions.isAboveDust(buyerAmount),
-                    "The buyerAmount is too low (dust limit).");
+                    Res.get("validation.amountBelowDust.shortVar", "buyerAmount"));
 
             tx.addOutput(buyerAmount, Address.fromString(params, buyerAddressString));
         }
         // sellerAmount can be 0
         if (sellerAmount.isPositive()) {
             Preconditions.checkArgument(Restrictions.isAboveDust(sellerAmount),
-                    "The sellerAmount is too low (dust limit).");
+                    Res.get("validation.amountBelowDust.shortVar", "sellerAmount"));
 
             tx.addOutput(sellerAmount, Address.fromString(params, sellerAddressString));
         }

--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -352,7 +352,7 @@ public class TradeWalletService {
         // We created the take offer fee tx in the structure that the second output is for the funds for the deposit tx.
         TransactionOutput reservedForTradeOutput = takeOfferFeeTx.getOutputs().get(1);
         checkArgument(reservedForTradeOutput.getValue().equals(inputAmount),
-                "Reserve amount does not equal input amount");
+                Res.get("validation.depositTx.reserveNotEqualInput"));
         dummyTX.addInput(reservedForTradeOutput);
 
         WalletService.verifyTransaction(dummyTX);

--- a/core/src/main/java/bisq/core/dao/governance/bond/reputation/MyReputation.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/reputation/MyReputation.java
@@ -18,6 +18,7 @@
 package bisq.core.dao.governance.bond.reputation;
 
 import bisq.core.dao.governance.bond.BondedAsset;
+import bisq.core.locale.Res;
 
 import bisq.common.crypto.Hash;
 import bisq.common.proto.network.NetworkPayload;
@@ -52,7 +53,7 @@ public final class MyReputation implements PersistablePayload, NetworkPayload, B
 
     public MyReputation(byte[] salt) {
         this(UUID.randomUUID().toString(), salt);
-        checkArgument(salt.length <= 20, "salt must not be longer then 20 bytes");
+        checkArgument(salt.length <= 20, Res.get("validation.myReputation.saltTooLong"));
     }
 
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3540,3 +3540,13 @@ validation.phone.tooManyDigits=There are too many digits in {0} to be a valid ph
 validation.phone.invalidDialingCode=Country dialing code for number {0} is invalid for country {1}.  \
   The correct dialing code is {2}.
 validation.invalidAddressList=Must be comma separated list of valid addresses
+validation.outputBelowDust=An output value is below the dust limit. Transaction={0}
+validation.amountBelowDust.short=The amount is below dust limit.
+validation.amountBelowDust.shortVar=The {0} is below dust limit.
+validation.refundPayoutTx.buyerSellerNotPositive=The sellerAmount + buyerAmount must be positive.
+validation.depositTx.reserveNotEqualInput=Reserve amount does not equal input amount
+validation.burnFee.details=Available BSQ balance={0} BSQ. Intended fee to burn={1} BSQ. Please increase your balance to at least {2} BSQ.
+validation.burnFee.insufficientBsqForFee=This transaction requires a change output of at least {0} BSQ (dust limit). {1}
+validation.burnFee.changeIsDust=This transaction would create a dust output of {0} BSQ. It requires a change output of at least {1} BSQ (dust limit). {2}
+validation.addInputsAndChangeOutput.changeIsDust=The change output of {0} BSQ is below the min. dust value of {1}. At least {2} BSQ is needed for this transaction.
+validation.myReputation.saltTooLong=salt must not be longer than 20 bytes


### PR DESCRIPTION
Fixes #2619

Messages in some checkArgument calls are replaced with translatable strings.

There are many more instances, incl. ones in calls of similar functions (notEmpty, notBlank, notNull). However, most seem to be unreachable by the users; the GUI prevents the conditions from ever happening. Many messages are not even intended to be seen by users; they include things like private method names and local variable names.

In fact, I wasn't able to reproduce even some of those few messages that are updated by this PR.