### PR TITLE
Fix find pid on OSX

### DIFF
--- a/apitest/scripts/trade-simulation-env.sh
+++ b/apitest/scripts/trade-simulation-env.sh
@@ -8,18 +8,37 @@ export ALICE_PORT=9998
 export BOB_PORT=9999
 export F2F_ACCT_FORM="f2f-acct.json"
 
+checkos() {
+    LINUX=FALSE
+    DARWIN=FALSE
+    UNAME=$(uname)
+    case "$UNAME" in
+      Linux* )
+        export LINUX=TRUE
+        ;;
+      Darwin* )
+        export DARWIN=TRUE
+        ;;
+    esac
+    if [[ "$LINUX" == "TRUE" ]]; then
+        printdate "Running on supported Linux OS."
+    elif [[ "$DARWIN" == "TRUE" ]]; then
+        printdate "Running on supported Mac OS."
+    else
+        printdate "Script cannot run on $OSTYPE OS, only Linux and OSX are supported."
+        exit 1
+    fi
+}
+
 checksetup() {
+    checkos
+
     apitestusage() {
-        echo "The apitest harness must be running a local bitcoin regtest node, a seednode, arbitration node, and Bob & Alice daemons."
+        echo "The apitest harness must be running a local bitcoin regtest node, a seednode, an arbitration node,"
+        echo "Bob & Alice daemons, and bitcoin-core's bitcoin-cli must be in the system PATH."
         echo ""
         echo "From the project's root dir, start all supporting nodes from a terminal:"
         echo "./bisq-apitest --apiPassword=xyz --supportingApps=bitcoind,seednode,arbdaemon,alicedaemon,bobdaemon  --shutdownAfterTests=false"
-        echo ""
-        echo "Register dispute agents in the arbitration daemon after it initializes."
-        echo "./bisq-cli --password=xyz --port=9997 registerdisputeagent --dispute-agent-type=mediator \
-            --registration-key=6ac43ea1df2a290c1c8391736aa42e4339c5cb4f110ff0257a13b63211977b7a"
-        echo "./bisq-cli --password=xyz --port=9997 registerdisputeagent --dispute-agent-type=refundagent \
-            --registration-key=6ac43ea1df2a290c1c8391736aa42e4339c5cb4f110ff0257a13b63211977b7a"
         exit 1;
     }
     printdate "Checking $APP_HOME for some expected directories and files."
@@ -35,33 +54,14 @@ checksetup() {
         printdate "Error:  The bisq-cli script not found, maybe because you are not running the script from the project root dir."
         exit 1
     fi
-    printdate "Checking to see local bitcoind is running."
+    printdate "Checking to see local bitcoind is running, and bitcoin-cli is in PATH."
     checkbitcoindrunning
+    checkbitcoincliinpath
     printdate "Checking to see bisq servers are running."
-    if pgrep -f "bisq.seednode.SeedNodeMain" > /dev/null ; then
-        printdate "The seednode is running on host."
-    else
-        printdate "Error:  seed is not running on host, exiting."
-        apitestusage
-    fi
-    if pgrep -f "bisq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Arb_dao" > /dev/null ; then
-        printdate "The arbitration node is running on host."
-    else
-        printdate "Error:  arbitration node is not running on host, exiting."
-        apitestusage
-    fi
-    if pgrep -f "bisq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Alice_dao" > /dev/null ; then
-        printdate "Alice's daemon node is running on host."
-    else
-        printdate "Error:  Alice's daemon node is not running on host, exiting."
-        apitestusage
-    fi
-    if pgrep -f "bisq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Bob_dao" > /dev/null ; then
-        printdate "Bob's daemon node is running on host."
-    else
-        printdate "Error:  Bob's daemon node is not running on host, exiting."
-        apitestusage
-    fi
+    checkseednoderunning
+    checkarbnoderunning
+    checkalicenoderunning
+    checkbobnoderunning
 }
 
 parseopts() {
@@ -190,6 +190,99 @@ checkbitcoindrunning() {
         printdate "The regtest bitcoind node is running on host."
     else
         printdate "Error:  regtest bitcoind node is not running on host, exiting."
+        apitestusage
+    fi
+}
+
+checkbitcoincliinpath() {
+    if which bitcoin-cli > /dev/null ; then
+        printdate "The bitcoin-cli binary is in the system PATH."
+    else
+        printdate "Error:  bitcoin-cli binary is not in the system PATH, exiting."
+        apitestusage
+    fi
+}
+
+checkseednoderunning() {
+    if [[ "$LINUX" == "TRUE" ]]; then
+        if pgrep -f "bisq.seednode.SeedNodeMain" > /dev/null ; then
+            printdate "The seed node is running on host."
+        else
+            printdate "Error:  seed node is not running on host, exiting."
+            apitestusage
+        fi
+    elif [[ "$DARWIN" == "TRUE" ]]; then
+        if ps -A | awk '/[S]eedNodeMain/ {print $1}' > /dev/null ; then
+            printdate "The seednode is running on host."
+        else
+            printdate "Error:  seed node is not running on host, exiting."
+            apitestusage
+        fi
+    else
+        printdate "Error:  seed node is not running on host, exiting."
+        apitestusage
+    fi
+}
+
+checkarbnoderunning() {
+    if [[ "$LINUX" == "TRUE" ]]; then
+        if pgrep -f "bisq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Arb_dao" > /dev/null ; then
+            printdate "The arbitration node is running on host."
+        else
+            printdate "Error:  arbitration node is not running on host, exiting."
+            apitestusage
+        fi
+    elif [[ "$DARWIN" == "TRUE" ]]; then
+        if ps -A | awk '/[b]isq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Arb_dao/ {print $1}' > /dev/null ; then
+            printdate "The arbitration node is running on host."
+        else
+            printdate "Error:  arbitration node is not running on host, exiting."
+            apitestusage
+        fi
+    else
+        printdate "Error:  arbitration node is not running on host, exiting."
+        apitestusage
+    fi
+}
+
+checkalicenoderunning() {
+    if [[ "$LINUX" == "TRUE" ]]; then
+        if pgrep -f "bisq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Alice_dao" > /dev/null ; then
+            printdate "Alice's node is running on host."
+        else
+            printdate "Error:  Alice's node is not running on host, exiting."
+            apitestusage
+        fi
+    elif [[ "$DARWIN" == "TRUE" ]]; then
+        if ps -A | awk '/[b]isq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Alice_dao/ {print $1}' > /dev/null ; then
+            printdate "Alice's node node is running on host."
+        else
+            printdate "Error:  Alice's node is not running on host, exiting."
+            apitestusage
+        fi
+    else
+        printdate "Error:  Alice's node is not running on host, exiting."
+        apitestusage
+    fi
+}
+
+checkbobnoderunning() {
+    if [[ "$LINUX" == "TRUE" ]]; then
+        if pgrep -f "bisq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Alice_dao" > /dev/null ; then
+            printdate "Bob's node is running on host."
+        else
+            printdate "Error:  Bob's node is not running on host, exiting."
+            apitestusage
+        fi
+    elif [[ "$DARWIN" == "TRUE" ]]; then
+        if ps -A | awk '/[b]isq.daemon.app.BisqDaemonMain --appName=bisq-BTC_REGTEST_Alice_dao/ {print $1}' > /dev/null ; then
+            printdate "Bob's node node is running on host."
+        else
+            printdate "Error:  Bob's node is not running on host, exiting."
+            apitestusage
+        fi
+    else
+        printdate "Error:  Bob's node is not running on host, exiting."
         apitestusage
     fi
 }


### PR DESCRIPTION
The trade simulation scripts check that bitcoind, a seed node, an arbitration node, and Bob & Alice nodes are running at startup, but the bash `pgrep` command used to find the PIDs does not work on OSX (darwin20).  An adjustment was made to the env script to find java PIDs with `ps` and `awk`,  if running on OSX.

Two additonal startup checks were added: make sure the script is running on supported OS (Linux or OSX), and `bitcoin-cli` is in the `PATH`.

Also removed some usage error text about registering dispute agents;  the scripts do that now.
