### PR TITLE
Define gRPC api call rate constraints

### DIFF
--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcDisputeAgentsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcDisputeAgentsService.java
@@ -56,14 +56,13 @@ class GrpcDisputeAgentsService extends DisputeAgentsGrpc.DisputeAgentsImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    // You can only register mainnet dispute agents in the UI.
-                    // Do not limit devs' ability to register test agents.
-                    put("registerDisputeAgent", new GrpcCallRateMeter(1, SECONDS));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            // You can only register mainnet dispute agents in the UI.
+                            // Do not limit devs' ability to register test agents.
+                            put("registerDisputeAgent", new GrpcCallRateMeter(1, SECONDS));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcDisputeAgentsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcDisputeAgentsService.java
@@ -6,11 +6,23 @@ import bisq.proto.grpc.DisputeAgentsGrpc;
 import bisq.proto.grpc.RegisterDisputeAgentReply;
 import bisq.proto.grpc.RegisterDisputeAgentRequest;
 
+import io.grpc.ServerInterceptor;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
 
+import java.util.HashMap;
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+
+import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+
+import bisq.daemon.grpc.interceptor.CallRateMeteringInterceptor;
+import bisq.daemon.grpc.interceptor.GrpcCallRateMeter;
 
 @Slf4j
 class GrpcDisputeAgentsService extends DisputeAgentsGrpc.DisputeAgentsImplBase {
@@ -35,5 +47,23 @@ class GrpcDisputeAgentsService extends DisputeAgentsGrpc.DisputeAgentsImplBase {
         } catch (Throwable cause) {
             exceptionHandler.handleException(cause, responseObserver);
         }
+    }
+
+    final ServerInterceptor[] interceptors() {
+        Optional<ServerInterceptor> rateMeteringInterceptor = rateMeteringInterceptor();
+        return rateMeteringInterceptor.map(serverInterceptor ->
+                new ServerInterceptor[]{serverInterceptor}).orElseGet(() -> new ServerInterceptor[0]);
+    }
+
+    final Optional<ServerInterceptor> rateMeteringInterceptor() {
+        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
+                new CallRateMeteringInterceptor(new HashMap<>() {{
+                    // You can only register mainnet dispute agents in the UI.
+                    // Do not limit devs' ability to register test agents.
+                    put("registerDisputeAgent", new GrpcCallRateMeter(1, SECONDS));
+                }});
+
+        return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
+                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcGetTradeStatisticsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcGetTradeStatisticsService.java
@@ -58,12 +58,11 @@ class GrpcGetTradeStatisticsService extends GetTradeStatisticsGrpc.GetTradeStati
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getTradeStatistics", new GrpcCallRateMeter(1, SECONDS));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("getTradeStatistics", new GrpcCallRateMeter(1, SECONDS));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcHelpService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcHelpService.java
@@ -23,11 +23,23 @@ import bisq.proto.grpc.GetMethodHelpReply;
 import bisq.proto.grpc.GetMethodHelpRequest;
 import bisq.proto.grpc.HelpGrpc;
 
+import io.grpc.ServerInterceptor;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
 
+import java.util.HashMap;
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+
+import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+
+import bisq.daemon.grpc.interceptor.CallRateMeteringInterceptor;
+import bisq.daemon.grpc.interceptor.GrpcCallRateMeter;
 
 @Slf4j
 class GrpcHelpService extends HelpGrpc.HelpImplBase {
@@ -52,5 +64,21 @@ class GrpcHelpService extends HelpGrpc.HelpImplBase {
         } catch (Throwable cause) {
             exceptionHandler.handleException(cause, responseObserver);
         }
+    }
+
+    final ServerInterceptor[] interceptors() {
+        Optional<ServerInterceptor> rateMeteringInterceptor = rateMeteringInterceptor();
+        return rateMeteringInterceptor.map(serverInterceptor ->
+                new ServerInterceptor[]{serverInterceptor}).orElseGet(() -> new ServerInterceptor[0]);
+    }
+
+    final Optional<ServerInterceptor> rateMeteringInterceptor() {
+        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
+                new CallRateMeteringInterceptor(new HashMap<>() {{
+                    put("getMethodHelp", new GrpcCallRateMeter(1, SECONDS));
+                }});
+
+        return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
+                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcHelpService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcHelpService.java
@@ -73,12 +73,11 @@ class GrpcHelpService extends HelpGrpc.HelpImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getMethodHelp", new GrpcCallRateMeter(1, SECONDS));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("getMethodHelp", new GrpcCallRateMeter(1, SECONDS));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -190,17 +190,16 @@ class GrpcOffersService extends OffersGrpc.OffersImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getOffer", new GrpcCallRateMeter(1, SECONDS));
-                    put("getMyOffer", new GrpcCallRateMeter(1, SECONDS));
-                    put("getOffers", new GrpcCallRateMeter(1, SECONDS));
-                    put("getMyOffers", new GrpcCallRateMeter(1, SECONDS));
-                    put("createOffer", new GrpcCallRateMeter(1, MINUTES));
-                    put("cancelOffer", new GrpcCallRateMeter(1, MINUTES));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("getOffer", new GrpcCallRateMeter(1, SECONDS));
+                            put("getMyOffer", new GrpcCallRateMeter(1, SECONDS));
+                            put("getOffers", new GrpcCallRateMeter(1, SECONDS));
+                            put("getMyOffers", new GrpcCallRateMeter(1, SECONDS));
+                            put("createOffer", new GrpcCallRateMeter(1, MINUTES));
+                            put("cancelOffer", new GrpcCallRateMeter(1, MINUTES));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -36,16 +36,27 @@ import bisq.proto.grpc.GetOffersReply;
 import bisq.proto.grpc.GetOffersRequest;
 import bisq.proto.grpc.OffersGrpc;
 
+import io.grpc.ServerInterceptor;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.api.model.OfferInfo.toOfferInfo;
+import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+
+import bisq.daemon.grpc.interceptor.CallRateMeteringInterceptor;
+import bisq.daemon.grpc.interceptor.GrpcCallRateMeter;
 
 @Slf4j
 class GrpcOffersService extends OffersGrpc.OffersImplBase {
@@ -170,5 +181,26 @@ class GrpcOffersService extends OffersGrpc.OffersImplBase {
         } catch (Throwable cause) {
             exceptionHandler.handleException(cause, responseObserver);
         }
+    }
+
+    final ServerInterceptor[] interceptors() {
+        Optional<ServerInterceptor> rateMeteringInterceptor = rateMeteringInterceptor();
+        return rateMeteringInterceptor.map(serverInterceptor ->
+                new ServerInterceptor[]{serverInterceptor}).orElseGet(() -> new ServerInterceptor[0]);
+    }
+
+    final Optional<ServerInterceptor> rateMeteringInterceptor() {
+        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
+                new CallRateMeteringInterceptor(new HashMap<>() {{
+                    put("getOffer", new GrpcCallRateMeter(1, SECONDS));
+                    put("getMyOffer", new GrpcCallRateMeter(1, SECONDS));
+                    put("getOffers", new GrpcCallRateMeter(1, SECONDS));
+                    put("getMyOffers", new GrpcCallRateMeter(1, SECONDS));
+                    put("createOffer", new GrpcCallRateMeter(1, MINUTES));
+                    put("cancelOffer", new GrpcCallRateMeter(1, MINUTES));
+                }});
+
+        return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
+                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
@@ -130,15 +130,14 @@ class GrpcPaymentAccountsService extends PaymentAccountsGrpc.PaymentAccountsImpl
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("createPaymentAccount", new GrpcCallRateMeter(1, MINUTES));
-                    put("getPaymentAccounts", new GrpcCallRateMeter(1, SECONDS));
-                    put("getPaymentMethods", new GrpcCallRateMeter(1, SECONDS));
-                    put("getPaymentAccountForm", new GrpcCallRateMeter(1, SECONDS));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("createPaymentAccount", new GrpcCallRateMeter(1, MINUTES));
+                            put("getPaymentAccounts", new GrpcCallRateMeter(1, SECONDS));
+                            put("getPaymentMethods", new GrpcCallRateMeter(1, SECONDS));
+                            put("getPaymentAccountForm", new GrpcCallRateMeter(1, SECONDS));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPriceService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPriceService.java
@@ -75,12 +75,11 @@ class GrpcPriceService extends PriceGrpc.PriceImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getMarketPrice", new GrpcCallRateMeter(1, SECONDS));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("getMarketPrice", new GrpcCallRateMeter(1, SECONDS));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPriceService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPriceService.java
@@ -23,11 +23,23 @@ import bisq.proto.grpc.MarketPriceReply;
 import bisq.proto.grpc.MarketPriceRequest;
 import bisq.proto.grpc.PriceGrpc;
 
+import io.grpc.ServerInterceptor;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
 
+import java.util.HashMap;
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+
+import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+
+import bisq.daemon.grpc.interceptor.CallRateMeteringInterceptor;
+import bisq.daemon.grpc.interceptor.GrpcCallRateMeter;
 
 @Slf4j
 class GrpcPriceService extends PriceGrpc.PriceImplBase {
@@ -54,5 +66,21 @@ class GrpcPriceService extends PriceGrpc.PriceImplBase {
         } catch (Throwable cause) {
             exceptionHandler.handleException(cause, responseObserver);
         }
+    }
+
+    final ServerInterceptor[] interceptors() {
+        Optional<ServerInterceptor> rateMeteringInterceptor = rateMeteringInterceptor();
+        return rateMeteringInterceptor.map(serverInterceptor ->
+                new ServerInterceptor[]{serverInterceptor}).orElseGet(() -> new ServerInterceptor[0]);
+    }
+
+    final Optional<ServerInterceptor> rateMeteringInterceptor() {
+        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
+                new CallRateMeteringInterceptor(new HashMap<>() {{
+                    put("getMarketPrice", new GrpcCallRateMeter(1, SECONDS));
+                }});
+
+        return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
+                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
@@ -60,15 +60,15 @@ public class GrpcServer {
                       GrpcWalletsService walletsService) {
         this.server = ServerBuilder.forPort(config.apiPort)
                 .executor(UserThread.getExecutor())
-                .addService(disputeAgentsService)
-                .addService(helpService)
-                .addService(offersService)
-                .addService(paymentAccountsService)
-                .addService(priceService)
-                .addService(tradeStatisticsService)
-                .addService(tradesService)
+                .addService(interceptForward(disputeAgentsService, disputeAgentsService.interceptors()))
+                .addService(interceptForward(helpService, helpService.interceptors()))
+                .addService(interceptForward(offersService, offersService.interceptors()))
+                .addService(interceptForward(paymentAccountsService, paymentAccountsService.interceptors()))
+                .addService(interceptForward(priceService, priceService.interceptors()))
+                .addService(interceptForward(tradeStatisticsService, tradeStatisticsService.interceptors()))
+                .addService(interceptForward(tradesService, tradesService.interceptors()))
                 .addService(interceptForward(versionService, versionService.interceptors()))
-                .addService(walletsService)
+                .addService(interceptForward(walletsService, walletsService.interceptors()))
                 .intercept(passwordAuthInterceptor)
                 .build();
         coreContext.setApiUser(true);

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcTradesService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcTradesService.java
@@ -162,17 +162,16 @@ class GrpcTradesService extends TradesGrpc.TradesImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getTrade", new GrpcCallRateMeter(1, SECONDS));
-                    put("takeOffer", new GrpcCallRateMeter(1, MINUTES));
-                    put("confirmPaymentStarted", new GrpcCallRateMeter(1, MINUTES));
-                    put("confirmPaymentReceived", new GrpcCallRateMeter(1, MINUTES));
-                    put("keepFunds", new GrpcCallRateMeter(1, MINUTES));
-                    put("withdrawFunds", new GrpcCallRateMeter(1, MINUTES));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("getTrade", new GrpcCallRateMeter(1, SECONDS));
+                            put("takeOffer", new GrpcCallRateMeter(1, MINUTES));
+                            put("confirmPaymentStarted", new GrpcCallRateMeter(1, MINUTES));
+                            put("confirmPaymentReceived", new GrpcCallRateMeter(1, MINUTES));
+                            put("keepFunds", new GrpcCallRateMeter(1, MINUTES));
+                            put("withdrawFunds", new GrpcCallRateMeter(1, MINUTES));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
@@ -74,12 +74,11 @@ public class GrpcVersionService extends GetVersionGrpc.GetVersionImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getVersion", new GrpcCallRateMeter(1, SECONDS));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("getVersion", new GrpcCallRateMeter(1, SECONDS));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcVersionService.java
@@ -74,13 +74,12 @@ public class GrpcVersionService extends GetVersionGrpc.GetVersionImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        @SuppressWarnings("unused")  // Defined as a usage example.
         CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
                 new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getVersion", new GrpcCallRateMeter(100, SECONDS));
+                    put("getVersion", new GrpcCallRateMeter(1, SECONDS));
                 }});
 
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(Optional::empty /* Optional.of(defaultCallRateMeteringInterceptor) */);
+                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -349,29 +349,28 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
     }
 
     final Optional<ServerInterceptor> rateMeteringInterceptor() {
-        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
-                new CallRateMeteringInterceptor(new HashMap<>() {{
-                    put("getBalances", new GrpcCallRateMeter(1, SECONDS));
-                    put("getAddressBalance", new GrpcCallRateMeter(1, SECONDS));
-                    put("getFundingAddresses", new GrpcCallRateMeter(1, SECONDS));
-                    put("getUnusedBsqAddress", new GrpcCallRateMeter(1, SECONDS));
-                    put("sendBsq", new GrpcCallRateMeter(1, MINUTES));
-                    put("sendBtc", new GrpcCallRateMeter(1, MINUTES));
-                    put("getTxFeeRate", new GrpcCallRateMeter(1, SECONDS));
-                    put("setTxFeeRatePreference", new GrpcCallRateMeter(1, SECONDS));
-                    put("unsetTxFeeRatePreference", new GrpcCallRateMeter(1, SECONDS));
-                    put("getTransaction", new GrpcCallRateMeter(1, SECONDS));
-
-                    // Trying to set or remove a wallet password several times before the 1st attempt has time to
-                    // persist the change to disk may corrupt the wallet, so allow only 1 attempt per 5 seconds.
-                    put("setWalletPassword", new GrpcCallRateMeter(1, SECONDS, 5));
-                    put("removeWalletPassword", new GrpcCallRateMeter(1, SECONDS, 5));
-
-                    put("lockWallet", new GrpcCallRateMeter(1, SECONDS));
-                    put("unlockWallet", new GrpcCallRateMeter(1, SECONDS));
-                }});
-
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
-                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            put("getBalances", new GrpcCallRateMeter(1, SECONDS));
+                            put("getAddressBalance", new GrpcCallRateMeter(1, SECONDS));
+                            put("getFundingAddresses", new GrpcCallRateMeter(1, SECONDS));
+                            put("getUnusedBsqAddress", new GrpcCallRateMeter(1, SECONDS));
+                            put("sendBsq", new GrpcCallRateMeter(1, MINUTES));
+                            put("sendBtc", new GrpcCallRateMeter(1, MINUTES));
+                            put("getTxFeeRate", new GrpcCallRateMeter(1, SECONDS));
+                            put("setTxFeeRatePreference", new GrpcCallRateMeter(1, SECONDS));
+                            put("unsetTxFeeRatePreference", new GrpcCallRateMeter(1, SECONDS));
+                            put("getTransaction", new GrpcCallRateMeter(1, SECONDS));
+
+                            // Trying to set or remove a wallet password several times before the 1st attempt has time to
+                            // persist the change to disk may corrupt the wallet, so allow only 1 attempt per 5 seconds.
+                            put("setWalletPassword", new GrpcCallRateMeter(1, SECONDS, 5));
+                            put("removeWalletPassword", new GrpcCallRateMeter(1, SECONDS, 5));
+
+                            put("lockWallet", new GrpcCallRateMeter(1, SECONDS));
+                            put("unlockWallet", new GrpcCallRateMeter(1, SECONDS));
+                        }}
+                )));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -53,6 +53,7 @@ import bisq.proto.grpc.UnsetTxFeeRatePreferenceReply;
 import bisq.proto.grpc.UnsetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.WalletsGrpc;
 
+import io.grpc.ServerInterceptor;
 import io.grpc.stub.StreamObserver;
 
 import org.bitcoinj.core.Transaction;
@@ -61,7 +62,9 @@ import javax.inject.Inject;
 
 import com.google.common.util.concurrent.FutureCallback;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +72,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import static bisq.core.api.model.TxInfo.toTxInfo;
+import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+
+import bisq.daemon.grpc.interceptor.CallRateMeteringInterceptor;
+import bisq.daemon.grpc.interceptor.GrpcCallRateMeter;
 
 @Slf4j
 class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
@@ -329,5 +340,38 @@ class GrpcWalletsService extends WalletsGrpc.WalletsImplBase {
         } catch (Throwable cause) {
             exceptionHandler.handleException(cause, responseObserver);
         }
+    }
+
+    final ServerInterceptor[] interceptors() {
+        Optional<ServerInterceptor> rateMeteringInterceptor = rateMeteringInterceptor();
+        return rateMeteringInterceptor.map(serverInterceptor ->
+                new ServerInterceptor[]{serverInterceptor}).orElseGet(() -> new ServerInterceptor[0]);
+    }
+
+    final Optional<ServerInterceptor> rateMeteringInterceptor() {
+        CallRateMeteringInterceptor defaultCallRateMeteringInterceptor =
+                new CallRateMeteringInterceptor(new HashMap<>() {{
+                    put("getBalances", new GrpcCallRateMeter(1, SECONDS));
+                    put("getAddressBalance", new GrpcCallRateMeter(1, SECONDS));
+                    put("getFundingAddresses", new GrpcCallRateMeter(1, SECONDS));
+                    put("getUnusedBsqAddress", new GrpcCallRateMeter(1, SECONDS));
+                    put("sendBsq", new GrpcCallRateMeter(1, MINUTES));
+                    put("sendBtc", new GrpcCallRateMeter(1, MINUTES));
+                    put("getTxFeeRate", new GrpcCallRateMeter(1, SECONDS));
+                    put("setTxFeeRatePreference", new GrpcCallRateMeter(1, SECONDS));
+                    put("unsetTxFeeRatePreference", new GrpcCallRateMeter(1, SECONDS));
+                    put("getTransaction", new GrpcCallRateMeter(1, SECONDS));
+
+                    // Trying to set or remove a wallet password several times before the 1st attempt has time to
+                    // persist the change to disk may corrupt the wallet, so allow only 1 attempt per 5 seconds.
+                    put("setWalletPassword", new GrpcCallRateMeter(1, SECONDS, 5));
+                    put("removeWalletPassword", new GrpcCallRateMeter(1, SECONDS, 5));
+
+                    put("lockWallet", new GrpcCallRateMeter(1, SECONDS));
+                    put("unlockWallet", new GrpcCallRateMeter(1, SECONDS));
+                }});
+
+        return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
+                .or(() -> Optional.of(defaultCallRateMeteringInterceptor));
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/interceptor/CallRateMeteringInterceptor.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/interceptor/CallRateMeteringInterceptor.java
@@ -25,6 +25,7 @@ import io.grpc.StatusRuntimeException;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -123,5 +124,11 @@ public final class CallRateMeteringInterceptor implements ServerInterceptor {
                 "serviceCallRateMeters {" + "\n\t\t" +
                 rateMetersString + "\n\t" + "}" + "\n"
                 + "}";
+    }
+
+    public static CallRateMeteringInterceptor valueOf(Map<String, GrpcCallRateMeter> rateMeters) {
+        return new CallRateMeteringInterceptor(new HashMap<>() {{
+            putAll(rateMeters);
+        }});
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/interceptor/GrpcServiceRateMeteringConfig.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/interceptor/GrpcServiceRateMeteringConfig.java
@@ -76,6 +76,7 @@ public class GrpcServiceRateMeteringConfig {
         this.methodRateMeters = methodRateMeters;
     }
 
+    @SuppressWarnings("unused")
     public GrpcServiceRateMeteringConfig addMethodCallRateMeter(String methodName,
                                                                 int maxCalls,
                                                                 TimeUnit timeUnit) {


### PR DESCRIPTION
The general rule is limit calls that change p2p data to 1/minute, others to 1/second.  An exception is made to set/remove wallet password methods (1/5s), due to the latency of writing wallet changes to disk.

This change may affect api testing in the future.  If that happens, further changes to the call rate metering interceptor may be made to loosen the constraints when running in regtest/dev mode.
