### PR TITLE
Disambiguate payment acct json form's "country" field

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/payment/AbstractPaymentAccountTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/payment/AbstractPaymentAccountTest.java
@@ -129,7 +129,10 @@ public class AbstractPaymentAccountTest extends MethodTest {
         assertEquals(paymentMethodId, emptyForm.get(PROPERTY_NAME_PAYMENT_METHOD_ID));
         assertEquals("your accountname", emptyForm.get(PROPERTY_NAME_ACCOUNT_NAME));
         for (String field : fields) {
-            assertEquals("your " + field.toLowerCase(), emptyForm.get(field));
+            if (field.equals("country"))
+                assertEquals("your two letter country code", emptyForm.get(field));
+            else
+                assertEquals("your " + field.toLowerCase(), emptyForm.get(field));
         }
     }
 

--- a/core/src/main/java/bisq/core/api/model/PaymentAccountTypeAdapter.java
+++ b/core/src/main/java/bisq/core/api/model/PaymentAccountTypeAdapter.java
@@ -147,7 +147,10 @@ class PaymentAccountTypeAdapter extends TypeAdapter<PaymentAccount> {
 
                     String fieldName = field.getName();
                     out.name(fieldName);
-                    out.value("your " + fieldName.toLowerCase());
+                    if (fieldName.equals("country"))
+                        out.value("your two letter country code");
+                    else
+                        out.value("your " + fieldName.toLowerCase());
                 }
             } catch (Exception ex) {
                 String errMsg = format("cannot create a new %s json form",


### PR DESCRIPTION
Make it clear the user needs to enter a two letter country code in the api's payment account json form's `country` field, not a country name.  A blank payment account json form now has a  `country` default value = `your two letter country code`.

The json form's field name was not changed to countryCode for the following reason:

The API's payment account forms are dynamically generated using reflection, and `PaymentAccount` class hierarchy `@Setter` methods determine which form fields are included or excluded.  Reflection and `@Setter` methods are also used when reading completed json forms, to set the field values on a new PaymentAccount instance before it is persisted.

`CountryBasedPaymentAccount` subclasses like `F2FAccount` have a `country` field and a `@Setter`, not a countryCode field, hence this shortcut to informing the user the country field value is a country-code.
