### PR TITLE
Avoid reverse DNS lookup in BtcNodeConverterTest

### DIFF
--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -456,8 +456,7 @@ public class WalletConfig extends AbstractIdleService {
         } else {
             // proxy case (tor).
             Proxy proxy = new Proxy(Proxy.Type.SOCKS,
-                    new InetSocketAddress(socks5Proxy.getInetAddress().getHostName(),
-                            socks5Proxy.getPort()));
+                    new InetSocketAddress(socks5Proxy.getInetAddress(), socks5Proxy.getPort()));
 
             ProxySocketFactory proxySocketFactory = new ProxySocketFactory(proxy);
             // We don't use tor mode if we have a local node running

--- a/core/src/test/java/bisq/core/btc/nodes/BtcNodeConverterTest.java
+++ b/core/src/test/java/bisq/core/btc/nodes/BtcNodeConverterTest.java
@@ -27,7 +27,6 @@ import org.bitcoinj.core.PeerAddress;
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 import org.junit.Test;
 
@@ -39,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 public class BtcNodeConverterTest {
     @Test
-    public void testConvertOnionHost() throws UnknownHostException {
+    public void testConvertOnionHost() {
         BtcNode node = mock(BtcNode.class);
         when(node.getOnionAddress()).thenReturn("aaa.onion");
 
@@ -63,7 +62,7 @@ public class BtcNodeConverterTest {
         PeerAddress peerAddress = new BtcNodeConverter().convertClearNode(node);
         // noinspection ConstantConditions
         InetAddress inetAddress = peerAddress.getAddr();
-        assertEquals(ip, inetAddress.getHostName());
+        assertEquals(ip, inetAddress.getHostAddress());
     }
 
     @Test


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Prevent failure of `testConvertClearNode()` on some machines, caused by use of `InetAddress.getHostName` on the mock peer address. This does a reverse DNS lookup and potentially returns something other than the expected "192.168.0.1" string. (For example, on my current local network I get "BrightBox.ee".)

Also avoid an unnecessary `getHostName()` call on the SOCKS5 Tor proxy InetAddress in `WalletConfig`, by using an alternative `InetSocketAddress` constructor.
