### PR TITLE
Fixed XRC coin title to correct one

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/BitcoinRhodium.java
+++ b/assets/src/main/java/bisq/asset/coins/BitcoinRhodium.java
@@ -24,7 +24,7 @@ import bisq.asset.NetworkParametersAdapter;
 public class BitcoinRhodium extends Coin {
 
     public BitcoinRhodium() {
-        super("Bitcoin Rhodium", "XRC", new Base58AddressValidator(new BitcoinRhodiumParams()));
+        super("XRhodium", "XRC", new Base58AddressValidator(new BitcoinRhodiumParams()));
     }
 
     public static class BitcoinRhodiumParams extends NetworkParametersAdapter {

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -137,7 +137,7 @@ public class CurrencyUtil {
 
     public static List<CryptoCurrency> getMainCryptoCurrencies() {
         final List<CryptoCurrency> result = new ArrayList<>();
-        result.add(new CryptoCurrency("XRC", "Bitcoin Rhodium"));
+        result.add(new CryptoCurrency("XRC", "XRhodium"));
 
         if (DevEnv.isDaoTradingActivated())
             result.add(new CryptoCurrency("BSQ", "BSQ"));


### PR DESCRIPTION
- Replaced string with old name in BitcoinRhodium.java to XRhodium

- Replaced string with old name in CurrencyUtil.java to XRhodium

This change is based on rebranding of Bitcoin Rhodium project because it isnt a fork of Bitcoin. Now it have codebase with Blockcore development.