### PR TITLE
Fix bug with ignoreLocalBtcNode

### DIFF
--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -460,7 +460,7 @@ public class WalletConfig extends AbstractIdleService {
 
             ProxySocketFactory proxySocketFactory = new ProxySocketFactory(proxy);
             // We don't use tor mode if we have a local node running
-            BlockingClientManager blockingClientManager = config.ignoreLocalBtcNode ?
+            BlockingClientManager blockingClientManager = localBitcoinNode.shouldBeUsed() ?
                     new BlockingClientManager() :
                     new BlockingClientManager(proxySocketFactory);
 


### PR DESCRIPTION
Do not pass proxySocketFactory to BlockingClientManager if we use a local Bitcoin node.