### PR TITLE
Select show-all currencies if TransferWise is selected

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -324,11 +324,8 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 currencyComboBox.getSelectionModel().select(SHOW_ALL);
             model.onSetTradeCurrency(currencyComboBox.getSelectionModel().getSelectedItem());
         });
+        updateCurrencyComboBoxFromModel();
 
-        if (model.showAllTradeCurrenciesProperty.get())
-            currencyComboBox.getSelectionModel().select(SHOW_ALL);
-        else
-            currencyComboBox.getSelectionModel().select(model.getSelectedTradeCurrency());
         currencyComboBox.getEditor().setText(new CurrencyStringConverter(currencyComboBox).toString(currencyComboBox.getSelectionModel().getSelectedItem()));
 
         volumeColumn.sortableProperty().bind(model.showAllTradeCurrenciesProperty.not());
@@ -359,6 +356,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
             if (paymentMethodComboBox.getEditor().getText().isEmpty())
                 paymentMethodComboBox.getSelectionModel().select(SHOW_ALL);
             model.onSetPaymentMethod(paymentMethodComboBox.getSelectionModel().getSelectedItem());
+            updateCurrencyComboBoxFromModel();
             updateSigningStateColumn();
         });
 
@@ -403,6 +401,14 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         nrOfOffersLabel.setText(Res.get("offerbook.nrOffers", model.getOfferList().size()));
 
         model.priceFeedService.updateCounterProperty().addListener(priceFeedUpdateCounterListener);
+    }
+
+    private void updateCurrencyComboBoxFromModel() {
+        if (model.showAllTradeCurrenciesProperty.get()) {
+            currencyComboBox.getSelectionModel().select(SHOW_ALL);
+        } else {
+            currencyComboBox.getSelectionModel().select(model.getSelectedTradeCurrency());
+        }
     }
 
     private void updateSigningStateColumn() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -281,10 +281,17 @@ class OfferBookViewModel extends ActivatableViewModel {
             return;
 
         showAllPaymentMethods = isShowAllEntry(paymentMethod.getId());
-        if (!showAllPaymentMethods)
+        if (!showAllPaymentMethods) {
             this.selectedPaymentMethod = paymentMethod;
-        else
+
+            // If we select TransferWise we switch to show all currencies as TransferWise supports
+            // sending to most currencies.
+            if (paymentMethod.getId().equals(PaymentMethod.TRANSFERWISE_ID)) {
+                onSetTradeCurrency(new CryptoCurrency(GUIUtil.SHOW_ALL_FLAG, ""));
+            }
+        } else {
             this.selectedPaymentMethod = PaymentMethod.getDummyPaymentMethod(GUIUtil.SHOW_ALL_FLAG);
+        }
 
         applyFilterPredicate();
     }


### PR DESCRIPTION
If we select TransferWise we switch to show all currencies as TransferWise supports sending to most currencies.

We could make a different handling for BUY and SELL side as sending to nearly all currencies is possible but not receiving (only the currencies which have been enabled in the account). But I think that would confuse the users and would appear like a bug as the reason is not trivial to see.