### PR TITLE
Replace slack with Keybase

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,7 +12,7 @@ In order to take part in the testing process, you will need to do the following:
 
 ## Communication Channels
 
-If you would like to discuss and/or contribute to Bisq's testing effort, join us in the [#testing](https://bisq.slack.com/messages/CEBLT79ML) channel within the [Bisq Slack workspace](https://bisq.network/slack-invite).
+If you would like to discuss and/or contribute to Bisq's testing effort, join us in the #testing channel within the [Bisq Keybase team](https://keybase.io/team/bisq).
 
 ## Compensation
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->


![Screen Shot 2021-03-08 at 12 55 41 PM](https://user-images.githubusercontent.com/2033945/110381962-16c7f500-800f-11eb-96fa-8274ebddc265.png)
The page currently points to slack.
![Screen Shot 2021-03-08 at 12 56 00 PM](https://user-images.githubusercontent.com/2033945/110381959-1596c800-800f-11eb-94ce-49204711d3ca.png)
Slack shows the link doesn't exist anymore. 

That is because the team has moved from Slack to Keybase.
Updated the document to reflect the new team location on Keybase.