### PR TITLE
Improve trade fee display at create and take offer screens and popups

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -192,7 +192,7 @@ shared.tradeWalletBalance=Trade wallet balance
 shared.makerTxFee=Maker: {0}
 shared.takerTxFee=Taker: {0}
 shared.iConfirm=I confirm
-shared.tradingFeeInBsqInfo=equivalent to {0} used as trading fee
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Open {0}
 shared.fiat=Fiat
 shared.crypto=Crypto
@@ -454,7 +454,6 @@ createOffer.warning.sellBelowMarketPrice=You will always get {0}% less than the 
 createOffer.warning.buyAboveMarketPrice=You will always pay {0}% more than the current market price as the price of your offer will be continuously updated.
 createOffer.tradeFee.descriptionBTCOnly=Trade fee
 createOffer.tradeFee.descriptionBSQEnabled=Select trade fee currency
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} of trade amount
 
 # new entries
 createOffer.placeOfferButton=Review: Place offer to {0} bitcoin
@@ -462,7 +461,14 @@ createOffer.alreadyFunded=You had already funded that offer.\nYour funds have be
 createOffer.createOfferFundWalletInfo.headline=Fund your offer
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Trade amount: {0} \n
-createOffer.createOfferFundWalletInfo.msg=You need to deposit {0} to this offer.\n\nThose funds are reserved in your local wallet and will get locked into the multisig deposit address once someone takes your offer.\n\nThe amount is the sum of:\n{1}- Your security deposit: {2}\n- Trading fee: {3}\n- Mining fee: {4}\n\nYou can choose between two options when funding your trade:\n- Use your Bisq wallet (convenient, but transactions may be linkable) OR\n- Transfer from an external wallet (potentially more private)\n\nYou will see all funding options and details after closing this popup.
+createOffer.createOfferFundWalletInfo.msg=You need to deposit {0} to this offer.\n\n\
+  Those funds are reserved in your local wallet and will get locked into the multisig deposit address once someone takes your offer.\n\n\
+  The amount is the sum of:\n\
+  {1}\
+  - Your security deposit: {2}\n\
+  - Trading fee: {3}\n\
+  - Mining fee: {4}\n\n\
+  You can choose between two options when funding your trade:\n- Use your Bisq wallet (convenient, but transactions may be linkable) OR\n- Transfer from an external wallet (potentially more private)\n\nYou will see all funding options and details after closing this popup.
 
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
 createOffer.amountPriceBox.error.message=An error occurred when placing the offer:\n\n{0}\n\n\
@@ -2702,6 +2708,8 @@ feeOptionWindow.info=You can choose to pay the trade fee in BSQ or in BTC. If yo
 feeOptionWindow.optionsLabel=Choose currency for trade fee payment
 feeOptionWindow.useBTC=Use BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################

--- a/desktop/src/main/java/bisq/desktop/main/offer/FeeUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/FeeUtil.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.offer;
+
+import bisq.desktop.util.DisplayUtils;
+import bisq.desktop.util.GUIUtil;
+
+import bisq.core.locale.Res;
+import bisq.core.monetary.Volume;
+import bisq.core.offer.OfferUtil;
+import bisq.core.util.coin.CoinFormatter;
+
+import bisq.common.app.DevEnv;
+
+import org.bitcoinj.core.Coin;
+
+import java.util.Optional;
+
+public class FeeUtil {
+    public static String getTradeFeeWithFiatEquivalent(OfferUtil offerUtil,
+                                                       Coin tradeFee,
+                                                       boolean isCurrencyForMakerFeeBtc,
+                                                       CoinFormatter formatter) {
+        if (!isCurrencyForMakerFeeBtc && !DevEnv.isDaoActivated()) {
+            return "";
+        }
+
+        Optional<Volume> optionalBtcFeeInFiat = offerUtil.getFeeInUserFiatCurrency(tradeFee,
+                isCurrencyForMakerFeeBtc,
+                formatter);
+
+        return DisplayUtils.getFeeWithFiatAmount(tradeFee, optionalBtcFeeInFiat, formatter);
+    }
+
+    public static String getTradeFeeWithFiatEquivalentAndPercentage(OfferUtil offerUtil,
+                                                                    Coin tradeFee,
+                                                                    Coin tradeAmount,
+                                                                    boolean isCurrencyForMakerFeeBtc,
+                                                                    CoinFormatter formatter,
+                                                                    Coin minTradeFee) {
+        if (isCurrencyForMakerFeeBtc) {
+            String feeAsBtc = formatter.formatCoinWithCode(tradeFee);
+            String percentage;
+            if (!tradeFee.isGreaterThan(minTradeFee)) {
+                percentage = Res.get("guiUtil.requiredMinimum")
+                        .replace("(", "")
+                        .replace(")", "");
+            } else {
+                percentage = GUIUtil.getPercentage(tradeFee, tradeAmount) +
+                        " " + Res.get("guiUtil.ofTradeAmount");
+            }
+            return offerUtil.getFeeInUserFiatCurrency(tradeFee,
+                    isCurrencyForMakerFeeBtc,
+                    formatter)
+                    .map(DisplayUtils::formatAverageVolumeWithCode)
+                    .map(feeInFiat -> Res.get("feeOptionWindow.btcFeeWithFiatAndPercentage", feeAsBtc, feeInFiat, percentage))
+                    .orElseGet(() -> Res.get("feeOptionWindow.btcFeeWithPercentage", feeAsBtc, percentage));
+        } else {
+            // For BSQ we use the fiat equivalent only. Calculating the % value would be more effort.
+            // We could calculate the BTC value if the BSQ fee and use that...
+            return FeeUtil.getTradeFeeWithFiatEquivalent(offerUtil,
+                    tradeFee,
+                    false,
+                    formatter);
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -126,7 +126,7 @@ public class DisplayUtils {
         return formatVolume(volume, FIAT_VOLUME_FORMAT, true);
     }
 
-    static String formatAverageVolumeWithCode(Volume volume) {
+    public static String formatAverageVolumeWithCode(Volume volume) {
         return formatVolume(volume, FIAT_VOLUME_FORMAT.minDecimals(2), true);
     }
 
@@ -257,15 +257,15 @@ public class DisplayUtils {
     public static String getFeeWithFiatAmount(Coin makerFeeAsCoin,
                                               Optional<Volume> optionalFeeInFiat,
                                               CoinFormatter formatter) {
-        String fee = makerFeeAsCoin != null ? formatter.formatCoinWithCode(makerFeeAsCoin) : Res.get("shared.na");
-        String feeInFiatAsString;
+        String feeInBtc = makerFeeAsCoin != null ? formatter.formatCoinWithCode(makerFeeAsCoin) : Res.get("shared.na");
         if (optionalFeeInFiat != null && optionalFeeInFiat.isPresent()) {
-            feeInFiatAsString = formatAverageVolumeWithCode(optionalFeeInFiat.get());
+            String feeInFiat = formatAverageVolumeWithCode(optionalFeeInFiat.get());
+            return Res.get("feeOptionWindow.fee", feeInBtc, feeInFiat);
         } else {
-            feeInFiatAsString = Res.get("shared.na");
+            return feeInBtc;
         }
-        return Res.get("feeOptionWindow.fee", fee, feeInFiatAsString);
     }
+
 
     /**
      * Converts to a coin with max. 4 decimal places. Last place gets rounded.


### PR DESCRIPTION
Shows the fiat value and % of trade amount for trade fee and tx fee. If BSQ then we only show fiat value. 

Special cases:
- Price feed not available: No % value shown
- DAO deactivated: BSQ part hidden