### PR TITLE
Add filter support on network level

### DIFF
--- a/common/src/main/java/bisq/common/proto/ProtoUtil.java
+++ b/common/src/main/java/bisq/common/proto/ProtoUtil.java
@@ -28,6 +28,7 @@ import com.google.common.base.Enums;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -105,4 +106,7 @@ public class ProtoUtil {
         return CollectionUtils.isEmpty(protocolStringList) ? new ArrayList<>() : new ArrayList<>(protocolStringList);
     }
 
+    public static Set<String> protocolStringListToSet(ProtocolStringList protocolStringList) {
+        return CollectionUtils.isEmpty(protocolStringList) ? new HashSet<>() : new HashSet<>(protocolStringList);
+    }
 }

--- a/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
@@ -73,6 +73,7 @@ public class SignedWitnessService {
     private final KeyRing keyRing;
     private final P2PService p2PService;
     private final ArbitratorManager arbitratorManager;
+    private final SignedWitnessStorageService signedWitnessStorageService;
     private final User user;
     private final FilterManager filterManager;
 
@@ -98,6 +99,7 @@ public class SignedWitnessService {
         this.keyRing = keyRing;
         this.p2PService = p2PService;
         this.arbitratorManager = arbitratorManager;
+        this.signedWitnessStorageService = signedWitnessStorageService;
         this.user = user;
         this.filterManager = filterManager;
 
@@ -117,7 +119,7 @@ public class SignedWitnessService {
         });
 
         // At startup the P2PDataStorage initializes earlier, otherwise we get the listener called.
-        p2PService.getP2PDataStorage().getAppendOnlyDataStoreMap().values().forEach(e -> {
+        signedWitnessStorageService.getMap().values().forEach(e -> {
             if (e instanceof SignedWitness)
                 addToMap((SignedWitness) e);
         });

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -18,6 +18,7 @@
 package bisq.core.app;
 
 import bisq.core.account.sign.SignedWitness;
+import bisq.core.account.sign.SignedWitnessStorageService;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.alert.Alert;
 import bisq.core.alert.AlertManager;
@@ -124,6 +125,7 @@ public class BisqSetup {
     private final WalletsSetup walletsSetup;
     private final BtcWalletService btcWalletService;
     private final P2PService p2PService;
+    private final SignedWitnessStorageService signedWitnessStorageService;
     private final TradeManager tradeManager;
     private final OpenOfferManager openOfferManager;
     private final Preferences preferences;
@@ -205,6 +207,7 @@ public class BisqSetup {
                      WalletsSetup walletsSetup,
                      BtcWalletService btcWalletService,
                      P2PService p2PService,
+                     SignedWitnessStorageService signedWitnessStorageService,
                      TradeManager tradeManager,
                      OpenOfferManager openOfferManager,
                      Preferences preferences,
@@ -225,6 +228,7 @@ public class BisqSetup {
         this.walletsSetup = walletsSetup;
         this.btcWalletService = btcWalletService;
         this.p2PService = p2PService;
+        this.signedWitnessStorageService = signedWitnessStorageService;
         this.tradeManager = tradeManager;
         this.openOfferManager = openOfferManager;
         this.preferences = preferences;
@@ -652,7 +656,7 @@ public class BisqSetup {
 
     private void checkSigningState(AccountAgeWitnessService.SignState state,
                                    String key, Consumer<String> displayHandler) {
-        boolean signingStateFound = p2PService.getP2PDataStorage().getAppendOnlyDataStoreMap().values().stream()
+        boolean signingStateFound = signedWitnessStorageService.getMap().values().stream()
                 .anyMatch(payload -> isSignedWitnessOfMineWithState(payload, state));
 
         maybeTriggerDisplayHandler(key, displayHandler, signingStateFound);

--- a/core/src/main/java/bisq/core/app/CoreModule.java
+++ b/core/src/main/java/bisq/core/app/CoreModule.java
@@ -21,6 +21,7 @@ import bisq.core.alert.AlertModule;
 import bisq.core.btc.BitcoinModule;
 import bisq.core.dao.DaoModule;
 import bisq.core.filter.FilterModule;
+import bisq.core.network.CoreNetworkFilter;
 import bisq.core.network.p2p.seed.DefaultSeedNodeRepository;
 import bisq.core.offer.OfferModule;
 import bisq.core.presentation.CorePresentationModule;
@@ -35,6 +36,7 @@ import bisq.core.util.coin.ImmutableCoinFormatter;
 import bisq.network.crypto.EncryptionServiceModule;
 import bisq.network.p2p.P2PModule;
 import bisq.network.p2p.network.BridgeAddressProvider;
+import bisq.network.p2p.network.NetworkFilter;
 import bisq.network.p2p.seed.SeedNodeRepository;
 
 import bisq.common.app.AppModule;
@@ -43,6 +45,8 @@ import bisq.common.crypto.PubKeyRing;
 import bisq.common.crypto.PubKeyRingProvider;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
+
+import com.google.inject.Singleton;
 
 import java.io.File;
 
@@ -62,6 +66,7 @@ public class CoreModule extends AppModule {
         bind(BridgeAddressProvider.class).to(Preferences.class);
 
         bind(SeedNodeRepository.class).to(DefaultSeedNodeRepository.class);
+        bind(NetworkFilter.class).to(CoreNetworkFilter.class).in(Singleton.class);
 
         bind(File.class).annotatedWith(named(STORAGE_DIR)).toInstance(config.storageDir);
 

--- a/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
@@ -22,6 +22,7 @@ import bisq.core.app.TorSetup;
 import bisq.core.btc.BitcoinModule;
 import bisq.core.dao.DaoModule;
 import bisq.core.filter.FilterModule;
+import bisq.core.network.CoreNetworkFilter;
 import bisq.core.network.p2p.seed.DefaultSeedNodeRepository;
 import bisq.core.offer.OfferModule;
 import bisq.core.proto.network.CoreNetworkProtoResolver;
@@ -33,6 +34,7 @@ import bisq.core.user.User;
 import bisq.network.crypto.EncryptionServiceModule;
 import bisq.network.p2p.P2PModule;
 import bisq.network.p2p.network.BridgeAddressProvider;
+import bisq.network.p2p.network.NetworkFilter;
 import bisq.network.p2p.seed.SeedNodeRepository;
 
 import bisq.common.ClockWatcher;
@@ -73,6 +75,7 @@ public class ModuleForAppWithP2p extends AppModule {
         bind(TorSetup.class).in(Singleton.class);
 
         bind(SeedNodeRepository.class).to(DefaultSeedNodeRepository.class).in(Singleton.class);
+        bind(NetworkFilter.class).to(CoreNetworkFilter.class).in(Singleton.class);
 
         bind(File.class).annotatedWith(named(STORAGE_DIR)).toInstance(config.storageDir);
         bind(File.class).annotatedWith(named(KEY_STORAGE_DIR)).toInstance(config.keyStorageDir);

--- a/core/src/main/java/bisq/core/dao/governance/proposal/ProposalService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/ProposalService.java
@@ -69,6 +69,7 @@ public class ProposalService implements HashMapChangedListener, AppendOnlyDataSt
         DaoStateListener, DaoSetupService {
     private final P2PService p2PService;
     private final PeriodService periodService;
+    private final ProposalStorageService proposalStorageService;
     private final DaoStateService daoStateService;
     private final ProposalValidatorProvider validatorProvider;
 
@@ -100,6 +101,7 @@ public class ProposalService implements HashMapChangedListener, AppendOnlyDataSt
                            @Named(Config.DAO_ACTIVATED) boolean daoActivated) {
         this.p2PService = p2PService;
         this.periodService = periodService;
+        this.proposalStorageService = proposalStorageService;
         this.daoStateService = daoStateService;
         this.validatorProvider = validatorProvider;
 
@@ -217,7 +219,7 @@ public class ProposalService implements HashMapChangedListener, AppendOnlyDataSt
     }
 
     private void fillListFromAppendOnlyDataStore() {
-        p2PService.getP2PDataStorage().getAppendOnlyDataStoreMap().values().forEach(e -> onAppendOnlyDataAdded(e, false));
+        proposalStorageService.getMap().values().forEach(e -> onAppendOnlyDataAdded(e, false));
     }
 
     private void maybePublishToAppendOnlyDataStore() {

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -48,10 +48,7 @@ import javax.annotation.Nullable;
 @Value
 public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
     private final List<String> bannedOfferIds;
-
-    // Those banned nodes cannot trade but still can access the network
-    private final List<String> bannedNodeAddress;
-
+    private final List<String> nodeAddressesBannedFromTrading;
     private final List<String> bannedAutoConfExplorers;
     private final List<PaymentAccountFilter> bannedPaymentAccounts;
     private final List<String> bannedCurrencies;
@@ -96,14 +93,12 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
     private final boolean disableAutoConf;
 
     // added at v1.5.5
-    // In contrast to bannedNodeAddress those addresses cannot access the network but are rejected immediately.
-    // Should be only used in case of dos attacks
     private final Set<String> nodeAddressesBannedFromNetwork;
 
     // After we have created the signature from the filter data we clone it and apply the signature
     static Filter cloneWithSig(Filter filter, String signatureAsBase64) {
         return new Filter(filter.getBannedOfferIds(),
-                filter.getBannedNodeAddress(),
+                filter.getNodeAddressesBannedFromTrading(),
                 filter.getBannedPaymentAccounts(),
                 filter.getBannedCurrencies(),
                 filter.getBannedPaymentMethods(),
@@ -133,7 +128,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
     // Used for signature verification as we created the sig without the signatureAsBase64 field we set it to null again
     static Filter cloneWithoutSig(Filter filter) {
         return new Filter(filter.getBannedOfferIds(),
-                filter.getBannedNodeAddress(),
+                filter.getNodeAddressesBannedFromTrading(),
                 filter.getBannedPaymentAccounts(),
                 filter.getBannedCurrencies(),
                 filter.getBannedPaymentMethods(),
@@ -161,7 +156,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
     }
 
     public Filter(List<String> bannedOfferIds,
-                  List<String> bannedNodeAddress,
+                  List<String> nodeAddressesBannedFromTrading,
                   List<PaymentAccountFilter> bannedPaymentAccounts,
                   List<String> bannedCurrencies,
                   List<String> bannedPaymentMethods,
@@ -184,7 +179,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                   List<String> bannedAutoConfExplorers,
                   Set<String> nodeAddressesBannedFromNetwork) {
         this(bannedOfferIds,
-                bannedNodeAddress,
+                nodeAddressesBannedFromTrading,
                 bannedPaymentAccounts,
                 bannedCurrencies,
                 bannedPaymentMethods,
@@ -218,7 +213,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
 
     @VisibleForTesting
     public Filter(List<String> bannedOfferIds,
-                  List<String> bannedNodeAddress,
+                  List<String> nodeAddressesBannedFromTrading,
                   List<PaymentAccountFilter> bannedPaymentAccounts,
                   List<String> bannedCurrencies,
                   List<String> bannedPaymentMethods,
@@ -244,7 +239,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                   List<String> bannedAutoConfExplorers,
                   Set<String> nodeAddressesBannedFromNetwork) {
         this.bannedOfferIds = bannedOfferIds;
-        this.bannedNodeAddress = bannedNodeAddress;
+        this.nodeAddressesBannedFromTrading = nodeAddressesBannedFromTrading;
         this.bannedPaymentAccounts = bannedPaymentAccounts;
         this.bannedCurrencies = bannedCurrencies;
         this.bannedPaymentMethods = bannedPaymentMethods;
@@ -285,7 +280,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
                 .collect(Collectors.toList());
 
         protobuf.Filter.Builder builder = protobuf.Filter.newBuilder().addAllBannedOfferIds(bannedOfferIds)
-                .addAllBannedNodeAddress(bannedNodeAddress)
+                .addAllNodeAddressesBannedFromTrading(nodeAddressesBannedFromTrading)
                 .addAllBannedPaymentAccounts(paymentAccountFilterList)
                 .addAllBannedCurrencies(bannedCurrencies)
                 .addAllBannedPaymentMethods(bannedPaymentMethods)
@@ -322,7 +317,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
 
 
         return new Filter(ProtoUtil.protocolStringListToList(proto.getBannedOfferIdsList()),
-                ProtoUtil.protocolStringListToList(proto.getBannedNodeAddressList()),
+                ProtoUtil.protocolStringListToList(proto.getNodeAddressesBannedFromTradingList()),
                 bannedPaymentAccountsList,
                 ProtoUtil.protocolStringListToList(proto.getBannedCurrenciesList()),
                 ProtoUtil.protocolStringListToList(proto.getBannedPaymentMethodsList()),
@@ -364,7 +359,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload {
     public String toString() {
         return "Filter{" +
                 "\n     bannedOfferIds=" + bannedOfferIds +
-                ",\n     bannedNodeAddress=" + bannedNodeAddress +
+                ",\n     nodeAddressesBannedFromTrading=" + nodeAddressesBannedFromTrading +
                 ",\n     bannedAutoConfExplorers=" + bannedAutoConfExplorers +
                 ",\n     bannedPaymentAccounts=" + bannedPaymentAccounts +
                 ",\n     bannedCurrencies=" + bannedCurrencies +

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -397,7 +397,7 @@ public class FilterManager {
 
     public boolean isNodeAddressBanned(NodeAddress nodeAddress) {
         return getFilter() != null &&
-                getFilter().getBannedNodeAddress().stream()
+                getFilter().getNodeAddressesBannedFromTrading().stream()
                         .anyMatch(e -> e.equals(nodeAddress.getFullAddress()));
     }
 

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -19,6 +19,7 @@ package bisq.core.filter;
 
 import bisq.core.btc.nodes.BtcNodes;
 import bisq.core.locale.Res;
+import bisq.core.network.CoreNetworkFilter;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.ProvidersRepository;
@@ -96,6 +97,7 @@ public class FilterManager {
     private final Preferences preferences;
     private final ConfigFileEditor configFileEditor;
     private final ProvidersRepository providersRepository;
+    private final CoreNetworkFilter coreNetworkFilter;
     private final boolean ignoreDevMsg;
     private final ObjectProperty<Filter> filterProperty = new SimpleObjectProperty<>();
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();
@@ -115,6 +117,7 @@ public class FilterManager {
                          Preferences preferences,
                          Config config,
                          ProvidersRepository providersRepository,
+                         CoreNetworkFilter coreNetworkFilter,
                          @Named(Config.IGNORE_DEV_MSG) boolean ignoreDevMsg,
                          @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
         this.p2PService = p2PService;
@@ -123,6 +126,7 @@ public class FilterManager {
         this.preferences = preferences;
         this.configFileEditor = new ConfigFileEditor(config.configFile);
         this.providersRepository = providersRepository;
+        this.coreNetworkFilter = coreNetworkFilter;
         this.ignoreDevMsg = ignoreDevMsg;
 
         publicKeys = useDevPrivilegeKeys ?

--- a/core/src/main/java/bisq/core/network/CoreNetworkFilter.java
+++ b/core/src/main/java/bisq/core/network/CoreNetworkFilter.java
@@ -28,12 +28,14 @@ import javax.inject.Named;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CoreNetworkFilter implements NetworkFilter {
     private final Set<NodeAddress> bannedPeersFromOptions = new HashSet<>();
+    private Function<NodeAddress, Boolean> bannedNodeFunction;
 
     /**
      * @param banList  List of banned peers from program argument
@@ -43,7 +45,14 @@ public class CoreNetworkFilter implements NetworkFilter {
         banList.stream().map(NodeAddress::new).forEach(bannedPeersFromOptions::add);
     }
 
+    @Override
+    public void setBannedNodeFunction(Function<NodeAddress, Boolean> bannedNodeFunction) {
+        this.bannedNodeFunction = bannedNodeFunction;
+    }
+
+    @Override
     public boolean isPeerBanned(NodeAddress nodeAddress) {
-        return bannedPeersFromOptions.contains(nodeAddress);
+        return bannedPeersFromOptions.contains(nodeAddress) ||
+                bannedNodeFunction != null && bannedNodeFunction.apply(nodeAddress);
     }
 }

--- a/core/src/main/java/bisq/core/network/CoreNetworkFilter.java
+++ b/core/src/main/java/bisq/core/network/CoreNetworkFilter.java
@@ -15,37 +15,35 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.network.p2p.peers;
+package bisq.core.network;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.network.NetworkFilter;
 
 import bisq.common.config.Config;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
-import javax.inject.Inject;
-
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
-public class BanList {
-    private static List<NodeAddress> list = new ArrayList<>();
+import lombok.extern.slf4j.Slf4j;
 
-    public static void add(NodeAddress onionAddress) {
-        list.add(onionAddress);
-    }
+@Slf4j
+public class CoreNetworkFilter implements NetworkFilter {
+    private final Set<NodeAddress> bannedPeersFromOptions = new HashSet<>();
 
-    public static boolean isBanned(NodeAddress nodeAddress) {
-        return list.contains(nodeAddress);
-    }
-
+    /**
+     * @param banList  List of banned peers from program argument
+     */
     @Inject
-    public BanList(@Named(Config.BAN_LIST) List<String> banList) {
-        if (!banList.isEmpty())
-            BanList.list = banList.stream().map(NodeAddress::new).collect(Collectors.toList());
+    public CoreNetworkFilter(@Named(Config.BAN_LIST) List<String> banList) {
+        banList.stream().map(NodeAddress::new).forEach(bannedPeersFromOptions::add);
+    }
+
+    public boolean isPeerBanned(NodeAddress nodeAddress) {
+        return bannedPeersFromOptions.contains(nodeAddress);
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2594,7 +2594,8 @@ enterPrivKeyWindow.headline=Enter private key for registration
 
 filterWindow.headline=Edit filter list
 filterWindow.offers=Filtered offers (comma sep.)
-filterWindow.onions=Filtered onion addresses (comma sep.)
+filterWindow.onions=Banned from trading addresses (comma sep.)
+filterWindow.bannedFromNetwork=Banned from network addresses (comma sep.)
 filterWindow.accounts=Filtered trading account data:\nFormat: comma sep. list of [payment method id | data field | value]
 filterWindow.bannedCurrencies=Filtered currency codes (comma sep.)
 filterWindow.bannedPaymentMethods=Filtered payment method IDs (comma sep.)

--- a/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
+++ b/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
@@ -25,6 +25,8 @@ import bisq.core.proto.CoreProtoResolver;
 
 import com.google.common.collect.Lists;
 
+import java.util.HashSet;
+
 import org.junit.Ignore;
 
 public class UserPayloadModelVOTest {
@@ -64,7 +66,8 @@ public class UserPayloadModelVOTest {
                 null,
                 null,
                 false,
-                Lists.newArrayList()));
+                Lists.newArrayList(),
+                new HashSet<>()));
 
         vo.setRegisteredArbitrator(ArbitratorTest.getArbitratorMock());
         vo.setRegisteredMediator(MediatorTest.getMediatorMock());

--- a/core/src/test/java/bisq/core/util/FeeReceiverSelectorTest.java
+++ b/core/src/test/java/bisq/core/util/FeeReceiverSelectorTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -123,6 +124,7 @@ public class FeeReceiverSelectorTest {
                 null,
                 null,
                 false,
-                Lists.newArrayList());
+                Lists.newArrayList(),
+                new HashSet<>());
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -36,10 +36,9 @@ import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.offer.OfferPayload;
 import bisq.core.trade.statistics.TradeStatistics3;
+import bisq.core.trade.statistics.TradeStatistics3StorageService;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
-
-import bisq.network.p2p.P2PService;
 
 import bisq.common.util.Utilities;
 
@@ -71,7 +70,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
     @FXML
     Tab offerBookTab, tradesTab, spreadTab;
     private final ViewLoader viewLoader;
-    private final P2PService p2PService;
+    private final TradeStatistics3StorageService tradeStatistics3StorageService;
     private final OfferBook offerBook;
     private final CoinFormatter formatter;
     private final Navigation navigation;
@@ -83,12 +82,12 @@ public class MarketView extends ActivatableView<TabPane, Void> {
 
     @Inject
     public MarketView(CachingViewLoader viewLoader,
-                      P2PService p2PService,
+                      TradeStatistics3StorageService tradeStatistics3StorageService,
                       OfferBook offerBook,
                       @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                       Navigation navigation) {
         this.viewLoader = viewLoader;
-        this.p2PService = p2PService;
+        this.tradeStatistics3StorageService = tradeStatistics3StorageService;
         this.offerBook = offerBook;
         this.formatter = formatter;
         this.navigation = navigation;
@@ -181,7 +180,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
         // all items of both traders in case the referral ID was only set by one trader.
         // If both traders had set it the tradeStatistics is only delivered once.
         // If both traders used a different referral ID then we would get 2 objects.
-        List<String> list = p2PService.getP2PDataStorage().getAppendOnlyDataStoreMap().values().stream()
+        List<String> list = tradeStatistics3StorageService.getMapOfAllData().values().stream()
                 .filter(e -> e instanceof TradeStatistics3)
                 .map(e -> (TradeStatistics3) e)
                 .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap() != null)

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -37,8 +37,6 @@ import javax.inject.Named;
 
 import org.apache.commons.lang3.StringUtils;
 
-import javafx.collections.FXCollections;
-
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -51,7 +49,11 @@ import javafx.scene.layout.Region;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 
+import javafx.collections.FXCollections;
+
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -124,6 +126,8 @@ public class FilterWindow extends Overlay<FilterWindow> {
                 Res.get("filterWindow.offers"));
         InputTextField nodesTF = addTopLabelInputTextField(gridPane, ++rowIndex,
                 Res.get("filterWindow.onions")).second;
+        InputTextField bannedFromNetworkTF = addTopLabelInputTextField(gridPane, ++rowIndex,
+                Res.get("filterWindow.bannedFromNetwork")).second;
         nodesTF.setPromptText("E.g. zqnzx6o3nifef5df.onion:9999"); // Do not translate
         InputTextField paymentAccountFilterTF = addTopLabelInputTextField(gridPane, ++rowIndex,
                 Res.get("filterWindow.accounts")).second;
@@ -170,6 +174,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
         if (filter != null) {
             setupFieldFromList(offerIdsTF, filter.getBannedOfferIds());
             setupFieldFromList(nodesTF, filter.getBannedNodeAddress());
+            setupFieldFromList(bannedFromNetworkTF, filter.getNodeAddressesBannedFromNetwork());
             setupFieldFromPaymentAccountFiltersList(paymentAccountFilterTF, filter.getBannedPaymentAccounts());
             setupFieldFromList(bannedCurrenciesTF, filter.getBannedCurrencies());
             setupFieldFromList(bannedPaymentMethodsTF, filter.getBannedPaymentMethods());
@@ -221,7 +226,8 @@ public class FilterWindow extends Overlay<FilterWindow> {
                         signerPubKeyAsHex,
                         readAsList(bannedPrivilegedDevPubKeysTF),
                         disableAutoConfCheckBox.isSelected(),
-                        readAsList(autoConfExplorersTF)
+                        readAsList(autoConfExplorersTF),
+                        new HashSet<>(readAsList(bannedFromNetworkTF))
                 );
 
                 // We remove first the old filter
@@ -270,7 +276,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
         hide();
     }
 
-    private void setupFieldFromList(InputTextField field, List<String> values) {
+    private void setupFieldFromList(InputTextField field, Collection<String> values) {
         if (values != null)
             field.setText(String.join(", ", values));
     }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -124,11 +124,11 @@ public class FilterWindow extends Overlay<FilterWindow> {
 
         InputTextField offerIdsTF = addInputTextField(gridPane, ++rowIndex,
                 Res.get("filterWindow.offers"));
-        InputTextField nodesTF = addTopLabelInputTextField(gridPane, ++rowIndex,
+        InputTextField bannedFromTradingTF = addTopLabelInputTextField(gridPane, ++rowIndex,
                 Res.get("filterWindow.onions")).second;
         InputTextField bannedFromNetworkTF = addTopLabelInputTextField(gridPane, ++rowIndex,
                 Res.get("filterWindow.bannedFromNetwork")).second;
-        nodesTF.setPromptText("E.g. zqnzx6o3nifef5df.onion:9999"); // Do not translate
+        bannedFromTradingTF.setPromptText("E.g. zqnzx6o3nifef5df.onion:9999"); // Do not translate
         InputTextField paymentAccountFilterTF = addTopLabelInputTextField(gridPane, ++rowIndex,
                 Res.get("filterWindow.accounts")).second;
         GridPane.setHalignment(paymentAccountFilterTF, HPos.RIGHT);
@@ -173,7 +173,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
         Filter filter = filterManager.getDevFilter();
         if (filter != null) {
             setupFieldFromList(offerIdsTF, filter.getBannedOfferIds());
-            setupFieldFromList(nodesTF, filter.getBannedNodeAddress());
+            setupFieldFromList(bannedFromTradingTF, filter.getNodeAddressesBannedFromTrading());
             setupFieldFromList(bannedFromNetworkTF, filter.getNodeAddressesBannedFromNetwork());
             setupFieldFromPaymentAccountFiltersList(paymentAccountFilterTF, filter.getBannedPaymentAccounts());
             setupFieldFromList(bannedCurrenciesTF, filter.getBannedCurrencies());
@@ -206,7 +206,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
                 String signerPubKeyAsHex = filterManager.getSignerPubKeyAsHex(privKeyString);
                 Filter newFilter = new Filter(
                         readAsList(offerIdsTF),
-                        readAsList(nodesTF),
+                        readAsList(bannedFromTradingTF),
                         readAsPaymentAccountFiltersList(paymentAccountFilterTF),
                         readAsList(bannedCurrenciesTF),
                         readAsList(bannedPaymentMethodsTF),

--- a/inventory/src/main/java/bisq/inventory/InventoryMonitor.java
+++ b/inventory/src/main/java/bisq/inventory/InventoryMonitor.java
@@ -257,6 +257,7 @@ public class InventoryMonitor implements SetupListener {
         CoreNetworkProtoResolver networkProtoResolver = new CoreNetworkProtoResolver(Clock.systemDefaultZone());
         return new NetworkNodeProvider(networkProtoResolver,
                 ArrayList::new,
+                null,
                 useLocalhostForP2P,
                 9999,
                 torDir,

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -116,7 +116,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
             // start the network node
             networkNode = new TorNetworkNode(Integer.parseInt(configuration.getProperty(TOR_PROXY_PORT, "9053")),
                     new CoreNetworkProtoResolver(Clock.systemDefaultZone()), false,
-                    new AvailableTor(Monitor.TOR_WORKING_DIR, torHiddenServiceDir.getName()));
+                    new AvailableTor(Monitor.TOR_WORKING_DIR, torHiddenServiceDir.getName()), null);
             networkNode.start(this);
 
             // wait for the HS to be published

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
@@ -155,7 +155,7 @@ public abstract class P2PSeedNodeSnapshotBase extends Metric implements MessageL
         // start the network node
         final NetworkNode networkNode = new TorNetworkNode(Integer.parseInt(configuration.getProperty(TOR_PROXY_PORT, "9054")),
                 new CoreNetworkProtoResolver(Clock.systemDefaultZone()), false,
-                new AvailableTor(Monitor.TOR_WORKING_DIR, "unused"));
+                new AvailableTor(Monitor.TOR_WORKING_DIR, "unused"), null);
         // we do not need to start the networkNode, as we do not need the HS
         //networkNode.start(this);
 

--- a/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
+++ b/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
@@ -19,6 +19,7 @@ package bisq.network.p2p;
 
 import bisq.network.p2p.network.BridgeAddressProvider;
 import bisq.network.p2p.network.LocalhostNetworkNode;
+import bisq.network.p2p.network.NetworkFilter;
 import bisq.network.p2p.network.NetworkNode;
 import bisq.network.p2p.network.NewTor;
 import bisq.network.p2p.network.RunningTor;
@@ -27,10 +28,9 @@ import bisq.network.p2p.network.TorNetworkNode;
 import bisq.common.config.Config;
 import bisq.common.proto.network.NetworkProtoResolver;
 
-import javax.inject.Provider;
-import javax.inject.Named;
-
 import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
 
 import java.io.File;
 
@@ -43,6 +43,7 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
     @Inject
     public NetworkNodeProvider(NetworkProtoResolver networkProtoResolver,
                                BridgeAddressProvider bridgeAddressProvider,
+                               @Nullable NetworkFilter networkFilter,
                                @Named(Config.USE_LOCALHOST_FOR_P2P) boolean useLocalhostForP2P,
                                @Named(Config.NODE_PORT) int port,
                                @Named(Config.TOR_DIR) File torDir,
@@ -52,13 +53,14 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
                                @Named(Config.TOR_CONTROL_PASSWORD) String password,
                                @Nullable @Named(Config.TOR_CONTROL_COOKIE_FILE) File cookieFile,
                                @Named(Config.TOR_STREAM_ISOLATION) boolean streamIsolation,
-                               @Named(Config.TOR_CONTROL_USE_SAFE_COOKIE_AUTH) boolean useSafeCookieAuthentication ) {
+                               @Named(Config.TOR_CONTROL_USE_SAFE_COOKIE_AUTH) boolean useSafeCookieAuthentication) {
         networkNode = useLocalhostForP2P ?
-                new LocalhostNetworkNode(port, networkProtoResolver) :
+                new LocalhostNetworkNode(port, networkProtoResolver, networkFilter) :
                 new TorNetworkNode(port, networkProtoResolver, streamIsolation,
                         controlPort != Config.UNSPECIFIED_PORT ?
                                 new RunningTor(torDir, controlPort, password, cookieFile, useSafeCookieAuthentication) :
-                                new NewTor(torDir, torrcFile, torrcOptions, bridgeAddressProvider.getBridgeAddresses()));
+                                new NewTor(torDir, torrcFile, torrcOptions, bridgeAddressProvider.getBridgeAddresses()),
+                        networkFilter);
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
+++ b/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
@@ -23,6 +23,7 @@ import bisq.network.p2p.network.NetworkFilter;
 import bisq.network.p2p.network.NetworkNode;
 import bisq.network.p2p.network.NewTor;
 import bisq.network.p2p.network.RunningTor;
+import bisq.network.p2p.network.TorMode;
 import bisq.network.p2p.network.TorNetworkNode;
 
 import bisq.common.config.Config;
@@ -54,13 +55,32 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
                                @Nullable @Named(Config.TOR_CONTROL_COOKIE_FILE) File cookieFile,
                                @Named(Config.TOR_STREAM_ISOLATION) boolean streamIsolation,
                                @Named(Config.TOR_CONTROL_USE_SAFE_COOKIE_AUTH) boolean useSafeCookieAuthentication) {
-        networkNode = useLocalhostForP2P ?
-                new LocalhostNetworkNode(port, networkProtoResolver, networkFilter) :
-                new TorNetworkNode(port, networkProtoResolver, streamIsolation,
-                        controlPort != Config.UNSPECIFIED_PORT ?
-                                new RunningTor(torDir, controlPort, password, cookieFile, useSafeCookieAuthentication) :
-                                new NewTor(torDir, torrcFile, torrcOptions, bridgeAddressProvider.getBridgeAddresses()),
-                        networkFilter);
+        if (useLocalhostForP2P) {
+            networkNode = new LocalhostNetworkNode(port, networkProtoResolver, networkFilter);
+        } else {
+            TorMode torMode = getTorMode(bridgeAddressProvider,
+                    torDir,
+                    torrcFile,
+                    torrcOptions,
+                    controlPort,
+                    password,
+                    cookieFile,
+                    useSafeCookieAuthentication);
+            networkNode = new TorNetworkNode(port, networkProtoResolver, streamIsolation, torMode, networkFilter);
+        }
+    }
+
+    private TorMode getTorMode(BridgeAddressProvider bridgeAddressProvider,
+                               File torDir,
+                               @Nullable File torrcFile,
+                               String torrcOptions,
+                               int controlPort,
+                               String password,
+                               @Nullable File cookieFile,
+                               boolean useSafeCookieAuthentication) {
+        return controlPort != Config.UNSPECIFIED_PORT ?
+                new RunningTor(torDir, controlPort, password, cookieFile, useSafeCookieAuthentication) :
+                new NewTor(torDir, torrcFile, torrcOptions, bridgeAddressProvider.getBridgeAddresses());
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/P2PModule.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PModule.java
@@ -22,7 +22,6 @@ import bisq.network.http.HttpClient;
 import bisq.network.http.HttpClientImpl;
 import bisq.network.p2p.network.Connection;
 import bisq.network.p2p.network.NetworkNode;
-import bisq.network.p2p.peers.BanList;
 import bisq.network.p2p.peers.Broadcaster;
 import bisq.network.p2p.peers.PeerManager;
 import bisq.network.p2p.peers.getdata.RequestDataManager;
@@ -68,7 +67,6 @@ public class P2PModule extends AppModule {
         bind(PeerExchangeManager.class).in(Singleton.class);
         bind(KeepAliveManager.class).in(Singleton.class);
         bind(Broadcaster.class).in(Singleton.class);
-        bind(BanList.class).in(Singleton.class);
         bind(NetworkNode.class).toProvider(NetworkNodeProvider.class).in(Singleton.class);
         bind(Socks5ProxyProvider.class).in(Singleton.class);
         bind(HttpClient.class).to(HttpClientImpl.class);

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -259,8 +259,6 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         }
 
         try {
-            String peersNodeAddress = peersNodeAddressOptional.map(NodeAddress::toString).orElse("null");
-
             if (networkEnvelope instanceof PrefixedSealedAndSignedMessage && peersNodeAddressOptional.isPresent()) {
                 setPeerType(Connection.PeerType.DIRECT_MSG_PEER);
 
@@ -268,7 +266,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                                 "Sending direct message to peer" +
                                 "Write object to outputStream to peer: {} (uid={})\ntruncated message={} / size={}" +
                                 "\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n",
-                        peersNodeAddress, uid, Utilities.toTruncatedString(networkEnvelope), -1);
+                        peersNodeAddressOptional.map(NodeAddress::toString).orElse("null"),
+                        uid, Utilities.toTruncatedString(networkEnvelope), -1);
             } else if (networkEnvelope instanceof GetDataResponse && ((GetDataResponse) networkEnvelope).isGetUpdatedDataResponse()) {
                 setPeerType(Connection.PeerType.PEER);
             }

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -886,6 +886,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
                                 if (networkFilter != null && networkFilter.isPeerBanned(senderNodeAddress)) {
                                     reportInvalidRequest(RuleViolation.PEER_BANNED);
+                                    return;
                                 }
                             }
                         }

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -842,10 +842,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
                         if (CloseConnectionReason.PEER_BANNED.name().equals(proto.getCloseConnectionMessage().getReason())) {
                             log.warn("We got shut down because we are banned by the other peer. (InputHandler.run CloseConnectionMessage)");
-                            shutDown(CloseConnectionReason.PEER_BANNED);
-                        } else {
-                            shutDown(CloseConnectionReason.CLOSE_REQUESTED_BY_PEER);
                         }
+                        shutDown(CloseConnectionReason.CLOSE_REQUESTED_BY_PEER);
                         return;
                     } else if (!stopped) {
                         // We don't want to get the activity ts updated by ping/pong msg

--- a/p2p/src/main/java/bisq/network/p2p/network/InboundConnection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/InboundConnection.java
@@ -21,11 +21,14 @@ import bisq.common.proto.network.NetworkProtoResolver;
 
 import java.net.Socket;
 
+import org.jetbrains.annotations.Nullable;
+
 public class InboundConnection extends Connection {
     public InboundConnection(Socket socket,
                              MessageListener messageListener,
                              ConnectionListener connectionListener,
-                             NetworkProtoResolver networkProtoResolver) {
-        super(socket, messageListener, connectionListener, null, networkProtoResolver);
+                             NetworkProtoResolver networkProtoResolver,
+                             @Nullable NetworkFilter networkFilter) {
+        super(socket, messageListener, connectionListener, null, networkProtoResolver, networkFilter);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
@@ -54,8 +54,10 @@ public class LocalhostNetworkNode extends NetworkNode {
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public LocalhostNetworkNode(int port, NetworkProtoResolver networkProtoResolver) {
-        super(port, networkProtoResolver);
+    public LocalhostNetworkNode(int port,
+                                NetworkProtoResolver networkProtoResolver,
+                                @Nullable NetworkFilter networkFilter) {
+        super(port, networkProtoResolver, networkFilter);
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkFilter.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkFilter.java
@@ -19,6 +19,10 @@ package bisq.network.p2p.network;
 
 import bisq.network.p2p.NodeAddress;
 
+import java.util.function.Function;
+
 public interface NetworkFilter {
     boolean isPeerBanned(NodeAddress nodeAddress);
+
+    void setBannedNodeFunction(Function<NodeAddress, Boolean> isNodeAddressBanned);
 }

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkFilter.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkFilter.java
@@ -19,19 +19,6 @@ package bisq.network.p2p.network;
 
 import bisq.network.p2p.NodeAddress;
 
-import bisq.common.proto.network.NetworkProtoResolver;
-
-import java.net.Socket;
-
-import org.jetbrains.annotations.Nullable;
-
-public class OutboundConnection extends Connection {
-    public OutboundConnection(Socket socket,
-                              MessageListener messageListener,
-                              ConnectionListener connectionListener,
-                              NodeAddress peersNodeAddress,
-                              NetworkProtoResolver networkProtoResolver,
-                              @Nullable NetworkFilter networkFilter) {
-        super(socket, messageListener, connectionListener, peersNodeAddress, networkProtoResolver, networkFilter);
-    }
+public interface NetworkFilter {
+    boolean isPeerBanned(NodeAddress nodeAddress);
 }

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -69,6 +69,8 @@ public abstract class NetworkNode implements MessageListener {
 
     final int servicePort;
     private final NetworkProtoResolver networkProtoResolver;
+    @Nullable
+    private final NetworkFilter networkFilter;
 
     private final CopyOnWriteArraySet<InboundConnection> inBoundConnections = new CopyOnWriteArraySet<>();
     private final CopyOnWriteArraySet<MessageListener> messageListeners = new CopyOnWriteArraySet<>();
@@ -87,9 +89,12 @@ public abstract class NetworkNode implements MessageListener {
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    NetworkNode(int servicePort, NetworkProtoResolver networkProtoResolver) {
+    NetworkNode(int servicePort,
+                NetworkProtoResolver networkProtoResolver,
+                @Nullable NetworkFilter networkFilter) {
         this.servicePort = servicePort;
         this.networkProtoResolver = networkProtoResolver;
+        this.networkFilter = networkFilter;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -190,7 +195,8 @@ public abstract class NetworkNode implements MessageListener {
                                 NetworkNode.this,
                                 connectionListener,
                                 peersNodeAddress,
-                                networkProtoResolver);
+                                networkProtoResolver,
+                                networkFilter);
 
                         if (log.isDebugEnabled()) {
                             log.debug("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" +
@@ -457,7 +463,8 @@ public abstract class NetworkNode implements MessageListener {
         server = new Server(serverSocket,
                 NetworkNode.this,
                 connectionListener,
-                networkProtoResolver);
+                networkProtoResolver,
+                networkFilter);
         executorService.submit(server);
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/network/Server.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Server.java
@@ -31,12 +31,16 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.jetbrains.annotations.Nullable;
+
 // Runs in UserThread
 class Server implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(Server.class);
 
     private final MessageListener messageListener;
     private final ConnectionListener connectionListener;
+    @Nullable
+    private final NetworkFilter networkFilter;
 
     // accessed from different threads
     private final ServerSocket serverSocket;
@@ -48,11 +52,13 @@ class Server implements Runnable {
     public Server(ServerSocket serverSocket,
                   MessageListener messageListener,
                   ConnectionListener connectionListener,
-                  NetworkProtoResolver networkProtoResolver) {
+                  NetworkProtoResolver networkProtoResolver,
+                  @Nullable NetworkFilter networkFilter) {
         this.networkProtoResolver = networkProtoResolver;
         this.serverSocket = serverSocket;
         this.messageListener = messageListener;
         this.connectionListener = connectionListener;
+        this.networkFilter = networkFilter;
     }
 
     @Override
@@ -69,7 +75,8 @@ class Server implements Runnable {
                         InboundConnection connection = new InboundConnection(socket,
                                 messageListener,
                                 connectionListener,
-                                networkProtoResolver);
+                                networkProtoResolver,
+                                networkFilter);
 
                         log.debug("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" +
                                 "Server created new inbound connection:"

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -87,9 +87,12 @@ public class TorNetworkNode extends NetworkNode {
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public TorNetworkNode(int servicePort, NetworkProtoResolver networkProtoResolver, boolean useStreamIsolation,
-                          TorMode torMode) {
-        super(servicePort, networkProtoResolver);
+    public TorNetworkNode(int servicePort,
+                          NetworkProtoResolver networkProtoResolver,
+                          boolean useStreamIsolation,
+                          TorMode torMode,
+                          @Nullable NetworkFilter networkFilter) {
+        super(servicePort, networkProtoResolver, networkFilter);
         this.torMode = torMode;
         this.streamIsolation = useStreamIsolation;
         createExecutorService();

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -262,6 +262,9 @@ class RequestDataHandler implements MessageListener {
         numPayloadsByClassName.putIfAbsent(className, new Tuple2<>(new AtomicInteger(0),
                 new AtomicInteger(0)));
         numPayloadsByClassName.get(className).first.getAndIncrement();
+        // toProtoMessage().getSerializedSize() is not very cheap. For about 1500 objects it takes about 20 ms
+        // I think its justified to get accurate metrics but if it turns out to be a performance issue we might need
+        // to remove it and use some more rough estimation by taking only the size of one data type and multiply it.
         numPayloadsByClassName.get(className).second.getAndAdd(networkPayload.toProtoMessage().getSerializedSize());
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -27,8 +27,8 @@ import bisq.common.app.Capabilities;
 import bisq.common.app.Version;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkProtoResolver;
+import bisq.common.util.Utilities;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -107,24 +107,18 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
         protobuf.NetworkEnvelope proto = getNetworkEnvelopeBuilder()
                 .setGetDataResponse(builder)
                 .build();
-        log.info("Sending a GetDataResponse with {} kB", proto.getSerializedSize() / 1000d);
+        log.info("Sending a GetDataResponse with {}", Utilities.readableFileSize(proto.getSerializedSize()));
         return proto;
     }
 
     public static GetDataResponse fromProto(protobuf.GetDataResponse proto,
                                             NetworkProtoResolver resolver,
                                             int messageVersion) {
-        log.info("Received a GetDataResponse with {} kB", proto.getSerializedSize() / 1000d);
-        Set<ProtectedStorageEntry> dataSet = new HashSet<>(
-                proto.getDataSetList().stream()
-                        .map(entry -> (ProtectedStorageEntry) resolver.fromProto(entry))
-                        .collect(Collectors.toSet()));
-
-        Set<PersistableNetworkPayload> persistableNetworkPayloadSet = new HashSet<>(
-                proto.getPersistableNetworkPayloadItemsList().stream()
-                                .map(e -> (PersistableNetworkPayload) resolver.fromProto(e))
-                                .collect(Collectors.toSet()));
-
+        log.info("Received a GetDataResponse with {}", Utilities.readableFileSize(proto.getSerializedSize()));
+        Set<ProtectedStorageEntry> dataSet = proto.getDataSetList().stream()
+                .map(entry -> (ProtectedStorageEntry) resolver.fromProto(entry)).collect(Collectors.toSet());
+        Set<PersistableNetworkPayload> persistableNetworkPayloadSet = proto.getPersistableNetworkPayloadItemsList().stream()
+                .map(e -> (PersistableNetworkPayload) resolver.fromProto(e)).collect(Collectors.toSet());
         return new GetDataResponse(dataSet,
                 persistableNetworkPayloadSet,
                 proto.getRequestNonce(),

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -534,7 +534,10 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         removeExpiredEntriesTimer = UserThread.runPeriodically(this::removeExpiredEntries, CHECK_TTL_INTERVAL_SEC);
     }
 
-    public Map<ByteArray, PersistableNetworkPayload> getAppendOnlyDataStoreMap() {
+    // Domain access should use the concrete appendOnlyDataStoreService if available. The Historical data store require
+    // care which data should be accessed (live data or all data).
+    @VisibleForTesting
+    Map<ByteArray, PersistableNetworkPayload> getAppendOnlyDataStoreMap() {
         return appendOnlyDataStoreService.getMap();
     }
 
@@ -642,7 +645,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         }
 
         ByteArray hashAsByteArray = new ByteArray(payload.getHash());
-        boolean payloadHashAlreadyInStore = getAppendOnlyDataStoreMap().containsKey(hashAsByteArray);
+        boolean payloadHashAlreadyInStore = appendOnlyDataStoreService.getMap().containsKey(hashAsByteArray);
 
         // Store already knows about this payload. Ignore it unless the caller specifically requests a republish.
         if (payloadHashAlreadyInStore && !reBroadcast) {

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
@@ -20,6 +20,7 @@ package bisq.network.p2p.storage.persistence;
 import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
 
+import bisq.common.app.DevEnv;
 import bisq.common.app.Version;
 import bisq.common.persistence.PersistenceManager;
 
@@ -109,15 +110,11 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
     // MapStoreService
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    // TODO optimize so that callers to AppendOnlyDataStoreService are not invoking that often getMap
-    // ProposalService is one of the main callers and could avoid it by using the ProposalStoreService directly
-    // instead of AppendOnlyDataStoreService
-
-    // By default we return the live data only. This method should not be used by domain clients but rather the
-    // custom methods getMapOfAllData, getMapOfLiveData or getMapSinceVersion
     @Override
     public Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> getMap() {
-        return store.getMap();
+        DevEnv.logErrorAndThrowIfDevMode("HistoricalDataStoreService.getMap should not be used by domain " +
+                "clients but rather the custom methods getMapOfAllData, getMapOfLiveData or getMapSinceVersion");
+        return getMapOfAllData();
     }
 
     @Override

--- a/p2p/src/test/java/bisq/network/p2p/DummySeedNode.java
+++ b/p2p/src/test/java/bisq/network/p2p/DummySeedNode.java
@@ -135,11 +135,9 @@ public class DummySeedNode {
                     checkArgument(arg.contains(":") && arg.split(":").length > 1 && arg.split(":")[1].length() > 3,
                             "Wrong program argument " + arg);
                     List<String> list = Arrays.asList(arg.split(","));
-                    Set<NodeAddress> bannedPeers = new HashSet<>();
                     list.forEach(e -> {
                         checkArgument(e.contains(":") && e.split(":").length == 2 && e.split(":")[1].length() == 4,
                                 "Wrong program argument " + e);
-                        bannedPeers.add(new NodeAddress(e));
                     });
                     log.debug("From processArgs: ignoreList=" + list);
                 } else if (arg.startsWith(HELP)) {

--- a/p2p/src/test/java/bisq/network/p2p/DummySeedNode.java
+++ b/p2p/src/test/java/bisq/network/p2p/DummySeedNode.java
@@ -17,8 +17,6 @@
 
 package bisq.network.p2p;
 
-import bisq.network.p2p.peers.BanList;
-
 import bisq.common.UserThread;
 import bisq.common.app.Log;
 import bisq.common.app.Version;
@@ -137,10 +135,11 @@ public class DummySeedNode {
                     checkArgument(arg.contains(":") && arg.split(":").length > 1 && arg.split(":")[1].length() > 3,
                             "Wrong program argument " + arg);
                     List<String> list = Arrays.asList(arg.split(","));
+                    Set<NodeAddress> bannedPeers = new HashSet<>();
                     list.forEach(e -> {
                         checkArgument(e.contains(":") && e.split(":").length == 2 && e.split(":")[1].length() == 4,
                                 "Wrong program argument " + e);
-                        BanList.add(new NodeAddress(e));
+                        bannedPeers.add(new NodeAddress(e));
                     });
                     log.debug("From processArgs: ignoreList=" + list);
                 } else if (arg.startsWith(HELP)) {

--- a/p2p/src/test/java/bisq/network/p2p/network/LocalhostNetworkNodeTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/network/LocalhostNetworkNodeTest.java
@@ -38,13 +38,10 @@ import org.junit.Test;
 public class LocalhostNetworkNodeTest {
     private static final Logger log = LoggerFactory.getLogger(LocalhostNetworkNodeTest.class);
 
-
-
-
     @Test
     public void testMessage() throws InterruptedException, IOException {
         CountDownLatch msgLatch = new CountDownLatch(2);
-        LocalhostNetworkNode node1 = new LocalhostNetworkNode(9001, TestUtils.getNetworkProtoResolver());
+        LocalhostNetworkNode node1 = new LocalhostNetworkNode(9001, TestUtils.getNetworkProtoResolver(), null);
         node1.addMessageListener((message, connection) -> {
             log.debug("onMessage node1 " + message);
             msgLatch.countDown();
@@ -72,7 +69,7 @@ public class LocalhostNetworkNodeTest {
             }
         });
 
-        LocalhostNetworkNode node2 = new LocalhostNetworkNode(9002, TestUtils.getNetworkProtoResolver());
+        LocalhostNetworkNode node2 = new LocalhostNetworkNode(9002, TestUtils.getNetworkProtoResolver(), null);
         node2.addMessageListener((message, connection) -> {
             log.debug("onMessage node2 " + message);
             msgLatch.countDown();

--- a/p2p/src/test/java/bisq/network/p2p/network/TorNetworkNodeTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/network/TorNetworkNodeTest.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import java.io.File;
 import java.io.IOException;
+
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
@@ -49,13 +50,12 @@ public class TorNetworkNodeTest {
     private CountDownLatch latch;
 
 
-
     @Test
     public void testTorNodeBeforeSecondReady() throws InterruptedException, IOException {
         latch = new CountDownLatch(1);
         int port = 9001;
         TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()));
+                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()), null);
         node1.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {
@@ -82,7 +82,7 @@ public class TorNetworkNodeTest {
         latch = new CountDownLatch(1);
         int port2 = 9002;
         TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()));
+                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()), null);
         node2.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {
@@ -140,7 +140,7 @@ public class TorNetworkNodeTest {
         latch = new CountDownLatch(2);
         int port = 9001;
         TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()));
+                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()), null);
         node1.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {
@@ -166,7 +166,7 @@ public class TorNetworkNodeTest {
 
         int port2 = 9002;
         TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()));
+                new NewTor(new File("torNode_" + port), null, "", new ArrayList<String>()), null);
         node2.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -677,6 +677,7 @@ message Filter {
     repeated string bannedPrivilegedDevPubKeys = 23;
     bool disable_auto_conf = 24;
     repeated string banned_auto_conf_explorers = 25;
+    repeated string node_addresses_banned_from_network = 26;
 }
 
 // Deprecated

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -652,7 +652,7 @@ message RefundAgent {
 }
 
 message Filter {
-    repeated string banned_node_address = 1;
+    repeated string node_addresses_banned_from_trading = 1;
     repeated string banned_offer_ids = 2;
     repeated PaymentAccountFilter banned_payment_accounts = 3;
     string signature_as_base64 = 4;


### PR DESCRIPTION
Adds a new field to the filter window for banning nodes on the network level. The existing one is only for banning nodes from trading. 

Based on #5031
Starts at commit 15b8f64