### PR TITLE
Slow down burnt BSQ moving average 4 fold

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2445,7 +2445,7 @@ dao.factsAndFigures.supply.compRequestIssueAmount=BSQ issued for compensation re
 dao.factsAndFigures.supply.reimbursementAmount=BSQ issued for reimbursement requests
 
 dao.factsAndFigures.supply.burnt=BSQ burnt
-dao.factsAndFigures.supply.burntMovingAverage=15-day moving average
+dao.factsAndFigures.supply.burntMovingAverage=60-day moving average
 dao.factsAndFigures.supply.burntZoomToInliers=Zoom to inliers
 
 dao.factsAndFigures.supply.locked=Global state of locked BSQ

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/SupplyView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/SupplyView.java
@@ -607,7 +607,7 @@ public class SupplyView extends ActivatableView<GridPane, Void> implements DaoSt
         var burntBsqXValues = sortedUpdatedBurntBsq.stream().map(XYChart.Data::getXValue);
         var burntBsqYValues = sortedUpdatedBurntBsq.stream().map(XYChart.Data::getYValue);
 
-        var maPeriod = 15;
+        var maPeriod = 60;
         var burntBsqMAYValues =
                 MovingAverageUtils.simpleMovingAverage(
                         burntBsqYValues,


### PR DESCRIPTION
Reduces the BSQ burnt moving average period in the BSQ Supply chart from 15-day to 60-day. This makes the moving average more readable. 15-day MA was for the early days of tracking BSQ burn when the burn events were more frequent and smaller.

15-day burnt Bisq MA (current state):

![15-day burnt Bisq MA](https://user-images.githubusercontent.com/2715476/106617578-6ed68c00-6577-11eb-862d-5acb60a4abba.png)

30-day burnt Bisq MA:

![30-day burnt Bisq MA](https://user-images.githubusercontent.com/2715476/106617603-75650380-6577-11eb-92a0-98a12f66dd39.png)

60-day burnt Bisq MA (proposed state):

![60-day burnt Bisq MA](https://user-images.githubusercontent.com/2715476/106617618-785ff400-6577-11eb-863a-c1ff272e34b0.png)

Note: an exponential moving average (as opposed to a simple moving average, which is what this chart is using now) would further improve readability, but implementing these algorithms on Java Streams is not trivial, so unless there's demand for it, I'll leave that as is.