### PR TITLE
[v1.5.5] Hide trigger price box if not used in confirmation step

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -426,6 +426,10 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         updateOfferElementsStyle();
 
+        if (triggerPriceInputTextField.getText().isEmpty()) {
+            triggerPriceVBox.setVisible(false);
+        }
+
         balanceTextField.setTargetAmount(model.getDataModel().totalToPayAsCoinProperty().get());
 
         if (!DevEnv.isDevMode()) {


### PR DESCRIPTION
The trigger price box should be hidden in confirmation step if not used.

<img width="1317" alt="Bildschirmfoto 2021-02-01 um 19 51 04" src="https://user-images.githubusercontent.com/170962/106504418-31b2c100-64c7-11eb-98a9-f60f36691e20.png">
<img width="1317" alt="Bildschirmfoto 2021-02-01 um 19 50 53" src="https://user-images.githubusercontent.com/170962/106504423-32e3ee00-64c7-11eb-851e-57f740d077de.png">
