### PR TITLE
Change file mentioned to from .desktop to .service

### DIFF
--- a/monitor/README.md
+++ b/monitor/README.md
@@ -1,6 +1,5 @@
 # Bisq Network Monitor Node
 
-
 The Bisq monitor node collects a set of metrics which are of interest to developers and users alike. These metrics are then made available through reporters.
 
 The *Settled* release features these metrics:

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -108,7 +108,7 @@ GraphiteReporter.serviceUrl=k6evlhg44acpchtc.onion:2003
 
 ## Run
 
-The distribution ships with a systemd .desktop file. Validate/change the executable/config paths within the shipped `bisq-monitor.service` file and copy/move the file to your systemd directory (something along `/usr/lib/systemd/system/`). Now you can control your *Monitor Node* via the usual systemd start/stop commands
+The distribution ships with a systemd .service file. Validate/change the executable/config paths within the shipped `bisq-monitor.service` file and copy/move the file to your systemd directory (something along `/usr/lib/systemd/system/`). Now you can control your *Monitor Node* via the usual systemd start/stop commands
 
 ```
 systemctl start bisq-monitor.service

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -1,5 +1,6 @@
 # Bisq Network Monitor Node
 
+
 The Bisq monitor node collects a set of metrics which are of interest to developers and users alike. These metrics are then made available through reporters.
 
 The *Settled* release features these metrics:


### PR DESCRIPTION
Bisq Monitor does not include a `.desktop` in the monitor folder.
It does have a `.service` file which is spoken about in the lines that follow the mention.
I think this was a brain fart. Author meant to introduce `.service` file, mentioned `.desktop` instead.