### PR TITLE
Fix key shortcut documentation when using CMD+Y

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1361,8 +1361,8 @@ setting.about.shortcuts.manualPayoutTxWindow=Open window for manual payout from 
 
 setting.about.shortcuts.reRepublishAllGovernanceData=Republish DAO governance data (proposals, votes)
 
-setting.about.shortcuts.removeStuckTrade=Open popup to move stuck trade to failed trades tab (only use if you are sure)
-setting.about.shortcuts.removeStuckTrade.value=Select pending trade and press: {0}
+setting.about.shortcuts.removeStuckTrade=Open popup to move failed trade to open trades tab again
+setting.about.shortcuts.removeStuckTrade.value=Select failed trade and press: {0}
 
 setting.about.shortcuts.registerArbitrator=Register arbitrator (mediator/arbitrator only)
 setting.about.shortcuts.registerArbitrator.value=Navigate to account and press: {0}


### PR DESCRIPTION
This behavior changed as you cannot manually fail an open trade anymore. Only unfail it after selecting it in the failed trades section and pressing CMD+Y