### PR TITLE
Allow Revolut username to be minimum 3 characters

### DIFF
--- a/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/RevolutValidator.java
@@ -24,7 +24,8 @@ public final class RevolutValidator extends LengthValidator {
         // that the old accountID as phone number or email is displayed at the username text field and we do not
         // want to break validation in those cases. So being too strict on the validators might cause more troubles
         // as its worth...
-        super(5, 100);
+        // UPDATE 04/2021: Revolut usernames could be edited (3-16 characters, lowercase a-z and numbers only)
+        super(3, 100);
     }
 
     public ValidationResult validate(String input) {


### PR DESCRIPTION
Since around a week, Revolut users could change their usernames.
Username could be at minimum of 3 characters so the validation has been adjusted accordingly.

Reference: https://www.revolut.com/en-US/help/making-payments/sending-money-to-another-revolut-account/username-payments/can-i-change-my-username

Maximum length has not been touched to preserve email and phone numbers usernames.
