### PR TITLE
[1.5.2] Fix wrong account age data access

### DIFF
--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -135,10 +135,10 @@ public class AccountAgeWitnessService {
     private final User user;
     private final SignedWitnessService signedWitnessService;
     private final ChargeBackRisk chargeBackRisk;
+    private final AccountAgeWitnessStorageService accountAgeWitnessStorageService;
     private final FilterManager filterManager;
     @Getter
     private final AccountAgeWitnessUtils accountAgeWitnessUtils;
-
     @Getter
     private final Map<P2PDataStorage.ByteArray, AccountAgeWitness> accountAgeWitnessMap = new HashMap<>();
 
@@ -162,6 +162,7 @@ public class AccountAgeWitnessService {
         this.user = user;
         this.signedWitnessService = signedWitnessService;
         this.chargeBackRisk = chargeBackRisk;
+        this.accountAgeWitnessStorageService = accountAgeWitnessStorageService;
         this.filterManager = filterManager;
 
         accountAgeWitnessUtils = new AccountAgeWitnessUtils(
@@ -185,10 +186,10 @@ public class AccountAgeWitnessService {
         });
 
         // At startup the P2PDataStorage initializes earlier, otherwise we get the listener called.
-        p2PService.getP2PDataStorage().getAppendOnlyDataStoreMap().values().forEach(e -> {
-            if (e instanceof AccountAgeWitness)
-                addToMap((AccountAgeWitness) e);
-        });
+        accountAgeWitnessStorageService.getMapOfAllData().values().stream()
+                .filter(e -> e instanceof AccountAgeWitness)
+                .map(e -> (AccountAgeWitness) e)
+                .forEach(this::addToMap);
 
         if (p2PService.isBootstrapped()) {
             onBootStrapped();


### PR DESCRIPTION
We need to user accountAgeWitnessStorageService as this supports the historical data store.
Using p2PService.getP2PDataStorage().getAppendOnlyDataStoreMap() would not deliver all the data.