### PR TITLE
Pricenode: Increase mempool fee suggestion from medium to high priority

### DIFF
--- a/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
+++ b/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
@@ -91,7 +91,7 @@ abstract class MempoolFeeRateProvider extends FeeRateProvider {
     private FeeRate getEstimatedFeeRate() {
         Set<Map.Entry<String, Long>> feeRatePredictions = getFeeRatePredictions();
         long estimatedFeeRate = feeRatePredictions.stream()
-                .filter(p -> p.getKey().equalsIgnoreCase("halfHourFee"))
+                .filter(p -> p.getKey().equalsIgnoreCase("fastestFee"))
                 .map(Map.Entry::getValue)
                 .findFirst()
                 .map(r -> Math.max(r, MIN_FEE_RATE))


### PR DESCRIPTION
Due to the recent high mining variance and mempool congestion, some users are reporting stuck trades due to TX getting stuck in the mempool. To help, this PR increases pricenodes usage of mempool.space fee suggestions from medium to high priority.