### PR TITLE
Fix missing apostrophe in Withdrawal view

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -269,8 +269,8 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
         feeToggleGroupListener = (observable, oldValue, newValue) -> {
             feeExcluded = newValue == feeExcludedRadioButton;
             amountLabel.setText(feeExcluded ?
-                    Res.get("funds.withdrawal.receiverAmount", Res.getBaseCurrencyCode()) :
-                    Res.get("funds.withdrawal.senderAmount", Res.getBaseCurrencyCode()));
+                    Res.get("funds.withdrawal.receiverAmount") :
+                    Res.get("funds.withdrawal.senderAmount"));
         };
     }
 


### PR DESCRIPTION
In **FUNDS > SEND FUNDS**, labels "_Sender's amount_"/"_Receiver's amount_" are missing an apostrophe.

The single quote characters are present in the property file but they get eaten up even though there is no variable substitution taking place (at least it shouldn't be). In the code, however, variable values are provided for no reason.

### Before:
![Send funds BEFORE](https://user-images.githubusercontent.com/16313562/103233456-7f269600-493d-11eb-8a11-740af97bcaef.png)

### After:
![Send funds AFTER](https://user-images.githubusercontent.com/16313562/103233460-82218680-493d-11eb-872a-eebb0eb3ce11.png)


