### PR TITLE
Add toggle for displaying volume in tradestatistics chart in USD

### DIFF
--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -50,6 +50,9 @@ import org.bitcoinj.utils.Fiat;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -71,6 +74,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayload, PersistableNetworkPayload,
         CapabilityRequiringPayload, DateSortedTruncatablePayload {
 
+    @JsonExclude
+    private transient static final ZoneId ZONE_ID = ZoneId.systemDefault();
 
     public static TradeStatistics3 from(Trade trade,
                                         @Nullable String referralId,
@@ -188,6 +193,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
 
     @JsonExclude
     private transient Volume volume = null;
+    @JsonExclude
+    private transient LocalDateTime localDateTime;
 
     public TradeStatistics3(String currency,
                             long price,
@@ -331,6 +338,13 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         return dateObj;
     }
 
+    public LocalDateTime getLocalDateTime() {
+        if (localDateTime == null) {
+            localDateTime = dateObj.toInstant().atZone(ZONE_ID).toLocalDateTime();
+        }
+        return localDateTime;
+    }
+
     public long getDateAsLong() {
         return date;
     }
@@ -353,8 +367,13 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         }
     }
 
+    private transient Price priceObj;
+
     public Price getTradePrice() {
-        return Price.valueOf(currency, price);
+        if (priceObj == null) {
+            priceObj = Price.valueOf(currency, price);
+        }
+        return priceObj;
     }
 
     public Coin getTradeAmount() {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -186,6 +186,9 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     @JsonExclude
     private transient final Date dateObj;
 
+    @JsonExclude
+    private transient Volume volume = null;
+
     public TradeStatistics3(String currency,
                             long price,
                             long amount,
@@ -359,12 +362,15 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     }
 
     public Volume getTradeVolume() {
-        if (getTradePrice().getMonetary() instanceof Altcoin) {
-            return new Volume(new AltcoinExchangeRate((Altcoin) getTradePrice().getMonetary()).coinToAltcoin(getTradeAmount()));
-        } else {
-            Volume volume = new Volume(new ExchangeRate((Fiat) getTradePrice().getMonetary()).coinToFiat(getTradeAmount()));
-            return VolumeUtil.getRoundedFiatVolume(volume);
+        if (volume == null) {
+            if (getTradePrice().getMonetary() instanceof Altcoin) {
+                volume = new Volume(new AltcoinExchangeRate((Altcoin) getTradePrice().getMonetary()).coinToAltcoin(getTradeAmount()));
+            } else {
+                Volume exactVolume = new Volume(new ExchangeRate((Fiat) getTradePrice().getMonetary()).coinToFiat(getTradeAmount()));
+                volume = VolumeUtil.getRoundedFiatVolume(exactVolume);
+            }
         }
+        return volume;
     }
 
     public boolean isValid() {

--- a/core/src/main/java/bisq/core/user/Cookie.java
+++ b/core/src/main/java/bisq/core/user/Cookie.java
@@ -45,6 +45,16 @@ public class Cookie extends HashMap<CookieKey, String> {
         }
     }
 
+    public void putAsBoolean(CookieKey key, boolean value) {
+        put(key, value ? "1" : "0");
+    }
+
+    public Optional<Boolean> getAsOptionalBoolean(CookieKey key) {
+        return containsKey(key) ?
+                Optional.of(get(key).equals("1")) :
+                Optional.empty();
+    }
+
     public Map<String, String> toProtoMessage() {
         Map<String, String> protoMap = new HashMap<>();
         this.forEach((key, value) -> protoMap.put(key.name(), value));

--- a/core/src/main/java/bisq/core/user/CookieKey.java
+++ b/core/src/main/java/bisq/core/user/CookieKey.java
@@ -22,5 +22,6 @@ public enum CookieKey {
     STAGE_X,
     STAGE_Y,
     STAGE_W,
-    STAGE_H
+    STAGE_H,
+    TRADE_STAT_CHART_USE_USD
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -316,7 +316,7 @@ market.spread.expanded=Expanded view
 
 # TradesChartsView
 market.trades.nrOfTrades=Trades: {0}
-market.trades.tooltip.volumeBar=Volume: {0}\nNo. of trades: {1}\nDate: {2}
+market.trades.tooltip.volumeBar=Volume: {0} / {1}\nNo. of trades: {2}\nDate: {3}
 market.trades.tooltip.candle.open=Open:
 market.trades.tooltip.candle.close=Close:
 market.trades.tooltip.candle.high=High:
@@ -324,6 +324,7 @@ market.trades.tooltip.candle.low=Low:
 market.trades.tooltip.candle.average=Average:
 market.trades.tooltip.candle.median=Median:
 market.trades.tooltip.candle.date=Date:
+market.trades.showVolumeInUSD=Show volume in USD
 
 ####################################################################
 # OfferView

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
@@ -34,6 +34,12 @@ public class TradeStatistics3ListItem {
     private final TradeStatistics3 tradeStatistics3;
     private final CoinFormatter coinFormatter;
     private final boolean showAllTradeCurrencies;
+    private String dateString;
+    private String market;
+    private String priceString;
+    private String volumeString;
+    private String paymentMethodString;
+    private String amountString;
 
     public TradeStatistics3ListItem(@Nullable TradeStatistics3 tradeStatistics3,
                                     CoinFormatter coinFormatter,
@@ -44,31 +50,47 @@ public class TradeStatistics3ListItem {
     }
 
     public String getDateString() {
-        return tradeStatistics3 != null ? DisplayUtils.formatDateTime(tradeStatistics3.getDate()) : "";
+        if (dateString == null) {
+            dateString = tradeStatistics3 != null ? DisplayUtils.formatDateTime(tradeStatistics3.getDate()) : "";
+        }
+        return dateString;
     }
 
     public String getMarket() {
-        return tradeStatistics3 != null ? CurrencyUtil.getCurrencyPair(tradeStatistics3.getCurrency()) : "";
+        if (market == null) {
+            market = tradeStatistics3 != null ? CurrencyUtil.getCurrencyPair(tradeStatistics3.getCurrency()) : "";
+        }
+        return market;
     }
 
     public String getPriceString() {
-        return tradeStatistics3 != null ? FormattingUtils.formatPrice(tradeStatistics3.getTradePrice()) : "";
+        if (priceString == null) {
+            priceString = tradeStatistics3 != null ? FormattingUtils.formatPrice(tradeStatistics3.getTradePrice()) : "";
+        }
+        return priceString;
     }
 
     public String getVolumeString() {
-        if (tradeStatistics3 == null) {
-            return "";
+        if (volumeString == null) {
+            volumeString = tradeStatistics3 != null ? showAllTradeCurrencies ?
+                    DisplayUtils.formatVolumeWithCode(tradeStatistics3.getTradeVolume()) :
+                    DisplayUtils.formatVolume(tradeStatistics3.getTradeVolume())
+                    : "";
         }
-        return showAllTradeCurrencies ?
-                DisplayUtils.formatVolumeWithCode(tradeStatistics3.getTradeVolume()) :
-                DisplayUtils.formatVolume(tradeStatistics3.getTradeVolume());
+        return volumeString;
     }
 
     public String getPaymentMethodString() {
-        return tradeStatistics3 != null ? Res.get(tradeStatistics3.getPaymentMethod()) : "";
+        if (paymentMethodString == null) {
+            paymentMethodString = tradeStatistics3 != null ? Res.get(tradeStatistics3.getPaymentMethod()) : "";
+        }
+        return paymentMethodString;
     }
 
     public String getAmountString() {
-        return tradeStatistics3 != null ? coinFormatter.formatCoin(tradeStatistics3.getTradeAmount(), 4) : "";
+        if (amountString == null) {
+            amountString = tradeStatistics3 != null ? coinFormatter.formatCoin(tradeStatistics3.getTradeAmount(), 4) : "";
+        }
+        return amountString;
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -241,7 +241,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             layoutChart();
         };
         tradeStatisticsByCurrencyListener = c -> nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades",
-                model.tradeStatisticsByCurrency.size()));
+                model.selectedTradeStatistics.size()));
         parentHeightListener = (observable, oldValue, newValue) -> layout();
 
         priceColumnLabelListener = (o, oldVal, newVal) -> priceColumn.setGraphic(new AutoTooltipLabel(newVal));
@@ -318,7 +318,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         toggleGroup.selectedToggleProperty().addListener(timeUnitChangeListener);
         priceAxisY.widthProperty().addListener(priceAxisYWidthListener);
         volumeAxisY.widthProperty().addListener(volumeAxisYWidthListener);
-        model.tradeStatisticsByCurrency.addListener(tradeStatisticsByCurrencyListener);
+        model.selectedTradeStatistics.addListener(tradeStatisticsByCurrencyListener);
 
         priceAxisY.labelProperty().bind(priceColumnLabel);
         priceColumnLabel.addListener(priceColumnLabelListener);
@@ -335,7 +335,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         volumeAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
         volumeInUsdAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
 
-        nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades", model.tradeStatisticsByCurrency.size()));
+        nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades", model.selectedTradeStatistics.size()));
 
         exportLink.setOnAction(e -> exportToCsv());
         UserThread.runAfter(this::updateChartData, 100, TimeUnit.MILLISECONDS);
@@ -368,7 +368,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         toggleGroup.selectedToggleProperty().removeListener(timeUnitChangeListener);
         priceAxisY.widthProperty().removeListener(priceAxisYWidthListener);
         volumeAxisY.widthProperty().removeListener(volumeAxisYWidthListener);
-        model.tradeStatisticsByCurrency.removeListener(tradeStatisticsByCurrencyListener);
+        model.selectedTradeStatistics.removeListener(tradeStatisticsByCurrencyListener);
 
         priceAxisY.labelProperty().unbind();
         priceColumnLabel.removeListener(priceColumnLabelListener);
@@ -397,7 +397,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     private void fillList() {
         ObservableList<TradeStatistics3ListItem> tradeStatistics3ListItems = FXCollections.observableList(
-                model.tradeStatisticsByCurrency.stream()
+                model.selectedTradeStatistics.stream()
                         .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
                                 coinFormatter,
                                 model.showAllTradeCurrenciesProperty.get()))

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.market.trades;
 import bisq.desktop.common.view.ActivatableViewAndModel;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.AutoTooltipLabel;
+import bisq.desktop.components.AutoTooltipSlideToggleButton;
 import bisq.desktop.components.AutoTooltipTableColumn;
 import bisq.desktop.components.AutoTooltipToggleButton;
 import bisq.desktop.components.AutocompleteComboBox;
@@ -34,6 +35,8 @@ import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Price;
 import bisq.core.trade.statistics.TradeStatistics3;
+import bisq.core.user.CookieKey;
+import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
@@ -140,8 +143,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     }
 
     private final CoinFormatter coinFormatter;
+    private final User user;
 
-    private VolumeChart volumeChart;
+    private VolumeChart volumeChart, volumeInUsdChart;
     private CandleStickChart priceChart;
     private AutocompleteComboBox<CurrencyListItem> currencyComboBox;
     private TableView<TradeStatistics3ListItem> tableView;
@@ -150,6 +154,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private Pane rootParent;
     private AnchorPane priceChartPane, volumeChartPane;
     private HBox footer;
+    private AutoTooltipSlideToggleButton showVolumeAsUsdToggleButton;
     private Label nrOfTradeStatisticsLabel;
     private ToggleGroup toggleGroup;
     private SingleSelectionModel<Tab> tabPaneSelectionModel;
@@ -172,9 +177,10 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private Subscription currencySelectionSubscriber;
 
     private final StringProperty priceColumnLabel = new SimpleStringProperty();
-    private NumberAxis priceAxisX, priceAxisY, volumeAxisY, volumeAxisX;
+    private NumberAxis priceAxisX, priceAxisY, volumeAxisY, volumeAxisX, volumeInUsdAxisY, volumeInUsdAxisX;
     private XYChart.Series<Number, Number> priceSeries;
-    private XYChart.Series<Number, Number> volumeSeries;
+    private final XYChart.Series<Number, Number> volumeSeries = new XYChart.Series<>();
+    private final XYChart.Series<Number, Number> volumeInUsdSeries = new XYChart.Series<>();
     private double priceAxisYWidth;
     private double volumeAxisYWidth;
 
@@ -186,9 +192,11 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     @SuppressWarnings("WeakerAccess")
     @Inject
     public TradesChartsView(TradesChartsViewModel model,
-                            @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter coinFormatter) {
+                            @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter coinFormatter,
+                            User user) {
         super(model);
         this.coinFormatter = coinFormatter;
+        this.user = user;
     }
 
     @Override
@@ -221,6 +229,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 model.setTickUnit((TradesChartsViewModel.TickUnit) newValue.getUserData());
                 priceAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
                 volumeAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
+                volumeInUsdAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
             }
         };
         priceAxisYWidthListener = (observable, oldValue, newValue) -> {
@@ -254,8 +263,10 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                             tableView.getColumns().add(1, marketColumn);
 
                         volumeChart.setPrefHeight(volumeChart.getMaxHeight());
+                        volumeInUsdChart.setPrefHeight(volumeInUsdChart.getMaxHeight());
                     } else {
                         volumeChart.setPrefHeight(volumeChart.getMinHeight());
+                        volumeInUsdChart.setPrefHeight(volumeInUsdChart.getMinHeight());
                         priceSeries.setName(selectedTradeCurrency.getName());
                         String code = selectedTradeCurrency.getCode();
                         volumeColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.amountWithCur", code)));
@@ -267,6 +278,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                     layout();
                     return null;
                 });
+
     }
 
     @Override
@@ -309,29 +321,38 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
         priceAxisY.labelProperty().bind(priceColumnLabel);
         priceColumnLabel.addListener(priceColumnLabelListener);
-
         currencySelectionSubscriber = currencySelectionBinding.subscribe((observable, oldValue, newValue) -> {
         });
 
-
         sortedList.comparatorProperty().bind(tableView.comparatorProperty());
         tableView.setItems(sortedList);
-
         priceChart.setAnimated(model.preferences.isUseAnimations());
         volumeChart.setAnimated(model.preferences.isUseAnimations());
+        volumeInUsdChart.setAnimated(model.preferences.isUseAnimations());
         priceAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
         volumeAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
+        volumeInUsdAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
 
         nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades", model.tradeStatisticsByCurrency.size()));
 
         exportLink.setOnAction(e -> exportToCsv());
-
         UserThread.runAfter(this::updateChartData, 100, TimeUnit.MILLISECONDS);
 
         if (root.getParent() instanceof Pane) {
             rootParent = (Pane) root.getParent();
             rootParent.heightProperty().addListener(parentHeightListener);
         }
+
+        user.getCookie().getAsOptionalBoolean(CookieKey.TRADE_STAT_CHART_USE_USD).ifPresent(showUsd -> {
+            showVolumeAsUsdToggleButton.setSelected(showUsd);
+            showVolumeAsUsd(showUsd);
+        });
+        showVolumeAsUsdToggleButton.setOnAction(e -> {
+            boolean selected = showVolumeAsUsdToggleButton.isSelected();
+            showVolumeAsUsd(selected);
+            user.getCookie().putAsBoolean(CookieKey.TRADE_STAT_CHART_USE_USD, selected);
+            user.requestPersistence();
+        });
 
         fillList();
         layout();
@@ -357,18 +378,27 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         priceChart.getData().clear();
 
         exportLink.setOnAction(null);
+        showVolumeAsUsdToggleButton.setOnAction(null);
 
         if (rootParent != null) {
             rootParent.heightProperty().removeListener(parentHeightListener);
         }
     }
 
+    private void showVolumeAsUsd(Boolean showUsd) {
+        volumeChart.setVisible(!showUsd);
+        volumeChart.setManaged(!showUsd);
+        volumeInUsdChart.setVisible(showUsd);
+        volumeInUsdChart.setManaged(showUsd);
+    }
+
     private void fillList() {
-        ObservableList<TradeStatistics3ListItem> tradeStatistics3ListItems = FXCollections.observableList(model.tradeStatisticsByCurrency.stream()
-                .map(tradeStatistics3 -> new TradeStatistics3ListItem(tradeStatistics3,
-                        coinFormatter,
-                        model.showAllTradeCurrenciesProperty.get()))
-                .collect(Collectors.toList()));
+        ObservableList<TradeStatistics3ListItem> tradeStatistics3ListItems = FXCollections.observableList(
+                model.tradeStatisticsByCurrency.stream()
+                        .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
+                                coinFormatter,
+                                model.showAllTradeCurrenciesProperty.get()))
+                        .collect(Collectors.toList()));
         listItems.clear();
         listItems.addAll(tradeStatistics3ListItems);
     }
@@ -493,24 +523,52 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
         priceChartPane.getChildren().add(priceChart);
 
-        volumeSeries = new XYChart.Series<>();
-
         volumeAxisX = new NumberAxis(0, model.maxTicks + 1, 1);
-        volumeAxisX.setTickUnit(4);
-        volumeAxisX.setMinorTickCount(4);
-        volumeAxisX.setMinorTickVisible(true);
-        volumeAxisX.setForceZeroInRange(false);
-        volumeAxisX.setTickLabelFormatter(getTimeAxisStringConverter());
-        addTickMarkLabelCssClass(volumeAxisX, "axis-tick-mark-text-node");
-
         volumeAxisY = new NumberAxis();
-        volumeAxisY.setForceZeroInRange(true);
-        volumeAxisY.setAutoRanging(true);
-        volumeAxisY.setLabel(Res.get("shared.volumeWithCur", Res.getBaseCurrencyCode()));
-        volumeAxisY.setTickLabelFormatter(new StringConverter<>() {
+        volumeChart = getVolumeChart(volumeAxisX, volumeAxisY, volumeSeries, "BTC");
+
+        volumeInUsdAxisX = new NumberAxis(0, model.maxTicks + 1, 1);
+        volumeInUsdAxisY = new NumberAxis();
+        volumeInUsdChart = getVolumeChart(volumeInUsdAxisX, volumeInUsdAxisY, volumeInUsdSeries, "USD");
+        volumeInUsdChart.setVisible(false);
+        volumeInUsdChart.setManaged(false);
+
+        showVolumeAsUsdToggleButton = new AutoTooltipSlideToggleButton();
+        showVolumeAsUsdToggleButton.setText(Res.get("market.trades.showVolumeInUSD"));
+        showVolumeAsUsdToggleButton.setPadding(new Insets(-15, 0, 0, 10));
+
+        VBox vBox = new VBox();
+        AnchorPane.setTopAnchor(vBox, 15d);
+        AnchorPane.setBottomAnchor(vBox, 10d);
+        AnchorPane.setLeftAnchor(vBox, 0d);
+        AnchorPane.setRightAnchor(vBox, 10d);
+        vBox.getChildren().addAll(showVolumeAsUsdToggleButton, volumeChart, volumeInUsdChart);
+
+        volumeChartPane = new AnchorPane();
+        volumeChartPane.getStyleClass().add("chart-pane");
+        volumeChartPane.getChildren().add(vBox);
+    }
+
+    private VolumeChart getVolumeChart(NumberAxis axisX,
+                                       NumberAxis axisY,
+                                       XYChart.Series<Number, Number> series,
+                                       String currency) {
+        axisX.setTickUnit(4);
+        axisX.setMinorTickCount(4);
+        axisX.setMinorTickVisible(true);
+        axisX.setForceZeroInRange(false);
+        axisX.setTickLabelFormatter(getTimeAxisStringConverter());
+        addTickMarkLabelCssClass(axisX, "axis-tick-mark-text-node");
+
+        axisY.setForceZeroInRange(true);
+        axisY.setAutoRanging(true);
+        axisY.setLabel(Res.get("shared.volumeWithCur", currency));
+        axisY.setTickLabelFormatter(new StringConverter<>() {
             @Override
-            public String toString(Number object) {
-                return coinFormatter.formatCoin(Coin.valueOf(MathUtils.doubleToLong((double) object)));
+            public String toString(Number volume) {
+                return currency.equals("BTC") ?
+                        coinFormatter.formatCoin(Coin.valueOf(MathUtils.doubleToLong((double) volume))) :
+                        DisplayUtils.formatLargeFiatWithUnitPostFix((double) volume, "USD");
             }
 
             @Override
@@ -519,38 +577,31 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             }
         });
 
-        volumeChart = new VolumeChart(volumeAxisX, volumeAxisY, new StringConverter<>() {
+        StringConverter<Number> btcStringConverter = new StringConverter<>() {
             @Override
-            public String toString(Number object) {
-                return coinFormatter.formatCoinWithCode(Coin.valueOf((long) object));
+            public String toString(Number volume) {
+                return coinFormatter.formatCoinWithCode(Coin.valueOf((long) volume));
             }
 
             @Override
             public Number fromString(String string) {
                 return null;
             }
-        });
+        };
+        VolumeChart volumeChart = new VolumeChart(axisX, axisY, btcStringConverter);
         volumeChart.setId("volume-chart");
-        volumeChart.setData(FXCollections.observableArrayList(List.of(volumeSeries)));
+        volumeChart.setData(FXCollections.observableArrayList(List.of(series)));
         volumeChart.setMinHeight(138);
         volumeChart.setPrefHeight(138);
         volumeChart.setMaxHeight(200);
         volumeChart.setLegendVisible(false);
         volumeChart.setPadding(new Insets(0));
-
-        volumeChartPane = new AnchorPane();
-        volumeChartPane.getStyleClass().add("chart-pane");
-
-        AnchorPane.setTopAnchor(volumeChart, 15d);
-        AnchorPane.setBottomAnchor(volumeChart, 10d);
-        AnchorPane.setLeftAnchor(volumeChart, 0d);
-        AnchorPane.setRightAnchor(volumeChart, 10d);
-
-        volumeChartPane.getChildren().add(volumeChart);
+        return volumeChart;
     }
 
     private void updateChartData() {
         volumeSeries.getData().setAll(model.volumeItems);
+        volumeInUsdSeries.getData().setAll(model.volumeInUsdItems);
 
         // At price chart we need to set the priceSeries new otherwise the lines are not rendered correctly
         // TODO should be fixed in candle chart
@@ -566,9 +617,11 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             if (volumeAxisYWidth > priceAxisYWidth) {
                 priceChart.setPadding(new Insets(0, 0, 0, volumeAxisYWidth - priceAxisYWidth));
                 volumeChart.setPadding(new Insets(0, 0, 0, 0));
+                volumeInUsdChart.setPadding(new Insets(0, 0, 0, 0));
             } else if (volumeAxisYWidth < priceAxisYWidth) {
                 priceChart.setPadding(new Insets(0, 0, 0, 0));
                 volumeChart.setPadding(new Insets(0, 0, 0, priceAxisYWidth - volumeAxisYWidth));
+                volumeInUsdChart.setPadding(new Insets(0, 0, 0, priceAxisYWidth - volumeAxisYWidth));
             }
         });
     }
@@ -586,21 +639,21 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                 long time = model.getTimeFromTickIndex(index);
                 String fmt = "";
                 switch (model.tickUnit) {
-                case YEAR:
-                    fmt = "yyyy";
-                    break;
-                case MONTH:
-                    fmt = "MMMyy";
-                    break;
-                case WEEK:
-                case DAY:
-                    fmt = "dd/MMM\nyyyy";
-                    break;
-                case HOUR :
-                case MINUTE_10:
-                    fmt = "HH:mm\ndd/MMM";
-                    break;
-                default:        // nothing here
+                    case YEAR:
+                        fmt = "yyyy";
+                        break;
+                    case MONTH:
+                        fmt = "MMMyy";
+                        break;
+                    case WEEK:
+                    case DAY:
+                        fmt = "dd/MMM\nyyyy";
+                        break;
+                    case HOUR:
+                    case MINUTE_10:
+                        fmt = "HH:mm\ndd/MMM";
+                        break;
+                    default:        // nothing here
                 }
 
                 return DisplayUtils.formatDateAxis(new Date(time), fmt);
@@ -616,16 +669,16 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private void addTickMarkLabelCssClass(NumberAxis axis, String cssClass) {
         // grab the axis tick mark label (text object) and add a CSS class.
         axis.getChildrenUnmodifiable().addListener((ListChangeListener<Node>) c -> {
-                while (c.next()) {
-                    if (c.wasAdded()) {
-                        for (Node mark : c.getAddedSubList()) {
-                            if (mark instanceof Text) {
-                                mark.getStyleClass().add(cssClass);
-                            }
+            while (c.next()) {
+                if (c.wasAdded()) {
+                    for (Node mark : c.getAddedSubList()) {
+                        if (mark instanceof Text) {
+                            mark.getStyleClass().add(cssClass);
                         }
                     }
                 }
-            });
+            }
+        });
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -107,7 +107,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
     final BooleanProperty showAllTradeCurrenciesProperty = new SimpleBooleanProperty(false);
     private final CurrencyList currencyListItems;
     private final CurrencyListItem showAllCurrencyListItem = new CurrencyListItem(new CryptoCurrency(GUIUtil.SHOW_ALL_FLAG, ""), -1);
-    final ObservableList<TradeStatistics3> tradeStatisticsByCurrency = FXCollections.observableArrayList();
+    final ObservableList<TradeStatistics3> selectedTradeStatistics = FXCollections.observableArrayList();
     final ObservableList<XYChart.Data<Number, Number>> priceItems = FXCollections.observableArrayList();
     final ObservableList<XYChart.Data<Number, Number>> volumeItems = FXCollections.observableArrayList();
     final ObservableList<XYChart.Data<Number, Number>> volumeInUsdItems = FXCollections.observableArrayList();
@@ -289,7 +289,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
 
     private void updateChartData() {
         String currencyCode = getCurrencyCode();
-        tradeStatisticsByCurrency.setAll(tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
+        selectedTradeStatistics.setAll(tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
                 .filter(e -> showAllTradeCurrenciesProperty.get() || e.getCurrency().equals(currencyCode))
                 .collect(Collectors.toList()));
 
@@ -305,7 +305,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
         }
 
         // Get all entries for the defined time interval
-        tradeStatisticsByCurrency.forEach(tradeStatistics -> {
+        selectedTradeStatistics.forEach(tradeStatistics -> {
             for (long i = maxTicks; i > 0; --i) {
                 Pair<Date, Set<TradeStatistics3>> pair = itemsPerInterval.get(i);
                 if (tradeStatistics.getDate().after(pair.getKey())) {

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -65,6 +65,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -291,8 +292,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
         long accumulatedVolume = 0;
         long accumulatedAmount = 0;
         long numTrades = set.size();
-        ObservableList<Long> tradePrices = FXCollections.observableArrayList();
-
+        List<Long> tradePrices = new ArrayList<>();
         for (TradeStatistics3 item : set) {
             long tradePriceAsLong = item.getTradePrice().getValue();
             // Previously a check was done which inverted the low and high for cryptocurrencies.
@@ -301,9 +301,9 @@ class TradesChartsViewModel extends ActivatableViewModel {
 
             accumulatedVolume += item.getTradeVolume().getValue();
             accumulatedAmount += item.getTradeAmount().getValue();
-            tradePrices.add(item.getTradePrice().getValue());
+            tradePrices.add(tradePriceAsLong);
         }
-        FXCollections.sort(tradePrices);
+        Collections.sort(tradePrices);
 
         List<TradeStatistics3> list = new ArrayList<>(set);
         ObservableList<TradeStatistics3> obsList = FXCollections.observableArrayList(list);

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -372,11 +372,10 @@ class TradesChartsViewModel extends ActivatableViewModel {
         Collections.sort(tradePrices);
 
         List<TradeStatistics3> list = new ArrayList<>(set);
-        ObservableList<TradeStatistics3> obsList = FXCollections.observableArrayList(list);
-        obsList.sort(Comparator.comparingLong(TradeStatistics3::getDateAsLong));
-        if (obsList.size() > 0) {
-            open = obsList.get(0).getTradePrice().getValue();
-            close = obsList.get(obsList.size() - 1).getTradePrice().getValue();
+        list.sort(Comparator.comparingLong(TradeStatistics3::getDateAsLong));
+        if (list.size() > 0) {
+            open = list.get(0).getTradePrice().getValue();
+            close = list.get(list.size() - 1).getTradePrice().getValue();
         }
 
         long averagePrice;

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -83,6 +83,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
     private static final int TAB_INDEX = 2;
     private static final ZoneId ZONE_ID = ZoneId.systemDefault();
 
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Enum
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -116,7 +117,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
     final int maxTicks = 90;
     private int selectedTabIndex;
     final Map<TickUnit, Map<Long, Long>> usdPriceMapsPerTickUnit = new HashMap<>();
-
+    private boolean fillTradeCurrenciesOnActiavetCalled;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor, lifecycle
@@ -150,7 +151,10 @@ class TradesChartsViewModel extends ActivatableViewModel {
     @Override
     protected void activate() {
         tradeStatisticsManager.getObservableTradeStatisticsSet().addListener(setChangeListener);
-        fillTradeCurrencies();
+        if (!fillTradeCurrenciesOnActiavetCalled) {
+            fillTradeCurrencies();
+            fillTradeCurrenciesOnActiavetCalled = true;
+        }
         buildUsdPricesPerDay();
         updateChartData();
         syncPriceFeedCurrency();
@@ -284,8 +288,9 @@ class TradesChartsViewModel extends ActivatableViewModel {
     }
 
     private void updateChartData() {
+        String currencyCode = getCurrencyCode();
         tradeStatisticsByCurrency.setAll(tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
-                .filter(e -> showAllTradeCurrenciesProperty.get() || e.getCurrency().equals(getCurrencyCode()))
+                .filter(e -> showAllTradeCurrenciesProperty.get() || e.getCurrency().equals(currencyCode))
                 .collect(Collectors.toList()));
 
         // Generate date range and create sets for all ticks

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -115,7 +115,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
     TickUnit tickUnit;
     final int maxTicks = 90;
     private int selectedTabIndex;
-    Map<TickUnit, Map<Long, Long>> usdPriceMapsPerTickUnit = new HashMap<>();
+    final Map<TickUnit, Map<Long, Long>> usdPriceMapsPerTickUnit = new HashMap<>();
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/CandleData.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/CandleData.java
@@ -30,10 +30,11 @@ public class CandleData {
     public final long numTrades;
     public final boolean isBullish;
     public final String date;
+    public final long volumeInUsd;
 
     public CandleData(long tick, long open, long close, long high, long low, long average, long median,
                       long accumulatedAmount, long accumulatedVolume, long numTrades,
-                      boolean isBullish, String date) {
+                      boolean isBullish, String date, long volumeInUsd) {
         this.tick = tick;
         this.open = open;
         this.close = close;
@@ -46,5 +47,6 @@ public class CandleData {
         this.numTrades = numTrades;
         this.isBullish = isBullish;
         this.date = date;
+        this.volumeInUsd = volumeInUsd;
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/price/Candle.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/price/Candle.java
@@ -58,15 +58,10 @@ import javafx.scene.shape.Line;
 
 import javafx.util.StringConverter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Candle node used for drawing a candle
  */
 public class Candle extends Group {
-    private static final Logger log = LoggerFactory.getLogger(Candle.class);
-
     private String seriesStyleClass;
     private String dataStyleClass;
     private final CandleTooltip candleTooltip;

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/price/CandleStickChart.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/price/CandleStickChart.java
@@ -108,14 +108,14 @@ public class CandleStickChart extends XYChart<Number, Number> {
         // update candle positions
         for (int seriesIndex = 0; seriesIndex < getData().size(); seriesIndex++) {
             XYChart.Series<Number, Number> series = getData().get(seriesIndex);
-            Iterator<XYChart.Data<Number, Number>> iter = getDisplayedDataIterator(series);
+            Iterator<XYChart.Data<Number, Number>> iterator = getDisplayedDataIterator(series);
             Path seriesPath = null;
             if (series.getNode() instanceof Path) {
                 seriesPath = (Path) series.getNode();
                 seriesPath.getElements().clear();
             }
-            while (iter.hasNext()) {
-                XYChart.Data<Number, Number> item = iter.next();
+            while (iterator.hasNext()) {
+                XYChart.Data<Number, Number> item = iterator.next();
                 double x = getXAxis().getDisplayPosition(getCurrentDisplayedXValue(item));
                 double y = getYAxis().getDisplayPosition(getCurrentDisplayedYValue(item));
                 Node itemNode = item.getNode();

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeBar.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeBar.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.market.trades.charts.volume;
 
 import bisq.desktop.main.market.trades.charts.CandleData;
+import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.Res;
 
@@ -55,8 +56,9 @@ public class VolumeBar extends Group {
 
     public void update(double height, double candleWidth, CandleData candleData) {
         bar.resizeRelocate(-candleWidth / 2, 0, candleWidth, height);
-        String vol = volumeStringConverter.toString(candleData.accumulatedAmount);
-        tooltip.setText(Res.get("market.trades.tooltip.volumeBar", vol, candleData.numTrades, candleData.date));
+        String volumeInBtc = volumeStringConverter.toString(candleData.accumulatedAmount);
+        String volumeInUsd = DisplayUtils.formatLargeFiat(candleData.volumeInUsd, "USD");
+        tooltip.setText(Res.get("market.trades.tooltip.volumeBar", volumeInBtc, volumeInUsd, candleData.numTrades, candleData.date));
     }
 
     private void updateStyleClasses() {

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeBar.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeBar.java
@@ -27,12 +27,7 @@ import javafx.scene.layout.Region;
 
 import javafx.util.StringConverter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class VolumeBar extends Group {
-    private static final Logger log = LoggerFactory.getLogger(VolumeBar.class);
-
     private String seriesStyleClass;
     private String dataStyleClass;
     private final StringConverter<Number> volumeStringConverter;

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeChart.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeChart.java
@@ -53,9 +53,9 @@ public class VolumeChart extends XYChart<Number, Number> {
         }
         for (int seriesIndex = 0; seriesIndex < getData().size(); seriesIndex++) {
             XYChart.Series<Number, Number> series = getData().get(seriesIndex);
-            Iterator<XYChart.Data<Number, Number>> iter = getDisplayedDataIterator(series);
-            while (iter.hasNext()) {
-                XYChart.Data<Number, Number> item = iter.next();
+            Iterator<XYChart.Data<Number, Number>> iterator = getDisplayedDataIterator(series);
+            while (iterator.hasNext()) {
+                XYChart.Data<Number, Number> item = iterator.next();
                 double x = getXAxis().getDisplayPosition(getCurrentDisplayedXValue(item));
                 double y = getYAxis().getDisplayPosition(getCurrentDisplayedYValue(item));
                 Node itemNode = item.getNode();

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -21,12 +21,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
 import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 import java.util.Date;
+import java.util.Locale;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
@@ -104,6 +107,24 @@ public class DisplayUtils {
             formattedVolume = FormattingUtils.fillUpPlacesWithEmptyStrings(formattedVolume, maxNumberOfDigits);
         }
         return formattedVolume;
+    }
+
+    public static String formatLargeFiat(double value, String currency) {
+        if (value <= 0) {
+            return "0";
+        }
+        NumberFormat numberFormat = DecimalFormat.getInstance(Locale.US);
+        numberFormat.setGroupingUsed(true);
+        return numberFormat.format(value) + " " + currency;
+    }
+
+    public static String formatLargeFiatWithUnitPostFix(double value, String currency) {
+        if (value <= 0) {
+            return "0";
+        }
+        String[] units = new String[]{"", "K", "M", "B"};
+        int digitGroups = (int) (Math.log10(value) / Math.log10(1000));
+        return new DecimalFormat("#,##0.###").format(value / Math.pow(1000, digitGroups)) + units[digitGroups] + " " + currency;
     }
 
     public static String formatVolume(Volume volume) {

--- a/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
@@ -167,7 +167,7 @@ public class TradesChartsViewModelTest {
                 null,
                 null));
 
-        CandleData candleData = model.getCandleData(model.roundToTick(now, TradesChartsViewModel.TickUnit.DAY).getTime(), set);
+        CandleData candleData = model.getCandleData(model.roundToTick(now, TradesChartsViewModel.TickUnit.DAY).getTime(), set, 0);
         assertEquals(open, candleData.open);
         assertEquals(close, candleData.close);
         assertEquals(high, candleData.high);


### PR DESCRIPTION
Adds a toggle to show trade statistics volume in USD instead of BTC

<img width="1200" alt="Screen Shot 2021-01-08 at 16 43 00" src="https://user-images.githubusercontent.com/54558767/104067205-bbc17f80-51d0-11eb-853a-30a4c14a58f4.png">
<img width="1189" alt="Screen Shot 2021-01-08 at 16 43 06" src="https://user-images.githubusercontent.com/54558767/104067216-bfed9d00-51d0-11eb-80a3-0ab6a7a3832f.png">
