### PR TITLE
Fix dark mode readibility of specific texts - Part 2

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/shared/ChatView.java
+++ b/desktop/src/main/java/bisq/desktop/main/shared/ChatView.java
@@ -477,7 +477,6 @@ public class ChatView extends AnchorPane {
                             visible = true;
                             icon = AwesomeIcon.OK_SIGN;
                             text = Res.get("support.acknowledged");
-
                         } else if (message.ackErrorProperty().get() != null) {
                             visible = true;
                             icon = AwesomeIcon.EXCLAMATION_SIGN;
@@ -488,12 +487,10 @@ public class ChatView extends AnchorPane {
                             visible = true;
                             icon = AwesomeIcon.OK;
                             text = Res.get("support.arrived");
-                            statusHBox.setOpacity(0.5);
                         } else if (message.storedInMailboxProperty().get()) {
                             visible = true;
                             icon = AwesomeIcon.ENVELOPE;
                             text = Res.get("support.savedInMailbox");
-                            statusHBox.setOpacity(0.5);
                         } else {
                             visible = false;
                             log.debug("updateMsgState called but no msg state available. message={}", message);

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -1291,14 +1291,14 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                                     listener = (observable, oldValue, newValue) -> {
                                         setText(newValue ? Res.get("support.closed") : Res.get("support.open"));
                                         if (getTableRow() != null)
-                                            getTableRow().setOpacity(newValue ? 0.4 : 1);
+                                            getTableRow().setOpacity(newValue && item.getBadgeCountProperty().get() == 0 ? 0.4 : 1);
                                     };
                                     closedProperty = item.isClosedProperty();
                                     closedProperty.addListener(listener);
                                     boolean isClosed = item.isClosed();
                                     setText(isClosed ? Res.get("support.closed") : Res.get("support.open"));
                                     if (getTableRow() != null)
-                                        getTableRow().setOpacity(isClosed ? 0.4 : 1);
+                                        getTableRow().setOpacity(isClosed && item.getBadgeCountProperty().get() == 0  ? 0.4 : 1);
                                 } else {
                                     if (closedProperty != null) {
                                         closedProperty.removeListener(listener);


### PR DESCRIPTION
This PR complements https://github.com/bisq-network/bisq/pull/5232.

We also need to remove opacity for the remaining 2 cases so to not have different looks.
Indeed we have no opacity set for some messages and a setOpacity(0.5) for other ones.

CSS is the same for everything:
`.status-icon {
    -fx-text-fill: -fx-faint-focus-color;
}`

Before:
<img width="571" alt="bisq_read_1" src="https://user-images.githubusercontent.com/79100296/111801117-ec0e5400-88cc-11eb-96ac-455367384126.png">

<img width="573" alt="bisq_read_2" src="https://user-images.githubusercontent.com/79100296/111801135-ef094480-88cc-11eb-8bc8-768993100997.png">


After:

<img width="570" alt="text3" src="https://user-images.githubusercontent.com/79100296/111801193-fdeff700-88cc-11eb-87c4-b3ee1fb7bca5.png">


<img width="570" alt="text4" src="https://user-images.githubusercontent.com/79100296/111801216-05170500-88cd-11eb-8d82-9f1a56cbbfb6.png">





