### PR TITLE
Add toggle for hiding not takable offers

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -772,6 +772,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         requestPersistence();
     }
 
+    public void setShowOffersMatchingMyAccounts(boolean value) {
+        prefPayload.setShowOffersMatchingMyAccounts(value);
+        requestPersistence();
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Getter
@@ -1081,5 +1086,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         void setAutoConfirmSettings(AutoConfirmSettings autoConfirmSettings);
 
         void setHideNonAccountPaymentMethods(boolean hideNonAccountPaymentMethods);
+
+        void setShowOffersMatchingMyAccounts(boolean value);
     }
 }

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -131,6 +131,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
 
     // Added in 1.5.5
     private boolean hideNonAccountPaymentMethods;
+    private boolean showOffersMatchingMyAccounts;
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -195,7 +197,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .addAllAutoConfirmSettings(autoConfirmSettingsList.stream()
                         .map(autoConfirmSettings -> ((protobuf.AutoConfirmSettings) autoConfirmSettings.toProtoMessage()))
                         .collect(Collectors.toList()))
-                .setHideNonAccountPaymentMethods(hideNonAccountPaymentMethods);
+                .setHideNonAccountPaymentMethods(hideNonAccountPaymentMethods)
+                .setShowOffersMatchingMyAccounts(showOffersMatchingMyAccounts);
 
         Optional.ofNullable(backupDirectory).ifPresent(builder::setBackupDirectory);
         Optional.ofNullable(preferredTradeCurrency).ifPresent(e -> builder.setPreferredTradeCurrency((protobuf.TradeCurrency) e.toProtoMessage()));
@@ -290,7 +293,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                         new ArrayList<>(proto.getAutoConfirmSettingsList().stream()
                                 .map(AutoConfirmSettings::fromProto)
                                 .collect(Collectors.toList())),
-                proto.getHideNonAccountPaymentMethods()
+                proto.getHideNonAccountPaymentMethods(),
+                proto.getShowOffersMatchingMyAccounts()
         );
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -342,6 +342,7 @@ offerbook.offerersAcceptedBankSeats=Accepted seat of bank countries (taker):\n {
 offerbook.availableOffers=Available offers
 offerbook.filterByCurrency=Filter by currency
 offerbook.filterByPaymentMethod=Filter by payment method
+offerbook.matchingOffers=Offers matching my accounts
 offerbook.timeSinceSigning=Account info
 offerbook.timeSinceSigning.info=This account was verified and {0}
 offerbook.timeSinceSigning.info.arbitrator=signed by an arbitrator and can sign peer accounts

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -215,8 +215,10 @@ class OfferBookViewModel extends ActivatableViewModel {
         };
 
         // If our accounts have changed we reset our myInsufficientTradeLimitCache as it depends on account data
-        user.getPaymentAccountsAsObservable().addListener((SetChangeListener<PaymentAccount>) c ->
-                myInsufficientTradeLimitCache.clear());
+        if (user != null) {
+            user.getPaymentAccountsAsObservable().addListener((SetChangeListener<PaymentAccount>) c ->
+                    myInsufficientTradeLimitCache.clear());
+        }
     }
 
     @Override
@@ -234,7 +236,9 @@ class OfferBookViewModel extends ActivatableViewModel {
         }
         tradeCurrencyCode.set(selectedTradeCurrency.getCode());
 
-        disableMatchToggle.set(user.getPaymentAccounts() == null || user.getPaymentAccounts().isEmpty());
+        if (user != null) {
+            disableMatchToggle.set(user.getPaymentAccounts() == null || user.getPaymentAccounts().isEmpty());
+        }
         useOffersMatchingMyAccountsFilter = !disableMatchToggle.get() && isShowOffersMatchingMyAccounts();
 
         fillAllTradeCurrencies();

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1615,6 +1615,7 @@ message PreferencesPayload {
     repeated AutoConfirmSettings auto_confirm_settings = 56;
     double bsq_average_trim_threshold = 57;
     bool hide_non_account_payment_methods = 58;
+    bool show_offers_matching_my_accounts = 59;
 }
 
 message AutoConfirmSettings {


### PR DESCRIPTION
Adds a toggle to the offer book views to filtering offers which can be taken from users accounts. It uses the same code which is used for the disable state for take offer buttons, so all the greyed out offers are hidden if toggle is selected. It can be combined with the other 2 dropbox filters.

We cache some method results for performance reasons. This also improves the performance without selecting the toggle.
https://github.com/bisq-network/bisq/pull/5047 will add more performance improvements which will speed up the first calls to the expensive methods further.

<strike>Based on #5045. Commits start at 26c1c0e </strike>
Rebased on master.