### PR TITLE
Wallet changes for Segwit BSQ implementation

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
@@ -2,7 +2,7 @@ package bisq.apitest.method.wallet;
 
 import bisq.proto.grpc.BsqBalanceInfo;
 
-import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.Address;
 import org.bitcoinj.core.NetworkParameters;
 
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +64,7 @@ public class BsqWalletTest extends MethodTest {
         assertFalse(address.isEmpty());
         assertTrue(address.startsWith("B"));
 
-        NetworkParameters networkParameters = LegacyAddress.getParametersFromAddress(address.substring(1));
+        NetworkParameters networkParameters = Address.fromString(null, address.substring(1)).getParameters();
         String addressNetwork = networkParameters.getPaymentProtocolId();
         assertNotEquals(PAYMENT_PROTOCOL_ID_MAINNET, addressNetwork);
         // TODO Fix bug causing the regtest bsq address network to be evaluated as 'testnet' here.

--- a/assets/src/main/java/bisq/asset/coins/BSQ.java
+++ b/assets/src/main/java/bisq/asset/coins/BSQ.java
@@ -18,7 +18,7 @@
 package bisq.asset.coins;
 
 import bisq.asset.AddressValidationResult;
-import bisq.asset.Base58AddressValidator;
+import bisq.asset.BitcoinAddressValidator;
 import bisq.asset.Coin;
 
 import org.bitcoinj.core.NetworkParameters;
@@ -57,7 +57,7 @@ public class BSQ extends Coin {
     }
 
 
-    public static class BSQAddressValidator extends Base58AddressValidator {
+    public static class BSQAddressValidator extends BitcoinAddressValidator {
 
         public BSQAddressValidator(NetworkParameters networkParameters) {
             super(networkParameters);
@@ -68,7 +68,7 @@ public class BSQ extends Coin {
             if (!address.startsWith("B"))
                 return AddressValidationResult.invalidAddress("BSQ address must start with 'B'");
 
-            String addressAsBtc = address.substring(1, address.length());
+            String addressAsBtc = address.substring(1);
 
             return super.validate(addressAsBtc);
         }

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -108,7 +108,7 @@ class CorePaymentAccountsService {
             throw new IllegalArgumentException("api does not currently support " + currencyCode + " accounts");
 
         // Validate the BSQ address string but ignore the return value.
-        coreWalletsService.getValidBsqLegacyAddress(address);
+        coreWalletsService.getValidBsqAddress(address);
 
         var cryptoCurrencyAccount = tradeInstant
                 ? (InstantCryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS_INSTANT)

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -581,7 +581,8 @@ class CoreWalletsService {
         if (btcWalletService.getAesKey() == null || bsqWalletService.getAesKey() == null) {
             KeyParameter aesKey = new KeyParameter(tempAesKey.getKey());
             walletsManager.setAesKey(aesKey);
-            walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().btcWallet(), aesKey);
+            walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().btcWallet(), aesKey, false);
+            walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().bsqWallet(), aesKey, true);
         }
     }
 

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -31,7 +31,6 @@ import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.exceptions.WalletException;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.model.BsqTransferModel;
-import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.btc.wallet.BsqTransferService;
 import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
@@ -97,7 +96,6 @@ class CoreWalletsService {
     private final CoreContext coreContext;
     private final Balances balances;
     private final WalletsManager walletsManager;
-    private final WalletsSetup walletsSetup;
     private final BsqWalletService bsqWalletService;
     private final BsqTransferService bsqTransferService;
     private final BsqFormatter bsqFormatter;
@@ -119,7 +117,6 @@ class CoreWalletsService {
                               CoreContext coreContext,
                               Balances balances,
                               WalletsManager walletsManager,
-                              WalletsSetup walletsSetup,
                               BsqWalletService bsqWalletService,
                               BsqTransferService bsqTransferService,
                               BsqFormatter bsqFormatter,
@@ -131,7 +128,6 @@ class CoreWalletsService {
         this.coreContext = coreContext;
         this.balances = balances;
         this.walletsManager = walletsManager;
-        this.walletsSetup = walletsSetup;
         this.bsqWalletService = bsqWalletService;
         this.bsqTransferService = bsqTransferService;
         this.bsqFormatter = bsqFormatter;
@@ -581,8 +577,7 @@ class CoreWalletsService {
         if (btcWalletService.getAesKey() == null || bsqWalletService.getAesKey() == null) {
             KeyParameter aesKey = new KeyParameter(tempAesKey.getKey());
             walletsManager.setAesKey(aesKey);
-            walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().btcWallet(), aesKey, false);
-            walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().bsqWallet(), aesKey, true);
+            walletsManager.maybeAddSegwitKeychains(aesKey);
         }
     }
 

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -424,7 +424,9 @@ public class BisqSetup {
                 requestWalletPasswordHandler.accept(aesKey -> {
                     walletsManager.setAesKey(aesKey);
                     walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().btcWallet(),
-                            aesKey);
+                            aesKey, false);
+                    walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().bsqWallet(),
+                            aesKey, true);
                     if (getResyncSpvSemaphore()) {
                         if (showFirstPopupIfResyncSPVRequestedHandler != null)
                             showFirstPopupIfResyncSPVRequestedHandler.run();

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -423,10 +423,7 @@ public class BisqSetup {
             if (requestWalletPasswordHandler != null) {
                 requestWalletPasswordHandler.accept(aesKey -> {
                     walletsManager.setAesKey(aesKey);
-                    walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().btcWallet(),
-                            aesKey, false);
-                    walletsSetup.getWalletConfig().maybeAddSegwitKeychain(walletsSetup.getWalletConfig().bsqWallet(),
-                            aesKey, true);
+                    walletsManager.maybeAddSegwitKeychains(aesKey);
                     if (getResyncSpvSemaphore()) {
                         if (showFirstPopupIfResyncSPVRequestedHandler != null)
                             showFirstPopupIfResyncSPVRequestedHandler.run();

--- a/core/src/main/java/bisq/core/btc/model/BsqTransferModel.java
+++ b/core/src/main/java/bisq/core/btc/model/BsqTransferModel.java
@@ -2,8 +2,8 @@ package bisq.core.btc.model;
 
 import bisq.core.dao.state.model.blockchain.TxType;
 
+import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Coin;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.Transaction;
 
 import lombok.Getter;
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public final class BsqTransferModel {
 
-    private final LegacyAddress receiverAddress;
+    private final Address receiverAddress;
     private final Coin receiverAmount;
     private final Transaction preparedSendTx;
     private final Transaction txWithBtcFee;
@@ -20,7 +20,7 @@ public final class BsqTransferModel {
     private final int txSize;
     private final TxType txType;
 
-    public BsqTransferModel(LegacyAddress receiverAddress,
+    public BsqTransferModel(Address receiverAddress,
                             Coin receiverAmount,
                             Transaction preparedSendTx,
                             Transaction txWithBtcFee,

--- a/core/src/main/java/bisq/core/btc/setup/BisqKeyChainGroupStructure.java
+++ b/core/src/main/java/bisq/core/btc/setup/BisqKeyChainGroupStructure.java
@@ -47,15 +47,14 @@ public class BisqKeyChainGroupStructure implements KeyChainGroupStructure {
             new ChildNumber(142, true),
             ChildNumber.ZERO_HARDENED);
 
-    // We don't use segwit for BSQ
-    // public static final ImmutableList<ChildNumber> BIP44_BSQ_SEGWIT_ACCOUNT_PATH = ImmutableList.of(
-    //        new ChildNumber(44, true),
-    //        new ChildNumber(142, true),
-    //        ChildNumber.ONE_HARDENED);
+    public static final ImmutableList<ChildNumber> BIP44_BSQ_SEGWIT_ACCOUNT_PATH = ImmutableList.of(
+            new ChildNumber(44, true),
+            new ChildNumber(142, true),
+            ChildNumber.ONE_HARDENED);
 
-    private boolean isBsqWallet;
+    private final boolean isBsqWallet;
 
-    public BisqKeyChainGroupStructure (boolean isBsqWallet) {
+    public BisqKeyChainGroupStructure(boolean isBsqWallet) {
         this.isBsqWallet = isBsqWallet;
     }
 
@@ -72,8 +71,7 @@ public class BisqKeyChainGroupStructure implements KeyChainGroupStructure {
             if (outputScriptType == null || outputScriptType == Script.ScriptType.P2PKH)
                 return BIP44_BSQ_NON_SEGWIT_ACCOUNT_PATH;
             else if (outputScriptType == Script.ScriptType.P2WPKH)
-                //return BIP44_BSQ_SEGWIT_ACCOUNT_PATH;
-                throw new IllegalArgumentException(outputScriptType.toString());
+                return BIP44_BSQ_SEGWIT_ACCOUNT_PATH;
             else
                 throw new IllegalArgumentException(outputScriptType.toString());
         }

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -109,7 +109,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 public class WalletsSetup {
 
-    public static final String PRE_SEGWIT_WALLET_BACKUP = "pre_segwit_bisq_BTC.wallet.backup";
+    public static final String PRE_SEGWIT_BTC_WALLET_BACKUP = "pre_segwit_bisq_BTC.wallet.backup";
+    public static final String PRE_SEGWIT_BSQ_WALLET_BACKUP = "pre_segwit_bisq_BSQ.wallet.backup";
 
     @Getter
     public final BooleanProperty walletsSetupFailed = new SimpleBooleanProperty();
@@ -427,12 +428,14 @@ public class WalletsSetup {
             e.printStackTrace();
         }
 
-        File segwitBackup = new File(walletDir, PRE_SEGWIT_WALLET_BACKUP);
-        try {
-            FileUtil.deleteFileIfExists(segwitBackup);
-        } catch (IOException e) {
-            log.error(e.toString(), e);
-        }
+        List.of(PRE_SEGWIT_BTC_WALLET_BACKUP, PRE_SEGWIT_BSQ_WALLET_BACKUP).forEach(filename -> {
+            File segwitBackup = new File(walletDir, filename);
+            try {
+                FileUtil.deleteFileIfExists(segwitBackup);
+            } catch (IOException e) {
+                log.error(e.toString(), e);
+            }
+        });
     }
 
 

--- a/core/src/main/java/bisq/core/btc/wallet/BsqTransferService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqTransferService.java
@@ -5,9 +5,9 @@ import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.exceptions.WalletException;
 import bisq.core.btc.model.BsqTransferModel;
 
+import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
@@ -32,7 +32,7 @@ public class BsqTransferService {
         this.btcWalletService = btcWalletService;
     }
 
-    public BsqTransferModel getBsqTransferModel(LegacyAddress address,
+    public BsqTransferModel getBsqTransferModel(Address address,
                                                 Coin receiverAmount,
                                                 Coin txFeePerVbyte)
             throws TransactionVerificationException,

--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -527,7 +527,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
     public Transaction getPreparedSendBsqTx(String receiverAddress, Coin receiverAmount)
             throws AddressFormatException, InsufficientBsqException, WalletException,
             TransactionVerificationException, BsqChangeBelowDustException {
-        return getPreparedSendTx(receiverAddress, receiverAmount, bsqCoinSelector, false);
+        return getPreparedSendTx(receiverAddress, receiverAmount, bsqCoinSelector);
     }
 
     public Transaction getPreparedSendBsqTx(String receiverAddress,
@@ -538,7 +538,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
         if (utxoCandidates != null) {
             bsqCoinSelector.setUtxoCandidates(utxoCandidates);
         }
-        return getPreparedSendTx(receiverAddress, receiverAmount, bsqCoinSelector, false);
+        return getPreparedSendTx(receiverAddress, receiverAmount, bsqCoinSelector);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -548,7 +548,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
     public Transaction getPreparedSendBtcTx(String receiverAddress, Coin receiverAmount)
             throws AddressFormatException, InsufficientBsqException, WalletException,
             TransactionVerificationException, BsqChangeBelowDustException {
-        return getPreparedSendTx(receiverAddress, receiverAmount, nonBsqCoinSelector, true);
+        return getPreparedSendTx(receiverAddress, receiverAmount, nonBsqCoinSelector);
     }
 
     public Transaction getPreparedSendBtcTx(String receiverAddress,
@@ -559,21 +559,16 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
         if (utxoCandidates != null) {
             nonBsqCoinSelector.setUtxoCandidates(utxoCandidates);
         }
-        return getPreparedSendTx(receiverAddress, receiverAmount, nonBsqCoinSelector, true);
+        return getPreparedSendTx(receiverAddress, receiverAmount, nonBsqCoinSelector);
     }
 
-    private Transaction getPreparedSendTx(String receiverAddress, Coin receiverAmount, CoinSelector coinSelector,
-                                          boolean allowSegwitOuput)
+    private Transaction getPreparedSendTx(String receiverAddress, Coin receiverAmount, CoinSelector coinSelector)
             throws AddressFormatException, InsufficientBsqException, WalletException, TransactionVerificationException, BsqChangeBelowDustException {
         daoKillSwitch.assertDaoIsNotDisabled();
         Transaction tx = new Transaction(params);
         checkArgument(Restrictions.isAboveDust(receiverAmount),
                 "The amount is too low (dust limit).");
-        if (allowSegwitOuput) {
-            tx.addOutput(receiverAmount, Address.fromString(params, receiverAddress));
-        } else {
-            tx.addOutput(receiverAmount, LegacyAddress.fromBase58(params, receiverAddress));
-        }
+        tx.addOutput(receiverAmount, Address.fromString(params, receiverAddress));
         SendRequest sendRequest = SendRequest.forTx(tx);
         sendRequest.fee = Coin.ZERO;
         sendRequest.feePerKb = Coin.ZERO;

--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -42,7 +42,6 @@ import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
@@ -50,6 +49,7 @@ import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.wallet.CoinSelection;
 import org.bitcoinj.wallet.CoinSelector;
@@ -807,12 +807,13 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
     // Addresses
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private LegacyAddress getChangeAddress() {
+    private Address getChangeAddress() {
         return getUnusedAddress();
     }
 
-    public LegacyAddress getUnusedAddress() {
-        return (LegacyAddress) wallet.getIssuedReceiveAddresses().stream()
+    public Address getUnusedAddress() {
+        return wallet.getIssuedReceiveAddresses().stream()
+                .filter(address -> Script.ScriptType.P2WPKH.equals(address.getOutputScriptType()))
                 .filter(this::isAddressUnused)
                 .findAny()
                 .orElse(wallet.freshReceiveAddress());

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -523,10 +523,10 @@ public class BtcWalletService extends WalletService {
             }
 
             Transaction tx = new Transaction(params);
-            preparedBsqTxInputs.stream().forEach(tx::addInput);
+            preparedBsqTxInputs.forEach(tx::addInput);
 
             if (forcedChangeValue.isZero()) {
-                preparedBsqTxOutputs.stream().forEach(tx::addOutput);
+                preparedBsqTxOutputs.forEach(tx::addOutput);
             } else {
                 //TODO test that case
                 checkArgument(preparedBsqTxOutputs.size() == 0, "preparedBsqTxOutputs.size must be null in that code branch");
@@ -598,10 +598,10 @@ public class BtcWalletService extends WalletService {
             } else if (ScriptPattern.isP2WPKH(connectedOutput.getScriptPubKey())) {
                 numSegwitInputs++;
             } else {
-                throw new IllegalArgumentException("Inputs should spend a P2PKH, P2PK or P2WPKH ouput");
+                throw new IllegalArgumentException("Inputs should spend a P2PKH, P2PK or P2WPKH output");
             }
         }
-        return new Tuple2(numLegacyInputs, numSegwitInputs);
+        return new Tuple2<>(numLegacyInputs, numSegwitInputs);
     }
 
 
@@ -871,7 +871,7 @@ public class BtcWalletService extends WalletService {
                 log.debug("txToDoubleSpend no. of inputs " + txToDoubleSpend.getInputs().size());
 
                 Transaction newTransaction = new Transaction(params);
-                txToDoubleSpend.getInputs().stream().forEach(input -> {
+                txToDoubleSpend.getInputs().forEach(input -> {
                             final TransactionOutput connectedOutput = input.getConnectedOutput();
                             if (connectedOutput != null &&
                                     connectedOutput.isMine(wallet) &&
@@ -1073,8 +1073,7 @@ public class BtcWalletService extends WalletService {
                         addressEntryOptional = findAddressEntry(address, AddressEntry.Context.ARBITRATOR);
                     return addressEntryOptional;
                 })
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .collect(Collectors.toSet());
         if (addressEntries.isEmpty())
             throw new AddressEntryException("No Addresses for withdraw  found in our wallet");
@@ -1255,8 +1254,7 @@ public class BtcWalletService extends WalletService {
                         addressEntryOptional = findAddressEntry(address, AddressEntry.Context.ARBITRATOR);
                     return addressEntryOptional;
                 })
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .collect(Collectors.toSet());
         if (addressEntries.isEmpty())
             throw new AddressEntryException("No Addresses for withdraw found in our wallet");

--- a/core/src/main/java/bisq/core/btc/wallet/WalletsManager.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletsManager.java
@@ -91,7 +91,9 @@ public class WalletsManager {
         return baseCurrencyWalletDetails + bsqWalletDetails;
     }
 
-    public void restoreSeedWords(@Nullable DeterministicSeed seed, ResultHandler resultHandler, ExceptionHandler exceptionHandler) {
+    public void restoreSeedWords(@Nullable DeterministicSeed seed,
+                                 ResultHandler resultHandler,
+                                 ExceptionHandler exceptionHandler) {
         walletsSetup.restoreSeedWords(seed, resultHandler, exceptionHandler);
     }
 
@@ -140,7 +142,15 @@ public class WalletsManager {
         tradeWalletService.setAesKey(aesKey);
     }
 
-    public DeterministicSeed getDecryptedSeed(KeyParameter aesKey, DeterministicSeed keyChainSeed, KeyCrypter keyCrypter) {
+    public void maybeAddSegwitKeychains(KeyParameter aesKey) {
+        var walletConfig = walletsSetup.getWalletConfig();
+        walletConfig.maybeAddSegwitKeychain(walletConfig.btcWallet(), aesKey, false);
+        walletConfig.maybeAddSegwitKeychain(walletConfig.bsqWallet(), aesKey, true);
+    }
+
+    public DeterministicSeed getDecryptedSeed(KeyParameter aesKey,
+                                              DeterministicSeed keyChainSeed,
+                                              KeyCrypter keyCrypter) {
         if (keyCrypter != null) {
             return keyChainSeed.decrypt(keyCrypter, "", aesKey);
         } else {

--- a/core/src/main/java/bisq/core/dao/governance/period/CycleService.java
+++ b/core/src/main/java/bisq/core/dao/governance/period/CycleService.java
@@ -134,8 +134,7 @@ public class CycleService implements DaoStateListener, DaoSetupService {
         // We add the default values from the Param enum to our StateChangeEvent list.
         List<DaoPhase> daoPhasesWithDefaultDuration = Arrays.stream(DaoPhase.Phase.values())
                 .map(this::getPhaseWithDefaultDuration)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .collect(Collectors.toList());
         return new Cycle(genesisBlockHeight, ImmutableList.copyOf(daoPhasesWithDefaultDuration));
     }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/IssuanceProposal.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/IssuanceProposal.java
@@ -17,10 +17,14 @@
 
 package bisq.core.dao.governance.proposal;
 
+import bisq.common.config.Config;
+
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
 
 /**
- * Marker interface for proposals which can lead to new BSQ issuance
+ * Interface for proposals which can lead to new BSQ issuance
  */
 public interface IssuanceProposal {
     Coin getRequestedBsq();
@@ -28,4 +32,10 @@ public interface IssuanceProposal {
     String getBsqAddress();
 
     String getTxId();
+
+    default Address getAddress() throws AddressFormatException {
+        // Remove leading 'B'
+        String underlyingBtcAddress = getBsqAddress().substring(1);
+        return Address.fromString(Config.baseCurrencyNetworkParameters(), underlyingBtcAddress);
+    }
 }

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/OpReturnType.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/OpReturnType.java
@@ -51,8 +51,6 @@ public enum OpReturnType implements ImmutableDaoStateModel {
     public static Optional<OpReturnType> getOpReturnType(byte type) {
         return Arrays.stream(OpReturnType.values())
                 .filter(opReturnType -> opReturnType.type == type)
-                .map(Optional::of)
-                .findAny()
-                .orElse(Optional.empty());
+                .findAny();
     }
 }

--- a/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
@@ -24,12 +24,9 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.config.Config;
 import bisq.common.util.CollectionUtils;
 
-import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
-import org.bitcoinj.core.LegacyAddress;
 
 import java.util.Date;
 import java.util.Map;
@@ -113,16 +110,10 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
     // Getters
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    @Override
     public Coin getRequestedBsq() {
         return Coin.valueOf(requestedBsq);
     }
-
-    public LegacyAddress getAddress() throws AddressFormatException {
-        // Remove leading 'B'
-        String underlyingBtcAddress = bsqAddress.substring(1, bsqAddress.length());
-        return LegacyAddress.fromBase58(Config.baseCurrencyNetworkParameters(), underlyingBtcAddress);
-    }
-
 
     @Override
     public ProposalType getType() {

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
@@ -24,12 +24,9 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.config.Config;
 import bisq.common.util.CollectionUtils;
 
-import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
-import org.bitcoinj.core.LegacyAddress;
 
 import java.util.Date;
 import java.util.Map;
@@ -113,16 +110,10 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
     // Getters
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    @Override
     public Coin getRequestedBsq() {
         return Coin.valueOf(requestedBsq);
     }
-
-    public LegacyAddress getAddress() throws AddressFormatException {
-        // Remove leading 'B'
-        String underlyingBtcAddress = bsqAddress.substring(1, bsqAddress.length());
-        return LegacyAddress.fromBase58(Config.baseCurrencyNetworkParameters(), underlyingBtcAddress);
-    }
-
 
     @Override
     public ProposalType getType() {

--- a/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
@@ -31,9 +31,9 @@ import bisq.common.app.DevEnv;
 import bisq.common.config.Config;
 import bisq.common.util.MathUtils;
 
+import org.bitcoinj.core.Address;
 import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.utils.MonetaryFormat;
 
 import javax.inject.Inject;
@@ -94,7 +94,7 @@ public class BsqFormatter implements CoinFormatter {
      * Returns the base-58 encoded String representation of this
      * object, including version and checksum bytes.
      */
-    public String getBsqAddressStringFromAddress(LegacyAddress address) {
+    public String getBsqAddressStringFromAddress(Address address) {
         final String addressString = address.toString();
         if (useBsqAddressFormat)
             return prefix + addressString;
@@ -103,13 +103,13 @@ public class BsqFormatter implements CoinFormatter {
 
     }
 
-    public LegacyAddress getAddressFromBsqAddress(String encoded) {
+    public Address getAddressFromBsqAddress(String encoded) {
         String maybeUpdatedEncoded = encoded;
         if (useBsqAddressFormat)
-            maybeUpdatedEncoded = encoded.substring(prefix.length(), encoded.length());
+            maybeUpdatedEncoded = encoded.substring(prefix.length());
 
         try {
-            return LegacyAddress.fromBase58(Config.baseCurrencyNetworkParameters(), maybeUpdatedEncoded);
+            return Address.fromString(Config.baseCurrencyNetworkParameters(), maybeUpdatedEncoded);
         } catch (AddressFormatException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/test/java/bisq/core/locale/MockTestnetCoin.java
+++ b/core/src/test/java/bisq/core/locale/MockTestnetCoin.java
@@ -17,16 +17,14 @@
 
 package bisq.core.locale;
 
+import bisq.asset.AddressValidationResult;
+import bisq.asset.BitcoinAddressValidator;
+import bisq.asset.Coin;
+
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.TestNet3Params;
-
-
-
-import bisq.asset.AddressValidationResult;
-import bisq.asset.Base58AddressValidator;
-import bisq.asset.Coin;
 
 public class MockTestnetCoin extends Coin {
 
@@ -55,7 +53,7 @@ public class MockTestnetCoin extends Coin {
         }
     }
 
-    public static class BSQAddressValidator extends Base58AddressValidator {
+    public static class BSQAddressValidator extends BitcoinAddressValidator {
 
         public BSQAddressValidator(NetworkParameters networkParameters) {
             super(networkParameters);

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
@@ -30,7 +30,6 @@ import bisq.core.util.coin.BsqFormatter;
 
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Coin;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionOutput;
 
@@ -103,10 +102,9 @@ class BsqTxListItem extends TxConfidenceListItem {
                     WalletService.isOutputScriptConvertibleToAddress(output)) {
                 // We don't support send txs with multiple outputs to multiple receivers, so we can
                 // assume that only one output is not from our own wallets.
-                // We ignore segwit outputs
                 Address addressFromOutput = WalletService.getAddressFromOutput(output);
-                if (addressFromOutput instanceof LegacyAddress) {
-                    sendToAddress = bsqFormatter.getBsqAddressStringFromAddress((LegacyAddress) addressFromOutput);
+                if (addressFromOutput != null) {
+                    sendToAddress = bsqFormatter.getBsqAddressStringFromAddress(addressFromOutput);
                     break;
                 }
             }
@@ -118,9 +116,8 @@ class BsqTxListItem extends TxConfidenceListItem {
         for (TransactionOutput output : transaction.getOutputs()) {
             if (WalletService.isOutputScriptConvertibleToAddress(output)) {
                 Address addressFromOutput = WalletService.getAddressFromOutput(output);
-                // We ignore segwit outputs
-                if (addressFromOutput instanceof LegacyAddress) {
-                    receivedWithAddress = bsqFormatter.getBsqAddressStringFromAddress((LegacyAddress) addressFromOutput);
+                if (addressFromOutput != null) {
+                    receivedWithAddress = bsqFormatter.getBsqAddressStringFromAddress(addressFromOutput);
                     break;
                 }
             }

--- a/desktop/src/main/java/bisq/desktop/util/validation/BsqAddressValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/BsqAddressValidator.java
@@ -46,7 +46,7 @@ public final class BsqAddressValidator extends InputValidator {
         try {
             bsqFormatter.getAddressFromBsqAddress(input);
             return new ValidationResult(true);
-        } catch (Throwable e) {
+        } catch (RuntimeException e) {
             return new ValidationResult(false, Res.get("validation.bsq.invalidFormat"));
         }
     }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This is a continuation from #5000, which replaces Bisq's Json RPC client to allow Segwit data (`"txinwitness"` fields) to be retrieved by DAO full nodes, in order to fill in the pubkeys of BSQ tx Segwit inputs (as necessary to support fully Segwit compensation and proof-of-burn txs).

This PR makes the necessary changes to the user's wallet and address formatting + validation to support Segwit BSQ, migrating the wallet upon startup in an analogous way to the Segwit BTC wallet upgrade (#4568). With these changes, newly generated BSQ addresses are native Segwit (p2wpkh) and take the form _'B' + \<bech32-address\>_, e.g.

> Bbc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq **(mainnet)**
> Bbcrt1qj4t04q4mpssfv9uzpm6w2n8rlhs7es47ktqx8x **(regtest)**

They should be valid everywhere the old base58 (p2pkh) BSQ addresses are, which continue to be supported (just never selected as new change or recipient addresses).

--

Note that this PR probably shouldn't be merged into master until the technical hard fork introduced by #5000 activates on mainnet, as otherwise upgraded users will have difficultly generating valid compensation requests or proof-of-burn txs. This is because native Segwit BSQ coins from their wallet may be arbitrarily selected as tx inputs.
