### PR TITLE
Update translations and fix a broken German translation

### DIFF
--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Vyberte obchodní účet
 shared.fundFromSavingsWalletButton=Přesunout finance z Bisq peněženky
 shared.fundFromExternalWalletButton=Otevřít vaši externí peněženku pro financování
 shared.openDefaultWalletFailed=Nepodařilo se otevřít aplikaci bitcoinové peněženky. Jste si jisti, že máte nějakou nainstalovanou?
-shared.distanceInPercent=Vzdálenost v % z tržní ceny
 shared.belowInPercent=% pod tržní cenou
 shared.aboveInPercent=% nad tržní cenou
 shared.enterPercentageValue=Zadejte % hodnotu
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Zůstatek obchodní peněženky
 shared.makerTxFee=Tvůrce: {0}
 shared.takerTxFee=Příjemce: {0}
 shared.iConfirm=Potvrzuji
-shared.tradingFeeInBsqInfo=odpovídá {0} použitému jako obchodní poplatek
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Otevřené {0}
 shared.fiat=Fiat
 shared.crypto=Krypto
@@ -206,7 +205,7 @@ shared.sellerUpperCase=Prodejce
 shared.new=NOVÝ
 shared.blindVoteTxId=ID transakce se slepým hlasováním
 shared.proposal=Návrh
-shared.votes=Hlasů
+shared.votes=Hlasy
 shared.learnMore=Zjistit více
 shared.dismiss=Zavřít
 shared.selectedArbitrator=Zvolený rozhodce
@@ -215,13 +214,13 @@ shared.selectedRefundAgent=Zvolený rozhodce
 shared.mediator=Mediátor
 shared.arbitrator=Rozhodce
 shared.refundAgent=Rozhodce
-shared.refundAgentForSupportStaff=Rozhodce
-shared.delayedPayoutTxId=ID zpožděné platební transakce
-shared.delayedPayoutTxReceiverAddress=Zpožděná výplatní transakce odeslána na
+shared.refundAgentForSupportStaff=Rozhodce pro vrácení peněz
+shared.delayedPayoutTxId=ID odložené platební transakce
+shared.delayedPayoutTxReceiverAddress=Odložená výplatní transakce odeslána na
 shared.unconfirmedTransactionsLimitReached=Momentálně máte příliš mnoho nepotvrzených transakcí. Prosím zkuste to znovu později.
-shared.numItemsLabel=Number of entries: {0}
-shared.filter=Filter
-shared.enabled=Povoleno
+shared.numItemsLabel=Počet položek: {0}
+shared.filter=Filtr
+shared.enabled=Aktivní
 
 
 ####################################################################
@@ -420,7 +419,7 @@ offerbook.info.roundedFiatVolume=Částka byla zaokrouhlena, aby se zvýšilo so
 createOffer.amount.prompt=Vložte množství v BTC
 createOffer.price.prompt=Zadejte cenu
 createOffer.volume.prompt=Vložte množství v {0}
-createOffer.amountPriceBox.amountDescription=Množství BTC k {0}
+createOffer.amountPriceBox.amountDescription=Množství BTC, které chcete {0}
 createOffer.amountPriceBox.buy.volumeDescription=Částka v {0}, kterou utratíte
 createOffer.amountPriceBox.sell.volumeDescription=Částka v {0}, kterou přijmete
 createOffer.amountPriceBox.minAmountDescription=Minimální množství BTC
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Vždy získáte o {0} % méně, než je
 createOffer.warning.buyAboveMarketPrice=Vždy zaplatíte o {0} % více, než je aktuální tržní cena, protože cena vaší nabídky bude průběžně aktualizována.
 createOffer.tradeFee.descriptionBTCOnly=Obchodní poplatek
 createOffer.tradeFee.descriptionBSQEnabled=Zvolte měnu obchodního poplatku
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} z částky obchodu
+
+createOffer.triggerPrice.prompt=Nepovinná limitní cena
+createOffer.triggerPrice.label=Deaktivovat nabídku, pokud tržní cena dosáhne {0}
+createOffer.triggerPrice.tooltip=Abyste se ochránili před prudkými výkyvy tržních cen, můžete nastavit limitní cenu, po jejímž dosažení bude vaše nabídka stažena.
+createOffer.triggerPrice.invalid.tooLow=Hodnota musí být vyšší než {0}
+createOffer.triggerPrice.invalid.tooHigh=Hodnota musí být nižší než {0}
 
 # new entries
 createOffer.placeOfferButton=Přehled: Umístěte nabídku k {0} bitcoinu
-createOffer.alreadyFunded=Tuto nabídku jste již financovali.\nVaše finanční prostředky byly přesunuty do vaší lokální peněženky Bisq a jsou k dispozici pro výběr na obrazovce \"Prostředky/Odeslat finanční prostředky\".
 createOffer.createOfferFundWalletInfo.headline=Financujte svou nabídku
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Výše obchodu: {0}\n
@@ -489,7 +492,7 @@ takeOffer.validation.amountSmallerThanMinAmount=Částka nesmí být menší ne�
 takeOffer.validation.amountLargerThanOfferAmount=Vstupní částka nesmí být vyšší než částka stanovená v nabídce.
 takeOffer.validation.amountLargerThanOfferAmountMinusFee=Toto vstupní množství by vytvořilo zanedbatelné drobné pro prodejce BTC.
 takeOffer.fundsBox.title=Financujte svůj obchod
-takeOffer.fundsBox.isOfferAvailable=Zkontrolujte, zda je nabídka k dispozici ...
+takeOffer.fundsBox.isOfferAvailable=Kontroluje se, zda je nabídka k dispozici ...
 takeOffer.fundsBox.tradeAmount=Částka k prodeji
 takeOffer.fundsBox.offerFee=Obchodní poplatek
 takeOffer.fundsBox.networkFee=Celkové poplatky za těžbu
@@ -503,7 +506,6 @@ takeOffer.error.message=Při převzetí nabídky došlo k chybě.\n\n{0}
 # new entries
 takeOffer.takeOfferButton=Přehled: Využijte nabídku {0} bitcoin(y)
 takeOffer.noPriceFeedAvailable=Tuto nabídku nemůžete vzít, protože používá procentuální cenu založenou na tržní ceně, ale není k dispozici žádný zdroj cen.
-takeOffer.alreadyFunded.movedFunds=Tuto nabídku jste již financovali.\nVaše finanční prostředky byly přesunuty do vaší lokální peněženky Bisq a jsou k dispozici pro výběr na obrazovce \"Prostředky/Odeslat finanční prostředky\".
 takeOffer.takeOfferFundWalletInfo.headline=Financujte svůj obchod
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Výše obchodu: {0} \n
@@ -530,6 +532,10 @@ takeOffer.tac=Přijetím této nabídky souhlasím s obchodními podmínkami def
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Limitní cena
+openOffer.triggerPrice=Limitní cena {0}
+openOffer.triggered=Nabídka byla deaktivována, protože tržní cena dosáhla vámi stanovené limitní ceny.\nProsím nastavte novou limitní cenu ve vaší nabídce
 
 editOffer.setPrice=Nastavit cenu
 editOffer.confirmEdit=Potvrdit: Upravit nabídku
@@ -764,7 +770,7 @@ portfolio.pending.openSupportTicket.msg=Použijte tuto funkci pouze v naléhavý
 portfolio.pending.timeLockNotOver=Než budete moci zahájit rozhodčí spor, musíte počkat do ≈{0} ({1} dalších bloků).
 portfolio.pending.error.depositTxNull=Vkladová operace je nulová. Nemůžete otevřít spor bez platné vkladové transakce. Přejděte do \"Nastavení/Informace o síti\" a proveďte resynchronizaci SPV.\n\nPro další pomoc prosím kontaktujte podpůrný kanál v Bisq Keybase týmu.
 portfolio.pending.mediationResult.error.depositTxNull=Vkladová transakce je nulová. Obchod můžete přesunout do neúspěšných obchodů.
-portfolio.pending.mediationResult.error.delayedPayoutTxNull=Zpožděná výplatní transakce je nulová. Obchod můžete přesunout do neúspěšných obchodů.
+portfolio.pending.mediationResult.error.delayedPayoutTxNull=Odložená výplatní transakce je nulová. Obchod můžete přesunout do neúspěšných obchodů.
 portfolio.pending.error.depositTxNotConfirmed=Vkladová transakce není potvrzena. Nemůžete zahájit rozhodčí spor s nepotvrzenou vkladovou transakcí. Počkejte prosím, až bude potvrzena, nebo přejděte do \"Nastavení/Informace o síti\" a proveďte resynchronizaci SPV.\n\nPro další pomoc prosím kontaktujte podpůrný kanál v Bisq Keybase týmu.
 
 portfolio.pending.support.headline.getHelp=Potřebujete pomoc?
@@ -798,8 +804,8 @@ portfolio.pending.mediationResult.popup.alreadyAccepted=Už jste přijali
 portfolio.pending.failedTrade.taker.missingTakerFeeTx=Chybí poplatek příjemce transakce.\n\nBez tohoto tx nelze obchod dokončit. Nebyly uzamčeny žádné prostředky a nebyl zaplacen žádný obchodní poplatek. Tento obchod můžete přesunout do neúspěšných obchodů.
 portfolio.pending.failedTrade.maker.missingTakerFeeTx=Chybí poplatek příjemce transakce.\n\nBez tohoto tx nelze obchod dokončit. Nebyly uzamčeny žádné prostředky. Vaše nabídka je stále k dispozici dalším obchodníkům, takže jste neztratili poplatek za vytvoření. Tento obchod můžete přesunout do neúspěšných obchodů.
 portfolio.pending.failedTrade.missingDepositTx=Vkladová transakce (transakce 2-of-2 multisig) chybí.\n\nBez tohoto tx nelze obchod dokončit. Nebyly uzamčeny žádné prostředky, ale byl zaplacen váš obchodní poplatek. Zde můžete požádat o vrácení obchodního poplatku: [HYPERLINK:https://github.com/bisq-network/support/issues]\n\nKlidně můžete přesunout tento obchod do neúspěšných obchodů.
-portfolio.pending.failedTrade.buyer.existingDepositTxButMissingDelayedPayoutTx=Zpožděná výplatní transakce chybí, ale prostředky byly uzamčeny v vkladové transakci.\n\nNezasílejte prosím fiat nebo altcoin platbu prodejci BTC, protože bez zpožděné platby tx nelze zahájit arbitráž. Místo toho otevřete mediační úkol pomocí Cmd/Ctrl+o. Mediátor by měl navrhnout, aby oba partneři dostali zpět celou částku svých bezpečnostních vkladů (přičemž prodejce také obdrží plnou částku obchodu). Tímto způsobem nehrozí žádné bezpečnostní riziko a jsou ztraceny pouze obchodní poplatky.\n\nO vrácení ztracených obchodních poplatků můžete požádat zde: [HYPERLINK:https://github.com/bisq-network/support/issues]
-portfolio.pending.failedTrade.seller.existingDepositTxButMissingDelayedPayoutTx=Zpožděná výplatní transakce chybí, ale prostředky byly v depozitní transakci uzamčeny.\n\nPokud kupujícímu chybí také zpožděná výplatní transakce, bude poučen, aby platbu NEPOSLAL a místo toho otevřel mediační úkol. Měli byste také otevřít mediační úkol pomocí Cmd/Ctrl+o.\n\nPokud kupující ještě neposlal platbu, měl by zprostředkovatel navrhnout, aby oba partneři dostali zpět celou částku svých bezpečnostních vkladů (přičemž prodejce také obdrží plnou částku obchodu). Jinak by částka obchodu měla jít kupujícímu.\n\nO vrácení ztracených obchodních poplatků můžete požádat zde: [HYPERLINK:https://github.com/bisq-network/support/issues]
+portfolio.pending.failedTrade.buyer.existingDepositTxButMissingDelayedPayoutTx=Odložená výplatní transakce chybí, ale prostředky byly uzamčeny v vkladové transakci.\n\nNezasílejte prosím fiat nebo altcoin platbu prodejci BTC, protože bez odložené platby tx nelze zahájit arbitráž. Místo toho otevřete mediační úkol pomocí Cmd/Ctrl+o. Mediátor by měl navrhnout, aby oba partneři dostali zpět celou částku svých bezpečnostních vkladů (přičemž prodejce také obdrží plnou částku obchodu). Tímto způsobem nehrozí žádné bezpečnostní riziko a jsou ztraceny pouze obchodní poplatky.\n\nO vrácení ztracených obchodních poplatků můžete požádat zde: [HYPERLINK:https://github.com/bisq-network/support/issues]
+portfolio.pending.failedTrade.seller.existingDepositTxButMissingDelayedPayoutTx=Odložená výplatní transakce chybí, ale prostředky byly v depozitní transakci uzamčeny.\n\nPokud kupujícímu chybí také odložená výplatní transakce, bude poučen, aby platbu NEPOSLAL a místo toho otevřel mediační úkol. Měli byste také otevřít mediační úkol pomocí Cmd/Ctrl+o.\n\nPokud kupující ještě neposlal platbu, měl by zprostředkovatel navrhnout, aby oba partneři dostali zpět celou částku svých bezpečnostních vkladů (přičemž prodejce také obdrží plnou částku obchodu). Jinak by částka obchodu měla jít kupujícímu.\n\nO vrácení ztracených obchodních poplatků můžete požádat zde: [HYPERLINK:https://github.com/bisq-network/support/issues]
 portfolio.pending.failedTrade.errorMsgSet=Během provádění obchodního protokolu došlo k chybě.\n\nChyba: {0}\n\nJe možné, že tato chyba není kritická a obchod lze dokončit normálně. Pokud si nejste jisti, otevřete si mediační úkol a získejte radu od mediátorů Bisq.\n\nPokud byla chyba kritická a obchod nelze dokončit, možná jste ztratili obchodní poplatek. O vrácení ztracených obchodních poplatků požádejte zde: [HYPERLINK:https://github.com/bisq-network/support/issues]
 portfolio.pending.failedTrade.missingContract=Obchodní kontrakt není stanoven.\n\nObchod nelze dokončit a možná jste ztratili poplatek za obchodování. Pokud ano, můžete požádat o vrácení ztracených obchodních poplatků zde: [HYPERLINK:https://github.com/bisq-network/support/issues]
 portfolio.pending.failedTrade.info.popup=Obchodní protokol narazil na některé problémy.\n\n{0}
@@ -818,7 +824,7 @@ portfolio.failed.Failed=Selhalo
 portfolio.failed.unfail=Před pokračováním se ujistěte, že máte zálohu vašeho datového adresáře!\nChcete tento obchod přesunout zpět do otevřených obchodů?\nJe to způsob, jak odemknout finanční prostředky uvízlé v neúspěšném obchodu.
 portfolio.failed.cantUnfail=Tento obchod nelze v tuto chvíli přesunout zpět do otevřených obchodů.\nZkuste to znovu po dokončení obchodu (obchodů) {0}
 portfolio.failed.depositTxNull=Obchod nelze změnit zpět na otevřený obchod. Transakce s vkladem je neplatná.
-portfolio.failed.delayedPayoutTxNull=Obchod nelze změnit zpět na otevřený obchod. Zpožděná výplatní transakce je nulová.
+portfolio.failed.delayedPayoutTxNull=Obchod nelze změnit zpět na otevřený obchod. Odložená výplatní transakce je nulová.
 
 
 ####################################################################
@@ -840,21 +846,21 @@ funds.deposit.withdrawFromWallet=Pošlete peníze z peněženky
 funds.deposit.amount=Částka v BTC (volitelná)
 funds.deposit.generateAddress=Vygenerujte novou adresu
 funds.deposit.generateAddressSegwit=Nativní formát segwit (Bech32)
-funds.deposit.selectUnused=Vyberte prosím nepoužívanou adresu z výše uvedené tabulky spíše než generovat novou.
+funds.deposit.selectUnused=Vyberte prosím nepoužívanou adresu z výše uvedené tabulky místo generování nové.
 
 funds.withdrawal.arbitrationFee=Poplatek za arbitráž
 funds.withdrawal.inputs=Volba vstupů
 funds.withdrawal.useAllInputs=Použijte všechny dostupné vstupy
 funds.withdrawal.useCustomInputs=Použijte vlastní vstupy
-funds.withdrawal.receiverAmount=Částka příjemce
-funds.withdrawal.senderAmount=Částka odesílatele
+funds.withdrawal.receiverAmount=Částka pro příjemce
+funds.withdrawal.senderAmount=Náklad pro odesílatele
 funds.withdrawal.feeExcluded=Částka nezahrnuje poplatek za těžbu
 funds.withdrawal.feeIncluded=Částka zahrnuje poplatek za těžbu
 funds.withdrawal.fromLabel=Výběr z adresy
-funds.withdrawal.toLabel=Adresa výběru
+funds.withdrawal.toLabel=Adresa příjemce
 funds.withdrawal.memoLabel=Poznámka k výběru
 funds.withdrawal.memo=Volitelně vyplňte poznámku
-funds.withdrawal.withdrawButton=Zvolen výběr
+funds.withdrawal.withdrawButton=Odeslat výběr
 funds.withdrawal.noFundsAvailable=Pro výběr nejsou k dispozici žádné finanční prostředky
 funds.withdrawal.confirmWithdrawalRequest=Potvrďte žádost o výběr
 funds.withdrawal.withdrawMultipleAddresses=Výběr z více adres ({0})
@@ -897,7 +903,7 @@ funds.tx.txSent=Transakce byla úspěšně odeslána na novou adresu v lokální
 funds.tx.direction.self=Poslat sobě
 funds.tx.daoTxFee=Poplatek za těžbu za BSQ tx
 funds.tx.reimbursementRequestTxFee=Žádost o vyrovnání
-funds.tx.compensationRequestTxFee=Žádost o odškodnění
+funds.tx.compensationRequestTxFee=Žádost o odměnu
 funds.tx.dustAttackTx=Přijaté drobné
 funds.tx.dustAttackTx.popup=Tato transakce odesílá do vaší peněženky velmi malou částku BTC a může se jednat o pokus společností provádějících analýzu blockchainu o špehování vaší peněženky.\n\nPoužijete-li tento transakční výstup ve výdajové transakci, zjistí, že jste pravděpodobně také vlastníkem jiné adresy (sloučení mincí).\n\nKvůli ochraně vašeho soukromí ignoruje peněženka Bisq takové drobné výstupy pro účely utrácení a na obrazovce zůstatku. Můžete nastavit hodnotu "drobnosti", kdy je výstup považován za drobné, v nastavení.
 
@@ -951,6 +957,7 @@ support.error=Příjemce nemohl zpracovat zprávu. Chyba: {0}
 support.buyerAddress=Adresa kupujícího BTC
 support.sellerAddress=Adresa prodejce BTC
 support.role=Role
+support.agent=Agent podpory
 support.state=Stav
 support.closed=Zavřeno
 support.open=Otevřené
@@ -970,7 +977,7 @@ support.peerOpenedDispute=Váš obchodní partner požádal o spor.\n\n{0}\n\nBi
 support.peerOpenedDisputeForMediation=Váš obchodní partner požádal o mediaci.\n\n{0}\n\nBisq verze: {1}
 support.mediatorsDisputeSummary=Systémová zpráva: Shrnutí sporu mediátora:\n{0}
 support.mediatorsAddress=Adresa uzlu mediátora: {0}
-support.warning.disputesWithInvalidDonationAddress=Zpožděná výplatní transakce použila neplatnou adresu příjemce. Neshoduje se s žádnou z hodnot parametrů DAO pro platné dárcovské adresy.\n\nMůže to být pokus o podvod. Informujte prosím vývojáře o tomto incidentu a neuzavírejte tento případ, dokud nebude situace vyřešena!\n\nAdresa použitá ve sporu: {0}\n\nVšechny parametry pro darovací adresy DAO: {1}\n\nObchodní ID: {2} {3}
+support.warning.disputesWithInvalidDonationAddress=Odložená výplatní transakce použila neplatnou adresu příjemce. Neshoduje se s žádnou z hodnot parametrů DAO pro platné dárcovské adresy.\n\nMůže to být pokus o podvod. Informujte prosím vývojáře o tomto incidentu a neuzavírejte tento případ, dokud nebude situace vyřešena!\n\nAdresa použitá ve sporu: {0}\n\nVšechny parametry pro darovací adresy DAO: {1}\n\nObchodní ID: {2} {3}
 support.warning.disputesWithInvalidDonationAddress.mediator=\n\nStále chcete spor uzavřít?
 support.warning.disputesWithInvalidDonationAddress.refundAgent=\n\nVýplatu nesmíte provést.
 
@@ -1162,7 +1169,7 @@ setting.info.msg=Při prodeji BTC za XMR můžete pomocí funkce automatického 
 ####################################################################
 
 account.tab.mediatorRegistration=Registrace mediátora
-account.tab.refundAgentRegistration=Registrace agenta vrácení peněz
+account.tab.refundAgentRegistration=Registrace rozhodce pro vrácení peněz
 account.tab.signing=Podepisování
 account.info.headline=Vítejte ve vašem účtu Bisq
 account.info.msg=Zde můžete přidat obchodní účty pro národní měny & altcoiny a vytvořit zálohu dat vaší peněženky a účtu.\n\nPři prvním spuštění Bisq byla vytvořena nová bitcoinová peněženka.\n\nDůrazně doporučujeme zapsat si seed slova bitcoinových peněženek (viz záložka nahoře) a před financováním zvážit přidání hesla. Vklady a výběry bitcoinů jsou spravovány v sekci \ "Finance \".\n\nOchrana osobních údajů a zabezpečení: protože Bisq je decentralizovaná směnárna, všechna data jsou uložena ve vašem počítači. Neexistují žádné servery, takže nemáme přístup k vašim osobním informacím, vašim finančním prostředkům ani vaší IP adrese. Údaje, jako jsou čísla bankovních účtů, adresy altcoinů a bitcoinu atd., jsou sdíleny pouze s obchodním partnerem za účelem uskutečnění obchodů, které zahájíte (v případě sporu uvidí Prostředník nebo Rozhodce stejná data jako váš obchodní peer uzel).
@@ -1171,26 +1178,26 @@ account.menu.paymentAccount=Účty v národní měně
 account.menu.altCoinsAccountView=Altcoinové účty
 account.menu.password=Heslo peněženky
 account.menu.seedWords=Seed peněženky
-account.menu.walletInfo=Wallet info
+account.menu.walletInfo=Info o peněžence
 account.menu.backup=Záloha
 account.menu.notifications=Oznámení
 
-account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
-account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
-account.menu.walletInfo.walletSelector={0} {1} wallet
-account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.balance.headLine=Zůstatky v peněžence
+account.menu.walletInfo.balance.info=Zde jsou zobrazeny celkové zůstatky v interní peněžence včetně nepotvrzených transakcí.\nInterní zůstatek BTC uvedený níže by měl odpovídat součtu hodnot 'Dostupný zůstatek' a 'Rezervováno v nabídkách' v pravém horním rohu aplikace.
+account.menu.walletInfo.xpub.headLine=Veřejné klíče (xpub)
+account.menu.walletInfo.walletSelector={0} {1} peněženka
+account.menu.walletInfo.path.headLine=HD identifikátory klíčů
+account.menu.walletInfo.path.info=Pokud importujete vaše seed slova do jiné peněženky (např. Electrum), budete muset nastavit také identifikátor klíčů (BIP32 path). Toto provádějte pouze ve výjimečných případech, např. pokud úplně ztratíte kontrolu nad Bisq peněženkou.\nMějte na paměti, že provádění transakcí pomocí jiných softwarových peněženek může snadno poškodit interní datové struktury systému Bisq, a znemožnit tak provádění obchodů.\n\nNIKDY neposílejte BSQ pomocí jiných softwarových peněženek než Bisq, protože byste tím velmi pravděpodobně vytvořili neplatnou BSQ transakci, a ztratili tak své BSQ.
 
-account.menu.walletInfo.openDetails=Show raw wallet details and private keys
+account.menu.walletInfo.openDetails=Zobrazit detailní data peněženky a soukromé klíče
 
 ## TODO should we rename the following to a gereric name?
 account.arbitratorRegistration.pubKey=Veřejný klíč
 
 account.arbitratorRegistration.register=Registrovat
-account.arbitratorRegistration.registration={0} registrace
+account.arbitratorRegistration.registration=Registrace {0}
 account.arbitratorRegistration.revoke=Odvolat
-account.arbitratorRegistration.info.msg=Upozorňujeme, že po odvolání musíte zůstat k dispozici 15 dní, protože mohou existovat obchody, které vás používají jako {0}. Max. povolené obchodní období je 8 dní a proces řešení sporu může trvat až 7 dní.
+account.arbitratorRegistration.info.msg=Upozorňujeme, že po odvolání musíte zůstat k dispozici 15 dní, protože mohou existovat obchody, pro které jste {0}. Max. povolené obchodní období je 8 dní a proces řešení sporu může trvat až 7 dní.
 account.arbitratorRegistration.warn.min1Language=Musíte nastavit alespoň 1 jazyk.\nPřidali jsme vám výchozí jazyk.
 account.arbitratorRegistration.removedSuccess=Úspěšně jste odstranili svou registraci ze sítě Bisq.
 account.arbitratorRegistration.removedFailed=Registraci se nepodařilo odebrat. {0}
@@ -1198,7 +1205,7 @@ account.arbitratorRegistration.registerSuccess=Úspěšně jste se zaregistroval
 account.arbitratorRegistration.registerFailed=Registraci se nepodařilo dokončit. {0}
 
 account.altcoin.yourAltcoinAccounts=Vaše altcoinové účty
-account.altcoin.popup.wallet.msg=Ujistěte se, že dodržujete požadavky na používání peněženek {0}, jak je popsáno na webové stránce {1}.\nPoužití peněženek z centralizovaných směnáren, kde (a) nevlastníte své privátní klíče nebo (b) které nepoužívají kompatibilní software peněženky, je riskantní: může to vést ke ztrátě obchodovaných prostředků!\nMediátor nebo rozhodce není specialista {2} a v takových případech nemůže pomoci.
+account.altcoin.popup.wallet.msg=Ujistěte se, že dodržujete požadavky na používání peněženek {0}, jak je popsáno na webové stránce {1}.\nPoužití peněženek z centralizovaných směnáren, kde (a) nevlastníte své soukromé klíče nebo (b) které nepoužívají kompatibilní software peněženky, je riskantní: může to vést ke ztrátě obchodovaných prostředků!\nMediátor nebo rozhodce není specialista {2} a v takových případech nemůže pomoci.
 account.altcoin.popup.wallet.confirm=Rozumím a potvrzuji, že vím, jakou peněženku musím použít.
 # suppress inspection "UnusedProperty"
 account.altcoin.popup.upx.msg=Obchodování s UPX na Bisq vyžaduje, abyste pochopili a splnili následující požadavky:\n\nK odeslání UPX musíte použít buď oficiální peněženku GUI uPlexa nebo CLI peněženku uPlexa s povoleným příznakem store-tx-info (výchozí hodnota v nových verzích). Ujistěte se, že máte přístup ke klíči tx, který může být vyžadován v případě sporu.\nuplexa-wallet-cli (použijte příkaz get_tx_key)\nuplexa-wallet-gui (přejděte na záložku historie a pro potvrzení platby klikněte na tlačítko (P))\n\nV normálním block exploreru není přenos ověřitelný.\n\nV případě sporu musíte rozhodci poskytnout následující údaje:\n- Soukromý klíč tx\n- Hash transakce\n- Veřejnou adresa příjemce\n\nPokud neposkytnete výše uvedená data nebo použijete nekompatibilní peněženku, dojde ke prohrání sporu. Odesílatel UPX odpovídá za zajištění ověření přenosu UPX rozhodci v případě sporu.\n\nNení požadováno žádné platební ID, pouze normální veřejná adresa.\nPokud si nejste jisti tímto procesem, vyhledejte další informace na discord kanálu uPlexa (https://discord.gg/vhdNSrV) nebo uPlexa Telegram Chatu (https://t.me/uplexaOfficial).
@@ -1309,14 +1316,14 @@ account.notifications.marketAlert.addButton=Přidat upozornění na nabídku
 account.notifications.marketAlert.manageAlertsButton=Spravovat upozornění na nabídku
 account.notifications.marketAlert.manageAlerts.title=Spravovat upozornění na nabídku
 account.notifications.marketAlert.manageAlerts.header.paymentAccount=Platební účet
-account.notifications.marketAlert.manageAlerts.header.trigger=Spouštěcí cena
+account.notifications.marketAlert.manageAlerts.header.trigger=Limitní cena
 account.notifications.marketAlert.manageAlerts.header.offerType=Typ nabídky
 account.notifications.marketAlert.message.title=Upozornění na nabídku
 account.notifications.marketAlert.message.msg.below=pod
 account.notifications.marketAlert.message.msg.above=nad
 account.notifications.marketAlert.message.msg=Do nabídky Bisq byla zveřejněna nová nabídka ''{0} {1}'' s cenou {2} ({3} {4} tržní cena) a způsob platby ''{5}''.\nID nabídky: {6}.
 account.notifications.priceAlert.message.title=Upozornění na cenu pro {0}
-account.notifications.priceAlert.message.msg=Vaše upozornění na cenu bylo spuštěno. Aktuální {0} cena je {1} {2}
+account.notifications.priceAlert.message.msg=Vaše upozornění na cenu bylo aktivováno. Aktuální {0} cena je {1} {2}
 account.notifications.noWebCamFound.warning=Nebyla nalezena žádná webkamera.\n\nPoužijte e-mailu k odeslání tokenu a šifrovacího klíče z vašeho mobilního telefonu do aplikace Bisq.
 account.notifications.priceAlert.warning.highPriceTooLow=Vyšší cena musí být větší než nižší cena.
 account.notifications.priceAlert.warning.lowerPriceTooHigh=Nižší cena musí být nižší než vyšší cena.
@@ -1370,7 +1377,7 @@ dao.results.cycles.header=Cykly
 dao.results.cycles.table.header.cycle=Cyklus
 dao.results.cycles.table.header.numProposals=Návrhy
 dao.results.cycles.table.header.voteWeight=Váha hlasování
-dao.results.cycles.table.header.issuance=Vydání
+dao.results.cycles.table.header.issuance=Emise
 
 dao.results.results.table.item.cycle=Cyklus {0} začal: {1}
 
@@ -1414,9 +1421,9 @@ dao.param.PROPOSAL_FEE=Poplatek za návrh v BSQ
 dao.param.BLIND_VOTE_FEE=Hlasovací poplatek v BSQ
 
 # suppress inspection "UnusedProperty"
-dao.param.COMPENSATION_REQUEST_MIN_AMOUNT=Žádost o odškodnění min. částka BSQ
+dao.param.COMPENSATION_REQUEST_MIN_AMOUNT=Žádost o odměnu - min. částka BSQ
 # suppress inspection "UnusedProperty"
-dao.param.COMPENSATION_REQUEST_MAX_AMOUNT=Žádost o odškodnění max. částka BSQ
+dao.param.COMPENSATION_REQUEST_MAX_AMOUNT=Žádost o odměnu - max. částka BSQ
 # suppress inspection "UnusedProperty"
 dao.param.REIMBURSEMENT_MIN_AMOUNT=Žádost o vyrovnání min. částka BSQ
 # suppress inspection "UnusedProperty"
@@ -1425,7 +1432,7 @@ dao.param.REIMBURSEMENT_MAX_AMOUNT=Žádost o vyrovnání max. částka BSQ
 # suppress inspection "UnusedProperty"
 dao.param.QUORUM_GENERIC=Požadované kvórum v BSQ pro obecný návrh
 # suppress inspection "UnusedProperty"
-dao.param.QUORUM_COMP_REQUEST=Požadované kvórum v BSQ pro žádost o odškodnění
+dao.param.QUORUM_COMP_REQUEST=Požadované kvórum v BSQ pro žádost o odměnu
 # suppress inspection "UnusedProperty"
 dao.param.QUORUM_REIMBURSEMENT=Požadované kvórum v BSQ pro žádost o vyrovnání
 # suppress inspection "UnusedProperty"
@@ -1440,7 +1447,7 @@ dao.param.QUORUM_ROLE=Požadované kvórum v BSQ pro žádost o upsání
 # suppress inspection "UnusedProperty"
 dao.param.THRESHOLD_GENERIC=Požadovaná prahová hodnota v % pro obecný návrh
 # suppress inspection "UnusedProperty"
-dao.param.THRESHOLD_COMP_REQUEST=Požadovaná prahová hodnota v % pro žádost o odškodnění
+dao.param.THRESHOLD_COMP_REQUEST=Požadovaná prahová hodnota v % pro žádost o odměnu
 # suppress inspection "UnusedProperty"
 dao.param.THRESHOLD_REIMBURSEMENT=Požadovaná prahová hodnota v % pro žádost o vyrovnání
 # suppress inspection "UnusedProperty"
@@ -1690,14 +1697,14 @@ dao.phase.separatedPhaseBar.PROPOSAL=Fáze návrhu
 # suppress inspection "UnusedProperty"
 dao.phase.separatedPhaseBar.BLIND_VOTE=Slepé hlasování
 # suppress inspection "UnusedProperty"
-dao.phase.separatedPhaseBar.VOTE_REVEAL=Odhalit hlasování
+dao.phase.separatedPhaseBar.VOTE_REVEAL=Odhalení hlasování
 # suppress inspection "UnusedProperty"
 dao.phase.separatedPhaseBar.RESULT=Výsledek hlasování
 
 # suppress inspection "UnusedProperty"
 dao.proposal.type.UNDEFINED=Nedefinováno
 # suppress inspection "UnusedProperty"
-dao.proposal.type.COMPENSATION_REQUEST=Žádost o odškodnění
+dao.proposal.type.COMPENSATION_REQUEST=Žádost o odměnu
 # suppress inspection "UnusedProperty"
 dao.proposal.type.REIMBURSEMENT_REQUEST=Žádost o vyrovnání
 # suppress inspection "UnusedProperty"
@@ -1714,7 +1721,7 @@ dao.proposal.type.CONFISCATE_BOND=Žádost o konfiskaci úpisu
 # suppress inspection "UnusedProperty"
 dao.proposal.type.short.UNDEFINED=Nedefinováno
 # suppress inspection "UnusedProperty"
-dao.proposal.type.short.COMPENSATION_REQUEST=Žádost o odškodnění
+dao.proposal.type.short.COMPENSATION_REQUEST=Žádost o odměnu
 # suppress inspection "UnusedProperty"
 dao.proposal.type.short.REIMBURSEMENT_REQUEST=Žádost o vyrovnání
 # suppress inspection "UnusedProperty"
@@ -1840,7 +1847,7 @@ dao.tx.type.enum.sent.TRANSFER_BSQ=Odeslané BSQ
 # suppress inspection "UnusedProperty"
 dao.tx.type.enum.PAY_TRADE_FEE=Obchodní poplatek
 # suppress inspection "UnusedProperty"
-dao.tx.type.enum.COMPENSATION_REQUEST=Poplatek za žádost o odškodnění
+dao.tx.type.enum.COMPENSATION_REQUEST=Poplatek za žádost o odměnu
 # suppress inspection "UnusedProperty"
 dao.tx.type.enum.REIMBURSEMENT_REQUEST=Poplatek za žádost o vyrovnání
 # suppress inspection "UnusedProperty"
@@ -1848,7 +1855,7 @@ dao.tx.type.enum.PROPOSAL=Poplatek za návrh
 # suppress inspection "UnusedProperty"
 dao.tx.type.enum.BLIND_VOTE=Poplatek za slepé hlasování
 # suppress inspection "UnusedProperty"
-dao.tx.type.enum.VOTE_REVEAL=Odhalit hlasování
+dao.tx.type.enum.VOTE_REVEAL=Odhalení hlasování
 # suppress inspection "UnusedProperty"
 dao.tx.type.enum.LOCKUP=Zamknout úpis
 # suppress inspection "UnusedProperty"
@@ -1861,10 +1868,10 @@ dao.tx.type.enum.PROOF_OF_BURN=Důkaz spálení
 dao.tx.type.enum.IRREGULAR=Nepravidelný
 
 dao.tx.withdrawnFromWallet=BTC vybrané z peněženky
-dao.tx.issuanceFromCompReq=Žádost o odškodnění/vydání
-dao.tx.issuanceFromCompReq.tooltip=Žádost o kompenzaci, která vedla k vydání nového BSQ.\nDatum vydání: {0}
-dao.tx.issuanceFromReimbursement=Žádost o vyrovnání/vydání
-dao.tx.issuanceFromReimbursement.tooltip=Žádost o kompenzaci, která vedla k vydání nového BSQ.\nDatum vydání: {0}
+dao.tx.issuanceFromCompReq=Vydání odměny
+dao.tx.issuanceFromCompReq.tooltip=Žádost o odměnu, která vedla k vydání nového BSQ.\nDatum vydání: {0}
+dao.tx.issuanceFromReimbursement=Vydání vyrovnání
+dao.tx.issuanceFromReimbursement.tooltip=Žádost o vyrovnání, která vedla k vydání nového BSQ.\nDatum vydání: {0}
 dao.proposal.create.missingBsqFunds=Pro vytvoření návrhu nemáte dostatečné prostředky BSQ. Pokud máte nepotvrzenou transakci BSQ, musíte počkat na potvrzení na blockchainu, protože BSQ je validováno, pouze pokud je zahrnuto v bloku.\nChybí: {0}
 
 dao.proposal.create.missingBsqFundsForBond=Pro tuto roli nemáte dostatečné prostředky BSQ. Tento návrh můžete stále zveřejnit, ale pokud bude přijat, budete potřebovat celou částku BSQ potřebnou pro tuto roli.\nChybí: {0}
@@ -1904,7 +1911,7 @@ dao.monitor.proposals=Stav návrhů
 dao.monitor.blindVotes=Stav slepých hlasů
 
 dao.monitor.table.peers=Peer uzly
-dao.monitor.table.conflicts=Konflikt
+dao.monitor.table.conflicts=Konflikty
 dao.monitor.state=Stav
 dao.monitor.requestAlHashes=Vyžádat si všechny hashe
 dao.monitor.resync=Znovu synchronizovat stav DAO
@@ -1957,8 +1964,8 @@ dao.factsAndFigures.supply.issuedVsBurnt=Vydaných BSQ vs. Spálených BSQ
 
 dao.factsAndFigures.supply.issued=Vydáno BSQ
 dao.factsAndFigures.supply.genesisIssueAmount=BSQ vydané při první (genesis) transakci
-dao.factsAndFigures.supply.compRequestIssueAmount=BSQ vydáno pro žádosti o odškodnění
-dao.factsAndFigures.supply.reimbursementAmount=BSQ vydané pro žádosti o vyrovnání
+dao.factsAndFigures.supply.compRequestIssueAmount=BSQ vydáno na žádosti o odměnu
+dao.factsAndFigures.supply.reimbursementAmount=BSQ vydáno na žádosti o vyrovnání
 
 dao.factsAndFigures.supply.burnt=Spálených BSQ
 dao.factsAndFigures.supply.burntMovingAverage=15denní klouzavý průměr
@@ -1978,8 +1985,8 @@ dao.factsAndFigures.transactions.genesisTxId=ID genesis transakce
 dao.factsAndFigures.transactions.txDetails=Statistiky transakcí BSQ
 dao.factsAndFigures.transactions.allTx=Počet všech transakcí BSQ
 dao.factsAndFigures.transactions.utxo=Počet všech nevyčerpaných transakčních výstupů
-dao.factsAndFigures.transactions.compensationIssuanceTx=Počet všech transakcí s žádostí o odškodnění
-dao.factsAndFigures.transactions.reimbursementIssuanceTx=Počet všech transakcí k vydání žádosti o vyrovnání
+dao.factsAndFigures.transactions.compensationIssuanceTx=Počet všech transakcí s vydáním odměn
+dao.factsAndFigures.transactions.reimbursementIssuanceTx=Počet všech transakcí s vydáním vyrovnání
 dao.factsAndFigures.transactions.burntTx=Počet všech poplatků platebních transakcí
 dao.factsAndFigures.transactions.invalidTx=Počet všech neplatných transakcí
 dao.factsAndFigures.transactions.irregularTx=Počet všech nepravidelných transakcí
@@ -2100,7 +2107,7 @@ filterWindow.bannedAccountWitnessSignerPubKeys=Filtrované veřejné klíče ú�
 filterWindow.bannedPrivilegedDevPubKeys=Filtrované privilegované klíče pub dev (hex nebo pub klíče oddělené čárkou)
 filterWindow.arbitrators=Filtrovaní rozhodci (onion adresy oddělené čárkami)
 filterWindow.mediators=Filtrovaní mediátoři (onion adresy oddělené čárkami)
-filterWindow.refundAgents=Filtrovaní zástupci pro vrácení peněz (adresy oddělené čárkami)
+filterWindow.refundAgents=Filtrovaní rozhodci pro vrácení peněz (onion adresy oddělené čárkami)
 filterWindow.seedNode=Filtrované seed nody (onion adresy oddělené čárkami)
 filterWindow.priceRelayNode=Filtrované cenové relay nody (onion adresy oddělené čárkami)
 filterWindow.btcNode=Filtrované Bitcoinové nody (adresy+porty oddělené čárkami)
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Můžete si vybrat, zda chcete zaplatit obchodní poplatek 
 feeOptionWindow.optionsLabel=Vyberte měnu pro platbu obchodního poplatku
 feeOptionWindow.useBTC=Použít BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Potvrzuji, že mohu provést vklad
 popup.info.shutDownWithOpenOffers=Bisq se vypíná, ale existují otevřené nabídky.\n\nTyto nabídky nebudou dostupné v síti P2P, pokud bude Bisq vypnutý, ale budou znovu publikovány do sítě P2P při příštím spuštění Bisq.\n\nChcete-li zachovat své nabídky online, udržujte Bisq spuštěný a ujistěte se, že tento počítač zůstává online (tj. Ujistěte se, že nepřejde do pohotovostního režimu...pohotovostní režim monitoru není problém).
 popup.info.qubesOSSetupInfo=Zdá se, že používáte Bisq na Qubes OS.\n\nUjistěte se, že je vaše Bisq qube nastaveno podle našeho průvodce nastavením na [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade z verze {0} na verzi {1} není podporován. Použijte prosím nejnovější verzi Bisq.
+popup.warn.daoRequiresRestart=Došlo k problému při synchronizaci stavu DAO. Pro nápravu prosím restartujte aplikaci.
 
 popup.privateNotification.headline=Důležité soukromé oznámení!
 
 popup.securityRecommendation.headline=Důležité bezpečnostní doporučení
 popup.securityRecommendation.msg=Chtěli bychom vám připomenout, abyste zvážili použití ochrany heslem pro vaši peněženku, pokud jste ji již neaktivovali.\n\nDůrazně se také doporučuje zapsat seed slova peněženky. Tato seed slova jsou jako hlavní heslo pro obnovení vaší bitcoinové peněženky.\nV sekci "Seed peněženky" naleznete další informace.\n\nDále byste měli zálohovat úplnou složku dat aplikace v sekci \"Záloha\".
 
-popup.bitcoinLocalhostNode.msg=Bisq detekoval lokálně spuštěný Bitcoin Core node (na localhostu).\nPřed spuštěním Bisq se ujistěte, že tento node je plně synchronizován a že není spuštěn v pruned mode režimu.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nPožadavky pro dobře nakonfigurovaný uzel jsou, aby bylo zakázáno prořezávání (pruning) a aby byly povoleny bloom filtry.
+popup.bitcoinLocalhostNode.msg=Bisq detekoval Bitcoin Core node běžící na tomto systému (na localhostu).\n\nProsím ujistěte se, že:\n- tento node je plně synchronizován před spuštěním Bisq\n- prořezávání je vypnuto ('prune=0' v bitcoin.conf)\n- Bloomovy filtry jsou zapnuty ('peerbloomfilters=1' v bitcoin.conf)
 
 popup.shutDownInProgress.headline=Probíhá vypínání
 popup.shutDownInProgress.msg=Vypnutí aplikace může trvat několik sekund.\nProsím, nepřerušujte tento proces.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=Jeden z vašich platebních účtů byl ověř
 popup.accountSigning.peerLimitLifted=Počáteční limit pro jeden z vašich účtů byl zrušen.\n\n{0}
 popup.accountSigning.peerSigner=Jeden z vašich účtů je dostatečně zralý, aby podepsal další platební účty, a počáteční limit pro jeden z vašich účtů byl zrušen.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Vyberte svědka stáří účtu
-popup.accountSigning.singleAccountSelect.description=Vyhledejte svědka stáří účtu.
-popup.accountSigning.singleAccountSelect.datePicker=Vyberte čas pro podpis
+popup.accountSigning.singleAccountSelect.headline=Importujte svědka stáří účtu k podepsání
 popup.accountSigning.confirmSingleAccount.headline=Potvrďte vybrané svědky o stáří účtu
 popup.accountSigning.confirmSingleAccount.selectedHash=Hash vybraného svědka
 popup.accountSigning.confirmSingleAccount.button=Podepsat svědka stáří účtu
 popup.accountSigning.successSingleAccount.description=Svědek {0} byl podepsán
 popup.accountSigning.successSingleAccount.success.headline=Úspěch
-popup.accountSigning.successSingleAccount.signError=Nepodařilo se podepsat svědka, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Nepodepsané Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Podepsat Pubkeys
@@ -2390,7 +2396,7 @@ guiUtil.accountExport.exportFailed=Export do CSV selhal kvůli chybě.\nChyba = 
 guiUtil.accountExport.selectExportPath=Vyberte složku pro export
 guiUtil.accountImport.imported=Obchodní účet importovaný z:\n{0}\n\nImportované účty:\n{1}
 guiUtil.accountImport.noAccountsFound=Nebyly nalezeny žádné exportované obchodní účty na: {0}.\nNázev souboru je {1}."
-guiUtil.openWebBrowser.warning=Chystáte se otevřít webovou stránku ve webovém prohlížeči.\nChcete nyní otevřít webovou stránku?\n\nPokud nepoužíváte \"Tor Browser\" jako výchozí systémový webový prohlížeč, připojíte se k webové stránce v čisté síti.\n\nURL: \"{0}\"
+guiUtil.openWebBrowser.warning=Chystáte se otevřít webovou stránku ve webovém prohlížeči.\nChcete nyní otevřít webovou stránku?\n\nPokud nepoužíváte \"Tor Browser\" jako výchozí systémový webový prohlížeč, připojíte se k webové stránce přes nechráněné spojení.\n\nURL: \"{0}\"
 guiUtil.openWebBrowser.doOpen=Otevřít webovou stránku a znovu se neptat
 guiUtil.openWebBrowser.copyUrl=Zkopírovat URL a zrušit
 guiUtil.ofTradeAmount=obchodní částky
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive="DAO/Peněženka BSQ/Přijmout"
 
 formatter.formatVolumeLabel={0} částka{1}
 formatter.makerTaker=Tvůrce jako {0} {1} / Příjemce jako {2} {3}
-formatter.youAreAsMaker={0}te {1} jako tvůrce / Příjemce {2} {3}
-formatter.youAreAsTaker={0}te {1} jako příjemce / Tvůrce {2} {3}
+formatter.youAreAsMaker=Jste {1} {0} (jako tvůrce) / Příjemce je {3} {2}
+formatter.youAreAsTaker=Jste {1} {0} (jako příjemce) / Tvůrce je {3} {2}
 formatter.youAre={0}te {1} ({2}te {3})
 formatter.youAreCreatingAnOffer.fiat=Vytváříte nabídku: {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Vytváříte nabídku: {0} {1} ({2}te {3})
@@ -2517,7 +2523,7 @@ time.seconds=sekundy
 password.enterPassword=Vložte heslo
 password.confirmPassword=Potvrďte heslo
 password.tooLong=Heslo musí mít méně než 500 znaků.
-password.deriveKey=Odvozte klíč z hesla
+password.deriveKey=Odvozuji klíč z hesla
 password.walletDecrypted=Peněženka úspěšně dešifrována a ochrana heslem byla odstraněna.
 password.wrongPw=Zadali jste nesprávné heslo.\n\nZkuste prosím zadat heslo znovu a pečlivě zkontrolujte překlepy nebo pravopisné chyby.
 password.walletEncrypted=Peněženka úspěšně šifrována a ochrana heslem povolena.
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Jméno
 payment.australia.payid=PayID
 payment.payid=PayID spojené s finanční institucí. Jako e-mailová adresa nebo mobilní telefon.
 payment.payid.info=PayID jako telefonní číslo, e-mailová adresa nebo australské obchodní číslo (ABN), které můžete bezpečně propojit se svou bankou, družstevní záložnou nebo účtem stavební spořitelny. Musíte mít již vytvořený PayID u své australské finanční instituce. Odesílající i přijímající finanční instituce musí podporovat PayID. Další informace najdete na [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=Chcete-li platit kartou Amazon eGift, musíte si na svém účtu Amazon zakoupit kartu Amazon eGift a použít e-mail nebo mobilní číslo prodejce BTC. jako příjemce. Amazon poté odešle příjemci e-mail nebo textovou zprávu. Pro pole zprávy použijte ID obchodu.\n\nKarty Amazon eGift lze uplatnit pouze na účtech Amazon se stejnou měnou.\n\nDalší informace najdete na webové stránce Amazon eGift Card. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=Chcete-li platit dárkovou kartou Amazon eGift, budete muset prodejci BTC poslat kartu Amazon eGift přes svůj účet Amazon.\n\nBisq zobrazí e-mail nebo mobilní číslo prodejce BTC, kam bude potřeba odeslat tuto dárkovou kartu. Na kartě ve zprávě pro příjemce musí být uvedeno ID obchodu. Pro další detaily a rady viz wiki: [HYPERLINK:https://bisq.wiki/Amazon_eGift_card].\n\nZde jsou tři důležité poznámky:\n- Preferujte dárkové karty v hodnotě do 100 USD, protože Amazon může považovat nákupy karet s vyššími částkami jako podezřelé a zablokovat je.\n- Na kartě do zprávy pro příjemce můžete přidat i vlastní originální text (např. "Happy birthday Susan!") spolu s ID obchodu. (V takovém případě o tom informujte protistranu pomocí obchodovacího chatu, aby mohli s jistotou ověřit, že obdržená dárková karta pochází od vás.)\n- Karty Amazon eGift lze uplatnit pouze na té stránce Amazon, na které byly také koupeny (např. karta koupená na amazon.it může být uplatněna zase jen na amazon.it).
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Handelskonto auswählen
 shared.fundFromSavingsWalletButton=Gelder aus Bisq-Wallet überweisen
 shared.fundFromExternalWalletButton=Ihre externe Wallet zum Finanzieren öffnen
 shared.openDefaultWalletFailed=Öffnen einer Bitcoin Wallet Applikation fehlgeschlagen. Bist du sicher, dass du eine installiert hast?
-shared.distanceInPercent=Abstand vom Marktpreis in %
 shared.belowInPercent=% unter dem Marktpreis
 shared.aboveInPercent=% über dem Marktpreis
 shared.enterPercentageValue=%-Wert eingeben
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Guthaben der Handels-Wallet
 shared.makerTxFee=Ersteller: {0}
 shared.takerTxFee=Abnehmer: {0}
 shared.iConfirm=Ich bestätige
-shared.tradingFeeInBsqInfo=gleichwertig mit {0} als Trading-Gebühr
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Öffne {0}
 shared.fiat=Fiat
 shared.crypto=Crypto
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Sie erhalten immer {0}% weniger als der
 createOffer.warning.buyAboveMarketPrice=Sie zahlen immer {0}% mehr als der aktuelle Marktpreis, da ihr Angebot ständig aktualisiert wird.
 createOffer.tradeFee.descriptionBTCOnly=Handelsgebühr
 createOffer.tradeFee.descriptionBSQEnabled=Gebührenwährung festlegen
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} vom Handelsbetrag
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Überprüfung: Anbieten Bitcoins zu {0}
-createOffer.alreadyFunded=Sie hatten das Angebot bereits finanziert.\nIhre Gelder wurden in Ihre lokale Bisq-Wallet verschoben und können unter \"Gelder/Gelder senden\" abgehoben werden.
 createOffer.createOfferFundWalletInfo.headline=Ihr Angebot finanzieren
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Handelsbetrag: {0} \n
@@ -503,7 +506,6 @@ takeOffer.error.message=Bei der Angebotsannahme trat ein Fehler auf.\n\n{0}
 # new entries
 takeOffer.takeOfferButton=Überprüfung: Angebot annehmen Bitcoins zu {0}
 takeOffer.noPriceFeedAvailable=Sie können dieses Angebot nicht annehmen, da es auf einem Prozentsatz vom Marktpreis basiert, jedoch keiner verfügbar ist.
-takeOffer.alreadyFunded.movedFunds=Sie haben das Angebot bereits finanziert.\nIhre Gelder wurden in Ihre lokale Bisq-Wallet verschoben und können unter \"Gelder/Gelder senden\" abgehoben werden.
 takeOffer.takeOfferFundWalletInfo.headline=Ihren Handel finanzieren
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Handelsbetrag: {0}\n
@@ -530,6 +532,10 @@ takeOffer.tac=Mit der Annahme dieses Angebots stimme ich den oben festgelegten H
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Triggerpreis
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=Preis festlegen
 editOffer.confirmEdit=Bestätigen: Angebot bearbeiten
@@ -951,6 +957,7 @@ support.error=Empfänger konnte die Nachricht nicht verarbeiten. Fehler: {0}
 support.buyerAddress=BTC-Adresse des Käufers
 support.sellerAddress=BTC-Adresse des Verkäufers
 support.role=Rolle
+support.agent=Support agent
 support.state=Status
 support.closed=Geschlossen
 support.open=Offen
@@ -1176,11 +1183,11 @@ account.menu.backup=Backup
 account.menu.notifications=Benachrichtigungen
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -1816,7 +1823,7 @@ dao.wallet.send.setDestinationAddress=Tragen Sie Ihre Zieladresse ein
 dao.wallet.send.send=BSQ-Gelder senden
 dao.wallet.send.sendBtc=BTC-Gelder senden
 dao.wallet.send.sendFunds.headline=Abhebeanfrage bestätigen
-dao.wallet.send.sendFunds.details=Senden: {0]\nEmpfangsadresse: {1}.\nBenötigte Mining-Gebühr beträgt: {2} ({3} satoshis/vbyte)\nTransaktion vsize: {4} vKb\n\nDer empfänger wird erhalten: {5}\n\nSind Sie sich sicher die Menge abzuheben?
+dao.wallet.send.sendFunds.details=Senden: {0}\nEmpfangsadresse: {1}.\nBenötigte Mining-Gebühr beträgt: {2} ({3} satoshis/vbyte)\nTransaktion vsize: {4} vKb\n\nDer empfänger wird erhalten: {5}\n\nSind Sie sich sicher die Menge abzuheben?
 dao.wallet.chainHeightSynced=Synchronisiert bis Block: {0}
 dao.wallet.chainHeightSyncing=Erwarte Blöcke... {0} von {1} Blöcken verifiziert
 dao.wallet.tx.type=Typ
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Sie können wählen, die Gebühr in BSQ oder BTC zu zahlen.
 feeOptionWindow.optionsLabel=Währung für Handelsgebührzahlung auswählen
 feeOptionWindow.useBTC=BTC nutzen
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Ich bestätige, dass ich die Kaution zahlen k
 popup.info.shutDownWithOpenOffers=Bisq wird heruntergefahren, aber Sie haben offene Angebote verfügbar.\n\nDiese Angebote sind nach dem Herunterfahren nicht mehr verfügbar und werden erneut im P2P-Netzwerk veröffentlicht wenn Sie das nächste Mal Bisq starten.\n\nLassen Sie Bisq weiter laufen und stellen Sie sicher, dass Ihr Computer online bleibt, um Ihre Angebote verfügbar zu halten (z.B.: verhindern Sie den Standby-Modus... der Standby-Modus des Monitors stellt kein Problem dar).
 popup.info.qubesOSSetupInfo=Es scheint so als ob Sie Bisq auf Qubes OS laufen haben.\n\nBitte stellen Sie sicher, dass Bisq qube nach unserem Setup Guide eingerichtet wurde: [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade von Version {0} auf Version {1} wird nicht unterstützt. Bitte nutzen Sie die aktuelle Bisq Version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Wichtige private Benachrichtigung!
 
 popup.securityRecommendation.headline=Wichtige Sicherheitsempfehlung
 popup.securityRecommendation.msg=Wir würden Sie gerne daran erinnern, sich zu überlegen, den Passwortschutz Ihrer Wallet zu verwenden, falls Sie diesen noch nicht aktiviert haben.\n\nEs wird außerdem dringend empfohlen, dass Sie die Wallet-Seed-Wörter aufschreiben. Diese Seed-Wörter sind wie ein Master-Passwort zum Wiederherstellen ihrer Bitcoin-Wallet.\nIm \"Wallet-Seed\"-Abschnitt finden Sie weitere Informationen.\n\nZusätzlich sollten Sie ein Backup des ganzen Anwendungsdatenordners im \"Backup\"-Abschnitt erstellen.
 
-popup.bitcoinLocalhostNode.msg=Bisq hat einen lokal laufenden Bitcoin-Core-Node entdeckt (bei localhost).\nStellen Sie bitte sicher, dass dieser Node vollständig synchronisiert ist, bevor Sie Bisq starten und dass er nicht im Pruned-Modus läuft.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nFür einen gut konfigurierten Node sind die Anforderungen, dass das Pruning deaktiviert und die Bloom-Filter aktiviert sind.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Anwendung wird heruntergefahren
 popup.shutDownInProgress.msg=Das Herunterfahren der Anwendung kann einige Sekunden dauern.\nBitte unterbrechen Sie diesen Vorgang nicht.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=Eines Ihrer Zahlungskonten wurde von einem Tra
 popup.accountSigning.peerLimitLifted=Das anfängliche Limit für eines Ihrer Konten wurde aufgehoben.\n\n{0}
 popup.accountSigning.peerSigner=Eines Ihrer Konten ist reif genug, um andere Zahlungskonten zu unterzeichnen, und das anfängliche Limit für eines Ihrer Konten wurde aufgehoben.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Zeuge für Konto-Alter auswählen
-popup.accountSigning.singleAccountSelect.description=Nach Zeuge für Konto-Alter suchen.
-popup.accountSigning.singleAccountSelect.datePicker=Zeitpunkt für Unterzeichnung auswählen
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Ausgewählten Zeugen für Konto-Alter bestätigen
 popup.accountSigning.confirmSingleAccount.selectedHash=Ausgewählter Zeugen-Hash
 popup.accountSigning.confirmSingleAccount.button=Zeuge für Konto-Alter unterzeichnen
 popup.accountSigning.successSingleAccount.description=Zeuge {0} wurde unterzeichnet
 popup.accountSigning.successSingleAccount.success.headline=Erfolg
-popup.accountSigning.successSingleAccount.signError=Zeuge nicht unterzeichnet (fehlgeschlagen), {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Nicht unterzeichnete Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Pubkeys unterzeichnen
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"DAO/BSQ-Wallet/Erhalten\"
 
 formatter.formatVolumeLabel={0} Betrag{1}
 formatter.makerTaker=Ersteller als {0} {1} / Abnehmer als {2} {3}
-formatter.youAreAsMaker=Sie {0} {1} als Ersteller / Abnehmer wird {3} {2}
-formatter.youAreAsTaker=Sie {0} {1} als Abnehmer / Ersteller wird {3} {2}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=Sie {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Sie erstellen ein Angebot um {1} zu {0}
 formatter.youAreCreatingAnOffer.altcoin=Sie erstellen ein Angebot {1} zu {0} ({3} zu {2})
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Name
 payment.australia.payid=PayID
 payment.payid=PayIDs wie E-Mail Adressen oder Telefonnummern die mit Finanzinstitutionen verbunden sind.
 payment.payid.info=Eine PayID wie eine Telefonnummer, E-Mail Adresse oder Australische Business Number (ABN) mit der Sie sicher Ihre Bank, Kreditgenossenschaft oder Bausparkassenkonto verlinken können. Sie müssen bereits eine PayID mit Ihrer Australischen Finanzinstitution erstellt haben. Beide Institutionen, die die sendet und die die empfängt, müssen PayID unterstützen. Weitere informationen finden Sie unter [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=Um mit Amazon eGift Karten zu bezahlen, müssen Sie Amazon eGift Karten mit Ihrem Amazon Konto kaufen und die E-Mail und Telefonnummer des BTC Verkäufers als Empfänger verwenden. Amazon sendet dann eine E-Mail oder SMS an den Empfänger. Benutzen Sie die Trade ID für das Nachrichtenfeld.\n\nAmazon eGift Karten können nur von Amazon Konten mit der gleichen Währung eingelöst werden.\n\nFür weitere Informationen besuchen Sie die Amazon eGift Karten Website.\n[HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Selecionar cuenta de intercambio
 shared.fundFromSavingsWalletButton=Transferir fondos desde la cartera Bisq
 shared.fundFromExternalWalletButton=Abrir su monedero externo para agregar fondos
 shared.openDefaultWalletFailed=Fallo al abrir la aplicación de cartera predeterminada. ¿Tal vez no tenga una instalada?
-shared.distanceInPercent=Distancia en % del precio de mercado
 shared.belowInPercent=% por debajo del precio de mercado
 shared.aboveInPercent=% por encima del precio de mercado
 shared.enterPercentageValue=Introduzca valor %
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Saldo de la cartera de intercambio
 shared.makerTxFee=Creador: {0}
 shared.takerTxFee=Tomador: {0}
 shared.iConfirm=Confirmo
-shared.tradingFeeInBsqInfo=equivalente a {0} usado como tasa de intercambio
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Abrir {0}
 shared.fiat=Fiat
 shared.crypto=Cripto
@@ -219,8 +218,8 @@ shared.refundAgentForSupportStaff=Agente de devolución de fondos
 shared.delayedPayoutTxId=ID de transacción del pago demorado
 shared.delayedPayoutTxReceiverAddress=Transacción de pago demorado enviada a
 shared.unconfirmedTransactionsLimitReached=Tiene demasiadas transacciones no confirmadas en este momento. Por favor, inténtelo de nuevo más tarde.
-shared.numItemsLabel=Number of entries: {0}
-shared.filter=Filter
+shared.numItemsLabel=Número de entradas: {0}
+shared.filter=Filtro
 shared.enabled=Habilitado
 
 
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Siempre tendrá {0}% menos que el preci
 createOffer.warning.buyAboveMarketPrice=Siempre pagará {0}% más que el precio de mercado ya que el precio de su oferta será actualizado continuamente.
 createOffer.tradeFee.descriptionBTCOnly=Comisión de transacción
 createOffer.tradeFee.descriptionBSQEnabled=Seleccionar moneda de comisión de intercambio
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} de cantidad de intercambio
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Revisar: Poner oferta para {0} bitcoin
-createOffer.alreadyFunded=Ya había destinado fondos para esa oferta.\nSus fondos han sido movidos a la cartera Bisq local y están disponibles para retirar en la pantalla \"Fondos/Enviar fondos\".
 createOffer.createOfferFundWalletInfo.headline=Dote de fondos su trato.
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Cantidad a intercambiar: {0}\n
@@ -503,7 +506,6 @@ takeOffer.error.message=Un error ocurrió al tomar la oferta.\n\n{0}
 # new entries
 takeOffer.takeOfferButton=Revisión: Tomar oferta a {0} bitcoin
 takeOffer.noPriceFeedAvailable=No puede tomar esta oferta porque utiliza un precio porcentual basado en el precio de mercado y no hay fuentes de precio disponibles.
-takeOffer.alreadyFunded.movedFunds=Ya había destinado fondos para esta oferta.\nSus fondos han sido movidos a la cartera Bisq local y están disponibles para retirar en la pantalla \"Fondos/Enviar fondos\".
 takeOffer.takeOfferFundWalletInfo.headline=Dotar de fondos su intercambio
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Cantidad a intercambiar: {0}\n
@@ -530,6 +532,10 @@ takeOffer.tac=Al tomar esta oferta, afirmo estar de acuerdo con las condiciones 
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Precio de activación
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=Establecer precio
 editOffer.confirmEdit=Confirmar: Editar oferta
@@ -951,6 +957,7 @@ support.error=El receptor no pudo procesar el mensaje. Error: {0}
 support.buyerAddress=Dirección del comprador de BTC
 support.sellerAddress=Dirección del vendedor de BTC
 support.role=Rol
+support.agent=Support agent
 support.state=Estado
 support.closed=Cerrado
 support.open=Abierto
@@ -1171,18 +1178,18 @@ account.menu.paymentAccount=Cuentas de moneda nacional
 account.menu.altCoinsAccountView=Cuentas de altcoin
 account.menu.password=Contraseña de monedero
 account.menu.seedWords=Semilla del monedero
-account.menu.walletInfo=Wallet info
+account.menu.walletInfo=Información de monedero
 account.menu.backup=Copia de seguridad
 account.menu.notifications=Notificaciones
 
-account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
-account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
-account.menu.walletInfo.walletSelector={0} {1} wallet
-account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.balance.headLine=Balances de monedero
+account.menu.walletInfo.balance.info=Esto muestrta el balance interno del monedero, incluyendo transacciones no confirmadas.\nPara BTC, el balance interno de monedero mostrado abajo debe cuadrar con la suma de balances 'Disponible' y 'Reservado' mostrado arriba a la derecha de esta ventana.
+account.menu.walletInfo.xpub.headLine=Claves centinela (xpub keys)
+account.menu.walletInfo.walletSelector={0} {1} monedero
+account.menu.walletInfo.path.headLine=ruta HD keychain
+account.menu.walletInfo.path.info=Si importa las palabras semilla en otro monedero (como Electru), tendrá que definir la ruta. Esto debería hacerse solo en casos de emergencia, cuando pierda acceso a el monedero Bisq y el directorio de datos.\nTenga en cuenta que gastar fondos desde un monedero no-Bisq puede estropear la estructura de datos interna de Bisq asociado a los datos de monedero, lo que puede llevar a intercambios fallidos.\n\nNUNCA envíe BSQ desde un monedero no-Bisq, ya que probablemente llevará a una transacción inválida de BSQ y le hará perder sus BSQ.
 
-account.menu.walletInfo.openDetails=Show raw wallet details and private keys
+account.menu.walletInfo.openDetails=Mostrar detalles en bruto y claves privadas
 
 ## TODO should we rename the following to a gereric name?
 account.arbitratorRegistration.pubKey=Llave pública
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Puede elegir pagar la tasa de intercambio en BSQ o BTC. Si 
 feeOptionWindow.optionsLabel=Elija moneda para el pago de comisiones de intercambio
 feeOptionWindow.useBTC=Usar BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Confirmo que puedo hacer el depósito
 popup.info.shutDownWithOpenOffers=Bisq se está cerrando, pero hay ofertas abiertas.\n\nEstas ofertas no estarán disponibles en la red P2P mientras Bisq esté cerrado, pero serán re-publicadas a la red P2P la próxima vez que inicie Bisq.\n\nPara mantener sus ofertas en línea, mantenga Bisq ejecutándose y asegúrese de que la computadora permanece en línea también (Ej. asegúrese de que no se pone en modo standby... el monitor en espera no es un problema).
 popup.info.qubesOSSetupInfo=Parece que está ejecutando Bisq en Qubes OS\n\nAsegúrese de que su Bisq qube esté configurado de acuerdo con nuestra Guía de configuración en [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes]
 popup.warn.downGradePrevention=Degradar desde la versión {0} a la versión {1} no está soportado. Por favor use la última versión de Bisq.
+popup.warn.daoRequiresRestart=Hubo un problema sincronizando el estado de la DAO. Tiene que reiniciar la aplicación para solucionar el problema.
 
 popup.privateNotification.headline=Notificación privada importante!
 
 popup.securityRecommendation.headline=Recomendación de seguridad importante
 popup.securityRecommendation.msg=Nos gustaría recordarle que considere usar protección por contraseña para su cartera, si no la ha activado ya.\n\nTambién es muy recomendable que escriba en un papel las palabras semilla del monedero. Esas palabras semilla son como una contraseña maestra para recuperar su cartera Bitcoin.\nEn la sección \"Semilla de cartera\" encontrará más información.\n\nAdicionalmente, debería hacer una copia de seguridad completa del directorio de aplicación en la sección \"Copia de seguridad\"
 
-popup.bitcoinLocalhostNode.msg=Bisq detectó un nodo Bitcoin Core operando localmente (en localhost).\nPor favor asegúrese de que este nodo esté completamente sincronizado antes de iniciar Bisq y que no esté operando en modo poda (pruned mode).
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nPara un nodo bien configurado, los requisitos son que el nodo tenga la poda desactivada y los filtros bloom habilitados.
+popup.bitcoinLocalhostNode.msg=Bisq ha detectado un nodo de Bitcoin Core ejecutándose en esta máquina (en local).\n\nPor favor, asegúrese de:\n- que el nodo está completamente sincronizado al iniciar Bisq\n- que el podado está desabilitado ('prune=0' en bitcoin.conf)\n- que los filtros bloom están deshabilitados ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Cerrando aplicación...
 popup.shutDownInProgress.msg=Cerrar la aplicación puede llevar unos segundos.\nPor favor no interrumpa el proceso.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=Una de sus cuentas de pago ha sido verificada 
 popup.accountSigning.peerLimitLifted=El límite inicial para una de sus cuentas se ha elevado.\n\n{0}
 popup.accountSigning.peerSigner=Una de sus cuentas es suficiente antigua para firmar otras cuentas de pago y el límite inicial para una de sus cuentas se ha elevado.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Seleccionar el testigo de edad de cuenta
-popup.accountSigning.singleAccountSelect.description=Buscar un testigo de edad de cuenta
-popup.accountSigning.singleAccountSelect.datePicker=Seleccionar un punto en el tiempo para el firmadoº
+popup.accountSigning.singleAccountSelect.headline=Importar edad de cuenta de testigos no firmados
 popup.accountSigning.confirmSingleAccount.headline=Confirmar el testigo de cuenta seleccionado
 popup.accountSigning.confirmSingleAccount.selectedHash=Hash del testigo seleccionado
 popup.accountSigning.confirmSingleAccount.button=Firmar testigo de edad de cuenta
 popup.accountSigning.successSingleAccount.description=Se seleccionón el testigo {0}
 popup.accountSigning.successSingleAccount.success.headline=Éxito
-popup.accountSigning.successSingleAccount.signError=Error al firmar el testigo, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Claves públicas no firmadas
 popup.accountSigning.unsignedPubKeys.sign=Firmar claves públicas
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"DAO/Monedero BSQ/Recibir\"
 
 formatter.formatVolumeLabel={0} cantidad{1}
 formatter.makerTaker=Creador como {0} {1} / Tomador como {2} {3}
-formatter.youAreAsMaker=Usted está {0} {1} como creador / Tomador está {2} {3}
-formatter.youAreAsTaker=Usted está {0} {1} como tomador / Creador está {2} {3}
+formatter.youAreAsMaker=Usted es: {1} {0} (creador) / El tomador es: {3} {2}
+formatter.youAreAsTaker=Usted es: {1} {0} (tomador) / Creador es: {3} {2}
 formatter.youAre=Usted es {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Está creando una oferta a {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Está creando una oferta a {0} {1} ({2} {3})
@@ -2584,7 +2590,7 @@ payment.venmo.venmoUserName=Nombre de usuario Venmo
 payment.popmoney.accountId=Correo electrónico o núm. de telefóno
 payment.promptPay.promptPayId=Citizen ID/Tax ID o número de teléfono
 payment.supportedCurrencies=Monedas soportadas
-payment.supportedCurrenciesForReceiver=Currencies for receiving funds
+payment.supportedCurrenciesForReceiver=Monedas para recibir fondos
 payment.limitations=Límitaciones:
 payment.salt="Salt" de la verificación de edad de la cuenta.
 payment.error.noHexSalt=El "salt" necesitar estar en formato HEX.\nSolo se recomienda editar el "salt" si quiere transferir el "salt" desde una cuenta antigua para mantener su edad de cuenta. La edad de cuenta se verifica usando el "salt" de la cuenta y datos de identificación de cuenta (Ej. IBAN).
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Nombre
 payment.australia.payid=PayID
 payment.payid=PayID conectado a una institución financiera. Como la dirección email o el número de móvil.
 payment.payid.info=Un PayID como un número de teléfono, dirección email o Australian Business Number (ABN), que puede conectar con seguridad a su banco, unión de crédito o cuenta de construcción de sociedad. Necesita haber creado una PayID con su institución financiera australiana. Tanto para enviar y recibir las instituciones financieras deben soportar PayID. Para más información por favor compruebe [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=Para pagar con una Tarjeta Amazon eGift necesita comprar una Tarjeta Amazon eGift en su cuenta Amazon y usar el email del vendedor, o el númeor de móvil como receptor. Amazon enviará un email o mensaje de texto al receptor. Use la ID de intercambio para el campo de mensaje.\n\nLas tarjetas Amazon eGift solo pueden redimirse por las cuentas Amazon con la misma moneda.\n\nPara más información visite la página web de Tarjeta Amazon eGift. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=حساب معاملات را انتخاب کنید
 shared.fundFromSavingsWalletButton=انتقال وجه از کیف  Bisq
 shared.fundFromExternalWalletButton=برای تهیه پول، کیف پول بیرونی خود را باز کنید
 shared.openDefaultWalletFailed=Failed to open a Bitcoin wallet application. Are you sure you have one installed?
-shared.distanceInPercent=فاصله در ٪ از قیمت بازار
 shared.belowInPercent= ٪ زیر قیمت بازار
 shared.aboveInPercent= ٪ بالای قیمت بازار
 shared.enterPercentageValue=ارزش ٪ را وارد کنید
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=موجودی کیف‌پول معاملات
 shared.makerTxFee=سفارش گذار: {0}
 shared.takerTxFee=پذیرنده سفارش: {0}
 shared.iConfirm=تایید می‌کنم
-shared.tradingFeeInBsqInfo=equivalent to {0} used as trading fee
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=باز {0}
 shared.fiat=فیات
 shared.crypto=کریپتو
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=شما همیشه {0}% کمتر از ن
 createOffer.warning.buyAboveMarketPrice=شما همیشه {0}% کمتر از نرخ روز فعلی بازار پرداخت خواهید کرد، زیرا قیمت پیشنهادتان به طور مداوم به روز رسانی خواهد شد.
 createOffer.tradeFee.descriptionBTCOnly=کارمزد معامله
 createOffer.tradeFee.descriptionBSQEnabled=انتخاب ارز برای کارمزد معامله
-createOffer.tradeFee.fiatAndPercent=≈ {1} / {0} از مبلغ معامله
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=بررسی: پیشنهاد را برای  {0} بیتکوین بگذارید
-createOffer.alreadyFunded=در حال حاضر آن پیشنهاد را تامین وجه کرده‌اید.\nوجوه شما به کیف پول محلی Bisq منتقل شده و برای برداشت در صفحه \"وجوه/ارسال وجوه\" در دسترس است.
 createOffer.createOfferFundWalletInfo.headline=پیشنهاد خود را تامین وجه نمایید
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=مقدار معامله:{0}\n
@@ -503,7 +506,6 @@ takeOffer.error.message=هنگام قبول کردن پیشنهاد، اتفاق
 # new entries
 takeOffer.takeOfferButton=بررسی: برای {0} بیتکوین پیشنهاد بگذارید.
 takeOffer.noPriceFeedAvailable=امکان پذیرفتن پیشنهاد وجود ندارد. پیشنهاد از قیمت درصدی مبتنی بر قیمت روز بازار استفاده می‌کند و قیمت‌های بازار هم‌اکنون در دسترس نیست.
-takeOffer.alreadyFunded.movedFunds=شما در حال حاضر آن پیشنهاد را تامین وجه کرده‌اید.\nوجوه شما به کیف پول محلی Bisq منتقل شده و برای برداشت در صفحه \"وجوه/ارسال وجوه\" در دسترس است.
 takeOffer.takeOfferFundWalletInfo.headline=معامله خود را تأمین وجه نمایید
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=مقدار معامله: {0}\n
@@ -530,6 +532,10 @@ takeOffer.tac=با پذیرفتن این پیشنهاد، من قبول می‌�
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=قیمت نشان‌شده
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=تنظیم قیمت
 editOffer.confirmEdit=تأیید: ویرایش پیشنهاد
@@ -951,6 +957,7 @@ support.error=گیرنده نتوانست پیام را پردازش کند. خ�
 support.buyerAddress=آدرس خریدار بیتکوین
 support.sellerAddress=آدرس فروشنده بیتکوین
 support.role=نقش
+support.agent=Support agent
 support.state=حالت
 support.closed=بسته
 support.open=باز
@@ -1176,11 +1183,11 @@ account.menu.backup=پشتیبان
 account.menu.notifications=اعلان‌ها
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=شما می توانید انتخاب کنید که هزی�
 feeOptionWindow.optionsLabel=انتخاب ارز برای پرداخت کارمزد معامله
 feeOptionWindow.useBTC=استفاده از BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=تأیید می کنم که می توانم �
 popup.info.shutDownWithOpenOffers=Bisq در حال خاموش شدن است ولی پیشنهاداتی وجود دارند که باز هستند.\n\nزمانی که Bisq بسته باشد این پیشنهادات در شبکه P2P در دسترس نخواهند بود، ولی هر وقت دوباره Bisq را باز کنید این پیشنهادات دوباره در شبکه P2P منتشر خواهند شد.\n\n برای اینکه پیشنهادات شما برخط بمانند، بگذارید Bisq در حال اجرابماند و همچنین مطمئن شوید که این کامپیوتر به اینترنت متصل است. (به عنوان مثال مطمئن شوید که به حالت آماده باش نمی‌رود.. البته حالت آماده باش برای نمایشگر ایرادی ندارد).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=اعلان خصوصی مهم!
 
 popup.securityRecommendation.headline=توصیه امنیتی مهم
 popup.securityRecommendation.msg=ما می خواهیم به شما یادآوری کنیم که استفاده از رمز محافظت برای کیف پول خود را در نظر بگیرید اگر از قبل آن را فعال نکرده اید.\n\nهمچنین شدیداً توصیه می شود که کلمات رمز خصوصی کیف پول را بنویسید. این کلمات رمز خصوصی مانند یک رمزعبور اصلی برای بازیابی کیف پول بیتکوین شما هستند. \nدر قسمت \"کلمات رمز خصوصی کیف پول\" اطلاعات بیشتری کسب می کنید.\n\n علاوه بر این شما باید از پوشه داده های کامل نرم افزار در بخش \"پشتیبان گیری\" پشتیبان تهیه کنید.
 
-popup.bitcoinLocalhostNode.msg=Bisq یک گره بیتکوین هسته محلی در حال اجرا را (در لوکا هاست) شناسایی کرد.\n لطفا اطمینان حاصل کنید که این گره قبل از شروع Bisq به طور کامل همگام سازی شده و در حالت هرس شده اجرا نمی شود.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nFor a well configured node, the requirements are for the node to have pruning disabled and bloom filters enabled.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=خاموش شدن در حال انجام است
 popup.shutDownInProgress.msg=خاتمه دادن به برنامه می تواند چند ثانیه طول بکشد.\n لطفا این روند را قطع نکنید.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=One of your payment accounts has been verified
 popup.accountSigning.peerLimitLifted=The initial limit for one of your accounts has been lifted.\n\n{0}
 popup.accountSigning.peerSigner=One of your accounts is mature enough to sign other payment accounts and the initial limit for one of your accounts has been lifted.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"DAO/کیف پول BSQ/دریافت\"
 
 formatter.formatVolumeLabel={0} مبلغ {1}
 formatter.makerTaker=سفارش گذار به عنوان {0} {1} / پذیرنده به عنوان {2} {3}
-formatter.youAreAsMaker=شما  {0} {1} به عنوان سفارش گذار هستید/ پذیرنده {2} {3} هست
-formatter.youAreAsTaker=شما {0} {1} به عنوان پذیرنده هستید/ سفارش گذار {2} {3} هست
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=شما {0} {1} ({2} {3}) هستید
 formatter.youAreCreatingAnOffer.fiat=شما در حال ایجاد یک پیشنهاد به {0} {1} هستید
 formatter.youAreCreatingAnOffer.altcoin=شما در حال ایجاد یک پیشنهاد به {0} {1} ({2} {3}) هستید
@@ -2659,7 +2665,8 @@ payment.japan.recipient=نام
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Sélectionner le compte de trading
 shared.fundFromSavingsWalletButton=Transférer des fonds depuis le portefeuille Bisq
 shared.fundFromExternalWalletButton=Ouvrez votre portefeuille externe pour provisionner
 shared.openDefaultWalletFailed=L'ouverture de l'application de portefeuille Bitcoin par défaut a échoué. Êtes-vous sûr de l'avoir installée?
-shared.distanceInPercent=Écart en % par rapport au du prix du marché
 shared.belowInPercent=% sous le prix du marché
 shared.aboveInPercent=% au-dessus du prix du marché
 shared.enterPercentageValue=Entrez la valeur en %
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Solde du portefeuille de trading
 shared.makerTxFee=Maker: {0}
 shared.takerTxFee=Taker: {0}
 shared.iConfirm=Je confirme
-shared.tradingFeeInBsqInfo=Équivalent à {0} utilisé en frais de transaction
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Ouvert {0}
 shared.fiat=Fiat
 shared.crypto=Crypto
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Vous obtiendrez toujours {0}% de moins 
 createOffer.warning.buyAboveMarketPrice=Vous paierez toujours {0}% de plus que le prix actuel du marché car le prix de votre ordre sera continuellement mis à jour.
 createOffer.tradeFee.descriptionBTCOnly=Frais de transaction
 createOffer.tradeFee.descriptionBSQEnabled=Choisir la devise des frais de transaction
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} du montant de la transaction
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Review: Placer un ordre de {0} Bitcoin
-createOffer.alreadyFunded=Vous aviez déjà financé cet ordre.\nVos fonds ont été transférés dans votre portefeuille Bisq local et peuvent être retirés dans l'onglet \"Fonds/Envoyer des fonds\"
 createOffer.createOfferFundWalletInfo.headline=Financer votre ordre
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=Montant du trade: {0}\n\n
@@ -503,7 +506,6 @@ takeOffer.error.message=Une erreur s''est produite pendant l’'acceptation de l
 # new entries
 takeOffer.takeOfferButton=Vérifier: Accepter l''ordre de {0} Bitcoin
 takeOffer.noPriceFeedAvailable=Vous ne pouvez pas accepter cet ordre, car celui-ci utilise un prix en pourcentage basé sur le prix du marché, mais il n'y a pas de prix de référence de disponible.
-takeOffer.alreadyFunded.movedFunds=Vous aviez déjà provisionner cette ordre.\nVos fonds ont été transféré dans votre portefeuille bisq local et sont disponible dans l'onglet \"Fonds/Envoyer des fonds\"
 takeOffer.takeOfferFundWalletInfo.headline=Provisionner votre trade
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Montant du trade: {0}\n
@@ -531,6 +533,10 @@ takeOffer.tac=En acceptant cet ordre vous acceptez les conditions de transaction
 # Offerbook / Edit offer
 ####################################################################
 
+openOffer.header.triggerPrice=Prix de déclenchement
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
+
 editOffer.setPrice=Définir le prix
 editOffer.confirmEdit=Confirmation: Modification de l'ordre
 editOffer.publishOffer=Publication de votre ordre.
@@ -550,7 +556,7 @@ portfolio.tab.editOpenOffer=Éditer l'ordre
 
 portfolio.closedTrades.deviation.help=Percentage price deviation from market
 
-portfolio.pending.invalidDelayedPayoutTx=Il y a un problème causé par des transactions manquantes ou indisponibles. \n\nVeuillez ne pas envoyer de monnaie fiduciaire ou de monnaie numérique. Contactez les développeurs Bisq sur Keybase à https://keybase.io/team/bisq ou sur le forum https://bisq.community pour plus d'aide. \n\nMessage d'erreur: {0}
+portfolio.pending.invalidDelayedPayoutTx=Il y a un problème causé par des transactions manquantes ou indisponibles. \n\nVeuillez ne pas envoyer de monnaie fiduciaire ou de monnaie numérique. Contactez les développeurs Bisq sur Keybase à https://keybase.io/team/bisq ou sur le forum [HYPERLINK:https://bisq.community] pour plus d'aide. \n\nMessage d'erreur: {0}
 
 portfolio.pending.step1.waitForConf=Attendre la confirmation de la blockchain
 portfolio.pending.step2_buyer.startPayment=Initier le paiement
@@ -645,7 +651,7 @@ portfolio.pending.step2_buyer.confirmStart.headline=Confirmez que vous avez init
 portfolio.pending.step2_buyer.confirmStart.msg=Avez-vous initié le {0} paiement auprès de votre partenaire de trading?
 portfolio.pending.step2_buyer.confirmStart.yes=Oui, j'ai initié le paiement
 portfolio.pending.step2_buyer.confirmStart.proof.warningTitle=You have not provided proof of payment
-portfolio.pending.step2_buyer.confirmStart.proof.noneProvided=Lorsque vous terminez une transaction BTC / XMR, vous pouvez utiliser la fonction de confirmation automatique pour vérifier si le montant correct de XMR a été envoyé à votre portefeuille, afin que Bisq puisse automatiquement marquer la transaction comme terminée et pour que tout le monde puisse aller plus vite. \n\nConfirmez automatiquement que les transactions XMR sont vérifiées sur au moins 2 nœuds d'explorateur de blocs XMR à l'aide de la clé de transaction fournie par l'expéditeur XMR. Par défaut, Bisq utilise un nœud d'explorateur de blocs exécuté par des contributeurs Bisq, mais nous vous recommandons d'exécuter votre propre nœud d'explorateur de blocs XMR pour maximiser la confidentialité et la sécurité. \n\nVous pouvez également définir le nombre maximum de BTC par transaction dans «Paramètres» pour confirmer automatiquement et le nombre de confirmations requises. \n\nPlus de détails sur Bisq Wiki (y compris comment configurer votre propre nœud d'explorateur de blocs): https://bisq.wiki/Trading_Monero#Auto-confirming_trades
+portfolio.pending.step2_buyer.confirmStart.proof.noneProvided=Lorsque vous terminez une transaction BTC / XMR, vous pouvez utiliser la fonction de confirmation automatique pour vérifier si le montant correct de XMR a été envoyé à votre portefeuille, afin que Bisq puisse automatiquement marquer la transaction comme terminée et pour que tout le monde puisse aller plus vite. \n\nConfirmez automatiquement que les transactions XMR sont vérifiées sur au moins 2 nœuds d'explorateur de blocs XMR à l'aide de la clé de transaction fournie par l'expéditeur XMR. Par défaut, Bisq utilise un nœud d'explorateur de blocs exécuté par des contributeurs Bisq, mais nous vous recommandons d'exécuter votre propre nœud d'explorateur de blocs XMR pour maximiser la confidentialité et la sécurité. \n\nVous pouvez également définir le nombre maximum de BTC par transaction dans «Paramètres» pour confirmer automatiquement et le nombre de confirmations requises. \n\nPlus de détails sur Bisq Wiki (y compris comment configurer votre propre nœud d'explorateur de blocs): [HYPERLINK:https://bisq.wiki/Trading_Monero#Auto-confirming_trades]
 portfolio.pending.step2_buyer.confirmStart.proof.invalidInput=Input is not a 32 byte hexadecimal value
 portfolio.pending.step2_buyer.confirmStart.warningButton=Ignore and continue anyway
 portfolio.pending.step2_seller.waitPayment.headline=En attende du paiement
@@ -790,14 +796,14 @@ portfolio.pending.mediationResult.info.peerAccepted=Votre pair de trading a acce
 portfolio.pending.mediationResult.button=Voir la résolution proposée
 portfolio.pending.mediationResult.popup.headline=Résultat de la médiation pour la transaction avec l''ID: {0}
 portfolio.pending.mediationResult.popup.headline.peerAccepted=Votre pair de trading a accepté la suggestion du médiateur pour la transaction {0}
-portfolio.pending.mediationResult.popup.info=Les frais recommandés par le médiateur sont les suivants: \nVous paierez: {0} \nVotre partenaire commercial paiera: {1} \n\nVous pouvez accepter ou refuser ces frais de médiation. \n\nEn acceptant, vous avez vérifié l'opération de paiement du contrat. Si votre partenaire commercial accepte et vérifie également, le paiement sera effectué et la transaction sera clôturée. \n\nSi l'un de vous ou les deux refusent la proposition, vous devrez attendre le {2} (bloc {3}) pour commencer le deuxième tour de discussion sur le différend avec l'arbitre, et ce dernier étudiera à nouveau le cas. Le paiement sera fait en fonction de ses résultats. \n\nL'arbitre peut facturer une somme modique (la limite supérieure des honoraires: la marge de la transaction) en compensation de son travail. Les deux commerçants conviennent que la suggestion du médiateur est une voie agréable. La demande d'arbitrage concerne des circonstances particulières, par exemple si un professionnel est convaincu que le médiateur n'a pas fait une recommandation de d'indemnisation équitable (ou si l'autre partenaire n'a pas répondu). \n\nPlus de détails sur le nouveau modèle d'arbitrage: https://docs.bisq.network/trading-rules.html#arbitration
-portfolio.pending.mediationResult.popup.selfAccepted.lockTimeOver=Vous avez accepté la proposition de paiement du médiateur, mais il semble que votre contrepartie ne l'ait pas acceptée. \n\nUne fois que le temps de verrouillage atteint {0} (bloc {1}), vous pouvez ouvrir le second tour de litige pour que l'arbitre réétudie le cas et prend une nouvelle décision de dépenses. \n\nVous pouvez trouver plus d'informations sur le modèle d'arbitrage sur:https://docs.bisq.network/trading-rules.html#arbitration
+portfolio.pending.mediationResult.popup.info=Les frais recommandés par le médiateur sont les suivants: \nVous paierez: {0} \nVotre partenaire commercial paiera: {1} \n\nVous pouvez accepter ou refuser ces frais de médiation. \n\nEn acceptant, vous avez vérifié l'opération de paiement du contrat. Si votre partenaire commercial accepte et vérifie également, le paiement sera effectué et la transaction sera clôturée. \n\nSi l'un de vous ou les deux refusent la proposition, vous devrez attendre le {2} (bloc {3}) pour commencer le deuxième tour de discussion sur le différend avec l'arbitre, et ce dernier étudiera à nouveau le cas. Le paiement sera fait en fonction de ses résultats. \n\nL'arbitre peut facturer une somme modique (la limite supérieure des honoraires: la marge de la transaction) en compensation de son travail. Les deux commerçants conviennent que la suggestion du médiateur est une voie agréable. La demande d'arbitrage concerne des circonstances particulières, par exemple si un professionnel est convaincu que le médiateur n'a pas fait une recommandation de d'indemnisation équitable (ou si l'autre partenaire n'a pas répondu). \n\nPlus de détails sur le nouveau modèle d'arbitrage: [HYPERLINK:https://docs.bisq.network/trading-rules.html#arbitration]
+portfolio.pending.mediationResult.popup.selfAccepted.lockTimeOver=Vous avez accepté la proposition de paiement du médiateur, mais il semble que votre contrepartie ne l'ait pas acceptée. \n\nUne fois que le temps de verrouillage atteint {0} (bloc {1}), vous pouvez ouvrir le second tour de litige pour que l'arbitre réétudie le cas et prend une nouvelle décision de dépenses. \n\nVous pouvez trouver plus d'informations sur le modèle d'arbitrage sur:[HYPERLINK:https://docs.bisq.network/trading-rules.html#arbitration]
 portfolio.pending.mediationResult.popup.openArbitration=Refuser et demander un arbitrage
 portfolio.pending.mediationResult.popup.alreadyAccepted=Vous avez déjà accepté
 
 portfolio.pending.failedTrade.taker.missingTakerFeeTx=The taker fee transaction is missing.\n\nWithout this tx, the trade cannot be completed. No funds have been locked and no trade fee has been paid. You can move this trade to failed trades.
 portfolio.pending.failedTrade.maker.missingTakerFeeTx=The peer's taker fee transaction is missing.\n\nWithout this tx, the trade cannot be completed. No funds have been locked. Your offer is still available to other traders, so you have not lost the maker fee. You can move this trade to failed trades.
-portfolio.pending.failedTrade.missingDepositTx=Cette transaction de marge (transaction multi-signature de 2 à 2) est manquante.\n\nSans ce tx, la transaction ne peut pas être complétée. Aucun fonds n'est bloqué, mais vos frais de transaction sont toujours payés. Vous pouvez lancer une demande de compensation des frais de transaction ici: https://github.com/bisq-network/support/issues \nN'hésitez pas à déplacer la transaction vers la transaction échouée.
+portfolio.pending.failedTrade.missingDepositTx=Cette transaction de marge (transaction multi-signature de 2 à 2) est manquante.\n\nSans ce tx, la transaction ne peut pas être complétée. Aucun fonds n'est bloqué, mais vos frais de transaction sont toujours payés. Vous pouvez lancer une demande de compensation des frais de transaction ici:  [HYPERLINK:https://github.com/bisq-network/support/issues] \nN'hésitez pas à déplacer la transaction vers la transaction échouée.
 portfolio.pending.failedTrade.buyer.existingDepositTxButMissingDelayedPayoutTx=The delayed payout transaction is missing, but funds have been locked in the deposit transaction.\n\nPlease do NOT send the fiat or altcoin payment to the BTC seller, because without the delayed payout tx, arbitration cannot be opened. Instead, open a mediation ticket with Cmd/Ctrl+o. The mediator should suggest that both peers each get back the the full amount of their security deposits (with seller receiving full trade amount back as well). This way, there is no security risk, and only trade fees are lost. \n\nYou can request a reimbursement for lost trade fees here: [HYPERLINK:https://github.com/bisq-network/support/issues]
 portfolio.pending.failedTrade.seller.existingDepositTxButMissingDelayedPayoutTx=The delayed payout transaction is missing but funds have been locked in the deposit transaction.\n\nIf the buyer is also missing the delayed payout transaction, they will be instructed to NOT send the payment and open a mediation ticket instead. You should also open a mediation ticket with Cmd/Ctrl+o. \n\nIf the buyer has not sent payment yet, the mediator should suggest that both peers each get back the full amount of their security deposits (with seller receiving full trade amount back as well). Otherwise the trade amount should go to the buyer. \n\nYou can request a reimbursement for lost trade fees here: [HYPERLINK:https://github.com/bisq-network/support/issues]
 portfolio.pending.failedTrade.errorMsgSet=There was an error during trade protocol execution.\n\nError: {0}\n\nIt might be that this error is not critical, and the trade can be completed normally. If you are unsure, open a mediation ticket to get advice from Bisq mediators. \n\nIf the error was critical and the trade cannot be completed, you might have lost your trade fee. Request a reimbursement for lost trade fees here: [HYPERLINK:https://github.com/bisq-network/support/issues]
@@ -951,6 +957,7 @@ support.error=Le destinataire n''a pas pu traiter le message. Erreur : {0}
 support.buyerAddress=Adresse de l'acheteur BTC
 support.sellerAddress=Adresse du vendeur BTC
 support.role=Rôle
+support.agent=Support agent
 support.state=État
 support.closed=Fermé
 support.open=Ouvert
@@ -1048,7 +1055,7 @@ settings.net.bitcoinNodesLabel=Nœuds Bitcoin Core pour se connecter à
 settings.net.useProvidedNodesRadio=Utiliser les nœuds Bitcoin Core fournis
 settings.net.usePublicNodesRadio=Utiliser le réseau Bitcoin public
 settings.net.useCustomNodesRadio=Utiliser des nœuds Bitcoin Core personnalisés
-settings.net.warn.usePublicNodes=Si vous utilisez le réseau public Bitcoin, vous serez confronté à de sérieux problèmes de confidentialité. Ceci est dû à la conception et à la mise en œuvre du bloom filter cassé. Il convient aux portefeuilles SPV comme BitcoinJ (utilisé dans Bisq). Tout nœud complet que vous connectez peut découvrir que toutes les adresses de votre portefeuille appartiennent à une seule entité. \n\nPour plus d'informations, veuillez visiter: https://bisq.network/blog/privacy-in-bitsquare \n\nÊtes-vous sûr de vouloir utiliser un nœud public?
+settings.net.warn.usePublicNodes=Si vous utilisez le réseau public Bitcoin, vous serez confronté à de sérieux problèmes de confidentialité. Ceci est dû à la conception et à la mise en œuvre du bloom filter cassé. Il convient aux portefeuilles SPV comme BitcoinJ (utilisé dans Bisq). Tout nœud complet que vous connectez peut découvrir que toutes les adresses de votre portefeuille appartiennent à une seule entité. \n\nPour plus d'informations, veuillez visiter: [HYPERLINK:https://bisq.network/blog/privacy-in-bitsquare] \n\nÊtes-vous sûr de vouloir utiliser un nœud public?
 settings.net.warn.usePublicNodes.useProvided=Non, utiliser les nœuds fournis.
 settings.net.warn.usePublicNodes.usePublic=Oui, utiliser un réseau public
 settings.net.warn.useCustomNodes.B2XWarning=Veuillez vous assurer que votre nœud Bitcoin est un nœud Bitcoin Core de confiance !\n\nLa connexion à des nœuds qui ne respectent pas les règles du consensus de Bitcoin Core peut corrompre votre portefeuille et causer des problèmes dans le processus de trading.\n\nLes utilisateurs qui se connectent à des nœuds qui ne respectent pas les règles du consensus sont responsables des dommages qui en résultent. Tout litige qui en résulte sera tranché en faveur de l'autre pair. Aucune assistance technique ne sera apportée aux utilisateurs qui ignorent ces mécanismes d'alertes et de protections !
@@ -1156,7 +1163,7 @@ setting.about.shortcuts.sendPrivateNotification=Envoyer une notification privée
 setting.about.shortcuts.sendPrivateNotification.value=Open peer info at avatar and press: {0}
 
 setting.info.headline=New XMR auto-confirm Feature
-setting.info.msg=Vous n'avez pas saisi l'ID et la clé de transaction. \n\nSi vous ne fournissez pas ces données, votre partenaire commercial ne peut pas utiliser la fonction de confirmation automatique pour libérer rapidement le BTC après avoir reçu le XMR.\nEn outre, Bisq demande aux expéditeurs XMR de fournir ces informations aux médiateurs et aux arbitres en cas de litige.\nPlus de détails sont dans Bisq Wiki: https://bisq.wiki/Trading_Monero#Auto-confirming_trades
+setting.info.msg=Vous n'avez pas saisi l'ID et la clé de transaction. \n\nSi vous ne fournissez pas ces données, votre partenaire commercial ne peut pas utiliser la fonction de confirmation automatique pour libérer rapidement le BTC après avoir reçu le XMR.\nEn outre, Bisq demande aux expéditeurs XMR de fournir ces informations aux médiateurs et aux arbitres en cas de litige.\nPlus de détails sont dans Bisq Wiki: [HYPERLINK:https://bisq.wiki/Trading_Monero#Auto-confirming_trades]
 ####################################################################
 # Account
 ####################################################################
@@ -1176,11 +1183,11 @@ account.menu.backup=Sauvegarde
 account.menu.notifications=Notifications
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -1205,7 +1212,7 @@ account.altcoin.popup.upx.msg=Pour échanger UPX sur Bisq, vous devez comprendre
 # suppress inspection "UnusedProperty"
 account.altcoin.popup.arq.msg=Le trading d'ARQ sur Bisq exige que vous compreniez et remplissiez les exigences suivantes:\n\nPour envoyer des ARQ, vous devez utiliser soit le portefeuille officiel ArQmA GUI soit le portefeuille ArQmA CLI avec le flag store-tx-info activé (par défaut dans les nouvelles versions). Veuillez vous assurer que vous pouvez accéder à la tx key car cela pourrait être nécessaire en cas de litige.\narqma-wallet-cli (utiliser la commande get_tx_key)\narqma-wallet-gui (allez dans l'onglet historique et cliquez sur le bouton (P) pour accéder à la preuve de paiement).\n\nAvec un l'explorateur de bloc normal, le transfert n'est pas vérifiable.\n\nVous devez fournir au médiateur ou à l'arbitre les données suivantes en cas de litige:\n- Le tx de la clé privée\n- Le hash de la transaction\n- L'adresse publique du destinataire\n\nSi vous manquez de communiquer les données ci-dessus ou si vous utilisez un portefeuille incompatible, vous perdrez le litige. L'expéditeur des ARQ est responsable de la transmission au médiateur ou à l'arbitre de la vérification du transfert ces informations relatives au litige.\n\nIl n'est pas nécessaire de fournir l'ID du paiement, seulement l'adresse publique normale.\nSi vous n'êtes pas sûr de ce processus, visitez le canal discord ArQmA (https://discord.gg/s9BQpJT) ou le forum ArQmA (https://labs.arqma.com) pour obtenir plus d'informations.
 # suppress inspection "UnusedProperty"
-account.altcoin.popup.xmr.msg=Pour échanger XMR sur Bisq, vous devez comprendre et respecter les exigences suivantes: \n\nSi vous vendez XMR, en cas de litige, vous devez fournir au médiateur ou à l'arbitre les informations suivantes: - clé de transaction (clé publique Tx, clé Tx, clé privée Tx) - ID de transaction (ID Tx Ou hachage Tx) - Adresse de destination de la transaction (adresse du destinataire) \n\nConsultez plus d'informations sur le portefeuille Monero dans le wiki: https: //bisq.wiki/Trading_Monero#Proving_payments \n\nSi vous ne fournissez pas les données de transaction requises, vous serez directement jugé échoue dans le litige. \n\nNotez également que Bisq fournit désormais la fonction de confirmation automatique des transactions XMR pour effectuer plus rapidement des transactions, mais vous devez l'activer dans les paramètres. \n\nPour plus d'informations sur la fonction de confirmation automatique, veuillez consulter le Wiki: https: //bisq.wiki/Trading_Monero#Auto-confirming_trades
+account.altcoin.popup.xmr.msg=Pour échanger XMR sur Bisq, vous devez comprendre et respecter les exigences suivantes: \n\nSi vous vendez XMR, en cas de litige, vous devez fournir au médiateur ou à l'arbitre les informations suivantes: - clé de transaction (clé publique Tx, clé Tx, clé privée Tx) - ID de transaction (ID Tx Ou hachage Tx) - Adresse de destination de la transaction (adresse du destinataire) \n\nConsultez plus d'informations sur le portefeuille Monero dans le wiki: https: //bisq.wiki/Trading_Monero#Proving_payments \n\nSi vous ne fournissez pas les données de transaction requises, vous serez directement jugé échoue dans le litige. \n\nNotez également que Bisq fournit désormais la fonction de confirmation automatique des transactions XMR pour effectuer plus rapidement des transactions, mais vous devez l'activer dans les paramètres. \n\nPour plus d'informations sur la fonction de confirmation automatique, veuillez consulter le Wiki: [HYPERLINK:https://bisq.wiki/Trading_Monero#Auto-confirming_trades]
 # suppress inspection "UnusedProperty"
 account.altcoin.popup.msr.msg=Le navigateur blockchain pour échanger MSR sur Bisq vous oblige à comprendre et à respecter les exigences suivantes: \n\nLors de l'envoi de MSR, vous devez utiliser le portefeuille officiel Masari GUI, le portefeuille Masari CLI avec le logo store-tx-info activé (activé par défaut) ou le portefeuille web Masari (https://wallet.getmasari.org). Assurez-vous d'avoir accès à la clé tx, car cela est nécessaire en cas de litige. monero-wallet-cli (à l'aide de la commande get_Tx_key) monero-wallet-gui: sur la page Avancé> Preuve / Vérification. \n\nLe portefeuille web Masari (accédez à Compte-> Historique des transactions et vérifiez les détails de la transaction que vous avez envoyés) \n\nLa vérification peut être effectuée dans le portefeuille. monero-wallet-cli: utilisez la commande (check_tx_key). monero-wallet-gui: sur la page Avancé> Preuve / Vérification La vérification peut être effectuée dans le navigateur blockchain. Ouvrez le navigateur blockchain (https://explorer.getmasari.org) et utilisez la barre de recherche pour trouver votre hachage de transaction. Une fois que vous avez trouvé la transaction, faites défiler jusqu'à la zone «certificat à envoyer» en bas et remplissez les détails requis. En cas de litige, vous devez fournir les informations suivantes au médiateur ou à l'arbitre: - Clé privée Tx- Hachage de transaction- Adresse publique du destinataire \n\nAucun ID de transaction n'est requis, seule une adresse publique normale est requise. Si vous ne fournissez pas les informations ci-dessus ou si vous utilisez un portefeuille incompatible, vous perdrez le litige. En cas de litige, l'expéditeur XMR est responsable de fournir la vérification du transfert XMR au médiateur ou un arbitre. \n\nSi vous n'êtes pas sûr du processus, veuillez visiter le Masari Discord officiel (https://discord.gg/sMCwMqs) pour obtenir de l'aide.
 # suppress inspection "UnusedProperty"
@@ -1255,7 +1262,7 @@ account.password.info=Avec la protection par mot de passe, vous devrez entrer vo
 
 account.seed.backup.title=Sauvegarder les mots composant la seed de votre portefeuille
 account.seed.info=Veuillez noter les mots de la seed du portefeuille ainsi que la date! Vous pouvez récupérer votre portefeuille à tout moment avec les mots de la seed et la date.\nLes mêmes mots-clés de la seed sont utilisés pour les portefeuilles BTC et BSQ.\n\nVous devriez écrire les mots de la seed sur une feuille de papier. Ne les enregistrez pas sur votre ordinateur.\n\nVeuillez noter que les mots de la seed ne remplacent PAS une sauvegarde.\nVous devez créer une sauvegarde de l'intégralité du répertoire de l'application à partir de l'écran \"Compte/Sauvergarde\" pour restaurer correctement les données de l'application.\nL'importation de mots de la seed n'est recommandée qu'en cas d'urgence. L'application ne sera pas fonctionnelle sans une sauvegarde adéquate des fichiers et des clés de la base de données !
-account.seed.backup.warning=Veuillez noter que les mots de départ ne peuvent pas remplacer les sauvegardes. Vous devez sauvegarder tout le répertoire de l'application (dans l'onglet «Compte / Sauvegarde») pour restaurer l'état et les données de l'application. L'importation de mots de départ n'est recommandée qu'en cas d'urgence. Si le fichier de base de données et la clé ne sont pas correctement sauvegardés, l'application ne fonctionnera pas! \n\nVoir plus d'informations sur le wiki Bisq: https://bisq.wiki/Backing_up_application_data
+account.seed.backup.warning=Veuillez noter que les mots de départ ne peuvent pas remplacer les sauvegardes. Vous devez sauvegarder tout le répertoire de l'application (dans l'onglet «Compte / Sauvegarde») pour restaurer l'état et les données de l'application. L'importation de mots de départ n'est recommandée qu'en cas d'urgence. Si le fichier de base de données et la clé ne sont pas correctement sauvegardés, l'application ne fonctionnera pas! \n\nVoir plus d'informations sur le wiki Bisq: [HYPERLINK:https://bisq.wiki/Backing_up_application_data]
 account.seed.warn.noPw.msg=Vous n'avez pas configuré un mot de passe de portefeuille qui protégerait l'affichage des mots composant la seed.\n\nVoulez-vous afficher les mots composant la seed?
 account.seed.warn.noPw.yes=Oui, et ne me le demander plus à l'avenir
 account.seed.enterPw=Entrer le mot de passe afficher les mots composant la seed
@@ -2009,9 +2016,9 @@ displayUpdateDownloadWindow.button.downloadLater=Télécharger plus tard
 displayUpdateDownloadWindow.button.ignoreDownload=Ignorer cette version
 displayUpdateDownloadWindow.headline=Une nouvelle mise à jour Bisq est disponible !
 displayUpdateDownloadWindow.download.failed.headline=Echec du téléchargement
-displayUpdateDownloadWindow.download.failed=Téléchargement échoué. Veuillez télécharger et vérifier via https://bisq.io/downloads
-displayUpdateDownloadWindow.installer.failed=Impossible de déterminer le bon programme d'installation. Veuillez télécharger et vérifier manuellement via https://bisq.network/downloads .
-displayUpdateDownloadWindow.verify.failed=Vérification échouée. Veuillez télécharger et vérifier manuellement via https://bisq.io/downloads
+displayUpdateDownloadWindow.download.failed=Téléchargement échoué. Veuillez télécharger et vérifier via [HYPERLINK:https://bisq.network/downloads]
+displayUpdateDownloadWindow.installer.failed=Impossible de déterminer le bon programme d'installation. Veuillez télécharger et vérifier manuellement via [HYPERLINK:https://bisq.network/downloads] .
+displayUpdateDownloadWindow.verify.failed=Vérification échouée. Veuillez télécharger et vérifier manuellement via [HYPERLINK:https://bisq.network/downloads]
 displayUpdateDownloadWindow.success=La nouvelle version a été téléchargée avec succès et la signature vérifiée.\n\nVeuillez ouvrir le répertoire de téléchargement, fermer l'application et installer la nouvelle version.
 displayUpdateDownloadWindow.download.openDir=Ouvrir le répertoire de téléchargement
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Vous pouvez choisir de payer les frais de transaction en BS
 feeOptionWindow.optionsLabel=Choisissez la devise pour le paiement des frais de transaction
 feeOptionWindow.useBTC=Utiliser BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2236,7 +2245,7 @@ error.closedTradeWithNoDepositTx=La transaction de dépôt de l'échange fermé 
 popup.warning.walletNotInitialized=Le portefeuille n'est pas encore initialisé
 popup.warning.osxKeyLoggerWarning=En raison de mesures de sécurité plus strictes dans MacOS 10.14 et dans la version supérieure, le lancement d'une application Java (Bisq utilise Java) provoquera un avertissement pop-up dans MacOS (« Bisq souhaite recevoir les frappes de toute application »). \n\nPour éviter ce problème, veuillez ouvrir «Paramètres MacOS», puis allez dans «Sécurité et confidentialité» -> «Confidentialité» -> «Surveillance des entrées», puis supprimez «Bisq» de la liste de droite. \n\nUne fois les limitations techniques résolues (le packager Java de la version Java requise n'a pas été livré), Bisq effectuera une mise à niveau vers la nouvelle version Java pour éviter ce problème.
 popup.warning.wrongVersion=Vous avez probablement une mauvaise version de Bisq sur cet ordinateur.\nL''architecture de votre ordinateur est: {0}.\nLa binary Bisq que vous avez installé est: {1}.\nVeuillez éteindre et réinstaller une bonne version ({2}).
-popup.warning.incompatibleDB=Nous avons détecté un fichier de base de données incompatible!\n\nCes fichiers de base de données ne sont pas compatibles avec notre base de code actuelle: {0}\n\nNous avons sauvegardé les fichiers endommagés et appliqué les valeurs par défaut à la nouvelle version de la base de données.\n\nLa sauvegarde se trouve dans: \n\n{1} / db / backup_of_corrupted_data. \n\nVeuillez vérifier si vous avez installé la dernière version de Bisq. \n\nVous pouvez télécharger: \n\nhttps://bisq.network/downloads \n\nVeuillez redémarrer l'application.
+popup.warning.incompatibleDB=Nous avons détecté un fichier de base de données incompatible!\n\nCes fichiers de base de données ne sont pas compatibles avec notre base de code actuelle: {0}\n\nNous avons sauvegardé les fichiers endommagés et appliqué les valeurs par défaut à la nouvelle version de la base de données.\n\nLa sauvegarde se trouve dans: \n\n{1} / db / backup_of_corrupted_data. \n\nVeuillez vérifier si vous avez installé la dernière version de Bisq. \n\nVous pouvez télécharger: \n\n[HYPERLINK:https://bisq.network/downloads] \n\nVeuillez redémarrer l'application.
 popup.warning.startupFailed.twoInstances=Bisq est déjà lancé. Vous ne pouvez pas lancer deux instances de bisq.
 popup.warning.tradePeriod.halfReached=Votre transaction avec ID {0} a atteint la moitié de la période de trading maximale autorisée et n''est toujours pas terminée.\n\nLa période de trade se termine le {1}.\n\nVeuillez vérifier l''état de votre transaction dans \"Portfolio/échanges en cours\" pour obtenir de plus amples informations.
 popup.warning.tradePeriod.ended=Votre échange avec l''ID {0} a atteint la période de trading maximale autorisée et n''est pas terminé.\n\nLa période d''échange s''est terminée le {1}.\n\nVeuillez vérifier votre transaction sur \"Portfolio/Echanges en cours\" pour contacter le médiateur.
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Je confirme que je peux effectuer le dépôt.
 popup.info.shutDownWithOpenOffers=Bisq est en cours de fermeture, mais des ordres sont en attente.\n\nCes ordres ne seront pas disponibles sur le réseau P2P si Bisq est éteint, mais ils seront republiés sur le réseau P2P la prochaine fois que vous lancerez Bisq.\n\nPour garder vos ordres en ligne, laissez Bisq en marche et assurez-vous que cet ordinateur reste aussi en ligne (pour cela, assurez-vous qu'il ne passe pas en mode veille...la veille du moniteur ne pose aucun problème).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Notification privée importante!
 
 popup.securityRecommendation.headline=Recommendation de sécurité importante
 popup.securityRecommendation.msg=Nous vous rappelons d'envisager d'utiliser la protection par mot de passe pour votre portefeuille si vous ne l'avez pas déjà activé.\n\nIl est également fortement recommandé d'écrire les mots de la seed de portefeuille. Ces mots de la seed sont comme un mot de passe principal pour récupérer votre portefeuille Bitcoin.\nVous trouverez plus d'informations à ce sujet dans l'onglet \"seed du portefeuille\".\n\nDe plus, il est recommandé de sauvegarder le dossier complet des données de l'application dans l'onglet \"Sauvegarde".
 
-popup.bitcoinLocalhostNode.msg=Bisq a détecté un noeud Bitcoin Core fonctionnant localement (sur localhost).\nVeuillez vous assurer que ce nœud est entièrement synchronisé avant de lancer Bisq et qu'il ne fonctionne pas en mode restreint.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nPour un nœud entièrement configuré, il est nécessaire de désactiver le pruning et d'activer les bloom filters.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Fermeture en cours
 popup.shutDownInProgress.msg=La fermeture de l'application nécessite quelques secondes.\nVeuillez ne pas interrompre ce processus.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=Un de vos comptes de paiement a été vérifi�
 popup.accountSigning.peerLimitLifted=La limite initiale pour l''un de vos comptes a été levée.\n\n{0}
 popup.accountSigning.peerSigner=Un de vos comptes est suffisamment mature pour signer d'autres comptes de paiement et la limite initiale pour un de vos comptes a été levée.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"DAO/BSQ Portefeuille/Recevoir\"
 
 formatter.formatVolumeLabel={0} montant{1}
 formatter.makerTaker=Maker comme {0} {1} / Taker comme {2} {3}
-formatter.youAreAsMaker=Vous êtes {0} {1} en tant que maker / Le taker est {2} {3}
-formatter.youAreAsTaker=Vous êtes {0} {1} en tant que taker/ le maker est {2} {3}.
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=Vous êtes {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Vous êtes en train de créer un ordre pour {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Vous êtes en train de créer un ordre pour {0} {1} ({2} {3})
@@ -2621,7 +2627,7 @@ payment.accountType=Type de compte
 payment.checking=Vérification
 payment.savings=Épargne
 payment.personalId=Pièce d'identité
-payment.clearXchange.info=Zelle est un service de transfert d'argent, qui fonctionne bien pour transférer de l'argent vers d'autres banques. \n\n1. Consultez cette page pour voir si (et comment) votre banque coopère avec Zelle: \n\nhttps: //www.zellepay.com/get-started\n\n2. Faites particulièrement attention à votre limite de transfert - les limites de versement varient d'une banque à l'autre, et les banques spécifient généralement des limites quotidiennes, hebdomadaires et mensuelles. \n\n3. Si votre banque ne peut pas utiliser Zelle, vous pouvez toujours l'utiliser via l'application mobile Zelle, mais votre limite de transfert sera bien inférieure. \n\n4. Le nom indiqué sur votre compte Bisq doit correspondre à celui du compte Zelle / bancaire. \n\nSi vous ne parvenez pas à réaliser la transaction Zelle comme stipulé dans le contrat commercial, vous risquez de perdre une partie (ou la totalité) de votre marge.\n\nComme Zelle présente un risque élevé de rétrofacturation, il est recommandé aux vendeurs de contacter les acheteurs non signés par e-mail ou SMS pour confirmer que les acheteurs ont le compte Zelle spécifié dans Bisq.
+payment.clearXchange.info=Zelle est un service de transfert d'argent, qui fonctionne bien pour transférer de l'argent vers d'autres banques. \n\n1. Consultez cette page pour voir si (et comment) votre banque coopère avec Zelle: \n[HYPERLINK:https://www.zellepay.com/get-started]\n\n2. Faites particulièrement attention à votre limite de transfert - les limites de versement varient d'une banque à l'autre, et les banques spécifient généralement des limites quotidiennes, hebdomadaires et mensuelles. \n\n3. Si votre banque ne peut pas utiliser Zelle, vous pouvez toujours l'utiliser via l'application mobile Zelle, mais votre limite de transfert sera bien inférieure. \n\n4. Le nom indiqué sur votre compte Bisq doit correspondre à celui du compte Zelle / bancaire. \n\nSi vous ne parvenez pas à réaliser la transaction Zelle comme stipulé dans le contrat commercial, vous risquez de perdre une partie (ou la totalité) de votre marge.\n\nComme Zelle présente un risque élevé de rétrofacturation, il est recommandé aux vendeurs de contacter les acheteurs non signés par e-mail ou SMS pour confirmer que les acheteurs ont le compte Zelle spécifié dans Bisq.
 payment.fasterPayments.newRequirements.info=Certaines banques ont déjà commencé à vérifier le nom complet du destinataire du paiement rapide. Votre compte de paiement rapide actuel ne remplit pas le nom complet. \n\nPensez à recréer votre compte de paiement rapide dans Bisq pour fournir un nom complet aux futurs {0} acheteurs. \n\nLors de la recréation d'un compte, assurez-vous de copier l'indicatif bancaire, le numéro de compte et le sel de vérification de l'âge de l'ancien compte vers le nouveau compte. Cela garantira que votre âge du compte et état de signature existant sont conservés.
 payment.moneyGram.info=When using MoneyGram the BTC buyer has to send the Authorisation number and a photo of the receipt by email to the BTC seller. The receipt must clearly show the seller's full name, country, state and the amount. The seller's email will be displayed to the buyer during the trade process.
 payment.westernUnion.info=When using Western Union the BTC buyer has to send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller. The receipt must clearly show the seller's full name, city, country and the amount. The seller's email will be displayed to the buyer during the trade process.
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Nom
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_it.properties
+++ b/core/src/main/resources/i18n/displayStrings_it.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Seleziona conto di trading
 shared.fundFromSavingsWalletButton=Trasferisci fondi dal portafoglio Bisq
 shared.fundFromExternalWalletButton=Apri il tuo portafoglio esterno per aggiungere fondi
 shared.openDefaultWalletFailed=Failed to open a Bitcoin wallet application. Are you sure you have one installed?
-shared.distanceInPercent=Distanza in % dal prezzo di mercato
 shared.belowInPercent=Sotto % del prezzo di mercato
 shared.aboveInPercent=Sopra % del prezzo di mercato
 shared.enterPercentageValue=Immetti il valore %
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Saldo del portafogli per gli scambi
 shared.makerTxFee=Maker: {0}
 shared.takerTxFee=Taker: {0}
 shared.iConfirm=Confermo
-shared.tradingFeeInBsqInfo=equivalente a {0} utilizzato come commissione di negoziazione
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Aperti {0}
 shared.fiat=Fiat
 shared.crypto=Crypto
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Otterrai sempre il {0}% in meno rispett
 createOffer.warning.buyAboveMarketPrice=Pagherai sempre il {0}% in più rispetto al prezzo di mercato corrente poiché il prezzo della tua offerta verrà costantemente aggiornato.
 createOffer.tradeFee.descriptionBTCOnly=Commissione di scambio
 createOffer.tradeFee.descriptionBSQEnabled=Seleziona la valuta della commissione di scambio
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} dell'importo di scambio
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Revisione: piazza l'offerta a {0} bitcoin
-createOffer.alreadyFunded=Hai già finanziato quell'offerta.\nI tuoi fondi sono stati spostati nel tuo portafoglio Bisq locale e sono disponibili per il prelievo nella schermata \"Fondi/Invia fondi\".
 createOffer.createOfferFundWalletInfo.headline=Finanzia la tua offerta
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Importo di scambio: {0} \n
@@ -503,7 +506,6 @@ takeOffer.error.message=Si è verificato un errore durante l'accettazione dell'o
 # new entries
 takeOffer.takeOfferButton=Rivedi: Accetta l'offerta per {0} bitcoin
 takeOffer.noPriceFeedAvailable=Non puoi accettare questa offerta poiché utilizza un prezzo in percentuale basato sul prezzo di mercato ma non è disponibile alcun feed di prezzi.
-takeOffer.alreadyFunded.movedFunds=Hai già finanziato quell'offerta.\nI tuoi fondi sono stati spostati nel tuo portafoglio Bisq locale e sono disponibili per il prelievo nella schermata \"Fondi/Invia fondi\".
 takeOffer.takeOfferFundWalletInfo.headline=Finanzia il tuo scambio
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Importo di scambio: {0} \n
@@ -530,6 +532,10 @@ takeOffer.tac=Accettando questa offerta, accetto le condizioni commerciali defin
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Prezzo di attivazione
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=Imposta prezzo
 editOffer.confirmEdit=Conferma: modifica offerta
@@ -951,6 +957,7 @@ support.error=Il destinatario non ha potuto elaborare il messaggio. Errore: {0}
 support.buyerAddress=Indirizzo BTC dell'acquirente
 support.sellerAddress=Indirizzo BTC del venditore
 support.role=Ruolo
+support.agent=Support agent
 support.state=Stato
 support.closed=Chiuso
 support.open=Aperto
@@ -1176,11 +1183,11 @@ account.menu.backup=Backup
 account.menu.notifications=Notifiche
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Puoi scegliere di pagare la commissione commerciale in BSQ 
 feeOptionWindow.optionsLabel=Scegli la valuta per il pagamento delle commissioni commerciali
 feeOptionWindow.useBTC=Usa BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Confermo di poter effettuare il deposito
 popup.info.shutDownWithOpenOffers=Bisq viene chiuso, ma ci sono offerte aperte.\n\nQueste offerte non saranno disponibili sulla rete P2P mentre Bisq rimane chiuso, ma verranno ripubblicate sulla rete P2P al prossimo avvio di Bisq.\n\nPer mantenere le tue offerte attive è necessario che Bisq rimanga in funzione ed il computer online (assicurati che non vada in modalità standby. Il solo monitor in standby non è un problema).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Notifica privata importante!
 
 popup.securityRecommendation.headline=Raccomandazione di sicurezza importante
 popup.securityRecommendation.msg=Vorremmo ricordarti di prendere in considerazione l'utilizzo della protezione con password per il tuo portafoglio se non l'avessi già abilitato.\n\nSi consiglia inoltre di annotare le parole seme del portafoglio. Le parole seme sono come una password principale per recuperare il tuo portafoglio Bitcoin.\nNella sezione \"Wallet Seed\" trovi ulteriori informazioni.\n\nInoltre, è necessario eseguire il backup della cartella completa dei dati dell'applicazione nella sezione \"Backup\".
 
-popup.bitcoinLocalhostNode.msg=Bisq ha rilevato un nodo Bitcoin Core in esecuzione localmente (su localhost).\nAssicurarsi che questo nodo sia completamente sincronizzato prima di avviare Bisq e che non sia in esecuzione in modalità di eliminazione.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nPer un nodo ben configurato, i requisiti necessari sono che il nodo abbia il pruning disabilitato e i filtri bloom abilitati.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Arresto in corso
 popup.shutDownInProgress.msg=La chiusura dell'applicazione può richiedere un paio di secondi.\nNon interrompere il processo.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=Uno dei tuoi conti di pagamento è stato verif
 popup.accountSigning.peerLimitLifted=Il limite iniziale per uno dei tuoi account è stato revocato.\n\n{0}
 popup.accountSigning.peerSigner=Uno dei tuoi account è abbastanza maturo per firmare altri account di pagamento e il limite iniziale per uno dei tuoi account è stato revocato.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"Portafoglio DAO/BSQ/Ricevi\"
 
 formatter.formatVolumeLabel={0} importo{1}
 formatter.makerTaker=Maker come {0} {1} / Taker come {2} {3}
-formatter.youAreAsMaker=Sei {0} {1} come maker / Taker è {2} {3}
-formatter.youAreAsTaker=Sei {0} {1} come Taker / make è {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=Sei {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Stai creando un'offerta per {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Stai creando un'offerta per {0} {1} ({2} {3})
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Nome
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_ja.properties
+++ b/core/src/main/resources/i18n/displayStrings_ja.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=取引アカウントを選択
 shared.fundFromSavingsWalletButton=Bisqウォレットから資金を移動する
 shared.fundFromExternalWalletButton=外部のwalletを開く
 shared.openDefaultWalletFailed=ビットコインウォレットのアプリを開けませんでした。インストールされているか確認して下さい。
-shared.distanceInPercent=市場価格から % の乖離
 shared.belowInPercent=市場価格から％以下
 shared.aboveInPercent=市場価格から％以上
 shared.enterPercentageValue=%を入力
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=トレードウォレット残高
 shared.makerTxFee=メイカー: {0}
 shared.takerTxFee=テイカー: {0}
 shared.iConfirm=確認します
-shared.tradingFeeInBsqInfo=トレード手数料として使用される{0}と同じ
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL={0} をオープン
 shared.fiat=法定通貨
 shared.crypto=暗号通貨
@@ -315,7 +314,7 @@ market.spread.spreadColumn=スプレッド
 # TradesChartsView
 market.trades.nrOfTrades=取引: {0}
 market.trades.tooltip.volumeBar=取引量: {0}\n取引数: {1}\n日付: {2}
-market.trades.tooltip.candle.open=オープン: 
+market.trades.tooltip.candle.open=オープン:
 market.trades.tooltip.candle.close=クローズ:
 market.trades.tooltip.candle.high=最高:
 market.trades.tooltip.candle.low=最低:
@@ -442,14 +441,18 @@ createOffer.warning.sellBelowMarketPrice=オファーの価格は継続的に更
 createOffer.warning.buyAboveMarketPrice=オファーの価格は継続的に更新されるため、常に現在の市場価格より{0}％以上で支払いするでしょう。
 createOffer.tradeFee.descriptionBTCOnly=取引手数料
 createOffer.tradeFee.descriptionBSQEnabled=トレード手数料通貨を選択
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} の取引額
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=再確認: ビットコインを{0}オファーを出す
-createOffer.alreadyFunded=このオファーは既に入金済みです。\n資金はローカルのBisqウォレットに移動済みで、「資金/送金する」画面から出金可能になっています。
 createOffer.createOfferFundWalletInfo.headline=あなたのオファーへ入金
 # suppress inspection "TrailingSpacesInProperty"
-createOffer.createOfferFundWalletInfo.tradeAmount= - 取引額: {0}\n
+createOffer.createOfferFundWalletInfo.tradeAmount=- 取引額: {0}\n
 createOffer.createOfferFundWalletInfo.msg=このオファーに対して {0} のデポジットを送金する必要があります。\n\nこの資金はあなたのローカルウォレットに予約済として保管され、オファーが受け入れられた時にマルチシグデポジットアドレスに移動しロックされます。\n\n金額の合計は以下の通りです\n{1} - セキュリティデポジット: {2}\n- 取引手数料: {3}\n- マイニング手数料: {4}\n\nこのオファーにデポジットを送金するには、以下の2つの方法があります。\n- Bisqウォレットを使う (便利ですがトランザクションが追跡される可能性があります)\n- 外部のウォレットから送金する (機密性の高い方法です)\n\nこのポップアップを閉じると全ての送金方法について詳細な情報が表示されます。
 
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
@@ -503,7 +506,6 @@ takeOffer.error.message=オファーの受け入れ時にエラーが発生し�
 # new entries
 takeOffer.takeOfferButton=再確認: ビットコインを{0}オファーを申し込む
 takeOffer.noPriceFeedAvailable=そのオファーは市場価格に基づくパーセント値を使用していますが、使用可能な価格フィードがないため、利用することはできません。
-takeOffer.alreadyFunded.movedFunds=このオファーは既に入金済みです。\n資金はローカルのBisqウォレットに移動済みで、「資金/送金する」画面から出金可能になっています。
 takeOffer.takeOfferFundWalletInfo.headline=あなたのオファーへ入金
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount= - 取引額: {0}\n
@@ -530,6 +532,10 @@ takeOffer.tac=このオファーを受けることで、この画面で定義さ
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=価格トリガー
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=価格設定
 editOffer.confirmEdit=承認: オファーを編集
@@ -874,7 +880,7 @@ funds.locked.locked=次のIDとのトレードはマルチシグでロック中�
 
 funds.tx.direction.sentTo=送信 to:
 funds.tx.direction.receivedWith=次に予約済:
-funds.tx.direction.genesisTx=ジェネシスTXから: 
+funds.tx.direction.genesisTx=ジェネシスTXから:
 funds.tx.txFeePaymentForBsqTx=BSQのTXのマイニング手数料
 funds.tx.createOfferFee=メイカーとTXの手数料: {0}
 funds.tx.takeOfferFee=テイカーとTXの手数料: {0}
@@ -943,7 +949,7 @@ support.input.prompt=メッセージを入力...
 support.send=送信
 support.addAttachments=添付ファイルを追加
 support.closeTicket=チケットを閉じる
-support.attachments=添付ファイル: 
+support.attachments=添付ファイル:
 support.savedInMailbox=メッセージ受信箱に保存されました
 support.arrived=メッセージが受信者へ届きました
 support.acknowledged=受信者からメッセージ到着が確認されました
@@ -951,6 +957,7 @@ support.error=受信者がメッセージを処理できませんでした。エ
 support.buyerAddress=BTC買い手のアドレス
 support.sellerAddress=BTC売り手のアドレス
 support.role=役割
+support.agent=Support agent
 support.state=状態
 support.closed=クローズ
 support.open=オープン
@@ -1044,7 +1051,7 @@ settings.net.onionAddressLabel=私のonionアドレス
 settings.net.btcNodesLabel=任意のビットコインノードを使う
 settings.net.bitcoinPeersLabel=接続されたピア
 settings.net.useTorForBtcJLabel=BitcoinネットワークにTorを使用
-settings.net.bitcoinNodesLabel=接続するBitcoin Coreノード: 
+settings.net.bitcoinNodesLabel=接続するBitcoin Coreノード:
 settings.net.useProvidedNodesRadio=提供されたBitcoin Core ノードを使う
 settings.net.usePublicNodesRadio=ビットコインの公共ネットワークを使用
 settings.net.useCustomNodesRadio=任意のビットコインノードを使う
@@ -1176,11 +1183,11 @@ account.menu.backup=バックアップ
 account.menu.notifications=通知
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=あなたは取引手数料の支払いにBSQまたはBTC�
 feeOptionWindow.optionsLabel=取引手数料の支払いに使用する通貨を選択してください
 feeOptionWindow.useBTC=BTCを使用
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2258,7 +2267,7 @@ popup.warning.bsqChangeBelowDustException=このトランザクションは、�
 popup.warning.btcChangeBelowDustException=このトランザクションは、ダスト制限（546 Satoshi）を下回るBSQおつりアウトプットを作成し、ビットコインネットワークによって拒否されます。\n\nダストアウトプットを生成しないように、あなたの送金額にダスト額を追加する必要があります。\n\nダストアウトプットは{0}。
 
 popup.warning.insufficientBsqFundsForBtcFeePayment=このトランザクションにはBSQが足りません。ビットコインプロトコルのダスト制限によると、ウォレットから最後の5.46BSQはトレード手数料に使われることができません。\n\nもっとBSQを買うか、BTCでトレード手数料を支払うことができます。\n\n不足している資金: {0}
-popup.warning.noBsqFundsForBtcFeePayment=BSQウォレットにBSQのトレード手数料を支払うのに十分な残高がありません。 
+popup.warning.noBsqFundsForBtcFeePayment=BSQウォレットにBSQのトレード手数料を支払うのに十分な残高がありません。
 popup.warning.messageTooLong=メッセージが許容サイズ上限を超えています。いくつかに分けて送信するか、　https://pastebin.com のようなサービスにアップロードしてください。
 popup.warning.lockedUpFunds=失敗したトレードから残高をロックしました。\nロックされた残高: {0} \nデポジットtxアドレス: {1} \nトレードID: {2}。\n\nオープントレード画面でこのトレードを選択し、「alt + o」または「option + o」を押してサポートチケットを開いてください。
 
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=デポジットを作成できるか確認し
 popup.info.shutDownWithOpenOffers=Bisqはシャットダウン中ですが、オファーはあります。\n\nこれらのオファーは、Bisqがシャットダウンされている間はP2Pネットワークでは利用できませんが、次回Bisqを起動したときにP2Pネットワークに再公開されます。\n\nオファーをオンラインに保つには、Bisqを実行したままにして、このコンピュータもオンラインにしたままにします（つまり、スタンバイモードにならないようにしてください。モニタースタンバイは問題ありません）。
 popup.info.qubesOSSetupInfo=Qubes OS内でBisqを実行しているようです。\n\nBisqのqubeはセットアップガイドに従って設定されていることを確かめて下さい: [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes]
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=重要なプライベート通知！
 
 popup.securityRecommendation.headline=重要なセキュリティ勧告
 popup.securityRecommendation.msg=ウォレットのパスワード保護をまだ有効にしてない場合は、使用することを検討してください。\n\nウォレットシードワードを書き留めることも強くお勧めします。 これらのシードワードは、あなたのビットコインウォレットを復元するためのマスターパスワードのようなものです。\n「ウォレットシード」セクションにてより詳細な情報を確認できます。\n\nまた、「バックアップ」セクションのアプリケーションデータフォルダ全体をバックアップするべきでしょう。
 
-popup.bitcoinLocalhostNode.msg=Bisqはローカルで動作するBitcoin Coreノード（ローカルホスト）を検出しました。Bisqを起動する前にこのノードが完全に同期されていることと、プルーニングモードで実行されていないことを確認してください。
-popup.bitcoinLocalhostNode.additionalRequirements=\n\n適切に設定されるノードの条件は、剪定が無効とされることそしてブルームフィルターが有効とされることです。
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=シャットダウン中
 popup.shutDownInProgress.msg=アプリケーションのシャットダウンには数秒かかることがあります。\nこのプロセスを中断しないでください。
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=支払いアカウントの1つはトレード
 popup.accountSigning.peerLimitLifted=支払いアカウントの1つにおいて初期の制限は解除されました。\n\n{0}
 popup.accountSigning.peerSigner=支払いアカウントの1つは十分に熟成されて、初期の制限は解除されました。\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=アカウント年齢witnessを選択
-popup.accountSigning.singleAccountSelect.description=アカウント年齢witnessを検索
-popup.accountSigning.singleAccountSelect.datePicker=署名の時点を選択
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=選択されたアカウント年齢witnessを確認
 popup.accountSigning.confirmSingleAccount.selectedHash=選択されたwitnessのハッシュ
 popup.accountSigning.confirmSingleAccount.button=アカウント年齢witnessを署名
 popup.accountSigning.successSingleAccount.description=Witness {0} は署名された
 popup.accountSigning.successSingleAccount.success.headline=成功
-popup.accountSigning.successSingleAccount.signError=Witnessの署名が失敗しました, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=無署名のパブリックキー
 popup.accountSigning.unsignedPubKeys.sign=パブリックキーを署名
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=「DAO/BSQウォレット/受取」
 
 formatter.formatVolumeLabel={0} 額{1}
 formatter.makerTaker=メイカーは{0} {1} / テイカーは{2} {3}
-formatter.youAreAsMaker=あなたは{0} {1}のメイカー / テイカーは{2} {3}
-formatter.youAreAsTaker=あなたは{0} {1}のテイカー / メイカーは{2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=あなたは{0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=あなたはオファーを{0} {1}に作成中です
 formatter.youAreCreatingAnOffer.altcoin=あなたはオファーを{0} {1} ({2} {3})に作成中です
@@ -2659,7 +2665,8 @@ payment.japan.recipient=名義
 payment.australia.payid=PayID
 payment.payid=金融機関と繋がっているPayID。例えばEメールアドレスそれとも携帯電話番号。
 payment.payid.info=銀行、信用金庫、あるいは住宅金融組合アカウントと安全に繋がれるPayIDとして使われる電話番号、Eメールアドレス、それともオーストラリア企業番号（ABN）。すでにオーストラリアの金融機関とPayIDを作った必要があります。送金と受取の金融機関は両方PayIDをサポートする必要があります。詳しくは以下を訪れて下さい [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=アマゾンeGiftカードで支払うには、アマゾンアカウントからeGiftカードを買って、BTC売り手のEメールアドレスあるいは携帯電話番号を受取人に設定します。アマゾンは受取人へメールあるいはSMSを送ります。メッセージ・フィールドにトレードIDを入力して下さい。\n\nアマゾンeGiftカードは同じ通貨を使うアマゾンアカウントのみに受け取られることができます。\n\n詳しくはアマゾンeGiftカードホームページを訪れて下さい。 [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ
@@ -2715,7 +2722,7 @@ WECHAT_PAY=WeChat Pay
 # suppress inspection "UnusedProperty"
 SEPA=SEPA
 # suppress inspection "UnusedProperty"
-SEPA_INSTANT=SEPAインスタント支払い 
+SEPA_INSTANT=SEPAインスタント支払い
 # suppress inspection "UnusedProperty"
 FASTER_PAYMENTS=Faster Payments
 # suppress inspection "UnusedProperty"
@@ -2868,7 +2875,7 @@ validation.amountBelowDust=ダスト制限である{0}サトシ未満の金額�
 validation.length=長さは{0}から{1}の間である必要があります
 validation.pattern=入力は次の形式である必要があります: {0}
 validation.noHexString=入力がHEXフォーマットではありません。
-validation.advancedCash.invalidFormat=有効なメールアドレスか次のウォレットID形式である必要があります: X000000000000 
+validation.advancedCash.invalidFormat=有効なメールアドレスか次のウォレットID形式である必要があります: X000000000000
 validation.invalidUrl=有効なURLではありません
 validation.mustBeDifferent=入力する値は現在の値と異なるべきです。
 validation.cannotBeChanged=パラメーターは変更できません

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Selecionar conta de negociação
 shared.fundFromSavingsWalletButton=Transferir fundos da carteira Bisq
 shared.fundFromExternalWalletButton=Abrir sua carteira externa para prover fundos
 shared.openDefaultWalletFailed=Failed to open a Bitcoin wallet application. Are you sure you have one installed?
-shared.distanceInPercent=Distância em % do preço de mercado
 shared.belowInPercent=% abaixo do preço de mercado
 shared.aboveInPercent=% acima do preço de mercado
 shared.enterPercentageValue=Insira a %
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Saldo da carteira de negociação
 shared.makerTxFee=Ofertante: {0}
 shared.takerTxFee=Aceitador: {0}
 shared.iConfirm=Eu confirmo
-shared.tradingFeeInBsqInfo=equivalente a {0} utilizado como taxa de negociação
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Aberto {0}
 shared.fiat=Fiat
 shared.crypto=Cripto
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Você irá sempre receber {0}% a menos 
 createOffer.warning.buyAboveMarketPrice=Você irá sempre pagar {0}% a mais do que o atual preço de mercado e o preço da sua oferta será atualizada constantemente.
 createOffer.tradeFee.descriptionBTCOnly=Taxa de negociação
 createOffer.tradeFee.descriptionBSQEnabled=Escolha a moeda da taxa de transação
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} da quantia da negociação
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Revisar: Criar oferta para {0} bitcoin
-createOffer.alreadyFunded=Você já havia financiado aquela oferta.\nSeus fundos foram movidos para sua carteira local da Bisq e estão disponíveis para retirada na janela \"Fundos/Enviar fundos\".
 createOffer.createOfferFundWalletInfo.headline=Financiar sua oferta
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Quantia da negociação: {0} \n
@@ -503,7 +506,6 @@ takeOffer.error.message=Ocorreu um erro ao aceitar a oferta.\n\n{0}
 # new entries
 takeOffer.takeOfferButton=Revisar: Aceitar oferta para {0} bitcoin
 takeOffer.noPriceFeedAvailable=Você não pode aceitar essa oferta pois ela usa uma porcentagem do preço baseada no preço de mercado, mas o canal de preços está indisponível no momento.
-takeOffer.alreadyFunded.movedFunds=Você já havia financiado essa oferta.\nSeus fundos foram movidos para sua carteira Bisq local e estão disponíveis para retirada na tela \"Fundos/Enviar fundos\"
 takeOffer.takeOfferFundWalletInfo.headline=Financiar sua negociação
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Quantia a negociar: {0} \n
@@ -530,6 +532,10 @@ takeOffer.tac=Ao aceitar essa oferta, eu concordo com as condições de negocia�
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Preço gatilho
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=Definir preço
 editOffer.confirmEdit=Editar oferta
@@ -951,6 +957,7 @@ support.error=O destinatário não pôde processar a mensagem. Erro: {0}
 support.buyerAddress=Endereço do comprador de BTC
 support.sellerAddress=Endereço do vendedor de BTC
 support.role=Função
+support.agent=Support agent
 support.state=Estado
 support.closed=Fechado
 support.open=Aberto
@@ -1176,11 +1183,11 @@ account.menu.backup=Backup
 account.menu.notifications=Notificações
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Você pode optar por pagar a taxa de negociação em BSQ ou
 feeOptionWindow.optionsLabel=Escolha a moeda para pagar a taxa de negociação
 feeOptionWindow.useBTC=Usar BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Eu confirmo que posso fazer o depósito
 popup.info.shutDownWithOpenOffers=O Bisq está desligando, mas há ofertas abertas.\n\nEstas ofertas não ficarão disponíveis na rede P2P enquanto o Bisq estiver desligado, mas elas serão republicadas na rede assim que você reiniciar o programa.\n\nPara manter suas ofertas online, mantenha o Bisq aberto e certifique-se de que o seu computador continua online (ex: certifique-se de que o computador não está entrando em modo de hibernação).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Notificação privada importante!
 
 popup.securityRecommendation.headline=Recomendação de segurança importante
 popup.securityRecommendation.msg=Lembre-se de proteger a sua carteira com uma senha, caso você já não tenha criado uma.\n\nRecomendamos que você escreva num papel as palavras da semente de sua carteira. Essas palavras funcionam como uma senha mestra para recuperar a sua carteira Bitcoin, caso o seu computador apresente algum problema.\nVocê irá encontrar mais informações na seção \"Semente da carteira\".\n\nTambém aconselhamos que você faça um backup completo da pasta de dados do programa na seção \"Backup\".
 
-popup.bitcoinLocalhostNode.msg=O Bisq detectou um node do Bitcoin Core em execução no ambiente local (localhost).\nPor favor, certifique-se de que este node esteja totalmente sincronizado antes de iniciar o Bisq e que ele não esteja em execução em pruned mode.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nPara que o nó esteja bem configurado, os requisitos são que o nó tenha pruning desativado e bloom filters ativados.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Desligando
 popup.shutDownInProgress.msg=O desligamento do programa pode levar alguns segundos.\nPor favor, não interrompa este processo.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=Uma de suas contas de pagamento foi verificada
 popup.accountSigning.peerLimitLifted=O limite inicial para uma de suas contas acaba de ser aumentado.
 popup.accountSigning.peerSigner=Uma das suas contas é antiga o suficiente para assinar outras contas de pagamento e o limite para uma de suas contas acaba de ser aumentado\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"DAO/Carteira BSQ/Receber\"
 
 formatter.formatVolumeLabel={0} quantia{1}
 formatter.makerTaker=Ofertante: {1} de {0} / Aceitador: {3} de {2}
-formatter.youAreAsMaker=Você está {0} {1} como ofertante / Aceitador está {2} {3}
-formatter.youAreAsTaker=Você está {0} {1} como aceitador / Ofertante está {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=Você está {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Você está criando uma oferta para {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Você está criando uma oferta para {0} {1} ({2} {3})
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Nome
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Selecionar conta de negociação
 shared.fundFromSavingsWalletButton=Transferir fundos da carteira Bisq
 shared.fundFromExternalWalletButton=Abrir sua carteira externa para o financiamento
 shared.openDefaultWalletFailed=Failed to open a Bitcoin wallet application. Are you sure you have one installed?
-shared.distanceInPercent=Distância em % do preço de mercado
 shared.belowInPercent=Abaixo % do preço de mercado
 shared.aboveInPercent=Acima % do preço de mercado
 shared.enterPercentageValue=Insira % do valor
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Saldo da carteira de negócio
 shared.makerTxFee=Ofertante: {0}
 shared.takerTxFee=Aceitador: {0}
 shared.iConfirm=Eu confirmo
-shared.tradingFeeInBsqInfo=equivalente à {0} utilizado como taxa de negociação
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Abrir {0}
 shared.fiat=Moeda fiduciária
 shared.crypto=Cripto
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Receberá sempre menos {0}% do que o at
 createOffer.warning.buyAboveMarketPrice=Pagará sempre mais {0}% do que o atual preço de mercado pois o preço da sua oferta será atualizado continuamente.
 createOffer.tradeFee.descriptionBTCOnly=taxa de negócio
 createOffer.tradeFee.descriptionBSQEnabled=Selecione a moeda da taxa de negócio
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} da quantia de negócio
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Rever: Colocar oferta para {0} bitcoin
-createOffer.alreadyFunded=Você já tinha financiado essa oferta.\nSeus fundos foram transferidos para sua carteira Bisq local e estão disponíveis para levantamento no ecrã \"Fundos/Enviar fundos\".
 createOffer.createOfferFundWalletInfo.headline=Financiar sua oferta
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Quantia de negócio: {0} \n
@@ -503,7 +506,6 @@ takeOffer.error.message=Ocorreu um erro ao aceitar a oferta .\n\n{0}
 # new entries
 takeOffer.takeOfferButton=Rever: Colocar oferta para {0} bitcoin
 takeOffer.noPriceFeedAvailable=Você não pode aceitar aquela oferta pois ela utiliza uma percentagem do preço baseada no preço de mercado, mas o feed de preços está indisponível no momento.
-takeOffer.alreadyFunded.movedFunds=Você já tinha financiado essa oferta.\nSeus fundos foram transferidos para a sua carteira Bisq local e estão disponíveis para levantamento na ecrã \"Fundos/Enviar fundos\".
 takeOffer.takeOfferFundWalletInfo.headline=Financiar seu negócio
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Quantia de negócio: {0} \n
@@ -530,6 +532,10 @@ takeOffer.tac=Ao aceitar esta oferta, eu concordo com as condições de negócio
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Preço de desencadeamento
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=Definir preço
 editOffer.confirmEdit=Confirmar: Editar oferta
@@ -951,6 +957,7 @@ support.error=O recipiente não pode processar a mensagem. Erro: {0}
 support.buyerAddress=Endereço do comprador de BTC
 support.sellerAddress=Endereço do vendedor de BTC
 support.role=Cargo
+support.agent=Support agent
 support.state=Estado
 support.closed=Fechado
 support.open=Aberto
@@ -1176,11 +1183,11 @@ account.menu.backup=Backup
 account.menu.notifications=Notificações
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Pode escolher pagar a taxa de negócio em BSQ ou em BTC. Se
 feeOptionWindow.optionsLabel=Escolha a moeda para o pagamento da taxa de negócio
 feeOptionWindow.useBTC=Usar BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Eu confirmo que eu posso fazer o depósito
 popup.info.shutDownWithOpenOffers=Bisq está sendo fechado, mas há ofertas abertas. \n\nEstas ofertas não estarão disponíveis na rede P2P enquanto o Bisq estiver desligado, mas elas serão publicadas novamente na rede P2P na próxima vez que você iniciar o Bisq.\n\nPara manter suas ofertas on-line, mantenha o Bisq em execução e certifique-se de que este computador também permaneça online (ou seja, certifique-se de que ele não entra no modo de espera... o modo de espera do monitor não causa problema).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Notificação privada importante!
 
 popup.securityRecommendation.headline=Recomendação de segurança importante
 popup.securityRecommendation.msg=Gostaríamos de lembrá-lo de considerar a possibilidade de usar a proteção por senha para sua carteira, caso você ainda não tenha ativado isso.\n\nTambém é altamente recomendável anotar as palavras-semente da carteira. Essas palavras-semente são como uma senha mestre para recuperar sua carteira Bitcoin.\nNa secção \"Semente da Carteira\", você encontrará mais informações.\n\nAlém disso, você deve fazer o backup da pasta completa de dados do programa na secção \"Backup\".
 
-popup.bitcoinLocalhostNode.msg=O Bisq detectou um nó do Bitcoin Core em execução localmente (no localhost).\nPor favor, certifique-se de que este nó esteja totalmente sincronizado antes de iniciar o Bisq e que ele não esteja em execução no pruned mode.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nFor a well configured node, the requirements are for the node to have pruning disabled and bloom filters enabled.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Desligando
 popup.shutDownInProgress.msg=Desligar o programa pode demorar alguns segundos.\nPor favor não interrompa este processo.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=Uma das suas contas de pagamento foi verificad
 popup.accountSigning.peerLimitLifted=O limite inicial de uma das suas contas foi aumentado.\n\n{0}
 popup.accountSigning.peerSigner=Uma das suas contas tem maturidade suficiente para assinar outras contas de pagamento e o limite inicial de uma delas foi aumentado.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"OAD/Carteira BSQ/Receber\"
 
 formatter.formatVolumeLabel={0} quantia{1}
 formatter.makerTaker=Ofertante como {0} {1} / Aceitador como {2} {3}
-formatter.youAreAsMaker=Você está {0} {1} como ofertante / Aceitador está {2} {3}
-formatter.youAreAsTaker=Você está {0} {1} como aceitador / Ofertante está {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=Você é {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Você está criando uma oferta para {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Você está criando uma oferta para {0} {1} ({2} {3})
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Nome
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_ru.properties
+++ b/core/src/main/resources/i18n/displayStrings_ru.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Выбрать торговый счёт
 shared.fundFromSavingsWalletButton=Перевести средства с кошелька Bisq
 shared.fundFromExternalWalletButton=Открыть внешний кошелёк для пополнения
 shared.openDefaultWalletFailed=Failed to open a Bitcoin wallet application. Are you sure you have one installed?
-shared.distanceInPercent=Отклонение от рыночного курса в %
 shared.belowInPercent=% ниже рыночного курса
 shared.aboveInPercent=% выше рыночного курса
 shared.enterPercentageValue=Ввести величину в %
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Баланс кошелька сделки
 shared.makerTxFee=Мейкер: {0}
 shared.takerTxFee=Тейкер: {0}
 shared.iConfirm=Подтверждаю
-shared.tradingFeeInBsqInfo=equivalent to {0} used as trading fee
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Открыть {0}
 shared.fiat=Нац. валюта
 shared.crypto=Криптовалюта
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Вы всегда получите на
 createOffer.warning.buyAboveMarketPrice=Вы всегда заплатите на {0}% больше текущего рыночного курса, так как курс вашего предложения будет постоянно обновляться.
 createOffer.tradeFee.descriptionBTCOnly=Комиссия за сделку
 createOffer.tradeFee.descriptionBSQEnabled=Выбрать валюту комиссии за сделку
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} от суммы сделки
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Проверка: разместить предложение {0} биткойн
-createOffer.alreadyFunded=Вы уже обеспечили это предложение.\nВаши средства были перемещены в локальный кошелёк Bisq. Они доступны для вывода в разделе \«Средства/Отправить средства\».
 createOffer.createOfferFundWalletInfo.headline=Обеспечить своё предложение
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Сумма сделки: {0} \n
@@ -503,7 +506,6 @@ takeOffer.error.message=Ошибка при принятии предложен�
 # new entries
 takeOffer.takeOfferButton=Проверка: принять предложение {0} биткойн
 takeOffer.noPriceFeedAvailable=Нельзя принять это предложение, поскольку в нем используется процентный курс на основе рыночного курса, источник которого недоступен.
-takeOffer.alreadyFunded.movedFunds=Вы уже обеспечили это предложение.\nВаши средства были перемещены в локальный кошелёк Bisq. Они доступны для вывода в разделе \«Средства/Отправить средства\».
 takeOffer.takeOfferFundWalletInfo.headline=Обеспечьте свою сделку
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Сумма сделки: {0} \n
@@ -530,6 +532,10 @@ takeOffer.tac=Принимая это предложение, я соглаша�
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Начальная цена
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=Укажите курс
 editOffer.confirmEdit=Подтвердите: изменить предложение
@@ -951,6 +957,7 @@ support.error=Получателю не удалось обработать со
 support.buyerAddress=Адрес покупателя ВТС
 support.sellerAddress=Адрес продавца ВТС
 support.role=Роль
+support.agent=Support agent
 support.state=Состояние
 support.closed=Закрыто
 support.open=Открыто
@@ -1176,11 +1183,11 @@ account.menu.backup=Резервное копирование
 account.menu.notifications=Уведомления
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Вы можете оплатить комиссию за с
 feeOptionWindow.optionsLabel=Выберите валюту для оплаты комиссии за сделку
 feeOptionWindow.useBTC=Использовать ВТС
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Я подтверждаю, что могу в
 popup.info.shutDownWithOpenOffers=Bisq закрывается, но у вас есть открытые предложения.\n\nЭти предложения будут недоступны в сети P2P, пока приложение Bisq закрыто, но будут повторно опубликованы в сети P2P при следующем запуске Bisq.\n\nЧтобы ваши предложения были доступны в сети, компьютер и приложение должны быть включены и подключены к сети (убедитесь, что компьютер не перешёл в режим ожидания; переход монитора в спящий режим не влияет на работу приложения).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Важное личное уведомление!
 
 popup.securityRecommendation.headline=Важная рекомендация по безопасности
 popup.securityRecommendation.msg=Рекомендуем вам защитить свой кошелёк паролем, если вы ещё этого не сделали.\n\nТакже убедительно рекомендуем записать вашу мнемоническую фразу. Она поможет восстановить ваш кошелёк Биткойн.\nДополнительная информация указана в разделе \«Мнемоническая фраза\».\n\nВам также следует сохранить копию папки со всеми данными программы в разделе \«Резервное копирование\».
 
-popup.bitcoinLocalhostNode.msg=Bisq обнаружил локальный узел Bitcoin Core.\nПеред запуском Bisq убедитесь, что этот узел полностью синхронизирован с сетью Биткойн и не работает в режиме обрезки данных (pruned mode).
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nFor a well configured node, the requirements are for the node to have pruning disabled and bloom filters enabled.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Завершение работы
 popup.shutDownInProgress.msg=Завершение работы приложения может занять несколько секунд.\nПросьба не прерывать этот процесс.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=One of your payment accounts has been verified
 popup.accountSigning.peerLimitLifted=The initial limit for one of your accounts has been lifted.\n\n{0}
 popup.accountSigning.peerSigner=One of your accounts is mature enough to sign other payment accounts and the initial limit for one of your accounts has been lifted.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\«ДАО/BSQ-кошелёк/Получить\»
 
 formatter.formatVolumeLabel={0} сумма {1}
 formatter.makerTaker=Мейкер как {0} {1} / Тейкер как {2} {3}
-formatter.youAreAsMaker=Вы как {0} {1} (мейкер) / тейкер как {2} {3}
-formatter.youAreAsTaker=Вы как {0} {1} (тейкер) / мейкер как {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=Вы {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Вы создаете предложение {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Вы создаете предложение {0} {1} ({2} {3})
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Имя
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=เลือกบัญชีการซื้อ�
 shared.fundFromSavingsWalletButton=โอนเงินจาก Bisq wallet
 shared.fundFromExternalWalletButton=เริ่มทำการระดมเงินทุนหาแหล่งเงินจากกระเป๋าสตางค์ภายนอกของคุณ
 shared.openDefaultWalletFailed=Failed to open a Bitcoin wallet application. Are you sure you have one installed?
-shared.distanceInPercent=ระดับราคาในรูปแบบ % จากราคาตลาด
 shared.belowInPercent=ต่ำกว่า % จากราคาตลาด
 shared.aboveInPercent=สูงกว่า % จากราคาตาด
 shared.enterPercentageValue=เข้าสู่ % ตามมูลค่า
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=ยอดคงเหลือของ Trade wallet
 shared.makerTxFee=ผู้ทำ: {0}
 shared.takerTxFee=ผู้รับ: {0}
 shared.iConfirm=ฉันยืนยัน
-shared.tradingFeeInBsqInfo=equivalent to {0} used as trading fee
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=เปิด {0}
 shared.fiat=คำสั่ง
 shared.crypto=คริปโต
@@ -442,14 +441,18 @@ createOffer.warning.sellBelowMarketPrice=คุณจะได้รับ {0}% 
 createOffer.warning.buyAboveMarketPrice=คุณจะต้องจ่ายเงิน {0}% มากกว่าราคาตลาดในปัจจุบันเนื่องจากราคาข้อเสนอของคุณจะได้รับการอัพเดตอย่างต่อเนื่อง
 createOffer.tradeFee.descriptionBTCOnly=ค่าธรรมเนียมการซื้อขาย
 createOffer.tradeFee.descriptionBSQEnabled=เลือกสกุลเงินค่าธรรมเนียมในการเทรด
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} จำนวนการเทรด
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=รีวิว: ใส่ข้อเสนอไปยัง {0} บิตคอย
-createOffer.alreadyFunded=คุณได้รับเงินจากข้อเสนอนั้นแล้ว\nเงินของคุณถูกย้ายไปที่กระเป๋าสตางค์ Bisq ของคุณและคุณสามารถถอนเงินออกได้โดยไปที่หน้า \"เงิน / ส่งเงิน \"
 createOffer.createOfferFundWalletInfo.headline=เงินทุนสำหรับข้อเสนอของคุณ
 # suppress inspection "TrailingSpacesInProperty"
-createOffer.createOfferFundWalletInfo.tradeAmount=- ปริมาณการซื้อขาย: {0} 
+createOffer.createOfferFundWalletInfo.tradeAmount=- ปริมาณการซื้อขาย: {0}
 createOffer.createOfferFundWalletInfo.msg=คุณต้องวางเงินมัดจำ {0} ข้อเสนอนี้\n\nเงินเหล่านั้นจะถูกสงวนไว้ใน wallet ภายในประเทศของคุณและจะถูกล็อคไว้ในที่อยู่ที่ฝากเงิน multisig เมื่อมีคนรับข้อเสนอของคุณ\n\nผลรวมของจำนวนของ: \n{1} - เงินประกันของคุณ: {2} \n- ค่าธรรมเนียมการซื้อขาย: {3} \n- ค่าขุด: {4} \n\nคุณสามารถเลือกระหว่างสองตัวเลือกเมื่อมีการระดุมทุนการซื้อขายของคุณ: \n- ใช้กระเป๋าสตางค์ Bisq ของคุณ (สะดวก แต่ธุรกรรมอาจเชื่อมโยงกันได้) หรือ\n- โอนเงินจากเงินภายนอกเข้ามา (อาจเป็นส่วนตัวมากขึ้น) \n\nคุณจะเห็นตัวเลือกและรายละเอียดการระดมทุนทั้งหมดหลังจากปิดป๊อปอัปนี้
 
 # only first part "An error occurred when placing the offer:" has been used before. We added now the rest (need update in existing translations!)
@@ -503,10 +506,9 @@ takeOffer.error.message=เกิดข้อผิดพลาดขณะร�
 # new entries
 takeOffer.takeOfferButton=รีวิว: รับข้อเสนอจาก {0} bitcoin
 takeOffer.noPriceFeedAvailable=คุณไม่สามารถรับข้อเสนอดังกล่าวเนื่องจากใช้ราคาร้อยละตามราคาตลาด แต่ไม่มีฟีดราคาที่พร้อมใช้งาน
-takeOffer.alreadyFunded.movedFunds=คุณได้รับเงินสนับสนุนแล้ว\nเงินของคุณถูกย้ายไปที่กระเป๋าสตางค์ Bisq ของคุณและพร้อมสำหรับการถอนเงินโดยไปที่หน้า \"เงิน / ส่งเงิน \"
 takeOffer.takeOfferFundWalletInfo.headline=ทุนการซื้อขายของคุณ
 # suppress inspection "TrailingSpacesInProperty"
-takeOffer.takeOfferFundWalletInfo.tradeAmount=- ปริมาณการซื้อขาย: {0} 
+takeOffer.takeOfferFundWalletInfo.tradeAmount=- ปริมาณการซื้อขาย: {0}
 takeOffer.takeOfferFundWalletInfo.msg=คุณต้องวางเงินประกัน {0} เพื่อรับข้อเสนอนี้\n\nจำนวนเงินคือผลรวมของ: \n{1} - เงินประกันของคุณ: {2} \n- ค่าธรรมเนียมการซื้อขาย: {3} \n- ค่าธรรมเนียมการขุดทั้งหมด: {4} \n\nคุณสามารถเลือกระหว่างสองตัวเลือกเมื่อลงทุนการซื้อขายของคุณ: \n- ใช้กระเป๋าสตางค์ Bisq ของคุณ (สะดวก แต่ธุรกรรมอาจเชื่อมโยงกันได้) หรือ\n- โอนเงินจากแหล่งเงินภายนอก (อาจเป็นส่วนตัวมากขึ้น) \n\nคุณจะเห็นตัวเลือกและรายละเอียดการลงทุนทั้งหมดหลังจากปิดป๊อปอัปนี้
 takeOffer.alreadyPaidInFunds=หากคุณได้ชำระเงินแล้วคุณสามารถถอนเงินออกได้ในหน้าจอ \"เงิน / ส่งเงิน \"
 takeOffer.paymentInfo=ข้อมูลการชำระเงิน
@@ -530,6 +532,10 @@ takeOffer.tac=ด้วยข้อเสนอนี้ฉันยอมรั
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=ราคาเงื่อนไขที่ตั้งไว้
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=ตั้งราคา
 editOffer.confirmEdit=ยืนยัน: แก้ไขข้อเสนอ
@@ -951,6 +957,7 @@ support.error=ผู้รับไม่สามารถประมวลผ
 support.buyerAddress=ที่อยู่ของผู้ซื้อ BTC
 support.sellerAddress=ที่อยู่ของผู้ขาย BTC
 support.role=บทบาท
+support.agent=Support agent
 support.state=สถานะ
 support.closed=ปิดแล้ว
 support.open=เปิด
@@ -1176,11 +1183,11 @@ account.menu.backup=การสำรองข้อมูล
 account.menu.notifications=การแจ้งเตือน
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=คุณสามารถเลือกที่จะ�
 feeOptionWindow.optionsLabel=เลือกสกุลเงินสำหรับการชำระค่าธรรมเนียมการซื้อขาย
 feeOptionWindow.useBTC=ใช้ BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=ฉันยืนยันว่าฉัน
 popup.info.shutDownWithOpenOffers=Bisq คือกำลังจะปิดลง แต่ยังคงมีการเปิดขายข้อเสนอปกติ\nข้อเสนอเหล่านี้จะไม่ใข้งานได้บนเครือข่าย P2P network ในขณะที่ Bisq ปิดตัวลง แต่จะมีการเผยแพร่บนเครือข่าย P2P ครั้งถัดไปเมื่อคุณมีการเริ่มใช้งาน Bisq.\n\nในการคงสถานะข้อเสนอแบบออนไลน์ คือเปิดใข้งาน Bisq และทำให้มั่นใจว่าคอมพิวเตอร์เครื่องนี้กำลังออนไลน์อยู่ด้วยเช่นกัน (เช่น ตรวจสอบว่าคอมพิวเตอร์ไม่ได้อยู่ในโหมดแสตนบายด์...หน้าจอแสตนบายด์ไม่มีปัญหา)
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=การแจ้งเตือนส่วนตัวที่สำคัญ!
 
 popup.securityRecommendation.headline=ข้อเสนอแนะด้านความปลอดภัยที่สำคัญ
 popup.securityRecommendation.msg=เราขอแจ้งเตือนให้คุณพิจารณาใช้การป้องกันด้วยรหัสผ่านสำหรับ wallet ของคุณ  หากยังไม่ได้เปิดใช้งาน\n\nขอแนะนำให้เขียนรหัสลับป้องกัน wallet รหัสลับเหล่านี้เหมือนกับรหัสผ่านหลักสำหรับการกู้คืน Bitcoin wallet ของคุณ\nไปที่ \"กระเป๋าสตางค์ \" คุณจะพบข้อมูลเพิ่มเติม\n\nนอกจากนี้คุณควรสำรองโฟลเดอร์ข้อมูลแอ็พพลิเคชั่นทั้งหมดไว้ที่ส่วน \"สำรองข้อมูล \"
 
-popup.bitcoinLocalhostNode.msg=Bisq ตรวจพบเฉพาะบิตโหนดหลักของ Bitcoin ที่ใช้งานอยู่ (ที่ localhost)\nโปรดตรวจสอบว่าโหนดนี้ได้รับการซิงค์อย่างสมบูรณ์ก่อนที่คุณจะเริ่ม Bisq และไม่ได้ทำงานในโหมด pruned
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nFor a well configured node, the requirements are for the node to have pruning disabled and bloom filters enabled.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=การปิดระบบอยู่ระหว่างดำเนินการ
 popup.shutDownInProgress.msg=การปิดแอพพลิเคชั่นอาจใช้เวลาสักครู่\nโปรดอย่าขัดจังหวะกระบวนการนี้
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=One of your payment accounts has been verified
 popup.accountSigning.peerLimitLifted=The initial limit for one of your accounts has been lifted.\n\n{0}
 popup.accountSigning.peerSigner=One of your accounts is mature enough to sign other payment accounts and the initial limit for one of your accounts has been lifted.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\ "Wallet DAO / BSQ / การรับ \"
 
 formatter.formatVolumeLabel={0} จำนวนยอด{1}
 formatter.makerTaker=ผู้สร้าง เป็น {0} {1} / ผู้รับเป็น {2} {3}
-formatter.youAreAsMaker=คุณคือ {0} {1} ในฐานะผู้สร้าง / ผู้รับคือ {2} {3}
-formatter.youAreAsTaker=คุณคือ {0} {1} เป็นผู้รับ / ผู้สร้างคือ {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=คุณคือ {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=คุณกำลังสร้างข้อเสนอให้ {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=คุณกำลังสร้างข้อเสนอให้กับ {0} {1} ({2} {3})
@@ -2625,7 +2631,7 @@ payment.clearXchange.info=Zelle is a money transfer service that works best *thr
 payment.fasterPayments.newRequirements.info=Some banks have started verifying the receiver''s full name for Faster Payments transfers. Your current Faster Payments account does not specify a full name.\n\nPlease consider recreating your Faster Payments account in Bisq to provide future {0} buyers with a full name.\n\nWhen you recreate the account, make sure to copy the precise sort code, account number and account age verification salt values from your old account to your new account. This will ensure your existing account''s age and signing status are preserved.
 payment.moneyGram.info=When using MoneyGram the BTC buyer has to send the Authorisation number and a photo of the receipt by email to the BTC seller. The receipt must clearly show the seller's full name, country, state and the amount. The seller's email will be displayed to the buyer during the trade process.
 payment.westernUnion.info=When using Western Union the BTC buyer has to send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller. The receipt must clearly show the seller's full name, city, country and the amount. The seller's email will be displayed to the buyer during the trade process.
-payment.halCash.info=เมื่อมีการใช้งาน HalCash ผู้ซื้อ BTC จำเป็นต้องส่งรหัส Halcash ให้กับผู้ขายทางข้อความโทรศัพท์มือถือ\n\nโปรดตรวจสอบว่าไม่เกินจำนวนเงินสูงสุดที่ธนาคารของคุณอนุญาตให้คุณส่งด้วย HalCash จำนวนเงินขั้นต่ำในการเบิกถอนคือ 10 EUR และสูงสุดในจำนวนเงิน 600 EUR สำหรับการถอนซ้ำเป็น 3000 EUR ต่อผู้รับและต่อวัน และ 6000 EUR ต่อผู้รับและต่อเดือน โปรดตรวจสอบข้อจำกัดจากทางธนาคารคุณเพื่อให้มั่นใจได้ว่าทางธนาคารได้มีการใช้มาตรฐานข้อกำหนดเดียวกันกับดังที่ระบุไว้ ณ ที่นี่\n\nจำนวนเงินที่ถอนจะต้องเป็นจำนวนเงินหลาย 10 EUR เนื่องจากคุณไม่สามารถถอนเงินอื่น ๆ ออกจากตู้เอทีเอ็มได้ UI ในหน้าจอสร้างข้อเสนอและรับข้อเสนอจะปรับจำนวนเงิน BTC เพื่อให้จำนวนเงิน EUR ถูกต้อง คุณไม่สามารถใช้ราคาตลาดเป็นจำนวนเงิน EUR ซึ่งจะเปลี่ยนแปลงไปตามราคาที่มีการปรับเปลี่ยน\n\nในกรณีที่มีข้อพิพาทผู้ซื้อ BTC ต้องแสดงหลักฐานว่าได้ส่ง EUR แล้ว 
+payment.halCash.info=เมื่อมีการใช้งาน HalCash ผู้ซื้อ BTC จำเป็นต้องส่งรหัส Halcash ให้กับผู้ขายทางข้อความโทรศัพท์มือถือ\n\nโปรดตรวจสอบว่าไม่เกินจำนวนเงินสูงสุดที่ธนาคารของคุณอนุญาตให้คุณส่งด้วย HalCash จำนวนเงินขั้นต่ำในการเบิกถอนคือ 10 EUR และสูงสุดในจำนวนเงิน 600 EUR สำหรับการถอนซ้ำเป็น 3000 EUR ต่อผู้รับและต่อวัน และ 6000 EUR ต่อผู้รับและต่อเดือน โปรดตรวจสอบข้อจำกัดจากทางธนาคารคุณเพื่อให้มั่นใจได้ว่าทางธนาคารได้มีการใช้มาตรฐานข้อกำหนดเดียวกันกับดังที่ระบุไว้ ณ ที่นี่\n\nจำนวนเงินที่ถอนจะต้องเป็นจำนวนเงินหลาย 10 EUR เนื่องจากคุณไม่สามารถถอนเงินอื่น ๆ ออกจากตู้เอทีเอ็มได้ UI ในหน้าจอสร้างข้อเสนอและรับข้อเสนอจะปรับจำนวนเงิน BTC เพื่อให้จำนวนเงิน EUR ถูกต้อง คุณไม่สามารถใช้ราคาตลาดเป็นจำนวนเงิน EUR ซึ่งจะเปลี่ยนแปลงไปตามราคาที่มีการปรับเปลี่ยน\n\nในกรณีที่มีข้อพิพาทผู้ซื้อ BTC ต้องแสดงหลักฐานว่าได้ส่ง EUR แล้ว
 # suppress inspection "UnusedMessageFormatParameter"
 payment.limits.info=Please be aware that all bank transfers carry a certain amount of chargeback risk. To mitigate this risk, Bisq sets per-trade limits based on the estimated level of chargeback risk for the payment method used.\n\nFor this payment method, your per-trade limit for buying and selling is {2}.\n\nThis limit only applies to the size of a single trade—you can place as many trades as you like.\n\nSee more details on the wiki [HYPERLINK:https://bisq.wiki/Account_limits].
 # suppress inspection "UnusedProperty"
@@ -2659,7 +2665,8 @@ payment.japan.recipient=ชื่อ
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=Chọn tài khoản giao dịch
 shared.fundFromSavingsWalletButton=Chuyển tiền từ Ví Bisq
 shared.fundFromExternalWalletButton=Mở ví ngoài để nộp tiền
 shared.openDefaultWalletFailed=Failed to open a Bitcoin wallet application. Are you sure you have one installed?
-shared.distanceInPercent=Chênh lệch % so với giá thị trường
 shared.belowInPercent=Thấp hơn % so với giá thị trường
 shared.aboveInPercent=Cao hơn % so với giá thị trường
 shared.enterPercentageValue=Nhập giá trị %
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=Số dư ví giao dịch
 shared.makerTxFee=Người tạo: {0}
 shared.takerTxFee=Người nhận: {0}
 shared.iConfirm=Tôi xác nhận
-shared.tradingFeeInBsqInfo=equivalent to {0} used as trading fee
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=Mở {0}
 shared.fiat=Tiền pháp định
 shared.crypto=Tiền mã hóa
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=Bạn sẽ luôn nhận {0}% thấp hơ
 createOffer.warning.buyAboveMarketPrice=Bạn sẽ luôn trả {0}% cao hơn so với giá thị trường hiện tại vì báo giá của bạn sẽ luôn được cập nhật.
 createOffer.tradeFee.descriptionBTCOnly=Phí giao dịch
 createOffer.tradeFee.descriptionBSQEnabled=Chọn loại tiền trả phí giao dịch
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1} giá trị giao dịch
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=Kiểm tra:: Đặt báo giá cho {0} bitcoin
-createOffer.alreadyFunded=Bạn đã nộp tiền cho chào giá.\nSố tiền của bạn đã được chuyển sang ví Bisq nội bộ và luôn sẵn sàng để rút ra tại màn hình \"Vốn/Gửi vốn\" screen.
 createOffer.createOfferFundWalletInfo.headline=Nộp tiền cho báo giá của bạn
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Khoản tiền giao dịch: {0} \n
@@ -503,7 +506,6 @@ takeOffer.error.message=Có lỗi xảy ra khi nhận báo giá.\n\n{0}
 # new entries
 takeOffer.takeOfferButton=Rà soát: Nhận báo giá cho {0} bitcoin
 takeOffer.noPriceFeedAvailable=Bạn không thể nhận báo giá này do sử dụng giá phần trăm dựa trên giá thị trường nhưng không có giá cung cấp.
-takeOffer.alreadyFunded.movedFunds=Bạn đã nộp tiền cho báo giá này.\nKhoản tiền này sẽ được chuyển sang ví Bisq nội bộ của bạn và sẵn sàng để rút tại màn hình \"Vốn/Gửi vốn\".
 takeOffer.takeOfferFundWalletInfo.headline=Nộp tiền cho giao dịch của bạn
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- Giá trị giao dịch: {0} \n
@@ -530,6 +532,10 @@ takeOffer.tac=Bằng cách nhận báo giá này, tôi đồng ý với các đi
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=Giá khởi phát
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=Cài đặt giá
 editOffer.confirmEdit=Xác nhận: Chỉnh sửa báo giá
@@ -951,6 +957,7 @@ support.error=Người nhận không thể tiến hành gửi tin nhắn: Lỗi:
 support.buyerAddress=Địa chỉ người mua BTC
 support.sellerAddress=Địa chỉ người bán BTC
 support.role=Vai trò
+support.agent=Support agent
 support.state=Trạng thái
 support.closed=Đóng
 support.open=Mở
@@ -1176,11 +1183,11 @@ account.menu.backup=Dự phòng
 account.menu.notifications=Thông báo
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=Bạn có thể chọn thanh toán phí giao dịch bằng 
 feeOptionWindow.optionsLabel=Chọn đồng tiền để thanh toán phí giao dịch
 feeOptionWindow.useBTC=Sử dụng BTC
 feeOptionWindow.fee={0} (≈ {1})
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=Tôi xác nhận tôi đã gửi tiền
 popup.info.shutDownWithOpenOffers=Bisq đang đóng, nhưng vẫn có các chào giá đang mở. \n\nNhững chào giá này sẽ không có tại mạng P2P khi Bisq đang đóng, nhưng chúng sẽ được công bố lại trên mạng P2P vào lần tiếp theo bạn khởi động Bisq.\nĐể giữ các chào giá luôn trực tuyến, vui lòng để Bisq chạy và đảm bảo là máy tính của bạn cũng đang trực tuyến(có nghĩa là đảm bảo là máy tính của bạn không chuyển về chế độ chờ...nếu màn hình về chế độ chờ thì không sao).
 popup.info.qubesOSSetupInfo=It appears you are running Bisq on Qubes OS. \n\nPlease make sure your Bisq qube is setup according to our Setup Guide at [HYPERLINK:https://bisq.wiki/Running_Bisq_on_Qubes].
 popup.warn.downGradePrevention=Downgrade from version {0} to version {1} is not supported. Please use the latest Bisq version.
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=Thông báo riêng tư quan trọng!
 
 popup.securityRecommendation.headline=Khuyến cáo an ninh quan trọng
 popup.securityRecommendation.msg=Chúng tôi muốn nhắc nhở bạn sử dụng bảo vệ bằng mật khẩu cho ví của bạn nếu bạn vẫn chưa sử dụng.\n\nChúng tôi cũng khuyên bạn nên viết Seed words ví của bạn ra giấy. Các Seed words này như là mật khẩu chủ để khôi phục ví Bitcoin của bạn.\nBạn có thể xem thông tin ở mục \"Wallet Seed\".\n\nNgoài ra bạn nên sao lưu dự phòng folder dữ liệu ứng dụng đầy đủ ở mục \"Backup\".
 
-popup.bitcoinLocalhostNode.msg=Bisq phát hiện Node Bitcoin Core đang chạy (ở máy chủ cục bộ).\nHãy chắc chắn rằng Node này đã được đồng bộ hóa hoàn toàn trước khi bạn khởi động Bisq và không chạy trong chế độ pruning.
-popup.bitcoinLocalhostNode.additionalRequirements=\n\nFor a well configured node, the requirements are for the node to have pruning disabled and bloom filters enabled.
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=Đang tắt ứng dụng
 popup.shutDownInProgress.msg=Tắt ứng dụng sẽ mất vài giây.\nVui lòng không gián đoạn quá trình này.
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=One of your payment accounts has been verified
 popup.accountSigning.peerLimitLifted=The initial limit for one of your accounts has been lifted.\n\n{0}
 popup.accountSigning.peerSigner=One of your accounts is mature enough to sign other payment accounts and the initial limit for one of your accounts has been lifted.\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=Select account age witness
-popup.accountSigning.singleAccountSelect.description=Search for account age witness.
-popup.accountSigning.singleAccountSelect.datePicker=Select point of time for signing
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=Confirm selected account age witness
 popup.accountSigning.confirmSingleAccount.selectedHash=Selected witness hash
 popup.accountSigning.confirmSingleAccount.button=Sign account age witness
 popup.accountSigning.successSingleAccount.description=Witness {0} was signed
 popup.accountSigning.successSingleAccount.success.headline=Success
-popup.accountSigning.successSingleAccount.signError=Failed to sign witness, {0}
 
 popup.accountSigning.unsignedPubKeys.headline=Unsigned Pubkeys
 popup.accountSigning.unsignedPubKeys.sign=Sign Pubkeys
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=\"DAO/Ví BSQ/Nhận\"
 
 formatter.formatVolumeLabel={0} giá trị {1}
 formatter.makerTaker=Người tạo là {0} {1} / Người nhận là {2} {3}
-formatter.youAreAsMaker=Bạn là {0} {1} như người tạo / Người nhận là {2} {3}
-formatter.youAreAsTaker=Bạn là {0} {1} như người nhận / Người tạo là {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=Bạn là {0} {1} ({2} {3})
 formatter.youAreCreatingAnOffer.fiat=Bạn đang tạo một chào giá đến {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=Bạn đang tạo một chào giá đến {0} {1} ({2} {3})
@@ -2659,7 +2665,8 @@ payment.japan.recipient=Tên
 payment.australia.payid=PayID
 payment.payid=PayID linked to financial institution. Like email address or mobile phone.
 payment.payid.info=A PayID like a phone number, email address or an Australian Business Number (ABN), that you can securely link to your bank, credit union or building society account. You need to have already created a PayID with your Australian financial institution. Both sending and receiving financial institutions must support PayID. For more information please check [HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=To pay with Amazon eGift Card you need to purchase an Amazon eGift Card at your Amazon account and use the BTC seller''s email or mobile nr. as receiver. Amazon sends then an email or text message to the receiver. Use the trade ID for the message field.\n\nAmazon eGift Cards can only be redeemed by Amazon accounts with the same currency.\n\nFor more information visit the Amazon eGift Card webpage. [HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_zh-hans.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hans.properties
@@ -71,7 +71,7 @@ shared.amountWithCur={0} 数量
 shared.volumeWithCur={0} 总量
 shared.currency=货币类型
 shared.market=交易项目
-shared.deviation=Deviation
+shared.deviation=偏差
 shared.paymentMethod=付款方式
 shared.tradeCurrency=交易货币
 shared.offerType=报价类型
@@ -105,7 +105,6 @@ shared.selectTradingAccount=选择交易账户
 shared.fundFromSavingsWalletButton=从 Bisq 钱包资金划转
 shared.fundFromExternalWalletButton=从您的外部钱包充值
 shared.openDefaultWalletFailed=打开默认的比特币钱包应用程序失败了。您确定您安装了吗？
-shared.distanceInPercent=与市场价格的差价 %
 shared.belowInPercent=低于市场价格 %
 shared.aboveInPercent=高于市场价格 %
 shared.enterPercentageValue=输入 % 值
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=交易钱包余额
 shared.makerTxFee=卖家：{0}
 shared.takerTxFee=买家：{0}
 shared.iConfirm=我确认
-shared.tradingFeeInBsqInfo=相当于使用 {0} 交易手续费
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=打开 {0}
 shared.fiat=法定货币
 shared.crypto=加密
@@ -219,8 +218,8 @@ shared.refundAgentForSupportStaff=退款助理
 shared.delayedPayoutTxId=延迟支付交易 ID
 shared.delayedPayoutTxReceiverAddress=延迟交易交易已发送至
 shared.unconfirmedTransactionsLimitReached=你现在有过多的未确认交易。请稍后尝试
-shared.numItemsLabel=Number of entries: {0}
-shared.filter=Filter
+shared.numItemsLabel=实体数：{0}
+shared.filter=过滤
 shared.enabled=启用
 
 
@@ -252,14 +251,14 @@ mainView.balance.locked=冻结余额
 mainView.balance.reserved.short=保证
 mainView.balance.locked.short=冻结
 
-mainView.footer.usingTor=(via Tor)
+mainView.footer.usingTor=（通过 Tor）
 mainView.footer.localhostBitcoinNode=（本地主机）
 mainView.footer.btcInfo={0} {1}
-mainView.footer.btcFeeRate=/ Fee rate: {0} sat/vB
+mainView.footer.btcFeeRate=/ 矿工手费率：{0} 聪/字节
 mainView.footer.btcInfo.initializing=连接至比特币网络
 mainView.footer.bsqInfo.synchronizing=正在同步 DAO
-mainView.footer.btcInfo.synchronizingWith=Synchronizing with {0} at block: {1} / {2}
-mainView.footer.btcInfo.synchronizedWith=Synced with {0} at block {1}
+mainView.footer.btcInfo.synchronizingWith=正在通过{0}同步区块：{1}/{2}
+mainView.footer.btcInfo.synchronizedWith=已通过{0}同步至区块{1}
 mainView.footer.btcInfo.connectingTo=连接至
 mainView.footer.btcInfo.connectionFailed=连接失败：
 mainView.footer.p2pInfo=比特币网络节点：{0} / Bisq 网络节点：{1}
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=由于您的价格是持续更新的，
 createOffer.warning.buyAboveMarketPrice=由于您的价格是持续更新的，因此您将始终支付高于市场价 {0}% 的价格。
 createOffer.tradeFee.descriptionBTCOnly=挂单费
 createOffer.tradeFee.descriptionBSQEnabled=选择手续费币种
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1}  交易数量
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=复审：报价挂单 {0} 比特币
-createOffer.alreadyFunded=您已经为该报价充值了。\n您的资金已经划转到您的本地 Bisq 钱包并在“资金/提现”界面可以提现。
 createOffer.createOfferFundWalletInfo.headline=为您的报价充值
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- 交易数量：{0}\n
@@ -503,7 +506,6 @@ takeOffer.error.message=下单时发生了一个错误。\n\n{0}
 # new entries
 takeOffer.takeOfferButton=复审：报价下单 {0} 比特币
 takeOffer.noPriceFeedAvailable=您不能对这笔报价下单，因为它使用交易所价格百分比定价，但是您没有获得可用的价格。
-takeOffer.alreadyFunded.movedFunds=您已经为该报价值了。\n您的资金已经划转到您的本地 Bisq 钱包，并可以在“资金/提现”界面提现。
 takeOffer.takeOfferFundWalletInfo.headline=为交易充值
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- 交易数量：{0}\n
@@ -531,6 +533,10 @@ takeOffer.tac=接受该报价，意味着我同意这交易界面中的条件。
 # Offerbook / Edit offer
 ####################################################################
 
+openOffer.header.triggerPrice=触发价格
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
+
 editOffer.setPrice=设定价格
 editOffer.confirmEdit=确认：编辑报价
 editOffer.publishOffer=发布您的报价。
@@ -548,7 +554,7 @@ portfolio.tab.history=历史记录
 portfolio.tab.failed=失败
 portfolio.tab.editOpenOffer=编辑报价
 
-portfolio.closedTrades.deviation.help=Percentage price deviation from market
+portfolio.closedTrades.deviation.help=与市场价格偏差百分比
 
 portfolio.pending.invalidDelayedPayoutTx=这里有一个缺失或不可用交易导致的问题\n\n请不要发送法币或者任何数字货币。联系 Bisq 开发者在 Keybase 上 https://keybase.io/team/bisq 或者在论坛上https://bisq.community 以寻求更多协助。\n\n错误信息：{0} 
 
@@ -951,6 +957,7 @@ support.error=收件人无法处理消息。错误：{0}
 support.buyerAddress=BTC 买家地址
 support.sellerAddress=BTC 卖家地址
 support.role=角色
+support.agent=Support agent
 support.state=状态
 support.closed=关闭
 support.open=打开
@@ -1084,7 +1091,7 @@ settings.net.inbound=接收数据包
 settings.net.outbound=发送数据包
 settings.net.reSyncSPVChainLabel=重新同步 SPV 链
 settings.net.reSyncSPVChainButton=删除 SPV 链文件并重新同步
-settings.net.reSyncSPVSuccess=Are you sure you want to do an SPV resync?  If you proceed, the SPV chain file will be deleted on the next startup.\n\nAfter the restart it can take a while to resync with the network and you will only see all transactions once the resync is completed.\n\nDepending on the number of transactions and the age of your wallet the resync can take up to a few hours and consumes 100% of CPU. Do not interrupt the process otherwise you have to repeat it.
+settings.net.reSyncSPVSuccess=您确定要进行 SPV 重新同步？如果您继续，SPV 链文件将会在下一次启动前删除。\n\n重新启动后，可能需要一段时间才能与网络重新同步，只有重新同步完成后才会看到所有的交易。\n\n根据交易的数量和钱包账龄，重新同步可能会花费几个小时，并消耗100%的 CPU。不要打断这个过程，否则你会不断地重复它。
 settings.net.reSyncSPVAfterRestart=SPV 链文件已被删除。请耐心等待，与网络重新同步可能需要一段时间。
 settings.net.reSyncSPVAfterRestartCompleted=重新同步刚刚完成，请重启应用程序。
 settings.net.reSyncSPVFailed=无法删除 SPV 链文件。\n错误：{0}
@@ -1171,18 +1178,18 @@ account.menu.paymentAccount=法定货币账户
 account.menu.altCoinsAccountView=数字货币账户
 account.menu.password=钱包密码
 account.menu.seedWords=钱包密钥
-account.menu.walletInfo=Wallet info
+account.menu.walletInfo=钱包信息
 account.menu.backup=备份
 account.menu.notifications=通知
 
-account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
-account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
-account.menu.walletInfo.walletSelector={0} {1} wallet
-account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.balance.headLine=钱包余额
+account.menu.walletInfo.balance.info=这里包括内部钱包余额包括未确认交易。\n对于 BTC，下方显示的内部钱包的余额将会是窗口右上方的“可用”与“保留”余额的总和。
+account.menu.walletInfo.xpub.headLine=监控密钥（xpub keys）
+account.menu.walletInfo.walletSelector={0} {1} 钱包
+account.menu.walletInfo.path.headLine=HD 密钥链路径
+account.menu.walletInfo.path.info=如果您导入其他钱包（例如  Electrum）的种子词，你需要去确认路径。这个操作只能用于你失去 Bisq 钱包和数据目录的控制的紧急情况。\n请记住使用非 Bisq 钱包的资金可能会打乱 Bisq 内部与之相连的钱包数据结构，这可能导致交易失败。\n\n请不要将 BSQ 发送至非 Bisq 钱包，因为这可能让您的 BSQ 交易记录失效以及损失 BSQ.
 
-account.menu.walletInfo.openDetails=Show raw wallet details and private keys
+account.menu.walletInfo.openDetails=显示原始钱包详情与私钥
 
 ## TODO should we rename the following to a gereric name?
 account.arbitratorRegistration.pubKey=公钥
@@ -2174,7 +2181,7 @@ tradeDetailsWindow.tradingPeersOnion=交易伙伴匿名地址
 tradeDetailsWindow.tradingPeersPubKeyHash=交易伙伴公钥哈希值
 tradeDetailsWindow.tradeState=交易状态
 tradeDetailsWindow.agentAddresses=仲裁员/调解员
-tradeDetailsWindow.detailData=Detail data
+tradeDetailsWindow.detailData=详情数据
 
 walletPasswordWindow.headline=输入密码解锁
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=您可以选择用 BSQ 或 BTC 支付交易费用。如果�
 feeOptionWindow.optionsLabel=选择货币支付交易手续费
 feeOptionWindow.useBTC=使用 BTC
 feeOptionWindow.fee={0}（≈ {1}）
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2276,7 +2285,7 @@ popup.warning.openOffer.makerFeeTxRejected=交易 ID 为 {0} 的挂单费交易�
 
 popup.warning.trade.txRejected.tradeFee=交易手续费
 popup.warning.trade.txRejected.deposit=押金
-popup.warning.trade.txRejected=The {0} transaction for trade with ID {1} was rejected by the Bitcoin network.\nTransaction ID={2}\nThe trade has been moved to failed trades.\nPlease go to \"Settings/Network info\" and do a SPV resync.\nFor further help please contact the Bisq support channel at the Bisq Keybase team.
+popup.warning.trade.txRejected=使用 ID {1} 进行交易的 {0} 交易被比特币网络拒绝。\n交易 ID = {2}\n交易已被移至失败交易。\n请到“设置/网络信息”进行 SPV 重新同步。\n如需更多帮助，请联系 Bisq Keybase 团队的 Support 频道
 
 popup.warning.openOfferWithInvalidMakerFeeTx=交易 ID 为 {0} 的挂单费交易无效。\n交易 ID = {1}。\n请到“设置/网络信息”进行 SPV 重新同步。\n如需更多帮助，请联系 Bisq Keybase 团队的 Support 频道
 
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=我确认我可以支付保证金
 popup.info.shutDownWithOpenOffers=Bisq 正在被关闭，但仍有公开的报价。\n\n当 Bisq 关闭时，这些提供将不能在 P2P 网络上使用，但是它们将在您下次启动 Bisq 时重新发布到 P2P 网络上。\n\n为了让您的报价在线，保持 Bisq 运行，并确保这台计算机也在线（即，确保它不会进入待机模式…显示器待机不是问题）。
 popup.info.qubesOSSetupInfo=你似乎好像在 Qubes OS 上运行 Bisq。\n\n请确保您的 Bisq qube 是参考设置指南的说明设置的 https://bisq.wiki/Running_Bisq_on_Qubes
 popup.warn.downGradePrevention=不支持从 {0} 版本降级到 {1} 版本。请使用最新的 Bisq 版本。
+popup.warn.daoRequiresRestart=在同步 DAO 状态时发生问题。你需要重启应用以修复此问题。
 
 popup.privateNotification.headline=重要私人通知！
 
 popup.securityRecommendation.headline=重要安全建议
 popup.securityRecommendation.msg=如果您还没有启用，我们想提醒您考虑为您的钱包使用密码保护。\n\n强烈建议你写下钱包还原密钥。 那些还原密钥就是恢复你的比特币钱包的主密码。\n在“钱包密钥”部分，您可以找到更多信息\n\n此外，您应该在“备份”界面备份完整的应用程序数据文件夹。
 
-popup.bitcoinLocalhostNode.msg=Bisq 检测到一个本地运行的比特币核心节点（在本地主机）。\n在启动 Bisq 之前，请确保此节点已完全同步，并且没有在删除模式下运行。
-popup.bitcoinLocalhostNode.additionalRequirements=\n\n对于配置完整的节点，要求该节点禁用 pruning 并启用 bloom filters。
+popup.bitcoinLocalhostNode.msg=Bisq 侦测到一个比特币核心节点在本机（本地）运行\n\n请确保：\n- 这个节点已经在运行 Bisq 之前已全部同步\n- 修饰已被禁用 （'prune=0' 在 bitcoin.conf 文件中)\n- Bloom 过滤器已经启用（'peerbloomfilters=1' 在 bitcoin.conf 文件中）
 
 popup.shutDownInProgress.headline=正在关闭
 popup.shutDownInProgress.msg=关闭应用可能会花一点时间。\n请不要打断关闭过程。
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=您的一个付款帐户已经被交易伙伴�
 popup.accountSigning.peerLimitLifted=您其中一个帐户的初始限额已被取消。\n\n{0}
 popup.accountSigning.peerSigner=您的一个帐户已足够成熟，可以验证其他付款帐户，您的一个帐户的初始限额已被取消。\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=选择账龄证据
-popup.accountSigning.singleAccountSelect.description=寻找账龄证据
-popup.accountSigning.singleAccountSelect.datePicker=选择要验证的帐户的时间点
+popup.accountSigning.singleAccountSelect.headline=导入未验证账龄证据
 popup.accountSigning.confirmSingleAccount.headline=确认所选账龄证据
 popup.accountSigning.confirmSingleAccount.selectedHash=已选择证据哈希值
 popup.accountSigning.confirmSingleAccount.button=验证账龄证据
 popup.accountSigning.successSingleAccount.description=证据 {0} 已被验证
 popup.accountSigning.successSingleAccount.success.headline=成功
-popup.accountSigning.successSingleAccount.signError=未能成功验证证据，{0}
 
 popup.accountSigning.unsignedPubKeys.headline=未验证公钥
 popup.accountSigning.unsignedPubKeys.sign=验证公钥
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=“DAO/BSQ 钱包/接收”
 
 formatter.formatVolumeLabel={0} 数量 {1}
 formatter.makerTaker=卖家 {0} {1} / 买家 {2} {3}
-formatter.youAreAsMaker=您是 {0} {1} 卖家 / 买家是 {2} {3}
-formatter.youAreAsTaker=您是 {0} {1} 买家 / 卖家是 {2} {3}
+formatter.youAreAsMaker=您是 {1} {0} 卖家 / 买家是 {3} {2}
+formatter.youAreAsTaker=您是 {1} {0} 买家 / 卖家是 {3} {2}
 formatter.youAre=您是 {0} {1} （{2} {3}）
 formatter.youAreCreatingAnOffer.fiat=您创建新的报价 {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=您正创建报价 {0} {1}（{2} {3}）
@@ -2584,7 +2590,7 @@ payment.venmo.venmoUserName=Venmo 用户名：
 payment.popmoney.accountId=电子邮箱或者电话号码
 payment.promptPay.promptPayId=公民身份证/税号或电话号码
 payment.supportedCurrencies=支持的货币
-payment.supportedCurrenciesForReceiver=Currencies for receiving funds
+payment.supportedCurrenciesForReceiver=收款
 payment.limitations=限制条件
 payment.salt=帐户年龄验证盐值
 payment.error.noHexSalt=盐值需要十六进制的。\n如果您想要从旧帐户转移盐值以保留帐龄，只建议编辑盐值字段。帐龄通过帐户盐值和识别帐户数据（例如 IBAN ）来验证。
@@ -2659,7 +2665,8 @@ payment.japan.recipient=名称
 payment.australia.payid=PayID
 payment.payid=PayID 需链接至金融机构。例如电子邮件地址或手机。
 payment.payid.info=PayID，如电话号码、电子邮件地址或澳大利亚商业号码（ABN），您可以安全地连接到您的银行、信用合作社或建立社会帐户。你需要在你的澳大利亚金融机构创建一个 PayID。发送和接收金融机构都必须支持 PayID。更多信息请查看[HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=要用亚马逊电子礼品卡付款，你需要在你的亚马逊账户上购买一张亚马逊电子礼品卡，并使用 BTC 卖家的电子邮件或手机号码作为接收方。然后，亚马逊会向接收者发送电子邮件或短信。在备注处填写交易 ID。\n\n亚马逊电子礼品卡只能由亚马逊账户使用相同货币兑换。更多信息请访问亚马逊电子礼品卡网页。\n\n更多信息请访问亚马逊电子礼品卡页面。[HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ

--- a/core/src/main/resources/i18n/displayStrings_zh-hant.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hant.properties
@@ -105,7 +105,6 @@ shared.selectTradingAccount=選擇交易賬户
 shared.fundFromSavingsWalletButton=從 Bisq 錢包資金劃轉
 shared.fundFromExternalWalletButton=從您的外部錢包充值
 shared.openDefaultWalletFailed=打開默認的比特幣錢包應用程序失敗了。您確定您安裝了嗎？
-shared.distanceInPercent=與市場價格的差價 %
 shared.belowInPercent=低於市場價格 %
 shared.aboveInPercent=高於市場價格 %
 shared.enterPercentageValue=輸入 % 值
@@ -192,7 +191,7 @@ shared.tradeWalletBalance=交易錢包餘額
 shared.makerTxFee=賣家：{0}
 shared.takerTxFee=買家：{0}
 shared.iConfirm=我確認
-shared.tradingFeeInBsqInfo=相當於使用 {0} 交易手續費
+shared.tradingFeeInBsqInfo=≈ {0}
 shared.openURL=打開 {0}
 shared.fiat=法定貨幣
 shared.crypto=加密
@@ -442,11 +441,15 @@ createOffer.warning.sellBelowMarketPrice=由於您的價格是持續更新的，
 createOffer.warning.buyAboveMarketPrice=由於您的價格是持續更新的，因此您將始終支付高於市場價 {0}% 的價格。
 createOffer.tradeFee.descriptionBTCOnly=掛單費
 createOffer.tradeFee.descriptionBSQEnabled=選擇手續費幣種
-createOffer.tradeFee.fiatAndPercent=≈ {0} / {1}  交易數量
+
+createOffer.triggerPrice.prompt=Set optional trigger price
+createOffer.triggerPrice.label=Deactivate offer if market price is {0}
+createOffer.triggerPrice.tooltip=As protecting against drastic price movements you can set a trigger price which deactivates the offer if the market price reaches that value.
+createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
+createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
 createOffer.placeOfferButton=複審：報價掛單 {0} 比特幣
-createOffer.alreadyFunded=您已經為該報價充值了。\n您的資金已經劃轉到您的本地 Bisq 錢包並在“資金/提現”界面可以提現。
 createOffer.createOfferFundWalletInfo.headline=為您的報價充值
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- 交易數量：{0}\n
@@ -503,7 +506,6 @@ takeOffer.error.message=下單時發生了一個錯誤。\n\n{0}
 # new entries
 takeOffer.takeOfferButton=複審：報價下單 {0} 比特幣
 takeOffer.noPriceFeedAvailable=您不能對這筆報價下單，因為它使用交易所價格百分比定價，但是您沒有獲得可用的價格。
-takeOffer.alreadyFunded.movedFunds=您已經為該報價值了。\n您的資金已經劃轉到您的本地 Bisq 錢包，並可以在“資金/提現”界面提現。
 takeOffer.takeOfferFundWalletInfo.headline=為交易充值
 # suppress inspection "TrailingSpacesInProperty"
 takeOffer.takeOfferFundWalletInfo.tradeAmount=- 交易數量：{0}\n
@@ -530,6 +532,10 @@ takeOffer.tac=接受該報價，意味着我同意這交易界面中的條件。
 ####################################################################
 # Offerbook / Edit offer
 ####################################################################
+
+openOffer.header.triggerPrice=觸發價格
+openOffer.triggerPrice=Trigger price {0}
+openOffer.triggered=The offer has been deactivated because the market price reached your trigger price.\nPlease edit the offer to define a new trigger price
 
 editOffer.setPrice=設定價格
 editOffer.confirmEdit=確認：編輯報價
@@ -951,6 +957,7 @@ support.error=收件人無法處理消息。錯誤：{0}
 support.buyerAddress=BTC 買家地址
 support.sellerAddress=BTC 賣家地址
 support.role=角色
+support.agent=Support agent
 support.state=狀態
 support.closed=關閉
 support.open=打開
@@ -1176,11 +1183,11 @@ account.menu.backup=備份
 account.menu.notifications=通知
 
 account.menu.walletInfo.balance.headLine=Wallet balances
-account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor Bitcoin the sum of the 'available balance' and the 'reserved for offers balance' must match the internal wallet balance displayed here.
+account.menu.walletInfo.balance.info=This shows the internal wallet balance including unconfirmed transactions.\nFor BTC, the internal wallet balance shown below should match the sum of the 'Available' and 'Reserved' balances shown in the top right of this window.
 account.menu.walletInfo.xpub.headLine=Watch keys (xpub keys)
 account.menu.walletInfo.walletSelector={0} {1} wallet
 account.menu.walletInfo.path.headLine=HD keychain paths
-account.menu.walletInfo.path.info=If you import the seed words in another wallet (like Electrum) you need to define the path. Use that only in emergency cases when you lost access to the Bisq wallet and the data directory.\nSpending funds from another wallet can easily screw up the Bisq internal data structures associated with the wallet data and can lead to failed trades.\nDo NEVER send BSQ from another wallet as that lead very likely to an invalid BSQ transaction and your BSQ get burned.
+account.menu.walletInfo.path.info=If you import seed words into another wallet (like Electrum), you'll need to define the path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\nKeep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet data, which can lead to failed trades.\n\nNEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 
@@ -2204,6 +2211,8 @@ feeOptionWindow.info=您可以選擇用 BSQ 或 BTC 支付交易費用。如果�
 feeOptionWindow.optionsLabel=選擇貨幣支付交易手續費
 feeOptionWindow.useBTC=使用 BTC
 feeOptionWindow.fee={0}（≈ {1}）
+feeOptionWindow.btcFeeWithFiatAndPercentage={0} (≈ {1} / {2})
+feeOptionWindow.btcFeeWithPercentage={0} ({1})
 
 
 ####################################################################
@@ -2287,14 +2296,14 @@ popup.info.cashDepositInfo.confirm=我確認我可以支付保證金
 popup.info.shutDownWithOpenOffers=Bisq 正在被關閉，但仍有公開的報價。\n\n當 Bisq 關閉時，這些提供將不能在 P2P 網絡上使用，但是它們將在您下次啟動 Bisq 時重新發布到 P2P 網絡上。\n\n為了讓您的報價在線，保持 Bisq 運行，並確保這台計算機也在線（即，確保它不會進入待機模式…顯示器待機不是問題）。
 popup.info.qubesOSSetupInfo=你似乎好像在 Qubes OS 上運行 Bisq。\n\n請確保您的 Bisq qube 是參考設置指南的説明設置的 https://bisq.wiki/Running_Bisq_on_Qubes
 popup.warn.downGradePrevention=不支持從 {0} 版本降級到 {1} 版本。請使用最新的 Bisq 版本。
+popup.warn.daoRequiresRestart=There was a problem with synchronizing the DAO state. You have to restart the application to fix the issue.
 
 popup.privateNotification.headline=重要私人通知！
 
 popup.securityRecommendation.headline=重要安全建議
 popup.securityRecommendation.msg=如果您還沒有啟用，我們想提醒您考慮為您的錢包使用密碼保護。\n\n強烈建議你寫下錢包還原密鑰。 那些還原密鑰就是恢復你的比特幣錢包的主密碼。\n在“錢包密鑰”部分，您可以找到更多信息\n\n此外，您應該在“備份”界面備份完整的應用程序數據文件夾。
 
-popup.bitcoinLocalhostNode.msg=Bisq 檢測到一個本地運行的比特幣核心節點（在本地主機）。\n在啟動 Bisq 之前，請確保此節點已完全同步，並且沒有在刪除模式下運行。
-popup.bitcoinLocalhostNode.additionalRequirements=\n\n對於配置完整的節點，要求該節點禁用 pruning 並啟用 bloom filters。
+popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this machine (at localhost).\n\nPlease ensure:\n- the node is fully synced before starting Bisq\n- pruning is disabled ('prune=0' in bitcoin.conf)\n- bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
 popup.shutDownInProgress.headline=正在關閉
 popup.shutDownInProgress.msg=關閉應用可能會花一點時間。\n請不要打斷關閉過程。
@@ -2326,15 +2335,12 @@ popup.accountSigning.signedByPeer=您的一個付款帳户已經被交易夥伴�
 popup.accountSigning.peerLimitLifted=您其中一個帳户的初始限額已被取消。\n\n{0}
 popup.accountSigning.peerSigner=您的一個帳户已足夠成熟，可以驗證其他付款帳户，您的一個帳户的初始限額已被取消。\n\n{0}
 
-popup.accountSigning.singleAccountSelect.headline=選擇賬齡證據
-popup.accountSigning.singleAccountSelect.description=尋找賬齡證據
-popup.accountSigning.singleAccountSelect.datePicker=選擇要驗證的帳户的時間點
+popup.accountSigning.singleAccountSelect.headline=Import unsigned account age witness
 popup.accountSigning.confirmSingleAccount.headline=確認所選賬齡證據
 popup.accountSigning.confirmSingleAccount.selectedHash=已選擇證據哈希值
 popup.accountSigning.confirmSingleAccount.button=驗證賬齡證據
 popup.accountSigning.successSingleAccount.description=證據 {0} 已被驗證
 popup.accountSigning.successSingleAccount.success.headline=成功
-popup.accountSigning.successSingleAccount.signError=未能成功驗證證據，{0}
 
 popup.accountSigning.unsignedPubKeys.headline=未驗證公鑰
 popup.accountSigning.unsignedPubKeys.sign=驗證公鑰
@@ -2470,8 +2476,8 @@ navigation.dao.wallet.receive=“DAO/BSQ 錢包/接收”
 
 formatter.formatVolumeLabel={0} 數量 {1}
 formatter.makerTaker=賣家 {0} {1} / 買家 {2} {3}
-formatter.youAreAsMaker=您是 {0} {1} 賣家 / 買家是 {2} {3}
-formatter.youAreAsTaker=您是 {0} {1} 買家 / 賣家是 {2} {3}
+formatter.youAreAsMaker=You are: {1} {0} (maker) / Taker is: {3} {2}
+formatter.youAreAsTaker=You are: {1} {0} (taker) / Maker is: {3} {2}
 formatter.youAre=您是 {0} {1} （{2} {3}）
 formatter.youAreCreatingAnOffer.fiat=您創建新的報價 {0} {1}
 formatter.youAreCreatingAnOffer.altcoin=您正創建報價 {0} {1}（{2} {3}）
@@ -2659,7 +2665,8 @@ payment.japan.recipient=名稱
 payment.australia.payid=PayID
 payment.payid=PayID 需鏈接至金融機構。例如電子郵件地址或手機。
 payment.payid.info=PayID，如電話號碼、電子郵件地址或澳大利亞商業號碼（ABN），您可以安全地連接到您的銀行、信用合作社或建立社會帳户。你需要在你的澳大利亞金融機構創建一個 PayID。發送和接收金融機構都必須支持 PayID。更多信息請查看[HYPERLINK:https://payid.com.au/faqs/]
-payment.amazonGiftCard.info=要用亞馬遜電子禮品卡付款，你需要在你的亞馬遜賬户上購買一張亞馬遜電子禮品卡，並使用 BTC 賣家的電子郵件或手機號碼作為接收方。然後，亞馬遜會向接收者發送電子郵件或短信。在備註處填寫交易 ID。\n\n亞馬遜電子禮品卡只能由亞馬遜賬户使用相同貨幣兑換。更多信息請訪問亞馬遜電子禮品卡網頁。\n\n更多信息請訪問亞馬遜電子禮品卡頁面。[HYPERLINK:https://www.amazon.com/Amazon-1_US_Email-eGift-Card/dp/B004LLIKVU]
+payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nBisq will show the BTC seller''s email address or phone number where the gift card should be sent, and you must include the trade ID in the gift card''s message field. Please see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") along with the trade ID (and use trader chat to tell your trading peer the reference text you picked so they can verify your payment)\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
+
 
 # We use constants from the code so we do not use our normal naming convention
 # dynamic values are not recognized by IntelliJ


### PR DESCRIPTION
Problematic key in German translation: dao.wallet.send.sendFunds.details

This was broken since version v1.5.2 and prevents users to send BSQ when German is selected.
Current workaround is to switch to English for this task.