### PR TITLE
Integrate new protection tools into api's offer & trade services

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -78,6 +78,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.cli.CurrencyFormat.formatTxFeeRateInfo;
 import static bisq.cli.CurrencyFormat.toSatoshis;
+import static bisq.cli.CurrencyFormat.toSecurityDepositAsPct;
 import static bisq.cli.NegativeNumberOptions.hasNegativeNumberOptions;
 import static bisq.cli.TableFormat.*;
 import static java.lang.String.format;
@@ -376,7 +377,7 @@ public class CliMain {
                     else
                         fixedPrice = nonOptionArgs.get(7);
 
-                    var securityDeposit = new BigDecimal(nonOptionArgs.get(8));
+                    var securityDeposit = toSecurityDepositAsPct(nonOptionArgs.get(8));
                     var makerFeeCurrencyCode = nonOptionArgs.size() == 10
                             ? nonOptionArgs.get(9)
                             : "btc";
@@ -389,7 +390,7 @@ public class CliMain {
                             .setUseMarketBasedPrice(useMarketBasedPrice)
                             .setPrice(fixedPrice)
                             .setMarketPriceMargin(marketPriceMargin.doubleValue())
-                            .setBuyerSecurityDeposit(securityDeposit.doubleValue())
+                            .setBuyerSecurityDeposit(securityDeposit)
                             .setPaymentAccountId(paymentAcctId)
                             .setMakerFeeCurrencyCode(makerFeeCurrencyCode)
                             .build();

--- a/cli/src/main/java/bisq/cli/CurrencyFormat.java
+++ b/cli/src/main/java/bisq/cli/CurrencyFormat.java
@@ -43,6 +43,8 @@ public class CurrencyFormat {
     static final BigDecimal BSQ_SATOSHI_DIVISOR = new BigDecimal(100);
     static final DecimalFormat BSQ_FORMAT = new DecimalFormat("###,###,###,##0.00");
 
+    static final BigDecimal SECURITY_DEPOSIT_MULTIPLICAND = new BigDecimal("0.01");
+
     @SuppressWarnings("BigDecimalMethodWithoutRoundingCalled")
     public static String formatSatoshis(long sats) {
         return BTC_FORMAT.format(BigDecimal.valueOf(sats).divide(SATOSHI_DIVISOR));
@@ -96,6 +98,15 @@ public class CurrencyFormat {
             return new BigDecimal(btc).multiply(SATOSHI_DIVISOR).longValue();
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(format("'%s' is not a number", btc));
+        }
+    }
+
+    static double toSecurityDepositAsPct(String securityDepositInput) {
+        try {
+            return new BigDecimal(securityDepositInput)
+                    .multiply(SECURITY_DEPOSIT_MULTIPLICAND).doubleValue();
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(format("'%s' is not a number", securityDepositInput));
         }
     }
 

--- a/cli/src/main/java/bisq/cli/NegativeNumberOptions.java
+++ b/cli/src/main/java/bisq/cli/NegativeNumberOptions.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import static java.util.Arrays.stream;
+import static java.util.stream.IntStream.range;
 
 class NegativeNumberOptions {
 
@@ -35,13 +36,13 @@ class NegativeNumberOptions {
     String[] removeNegativeNumberOptions(String[] args) {
         // Cache any negative number params that will be rejected by the parser.
         // This should be called before command line parsing.
-        for (int i = 1; i < args.length; i++) {
-            // Start at i=1;  args[0] is the method name.
+        int skipped = getIndexOfMethodInArgs(args);
+        for (int i = skipped; i < args.length; i++) {
             if (isNegativeNumber.test(args[i])) {
                 String param = args[i];
-                negativeNumberParams.put(i - 1, new BigDecimal(param).toString());
+                negativeNumberParams.put(i - skipped, new BigDecimal(param).toString());
                 // Substitute a zero placeholder at the index containing the
-                // negative number option value.
+                // negative number positional option value.
                 args[i] = "0";
             }
         }
@@ -80,4 +81,17 @@ class NegativeNumberOptions {
         }
         return false;
     };
+
+    private int getIndexOfMethodInArgs(String[] args) {
+        // The first argument that does not start with '-' or '--' is the method name.
+        // Skip over the --password=xyz [--host=s --port=n] options.
+        int skipped = range(0, args.length)
+                .filter(i -> !args[i].startsWith("-"))
+                .findFirst()
+                .orElse(-1);
+        if (skipped >= 0)
+            return skipped;
+        else
+            throw new IllegalArgumentException("required --password option not found");
+    }
 }

--- a/core/src/main/java/bisq/core/api/CoreContext.java
+++ b/core/src/main/java/bisq/core/api/CoreContext.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.api;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static java.lang.Thread.currentThread;
+
+@Singleton
+@Slf4j
+class CoreContext {
+
+    @Inject
+    public CoreContext() {
+    }
+
+    public boolean isApiUser() {
+        String threadName = currentThread().getName();
+        return threadName.equals("BisqDaemonMain") || threadName.contains("grpc");
+    }
+}

--- a/core/src/main/java/bisq/core/api/CoreContext.java
+++ b/core/src/main/java/bisq/core/api/CoreContext.java
@@ -20,20 +20,19 @@ package bisq.core.api;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-
-import static java.lang.Thread.currentThread;
 
 @Singleton
 @Slf4j
-class CoreContext {
+public class CoreContext {
+
+    @Getter
+    @Setter
+    private boolean isApiUser;
 
     @Inject
     public CoreContext() {
-    }
-
-    public boolean isApiUser() {
-        String threadName = currentThread().getName();
-        return threadName.equals("BisqDaemonMain") || threadName.contains("grpc");
     }
 }

--- a/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
+++ b/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
@@ -32,6 +32,7 @@ import bisq.common.crypto.KeyRing;
 import org.bitcoinj.core.ECKey;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.util.Date;
 import java.util.List;
@@ -49,6 +50,7 @@ import static java.lang.String.format;
 import static java.net.InetAddress.getLoopbackAddress;
 import static java.util.Arrays.asList;
 
+@Singleton
 @Slf4j
 class CoreDisputeAgentsService {
 

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -24,6 +24,7 @@ import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.user.User;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.io.File;
 
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+@Singleton
 @Slf4j
 class CorePaymentAccountsService {
 

--- a/core/src/main/java/bisq/core/api/CorePriceService.java
+++ b/core/src/main/java/bisq/core/api/CorePriceService.java
@@ -21,6 +21,7 @@ import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,7 +29,7 @@ import static bisq.common.util.MathUtils.roundDouble;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-
+@Singleton
 @Slf4j
 class CorePriceService {
 

--- a/core/src/main/java/bisq/core/api/CoreTradesService.java
+++ b/core/src/main/java/bisq/core/api/CoreTradesService.java
@@ -35,6 +35,7 @@ import bisq.core.util.validation.BtcAddressValidator;
 import org.bitcoinj.core.Coin;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -44,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 import static bisq.core.btc.model.AddressEntry.Context.TRADE_PAYOUT;
 import static java.lang.String.format;
 
+@Singleton
 @Slf4j
 class CoreTradesService {
 
@@ -59,9 +61,11 @@ class CoreTradesService {
     private final TradeManager tradeManager;
     private final TradeUtil tradeUtil;
     private final User user;
+    private final boolean isApiUser;
 
     @Inject
-    public CoreTradesService(CoreWalletsService coreWalletsService,
+    public CoreTradesService(CoreContext coreContext,
+                             CoreWalletsService coreWalletsService,
                              BtcWalletService btcWalletService,
                              OfferUtil offerUtil,
                              ClosedTradableManager closedTradableManager,
@@ -77,6 +81,7 @@ class CoreTradesService {
         this.tradeManager = tradeManager;
         this.tradeUtil = tradeUtil;
         this.user = user;
+        this.isApiUser = coreContext.isApiUser();
     }
 
     void takeOffer(Offer offer,
@@ -108,7 +113,7 @@ class CoreTradesService {
                 offer,
                 paymentAccountId,
                 useSavingsWallet,
-                true,
+                isApiUser,
                 resultHandler::accept,
                 errorMessage -> {
                     log.error(errorMessage);

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -56,6 +56,7 @@ import org.bitcoinj.crypto.KeyCrypterScrypt;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -83,6 +84,7 @@ import static bisq.core.util.ParsingUtils.parseToCoin;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+@Singleton
 @Slf4j
 class CoreWalletsService {
 

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
@@ -17,6 +17,8 @@
 
 package bisq.daemon.grpc;
 
+import bisq.core.api.CoreContext;
+
 import bisq.common.UserThread;
 import bisq.common.config.Config;
 
@@ -44,7 +46,8 @@ public class GrpcServer {
     private final Server server;
 
     @Inject
-    public GrpcServer(Config config,
+    public GrpcServer(CoreContext coreContext,
+                      Config config,
                       PasswordAuthInterceptor passwordAuthInterceptor,
                       GrpcDisputeAgentsService disputeAgentsService,
                       GrpcOffersService offersService,
@@ -66,6 +69,7 @@ public class GrpcServer {
                 .addService(walletsService)
                 .intercept(passwordAuthInterceptor)
                 .build();
+        coreContext.setApiUser(true);
     }
 
     public void start() {


### PR DESCRIPTION
- Injected `OfferFilter` into `CoreOffersService` and `CoreTradesService`.
The filter constrains `getoffer(s)` results to offers an api user can take, as the first part of ongoing protection tools / api integration.

- Created a new `CoreContext` singleton.
Initially, lets `Core*Services` know if the user is using the api -- `isApiUser=true` if the current thread's name is "BisqDaemonMain", or the name contains "grpc".  We cannot check `BisqDaemonMain.class.getSimpleName()` because `:core` cannot have a circular dependency on `:daemon`, but there is probably a better way to do this than depending on the thread name set in `BisqDaemonMain#configUserThread()`.  We do this anticipating future `:desktop` dependencies on the core api, and we don't pass hardcoded `isApiUser=true` params to lower level domain objects.  

- Added `@Singleton` annotation to all Core*Service classes.
      
Related to https://github.com/bisq-network/bisq/pull/5053.

PR https://github.com/bisq-network/bisq/pull/5063 should be reviewed and merged before this one.