### PR TITLE
Fix length check text on manual payout tool

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3624,6 +3624,7 @@ validation.inputTooSmall=Input has to be larger than {0}
 validation.inputToBeAtLeast=Input has to be at least {0}
 validation.amountBelowDust=An amount below the dust limit of {0} satoshi is not allowed.
 validation.length=Length must be between {0} and {1}
+validation.fixedLength=Length must be {0}
 validation.pattern=Input must be of format: {0}
 validation.noHexString=The input is not in HEX format.
 validation.advancedCash.invalidFormat=Must be a valid email or wallet id of format: X000000000000

--- a/desktop/src/main/java/bisq/desktop/util/validation/LengthValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/LengthValidator.java
@@ -21,6 +21,10 @@ public class LengthValidator extends InputValidator {
         ValidationResult result = new ValidationResult(true);
         int length = (input == null) ? 0 : input.length();
 
+        if (this.minLength == this.maxLength) {
+            if (length != this.minLength)
+                result = new ValidationResult(false, Res.get("validation.fixedLength", this.minLength));
+        } else
         if (length < this.minLength || length > this.maxLength)
             result = new ValidationResult(false, Res.get("validation.length", this.minLength, this.maxLength));
 

--- a/desktop/src/test/java/bisq/desktop/util/validation/LengthValidatorTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/validation/LengthValidatorTest.java
@@ -69,5 +69,4 @@ public class LengthValidatorTest {
         assertFalse(validator2.validate(null).isValid); // too short
         assertFalse(validator2.validate("123456789").isValid); // too long
     }
-
 }


### PR DESCRIPTION
Fix the test displayed on the manual payout check tool.

Before it used everywhere the text _The length must be between X and Y_.

<img width="760" alt="bisq" src="https://user-images.githubusercontent.com/79100296/108860110-2f3b1700-75ee-11eb-9367-20aec9bb2657.png">


P.S.
This is my first PR, so let me know if everything is ok.