### PR TITLE
Change trade period for transferwise from 1 day to 4 days

### DIFF
--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -185,7 +185,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
             REVOLUT = new PaymentMethod(REVOLUT_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
             PERFECT_MONEY = new PaymentMethod(PERFECT_MONEY_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),
             ADVANCED_CASH = new PaymentMethod(ADVANCED_CASH_ID, DAY, DEFAULT_TRADE_LIMIT_VERY_LOW_RISK),
-            TRANSFERWISE = new PaymentMethod(TRANSFERWISE_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
+            TRANSFERWISE = new PaymentMethod(TRANSFERWISE_ID, 4 * DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
 
             // Japan
             JAPAN_BANK = new PaymentMethod(JAPAN_BANK_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),


### PR DESCRIPTION
If a bank transfer it takes longer than 1 day. 1 day works only for local TW to local TW account if the sender has already funds on their account.
The trade period is part of the offer, so all offers created with 1.5.2 or earlier will have still 1 day. Users don't need to change anything, the old account will use 4 days for any new offer. 