### PR TITLE
onUpdatedDataReceived must be called in the correct order

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -147,7 +147,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
         this.networkNode.addConnectionListener(this);
         this.networkNode.addMessageListener(this);
-        this.requestDataManager.addListener(this);
+        this.requestDataManager.setListener(this);
 
         // We need to have both the initial data delivered and the hidden service published
         networkReadyBinding = EasyBind.combine(hiddenServicePublished, preliminaryDataReceived,
@@ -317,6 +317,11 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     public void onUpdatedDataReceived() {
         if (!isBootstrapped) {
             isBootstrapped = true;
+            // We don't use a listener at mailboxMessageService as we require the correct
+            // order of execution. The p2pServiceListeners must be called after
+            // mailboxMessageService.onUpdatedDataReceived.
+            mailboxMessageService.onUpdatedDataReceived();
+
             p2pServiceListeners.forEach(P2PServiceListener::onUpdatedDataReceived);
             p2PDataStorage.onBootstrapComplete();
         }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -40,11 +40,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -53,6 +51,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class RequestDataManager implements MessageListener, ConnectionListener, PeerManager.Listener {
@@ -91,7 +90,10 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     private final P2PDataStorage dataStorage;
     private final PeerManager peerManager;
     private final List<NodeAddress> seedNodeAddresses;
-    private final Set<Listener> listeners = new HashSet<>();
+
+    // As we use Guice injection we cannot set the listener in our constructor but the P2PService calls the setListener
+    // in it's constructor so we can guarantee it is not null.
+    private Listener listener;
 
     private final Map<NodeAddress, RequestDataHandler> handlerMap = new HashMap<>();
     private final Map<String, GetDataRequestHandler> getDataRequestHandlers = new HashMap<>();
@@ -147,8 +149,10 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public void addListener(Listener listener) {
-        listeners.add(listener);
+    // We only support one listener as P2PService will manage calls on other clients in the correct order of execution.
+    // The listener is set from the P2PService constructor so we can guarantee it is not null.
+    public void setListener(Listener listener) {
+        this.listener = listener;
     }
 
     public boolean requestPreliminaryData() {
@@ -334,16 +338,16 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                     // We delay because it can be that we get the HS published before we receive the
                                     // preliminary data and the onPreliminaryDataReceived call triggers the
                                     // dataUpdateRequested set to true, so we would also call the onUpdatedDataReceived.
-                                    UserThread.runAfter(() -> listeners.forEach(Listener::onPreliminaryDataReceived), 100, TimeUnit.MILLISECONDS);
+                                    UserThread.runAfter(checkNotNull(listener)::onPreliminaryDataReceived, 100, TimeUnit.MILLISECONDS);
                                 }
 
                                 // 2. Later we get a response from requestUpdatesData
                                 if (dataUpdateRequested) {
                                     dataUpdateRequested = false;
-                                    listeners.forEach(Listener::onUpdatedDataReceived);
+                                    checkNotNull(listener).onUpdatedDataReceived();
                                 }
 
-                                listeners.forEach(Listener::onDataReceived);
+                                checkNotNull(listener).onDataReceived();
                             }
 
                             @Override
@@ -371,9 +375,9 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                     // Notify listeners
                                     if (!nodeAddressOfPreliminaryDataRequest.isPresent()) {
                                         if (peerManager.isSeedNode(nodeAddress)) {
-                                            listeners.forEach(Listener::onNoSeedNodeAvailable);
+                                            checkNotNull(listener).onNoSeedNodeAvailable();
                                         } else {
-                                            listeners.forEach(Listener::onNoPeersAvailable);
+                                            checkNotNull(listener).onNoPeersAvailable();
                                         }
                                     }
 


### PR DESCRIPTION
We cannot use a listener at RequestDataManager as the order
is not defined if doing so.
So we use P2PService as our controlling entity to call
further clients in the correct order.
