### PR TITLE
Remove the apparent link for cases where the trade is not available for mediators

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -1139,14 +1139,14 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
-                                    field = new HyperlinkWithIcon(item.getShortTradeId());
                                     Optional<Trade> tradeOptional = tradeManager.getTradeById(item.getTradeId());
                                     if (tradeOptional.isPresent()) {
+                                        field = new HyperlinkWithIcon(item.getShortTradeId());
                                         field.setMouseTransparent(false);
                                         field.setTooltip(new Tooltip(Res.get("tooltip.openPopupForDetails")));
                                         field.setOnAction(event -> tradeDetailsWindow.show(tradeOptional.get()));
                                     } else {
-                                        field.setMouseTransparent(true);
+                                        setText(item.getShortTradeId());
                                     }
                                     setGraphic(field);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -1151,6 +1151,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                                     setGraphic(field);
                                 } else {
                                     setGraphic(null);
+                                    setText("");
                                     if (field != null)
                                         field.setOnAction(null);
                                 }


### PR DESCRIPTION
This is how it appears now the TradeID column for mediators:

<img width="494" alt="bisq_mediator" src="https://user-images.githubusercontent.com/79100296/112488539-e8237b80-8d7d-11eb-9b2b-73f1fcc5ceca.png">

Before it appeared as an hyperlink that was not actually working.

Note that the trade is only known to the 2 people involved in the trade. 
It is not shared with the Mediator/Arbitrator and for this reason a mediator is expected to not be able to pull trade details as it happens for the peers involved.

EDIT:
WAIT for the merge. Me and @jmacxx are investigating some display issues.

EDIT2:
Now it could be merged.