### PR TITLE
Git-ignore apitest dao-setup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ deploy
 /monitor/monitor-tor/*
 .java-version
 .localnet
+/apitest/src/main/resources/dao-setup*


### PR DESCRIPTION
Added `.gitignore` line for apitest dao-setup files.  Regtest/DAO setup files downloaded during a build should not be tracked by git, nor saved in the repo.  These are the files downloaded, unzipped and installed by the gradle task `installDaoSetup`:

    $ ./gradlew clean build :apitest:installDaoSetup
