### PR TITLE
[1.5.4] We need to use the getMapOfAllData method for HistoricalDataStoreServices

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
@@ -78,7 +78,12 @@ public class AppendOnlyDataStoreService {
 
     public Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> getMap() {
         return services.stream()
-                .flatMap(service -> service.getMap().entrySet().stream())
+                .flatMap(service -> {
+                    Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> map = service instanceof HistoricalDataStoreService ?
+                            ((HistoricalDataStoreService) service).getMapOfAllData() :
+                            service.getMap();
+                    return map.entrySet().stream();
+                })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 


### PR DESCRIPTION
The map access to HistoricalDataStoreServices from the p2pDataStorage was incorrect. I has accessed the live map instead of all data. That has led that at addPersistableNetworkPayload the data got rebroadcast as it was assumed the data has not been already received.

How to test it?
- Add some logs in P2PDataStorage.addPersistableNetworkPayload to see if data gets added and broadcast
- Change the  delay at republishAllFiatAccounts in AccountAgeWitnessService otherwise it takes 20-60 sec. for republishing
- Create a new fresh regtest seed and new fresh app node. 
- Start the app. Create one fiat payment account. Shut down and copy the AccountAgeWitnessStore which must have 1 entry now and copy it to the resources and rename it to AccountAgeWitnessStore_1.5.0_BTC_REGTEST
- Restart seed node and app
- Now you should see repeated logs that the data gets added and broadcast

It is still not clear to me why we did not see much more AccountAgeWitness data but only one in massive numbers... 