### PR TITLE
Handle rounding of infinite Doubles

### DIFF
--- a/common/src/main/java/bisq/common/util/MathUtils.java
+++ b/common/src/main/java/bisq/common/util/MathUtils.java
@@ -42,6 +42,8 @@ public class MathUtils {
     public static double roundDouble(double value, int precision, RoundingMode roundingMode) {
         if (precision < 0)
             throw new IllegalArgumentException();
+        if (!Double.isFinite(value))
+            throw new IllegalArgumentException("Expected a finite double, but found " + value);
 
         try {
             BigDecimal bd = BigDecimal.valueOf(value);

--- a/common/src/test/java/bisq/common/util/MathUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/MathUtilsTest.java
@@ -24,6 +24,20 @@ import static org.junit.Assert.assertFalse;
 
 public class MathUtilsTest {
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testRoundDoubleWithInfiniteArg() {
+        MathUtils.roundDouble(Double.POSITIVE_INFINITY, 2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRoundDoubleWithNaNArg() {
+        MathUtils.roundDouble(Double.NaN, 2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRoundDoubleWithNegativePrecision() {
+        MathUtils.roundDouble(3, -1);
+    }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test


### PR DESCRIPTION
In certain situations we deal with infinite (or NaN) doubles. This causes issues when trying to instantiate a BigDecimal from it, which is an intermediary step in the process of rounding the double.

This commit checks for such non-finite doubles and throws a specific exception if their rounding is attempted.

Related to #5366, #5362