### PR TITLE
Add generic map (cookie) to UserPayload

### DIFF
--- a/core/src/main/java/bisq/core/user/Cookie.java
+++ b/core/src/main/java/bisq/core/user/Cookie.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.user;
+
+import bisq.common.proto.ProtoUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+/**
+ * Serves as flexible container for persisting UI states, layout,...
+ * Should not be over-used for domain specific data where type safety and data integrity is important.
+ */
+public class Cookie extends HashMap<CookieKey, String> {
+
+    public void putAsDouble(CookieKey key, double value) {
+        put(key, String.valueOf(value));
+    }
+
+    public Optional<Double> getAsOptionalDouble(CookieKey key) {
+        try {
+            return containsKey(key) ?
+                    Optional.of(Double.parseDouble(get(key))) :
+                    Optional.empty();
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
+    }
+
+    public Map<String, String> toProtoMessage() {
+        Map<String, String> protoMap = new HashMap<>();
+        this.forEach((key, value) -> protoMap.put(key.name(), value));
+        return protoMap;
+    }
+
+    public static Cookie fromProto(@Nullable Map<String, String> protoMap) {
+        Cookie cookie = new Cookie();
+        if (protoMap != null) {
+            protoMap.forEach((key, value) -> cookie.put(ProtoUtil.enumFromProto(CookieKey.class, key), value));
+        }
+        return cookie;
+    }
+
+
+}

--- a/core/src/main/java/bisq/core/user/CookieKey.java
+++ b/core/src/main/java/bisq/core/user/CookieKey.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.user;
+
+// Used for persistence of Cookie. Entries must not be changes or removed. Only adding entries is permitted.
+public enum CookieKey {
+    STAGE_X,
+    STAGE_Y,
+    STAGE_W,
+    STAGE_H
+}

--- a/core/src/main/java/bisq/core/user/User.java
+++ b/core/src/main/java/bisq/core/user/User.java
@@ -514,4 +514,8 @@ public class User implements PersistedDataHost {
     private boolean paymentAccountExists(PaymentAccount paymentAccount) {
         return getPaymentAccountsAsObservable().stream().anyMatch(e -> e.equals(paymentAccount));
     }
+
+    public Cookie getCookie() {
+        return userPayload.getCookie();
+    }
 }

--- a/core/src/main/java/bisq/core/user/UserPayload.java
+++ b/core/src/main/java/bisq/core/user/UserPayload.java
@@ -80,6 +80,11 @@ public class UserPayload implements PersistableEnvelope {
     @Nullable
     private List<RefundAgent> acceptedRefundAgents = new ArrayList<>();
 
+    // Added at 1.5.3
+    // Generic map for persisting various UI states. We keep values un-typed as string to
+    // provide sufficient flexibility.
+    private Cookie cookie = new Cookie();
+
     public UserPayload() {
     }
 
@@ -118,6 +123,7 @@ public class UserPayload implements PersistableEnvelope {
         Optional.ofNullable(acceptedRefundAgents)
                 .ifPresent(e -> builder.addAllAcceptedRefundAgents(ProtoUtil.collectionToProto(acceptedRefundAgents,
                         message -> ((protobuf.StoragePayload) message).getRefundAgent())));
+        Optional.ofNullable(cookie).ifPresent(e -> builder.putAllCookie(cookie.toProtoMessage()));
         return protobuf.PersistableEnvelope.newBuilder().setUserPayload(builder).build();
     }
 
@@ -147,7 +153,8 @@ public class UserPayload implements PersistableEnvelope {
                 proto.hasRegisteredRefundAgent() ? RefundAgent.fromProto(proto.getRegisteredRefundAgent()) : null,
                 proto.getAcceptedRefundAgentsList().isEmpty() ? new ArrayList<>() : new ArrayList<>(proto.getAcceptedRefundAgentsList().stream()
                         .map(RefundAgent::fromProto)
-                        .collect(Collectors.toList()))
+                        .collect(Collectors.toList())),
+                Cookie.fromProto(proto.getCookieMap())
         );
     }
 }

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1642,6 +1642,7 @@ message UserPayload {
     repeated MarketAlertFilter market_alert_filters = 13;
     repeated RefundAgent accepted_refund_agents = 14;
     RefundAgent registered_refund_agent = 15;
+    map<string, string> cookie = 16;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add generic map (cookie) to UserPayload for persisting UI states like app layout

This opens the app window in the same position and size as it has been before closing.
This new cookie field can be used as generic map container for UI state or not domain specific non critical data. It should NOT be seen as easy way to throw any kind of data in! Intention is to make it easier for persisting app state which is not important enough that developers do all the work with adding a proto field but still would be an improvement of UX.