### PR TITLE
Fix log statement format

### DIFF
--- a/core/src/main/java/bisq/core/offer/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/CreateOfferService.java
@@ -146,7 +146,7 @@ public class CreateOfferService {
                 amount.value,
                 minAmount.value,
                 useMarketBasedPrice,
-                (useMarketBasedPrice == true ? marketPriceMargin : price.getValue()),
+                (useMarketBasedPrice ? marketPriceMargin : price.getValue()),
                 buyerSecurityDepositAsDouble);
 
         long creationTime = new Date().getTime();

--- a/core/src/main/java/bisq/core/offer/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/CreateOfferService.java
@@ -110,7 +110,7 @@ public class CreateOfferService {
                                    double buyerSecurityDepositAsDouble,
                                    PaymentAccount paymentAccount) {
 
-        log.info("offerId={}, \n" +
+        log.info("create and get offer with offerId={}, \n" +
                         "currencyCode={}, \n" +
                         "direction={}, \n" +
                         "price={}, \n" +
@@ -118,14 +118,21 @@ public class CreateOfferService {
                         "marketPriceMargin={}, \n" +
                         "amount={}, \n" +
                         "minAmount={}, \n" +
-                        "buyerSecurityDeposit={}, \n" +
-                        offerId, currencyCode, direction, price.getValue(), useMarketBasedPrice, marketPriceMargin,
-                amount.value, minAmount.value, buyerSecurityDepositAsDouble);
+                        "buyerSecurityDeposit={}",
+                offerId,
+                currencyCode,
+                direction,
+                price.getValue(),
+                useMarketBasedPrice,
+                marketPriceMargin,
+                amount.value,
+                minAmount.value,
+                buyerSecurityDepositAsDouble);
 
-        // prints our param list for dev testing api
-        log.info("{} " +
-                        "{} " +
-                        "{} " +
+        // Log an approximate api CLI 'createoffer' dev/test param list.
+        log.info("cli's createoffer positional option names: paymentAccountId direction currencyCode amount minAmount"
+                + " useMarketBasedPrice fixedPrice|marketPriceMargin buyerSecurityDeposit");
+        log.info("cli's createoffer positional option values: {} " +
                         "{} " +
                         "{} " +
                         "{} " +
@@ -133,8 +140,14 @@ public class CreateOfferService {
                         "{} " +
                         "{} " +
                         "{}",
-                offerId, currencyCode, direction.name(), price.getValue(), useMarketBasedPrice, marketPriceMargin,
-                amount.value, minAmount.value, buyerSecurityDepositAsDouble, paymentAccount.getId());
+                paymentAccount.getId(),
+                direction.name(),
+                currencyCode,
+                amount.value,
+                minAmount.value,
+                useMarketBasedPrice,
+                (useMarketBasedPrice == true ? marketPriceMargin : price.getValue()),
+                buyerSecurityDepositAsDouble);
 
         long creationTime = new Date().getTime();
         NodeAddress makerAddress = p2PService.getAddress();


### PR DESCRIPTION
Fix log statement format

A log statement was mismatching argument placeholders with argument values because it was formatted as 
    `log.info("msg={}, \n" + args...)`	
instead of
    `log.info("msg={}", args...)`

Some code formatting was also done to this block, and a closer approximation of a CLI `createoffer` param list replaces the next  log statement.