### PR TITLE
Fix singleton CoreContext usage

### DIFF
--- a/core/src/main/java/bisq/core/api/CoreTradesService.java
+++ b/core/src/main/java/bisq/core/api/CoreTradesService.java
@@ -49,11 +49,11 @@ import static java.lang.String.format;
 @Slf4j
 class CoreTradesService {
 
+    private final CoreContext coreContext;
     // Dependencies on core api services in this package must be kept to an absolute
     // minimum, but some trading functions require an unlocked wallet's key, so an
     // exception is made in this case.
     private final CoreWalletsService coreWalletsService;
-
     private final BtcWalletService btcWalletService;
     private final OfferUtil offerUtil;
     private final ClosedTradableManager closedTradableManager;
@@ -61,7 +61,6 @@ class CoreTradesService {
     private final TradeManager tradeManager;
     private final TradeUtil tradeUtil;
     private final User user;
-    private final boolean isApiUser;
 
     @Inject
     public CoreTradesService(CoreContext coreContext,
@@ -73,6 +72,7 @@ class CoreTradesService {
                              TradeManager tradeManager,
                              TradeUtil tradeUtil,
                              User user) {
+        this.coreContext = coreContext;
         this.coreWalletsService = coreWalletsService;
         this.btcWalletService = btcWalletService;
         this.offerUtil = offerUtil;
@@ -81,7 +81,6 @@ class CoreTradesService {
         this.tradeManager = tradeManager;
         this.tradeUtil = tradeUtil;
         this.user = user;
-        this.isApiUser = coreContext.isApiUser();
     }
 
     void takeOffer(Offer offer,
@@ -113,7 +112,7 @@ class CoreTradesService {
                 offer,
                 paymentAccountId,
                 useSavingsWallet,
-                isApiUser,
+                coreContext.isApiUser(),
                 resultHandler::accept,
                 errorMessage -> {
                     log.error(errorMessage);


### PR DESCRIPTION
After `GrpcServer` builds a gRPC server instance, it calls injected `CoreContext#setApiUser(true)`.  The same, singleton `CoreContext` instance is injected into CoreService constructors, which use the `coreContext#isApiUser` value (set true by the server builder) to set their own class level boolean `isApiUser` fields.

When `CoreContext` was added, I was fooled by the correct behavior I saw while stepping through the server debugger.  But now I see that the correct boolean value in `CoreContext` is only available after CoreService constructors have finished instantiating themselves -- not in time.

In this change, the `isApiUser` field is removed from CoreServices, `CoreContext coreContext` becomes a class level final field in CoreServices, and the correct `coreContex.isApiUser` value is available in the CoreService methods.

This PR is the first in a new API PR chain.