### PR TITLE
Add "Buy BSQ" button next to trade fee selector

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -388,6 +388,7 @@ offerbook.createOfferToBuy.withFiat=Create new offer to buy {0} with {1}
 offerbook.createOfferToSell.forFiat=Create new offer to sell {0} for {1}
 offerbook.createOfferToBuy.withCrypto=Create new offer to sell {0} (buy {1})
 offerbook.createOfferToSell.forCrypto=Create new offer to buy {0} (sell {1})
+offerbook.createOfferDisabled.tooltip=You can only create one offer at a time
 
 offerbook.takeOfferButton.tooltip=Take offer for {0}
 offerbook.yesCreateOffer=Yes, create offer

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -483,7 +483,8 @@ createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 createOffer.buyBsq.popupMessage=Trading fees are paid to fund the Bisq DAO when making or taking an offer. Fees can be paid in BSQ or BTC.\n\n\
   Bisq encourages traders to use BSQ by offering a discount of approximately 50%, since BSQ fees help fund Bisq's development. \
-  This discount varies as the BSQ/BTC rate fluctuates. To maintain the 50% discount target, trading fees are updated every cycle as necessary.
+  This discount varies as the BSQ/BTC rate fluctuates. To maintain the 50% discount target, trading fees are updated every cycle as necessary.\n\n\
+  For more details see [HYPERLINK:https://bisq.wiki/Trading_fees]
 
 # new entries
 createOffer.placeOfferButton=Review: Place offer to {0} bitcoin

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -481,10 +481,10 @@ createOffer.triggerPrice.tooltip=As protection against drastic price movements y
 createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
 createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
-createOffer.buyBsq.popupMessage=Trading fees are paid to fund the Bisq DAO when making or taking an offer. Fees can be paid in BSQ or BTC.\n\n\
-  Bisq encourages traders to use BSQ by offering a discount of approximately 50%, since BSQ fees help fund Bisq's development. \
+createOffer.buyBsq.popupMessage=Trading fees are paid to fund the Bisq DAO. Fees can be paid in BSQ or BTC.\n\n\
+  BSQ fees directly help fund Bisq's development, so Bisq encourages traders to use BSQ by offering a 50% discount on trading fees. \
   This discount varies as the BSQ/BTC rate fluctuates. To maintain the 50% discount target, trading fees are updated every cycle as necessary.\n\n\
-  For more details see [HYPERLINK:https://bisq.wiki/Trading_fees]
+  For more about fees, see [HYPERLINK:https://bisq.wiki/Trading_fees]. For more about the Bisq DAO, see [HYPERLINK:https://bisq.wiki/Introduction_to_the_DAO#The_Bisq_DAO].
 
 # new entries
 createOffer.placeOfferButton=Review: Place offer to {0} bitcoin

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -865,6 +865,7 @@ portfolio.pending.step3_seller.xmrTxHash=Transaction ID
 portfolio.pending.step3_seller.xmrTxKey=Transaction key
 portfolio.pending.step3_seller.buyersAccount=Buyers account data
 portfolio.pending.step3_seller.confirmReceipt=Confirm payment receipt
+portfolio.pending.step3_seller.showBsqWallet=Show payment in BSQ wallet
 portfolio.pending.step3_seller.buyerStartedPayment=The BTC buyer has started the {0} payment.\n{1}
 portfolio.pending.step3_seller.buyerStartedPayment.altcoin=Check for blockchain confirmations at your altcoin wallet or block explorer and confirm the payment when you have sufficient blockchain confirmations.
 portfolio.pending.step3_seller.buyerStartedPayment.fiat=Check at your trading account (e.g. bank account) and confirm when you have received the payment.

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -484,7 +484,7 @@ createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 createOffer.buyBsq.popupMessage=Trading fees are paid to fund the Bisq DAO. Fees can be paid in BSQ or BTC.\n\n\
   BSQ fees directly help fund Bisq's development, so Bisq encourages traders to use BSQ by offering a 50% discount on trading fees. \
   This discount varies as the BSQ/BTC rate fluctuates. To maintain the 50% discount target, trading fees are updated every cycle as necessary.\n\n\
-  For more about fees, see [HYPERLINK:https://bisq.wiki/Trading_fees]. For more about the Bisq DAO, see [HYPERLINK:https://bisq.wiki/Introduction_to_the_DAO#The_Bisq_DAO].
+  For more about fees, see [HYPERLINK:https://bisq.wiki/Trading_fees]. For more about trading BSQ, see [HYPERLINK:https://bisq.wiki/Trading_BSQ]. For more about the Bisq DAO, see [HYPERLINK:https://bisq.wiki/Introduction_to_the_DAO#The_Bisq_DAO].
 
 # new entries
 createOffer.placeOfferButton=Review: Place offer to {0} bitcoin

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -446,10 +446,10 @@ offerbook.info.roundedFiatVolume=The amount was rounded to increase the privacy 
 offerbook.info.accountCreated.headline=Congratulations
 offerbook.info.accountCreated.message=You''ve just successfully created a BSQ payment account.\n\
   Your account can be found under Account > Altcoins Accounts > {0} and your BSQ wallet under DAO > BSQ Wallet.\n\n
-offerbook.info.accountCreated.tradeInstant=As you've chosen to take a BSQ instant offer a BSQ instant account was created for you. \
-  For instant trading it is required that both trading peers are online to be able \
-  to complete the trade in less than 1 hour.\n\n
-offerbook.info.accountCreated.takeOffer=You can no proceed to take this offer after closing this popup.
+offerbook.info.accountCreated.tradeInstant=You've chosen to take a BSQ instant offer, so a BSQ instant payment account was created for you. \
+  Be aware that instant trades are meant to be completed within 1 hour, \
+  so you should be online and available for the next 1 hour.\n\n
+offerbook.info.accountCreated.takeOffer=You can now proceed to take this offer after closing this popup.
 
 offerbook.bsqSwap.createOffer=Create Bsq swap offer
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -443,6 +443,13 @@ offerbook.info.buyAtFixedPrice=You will buy at this fixed price.
 offerbook.info.sellAtFixedPrice=You will sell at this fixed price.
 offerbook.info.noArbitrationInUserLanguage=In case of a dispute, please note that arbitration for this offer will be handled in {0}. Language is currently set to {1}.
 offerbook.info.roundedFiatVolume=The amount was rounded to increase the privacy of your trade.
+offerbook.info.accountCreated.headline=Congratulations
+offerbook.info.accountCreated.message=You''ve just successfully created a BSQ payment account.\n\
+  Your account can be found under Account > Altcoins Accounts > {0} and your BSQ wallet under DAO > BSQ Wallet.\n\n
+offerbook.info.accountCreated.tradeInstant=As you've chosen to take a BSQ instant offer a BSQ instant account was created for you. \
+  For instant trading it is required that both trading peers are online to be able \
+  to complete the trade in less than 1 hour.\n\n
+offerbook.info.accountCreated.takeOffer=You can no proceed to take this offer after closing this popup.
 
 offerbook.bsqSwap.createOffer=Create Bsq swap offer
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -481,6 +481,10 @@ createOffer.triggerPrice.tooltip=As protection against drastic price movements y
 createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
 createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
+createOffer.buyBsq.popupMessage=Trading fees are paid to fund the Bisq DAO when making or taking an offer. Fees can be paid in BSQ or BTC.\n\n\
+  Bisq encourages traders to use BSQ by offering a discount of approximately 50%, since BSQ fees help fund Bisq's development. \
+  This discount varies as the BSQ/BTC rate fluctuates. To maintain the 50% discount target, trading fees are updated every cycle as necessary.
+
 # new entries
 createOffer.placeOfferButton=Review: Place offer to {0} bitcoin
 createOffer.createOfferFundWalletInfo.headline=Fund your offer

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -336,6 +336,7 @@ market.trades.showVolumeInUSD=Show volume in USD
 
 offerbook.createOffer=Create offer
 offerbook.takeOffer=Take offer
+offerbook.takeOffer.createAccount=Create account and take offer
 offerbook.takeOfferToBuy=Take offer to buy {0}
 offerbook.takeOfferToSell=Take offer to sell {0}
 offerbook.trader=Trader
@@ -403,6 +404,7 @@ offerbook.warning.noTradingAccountForCurrency.headline=No payment account for se
 offerbook.warning.noTradingAccountForCurrency.msg=You don't have a payment account set up for the selected currency.\n\nWould you like to create an offer for another currency instead?
 offerbook.warning.noMatchingAccount.headline=No matching payment account.
 offerbook.warning.noMatchingAccount.msg=This offer uses a payment method you haven't set up yet. \n\nWould you like to set up a new payment account now?
+offerbook.warning.noMatchingBsqAccount.msg=This offer uses BSQ as a payment method you haven't set up yet. \n\nWould you like to automatically create an account now?
 
 offerbook.warning.counterpartyTradeRestrictions=This offer cannot be taken due to counterparty trade restrictions
 

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -175,6 +175,13 @@
     -fx-padding: 0 10 0 10;
 }
 
+.tiny-button, .action-button.tiny-button {
+    -fx-font-size: 0.769em;
+    -fx-pref-height: 20;
+    -fx-padding: 3 8 3 8;
+    -fx-border-radius: 5;
+}
+
 .text-button {
     -fx-background-color: transparent;
     -fx-underline: true;

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -175,7 +175,8 @@
     -fx-padding: 0 10 0 10;
 }
 
-.tiny-button, .action-button.tiny-button {
+.tiny-button,
+.action-button.tiny-button {
     -fx-font-size: 0.769em;
     -fx-pref-height: 20;
     -fx-padding: 3 8 3 8;

--- a/desktop/src/main/java/bisq/desktop/components/HyperlinkWithIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/HyperlinkWithIcon.java
@@ -41,11 +41,15 @@ public class HyperlinkWithIcon extends Hyperlink {
         this(text, AwesomeIcon.INFO_SIGN);
     }
 
-    public HyperlinkWithIcon(String text, AwesomeIcon awesomeIcon) {
+    public HyperlinkWithIcon(String text, String fontSize) {
+        this(text, AwesomeIcon.INFO_SIGN, fontSize);
+    }
+
+    public HyperlinkWithIcon(String text, AwesomeIcon awesomeIcon, String fontSize) {
         super(text);
 
         Label icon = new Label();
-        AwesomeDude.setIcon(icon, awesomeIcon);
+        AwesomeDude.setIcon(icon, awesomeIcon, fontSize);
         icon.setMinWidth(20);
         icon.setOpacity(0.7);
         icon.getStyleClass().addAll("hyperlink", "no-underline");
@@ -53,6 +57,10 @@ public class HyperlinkWithIcon extends Hyperlink {
         icon.setPadding(new Insets(0));
 
         setIcon(icon);
+    }
+
+    public HyperlinkWithIcon(String text, AwesomeIcon awesomeIcon) {
+        this(text, awesomeIcon, "1.231em");
     }
 
     public HyperlinkWithIcon(String text, GlyphIcons icon) {

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AdvancedCashForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AdvancedCashForm.java
@@ -34,8 +34,6 @@ import bisq.core.util.validation.InputValidator;
 
 import bisq.common.util.Tuple2;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
@@ -62,8 +60,13 @@ public class AdvancedCashForm extends PaymentMethodForm {
         return gridRow;
     }
 
-    public AdvancedCashForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService, AdvancedCashValidator advancedCashValidator,
-                     InputValidator inputValidator, GridPane gridPane, int gridRow, CoinFormatter formatter) {
+    public AdvancedCashForm(PaymentAccount paymentAccount,
+                            AccountAgeWitnessService accountAgeWitnessService,
+                            AdvancedCashValidator advancedCashValidator,
+                            InputValidator inputValidator,
+                            GridPane gridPane,
+                            int gridRow,
+                            CoinFormatter formatter) {
         super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
         this.advancedCashAccount = (AdvancedCashAccount) paymentAccount;
         this.advancedCashValidator = advancedCashValidator;
@@ -101,12 +104,7 @@ public class AdvancedCashForm extends PaymentMethodForm {
 
     @Override
     protected void autoFillNameTextField() {
-        if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected()) {
-            String accountNr = accountNrInputTextField.getText();
-            accountNr = StringUtils.abbreviate(accountNr, 9);
-            String method = Res.get(paymentAccount.getPaymentMethod().getId());
-            accountNameTextField.setText(method.concat(": ").concat(accountNr));
-        }
+        setAccountNameWithString(accountNrInputTextField.getText());
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
@@ -41,8 +41,6 @@ import bisq.core.util.validation.InputValidator;
 import bisq.common.UserThread;
 import bisq.common.util.Tuple3;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
@@ -53,6 +51,7 @@ import javafx.geometry.Insets;
 
 import javafx.util.StringConverter;
 
+import static bisq.desktop.util.DisplayUtils.createAssetsAccountName;
 import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextField;
 import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
 import static bisq.desktop.util.FormBuilder.addLabelCheckBox;
@@ -169,9 +168,7 @@ public class AssetsForm extends PaymentMethodForm {
         if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected()) {
             String currency = paymentAccount.getSingleTradeCurrency() != null ? paymentAccount.getSingleTradeCurrency().getCode() : "";
             if (currency != null) {
-                String address = addressInputTextField.getText();
-                address = StringUtils.abbreviate(address, 9);
-                accountNameTextField.setText(currency.concat(": ").concat(address));
+                accountNameTextField.setText(createAssetsAccountName(currency, addressInputTextField.getText()));
             }
         }
     }

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/AssetsForm.java
@@ -166,10 +166,7 @@ public class AssetsForm extends PaymentMethodForm {
     @Override
     protected void autoFillNameTextField() {
         if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected()) {
-            String currency = paymentAccount.getSingleTradeCurrency() != null ? paymentAccount.getSingleTradeCurrency().getCode() : "";
-            if (currency != null) {
-                accountNameTextField.setText(createAssetsAccountName(currency, addressInputTextField.getText()));
-            }
+            accountNameTextField.setText(createAssetsAccountName(paymentAccount, addressInputTextField.getText()));
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/CapitualForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/CapitualForm.java
@@ -34,8 +34,6 @@ import bisq.core.util.validation.InputValidator;
 
 import bisq.common.util.Tuple2;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
@@ -100,12 +98,7 @@ public class CapitualForm extends PaymentMethodForm {
 
     @Override
     protected void autoFillNameTextField() {
-        if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected()) {
-            String accountNr = accountNrInputTextField.getText();
-            accountNr = StringUtils.abbreviate(accountNr, 9);
-            String method = Res.get(paymentAccount.getPaymentMethod().getId());
-            accountNameTextField.setText(method.concat(": ").concat(accountNr));
-        }
+        setAccountNameWithString(accountNrInputTextField.getText());
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/JapanBankTransferForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/JapanBankTransferForm.java
@@ -25,7 +25,6 @@ import bisq.desktop.util.validation.JapanBankAccountNameValidator;
 import bisq.desktop.util.validation.JapanBankAccountNumberValidator;
 import bisq.desktop.util.validation.JapanBankBranchCodeValidator;
 import bisq.desktop.util.validation.JapanBankBranchNameValidator;
-import bisq.desktop.util.validation.JapanBankTransferValidator;
 import bisq.desktop.util.validation.LengthValidator;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
@@ -57,24 +56,17 @@ import javafx.util.StringConverter;
 import static bisq.desktop.util.FormBuilder.*;
 import static bisq.desktop.util.GUIUtil.getComboBoxButtonCell;
 
-public class JapanBankTransferForm extends PaymentMethodForm
-{
+public class JapanBankTransferForm extends PaymentMethodForm {
     private final JapanBankAccount japanBankAccount;
-    protected ComboBox<String> bankComboBox, bankAccountTypeComboBox;
-    private InputTextField bankAccountNumberInputTextField;
+    protected ComboBox<String> bankComboBox;
 
-    private JapanBankTransferValidator japanBankTransferValidator;
-    private JapanBankBranchNameValidator japanBankBranchNameValidator;
-    private JapanBankBranchCodeValidator japanBankBranchCodeValidator;
-    private JapanBankAccountNameValidator japanBankAccountNameValidator;
-    private JapanBankAccountNumberValidator japanBankAccountNumberValidator;
+    private final JapanBankBranchNameValidator japanBankBranchNameValidator;
+    private final JapanBankBranchCodeValidator japanBankBranchCodeValidator;
+    private final JapanBankAccountNameValidator japanBankAccountNameValidator;
+    private final JapanBankAccountNumberValidator japanBankAccountNumberValidator;
 
-    private LengthValidator lengthValidator;
-    private RegexValidator regexValidator;
-
-    public static int addFormForBuyer(GridPane gridPane, int gridRow, // {{{
-                                      PaymentAccountPayload paymentAccountPayload)
-    {
+    public static int addFormForBuyer(GridPane gridPane, int gridRow,
+                                      PaymentAccountPayload paymentAccountPayload) {
         JapanBankAccountPayload japanBankAccount = ((JapanBankAccountPayload) paymentAccountPayload);
 
         String bankText = japanBankAccount.getBankCode() + " " + japanBankAccount.getBankName();
@@ -90,30 +82,26 @@ public class JapanBankTransferForm extends PaymentMethodForm
         addCompactTopLabelTextFieldWithCopyIcon(gridPane, gridRow, 1, Res.get("payment.japan.recipient"), accountNameText);
 
         return gridRow;
-    } // }}}
+    }
 
     public JapanBankTransferForm(PaymentAccount paymentAccount,
-                                  AccountAgeWitnessService accountAgeWitnessService,
-                                  JapanBankTransferValidator japanBankTransferValidator,
-                                  InputValidator inputValidator, GridPane gridPane,
-                                  int gridRow, CoinFormatter formatter)
-    {
+                                 AccountAgeWitnessService accountAgeWitnessService,
+                                 InputValidator inputValidator, GridPane gridPane,
+                                 int gridRow, CoinFormatter formatter) {
         super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
         this.japanBankAccount = (JapanBankAccount) paymentAccount;
 
-        this.japanBankTransferValidator = japanBankTransferValidator;
         this.japanBankBranchCodeValidator = new JapanBankBranchCodeValidator();
         this.japanBankAccountNumberValidator = new JapanBankAccountNumberValidator();
 
-        this.lengthValidator = new LengthValidator();
-        this.regexValidator = new RegexValidator();
+        LengthValidator lengthValidator = new LengthValidator();
+        RegexValidator regexValidator = new RegexValidator();
         this.japanBankBranchNameValidator = new JapanBankBranchNameValidator(lengthValidator, regexValidator);
         this.japanBankAccountNameValidator = new JapanBankAccountNameValidator(lengthValidator, regexValidator);
     }
 
     @Override
-    public void addFormForDisplayAccount() // {{{
-    {
+    public void addFormForDisplayAccount() {
         gridRowFrom = gridRow;
 
         addTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.name"),
@@ -128,37 +116,36 @@ public class JapanBankTransferForm extends PaymentMethodForm
         addBankAccountTypeDisplay();
 
         addLimitations(true);
-    } // }}}
-    private void addBankDisplay() // {{{
-    {
+    }
+
+    private void addBankDisplay() {
         String bankText = japanBankAccount.getBankCode() + " " + japanBankAccount.getBankName();
         TextField bankTextField = addCompactTopLabelTextField(gridPane, ++gridRow, JapanBankData.getString("bank"), bankText).second;
         bankTextField.setEditable(false);
-    } // }}}
-    private void addBankBranchDisplay() // {{{
-    {
+    }
+
+    private void addBankBranchDisplay() {
         String branchText = japanBankAccount.getBankBranchCode() + " " + japanBankAccount.getBankBranchName();
         TextField branchTextField = addCompactTopLabelTextField(gridPane, ++gridRow, JapanBankData.getString("branch"), branchText).second;
         branchTextField.setEditable(false);
-    } // }}}
-    private void addBankAccountDisplay() // {{{
-    {
+    }
+
+    private void addBankAccountDisplay() {
         String accountText = japanBankAccount.getBankAccountNumber() + " " + japanBankAccount.getBankAccountName();
         TextField accountTextField = addCompactTopLabelTextField(gridPane, ++gridRow, JapanBankData.getString("account"), accountText).second;
         accountTextField.setEditable(false);
-    } // }}}
-    private void addBankAccountTypeDisplay() // {{{
-    {
+    }
+
+    private void addBankAccountTypeDisplay() {
         TradeCurrency singleTradeCurrency = japanBankAccount.getSingleTradeCurrency();
         String currency = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "null";
         String accountTypeText = currency + " " + japanBankAccount.getBankAccountType();
         TextField accountTypeTextField = addCompactTopLabelTextField(gridPane, ++gridRow, JapanBankData.getString("account.type"), accountTypeText).second;
         accountTypeTextField.setEditable(false);
-    } // }}}
+    }
 
     @Override
-    public void addFormForAddAccount() // {{{
-    {
+    public void addFormForAddAccount() {
         gridRowFrom = gridRow;
 
         addBankInput();
@@ -168,9 +155,9 @@ public class JapanBankTransferForm extends PaymentMethodForm
 
         addLimitations(false);
         addAccountNameTextFieldWithAutoFillToggleButton();
-    } // }}}
-    private void addBankInput() // {{{
-    {
+    }
+
+    private void addBankInput() {
         gridRow++;
 
         Tuple4<Label, TextField, Label, ComboBox<String>> tuple4 = addTopLabelTextFieldAutocompleteComboBox(gridPane, gridRow, JapanBankData.getString("bank.code"), JapanBankData.getString("bank.name"), 10);
@@ -185,14 +172,13 @@ public class JapanBankTransferForm extends PaymentMethodForm
         bankComboBox = tuple4.fourth;
         bankComboBox.setPromptText(JapanBankData.getString("bank.select"));
         bankComboBox.setButtonCell(getComboBoxButtonCell(JapanBankData.getString("bank.name"), bankComboBox));
-        bankComboBox.getEditor().focusedProperty().addListener(observable -> {
-            bankComboBox.setPromptText("");
-        });
-        bankComboBox.setConverter(new StringConverter<String>() {
+        bankComboBox.getEditor().focusedProperty().addListener(observable -> bankComboBox.setPromptText(""));
+        bankComboBox.setConverter(new StringConverter<>() {
             @Override
             public String toString(String bank) {
                 return bank != null ? bank : "";
             }
+
             public String fromString(String s) {
                 return s != null ? s : "";
             }
@@ -208,8 +194,7 @@ public class JapanBankTransferForm extends PaymentMethodForm
 
             // parse first 4 characters as bank code
             String bankCode = StringUtils.substring(bank, 0, 4);
-            if (bankCode != null)
-            {
+            if (bankCode != null) {
                 // set bank code field to this value
                 bankCodeField.setText(bankCode);
                 // save to payload
@@ -217,26 +202,20 @@ public class JapanBankTransferForm extends PaymentMethodForm
 
                 // parse remainder as bank name
                 String bankNameFull = StringUtils.substringAfter(bank, JapanBankData.SPACE);
-                if (bankNameFull != null)
-                {
-                    // parse beginning as Japanese bank name
-                    String bankNameJa = StringUtils.substringBefore(bankNameFull, JapanBankData.SPACE);
-                    if (bankNameJa != null)
-                    {
-                        // set bank name field to this value
-                        bankComboBox.getEditor().setText(bankNameJa);
-                        // save to payload
-                        japanBankAccount.setBankName(bankNameJa);
-                    }
-                }
+                // parse beginning as Japanese bank name
+                String bankNameJa = StringUtils.substringBefore(bankNameFull, JapanBankData.SPACE);
+                // set bank name field to this value
+                bankComboBox.getEditor().setText(bankNameJa);
+                // save to payload
+                japanBankAccount.setBankName(bankNameJa);
             }
 
 
             updateFromInputs();
         });
-    } // }}}
-    private void addBankBranchInput() // {{{
-    {
+    }
+
+    private void addBankBranchInput() {
         gridRow++;
         Tuple2<InputTextField, InputTextField> tuple2 = addInputTextFieldInputTextField(gridPane, gridRow, JapanBankData.getString("branch.code"), JapanBankData.getString("branch.name"));
 
@@ -259,14 +238,14 @@ public class JapanBankTransferForm extends PaymentMethodForm
             japanBankAccount.setBankBranchName(newValue);
             updateFromInputs();
         });
-    } // }}}
-    private void addBankAccountInput() // {{{
-    {
+    }
+
+    private void addBankAccountInput() {
         gridRow++;
         Tuple2<InputTextField, InputTextField> tuple2 = addInputTextFieldInputTextField(gridPane, gridRow, JapanBankData.getString("account.number"), JapanBankData.getString("account.name"));
 
         // account number
-        bankAccountNumberInputTextField = tuple2.first;
+        InputTextField bankAccountNumberInputTextField = tuple2.first;
         bankAccountNumberInputTextField.setValidator(japanBankAccountNumberValidator);
         bankAccountNumberInputTextField.setPrefWidth(200);
         bankAccountNumberInputTextField.setMaxWidth(200);
@@ -284,9 +263,9 @@ public class JapanBankTransferForm extends PaymentMethodForm
             japanBankAccount.setBankAccountName(newValue);
             updateFromInputs();
         });
-    } // }}}
-    private void addBankAccountTypeInput() // {{{
-    {
+    }
+
+    private void addBankAccountTypeInput() {
         // account currency
         gridRow++;
 
@@ -299,13 +278,13 @@ public class JapanBankTransferForm extends PaymentMethodForm
 
         ToggleGroup toggleGroup = new ToggleGroup();
         Tuple3<Label, RadioButton, RadioButton> tuple3 =
-            addTopLabelRadioButtonRadioButton(
-                gridPane, gridRow, toggleGroup,
-                JapanBankData.getString("account.type.select"),
-                JapanBankData.getString("account.type.futsu"),
-                JapanBankData.getString("account.type.touza"),
-                0
-            );
+                addTopLabelRadioButtonRadioButton(
+                        gridPane, gridRow, toggleGroup,
+                        JapanBankData.getString("account.type.select"),
+                        JapanBankData.getString("account.type.futsu"),
+                        JapanBankData.getString("account.type.touza"),
+                        0
+                );
 
         toggleGroup.getToggles().get(0).setSelected(true);
         japanBankAccount.setBankAccountType(JapanBankData.getString("account.type.futsu.ja"));
@@ -314,66 +293,60 @@ public class JapanBankTransferForm extends PaymentMethodForm
         RadioButton touza = tuple3.third;
 
         toggleGroup.selectedToggleProperty().addListener
-        (
-            (ov, oldValue, newValue) ->
-            {
-                if (futsu.isSelected())
-                    japanBankAccount.setBankAccountType(JapanBankData.getString("account.type.futsu.ja"));
-                if (touza.isSelected())
-                    japanBankAccount.setBankAccountType(JapanBankData.getString("account.type.touza.ja"));
-            }
-        );
-    } // }}}
+                (
+                        (ov, oldValue, newValue) ->
+                        {
+                            if (futsu.isSelected())
+                                japanBankAccount.setBankAccountType(JapanBankData.getString("account.type.futsu.ja"));
+                            if (touza.isSelected())
+                                japanBankAccount.setBankAccountType(JapanBankData.getString("account.type.touza.ja"));
+                        }
+                );
+    }
 
     @Override
-    public void updateFromInputs() // {{{
-    {
+    public void updateFromInputs() {
         System.out.println("JapanBankTransferForm: updateFromInputs()");
-        System.out.println("bankName: "+japanBankAccount.getBankName());
-        System.out.println("bankCode: "+japanBankAccount.getBankCode());
-        System.out.println("bankBranchName: "+japanBankAccount.getBankBranchName());
-        System.out.println("bankBranchCode: "+japanBankAccount.getBankBranchCode());
-        System.out.println("bankAccountType: "+japanBankAccount.getBankAccountType());
-        System.out.println("bankAccountName: "+japanBankAccount.getBankAccountName());
-        System.out.println("bankAccountNumber: "+japanBankAccount.getBankAccountNumber());
+        System.out.println("bankName: " + japanBankAccount.getBankName());
+        System.out.println("bankCode: " + japanBankAccount.getBankCode());
+        System.out.println("bankBranchName: " + japanBankAccount.getBankBranchName());
+        System.out.println("bankBranchCode: " + japanBankAccount.getBankBranchCode());
+        System.out.println("bankAccountType: " + japanBankAccount.getBankAccountType());
+        System.out.println("bankAccountName: " + japanBankAccount.getBankAccountName());
+        System.out.println("bankAccountNumber: " + japanBankAccount.getBankAccountNumber());
         super.updateFromInputs();
-    } // }}}
+    }
 
     @Override
-    protected void autoFillNameTextField() // {{{
-    {
-        if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected())
-        {
+    protected void autoFillNameTextField() {
+        if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected()) {
             accountNameTextField.setText(
                     Res.get(paymentAccount.getPaymentMethod().getId())
-                    .concat(": ")
-                    .concat(japanBankAccount.getBankName())
-                    .concat(" ")
-                    .concat(japanBankAccount.getBankBranchName())
-                    .concat(" ")
-                    .concat(japanBankAccount.getBankAccountNumber())
-                    .concat(" ")
-                    .concat(japanBankAccount.getBankAccountName())
+                            .concat(": ")
+                            .concat(japanBankAccount.getBankName())
+                            .concat(" ")
+                            .concat(japanBankAccount.getBankBranchName())
+                            .concat(" ")
+                            .concat(japanBankAccount.getBankAccountNumber())
+                            .concat(" ")
+                            .concat(japanBankAccount.getBankAccountName())
             );
         }
-    } // }}}
+    }
 
     @Override
-    public void updateAllInputsValid() // {{{
-    {
+    public void updateAllInputsValid() {
         boolean result =
-            (
-                isAccountNameValid() &&
-                inputValidator.validate(japanBankAccount.getBankCode()).isValid &&
-                inputValidator.validate(japanBankAccount.getBankName()).isValid &&
-                japanBankBranchCodeValidator.validate(japanBankAccount.getBankBranchCode()).isValid &&
-                japanBankBranchNameValidator.validate(japanBankAccount.getBankBranchName()).isValid &&
-                japanBankAccountNumberValidator.validate(japanBankAccount.getBankAccountNumber()).isValid &&
-                japanBankAccountNameValidator.validate(japanBankAccount.getBankAccountName()).isValid &&
-                inputValidator.validate(japanBankAccount.getBankAccountType()).isValid
-            );
+                (
+                        isAccountNameValid() &&
+                                inputValidator.validate(japanBankAccount.getBankCode()).isValid &&
+                                inputValidator.validate(japanBankAccount.getBankName()).isValid &&
+                                japanBankBranchCodeValidator.validate(japanBankAccount.getBankBranchCode()).isValid &&
+                                japanBankBranchNameValidator.validate(japanBankAccount.getBankBranchName()).isValid &&
+                                japanBankAccountNumberValidator.validate(japanBankAccount.getBankAccountNumber()).isValid &&
+                                japanBankAccountNameValidator.validate(japanBankAccount.getBankAccountName()).isValid &&
+                                inputValidator.validate(japanBankAccount.getBankAccountType()).isValid
+                );
         allInputsValid.set(result);
-    } // }}}
+    }
 }
-
-// vim:ts=4:sw=4:expandtab:foldmethod=marker:nowrap:

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/MoneyGramForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/MoneyGramForm.java
@@ -37,8 +37,6 @@ import bisq.core.util.validation.InputValidator;
 
 import bisq.common.util.Tuple2;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
@@ -172,11 +170,7 @@ public class MoneyGramForm extends PaymentMethodForm {
 
     @Override
     protected void autoFillNameTextField() {
-        if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected()) {
-            accountNameTextField.setText(Res.get(paymentAccount.getPaymentMethod().getId())
-                    .concat(": ")
-                    .concat(StringUtils.abbreviate(holderNameInputTextField.getText(), 9)));
-        }
+        setAccountNameWithString(holderNameInputTextField.getText());
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -73,6 +73,7 @@ import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.desktop.util.DisplayUtils.createAccountName;
 import static bisq.desktop.util.FormBuilder.*;
 
 @Slf4j
@@ -287,10 +288,8 @@ public abstract class PaymentMethodForm {
 
     void setAccountNameWithString(String name) {
         if (useCustomAccountNameToggleButton != null && !useCustomAccountNameToggleButton.isSelected()) {
-            name = name.trim();
-            name = StringUtils.abbreviate(name, 9);
-            String method = Res.get(paymentAccount.getPaymentMethod().getId());
-            accountNameTextField.setText(method.concat(": ").concat(name));
+            String accountName = createAccountName(paymentAccount.getPaymentMethod().getId(), name);
+            accountNameTextField.setText(accountName);
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
@@ -21,7 +21,6 @@ import bisq.desktop.common.model.ActivatableDataModel;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
-import bisq.core.locale.CryptoCurrency;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.FiatCurrency;
 import bisq.core.locale.TradeCurrency;
@@ -109,22 +108,14 @@ class FiatAccountsDataModel extends ActivatableDataModel {
         TradeCurrency singleTradeCurrency = paymentAccount.getSingleTradeCurrency();
         List<TradeCurrency> tradeCurrencies = paymentAccount.getTradeCurrencies();
         if (singleTradeCurrency != null) {
-            if (singleTradeCurrency instanceof FiatCurrency)
-                preferences.addFiatCurrency((FiatCurrency) singleTradeCurrency);
-            else
-                preferences.addCryptoCurrency((CryptoCurrency) singleTradeCurrency);
+            preferences.addFiatCurrency((FiatCurrency) singleTradeCurrency);
         } else if (tradeCurrencies != null && !tradeCurrencies.isEmpty()) {
             if (tradeCurrencies.contains(CurrencyUtil.getDefaultTradeCurrency()))
                 paymentAccount.setSelectedTradeCurrency(CurrencyUtil.getDefaultTradeCurrency());
             else
                 paymentAccount.setSelectedTradeCurrency(tradeCurrencies.get(0));
 
-            tradeCurrencies.forEach(tradeCurrency -> {
-                if (tradeCurrency instanceof FiatCurrency)
-                    preferences.addFiatCurrency((FiatCurrency) tradeCurrency);
-                else
-                    preferences.addCryptoCurrency((CryptoCurrency) tradeCurrency);
-            });
+            tradeCurrencies.forEach(tradeCurrency -> preferences.addFiatCurrency((FiatCurrency) tradeCurrency));
         }
 
         user.addPaymentAccount(paymentAccount);
@@ -154,9 +145,9 @@ class FiatAccountsDataModel extends ActivatableDataModel {
 
     public void exportAccounts(Stage stage) {
         if (user.getPaymentAccounts() != null) {
-            ArrayList<PaymentAccount> accounts = new ArrayList<>(user.getPaymentAccounts().stream()
+            ArrayList<PaymentAccount> accounts = user.getPaymentAccounts().stream()
                     .filter(paymentAccount -> !(paymentAccount instanceof AssetAccount))
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toCollection(ArrayList::new));
             GUIUtil.exportAccounts(accounts, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler);
         }
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -520,7 +520,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
             case PaymentMethod.SPECIFIC_BANKS_ID:
                 return new SpecificBankForm(paymentAccount, accountAgeWitnessService, inputValidator, root, gridRow, formatter);
             case PaymentMethod.JAPAN_BANK_ID:
-                return new JapanBankTransferForm(paymentAccount, accountAgeWitnessService, japanBankTransferValidator, inputValidator, root, gridRow, formatter);
+                return new JapanBankTransferForm(paymentAccount, accountAgeWitnessService, inputValidator, root, gridRow, formatter);
             case PaymentMethod.AUSTRALIA_PAYID_ID:
                 return new AustraliaPayidForm(paymentAccount, accountAgeWitnessService, australiapayidValidator, inputValidator, root, gridRow, formatter);
             case PaymentMethod.ALI_PAY_ID:

--- a/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
@@ -176,7 +176,9 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
         root.getSelectionModel().selectedItemProperty().addListener(tabChangeListener);
         root.getTabs().addListener(tabListChangeListener);
         navigation.addListener(navigationListener);
-        navigation.navigateTo(MainView.class, this.getClass(), OfferBookView.class);
+        if (offerBookView == null) {
+            navigation.navigateTo(MainView.class, this.getClass(), OfferBookView.class);
+        }
     }
 
     @Override
@@ -202,17 +204,21 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
         View view;
         boolean isBuy = direction == OfferDirection.BUY;
 
-        if (viewClass == OfferBookView.class && offerBookView == null) {
-            view = viewLoader.load(viewClass);
-            // Offerbook must not be cached by ViewLoader as we use 2 instances for sell and buy screens.
-            offerBookTab = new Tab(isBuy ? Res.get("shared.buyBitcoin").toUpperCase() : Res.get("shared.sellBitcoin").toUpperCase());
-            offerBookTab.setClosable(false);
-            offerBookTab.setContent(view.getRoot());
-            tabPane.getTabs().add(offerBookTab);
-            offerBookView = (OfferBookView) view;
-            offerBookView.onTabSelected(true);
-            offerBookView.setOfferActionHandler(offerActionHandler);
-            offerBookView.setDirection(direction);
+        if (viewClass == OfferBookView.class) {
+            if (offerBookTab != null && offerBookView != null) {
+                tabPane.getSelectionModel().select(offerBookTab);
+            } else {
+                view = viewLoader.load(viewClass);
+                // Offerbook must not be cached by ViewLoader as we use 2 instances for sell and buy screens.
+                offerBookTab = new Tab(isBuy ? Res.get("shared.buyBitcoin").toUpperCase() : Res.get("shared.sellBitcoin").toUpperCase());
+                offerBookTab.setClosable(false);
+                offerBookTab.setContent(view.getRoot());
+                tabPane.getTabs().add(offerBookTab);
+                offerBookView = (OfferBookView) view;
+                offerBookView.onTabSelected(true);
+                offerBookView.setOfferActionHandler(offerActionHandler);
+                offerBookView.setDirection(direction);
+            }
         } else if (viewClass == CreateOfferView.class && createOfferView == null) {
             view = viewLoader.load(viewClass);
             // CreateOffer and TakeOffer must not be cached by ViewLoader as we cannot use a view multiple times

--- a/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
@@ -253,7 +253,7 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
             // in different graphs
             takeOfferView = (TakeOfferView) view;
             takeOfferView.initWithData(offer);
-            takeOfferPane = ((TakeOfferView) view).getRoot();
+            takeOfferPane = takeOfferView.getRoot();
             takeOfferTab = new Tab(getTakeOfferTabName());
             takeOfferTab.setClosable(true);
             // close handler from close on take offer action

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferDataModel.java
@@ -781,6 +781,10 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
         return offerUtil.isBsqForMakerFeeAvailable(amount.get());
     }
 
+    boolean isBuyBsqOffer() {
+        return !isBuyOffer() && getTradeCurrency().getCode().equals("BSQ");
+    }
+
     boolean canPlaceOffer() {
         return GUIUtil.isBootstrappedOrShowPopup(p2PService) &&
                 GUIUtil.canCreateOrTakeOfferOrShowPopup(user, navigation, tradeCurrency);

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferDataModel.java
@@ -781,7 +781,9 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
         return offerUtil.isBsqForMakerFeeAvailable(amount.get());
     }
 
-    boolean isBuyBsqOffer() {
+    boolean isAttemptToBuyBsq() {
+        // When you buy an asset you actually sell BTC.
+        // This is why an offer to buy BSQ is actually an offer to sell BTC for BSQ.
         return !isBuyOffer() && getTradeCurrency().getCode().equals("BSQ");
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -900,7 +900,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBtcToggle.setVisible(newValue);
                 tradeFeeInBsqToggle.setVisible(newValue);
-                if (!(newValue && model.dataModel.isBsqForFeeAvailable())) {
+                if (model.isShowBuyBsqHint()) {
                     buyBsqButton.setVisible(newValue);
                 }
             }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -899,7 +899,9 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBtcToggle.setVisible(newValue);
                 tradeFeeInBsqToggle.setVisible(newValue);
-                buyBsqButton.setVisible(newValue);
+                if (!(newValue && model.dataModel.isBsqForFeeAvailable())) {
+                    buyBsqButton.setVisible(newValue);
+                }
             }
         };
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -168,7 +168,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private ChangeListener<String> tradeCurrencyCodeListener, errorMessageListener,
             marketPriceMarginListener, volumeListener, buyerSecurityDepositInBTCListener;
     private ChangeListener<Number> marketPriceAvailableListener;
-    private Navigation.Listener navigationWithCloseListener;
+    private Navigation.Listener closeViewListener;
     private EventHandler<ActionEvent> currencyComboBoxSelectionHandler, paymentAccountsComboBoxSelectionHandler;
     private OfferView.CloseHandler closeHandler;
 
@@ -914,10 +914,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             }
         });
 
-        navigationWithCloseListener = (path, data) -> {
-            log.warn("*** target path={}, data={}, dir={}", path, data, model.getDataModel().getDirection());
-            if ("closeOfferView".equals(data)) {
-                log.warn("*** WILL CLOSE");
+        closeViewListener = (path, data) -> {
+            if (OfferViewUtil.isCloseView((String) data)) {
                 close();
             }
         };
@@ -978,7 +976,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         paymentAccountsComboBox.setOnAction(paymentAccountsComboBoxSelectionHandler);
         currencyComboBox.setOnAction(currencyComboBoxSelectionHandler);
 
-        navigation.addListener(navigationWithCloseListener);
+        navigation.addListener(closeViewListener);
     }
 
     private void removeListeners() {
@@ -1015,7 +1013,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         paymentAccountsComboBox.setOnAction(null);
         currencyComboBox.setOnAction(null);
 
-        navigation.removeListener(navigationWithCloseListener);
+        navigation.removeListener(closeViewListener);
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -168,6 +168,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private ChangeListener<String> tradeCurrencyCodeListener, errorMessageListener,
             marketPriceMarginListener, volumeListener, buyerSecurityDepositInBTCListener;
     private ChangeListener<Number> marketPriceAvailableListener;
+    private Navigation.Listener navigationWithCloseListener;
     private EventHandler<ActionEvent> currencyComboBoxSelectionHandler, paymentAccountsComboBoxSelectionHandler;
     private OfferView.CloseHandler closeHandler;
 
@@ -916,6 +917,14 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 buyerSecurityDepositInputTextField.setDisable(false);
             }
         });
+
+        navigationWithCloseListener = (path, data) -> {
+            log.warn("*** target path={}, data={}, dir={}", path, data, model.getDataModel().getDirection());
+            if ("closeOfferView".equals(data)) {
+                log.warn("*** WILL CLOSE");
+                close();
+            }
+        };
     }
 
     private void setIsCurrencyForMakerFeeBtc(boolean isCurrencyForMakerFeeBtc) {
@@ -972,6 +981,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         // UI actions
         paymentAccountsComboBox.setOnAction(paymentAccountsComboBoxSelectionHandler);
         currencyComboBox.setOnAction(currencyComboBoxSelectionHandler);
+
+        navigation.addListener(navigationWithCloseListener);
     }
 
     private void removeListeners() {
@@ -1007,6 +1018,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         // UI actions
         paymentAccountsComboBox.setOnAction(null);
         currencyComboBox.setOnAction(null);
+
+        navigation.removeListener(navigationWithCloseListener);
     }
 
 
@@ -1118,7 +1131,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         GridPane.setMargin(advancedOptionsBox, new Insets(Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE, 0, 0, 0));
         gridPane.getChildren().add(advancedOptionsBox);
 
-        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(navigation, preferences);
+        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
+                navigation, preferences, model.dataModel::getDirection);
         buyBsqButton = buyBsqButtonBox.first;
         buyBsqButton.setVisible(false);
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -137,7 +137,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private TitledGroupBg payFundsTitledGroupBg, setDepositTitledGroupBg, paymentTitledGroupBg;
     protected TitledGroupBg amountTitledGroupBg;
     private BusyAnimation waitingForFundsSpinner;
-    private AutoTooltipButton nextButton, cancelButton1, cancelButton2, placeOfferButton, buyBsqButton;
+    private AutoTooltipButton nextButton, cancelButton1, cancelButton2, placeOfferButton;
     private Button priceTypeToggleButton;
     private InputTextField fixedPriceTextField, marketBasedPriceTextField, triggerPriceInputTextField;
     protected InputTextField amountTextField, minAmountTextField, volumeTextField, buyerSecurityDepositInputTextField;
@@ -153,7 +153,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private ComboBox<PaymentAccount> paymentAccountsComboBox;
     private ComboBox<TradeCurrency> currencyComboBox;
     private ImageView qrCodeImageView;
-    private VBox currencySelection, fixedPriceBox, percentagePriceBox, currencyTextFieldBox, triggerPriceVBox;
+    private VBox currencySelection, fixedPriceBox, percentagePriceBox, currencyTextFieldBox, triggerPriceVBox, buyBsqBox;
     private HBox fundingHBox, firstRowHBox, secondRowHBox, placeOfferBox, amountValueCurrencyBox,
             priceAsPercentageValueCurrencyBox, volumeValueCurrencyBox, priceValueCurrencyBox,
             minAmountValueCurrencyBox, advancedOptionsBox, triggerPriceHBox;
@@ -270,8 +270,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 tradeFeeInBtcToggle.setManaged(false);
                 tradeFeeInBsqToggle.setVisible(false);
                 tradeFeeInBsqToggle.setManaged(false);
-                buyBsqButton.setVisible(false);
-                buyBsqButton.setManaged(false);
+                buyBsqBox.setVisible(false);
+                buyBsqBox.setManaged(false);
             }
 
             Label popOverLabel = OfferViewUtil.createPopOverLabel(Res.get("createOffer.triggerPrice.tooltip"));
@@ -405,9 +405,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         cancelButton1.setVisible(false);
         cancelButton1.setManaged(false);
         cancelButton1.setOnAction(null);
-        buyBsqButton.setVisible(false);
-        buyBsqButton.setManaged(false);
-        buyBsqButton.setOnAction(null);
+        buyBsqBox.setVisible(false);
+        buyBsqBox.setManaged(false);
 
         tradeFeeInBtcToggle.setMouseTransparent(true);
         tradeFeeInBsqToggle.setMouseTransparent(true);
@@ -896,7 +895,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 tradeFeeInBtcToggle.setVisible(newValue);
                 tradeFeeInBsqToggle.setVisible(newValue);
                 if (model.isShowBuyBsqHint()) {
-                    buyBsqButton.setVisible(newValue);
+                    buyBsqBox.setVisible(newValue);
                 }
             }
         };
@@ -1102,10 +1101,10 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
                 navigation, preferences);
-        buyBsqButton = buyBsqButtonBox.first;
-        buyBsqButton.setVisible(false);
+        buyBsqBox = buyBsqButtonBox.second;
+        buyBsqBox.setVisible(false);
 
-        advancedOptionsBox.getChildren().addAll(getBuyerSecurityDepositBox(), getTradeFeeFieldsBox(), buyBsqButtonBox.second);
+        advancedOptionsBox.getChildren().addAll(getBuyerSecurityDepositBox(), getTradeFeeFieldsBox(), buyBsqBox);
 
         Tuple2<Button, Button> tuple = add2ButtonsAfterGroup(gridPane, ++gridRow,
                 Res.get("shared.nextStep"), Res.get("shared.cancel"));

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -274,6 +274,11 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 buyBsqBox.setManaged(false);
             }
 
+            if (!model.isShowBuyBsqHint()) {
+                buyBsqBox.setVisible(false);
+                buyBsqBox.setManaged(false);
+            }
+
             Label popOverLabel = OfferViewUtil.createPopOverLabel(Res.get("createOffer.triggerPrice.tooltip"));
             triggerPriceInfoInputTextField.setContentForPopOver(popOverLabel, AwesomeIcon.SHIELD);
         }
@@ -405,11 +410,11 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         cancelButton1.setVisible(false);
         cancelButton1.setManaged(false);
         cancelButton1.setOnAction(null);
-        buyBsqBox.setVisible(false);
-        buyBsqBox.setManaged(false);
 
         tradeFeeInBtcToggle.setMouseTransparent(true);
         tradeFeeInBsqToggle.setMouseTransparent(true);
+        buyBsqBox.setVisible(false);
+        buyBsqBox.setManaged(false);
 
         setDepositTitledGroupBg.setVisible(false);
         setDepositTitledGroupBg.setManaged(false);
@@ -896,6 +901,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 tradeFeeInBsqToggle.setVisible(newValue);
                 if (model.isShowBuyBsqHint()) {
                     buyBsqBox.setVisible(newValue);
+                    buyBsqBox.setManaged(newValue);
                 }
             }
         };
@@ -1102,6 +1108,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
                 navigation, preferences);
         buyBsqBox = buyBsqButtonBox.second;
+        buyBsqBox.setManaged(false);
         buyBsqBox.setVisible(false);
 
         advancedOptionsBox.getChildren().addAll(getBuyerSecurityDepositBox(), getTradeFeeFieldsBox(), buyBsqBox);

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -121,8 +121,8 @@ import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import static bisq.core.payment.payload.PaymentMethod.HAL_CASH_ID;
+import static bisq.desktop.main.offer.OfferViewUtil.addPayInfoEntry;
 import static bisq.desktop.util.FormBuilder.*;
-import static bisq.desktop.util.GUIUtil.addPayInfoEntry;
 import static javafx.beans.binding.Bindings.createStringBinding;
 
 public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> extends ActivatableViewAndModel<AnchorPane, M> {
@@ -526,7 +526,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
     private void maybeShowAccountWarning(PaymentAccount paymentAccount, boolean isBuyer) {
         String msgKey = paymentAccount.getPreTradeMessage(isBuyer);
-        GUIUtil.showPaymentAccountWarning(msgKey, paymentAccountWarningDisplayed);
+        OfferViewUtil.showPaymentAccountWarning(msgKey, paymentAccountWarningDisplayed);
     }
 
     protected void onPaymentAccountsComboBoxSelected() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -168,7 +168,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private ChangeListener<String> tradeCurrencyCodeListener, errorMessageListener,
             marketPriceMarginListener, volumeListener, buyerSecurityDepositInBTCListener;
     private ChangeListener<Number> marketPriceAvailableListener;
-    private Navigation.Listener closeViewListener;
     private EventHandler<ActionEvent> currencyComboBoxSelectionHandler, paymentAccountsComboBoxSelectionHandler;
     private OfferView.CloseHandler closeHandler;
 
@@ -913,12 +912,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 buyerSecurityDepositInputTextField.setDisable(false);
             }
         });
-
-        closeViewListener = (path, data) -> {
-            if (OfferViewUtil.isCloseView((String) data)) {
-                close();
-            }
-        };
     }
 
     private void setIsCurrencyForMakerFeeBtc(boolean isCurrencyForMakerFeeBtc) {
@@ -975,8 +968,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         // UI actions
         paymentAccountsComboBox.setOnAction(paymentAccountsComboBoxSelectionHandler);
         currencyComboBox.setOnAction(currencyComboBoxSelectionHandler);
-
-        navigation.addListener(closeViewListener);
     }
 
     private void removeListeners() {
@@ -1012,8 +1003,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         // UI actions
         paymentAccountsComboBox.setOnAction(null);
         currencyComboBox.setOnAction(null);
-
-        navigation.removeListener(closeViewListener);
     }
 
 
@@ -1112,7 +1101,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         gridPane.getChildren().add(advancedOptionsBox);
 
         Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
-                navigation, preferences, model.dataModel::getDirection);
+                navigation, preferences);
         buyBsqButton = buyBsqButtonBox.first;
         buyBsqButton.setVisible(false);
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -338,7 +338,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             showInsufficientBsqFundsForBtcFeePaymentPopup();
     }
 
-    // called form parent as the view does not get notified when the tab is closed
+    // called from parent as the view does not get notified when the tab is closed
     public void onClose() {
         // we use model.placeOfferCompleted to not react on close which was triggered by a successful placeOffer
         if (model.getDataModel().getBalance().get().isPositive() && !model.placeOfferCompleted.get()) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -121,7 +121,7 @@ import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import static bisq.core.payment.payload.PaymentMethod.HAL_CASH_ID;
-import static bisq.desktop.main.offer.OfferViewUtil.addPayInfoEntry;
+import static bisq.desktop.main.offer.bisq_v1.OfferViewUtil.addPayInfoEntry;
 import static bisq.desktop.util.FormBuilder.*;
 import static javafx.beans.binding.Bindings.createStringBinding;
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -153,10 +153,10 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private ComboBox<PaymentAccount> paymentAccountsComboBox;
     private ComboBox<TradeCurrency> currencyComboBox;
     private ImageView qrCodeImageView;
-    private VBox currencySelection, fixedPriceBox, percentagePriceBox, currencyTextFieldBox, triggerPriceVBox, buyBsqBox;
+    private VBox currencySelection, fixedPriceBox, percentagePriceBox, currencyTextFieldBox, triggerPriceVBox;
     private HBox fundingHBox, firstRowHBox, secondRowHBox, placeOfferBox, amountValueCurrencyBox,
             priceAsPercentageValueCurrencyBox, volumeValueCurrencyBox, priceValueCurrencyBox,
-            minAmountValueCurrencyBox, advancedOptionsBox, triggerPriceHBox;
+            minAmountValueCurrencyBox, advancedOptionsBox, triggerPriceHBox, buyBsqBox;
 
     private Subscription isWaitingForFundsSubscription, balanceSubscription;
     private ChangeListener<Boolean> amountFocusedListener, minAmountFocusedListener, volumeFocusedListener,
@@ -1100,18 +1100,21 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         advancedOptionsBox.setSpacing(40);
 
         GridPane.setRowIndex(advancedOptionsBox, gridRow);
+        GridPane.setColumnSpan(advancedOptionsBox, GridPane.REMAINING);
         GridPane.setColumnIndex(advancedOptionsBox, 0);
         GridPane.setHalignment(advancedOptionsBox, HPos.LEFT);
         GridPane.setMargin(advancedOptionsBox, new Insets(Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE, 0, 0, 0));
         gridPane.getChildren().add(advancedOptionsBox);
 
-        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
+        Tuple2<AutoTooltipButton, HBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
                 navigation, preferences);
         buyBsqBox = buyBsqButtonBox.second;
         buyBsqBox.setManaged(false);
         buyBsqBox.setVisible(false);
 
-        advancedOptionsBox.getChildren().addAll(getBuyerSecurityDepositBox(), getTradeFeeFieldsBox(), buyBsqBox);
+        VBox tradeFeeFieldsBox = getTradeFeeFieldsBox();
+        tradeFeeFieldsBox.setMinWidth(240);
+        advancedOptionsBox.getChildren().addAll(getBuyerSecurityDepositBox(), tradeFeeFieldsBox, buyBsqBox);
 
         Tuple2<Button, Button> tuple = add2ButtonsAfterGroup(gridPane, ++gridRow,
                 Res.get("shared.nextStep"), Res.get("shared.cancel"));

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -137,7 +137,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private TitledGroupBg payFundsTitledGroupBg, setDepositTitledGroupBg, paymentTitledGroupBg;
     protected TitledGroupBg amountTitledGroupBg;
     private BusyAnimation waitingForFundsSpinner;
-    private AutoTooltipButton nextButton, cancelButton1, cancelButton2, placeOfferButton;
+    private AutoTooltipButton nextButton, cancelButton1, cancelButton2, placeOfferButton, buyBsqButton;
     private Button priceTypeToggleButton;
     private InputTextField fixedPriceTextField, marketBasedPriceTextField, triggerPriceInputTextField;
     protected InputTextField amountTextField, minAmountTextField, volumeTextField, buyerSecurityDepositInputTextField;
@@ -270,6 +270,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 tradeFeeInBtcToggle.setManaged(false);
                 tradeFeeInBsqToggle.setVisible(false);
                 tradeFeeInBsqToggle.setManaged(false);
+                buyBsqButton.setVisible(false);
+                buyBsqButton.setManaged(false);
             }
 
             Label popOverLabel = OfferViewUtil.createPopOverLabel(Res.get("createOffer.triggerPrice.tooltip"));
@@ -397,6 +399,9 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         cancelButton1.setVisible(false);
         cancelButton1.setManaged(false);
         cancelButton1.setOnAction(null);
+        buyBsqButton.setVisible(false);
+        buyBsqButton.setManaged(false);
+        buyBsqButton.setOnAction(null);
 
         tradeFeeInBtcToggle.setMouseTransparent(true);
         tradeFeeInBsqToggle.setMouseTransparent(true);
@@ -894,6 +899,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBtcToggle.setVisible(newValue);
                 tradeFeeInBsqToggle.setVisible(newValue);
+                buyBsqButton.setVisible(newValue);
             }
         };
 
@@ -1110,7 +1116,11 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         GridPane.setMargin(advancedOptionsBox, new Insets(Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE, 0, 0, 0));
         gridPane.getChildren().add(advancedOptionsBox);
 
-        advancedOptionsBox.getChildren().addAll(getBuyerSecurityDepositBox(), getTradeFeeFieldsBox());
+        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(navigation, preferences);
+        buyBsqButton = buyBsqButtonBox.first;
+        buyBsqButton.setVisible(false);
+
+        advancedOptionsBox.getChildren().addAll(getBuyerSecurityDepositBox(), getTradeFeeFieldsBox(), buyBsqButtonBox.second);
 
         Tuple2<Button, Button> tuple = add2ButtonsAfterGroup(gridPane, ++gridRow,
                 Res.get("shared.nextStep"), Res.get("shared.cancel"));

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
@@ -1355,4 +1355,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             }
         }
     }
+
+    public boolean isShowBuyBsqHint() {
+        return !dataModel.isBsqForFeeAvailable() && !dataModel.isBuyBsqOffer();
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
@@ -678,11 +678,10 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         updateSpinnerInfo();
     }
 
-    boolean fundFromSavingsWallet() {
+    void fundFromSavingsWallet() {
         dataModel.fundFromSavingsWallet();
         if (dataModel.getIsBtcWalletFunded().get()) {
             updateButtonDisableState();
-            return true;
         } else {
             new Popup().warning(Res.get("shared.notEnoughFunds",
                             btcFormatter.formatCoinWithCode(dataModel.totalToPayAsCoinProperty().get()),
@@ -690,7 +689,6 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                     .actionButtonTextWithGoTo("navigation.funds.depositFunds")
                     .onAction(() -> navigation.navigateTo(MainView.class, FundsView.class, DepositView.class))
                     .show();
-            return false;
         }
 
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
@@ -1355,6 +1355,6 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     }
 
     public boolean isShowBuyBsqHint() {
-        return !dataModel.isBsqForFeeAvailable() && !dataModel.isBuyBsqOffer();
+        return !dataModel.isBsqForFeeAvailable() && !dataModel.isAttemptToBuyBsq();
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -22,6 +22,7 @@ import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.main.MainView;
+import bisq.desktop.main.offer.SellOfferView;
 import bisq.desktop.main.offer.offerbook.OfferBookView;
 import bisq.desktop.main.overlays.popups.Popup;
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.offer.bisq_v1;
 
 import bisq.desktop.Navigation;
 import bisq.desktop.components.AutoTooltipButton;
+import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.offer.offerbook.OfferBookView;
 import bisq.desktop.main.overlays.popups.Popup;
@@ -27,14 +28,21 @@ import bisq.core.locale.Res;
 import bisq.core.offer.OfferPayload;
 import bisq.core.user.Preferences;
 
+import bisq.common.UserThread;
 import bisq.common.util.Tuple2;
 
 import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 
 // Shared utils for Views
 public class OfferViewUtil {
@@ -45,6 +53,33 @@ public class OfferViewUtil {
         label.setLineSpacing(1);
         label.setPadding(new Insets(10));
         return label;
+    }
+
+    public static void showPaymentAccountWarning(String msgKey,
+                                                 HashMap<String, Boolean> paymentAccountWarningDisplayed) {
+        if (msgKey == null || paymentAccountWarningDisplayed.getOrDefault(msgKey, false)) {
+            return;
+        }
+        paymentAccountWarningDisplayed.put(msgKey, true);
+        UserThread.runAfter(() -> {
+            new Popup().information(Res.get(msgKey))
+                    .width(900)
+                    .closeButtonText(Res.get("shared.iConfirm"))
+                    .dontShowAgainId(msgKey)
+                    .show();
+        }, 500, TimeUnit.MILLISECONDS);
+    }
+
+    public static void addPayInfoEntry(GridPane infoGridPane, int row, String labelText, String value) {
+        Label label = new AutoTooltipLabel(labelText);
+        TextField textField = new TextField(value);
+        textField.setMinWidth(500);
+        textField.setEditable(false);
+        textField.setFocusTraversable(false);
+        textField.setId("payment-info");
+        GridPane.setConstraints(label, 0, row, 1, 1, HPos.RIGHT, VPos.CENTER);
+        GridPane.setConstraints(textField, 1, row);
+        infoGridPane.getChildren().addAll(label, textField);
     }
 
     public interface DirectionClosure {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -24,6 +24,7 @@ import bisq.desktop.main.offer.offerbook.OfferBookView;
 import bisq.desktop.main.overlays.popups.Popup;
 
 import bisq.core.locale.Res;
+import bisq.core.offer.OfferPayload;
 import bisq.core.user.Preferences;
 
 import bisq.common.util.Tuple2;
@@ -46,7 +47,13 @@ public class OfferViewUtil {
         return label;
     }
 
-    public static Tuple2<AutoTooltipButton, VBox> createBuyBsqButtonBox(Navigation navigation, Preferences preferences) {
+    public interface DirectionClosure {
+        OfferPayload.Direction getDirection();
+    }
+
+    public static Tuple2<AutoTooltipButton, VBox> createBuyBsqButtonBox(Navigation navigation,
+                                                                        Preferences preferences,
+                                                                        DirectionClosure directionClosure) {
         String buyBsqText = Res.get("shared.buyCurrency", "BSQ");
         var buyBsqButton = new AutoTooltipButton(buyBsqText);
         buyBsqButton.getStyleClass().add("action-button");
@@ -57,7 +64,10 @@ public class OfferViewUtil {
                 .buttonAlignment(HPos.CENTER)
                 .onAction(() -> {
                     preferences.setSellScreenCurrencyCode("BSQ");
-                    navigation.navigateTo(MainView.class, SellOfferView.class, OfferBookView.class);
+                    navigation.navigateToWithData(
+                            // FIXME: replace "closeOfferView" with a more unique object?
+                            directionClosure.getDirection() == OfferPayload.Direction.SELL ? "closeOfferView" : null,
+                            MainView.class, SellOfferView.class, OfferBookView.class);
                 }).show());
 
         final VBox buyBsqButtonVBox = new VBox(buyBsqButton);

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -36,7 +36,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.VBox;
 
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
@@ -85,12 +84,13 @@ public class OfferViewUtil {
         infoGridPane.getChildren().addAll(label, textField);
     }
 
-    public static Tuple2<AutoTooltipButton, VBox> createBuyBsqButtonBox(Navigation navigation,
+    public static Tuple2<AutoTooltipButton, HBox> createBuyBsqButtonBox(Navigation navigation,
                                                                         Preferences preferences) {
         String buyBsqText = Res.get("shared.buyCurrency", "BSQ");
         var buyBsqButton = new AutoTooltipButton(buyBsqText);
         buyBsqButton.getStyleClass().add("action-button");
         buyBsqButton.getStyleClass().add("tiny-button");
+        buyBsqButton.setMinWidth(60);
         buyBsqButton.setOnAction(e -> openBuyBsqOfferBook(navigation, preferences)
         );
 
@@ -101,17 +101,14 @@ public class OfferViewUtil {
                 .actionButtonText(buyBsqText)
                 .buttonAlignment(HPos.CENTER)
                 .onAction(() -> openBuyBsqOfferBook(navigation, preferences)).show());
+        learnMore.setMinWidth(100);
 
-        final HBox buyBsqBox = new HBox(buyBsqButton, info, learnMore);
+        HBox buyBsqBox = new HBox(buyBsqButton, info, learnMore);
         buyBsqBox.setAlignment(Pos.BOTTOM_LEFT);
         buyBsqBox.setSpacing(10);
+        buyBsqBox.setPadding(new Insets(0, 0, 4, -20));
 
-        final VBox buyBsqButtonVBox = new VBox(buyBsqBox);
-        buyBsqButtonVBox.setAlignment(Pos.BOTTOM_LEFT);
-        buyBsqButtonVBox.setPadding(new Insets(0, 0, 0, -20));
-        VBox.setMargin(buyBsqButton, new Insets(0, 0, 4, 0));
-
-        return new Tuple2<>(buyBsqButton, buyBsqButtonVBox);
+        return new Tuple2<>(buyBsqButton, buyBsqBox);
     }
 
     private static void openBuyBsqOfferBook(Navigation navigation, Preferences preferences) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -17,9 +17,23 @@
 
 package bisq.desktop.main.offer.bisq_v1;
 
-import javafx.scene.control.Label;
+import bisq.desktop.Navigation;
+import bisq.desktop.components.AutoTooltipButton;
+import bisq.desktop.main.MainView;
+import bisq.desktop.main.offer.offerbook.OfferBookView;
+import bisq.desktop.main.overlays.popups.Popup;
 
+import bisq.core.locale.Res;
+import bisq.core.user.Preferences;
+
+import bisq.common.util.Tuple2;
+
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+
+import javafx.geometry.HPos;
 import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 
 // Shared utils for Views
 public class OfferViewUtil {
@@ -30,5 +44,27 @@ public class OfferViewUtil {
         label.setLineSpacing(1);
         label.setPadding(new Insets(10));
         return label;
+    }
+
+    public static Tuple2<AutoTooltipButton, VBox> createBuyBsqButtonBox(Navigation navigation, Preferences preferences) {
+        String buyBsqText = Res.get("shared.buyCurrency", "BSQ");
+        var buyBsqButton = new AutoTooltipButton(buyBsqText);
+        buyBsqButton.getStyleClass().add("action-button");
+        buyBsqButton.setStyle("-fx-pref-height: 20; -fx-padding: 3 8 3 8; -fx-font-size: 0.769em; -fx-border-radius: 5;");
+        buyBsqButton.setOnAction(e -> new Popup().headLine(buyBsqText)
+                .information(Res.get("createOffer.buyBsq.popupMessage"))
+                .actionButtonText(buyBsqText)
+                .buttonAlignment(HPos.CENTER)
+                .onAction(() -> {
+                    preferences.setSellScreenCurrencyCode("BSQ");
+                    navigation.navigateTo(MainView.class, SellOfferView.class, OfferBookView.class);
+                }).show());
+
+        final VBox buyBsqButtonVBox = new VBox(buyBsqButton);
+        buyBsqButtonVBox.setAlignment(Pos.BOTTOM_LEFT);
+        buyBsqButtonVBox.setPadding(new Insets(0, 0, 0, -20));
+        VBox.setMargin(buyBsqButton, new Insets(0, 0, 4, 0));
+
+        return new Tuple2<>(buyBsqButton, buyBsqButtonVBox);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -46,6 +46,9 @@ import java.util.concurrent.TimeUnit;
 
 // Shared utils for Views
 public class OfferViewUtil {
+
+    public static final String CLOSE_VIEW = "closeView";
+
     public static Label createPopOverLabel(String text) {
         final Label label = new Label(text);
         label.setPrefWidth(300);
@@ -101,7 +104,7 @@ public class OfferViewUtil {
                     preferences.setSellScreenCurrencyCode("BSQ");
                     navigation.navigateToWithData(
                             // FIXME: replace "closeOfferView" with a more unique object?
-                            directionClosure.getDirection() == OfferPayload.Direction.SELL ? "closeOfferView" : null,
+                            directionClosure.getDirection() == OfferPayload.Direction.SELL ? CLOSE_VIEW : null,
                             MainView.class, SellOfferView.class, OfferBookView.class);
                 }).show());
 
@@ -111,5 +114,9 @@ public class OfferViewUtil {
         VBox.setMargin(buyBsqButton, new Insets(0, 0, 4, 0));
 
         return new Tuple2<>(buyBsqButton, buyBsqButtonVBox);
+    }
+
+    public static boolean isCloseView(String data) {
+        return CLOSE_VIEW.equals(data);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -25,7 +25,6 @@ import bisq.desktop.main.offer.offerbook.OfferBookView;
 import bisq.desktop.main.overlays.popups.Popup;
 
 import bisq.core.locale.Res;
-import bisq.core.offer.OfferPayload;
 import bisq.core.user.Preferences;
 
 import bisq.common.UserThread;
@@ -46,8 +45,6 @@ import java.util.concurrent.TimeUnit;
 
 // Shared utils for Views
 public class OfferViewUtil {
-
-    public static final String CLOSE_VIEW = "closeView";
 
     public static Label createPopOverLabel(String text) {
         final Label label = new Label(text);
@@ -85,13 +82,8 @@ public class OfferViewUtil {
         infoGridPane.getChildren().addAll(label, textField);
     }
 
-    public interface DirectionClosure {
-        OfferPayload.Direction getDirection();
-    }
-
     public static Tuple2<AutoTooltipButton, VBox> createBuyBsqButtonBox(Navigation navigation,
-                                                                        Preferences preferences,
-                                                                        DirectionClosure directionClosure) {
+                                                                        Preferences preferences) {
         String buyBsqText = Res.get("shared.buyCurrency", "BSQ");
         var buyBsqButton = new AutoTooltipButton(buyBsqText);
         buyBsqButton.getStyleClass().add("action-button");
@@ -102,9 +94,7 @@ public class OfferViewUtil {
                 .buttonAlignment(HPos.CENTER)
                 .onAction(() -> {
                     preferences.setSellScreenCurrencyCode("BSQ");
-                    navigation.navigateToWithData(
-                            // FIXME: replace "closeOfferView" with a more unique object?
-                            directionClosure.getDirection() == OfferPayload.Direction.SELL ? CLOSE_VIEW : null,
+                    navigation.navigateTo(
                             MainView.class, SellOfferView.class, OfferBookView.class);
                 }).show());
 
@@ -114,9 +104,5 @@ public class OfferViewUtil {
         VBox.setMargin(buyBsqButton, new Insets(0, 0, 4, 0));
 
         return new Tuple2<>(buyBsqButton, buyBsqButtonVBox);
-    }
-
-    public static boolean isCloseView(String data) {
-        return CLOSE_VIEW.equals(data);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -50,7 +50,7 @@ public class OfferViewUtil {
         String buyBsqText = Res.get("shared.buyCurrency", "BSQ");
         var buyBsqButton = new AutoTooltipButton(buyBsqText);
         buyBsqButton.getStyleClass().add("action-button");
-        buyBsqButton.setStyle("-fx-pref-height: 20; -fx-padding: 3 8 3 8; -fx-font-size: 0.769em; -fx-border-radius: 5;");
+        buyBsqButton.getStyleClass().add("tiny-button");
         buyBsqButton.setOnAction(e -> new Popup().headLine(buyBsqText)
                 .information(Res.get("createOffer.buyBsq.popupMessage"))
                 .actionButtonText(buyBsqText)

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/OfferViewUtil.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.offer.bisq_v1;
 import bisq.desktop.Navigation;
 import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.AutoTooltipLabel;
+import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.offer.offerbook.OfferBookView;
 import bisq.desktop.main.overlays.popups.Popup;
@@ -33,6 +34,7 @@ import bisq.common.util.Tuple2;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
 import javafx.geometry.HPos;
@@ -88,21 +90,32 @@ public class OfferViewUtil {
         var buyBsqButton = new AutoTooltipButton(buyBsqText);
         buyBsqButton.getStyleClass().add("action-button");
         buyBsqButton.getStyleClass().add("tiny-button");
-        buyBsqButton.setOnAction(e -> new Popup().headLine(buyBsqText)
+        buyBsqButton.setOnAction(e -> openBuyBsqOfferBook(navigation, preferences)
+        );
+
+        var info = new AutoTooltipLabel("BSQ is colored BTC that helps fund Bisq developers.");
+        var learnMore = new HyperlinkWithIcon("Learn More");
+        learnMore.setOnAction(e -> new Popup().headLine(buyBsqText)
                 .information(Res.get("createOffer.buyBsq.popupMessage"))
                 .actionButtonText(buyBsqText)
                 .buttonAlignment(HPos.CENTER)
-                .onAction(() -> {
-                    preferences.setSellScreenCurrencyCode("BSQ");
-                    navigation.navigateTo(
-                            MainView.class, SellOfferView.class, OfferBookView.class);
-                }).show());
+                .onAction(() -> openBuyBsqOfferBook(navigation, preferences)).show());
 
-        final VBox buyBsqButtonVBox = new VBox(buyBsqButton);
+        final HBox buyBsqBox = new HBox(buyBsqButton, info, learnMore);
+        buyBsqBox.setAlignment(Pos.BOTTOM_LEFT);
+        buyBsqBox.setSpacing(10);
+
+        final VBox buyBsqButtonVBox = new VBox(buyBsqBox);
         buyBsqButtonVBox.setAlignment(Pos.BOTTOM_LEFT);
         buyBsqButtonVBox.setPadding(new Insets(0, 0, 0, -20));
         VBox.setMargin(buyBsqButton, new Insets(0, 0, 4, 0));
 
         return new Tuple2<>(buyBsqButton, buyBsqButtonVBox);
+    }
+
+    private static void openBuyBsqOfferBook(Navigation navigation, Preferences preferences) {
+        preferences.setSellScreenCurrencyCode("BSQ");
+        navigation.navigateTo(
+                MainView.class, SellOfferView.class, OfferBookView.class);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
@@ -712,4 +712,8 @@ class TakeOfferDataModel extends OfferDataModel {
     public boolean isBsqForFeeAvailable() {
         return offerUtil.isBsqForTakerFeeAvailable(amount.get());
     }
+
+    public boolean isBuyBsqOffer() {
+        return !isBuyOffer() && getOffer().getCurrencyCode().equals("BSQ");
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
@@ -713,7 +713,9 @@ class TakeOfferDataModel extends OfferDataModel {
         return offerUtil.isBsqForTakerFeeAvailable(amount.get());
     }
 
-    public boolean isBuyBsqOffer() {
+    public boolean isAttemptToBuyBsq() {
+        // When you buy an asset you actually sell BTC.
+        // This is why an offer to buy BSQ is actually an offer to sell BTC for BSQ.
         return !isBuyOffer() && getOffer().getCurrencyCode().equals("BSQ");
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -117,8 +117,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.jetbrains.annotations.NotNull;
 
+import static bisq.desktop.main.offer.OfferViewUtil.addPayInfoEntry;
 import static bisq.desktop.util.FormBuilder.*;
-import static bisq.desktop.util.GUIUtil.addPayInfoEntry;
 import static javafx.beans.binding.Bindings.createStringBinding;
 
 @FxmlView
@@ -1268,7 +1268,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
     private void maybeShowAccountWarning(PaymentAccount paymentAccount, boolean isBuyer) {
         String msgKey = paymentAccount.getPreTradeMessage(!isBuyer);
-        GUIUtil.showPaymentAccountWarning(msgKey, paymentAccountWarningDisplayed);
+        OfferViewUtil.showPaymentAccountWarning(msgKey, paymentAccountWarningDisplayed);
     }
 
     private void maybeShowCashByMailWarning(PaymentAccount paymentAccount, Offer offer) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -132,7 +132,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     private ScrollPane scrollPane;
     private GridPane gridPane;
     private TitledGroupBg payFundsTitledGroupBg, paymentAccountTitledGroupBg, advancedOptionsGroup;
-    private VBox priceAsPercentageInputBox, amountRangeBox;
+    private VBox priceAsPercentageInputBox, amountRangeBox, buyBsqBox;
     private HBox fundingHBox, amountValueCurrencyBox, priceValueCurrencyBox, volumeValueCurrencyBox,
             priceAsPercentageValueCurrencyBox, minAmountValueCurrencyBox, advancedOptionsBox,
             takeOfferBox, buttonBox, firstRowHBox;
@@ -247,6 +247,10 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
             if (DevEnv.isDaoActivated()) {
                 tradeFeeInBtcToggle.setVisible(newValue);
                 tradeFeeInBsqToggle.setVisible(newValue);
+                if (model.isShowBuyBsqHint()) {
+                    buyBsqBox.setVisible(newValue);
+                    buyBsqBox.setManaged(newValue);
+                }
             }
         };
 
@@ -330,6 +334,13 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
             tradeFeeInBtcToggle.setManaged(false);
             tradeFeeInBsqToggle.setVisible(false);
             tradeFeeInBsqToggle.setManaged(false);
+            buyBsqBox.setVisible(false);
+            buyBsqBox.setManaged(false);
+        }
+
+        if (!model.isShowBuyBsqHint()) {
+            buyBsqBox.setVisible(false);
+            buyBsqBox.setManaged(false);
         }
     }
 
@@ -470,6 +481,8 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         tradeFeeInBtcToggle.setMouseTransparent(true);
         tradeFeeInBsqToggle.setMouseTransparent(true);
+        buyBsqBox.setVisible(false);
+        buyBsqBox.setManaged(false);
 
         int delay = 500;
         int diff = 100;
@@ -872,8 +885,11 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
         Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
                 navigation, model.dataModel.preferences);
+        buyBsqBox = buyBsqButtonBox.second;
+        buyBsqBox.setManaged(false);
+        buyBsqBox.setVisible(false);
 
-        advancedOptionsBox.getChildren().addAll(getTradeFeeFieldsBox(), buyBsqButtonBox.second);
+        advancedOptionsBox.getChildren().addAll(getTradeFeeFieldsBox(), buyBsqBox);
     }
 
     private void addButtons() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -117,7 +117,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jetbrains.annotations.NotNull;
 
-import static bisq.desktop.main.offer.OfferViewUtil.addPayInfoEntry;
+import static bisq.desktop.main.offer.bisq_v1.OfferViewUtil.addPayInfoEntry;
 import static bisq.desktop.util.FormBuilder.*;
 import static javafx.beans.binding.Bindings.createStringBinding;
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -871,7 +871,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         gridPane.getChildren().add(advancedOptionsBox);
 
         Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
-                navigation, model.dataModel.preferences, model.dataModel::getDirection);
+                navigation, model.dataModel.preferences);
 
         advancedOptionsBox.getChildren().addAll(getTradeFeeFieldsBox(), buyBsqButtonBox.second);
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -90,7 +90,6 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -119,6 +118,7 @@ import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 
 import static bisq.desktop.util.FormBuilder.*;
+import static bisq.desktop.util.GUIUtil.addPayInfoEntry;
 import static javafx.beans.binding.Bindings.createStringBinding;
 
 @FxmlView
@@ -672,7 +672,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
                     offerDetailsWindow.hide();
 
                 UserThread.runAfter(() -> new Popup().warning(newValue + "\n\n" +
-                        Res.get("takeOffer.alreadyPaidInFunds"))
+                                Res.get("takeOffer.alreadyPaidInFunds"))
                         .actionButtonTextWithGoTo("navigation.funds.availableForWithdrawal")
                         .onAction(() -> {
                             errorPopupDisplayed.set(true);
@@ -787,15 +787,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void addScrollPane() {
-        scrollPane = new ScrollPane();
-        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        scrollPane.setFitToWidth(true);
-        scrollPane.setFitToHeight(true);
-        AnchorPane.setLeftAnchor(scrollPane, 0d);
-        AnchorPane.setTopAnchor(scrollPane, 0d);
-        AnchorPane.setRightAnchor(scrollPane, 0d);
-        AnchorPane.setBottomAnchor(scrollPane, 0d);
+        scrollPane = GUIUtil.createScrollPane();
         root.getChildren().add(scrollPane);
     }
 
@@ -805,13 +797,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         gridPane.setPadding(new Insets(15, 15, -1, 15));
         gridPane.setHgap(5);
         gridPane.setVgap(5);
-        ColumnConstraints columnConstraints1 = new ColumnConstraints();
-        columnConstraints1.setHalignment(HPos.RIGHT);
-        columnConstraints1.setHgrow(Priority.NEVER);
-        columnConstraints1.setMinWidth(200);
-        ColumnConstraints columnConstraints2 = new ColumnConstraints();
-        columnConstraints2.setHgrow(Priority.ALWAYS);
-        gridPane.getColumnConstraints().addAll(columnConstraints1, columnConstraints2);
+        GUIUtil.setDefaultTwoColumnConstraintsForGridPane(gridPane);
         scrollPane.setContent(gridPane);
     }
 
@@ -1282,17 +1268,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
 
     private void maybeShowAccountWarning(PaymentAccount paymentAccount, boolean isBuyer) {
         String msgKey = paymentAccount.getPreTradeMessage(!isBuyer);
-        if (msgKey == null || paymentAccountWarningDisplayed.getOrDefault(msgKey, false)) {
-            return;
-        }
-        paymentAccountWarningDisplayed.put(msgKey, true);
-        UserThread.runAfter(() -> {
-            new Popup().information(Res.get(msgKey))
-                    .width(900)
-                    .closeButtonText(Res.get("shared.iConfirm"))
-                    .dontShowAgainId(msgKey)
-                    .show();
-        }, 500, TimeUnit.MILLISECONDS);
+        GUIUtil.showPaymentAccountWarning(msgKey, paymentAccountWarningDisplayed);
     }
 
     private void maybeShowCashByMailWarning(PaymentAccount paymentAccount, Offer offer) {
@@ -1332,8 +1308,9 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         infoGridPane.setPadding(new Insets(10, 10, 10, 10));
 
         int i = 0;
-        if (model.isSeller())
+        if (model.isSeller()) {
             addPayInfoEntry(infoGridPane, i++, Res.get("takeOffer.fundsBox.tradeAmount"), model.getTradeAmount());
+        }
 
         addPayInfoEntry(infoGridPane, i++, Res.getWithCol("shared.yourSecurityDeposit"), model.getSecurityDepositInfo());
         addPayInfoEntry(infoGridPane, i++, Res.get("takeOffer.fundsBox.offerFee"), model.getTradeFee());
@@ -1347,18 +1324,6 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
                 model.getTotalToPayInfo());
 
         return infoGridPane;
-    }
-
-    private void addPayInfoEntry(GridPane infoGridPane, int row, String labelText, String value) {
-        Label label = new AutoTooltipLabel(labelText);
-        TextField textField = new TextField(value);
-        textField.setMinWidth(500);
-        textField.setEditable(false);
-        textField.setFocusTraversable(false);
-        textField.setId("payment-info");
-        GridPane.setConstraints(label, 0, row, 1, 1, HPos.RIGHT, VPos.CENTER);
-        GridPane.setConstraints(textField, 1, row);
-        infoGridPane.getChildren().addAll(label, textField);
     }
 }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -132,10 +132,10 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     private ScrollPane scrollPane;
     private GridPane gridPane;
     private TitledGroupBg payFundsTitledGroupBg, paymentAccountTitledGroupBg, advancedOptionsGroup;
-    private VBox priceAsPercentageInputBox, amountRangeBox, buyBsqBox;
+    private VBox priceAsPercentageInputBox, amountRangeBox;
     private HBox fundingHBox, amountValueCurrencyBox, priceValueCurrencyBox, volumeValueCurrencyBox,
             priceAsPercentageValueCurrencyBox, minAmountValueCurrencyBox, advancedOptionsBox,
-            takeOfferBox, buttonBox, firstRowHBox;
+            takeOfferBox, buttonBox, firstRowHBox, buyBsqBox;
     private ComboBox<PaymentAccount> paymentAccountsComboBox;
     private Label amountDescriptionLabel,
             paymentMethodLabel,
@@ -878,18 +878,21 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         advancedOptionsBox.setSpacing(40);
 
         GridPane.setRowIndex(advancedOptionsBox, gridRow);
+        GridPane.setColumnSpan(advancedOptionsBox, GridPane.REMAINING);
         GridPane.setColumnIndex(advancedOptionsBox, 0);
         GridPane.setHalignment(advancedOptionsBox, HPos.LEFT);
         GridPane.setMargin(advancedOptionsBox, new Insets(Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE, 0, 0, 0));
         gridPane.getChildren().add(advancedOptionsBox);
 
-        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
+        Tuple2<AutoTooltipButton, HBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
                 navigation, model.dataModel.preferences);
         buyBsqBox = buyBsqButtonBox.second;
         buyBsqBox.setManaged(false);
         buyBsqBox.setVisible(false);
 
-        advancedOptionsBox.getChildren().addAll(getTradeFeeFieldsBox(), buyBsqBox);
+        VBox tradeFeeFieldsBox = getTradeFeeFieldsBox();
+        tradeFeeFieldsBox.setMinWidth(240);
+        advancedOptionsBox.getChildren().addAll(tradeFeeFieldsBox, buyBsqBox);
     }
 
     private void addButtons() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -884,7 +884,8 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         GridPane.setMargin(advancedOptionsBox, new Insets(Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE, 0, 0, 0));
         gridPane.getChildren().add(advancedOptionsBox);
 
-        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(navigation, model.dataModel.preferences);
+        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(
+                navigation, model.dataModel.preferences, model.dataModel::getDirection);
 
         advancedOptionsBox.getChildren().addAll(getTradeFeeFieldsBox(), buyBsqButtonBox.second);
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -884,7 +884,9 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         GridPane.setMargin(advancedOptionsBox, new Insets(Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE, 0, 0, 0));
         gridPane.getChildren().add(advancedOptionsBox);
 
-        advancedOptionsBox.getChildren().addAll(getTradeFeeFieldsBox());
+        Tuple2<AutoTooltipButton, VBox> buyBsqButtonBox = OfferViewUtil.createBuyBsqButtonBox(navigation, model.dataModel.preferences);
+
+        advancedOptionsBox.getChildren().addAll(getTradeFeeFieldsBox(), buyBsqButtonBox.second);
     }
 
     private void addButtons() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferViewModel.java
@@ -802,6 +802,6 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     }
 
     public boolean isShowBuyBsqHint() {
-        return !dataModel.isBsqForFeeAvailable() && !dataModel.isBuyBsqOffer();
+        return !dataModel.isBsqForFeeAvailable() && !dataModel.isAttemptToBuyBsq();
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferViewModel.java
@@ -800,4 +800,8 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
                     Res.get("shared.aboveInPercent");
         }
     }
+
+    public boolean isShowBuyBsqHint() {
+        return !dataModel.isBsqForFeeAvailable() && !dataModel.isBuyBsqOffer();
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -752,7 +752,18 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
             new Popup().headLine(headline)
                     .instruction(Res.get("offerbook.warning.noMatchingBsqAccount.msg"))
                     .actionButtonText(Res.get("offerbook.takeOffer.createAccount"))
-                    .onAction(() -> model.createBsqAccountAndTakeOffer(offer)).show();
+                    .onAction(() -> {
+                        var bsqAccount = model.createBsqAccount(offer);
+                        var message = Res.get("offerbook.info.accountCreated.message", bsqAccount.getAccountName());
+                        if (model.isInstantPaymentMethod(offer)) {
+                            message += Res.get("offerbook.info.accountCreated.tradeInstant");
+                        }
+                        message += Res.get("offerbook.info.accountCreated.takeOffer");
+                        new Popup().headLine(Res.get("offerbook.info.accountCreated.headline"))
+                                .information(message)
+                                .onClose(() -> model.onTakeOffer(offer))
+                                .show();
+                    }).show();
         } else {
 
             var accountViewClass = CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ? FiatAccountsView.class : AltCoinAccountsView.class;

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -613,6 +613,11 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
 
     public void onTabSelected(boolean isSelected) {
         model.onTabSelected(isSelected);
+
+        if (isSelected) {
+            updateCurrencyComboBoxFromModel();
+            root.requestFocus();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -688,7 +688,8 @@ class OfferBookViewModel extends ActivatableViewModel {
         return coreApi.createCryptoCurrencyPaymentAccount(DisplayUtils.createAssetsAccountName("BSQ", unusedBsqAddressAsString),
                 "BSQ",
                 unusedBsqAddressAsString,
-                isInstantPaymentMethod(offer));
+                isInstantPaymentMethod(offer),
+                false);
     }
 
     public void setOfferActionHandler(OfferView.OfferActionHandler offerActionHandler) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -21,7 +21,6 @@ import bisq.desktop.Navigation;
 import bisq.desktop.common.model.ActivatableViewModel;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.offer.OfferView;
-import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.settings.SettingsView;
 import bisq.desktop.main.settings.preferences.PreferencesView;
 import bisq.desktop.util.DisplayUtils;
@@ -679,22 +678,17 @@ class OfferBookViewModel extends ActivatableViewModel {
         return PaymentMethod.getDummyPaymentMethod(GUIUtil.SHOW_ALL_FLAG);
     }
 
-    public void createBsqAccountAndTakeOffer(Offer offer) {
+    public boolean isInstantPaymentMethod(Offer offer) {
+        return offer.getPaymentMethod().equals(PaymentMethod.BLOCK_CHAINS_INSTANT);
+    }
+
+    public PaymentAccount createBsqAccount(Offer offer) {
         var unusedBsqAddressAsString = bsqWalletService.getUnusedBsqAddressAsString();
 
-        // create required BSQ payment account
-        boolean isInstantPaymentMethod = offer.getPaymentMethod().equals(PaymentMethod.BLOCK_CHAINS_INSTANT);
-        coreApi.createCryptoCurrencyPaymentAccount(DisplayUtils.createAssetsAccountName("BSQ", unusedBsqAddressAsString),
+        return coreApi.createCryptoCurrencyPaymentAccount(DisplayUtils.createAssetsAccountName("BSQ", unusedBsqAddressAsString),
                 "BSQ",
                 unusedBsqAddressAsString,
-                isInstantPaymentMethod);
-
-        if (isInstantPaymentMethod) {
-            new Popup().information(Res.get("payment.altcoin.tradeInstant.popup")).show();
-        }
-
-        // take offer
-        onTakeOffer(offer);
+                isInstantPaymentMethod(offer));
     }
 
     public void setOfferActionHandler(OfferView.OfferActionHandler offerActionHandler) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -226,16 +226,7 @@ class OfferBookViewModel extends ActivatableViewModel {
     protected void activate() {
         filteredItems.addListener(filterItemsListener);
 
-        String code = direction == OfferDirection.BUY ? preferences.getBuyScreenCurrencyCode() : preferences.getSellScreenCurrencyCode();
-        if (code != null && !code.isEmpty() && !isShowAllEntry(code) &&
-                CurrencyUtil.getTradeCurrency(code).isPresent()) {
-            showAllTradeCurrenciesProperty.set(false);
-            selectedTradeCurrency = CurrencyUtil.getTradeCurrency(code).get();
-        } else {
-            showAllTradeCurrenciesProperty.set(true);
-            selectedTradeCurrency = GlobalSettings.getDefaultTradeCurrency();
-        }
-        tradeCurrencyCode.set(selectedTradeCurrency.getCode());
+        updateSelectedTradeCurrency();
 
         if (user != null) {
             disableMatchToggle.set(user.getPaymentAccounts() == null || user.getPaymentAccounts().isEmpty());
@@ -269,6 +260,11 @@ class OfferBookViewModel extends ActivatableViewModel {
     void onTabSelected(boolean isSelected) {
         this.isTabSelected = isSelected;
         setMarketPriceFeedCurrency();
+
+        if (isTabSelected) {
+            updateSelectedTradeCurrency();
+            filterOffers();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -702,5 +698,18 @@ class OfferBookViewModel extends ActivatableViewModel {
 
     public void onTakeOffer(Offer offer) {
         offerActionHandler.onTakeOffer(offer);
+    }
+
+    private void updateSelectedTradeCurrency() {
+        String code = direction == OfferDirection.BUY ? preferences.getBuyScreenCurrencyCode() : preferences.getSellScreenCurrencyCode();
+        if (code != null && !code.isEmpty() && !isShowAllEntry(code) &&
+                CurrencyUtil.getTradeCurrency(code).isPresent()) {
+            showAllTradeCurrenciesProperty.set(false);
+            selectedTradeCurrency = CurrencyUtil.getTradeCurrency(code).get();
+        } else {
+            showAllTradeCurrenciesProperty.set(true);
+            selectedTradeCurrency = GlobalSettings.getDefaultTradeCurrency();
+        }
+        tradeCurrencyCode.set(selectedTradeCurrency.getCode());
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -17,10 +17,15 @@
 
 package bisq.desktop.main.portfolio.pendingtrades.steps.seller;
 
+import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.BusyAnimation;
 import bisq.desktop.components.InfoTextField;
 import bisq.desktop.components.TextFieldWithCopyIcon;
 import bisq.desktop.components.indicator.TxConfidenceIndicator;
+import bisq.desktop.main.MainView;
+import bisq.desktop.main.dao.DaoView;
+import bisq.desktop.main.dao.wallet.BsqWalletView;
+import bisq.desktop.main.dao.wallet.tx.BsqTxView;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import bisq.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
@@ -82,6 +87,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class SellerStep3View extends TradeStepView {
 
     private Button confirmButton;
+    private AutoTooltipButton showBsqWallet;
     private Label statusLabel;
     private BusyAnimation busyAnimation;
     private Subscription tradeStatePropertySubscription;
@@ -296,11 +302,21 @@ public class SellerStep3View extends TradeStepView {
         Tuple4<Button, BusyAnimation, Label, HBox> tuple = addButtonBusyAnimationLabelAfterGroup(gridPane, ++gridRow,
                 Res.get("portfolio.pending.step3_seller.confirmReceipt"));
 
+        HBox hBox = tuple.fourth;
         GridPane.setColumnSpan(tuple.fourth, 2);
         confirmButton = tuple.first;
         confirmButton.setOnAction(e -> onPaymentReceived());
         busyAnimation = tuple.second;
         statusLabel = tuple.third;
+
+        if (trade.getOffer().getCurrencyCode().equals("BSQ")) {
+            showBsqWallet = new AutoTooltipButton(Res.get("portfolio.pending.step3_seller.showBsqWallet"));
+            hBox.getChildren().add(1, showBsqWallet);
+            showBsqWallet.setOnAction(e -> {
+                model.getNavigation().navigateTo(MainView.class, DaoView.class, BsqWalletView.class,
+                        BsqTxView.class);
+            });
+        }
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -6,8 +6,9 @@ import bisq.core.locale.Res;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
-import bisq.core.offer.OfferDirection;
 import bisq.core.util.FormattingUtils;
+import bisq.core.offer.OfferDirection;
+import bisq.core.payment.PaymentAccount;
 import bisq.core.util.ParsingUtils;
 import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
@@ -257,6 +258,11 @@ public class DisplayUtils {
         name = StringUtils.abbreviate(name, 9);
         String method = Res.get(paymentMethodId);
         return method.concat(": ").concat(name);
+    }
+
+    public static String createAssetsAccountName(PaymentAccount paymentAccount, String address) {
+        String currency = paymentAccount.getSingleTradeCurrency() != null ? paymentAccount.getSingleTradeCurrency().getCode() : "";
+        return createAssetsAccountName(currency, address);
     }
 
     public static String createAssetsAccountName(String currency, String address) {

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -251,4 +251,16 @@ public class DisplayUtils {
     public static Coin reduceTo4Decimals(Coin coin, CoinFormatter coinFormatter) {
         return ParsingUtils.parseToCoin(coinFormatter.formatCoin(coin), coinFormatter);
     }
+
+    public static String createAccountName(String paymentMethodId, String name) {
+        name = name.trim();
+        name = StringUtils.abbreviate(name, 9);
+        String method = Res.get(paymentMethodId);
+        return method.concat(": ").concat(name);
+    }
+
+    public static String createAssetsAccountName(String currency, String address) {
+        address = StringUtils.abbreviate(address, 9);
+        return currency.concat(": ").concat(address);
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -111,7 +111,6 @@ import javafx.scene.control.ScrollBar;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
-import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.ColumnConstraints;
@@ -121,7 +120,6 @@ import javafx.scene.layout.Priority;
 
 import javafx.geometry.HPos;
 import javafx.geometry.Orientation;
-import javafx.geometry.VPos;
 
 import javafx.collections.FXCollections;
 
@@ -1248,30 +1246,4 @@ public class GUIUtil {
         gridPane.getColumnConstraints().addAll(columnConstraints1, columnConstraints2);
     }
 
-    public static void showPaymentAccountWarning(String msgKey,
-                                                 HashMap<String, Boolean> paymentAccountWarningDisplayed) {
-        if (msgKey == null || paymentAccountWarningDisplayed.getOrDefault(msgKey, false)) {
-            return;
-        }
-        paymentAccountWarningDisplayed.put(msgKey, true);
-        UserThread.runAfter(() -> {
-            new Popup().information(Res.get(msgKey))
-                    .width(900)
-                    .closeButtonText(Res.get("shared.iConfirm"))
-                    .dontShowAgainId(msgKey)
-                    .show();
-        }, 500, TimeUnit.MILLISECONDS);
-    }
-
-    public static void addPayInfoEntry(GridPane infoGridPane, int row, String labelText, String value) {
-        Label label = new AutoTooltipLabel(labelText);
-        TextField textField = new TextField(value);
-        textField.setMinWidth(500);
-        textField.setEditable(false);
-        textField.setFocusTraversable(false);
-        textField.setId("payment-info");
-        GridPane.setConstraints(label, 0, row, 1, 1, HPos.RIGHT, VPos.CENTER);
-        GridPane.setConstraints(textField, 1, row);
-        infoGridPane.getChildren().addAll(label, textField);
-    }
 }

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -108,14 +108,20 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.ScrollBar;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 
+import javafx.geometry.HPos;
 import javafx.geometry.Orientation;
+import javafx.geometry.VPos;
 
 import javafx.collections.FXCollections;
 
@@ -1217,5 +1223,55 @@ public class GUIUtil {
             default:
                 return result.name();
         }
+    }
+
+    public static ScrollPane createScrollPane() {
+        ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setFitToHeight(true);
+        AnchorPane.setLeftAnchor(scrollPane, 0d);
+        AnchorPane.setTopAnchor(scrollPane, 0d);
+        AnchorPane.setRightAnchor(scrollPane, 0d);
+        AnchorPane.setBottomAnchor(scrollPane, 0d);
+        return scrollPane;
+    }
+
+    public static void setDefaultTwoColumnConstraintsForGridPane(GridPane gridPane) {
+        ColumnConstraints columnConstraints1 = new ColumnConstraints();
+        columnConstraints1.setHalignment(HPos.RIGHT);
+        columnConstraints1.setHgrow(Priority.NEVER);
+        columnConstraints1.setMinWidth(200);
+        ColumnConstraints columnConstraints2 = new ColumnConstraints();
+        columnConstraints2.setHgrow(Priority.ALWAYS);
+        gridPane.getColumnConstraints().addAll(columnConstraints1, columnConstraints2);
+    }
+
+    public static void showPaymentAccountWarning(String msgKey,
+                                                 HashMap<String, Boolean> paymentAccountWarningDisplayed) {
+        if (msgKey == null || paymentAccountWarningDisplayed.getOrDefault(msgKey, false)) {
+            return;
+        }
+        paymentAccountWarningDisplayed.put(msgKey, true);
+        UserThread.runAfter(() -> {
+            new Popup().information(Res.get(msgKey))
+                    .width(900)
+                    .closeButtonText(Res.get("shared.iConfirm"))
+                    .dontShowAgainId(msgKey)
+                    .show();
+        }, 500, TimeUnit.MILLISECONDS);
+    }
+
+    public static void addPayInfoEntry(GridPane infoGridPane, int row, String labelText, String value) {
+        Label label = new AutoTooltipLabel(labelText);
+        TextField textField = new TextField(value);
+        textField.setMinWidth(500);
+        textField.setEditable(false);
+        textField.setFocusTraversable(false);
+        textField.setId("payment-info");
+        GridPane.setConstraints(label, 0, row, 1, 1, HPos.RIGHT, VPos.CENTER);
+        GridPane.setConstraints(textField, 1, row);
+        infoGridPane.getChildren().addAll(label, textField);
     }
 }

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -239,7 +239,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         assertEquals(0, model.maxPlacesForAmount.intValue());
     }
 
@@ -253,7 +253,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         model.activate();
 
         assertEquals(6, model.maxPlacesForAmount.intValue());
@@ -271,7 +271,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         model.activate();
 
         assertEquals(15, model.maxPlacesForAmount.intValue());
@@ -290,7 +290,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         assertEquals(0, model.maxPlacesForVolume.intValue());
     }
 
@@ -304,7 +304,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         model.activate();
 
         assertEquals(5, model.maxPlacesForVolume.intValue());
@@ -322,7 +322,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         model.activate();
 
         assertEquals(9, model.maxPlacesForVolume.intValue());
@@ -341,7 +341,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         assertEquals(0, model.maxPlacesForPrice.intValue());
     }
 
@@ -355,7 +355,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         model.activate();
 
         assertEquals(7, model.maxPlacesForPrice.intValue());
@@ -373,7 +373,7 @@ public class OfferBookViewModelTest {
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, null, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         assertEquals(0, model.maxPlacesForMarketPriceMargin.intValue());
     }
 
@@ -408,7 +408,7 @@ public class OfferBookViewModelTest {
         offerBookListItems.addAll(item1, item2);
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, priceFeedService,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
         model.activate();
 
         assertEquals(8, model.maxPlacesForMarketPriceMargin.intValue()); //" (1.97%)"
@@ -429,7 +429,7 @@ public class OfferBookViewModelTest {
         when(priceFeedService.getMarketPrice(anyString())).thenReturn(new MarketPrice("USD", 12684.0450, Instant.now().getEpochSecond(), true));
 
         final OfferBookViewModel model = new OfferBookViewModel(null, openOfferManager, offerBook, empty, null, null, null,
-                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter());
+                null, null, null, getPriceUtil(), null, coinFormatter, new BsqFormatter(), null, null);
 
         final OfferBookListItem item = make(btcBuyItem.but(
                 with(useMarketBasedPrice, true),


### PR DESCRIPTION
Fixes #4579 

New button is added in the _CREATE OFFER_ and _TAKE OFFER_ tabs. When clicked, it shows a popup and then brings the user to the Sell Offer Book (_SELL BITCOIN_), with BSQ preselected in the currency filter.

The button is visible only when the fee currency toggles are visible (relevant in the _CREATE OFFER_ tab).

## Screenshots

start creating or take any offer ->

![Buy BSQ 1](https://user-images.githubusercontent.com/16313562/103590775-04d2b480-4eef-11eb-8337-5a9dfe643493.png)

-> click "BUY BSQ" ->

![Buy BSQ popup](https://user-images.githubusercontent.com/16313562/103590785-069c7800-4eef-11eb-8681-f30f69e604b5.png)

-> click "BUY BSQ" in popup ->

![image](https://user-images.githubusercontent.com/16313562/103597084-9fd38a80-4eff-11eb-9565-f1b05f8027c9.png)


## Situations when the button is clicked (unchecked are still buggy):

- [x] user is creating/taking offer to _BUY BTC_, and under _SELL BTC_ the tab "_CREATE OFFER_" is **not** active (it may be open but not selected);
- [x] user is creating/taking offer to _BUY BTC_, and under _SELL BTC_ the active tab is "_CREATE OFFER_";
- [x] user is creating offer to _SELL BTC_;
- [x] user is taking offer to _SELL BTC_.

## TODOs from discussion below:
- [x] close the current tab instead of just navigating away from it to the Offer Book;
- [x] don't display the button when the BSQ balance is already high enough.

## Known bug:

- Certain combination of the source and destination views may cause the "_Filter by currency_" combo box to receive focus, clearing it as a result. At that point, the value "BSQ" is still in effect, but any user action after that clears the filter. (More on that in the comments below.)

## Discussion:

1. If _CREATE OFFER_ to _SELL BTC_ is already open, user will be unable to create an offer, as the button _CREATE NEW OFFER TO BUY BSQ_ will be disabled. There is no indication why. A tooltip explaining why it's disabled may be helpful.
2. Should the popup include the "_don't remind me again_" option?
3. Should we hide the button when we're creating/taking an offer to trade BTC for BSQ already?
4. Having to create an altcoin account for BSQ seems like an unnecessary step. Can we have a built-in BSQ account, ideally one that will update the address to the next unused one dynamically?