### PR TITLE
Speed up deposit and transactions view loads

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -99,10 +99,7 @@ public class BtcWalletService extends WalletService {
 
         walletsSetup.addSetupCompletedHandler(() -> {
             wallet = walletsSetup.getBtcWallet();
-            wallet.addCoinsReceivedEventListener(walletEventListener);
-            wallet.addCoinsSentEventListener(walletEventListener);
-            wallet.addReorganizeEventListener(walletEventListener);
-            wallet.addTransactionConfidenceEventListener(walletEventListener);
+            addListenersToWallet();
 
             walletsSetup.getChain().addNewBestBlockListener(block -> chainHeightProperty.set(block.getHeight()));
             chainHeightProperty.set(walletsSetup.getChain().getBestChainHeight());
@@ -676,8 +673,7 @@ public class BtcWalletService extends WalletService {
                 .filter(e -> {
                     boolean isSegwitOutputScriptType = Script.ScriptType.P2WPKH.equals(e.getAddress().getOutputScriptType());
                     // We need to ensure that we take only addressEntries which matches our segWit flag
-                    boolean isMatchingOutputScriptType = isSegwitOutputScriptType == segwit;
-                    return isMatchingOutputScriptType;
+                    return isSegwitOutputScriptType == segwit;
                 })
                 .findAny();
         return getOrCreateAddressEntry(context, addressEntry, segwit);

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -106,10 +106,10 @@ public abstract class WalletService {
     protected final Preferences preferences;
     protected final FeeService feeService;
     protected final NetworkParameters params;
-    protected final BisqWalletListener walletEventListener = new BisqWalletListener();
-    protected final CopyOnWriteArraySet<AddressConfidenceListener> addressConfidenceListeners = new CopyOnWriteArraySet<>();
-    protected final CopyOnWriteArraySet<TxConfidenceListener> txConfidenceListeners = new CopyOnWriteArraySet<>();
-    protected final CopyOnWriteArraySet<BalanceListener> balanceListeners = new CopyOnWriteArraySet<>();
+    private final BisqWalletListener walletEventListener = new BisqWalletListener();
+    private final CopyOnWriteArraySet<AddressConfidenceListener> addressConfidenceListeners = new CopyOnWriteArraySet<>();
+    private final CopyOnWriteArraySet<TxConfidenceListener> txConfidenceListeners = new CopyOnWriteArraySet<>();
+    private final CopyOnWriteArraySet<BalanceListener> balanceListeners = new CopyOnWriteArraySet<>();
     @Getter
     protected Wallet wallet;
     @Getter
@@ -138,9 +138,15 @@ public abstract class WalletService {
     // Lifecycle
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    protected void addListenersToWallet() {
+        wallet.addCoinsReceivedEventListener(walletEventListener);
+        wallet.addCoinsSentEventListener(walletEventListener);
+        wallet.addReorganizeEventListener(walletEventListener);
+        wallet.addTransactionConfidenceEventListener(walletEventListener);
+    }
+
     public void shutDown() {
         if (wallet != null) {
-            //noinspection deprecation
             wallet.removeCoinsReceivedEventListener(walletEventListener);
             wallet.removeCoinsSentEventListener(walletEventListener);
             wallet.removeReorganizeEventListener(walletEventListener);
@@ -595,17 +601,13 @@ public abstract class WalletService {
         wallet.removeChangeEventListener(listener);
     }
 
-    @SuppressWarnings("deprecation")
     public void addNewBestBlockListener(NewBestBlockListener listener) {
-        //noinspection deprecation
         final BlockChain chain = walletsSetup.getChain();
         if (isWalletReady() && chain != null)
             chain.addNewBestBlockListener(listener);
     }
 
-    @SuppressWarnings("deprecation")
     public void removeNewBestBlockListener(NewBestBlockListener listener) {
-        //noinspection deprecation
         final BlockChain chain = walletsSetup.getChain();
         if (isWalletReady() && chain != null)
             chain.removeNewBestBlockListener(listener);
@@ -786,7 +788,6 @@ public abstract class WalletService {
     // bisqWalletEventListener
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    @SuppressWarnings("deprecation")
     public class BisqWalletListener implements WalletCoinsReceivedEventListener, WalletCoinsSentEventListener, WalletReorganizeEventListener, TransactionConfidenceEventListener {
         @Override
         public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {

--- a/core/src/main/java/bisq/core/support/dispute/DisputeListService.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeListService.java
@@ -34,8 +34,10 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.ObservableList;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -53,6 +55,8 @@ public abstract class DisputeListService<T extends DisputeList<Dispute>> impleme
     private final Map<String, Subscription> disputeIsClosedSubscriptionsMap = new HashMap<>();
     @Getter
     private final IntegerProperty numOpenDisputes = new SimpleIntegerProperty();
+    @Getter
+    private final Set<String> disputedTradeIds = new HashSet<>();
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -154,6 +158,7 @@ public abstract class DisputeListService<T extends DisputeList<Dispute>> impleme
                     disputeIsClosedSubscriptionsMap.get(id).unsubscribe();
                     disputeIsClosedSubscriptionsMap.remove(id);
                 }
+                disputedTradeIds.remove(dispute.getTradeId());
             });
         }
         addedList.forEach(dispute -> {
@@ -168,6 +173,7 @@ public abstract class DisputeListService<T extends DisputeList<Dispute>> impleme
                         });
                     });
             disputeIsClosedSubscriptionsMap.put(id, disputeStateSubscription);
+            disputedTradeIds.add(dispute.getTradeId());
         });
     }
 

--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -69,6 +69,7 @@ import java.security.KeyPair;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -231,6 +232,9 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
         return disputeListService.getDisputeList();
     }
 
+    public Set<String> getDisputedTradeIds() {
+        return disputeListService.getDisputedTradeIds();
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositListItem.java
@@ -51,6 +51,7 @@ class DepositListItem {
     private final String addressString;
     private String usage = "-";
     private TxConfidenceListener txConfidenceListener;
+    private BalanceListener balanceListener;
     private int numTxOutputs = 0;
 
     public DepositListItem(AddressEntry addressEntry, BtcWalletService walletService, CoinFormatter formatter) {
@@ -66,7 +67,7 @@ class DepositListItem {
         txConfidenceIndicator.setTooltip(tooltip);
 
         final Address address = addressEntry.getAddress();
-        walletService.addBalanceListener(new BalanceListener(address) {
+        balanceListener = new BalanceListener(address) {
             @Override
             public void onBalanceChanged(Coin balanceAsCoin, Transaction tx) {
                 DepositListItem.this.balanceAsCoin = balanceAsCoin;
@@ -74,7 +75,8 @@ class DepositListItem {
                 GUIUtil.updateConfidence(walletService.getConfidenceForTxId(tx.getTxId().toString()), tooltip, txConfidenceIndicator);
                 updateUsage(address);
             }
-        });
+        };
+        walletService.addBalanceListener(balanceListener);
 
         balanceAsCoin = walletService.getBalanceForAddress(address);
         balance.set(formatter.formatCoin(balanceAsCoin));
@@ -102,6 +104,7 @@ class DepositListItem {
 
     public void cleanup() {
         walletService.removeTxConfidenceListener(txConfidenceListener);
+        walletService.removeBalanceListener(balanceListener);
     }
 
     public TxConfidenceIndicator getTxConfidenceIndicator() {

--- a/desktop/src/test/java/bisq/desktop/main/funds/transactions/TransactionAwareTradeTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/funds/transactions/TransactionAwareTradeTest.java
@@ -28,7 +28,7 @@ import org.bitcoinj.core.Transaction;
 
 import javafx.collections.FXCollections;
 
-import java.util.Collections;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -40,8 +40,6 @@ import static org.mockito.Mockito.when;
 
 public class TransactionAwareTradeTest {
     private static final Sha256Hash XID = Sha256Hash.wrap("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
-
-
 
     private Transaction transaction;
     private ArbitrationManager arbitrationManager;
@@ -95,7 +93,10 @@ public class TransactionAwareTradeTest {
         when(dispute.getTradeId()).thenReturn(tradeId);
 
         when(arbitrationManager.getDisputesAsObservableList())
-                .thenReturn(FXCollections.observableArrayList(Collections.singleton(dispute)));
+                .thenReturn(FXCollections.observableArrayList(Set.of(dispute)));
+
+        when(arbitrationManager.getDisputedTradeIds())
+                .thenReturn(Set.of(tradeId));
 
         when(delegate.getId()).thenReturn(tradeId);
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This PR speeds up the loading of the deposit ("Receive funds") and transactions views (under the "Funds" tab), by adding some caches to `WalletService` and `DisputeListService`, lazily loading tx confidence tooltips for the two respective lists of items (`DepositListItem` and `TransactionsListItem`) and applying some low level optimisations to `TransactionsAwareTrade.isRelatedToTransaction`.

This also fixes a fairly minor bug in the transactions view due to a broken `TranscationsAwareTrade.isRefundPayoutTx` method, as well as a somewhat serious memory leak in the deposit view due to missing `BalanceListener` removals from the `BtcWalletService` instance.

The performance issues in these two views had started to become severe with the number of transactions and addresses now in my Bisq wallet. The deposit view was the worst, taking around 25 seconds to load, with bottlenecks in `WalletService.getTransactionConfidence` & `WalletService.getNumTxOutputsForAddress` as seen with JProfiler:

![Screenshot from 2021-01-27 02-41-06](https://user-images.githubusercontent.com/54855381/105935157-621ed900-6049-11eb-91bb-2cf83e28984e.png)

The transactions view (with 1210 rows) was taking around 5 seconds to load, with bottlenecks in `TransactionsAwareTrade.isRelatedToTransaction` & `Tooltip.<init>`:

![Screenshot from 2021-01-27 02-41-25](https://user-images.githubusercontent.com/54855381/105935191-6f3bc800-6049-11eb-8d6c-526ba9a96aa8.png)

They both seem significantly faster (in my Bisq client) with the changes in this PR, with the biggest improvement to the deposit view via the two caches added to `WalletService`. The quadratic time issue (# transactions * # past trades) causing the slowness of the transactions view is alleviated but not completely fixed by these changes. It may be possible to do more extensive lazy loading of the relevant `TransactionsListItem` fields to get further speedups.
