### PR TITLE
Fix prompt labels overflows in create order

### DIFF
--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -3,7 +3,7 @@ package bisq.common.util;
 public class StringUtils {
 
     public static String truncatePromptString(String str, int strMaxLen) {
-        if(str.length() <= strMaxLen){
+        if (str.length() <= strMaxLen) {
             return str;
         } else {
             return str.substring(0, strMaxLen - 3).concat("...");

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -1,0 +1,14 @@
+package bisq.common.util;
+
+public class StringUtils {
+
+    public static String truncatePromptString(String str, int strMaxLen) {
+        if(str.length() <= strMaxLen){
+            return str;
+        } else {
+            return str.substring(0, strMaxLen - 3).concat("...");
+        }
+
+    }
+
+}

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -59,6 +59,7 @@ import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
+import bisq.common.util.StringUtils;
 import bisq.common.util.Tuple2;
 import bisq.common.util.Tuple3;
 import bisq.common.util.Utilities;
@@ -1288,7 +1289,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
     private void addAmountPriceFields() {
         // amountBox
-        Tuple3<HBox, InputTextField, Label> amountValueCurrencyBoxTuple = getEditableValueBox(Res.get("createOffer.amount.prompt"));
+        Tuple3<HBox, InputTextField, Label> amountValueCurrencyBoxTuple = getEditableValueBox(StringUtils.truncatePromptString(Res.get("createOffer.amount.prompt"), 28));
         amountValueCurrencyBox = amountValueCurrencyBoxTuple.first;
         amountTextField = amountValueCurrencyBoxTuple.second;
         editOfferElements.add(amountTextField);
@@ -1385,7 +1386,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private void addSecondRow() {
         // price as fiat
         Tuple3<HBox, InputTextField, Label> priceValueCurrencyBoxTuple = getEditableValueBox(
-                Res.get("createOffer.price.prompt"));
+                StringUtils.truncatePromptString(Res.get("createOffer.price.prompt"), 28));
         priceValueCurrencyBox = priceValueCurrencyBoxTuple.first;
         fixedPriceTextField = priceValueCurrencyBoxTuple.second;
         editOfferElements.add(fixedPriceTextField);
@@ -1399,10 +1400,10 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         editOfferElements.add(priceDescriptionLabel);
         fixedPriceBox = priceInputBoxTuple.second;
 
-        marketBasedPriceTextField.setPromptText(Res.get("shared.enterPercentageValue"));
+        marketBasedPriceTextField.setPromptText(StringUtils.truncatePromptString(Res.get("shared.enterPercentageValue"), 28));
         marketBasedPriceLabel.setText("%");
 
-        Tuple3<HBox, InputTextField, Label> amountValueCurrencyBoxTuple = getEditableValueBox(Res.get("createOffer.amount.prompt"));
+        Tuple3<HBox, InputTextField, Label> amountValueCurrencyBoxTuple = getEditableValueBox(StringUtils.truncatePromptString(Res.get("createOffer.amount.prompt"), 28));
         minAmountValueCurrencyBox = amountValueCurrencyBoxTuple.first;
         minAmountTextField = amountValueCurrencyBoxTuple.second;
         editOfferElements.add(minAmountTextField);
@@ -1424,7 +1425,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
                 updatePriceToggleButtons(model.getDataModel().getUseMarketBasedPrice().getValue()));
 
         // triggerPrice
-        Tuple3<HBox, InfoInputTextField, Label> triggerPriceTuple3 = getEditableValueBoxWithInfo(Res.get("createOffer.triggerPrice.prompt"));
+        Tuple3<HBox, InfoInputTextField, Label> triggerPriceTuple3 = getEditableValueBoxWithInfo(StringUtils.truncatePromptString(Res.get("createOffer.triggerPrice.prompt"), 28));
         triggerPriceHBox = triggerPriceTuple3.first;
         triggerPriceInfoInputTextField = triggerPriceTuple3.second;
         editOfferElements.add(triggerPriceInfoInputTextField);

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -65,6 +65,7 @@ import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
 import bisq.common.util.MathUtils;
+import bisq.common.util.StringUtils;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.utils.Fiat;
@@ -276,7 +277,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                     dataModel.getTradeCurrencyCode()));
         }
         volumePromptLabel.bind(createStringBinding(
-                () -> Res.get("createOffer.volume.prompt", dataModel.getTradeCurrencyCode().get()),
+                () -> StringUtils.truncatePromptString(Res.get("createOffer.volume.prompt", dataModel.getTradeCurrencyCode().get()), 28),
                 dataModel.getTradeCurrencyCode()));
 
         totalToPay.bind(createStringBinding(() -> btcFormatter.formatCoinWithCode(dataModel.totalToPayAsCoinProperty().get()),


### PR DESCRIPTION
Fixes #5189

This change is to fix the prompt labels that where overflowing  
outside the InputTextBoxes in the CreateOffer section (Buy and Sell).

- Created a class StringUtils providing truncatePromptString.
- Call truncatePromptString in MutableOfferView and in MutableOfferViewModel.
