### PR TITLE
Add option to hide non supported payment methods

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -487,6 +487,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         });
     }
 
+    public void setHideNonAccountPaymentMethods(boolean hideNonAccountPaymentMethods) {
+        prefPayload.setHideNonAccountPaymentMethods(hideNonAccountPaymentMethods);
+        requestPersistence();
+    }
+
     private void requestPersistence() {
         if (initialReadDone)
             persistenceManager.requestPersistence();
@@ -1074,5 +1079,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         void setBsqAverageTrimThreshold(double bsqAverageTrimThreshold);
 
         void setAutoConfirmSettings(AutoConfirmSettings autoConfirmSettings);
+
+        void setHideNonAccountPaymentMethods(boolean hideNonAccountPaymentMethods);
     }
 }

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -129,6 +129,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
     // Added at 1.3.8
     private List<AutoConfirmSettings> autoConfirmSettingsList = new ArrayList<>();
 
+    // Added in 1.5.5
+    private boolean hideNonAccountPaymentMethods;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -192,7 +194,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .setBsqAverageTrimThreshold(bsqAverageTrimThreshold)
                 .addAllAutoConfirmSettings(autoConfirmSettingsList.stream()
                         .map(autoConfirmSettings -> ((protobuf.AutoConfirmSettings) autoConfirmSettings.toProtoMessage()))
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()))
+                .setHideNonAccountPaymentMethods(hideNonAccountPaymentMethods);
 
         Optional.ofNullable(backupDirectory).ifPresent(builder::setBackupDirectory);
         Optional.ofNullable(preferredTradeCurrency).ifPresent(e -> builder.setPreferredTradeCurrency((protobuf.TradeCurrency) e.toProtoMessage()));
@@ -286,7 +289,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.getAutoConfirmSettingsList().isEmpty() ? new ArrayList<>() :
                         new ArrayList<>(proto.getAutoConfirmSettingsList().stream()
                                 .map(AutoConfirmSettings::fromProto)
-                                .collect(Collectors.toList()))
+                                .collect(Collectors.toList())),
+                proto.getHideNonAccountPaymentMethods()
         );
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1219,6 +1219,7 @@ setting.preferences.showOwnOffers=Show my own offers in offer book
 setting.preferences.useAnimations=Use animations
 setting.preferences.useDarkMode=Use dark mode
 setting.preferences.sortWithNumOffers=Sort market lists with no. of offers/trades
+setting.preferences.onlyShowPaymentMethodsFromAccount=Hide non-supported payment methods
 setting.preferences.resetAllFlags=Reset all \"Don't show again\" flags
 settings.preferences.languageChange=To apply the language change to all screens requires a restart.
 settings.preferences.supportLanguageWarning=In case of a dispute, please note that mediation is handled in {0} and arbitration in {1}.

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -324,11 +324,8 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                 currencyComboBox.getSelectionModel().select(SHOW_ALL);
             model.onSetTradeCurrency(currencyComboBox.getSelectionModel().getSelectedItem());
         });
+        updateCurrencyComboBoxFromModel();
 
-        if (model.showAllTradeCurrenciesProperty.get())
-            currencyComboBox.getSelectionModel().select(SHOW_ALL);
-        else
-            currencyComboBox.getSelectionModel().select(model.getSelectedTradeCurrency());
         currencyComboBox.getEditor().setText(new CurrencyStringConverter(currencyComboBox).toString(currencyComboBox.getSelectionModel().getSelectedItem()));
 
         volumeColumn.sortableProperty().bind(model.showAllTradeCurrenciesProperty.not());
@@ -359,6 +356,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
             if (paymentMethodComboBox.getEditor().getText().isEmpty())
                 paymentMethodComboBox.getSelectionModel().select(SHOW_ALL);
             model.onSetPaymentMethod(paymentMethodComboBox.getSelectionModel().getSelectedItem());
+            updateCurrencyComboBoxFromModel();
             updateSigningStateColumn();
         });
 
@@ -403,6 +401,14 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
         nrOfOffersLabel.setText(Res.get("offerbook.nrOffers", model.getOfferList().size()));
 
         model.priceFeedService.updateCounterProperty().addListener(priceFeedUpdateCounterListener);
+    }
+
+    private void updateCurrencyComboBoxFromModel() {
+        if (model.showAllTradeCurrenciesProperty.get()) {
+            currencyComboBox.getSelectionModel().select(SHOW_ALL);
+        } else {
+            currencyComboBox.getSelectionModel().select(model.getSelectedTradeCurrency());
+        }
     }
 
     private void updateSigningStateColumn() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -281,10 +281,17 @@ class OfferBookViewModel extends ActivatableViewModel {
             return;
 
         showAllPaymentMethods = isShowAllEntry(paymentMethod.getId());
-        if (!showAllPaymentMethods)
+        if (!showAllPaymentMethods) {
             this.selectedPaymentMethod = paymentMethod;
-        else
+
+            // If we select TransferWise we switch to show all currencies as TransferWise supports
+            // sending to most currencies.
+            if (paymentMethod.getId().equals(PaymentMethod.TRANSFERWISE_ID)) {
+                onSetTradeCurrency(new CryptoCurrency(GUIUtil.SHOW_ALL_FLAG, ""));
+            }
+        } else {
             this.selectedPaymentMethod = PaymentMethod.getDummyPaymentMethod(GUIUtil.SHOW_ALL_FLAG);
+        }
 
         applyFilterPredicate();
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -87,6 +87,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -338,6 +339,14 @@ class OfferBookViewModel extends ActivatableViewModel {
 
     ObservableList<PaymentMethod> getPaymentMethods() {
         ObservableList<PaymentMethod> list = FXCollections.observableArrayList(PaymentMethod.getPaymentMethods());
+        if (preferences.isHideNonAccountPaymentMethods() && user.getPaymentAccounts() != null) {
+            Set<PaymentMethod> supportedPaymentMethods = user.getPaymentAccounts().stream()
+                    .map(PaymentAccount::getPaymentMethod).collect(Collectors.toSet());
+            if (!supportedPaymentMethods.isEmpty()) {
+                list = FXCollections.observableArrayList(supportedPaymentMethods);
+            }
+        }
+
         list.sort(Comparator.naturalOrder());
         list.add(0, PaymentMethod.getDummyPaymentMethod(GUIUtil.SHOW_ALL_FLAG));
         return list;

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -45,8 +45,11 @@ import bisq.core.locale.FiatCurrency;
 import bisq.core.locale.LanguageUtil;
 import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
+import bisq.core.payment.PaymentAccount;
+import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
+import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
 import bisq.core.util.coin.CoinFormatter;
@@ -100,13 +103,16 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static bisq.desktop.util.FormBuilder.*;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @FxmlView
 public class PreferencesView extends ActivatableViewAndModel<GridPane, PreferencesViewModel> {
+    private final User user;
     private final CoinFormatter formatter;
     private TextField btcExplorerTextField, bsqExplorerTextField;
     private ComboBox<String> userLanguageComboBox;
@@ -114,7 +120,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     private ComboBox<TradeCurrency> preferredTradeCurrencyComboBox;
 
     private ToggleButton showOwnOffersInOfferBook, useAnimations, useDarkMode, sortMarketCurrenciesNumerically,
-            avoidStandbyMode, useCustomFee, autoConfirmXmrToggle;
+            avoidStandbyMode, useCustomFee, autoConfirmXmrToggle, hideNonAccountPaymentMethodsToggle;
     private int gridRow = 0;
     private int displayCurrenciesGridRowIndex = 0;
     private InputTextField transactionFeeInputTextField, ignoreTradersListInputTextField, ignoreDustThresholdInputTextField,
@@ -171,12 +177,14 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                            FilterManager filterManager,
                            DaoFacade daoFacade,
                            Config config,
+                           User user,
                            @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                            @Named(Config.RPC_USER) String rpcUser,
                            @Named(Config.RPC_PASSWORD) String rpcPassword,
                            @Named(Config.RPC_BLOCK_NOTIFICATION_PORT) int rpcBlockNotificationPort,
                            @Named(Config.STORAGE_DIR) File storageDir) {
         super(model);
+        this.user = user;
         this.formatter = formatter;
         this.preferences = preferences;
         this.feeService = feeService;
@@ -595,14 +603,14 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     }
 
     private void initializeDisplayOptions() {
-        TitledGroupBg titledGroupBg = addTitledGroupBg(root, ++gridRow, 5, Res.get("setting.preferences.displayOptions"), Layout.GROUP_DISTANCE);
+        TitledGroupBg titledGroupBg = addTitledGroupBg(root, ++gridRow, 6, Res.get("setting.preferences.displayOptions"), Layout.GROUP_DISTANCE);
         GridPane.setColumnSpan(titledGroupBg, 1);
 
         showOwnOffersInOfferBook = addSlideToggleButton(root, gridRow, Res.get("setting.preferences.showOwnOffers"), Layout.FIRST_ROW_AND_GROUP_DISTANCE);
         useAnimations = addSlideToggleButton(root, ++gridRow, Res.get("setting.preferences.useAnimations"));
         useDarkMode = addSlideToggleButton(root, ++gridRow, Res.get("setting.preferences.useDarkMode"));
-        // useStickyMarketPriceCheckBox = addLabelCheckBox(root, ++gridRow, "Use sticky market price:", "").second;
         sortMarketCurrenciesNumerically = addSlideToggleButton(root, ++gridRow, Res.get("setting.preferences.sortWithNumOffers"));
+        hideNonAccountPaymentMethodsToggle = addSlideToggleButton(root, ++gridRow, Res.get("setting.preferences.onlyShowPaymentMethodsFromAccount"));
         resetDontShowAgainButton = addButton(root, ++gridRow, Res.get("setting.preferences.resetAllFlags"), 0);
         resetDontShowAgainButton.getStyleClass().add("compact-button");
         resetDontShowAgainButton.setMaxWidth(Double.MAX_VALUE);
@@ -932,6 +940,16 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         sortMarketCurrenciesNumerically.setSelected(preferences.isSortMarketCurrenciesNumerically());
         sortMarketCurrenciesNumerically.setOnAction(e -> preferences.setSortMarketCurrenciesNumerically(sortMarketCurrenciesNumerically.isSelected()));
 
+        boolean disableToggle = false;
+        if (user.getPaymentAccounts() != null) {
+            Set<PaymentMethod> supportedPaymentMethods = user.getPaymentAccounts().stream()
+                    .map(PaymentAccount::getPaymentMethod).collect(Collectors.toSet());
+            disableToggle = supportedPaymentMethods.isEmpty();
+        }
+        hideNonAccountPaymentMethodsToggle.setSelected(preferences.isHideNonAccountPaymentMethods() && !disableToggle);
+        hideNonAccountPaymentMethodsToggle.setOnAction(e -> preferences.setHideNonAccountPaymentMethods(hideNonAccountPaymentMethodsToggle.isSelected()));
+        hideNonAccountPaymentMethodsToggle.setDisable(disableToggle);
+
         resetDontShowAgainButton.setOnAction(e -> preferences.resetDontShowAgain());
 
         editCustomBtcExplorer.setOnAction(e -> {
@@ -1108,8 +1126,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     private void deactivateDisplayPreferences() {
         useAnimations.setOnAction(null);
         useDarkMode.setOnAction(null);
-        // useStickyMarketPriceCheckBox.setOnAction(null);
         sortMarketCurrenciesNumerically.setOnAction(null);
+        hideNonAccountPaymentMethodsToggle.setOnAction(null);
         showOwnOffersInOfferBook.setOnAction(null);
         resetDontShowAgainButton.setOnAction(null);
         if (displayStandbyModeFeature) {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1613,6 +1613,7 @@ message PreferencesPayload {
     bool tac_accepted_v120 = 55;
     repeated AutoConfirmSettings auto_confirm_settings = 56;
     double bsq_average_trim_threshold = 57;
+    bool hide_non_account_payment_methods = 58;
 }
 
 message AutoConfirmSettings {


### PR DESCRIPTION
Add option in preferences to hide payment methods from combobox in the Offer views which are not part of the users accounts.

Default value is false, so same behaviour as before that PR.
If no payment account is setup then we also show all payment methods.
In that case (no payment account) we disable the toggle as well as show it in false state.

Based on #5042 
Starts at commit eddb7cb