### PR TITLE
Fix API startup's wallet.init failure when wallet is encrypted

### DIFF
--- a/cli/src/main/java/bisq/cli/TableFormat.java
+++ b/cli/src/main/java/bisq/cli/TableFormat.java
@@ -57,8 +57,8 @@ public class TableFormat {
 
         String colDataFormat = "%-" + COL_HEADER_ADDRESS.length() + "s" // lt justify
                 + "  %" + (COL_HEADER_AVAILABLE_BALANCE.length() - 1) + "s" // rt justify
-                + "  %" + COL_HEADER_CONFIRMATIONS.length() + "d"       // lt justify
-                + "  %" + COL_HEADER_IS_USED_ADDRESS.length() + "s";  // lt justify
+                + "  %" + COL_HEADER_CONFIRMATIONS.length() + "d"       // rt justify
+                + "  %-" + COL_HEADER_IS_USED_ADDRESS.length() + "s";  // lt justify
         return headerLine
                 + addressBalanceInfo.stream()
                 .map(info -> format(colDataFormat,

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -474,6 +474,10 @@ class CoreWalletsService {
     void verifyWalletsAreAvailable() {
         verifyWalletAndNetworkIsReady();
 
+        // TODO This check may be redundant, but the AppStartupState is new and unused
+        //  prior to commit 838595cb03886c3980c40df9cfe5f19e9f8a0e39.  I would prefer
+        //  to leave this check in place until certain AppStartupState will always work
+        //  as expected.
         if (!walletsManager.areWalletsAvailable())
             throw new IllegalStateException("wallet is not yet available");
     }
@@ -520,7 +524,6 @@ class CoreWalletsService {
     private void maybeInitWallet() {
         // Unlike the UI, a daemon cannot capture the user's wallet encryption password
         // during startup.  This method will set the wallet service's aesKey if necessary.
-        log.info("Init wallet");
         if (tempAesKey == null)
             throw new IllegalStateException("cannot init encrypted wallet without key");
 

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -445,7 +445,7 @@ class CoreWalletsService {
         }
 
         if (coreContext.isApiUser())
-            maybeInitWallet();
+            maybeSetWalletsManagerKey();
 
         lockTimer = UserThread.runAfter(() -> {
             if (tempAesKey != null) {
@@ -521,11 +521,11 @@ class CoreWalletsService {
             throw new IllegalStateException(format("wallet does not support %s", currencyCode));
     }
 
-    private void maybeInitWallet() {
+    private void maybeSetWalletsManagerKey() {
         // Unlike the UI, a daemon cannot capture the user's wallet encryption password
         // during startup.  This method will set the wallet service's aesKey if necessary.
         if (tempAesKey == null)
-            throw new IllegalStateException("cannot init encrypted wallet without key");
+            throw new IllegalStateException("cannot use null key, unlockwallet timeout may have expired");
 
         if (btcWalletService.getAesKey() == null || bsqWalletService.getAesKey() == null) {
             KeyParameter aesKey = new KeyParameter(tempAesKey.getKey());

--- a/core/src/main/java/bisq/core/app/AppStartupState.java
+++ b/core/src/main/java/bisq/core/app/AppStartupState.java
@@ -130,7 +130,7 @@ public class AppStartupState {
         return updatedDataReceived;
     }
 
-    public boolean isIsBlockDownloadComplete() {
+    public boolean isBlockDownloadComplete() {
         return isBlockDownloadComplete.get();
     }
 

--- a/core/src/main/java/bisq/core/app/WalletAppSetup.java
+++ b/core/src/main/java/bisq/core/app/WalletAppSetup.java
@@ -17,6 +17,7 @@
 
 package bisq.core.app;
 
+import bisq.core.api.CoreContext;
 import bisq.core.btc.exceptions.InvalidHostException;
 import bisq.core.btc.exceptions.RejectedTxException;
 import bisq.core.btc.setup.WalletsSetup;
@@ -63,6 +64,7 @@ import javax.annotation.Nullable;
 @Singleton
 public class WalletAppSetup {
 
+    private final CoreContext coreContext;
     private final WalletsManager walletsManager;
     private final WalletsSetup walletsSetup;
     private final FeeService feeService;
@@ -86,11 +88,13 @@ public class WalletAppSetup {
     private final BooleanProperty useTorForBTC = new SimpleBooleanProperty();
 
     @Inject
-    public WalletAppSetup(WalletsManager walletsManager,
+    public WalletAppSetup(CoreContext coreContext,
+                          WalletsManager walletsManager,
                           WalletsSetup walletsSetup,
                           FeeService feeService,
                           Config config,
                           Preferences preferences) {
+        this.coreContext = coreContext;
         this.walletsManager = walletsManager;
         this.walletsSetup = walletsSetup;
         this.feeService = feeService;
@@ -172,10 +176,10 @@ public class WalletAppSetup {
         walletsSetup.initialize(null,
                 () -> {
                     // We only check one wallet as we apply encryption to all or none
-                    if (walletsManager.areWalletsEncrypted()) {
+                    if (walletsManager.areWalletsEncrypted() && !coreContext.isApiUser()) {
                         walletPasswordHandler.run();
                     } else {
-                        if (preferences.isResyncSpvRequested()) {
+                        if (preferences.isResyncSpvRequested() && !coreContext.isApiUser()) {
                             if (showFirstPopupIfResyncSPVRequestedHandler != null)
                                 showFirstPopupIfResyncSPVRequestedHandler.run();
                         } else {


### PR DESCRIPTION
This bug fix makes sure encrypted wallet initialization happens during startup, without prompting the user for a wallet password.

- Block UI popups in api startup's encrypted wallet init.
Running the UI's `walletPasswordHandler` during wallet initialization will block the API's wallet initialization.  This change ensures an encrypted wallet does not trigger `walletPasswordHandler.run()` if `isApiUser=true` during startup.


- Set `WalletsManager` key in first `CoreWalletsService#unlockWallet` call.
This is necessary because the key cannot be set during api daemon startup, which does happen during the UI's startup.  See commit eb15fda229bd9481b11844ee95f2243613842034.