### PR TITLE
Change rule for "reason for payment" field to not use trade ID but leave it empty

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2884,6 +2884,9 @@ popup.shutDownInProgress.headline=Shut down in progress
 popup.shutDownInProgress.msg=Shutting down application can take a few seconds.\nPlease don't interrupt this process.
 
 popup.attention.forTradeWithId=Attention required for trade with ID {0}
+popup.attention.reasonForPaymentRuleChange=Version 1.5.5. introduces a trade rule change regarding the usage of \
+  the \"reason for payment\" field in bank transfers. Please leave the field empty and DO NOT use the trade ID anymore \
+  as it was required in the past.
 
 popup.info.multiplePaymentAccounts.headline=Multiple payment accounts available
 popup.info.multiplePaymentAccounts.msg=You have multiple payment accounts available for this offer. Please make sure you've picked the right one.

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2884,9 +2884,9 @@ popup.shutDownInProgress.headline=Shut down in progress
 popup.shutDownInProgress.msg=Shutting down application can take a few seconds.\nPlease don't interrupt this process.
 
 popup.attention.forTradeWithId=Attention required for trade with ID {0}
-popup.attention.reasonForPaymentRuleChange=Version 1.5.5. introduces a trade rule change regarding the usage of \
-  the \"reason for payment\" field in bank transfers. Please leave the field empty and DO NOT use the trade ID anymore \
-  as it was required in the past.
+popup.attention.reasonForPaymentRuleChange=Version 1.5.5 introduces a critical trade rule change regarding \
+  the \"reason for payment\" field in bank transfers. Please leave this field empty -- \
+  DO NOT use the trade ID as \"reason for payment\" anymore.
 
 popup.info.multiplePaymentAccounts.headline=Multiple payment accounts available
 popup.info.multiplePaymentAccounts.msg=You have multiple payment accounts available for this offer. Please make sure you've picked the right one.

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -636,7 +636,7 @@ portfolio.pending.step1.openForDispute=The deposit transaction is still not conf
 portfolio.pending.step2.confReached=Your trade has reached at least one blockchain confirmation.\n(You can wait for more confirmations if you want - 6 confirmations are considered as very secure.)\n\n
 
 portfolio.pending.step2_buyer.copyPaste=(You can copy & paste the values from the main screen after closing that popup.)
-portfolio.pending.step2_buyer.refTextWarn=DO NOT use any additional notice in the \"reason for payment\" text like bitcoin, BTC, Bisq or the trade ID. Leave the field empty.
+portfolio.pending.step2_buyer.refTextWarn=Leave the \"reason for payment\" field empty. DO NOT put the trade ID or any other text like 'bitcoin', 'BTC', or 'Bisq'.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.accountDetails=Here are the trade account details of the BTC seller:\n
 portfolio.pending.step2_buyer.fees=If your bank charges fees you have to cover those fees.

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -114,7 +114,6 @@ shared.waitingForFunds=Waiting for funds...
 shared.depositTransactionId=Deposit transaction ID
 shared.TheBTCBuyer=The BTC buyer
 shared.You=You
-shared.reasonForPayment=Reason for payment
 shared.sendingConfirmation=Sending confirmation...
 shared.sendingConfirmationAgain=Please send confirmation again
 shared.exportCSV=Export to CSV
@@ -637,12 +636,9 @@ portfolio.pending.step1.openForDispute=The deposit transaction is still not conf
 portfolio.pending.step2.confReached=Your trade has reached at least one blockchain confirmation.\n(You can wait for more confirmations if you want - 6 confirmations are considered as very secure.)\n\n
 
 portfolio.pending.step2_buyer.copyPaste=(You can copy & paste the values from the main screen after closing that popup.)
-portfolio.pending.step2_buyer.refTextWarn=DO NOT use any additional notice in the \"reason for payment\" text like bitcoin, BTC or Bisq.
+portfolio.pending.step2_buyer.refTextWarn=DO NOT use any additional notice in the \"reason for payment\" text like bitcoin, BTC, Bisq or the trade ID. Leave the field empty.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.accountDetails=Here are the trade account details of the BTC seller:\n
-portfolio.pending.step2_buyer.tradeId=Please don't forget to add the trade ID
-# suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step2_buyer.assign=as \"reason for payment\" so the receiver can assign your payment to this trade.\n\n
 portfolio.pending.step2_buyer.fees=If your bank charges fees you have to cover those fees.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.altcoin=Please transfer from your external {0} wallet\n{1} to the BTC seller.\n\n
@@ -755,12 +751,10 @@ portfolio.pending.step3_seller.altcoin={0}Please check {1} if the transaction to
 {2}\n\
 has already sufficient blockchain confirmations.\nThe payment amount has to be {3}\n\n\
 You can copy & paste your {4} address from the main screen after closing that popup.
-portfolio.pending.step3_seller.postal={0}Please check if you have received {1} with \"US Postal Money Order\" from the BTC buyer.\n\n\
-The trade ID (\"reason for payment\" text) of the transaction is: \"{2}\"
+portfolio.pending.step3_seller.postal={0}Please check if you have received {1} with \"US Postal Money Order\" from the BTC buyer.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.bank=Your trading partner has confirmed that they have initiated the {0} payment.\n\n\
-  Please go to your online banking web page and check if you have received {1} from the BTC buyer.\n\n\
-The trade ID (\"reason for payment\" text) of the transaction is: \"{2}\"\n\n
+  Please go to your online banking web page and check if you have received {1} from the BTC buyer.
 portfolio.pending.step3_seller.cash=Because the payment is done via Cash Deposit the BTC buyer has to write \"NO REFUND\" on the paper receipt, tear it in 2 parts and send you a photo by email.\n\n\
 To avoid chargeback risk, only confirm if you received the email and if you are sure the paper receipt is valid.\n\
 If you are not sure, {0}
@@ -802,8 +796,6 @@ portfolio.pending.step3_seller.openForDispute=You have not confirmed the receipt
   The max. period for the trade has elapsed.\nPlease confirm or request assistance from the mediator.
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.part1=Have you received the {0} payment from your trading partner?\n\n
-# suppress inspection "TrailingSpacesInProperty"
-portfolio.pending.step3_seller.onPaymentReceived.fiat=The trade ID (\"reason for payment\" text) of the transaction is: \"{0}\"\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step3_seller.onPaymentReceived.name=Please also verify that the name of the sender specified on the trade contract matches the name that appears on your bank statement:\nSender''s name, per trade contract: {0}\n\nIf the names are not exactly the same, don''t confirm payment receipt. Instead, open a dispute by pressing \"alt + o\" or \"option + o\".\n\n
 # suppress inspection "TrailingSpacesInProperty"

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
@@ -86,13 +86,15 @@ public class TacWindow extends Overlay<TacWindow> {
                 "    - DO NOT use any additional notice in the \"reason for payment\" text like bitcoin, BTC, Bisq or the trade ID. Leave the field empty.\n" +
                 "    - If the bank of the fiat sender charges fees, the sender (" + Res.getBaseCurrencyCode() + " buyer) has to cover the fees.\n" +
                 "    - You must cooperate with the mediator during the mediation process, and respond to each mediator message within 48 hours.\n" +
-                "    - If either (or both) traders do not accept the mediator's suggested payout, traders can open a refund request from an arbitrator after 10 days in case of altcoin trades and 20 days for fiat trades.\n" +
+                "    - If either (or both) traders do not accept the mediator's suggested payout, traders can open a refund request from an arbitrator after 10 days in case of altcoin trades\n" +
+                "      and 20 days for fiat trades.\n" +
                 "    - You should only open a refund request from an arbitrator if you think the mediator's suggested payout is unfair, or if your trading peer is unresponsive.\n" +
-                "    - Opening a refund request from an arbitrator triggers the delayed payout transaction, sending all funds from the deposit transaction to the Bisq DAO receiver address ('collateral for refund to avoid scamming the refund process'). At this point, the arbitrator will re-investigate the case and personally refund (at their discretion) the trader who requested arbitration.\n" +
-                "The arbitrator may charge a small fee (max. the traders security deposit) as compensation for their work.\n" +
+                "    - Opening a refund request from an arbitrator triggers the delayed payout transaction, sending all funds from the deposit transaction to the Bisq DAO receiver\n" +
+                "      address ('collateral for refund to avoid scamming the refund process'). At this point, the arbitrator will re-investigate the case and personally refund \n" +
+                "      (at their discretion) the trader who requested arbitration.\n" +
+                "    - The arbitrator may charge a small fee (max. the traders security deposit) as compensation for their work.\n" +
                 "    - The arbitrator will then make a reimbursement request to the Bisq DAO to get reimbursed for the refund they paid to the trader.\n\n" +
-                "For more details and a general overview please read the full documentation about " +
-                "dispute resolution.";
+                "For more details and a general overview please read the full documentation about dispute resolution.";
         message(text);
         actionButtonText(Res.get("tacWindow.agree"));
         closeButtonText(Res.get("tacWindow.disagree"));

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
@@ -83,7 +83,7 @@ public class TacWindow extends Overlay<TacWindow> {
 
                 "6. The user confirms that they have read and agreed to the rules regarding the dispute process:\n" +
                 "    - You must complete trades within the maximum duration specified for each payment method.\n" +
-                "    - DO NOT use any additional notice in the \"reason for payment\" text like bitcoin, BTC, Bisq or the trade ID. Leave the field empty.\n" +
+                "    - Leave the \"reason for payment\" field empty. DO NOT put the trade ID or any other text like 'bitcoin', 'BTC', or 'Bisq'.\n" +
                 "    - If the bank of the fiat sender charges fees, the sender (" + Res.getBaseCurrencyCode() + " buyer) has to cover the fees.\n" +
                 "    - You must cooperate with the mediator during the mediation process, and respond to each mediator message within 48 hours.\n" +
                 "    - If either (or both) traders do not accept the mediator's suggested payout, traders can open a refund request from an arbitrator after 10 days in case of altcoin trades\n" +

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
@@ -83,7 +83,7 @@ public class TacWindow extends Overlay<TacWindow> {
 
                 "6. The user confirms that they have read and agreed to the rules regarding the dispute process:\n" +
                 "    - You must complete trades within the maximum duration specified for each payment method.\n" +
-                "    - You must enter the trade ID in the \"reason for payment\" text field (if possible) when doing the fiat payment transfer.\n" +
+                "    - DO NOT use any additional notice in the \"reason for payment\" text like bitcoin, BTC, Bisq or the trade ID. Leave the field empty.\n" +
                 "    - If the bank of the fiat sender charges fees, the sender (" + Res.getBaseCurrencyCode() + " buyer) has to cover the fees.\n" +
                 "    - You must cooperate with the mediator during the mediation process, and respond to each mediator message within 48 hours.\n" +
                 "    - If either (or both) traders do not accept the mediator's suggested payout, traders can open a refund request from an arbitrator after 10 days in case of altcoin trades and 20 days for fiat trades.\n" +

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -218,13 +218,6 @@ public class BuyerStep2View extends TradeStepView {
                 Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE).second;
         field.setCopyWithoutCurrencyPostFix(true);
 
-        if (!(paymentAccountPayload instanceof AssetsAccountPayload) &&
-                !(paymentAccountPayload instanceof F2FAccountPayload)) {
-            addTopLabelTextFieldWithCopyIcon(gridPane, gridRow, 1,
-                    Res.get("shared.reasonForPayment"), model.dataModel.getReference(),
-                    Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE);
-        }
-
         switch (paymentMethodId) {
             case PaymentMethod.UPHOLD_ID:
                 gridRow = UpholdForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
@@ -539,11 +532,8 @@ public class BuyerStep2View extends TradeStepView {
             String copyPaste = Res.get("portfolio.pending.step2_buyer.copyPaste");
             String refTextWarn = Res.get("portfolio.pending.step2_buyer.refTextWarn");
             String accountDetails = Res.get("portfolio.pending.step2_buyer.accountDetails");
-            String tradeId = Res.get("portfolio.pending.step2_buyer.tradeId");
-            String assign = Res.get("portfolio.pending.step2_buyer.assign");
             String fees = Res.get("portfolio.pending.step2_buyer.fees");
             String id = trade.getShortId();
-            String paddedId = " " + id + " ";
             String amount = DisplayUtils.formatVolumeWithCode(trade.getTradeVolume());
             if (paymentAccountPayload instanceof AssetsAccountPayload) {
                 message += Res.get("portfolio.pending.step2_buyer.altcoin",
@@ -558,8 +548,6 @@ public class BuyerStep2View extends TradeStepView {
                         accountDetails +
                         paymentDetailsForTradePopup + ".\n\n" +
                         copyPaste + "\n\n" +
-                        tradeId + paddedId +
-                        assign +
                         refTextWarn + "\n\n" +
                         fees + "\n\n" +
                         Res.get("portfolio.pending.step2_buyer.cash.extra");
@@ -586,8 +574,6 @@ public class BuyerStep2View extends TradeStepView {
                         accountDetails +
                         paymentDetailsForTradePopup + ".\n\n" +
                         copyPaste + "\n\n" +
-                        tradeId + paddedId +
-                        assign +
                         refTextWarn;
             } else if (paymentAccountPayload instanceof F2FAccountPayload) {
                 message += Res.get("portfolio.pending.step2_buyer.f2f", amount) +
@@ -605,8 +591,6 @@ public class BuyerStep2View extends TradeStepView {
                         paymentDetailsForTradePopup + ".\n\n" +
                         Res.get("portfolio.pending.step2_buyer.fasterPaymentsHolderNameInfo") + "\n\n" +
                         copyPaste + "\n\n" +
-                        tradeId + paddedId +
-                        assign +
                         refTextWarn + "\n\n" +
                         fees;
             } else if (paymentAccountPayload instanceof AmazonGiftCardAccountPayload) {
@@ -620,8 +604,6 @@ public class BuyerStep2View extends TradeStepView {
                         accountDetails +
                         paymentDetailsForTradePopup + ".\n\n" +
                         copyPaste + "\n\n" +
-                        tradeId + paddedId +
-                        assign +
                         refTextWarn + "\n\n" +
                         fees;
             }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -40,7 +40,6 @@ import bisq.core.payment.payload.F2FAccountPayload;
 import bisq.core.payment.payload.HalCashAccountPayload;
 import bisq.core.payment.payload.MoneyGramAccountPayload;
 import bisq.core.payment.payload.PaymentAccountPayload;
-import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.payment.payload.SepaAccountPayload;
 import bisq.core.payment.payload.SepaInstantAccountPayload;
 import bisq.core.payment.payload.USPostalMoneyOrderAccountPayload;
@@ -238,13 +237,6 @@ public class SellerStep3View extends TradeStepView {
             }
         }
 
-        if (!isBlockChain && !checkNotNull(trade.getOffer()).getPaymentMethod().equals(PaymentMethod.F2F)) {
-            addTopLabelTextFieldWithCopyIcon(
-                    gridPane, gridRow, 1, Res.get("shared.reasonForPayment"),
-                    model.dataModel.getReference(), Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE);
-            GridPane.setRowSpan(titledGroupBg, 4);
-        }
-
         if (isXmrTrade()) {
             assetTxProofResultField = new InfoTextField();
 
@@ -368,12 +360,6 @@ public class SellerStep3View extends TradeStepView {
                 PaymentAccountPayload paymentAccountPayload = model.dataModel.getSellersPaymentAccountPayload();
                 String message = Res.get("portfolio.pending.step3_seller.onPaymentReceived.part1", getCurrencyName(trade));
                 if (!(paymentAccountPayload instanceof AssetsAccountPayload)) {
-                    if (!(paymentAccountPayload instanceof WesternUnionAccountPayload) &&
-                            !(paymentAccountPayload instanceof HalCashAccountPayload) &&
-                            !(paymentAccountPayload instanceof F2FAccountPayload)) {
-                        message += Res.get("portfolio.pending.step3_seller.onPaymentReceived.fiat", trade.getShortId());
-                    }
-
                     Optional<String> optionalHolderName = getOptionalHolderName();
                     if (optionalHolderName.isPresent()) {
                         message += Res.get("portfolio.pending.step3_seller.onPaymentReceived.name", optionalHolderName.get());
@@ -405,7 +391,6 @@ public class SellerStep3View extends TradeStepView {
         String tradeVolumeWithCode = DisplayUtils.formatVolumeWithCode(trade.getTradeVolume());
         String currencyName = getCurrencyName(trade);
         String part1 = Res.get("portfolio.pending.step3_seller.part", currencyName);
-        String id = trade.getShortId();
         if (paymentAccountPayload instanceof AssetsAccountPayload) {
             String address = ((AssetsAccountPayload) paymentAccountPayload).getAddress();
             String explorerOrWalletString = isXmrTrade() ?
@@ -414,12 +399,12 @@ public class SellerStep3View extends TradeStepView {
             message = Res.get("portfolio.pending.step3_seller.altcoin", part1, explorerOrWalletString, address, tradeVolumeWithCode, currencyName);
         } else {
             if (paymentAccountPayload instanceof USPostalMoneyOrderAccountPayload) {
-                message = Res.get("portfolio.pending.step3_seller.postal", part1, tradeVolumeWithCode, id);
+                message = Res.get("portfolio.pending.step3_seller.postal", part1, tradeVolumeWithCode);
             } else if (!(paymentAccountPayload instanceof WesternUnionAccountPayload) &&
                     !(paymentAccountPayload instanceof HalCashAccountPayload) &&
                     !(paymentAccountPayload instanceof F2FAccountPayload) &&
                     !(paymentAccountPayload instanceof AmazonGiftCardAccountPayload)) {
-                message = Res.get("portfolio.pending.step3_seller.bank", currencyName, tradeVolumeWithCode, id);
+                message = Res.get("portfolio.pending.step3_seller.bank", currencyName, tradeVolumeWithCode);
             }
 
             String part = Res.get("portfolio.pending.step3_seller.openDispute");
@@ -447,7 +432,7 @@ public class SellerStep3View extends TradeStepView {
         }
         if (!DevEnv.isDevMode() && DontShowAgainLookup.showAgain(key)) {
             DontShowAgainLookup.dontShowAgain(key, true);
-            new Popup().headLine(Res.get("popup.attention.forTradeWithId", id))
+            new Popup().headLine(Res.get("popup.attention.forTradeWithId", trade.getShortId()))
                     .attention(message)
                     .show();
         }


### PR DESCRIPTION
Implements https://github.com/bisq-network/bisq/issues/2869

- Adds popup at startup with rule change for users who have already a fiat account.
- Change TAC text to leave field empty and not use Bisq, BTC or trade id
- Change buyer popup in trade process to tell to leave field empty
- Remove text fields with reason for payment in trade process
- Remove text from popup for seller to check for reason for payment to match trade id

Hope I did not missed some...

@m52go @pazza83 I am not 100% sure if the popup at startup is enough to announce the change. I think we should additionally communicate it clearly in all our channels and of course to our support guys.

