### PR TITLE
Rename summary notes "Seller not responding"  category

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2553,7 +2553,7 @@ disputeSummaryWindow.reason.BANK_PROBLEMS=Bank
 # suppress inspection "UnusedProperty"
 disputeSummaryWindow.reason.OPTION_TRADE=Option trade
 # suppress inspection "UnusedProperty"
-disputeSummaryWindow.reason.SELLER_NOT_RESPONDING=Seller not responding
+disputeSummaryWindow.reason.SELLER_NOT_RESPONDING=Trader not responding
 # suppress inspection "UnusedProperty"
 disputeSummaryWindow.reason.WRONG_SENDER_ACCOUNT=Wrong sender account
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
I renamed the string for the
disputeSummaryWindow.reason.SELLER_NOT_RESPONDING key because
BTC buyers can also be unresponsive.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".


Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.

-->
