### PR TITLE
Show popup if no filter is delivered

### DIFF
--- a/core/src/main/java/bisq/core/app/DomainInitialisation.java
+++ b/core/src/main/java/bisq/core/app/DomainInitialisation.java
@@ -242,8 +242,8 @@ public class DomainInitialisation {
 
         priceFeedService.setCurrencyCodeOnInit();
 
-        filterManager.onAllServicesInitialized();
         filterManager.setFilterWarningHandler(filterWarningHandler);
+        filterManager.onAllServicesInitialized();
 
         voteResultService.getVoteResultExceptions().addListener((ListChangeListener<VoteResultException>) c -> {
             c.next();

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2841,6 +2841,7 @@ popup.warning.mandatoryUpdate.dao=Please update to the latest Bisq version. \
   Please check out the Bisq Forum for more information.
 popup.warning.disable.dao=The Bisq DAO and BSQ are temporary disabled. \
   Please check out the Bisq Forum for more information.
+popup.warning.noFilter=We did not receive a filter object from the seed nodes. This is a not expected situation. Please inform the Bisq developers.
 popup.warning.burnBTC=This transaction is not possible, as the mining fees of {0} would exceed the amount to transfer of {1}. \
   Please wait until the mining fees are low again or until you''ve accumulated more BTC to transfer.
 


### PR DESCRIPTION
On mainNet we expect to have received a filter object, if not show a popup to the user to inform the Bisq devs.