### PR TITLE
Design fixes #4019 Dark mode ColoredDecimalPlacesWithZerosText

### DIFF
--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -294,8 +294,7 @@
 }
 
 .zero-decimals {
-    -fx-text-fill: -bs-decimals;
-    -fx-fill: -bs-decimals;
+    -bs-text-color: -bs-color-gray-3;
 }
 
 .confirmation-label {


### PR DESCRIPTION
## Fixes #4019
Just css text color fixed. 
The leading decimal zeroes will become grey now in lists views of offer book.

Suggested solution results into similar behavior known from light mode:

![paste](https://user-images.githubusercontent.com/79169291/108118889-e38ce880-7096-11eb-99b1-d7cd9a604a89.png)


