### PR TITLE
Display up-to-date error messages under text fields

### DIFF
--- a/core/src/main/java/bisq/core/util/validation/InputValidator.java
+++ b/core/src/main/java/bisq/core/util/validation/InputValidator.java
@@ -21,6 +21,7 @@ import bisq.core.locale.Res;
 
 import java.math.BigInteger;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 public class InputValidator {
@@ -63,6 +64,12 @@ public class InputValidator {
                     "isValid=" + isValid +
                     ", errorMessage='" + errorMessage + '\'' +
                     '}';
+        }
+
+        public boolean errorMessageEquals(ValidationResult other) {
+            if (this == other) return true;
+            if (other == null) return false;
+            return Objects.equals(errorMessage, other.errorMessage);
         }
 
         public interface Validator extends Function<String, ValidationResult> {

--- a/desktop/src/main/java/bisq/desktop/components/InputTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/InputTextField.java
@@ -78,6 +78,9 @@ public class InputTextField extends JFXTextField {
             if (newValue != null) {
                 resetValidation();
                 if (!newValue.isValid) {
+                    if (!newValue.errorMessageEquals(oldValue)) {  // avoid blinking
+                        validate();  // ensure that the new error message replaces the old one
+                    }
                     if (this.errorMessage != null) {
                         jfxValidationWrapper.applyErrorMessage(this.errorMessage);
                     } else {


### PR DESCRIPTION
As user types into a validated text field,
if the new string is still invalid but the error message changed,
ensure the new message will be displayed.

Fixes #5005


### Before
Below are the states of a field as the value `0.0011` is being entered, and then cleared again.

![instant-error-message-update BEFORE](https://user-images.githubusercontent.com/16313562/103141536-d33f3980-46f5-11eb-8cce-3071b31b11c9.png)

### After
Now, the error message indicates the error condition every step of the way.

![instant-error-message-update AFTER](https://user-images.githubusercontent.com/16313562/103141537-d9351a80-46f5-11eb-8804-2117e1342ef7.png)

