### PR TITLE
Persist failed attempts of decrypting mailbox messages

### DIFF
--- a/core/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
@@ -44,6 +44,7 @@ import bisq.core.user.PreferencesPayload;
 import bisq.core.user.UserPayload;
 
 import bisq.network.p2p.MailboxMessageList;
+import bisq.network.p2p.mailbox.IgnoredMailboxMap;
 import bisq.network.p2p.peers.peerexchange.PeerList;
 import bisq.network.p2p.storage.persistence.SequenceNumberMap;
 
@@ -132,7 +133,8 @@ public class CorePersistenceProtoResolver extends CoreProtoResolver implements P
                     return TradeStatistics3Store.fromProto(proto.getTradeStatistics3Store());
                 case MAILBOX_MESSAGE_LIST:
                     return MailboxMessageList.fromProto(proto.getMailboxMessageList(), networkProtoResolver);
-
+                case IGNORED_MAILBOX_MAP:
+                    return IgnoredMailboxMap.fromProto(proto.getIgnoredMailboxMap());
                 default:
                     throw new ProtobufferRuntimeException("Unknown proto message case(PB.PersistableEnvelope). " +
                             "messageCase=" + proto.getMessageCase() + "; proto raw data=" + proto.toString());

--- a/core/src/main/java/bisq/core/setup/CorePersistedDataHost.java
+++ b/core/src/main/java/bisq/core/setup/CorePersistedDataHost.java
@@ -36,6 +36,7 @@ import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
 import bisq.network.p2p.P2PService;
+import bisq.network.p2p.mailbox.IgnoredMailboxService;
 import bisq.network.p2p.peers.PeerManager;
 import bisq.network.p2p.storage.P2PDataStorage;
 
@@ -68,6 +69,7 @@ public class CorePersistedDataHost {
         persistedDataHosts.add(injector.getInstance(P2PDataStorage.class));
         persistedDataHosts.add(injector.getInstance(PeerManager.class));
         persistedDataHosts.add(injector.getInstance(P2PService.class));
+        persistedDataHosts.add(injector.getInstance(IgnoredMailboxService.class));
 
         if (injector.getInstance(Config.class).daoActivated) {
             persistedDataHosts.add(injector.getInstance(BallotListService.class));

--- a/p2p/src/main/java/bisq/network/p2p/mailbox/IgnoredMailboxMap.java
+++ b/p2p/src/main/java/bisq/network/p2p/mailbox/IgnoredMailboxMap.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.mailbox;
+
+
+import bisq.common.proto.persistable.PersistableEnvelope;
+import bisq.common.util.CollectionUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@EqualsAndHashCode
+public class IgnoredMailboxMap implements PersistableEnvelope {
+    @Getter
+    private final Map<String, Long> dataMap;
+
+    public IgnoredMailboxMap() {
+        this.dataMap = new HashMap<>();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public IgnoredMailboxMap(Map<String, Long> ignored) {
+        this.dataMap = ignored;
+    }
+
+    @Override
+    public protobuf.PersistableEnvelope toProtoMessage() {
+        return protobuf.PersistableEnvelope.newBuilder()
+                .setIgnoredMailboxMap(protobuf.IgnoredMailboxMap.newBuilder().putAllData(dataMap))
+                .build();
+    }
+
+    public static IgnoredMailboxMap fromProto(protobuf.IgnoredMailboxMap proto) {
+        return new IgnoredMailboxMap(CollectionUtils.isEmpty(proto.getDataMap()) ? new HashMap<>() : proto.getDataMap());
+    }
+
+    public void putAll(Map<String, Long> map) {
+        dataMap.putAll(map);
+    }
+
+    public boolean containsKey(String uid) {
+        return dataMap.containsKey(uid);
+    }
+
+    public void put(String uid, long creationTimeStamp) {
+        dataMap.put(uid, creationTimeStamp);
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/mailbox/IgnoredMailboxService.java
+++ b/p2p/src/main/java/bisq/network/p2p/mailbox/IgnoredMailboxService.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.mailbox;
+
+import bisq.network.p2p.storage.payload.MailboxStoragePayload;
+
+import bisq.common.persistence.PersistenceManager;
+import bisq.common.proto.persistable.PersistedDataHost;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * We persist failed attempts to decrypt mailbox messages (expected if mailbox message was not addressed to us).
+ * This improves performance at processing mailbox messages.
+ * On a fast 4 core machine 1000 mailbox messages take about 1.5 second. At second start-up using the persisted data
+ * it only takes about 30 ms.
+ */
+@Singleton
+public class IgnoredMailboxService implements PersistedDataHost {
+    private final PersistenceManager<IgnoredMailboxMap> persistenceManager;
+    private final IgnoredMailboxMap ignoredMailboxMap = new IgnoredMailboxMap();
+
+    @Inject
+    public IgnoredMailboxService(PersistenceManager<IgnoredMailboxMap> persistenceManager) {
+        this.persistenceManager = persistenceManager;
+        this.persistenceManager.initialize(ignoredMailboxMap, PersistenceManager.Source.PRIVATE_LOW_PRIO);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PersistedDataHost
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void readPersisted(Runnable completeHandler) {
+        persistenceManager.readPersisted(persisted -> {
+                    // At each load we cleanup outdated entries
+                    long expiredDate = System.currentTimeMillis() - MailboxStoragePayload.TTL;
+                    persisted.getDataMap().entrySet().stream()
+                            .filter(e -> e.getValue() > expiredDate)
+                            .forEach(e -> ignoredMailboxMap.put(e.getKey(), e.getValue()));
+                    persistenceManager.requestPersistence();
+                    completeHandler.run();
+                },
+                completeHandler);
+    }
+
+    public boolean isIgnored(String uid) {
+        return ignoredMailboxMap.containsKey(uid);
+    }
+
+    public void ignore(String uid, long creationTimeStamp) {
+        ignoredMailboxMap.put(uid, creationTimeStamp);
+        persistenceManager.requestPersistence();
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
@@ -53,6 +53,8 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode
 @Slf4j
 public final class MailboxStoragePayload implements ProtectedStoragePayload, ExpirablePayload, AddOncePayload {
+    public static final long TTL = TimeUnit.DAYS.toMillis(15);
+
     private final PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage;
     private PublicKey senderPubKeyForAddOperation;
     private final byte[] senderPubKeyForAddOperationBytes;
@@ -118,6 +120,6 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
 
     @Override
     public long getTTL() {
-        return TimeUnit.DAYS.toMillis(15);
+        return TTL;
     }
 }

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -576,6 +576,10 @@ message MailboxMessageList {
     repeated MailboxItem mailbox_item = 1;
 }
 
+message IgnoredMailboxMap {
+    map<string, uint64> data = 1;
+}
+
 message MailboxItem {
     ProtectedMailboxStorageEntry protected_mailbox_storage_entry = 1;
     DecryptedMessageWithPubKey decrypted_message_with_pub_key = 2;
@@ -1211,6 +1215,7 @@ message PersistableEnvelope {
         RefundDisputeList refund_dispute_list = 30;
         TradeStatistics3Store trade_statistics3_store = 31;
         MailboxMessageList mailbox_message_list = 32;
+        IgnoredMailboxMap ignored_mailbox_map = 33;
     }
 }
 


### PR DESCRIPTION
We persist failed attempts to decrypt mailbox messages (expected if mailbox message was not addressed to us).
This improves performance at processing mailbox messages.
On a fast 4 core machine 1000 mailbox messages take about 1.5 second. At second start-up using the persisted data
it only takes about 30 ms.
We clean up old entries at startup using the TTL field.