### PR TITLE
Fix layout of button and checkbox in Receive funds

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
@@ -42,6 +42,7 @@ import bisq.core.util.coin.CoinFormatter;
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
 import bisq.common.config.Config;
+import bisq.common.util.Tuple3;
 
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Coin;
@@ -66,9 +67,9 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
-import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 
 import org.fxmisc.easybind.EasyBind;
@@ -198,17 +199,15 @@ public class DepositView extends ActivatableView<VBox, Void> {
         addressTextField.setManaged(false);
         amountTextField.setManaged(false);
 
-        generateNewAddressButton = addButton(gridPane, ++gridRow, Res.get("funds.deposit.generateAddress"), -20);
-        GridPane.setColumnIndex(generateNewAddressButton, 0);
-        GridPane.setHalignment(generateNewAddressButton, HPos.LEFT);
-
-        generateNewAddressSegwitCheckbox = addCheckBox(gridPane, gridRow,
-                Res.get("funds.deposit.generateAddressSegwit"), 0);
+        Tuple3<Button, CheckBox, HBox> buttonCheckBoxHBox = addButtonCheckBoxWithBox(gridPane, ++gridRow,
+                Res.get("funds.deposit.generateAddress"),
+                Res.get("funds.deposit.generateAddressSegwit"),
+                15);
+        buttonCheckBoxHBox.third.setSpacing(25);
+        generateNewAddressButton = buttonCheckBoxHBox.first;
+        generateNewAddressSegwitCheckbox = buttonCheckBoxHBox.second;
         generateNewAddressSegwitCheckbox.setAllowIndeterminate(false);
         generateNewAddressSegwitCheckbox.setSelected(true);
-        GridPane.setColumnIndex(generateNewAddressSegwitCheckbox, 0);
-        GridPane.setHalignment(generateNewAddressSegwitCheckbox, HPos.LEFT);
-        GridPane.setMargin(generateNewAddressSegwitCheckbox, new Insets(15, 0, 0, 250));
 
         generateNewAddressButton.setOnAction(event -> {
             boolean segwit = generateNewAddressSegwitCheckbox.isSelected();

--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -901,20 +901,26 @@ public class FormBuilder {
                                                              String buttonTitle,
                                                              String checkBoxTitle,
                                                              double top) {
-        Button button = new AutoTooltipButton(buttonTitle);
-        button.setDefaultButton(true);
-        CheckBox checkBox = new AutoTooltipCheckBox(checkBoxTitle);
-        HBox.setMargin(checkBox, new Insets(6, 0, 0, 0));
+        final Tuple3<Button, CheckBox, HBox> tuple = addButtonCheckBoxWithBox(gridPane, rowIndex, buttonTitle, checkBoxTitle, top);
+        return new Tuple2<>(tuple.first, tuple.second);
+    }
 
-        HBox hBox = new HBox();
-        hBox.setSpacing(20);
+    public static Tuple3<Button, CheckBox, HBox> addButtonCheckBoxWithBox(GridPane gridPane,
+                                                             int rowIndex,
+                                                             String buttonTitle,
+                                                             String checkBoxTitle,
+                                                             double top) {
+        Button button = new AutoTooltipButton(buttonTitle);
+        CheckBox checkBox = new AutoTooltipCheckBox(checkBoxTitle);
+
+        HBox hBox = new HBox(20);
+        hBox.setAlignment(Pos.CENTER_LEFT);
         hBox.getChildren().addAll(button, checkBox);
         GridPane.setRowIndex(hBox, rowIndex);
-        GridPane.setColumnIndex(hBox, 1);
         hBox.setPadding(new Insets(top, 0, 0, 0));
         gridPane.getChildren().add(hBox);
 
-        return new Tuple2<>(button, checkBox);
+        return new Tuple3<>(button, checkBox, hBox);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #5017 

The checkbox "_Native segwit format_" had a fixed position in a  GridPane cell that is shared with the _Generate_ button. Now the two elements are placed in a HBox which will handle the varying width of the button gracefully.

I have repurposed a set of methods `addButtonCheckBox` that are not used anywhere in the project. I decided to change a few details in the method (added `CENTER_LEFT` alignment; leaving column index at default); these seem to be sensible defaults. Adding an additional method argument seemed unnecessary at this point.


## Before:

![button + checkbox official CZ](https://user-images.githubusercontent.com/16313562/103250863-57075900-4976-11eb-8b0f-7d5c8de9b334.png)


## After:

![image](https://user-images.githubusercontent.com/16313562/103250881-71d9cd80-4976-11eb-8069-52f61f4f3563.png)
![image](https://user-images.githubusercontent.com/16313562/103250899-8a49e800-4976-11eb-8070-40cbf2b3fcfe.png)


