### PR TITLE
Update testing steps.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ This guide describes the testing process performed prior to each release.
 In order to take part in the testing process, you will need to do the following:
 
 - Build Bisq from source (see [build.md](build.md))
-- Setup a development/testing environment (see [Makefile.md](Makefile.md))
+- Setup a development/testing environment (see [Makefile](Makefile) (new) or [dev-setup.md](dev-setup.md) (deprecated))
 - Request access to [TestPad](https://bisq.ontestpad.com) (our test management tool)
 
 ## Communication Channels

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ This guide describes the testing process performed prior to each release.
 In order to take part in the testing process, you will need to do the following:
 
 - Build Bisq from source (see [build.md](build.md))
-- Setup a development/testing environment (see [Makefile](../Makefile) (new) or [dev-setup.md](dev-setup.md) (deprecated))
+- Setup a development/testing environment (see [Makefile](../Makefile) or [dev-setup.md](dev-setup.md))
 - Request access to [TestPad](https://bisq.ontestpad.com) (our test management tool)
 
 ## Communication Channels

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ This guide describes the testing process performed prior to each release.
 In order to take part in the testing process, you will need to do the following:
 
 - Build Bisq from source (see [build.md](build.md))
-- Setup a development/testing environment (see [Makefile](Makefile) (new) or [dev-setup.md](dev-setup.md) (deprecated))
+- Setup a development/testing environment (see [Makefile](../Makefile) (new) or [dev-setup.md](dev-setup.md) (deprecated))
 - Request access to [TestPad](https://bisq.ontestpad.com) (our test management tool)
 
 ## Communication Channels

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ This guide describes the testing process performed prior to each release.
 In order to take part in the testing process, you will need to do the following:
 
 - Build Bisq from source (see [build.md](build.md))
-- Setup a development/testing environment (see [dev-setup.md](dev-setup.md))
+- Setup a development/testing environment (see [Makefile.md](Makefile.md))
 - Request access to [TestPad](https://bisq.ontestpad.com) (our test management tool)
 
 ## Communication Channels


### PR DESCRIPTION
Instructions for setting up a self-contained local Bisq network on Bitcoin regtest have been updated. 
`dev-setup.md` is deprecated. `Makefile` is new new version. 

Reference: https://github.com/bisq-network/bisq/blob/master/docs/README.md