### PR TITLE
Move BSQ price in USD at first row

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
@@ -171,7 +171,6 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
                 Res.get("dao.factsAndFigures.dashboard.availableAmount")).second;
     }
 
-
     @Override
     protected void activate() {
         daoFacade.addBsqStateListener(this);

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/BsqDashboardView.java
@@ -150,19 +150,19 @@ public class BsqDashboardView extends ActivatableView<GridPane, Void> implements
 
         marketPriceBox.second.getStyleClass().add("dao-kpi-subtext");
 
-        avgPrice90TextField = addTopLabelReadOnlyTextField(root, ++gridRow,
-                Res.get("dao.factsAndFigures.dashboard.avgPrice90")).second;
-
-        avgPrice30TextField = addTopLabelTextFieldWithIcon(root, gridRow, 1,
-                Res.get("dao.factsAndFigures.dashboard.avgPrice30"), -15).second;
-        AnchorPane.setRightAnchor(avgPrice30TextField.getIconLabel(), 10d);
-
         avgUSDPrice90TextField = addTopLabelReadOnlyTextField(root, ++gridRow,
                 Res.get("dao.factsAndFigures.dashboard.avgUSDPrice90")).second;
 
         avgUSDPrice30TextField = addTopLabelTextFieldWithIcon(root, gridRow, 1,
                 Res.get("dao.factsAndFigures.dashboard.avgUSDPrice30"), -15).second;
         AnchorPane.setRightAnchor(avgUSDPrice30TextField.getIconLabel(), 10d);
+
+        avgPrice90TextField = addTopLabelReadOnlyTextField(root, ++gridRow,
+                Res.get("dao.factsAndFigures.dashboard.avgPrice90")).second;
+
+        avgPrice30TextField = addTopLabelTextFieldWithIcon(root, gridRow, 1,
+                Res.get("dao.factsAndFigures.dashboard.avgPrice30"), -15).second;
+        AnchorPane.setRightAnchor(avgPrice30TextField.getIconLabel(), 10d);
 
         marketCapTextField = addTopLabelReadOnlyTextField(root, ++gridRow,
                 Res.get("dao.factsAndFigures.dashboard.marketCap")).second;


### PR DESCRIPTION
The USD price is more relevant for the DAO than the BSQ/BTC price. Also the arrow if price goes up or down is more stable and meaningful for the USD pair than for BTC as BTC price can be very volatile. 