### PR TITLE
Pass hash to bitcoind blocknotify script

### DIFF
--- a/apitest/src/main/java/bisq/apitest/linux/BitcoinDaemon.java
+++ b/apitest/src/main/java/bisq/apitest/linux/BitcoinDaemon.java
@@ -59,7 +59,7 @@ public class BitcoinDaemon extends AbstractLinuxProcess implements LinuxProcess 
                 + " -rpcport=" + config.bitcoinRpcPort
                 + " -rpcuser=" + config.bitcoinRpcUser
                 + " -rpcpassword=" + config.bitcoinRpcPassword
-                + " -blocknotify=" + config.bitcoinDatadir + "/blocknotify";
+                + " -blocknotify=" + "\"" + config.bitcoinDatadir + "/blocknotify" + " %s\"";
 
         BashCommand cmd = new BashCommand(bitcoindCmd).run();
         log.info("Starting ...\n$ {}", cmd.getCommand());


### PR DESCRIPTION
Added the missing `%s` to bitcoind's -blocknotify option.