### PR TITLE
Fix two CLI option parsing bugs

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -78,6 +78,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.cli.CurrencyFormat.formatTxFeeRateInfo;
 import static bisq.cli.CurrencyFormat.toSatoshis;
+import static bisq.cli.CurrencyFormat.toSecurityDepositAsPct;
 import static bisq.cli.NegativeNumberOptions.hasNegativeNumberOptions;
 import static bisq.cli.TableFormat.*;
 import static java.lang.String.format;
@@ -376,7 +377,7 @@ public class CliMain {
                     else
                         fixedPrice = nonOptionArgs.get(7);
 
-                    var securityDeposit = new BigDecimal(nonOptionArgs.get(8));
+                    var securityDeposit = toSecurityDepositAsPct(nonOptionArgs.get(8));
                     var makerFeeCurrencyCode = nonOptionArgs.size() == 10
                             ? nonOptionArgs.get(9)
                             : "btc";
@@ -389,7 +390,7 @@ public class CliMain {
                             .setUseMarketBasedPrice(useMarketBasedPrice)
                             .setPrice(fixedPrice)
                             .setMarketPriceMargin(marketPriceMargin.doubleValue())
-                            .setBuyerSecurityDeposit(securityDeposit.doubleValue())
+                            .setBuyerSecurityDeposit(securityDeposit)
                             .setPaymentAccountId(paymentAcctId)
                             .setMakerFeeCurrencyCode(makerFeeCurrencyCode)
                             .build();

--- a/cli/src/main/java/bisq/cli/CurrencyFormat.java
+++ b/cli/src/main/java/bisq/cli/CurrencyFormat.java
@@ -43,6 +43,8 @@ public class CurrencyFormat {
     static final BigDecimal BSQ_SATOSHI_DIVISOR = new BigDecimal(100);
     static final DecimalFormat BSQ_FORMAT = new DecimalFormat("###,###,###,##0.00");
 
+    static final BigDecimal SECURITY_DEPOSIT_MULTIPLICAND = new BigDecimal("0.01");
+
     @SuppressWarnings("BigDecimalMethodWithoutRoundingCalled")
     public static String formatSatoshis(long sats) {
         return BTC_FORMAT.format(BigDecimal.valueOf(sats).divide(SATOSHI_DIVISOR));
@@ -96,6 +98,15 @@ public class CurrencyFormat {
             return new BigDecimal(btc).multiply(SATOSHI_DIVISOR).longValue();
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(format("'%s' is not a number", btc));
+        }
+    }
+
+    static double toSecurityDepositAsPct(String securityDepositInput) {
+        try {
+            return new BigDecimal(securityDepositInput)
+                    .multiply(SECURITY_DEPOSIT_MULTIPLICAND).doubleValue();
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(format("'%s' is not a number", securityDepositInput));
         }
     }
 

--- a/cli/src/main/java/bisq/cli/NegativeNumberOptions.java
+++ b/cli/src/main/java/bisq/cli/NegativeNumberOptions.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import static java.util.Arrays.stream;
+import static java.util.stream.IntStream.range;
 
 class NegativeNumberOptions {
 
@@ -35,13 +36,13 @@ class NegativeNumberOptions {
     String[] removeNegativeNumberOptions(String[] args) {
         // Cache any negative number params that will be rejected by the parser.
         // This should be called before command line parsing.
-        for (int i = 1; i < args.length; i++) {
-            // Start at i=1;  args[0] is the method name.
+        int skipped = getIndexOfMethodInArgs(args);
+        for (int i = skipped; i < args.length; i++) {
             if (isNegativeNumber.test(args[i])) {
                 String param = args[i];
-                negativeNumberParams.put(i - 1, new BigDecimal(param).toString());
+                negativeNumberParams.put(i - skipped, new BigDecimal(param).toString());
                 // Substitute a zero placeholder at the index containing the
-                // negative number option value.
+                // negative number positional option value.
                 args[i] = "0";
             }
         }
@@ -80,4 +81,17 @@ class NegativeNumberOptions {
         }
         return false;
     };
+
+    private int getIndexOfMethodInArgs(String[] args) {
+        // The first argument that does not start with '-' or '--' is the method name.
+        // Skip over the --password=xyz [--host=s --port=n] options.
+        int skipped = range(0, args.length)
+                .filter(i -> !args[i].startsWith("-"))
+                .findFirst()
+                .orElse(-1);
+        if (skipped >= 0)
+            return skipped;
+        else
+            throw new IllegalArgumentException("required --password option not found");
+    }
 }


### PR DESCRIPTION
- Fix bug locating index of method name in String[] args when handling any negative number opt.

- Make `createoffer` method's security-deposit param format consistent with UI's.
When creating an offer, the CLI should take "15.0", not "0.15" as a 15% security deposit.  This is consistent with the UI, and the CLI's mkt-price-margin input format.
