### PR TITLE
Fix stale trade statistics list view when new entries arrive

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -240,8 +240,10 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             volumeAxisYWidth = (double) newValue;
             layoutChart();
         };
-        tradeStatisticsByCurrencyListener = c -> nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades",
-                model.selectedTradeStatistics.size()));
+        tradeStatisticsByCurrencyListener = c -> {
+            nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades", model.selectedTradeStatistics.size()));
+            fillList();
+        };
         parentHeightListener = (observable, oldValue, newValue) -> layout();
 
         priceColumnLabelListener = (o, oldVal, newVal) -> priceColumn.setGraphic(new AutoTooltipLabel(newVal));
@@ -308,7 +310,6 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             CurrencyListItem selectedItem = currencyComboBox.getSelectionModel().getSelectedItem();
             if (selectedItem != null) {
                 model.onSetTradeCurrency(selectedItem.tradeCurrency);
-                fillList();
             }
         });
 
@@ -396,14 +397,12 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     }
 
     private void fillList() {
-        ObservableList<TradeStatistics3ListItem> tradeStatistics3ListItems = FXCollections.observableList(
-                model.selectedTradeStatistics.stream()
-                        .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
-                                coinFormatter,
-                                model.showAllTradeCurrenciesProperty.get()))
-                        .collect(Collectors.toList()));
-        listItems.clear();
-        listItems.addAll(tradeStatistics3ListItems);
+        List<TradeStatistics3ListItem> tradeStatistics3ListItems = model.selectedTradeStatistics.stream()
+                .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
+                        coinFormatter,
+                        model.showAllTradeCurrenciesProperty.get()))
+                .collect(Collectors.toList());
+        listItems.setAll(tradeStatistics3ListItems);
     }
 
     private void exportToCsv() {


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Ensure the trade statistics list in `TradesChartsView` doesn't go stale upon new statistics arrivals, by moving a `fillList()` call from the _onChangeConfirmed_ currency combobox event handler to the listener of the `selectedTradeStatistics` `TradesChartsViewModel` field.

(Also avoid unnecessary use of an `ObservableList` as a temporary variable in the `fillList()` method.)

--

I first spotted this bug a little while ago and it appears to have been present since early November 2020, at least looking through the commit history, so it most likely affects both master and the current v1.5.5 release candidate.