### PR TITLE
Update docs references to Java 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #  - Linux, macOS or similar *nix with standard tools like `make`
 #  - bitcoind and bitcoin-cli (`brew install bitcoin` on macOS)
 #  - JDK 11 to build and run Bisq binaries; see
-#    https://www.oracle.com/java/technologies/java-archive-javase10-downloads.html
+#    https://jdk.java.net/archive/
 #
 #
 # USAGE

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #
 #  - Linux, macOS or similar *nix with standard tools like `make`
 #  - bitcoind and bitcoin-cli (`brew install bitcoin` on macOS)
-#  - JDK 10 to build and run Bisq binaries; see
+#  - JDK 11 to build and run Bisq binaries; see
 #    https://www.oracle.com/java/technologies/java-archive-javase10-downloads.html
 #
 #

--- a/docs/build.md
+++ b/docs/build.md
@@ -50,7 +50,7 @@
    javac -version
    ```
 
-If your Java version is not 11, check out scripts in the [scripts](../scripts) directory (or online at https://github.com/bisq-network/bisq/tree/master/scripts).
+If you do not have JDK 11 installed, check out scripts in the [scripts](../scripts) directory or download it manually from https://jdk.java.net/archive/.
 
 ## Running Bisq
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -43,14 +43,14 @@
 
 1. You do _not_ need to install Gradle to build Bisq. The `gradlew` shell script will install it for you, if necessary.
 
-2. Bisq currently works with JDK 10 and 11 only. JDK 12 and above are not supported. You can find out which
+2. Bisq currently works with JDK 11 only. JDK 12 and above are not supported. You can find out which
    version you have with:
 
    ```sh
    javac -version
    ```
 
-If your Java version is not 10 or 11, check out scripts in the [scripts](../scripts) directory (or online at https://github.com/bisq-network/bisq/tree/master/scripts).
+If your Java version is not 11, check out scripts in the [scripts](../scripts) directory (or online at https://github.com/bisq-network/bisq/tree/master/scripts).
 
 ## Running Bisq
 

--- a/docs/idea-import.md
+++ b/docs/idea-import.md
@@ -11,7 +11,7 @@ Most Bisq contributors use IDEA for development. The following instructions have
  1. In the `Import Project from Gradle` screen, check the `Use auto-import` option and click `OK`
  1. When prompted whether to overwrite the existing `.idea` directory, click `Yes` (This step was not required with 2019.2 but is kept here in case you are running an older version)
  1. In the `Project` tool window, right click on the root-level `.idea` folder, select `Git->Revert...` and click OK in the dialog that appears (to restore source-controlled `.idea` configuration files that get overwritten during project import)
- 1. If you did not yet setup JDK11 in IntelliJ, Go to `File->Project Structure->Project` and under the `Project SDK` option locate your JAVA_HOME folder, then in `Project language level` beneath select `11 - ...`.
+ 1. If you have not set up JDK11 in IntelliJ, Go to `File->Project Structure->Project` and under the `Project SDK` option locate your JAVA_HOME folder, then in `Project language level` beneath select `11 - ...`.
  1. Select JDK 11 for gradle as well. Go to `Preferences->Build, Execution, Deployment->Build Tools->Gradle` and select the JDK11 location for Gradle JVM
  1. Go to `Build->Build Project`. Everything should build cleanly. You should be able to run tests, run `main` methods in any component, etc.
 

--- a/docs/idea-import.md
+++ b/docs/idea-import.md
@@ -11,8 +11,8 @@ Most Bisq contributors use IDEA for development. The following instructions have
  1. In the `Import Project from Gradle` screen, check the `Use auto-import` option and click `OK`
  1. When prompted whether to overwrite the existing `.idea` directory, click `Yes` (This step was not required with 2019.2 but is kept here in case you are running an older version)
  1. In the `Project` tool window, right click on the root-level `.idea` folder, select `Git->Revert...` and click OK in the dialog that appears (to restore source-controlled `.idea` configuration files that get overwritten during project import)
- 1. If you did not yet setup JDK10 in IntelliJ, Go to `File->Project Structure->Project` and under the `Project SDK` option locate your JAVA_HOME folder, then in `Project language level` beneath select `10 - ...`. (JDK10 is no longer supported but you can still download it from the [archive](https://jdk.java.net/archive/))
- 1. Select JDK 10 for gradle as well. Go to `Preferences->Build, Execution, Deployment->Build Tools->Gradle` and select the JDK10 location for Gradle JVM
+ 1. If you did not yet setup JDK11 in IntelliJ, Go to `File->Project Structure->Project` and under the `Project SDK` option locate your JAVA_HOME folder, then in `Project language level` beneath select `11 - ...`.
+ 1. Select JDK 11 for gradle as well. Go to `Preferences->Build, Execution, Deployment->Build Tools->Gradle` and select the JDK11 location for Gradle JVM
  1. Go to `Build->Build Project`. Everything should build cleanly. You should be able to run tests, run `main` methods in any component, etc.
 
 > TIP: If you encounter compilation errors in IDEA related to the `protobuf.*` classes, it is probably because you didn't build Bisq at the command line as instructed above. You need to run the `generateProto` task in the `common` project. You can do this via the Gradle tool window in IDEA, or you can do it the command line with `./gradlew :common:generateProto`. Once you've done that, run `Build->Build Project` again and you should have no errors.

--- a/scripts/install_java.bat
+++ b/scripts/install_java.bat
@@ -25,9 +25,9 @@ cd /D "%~dp0"
 
 title Install Java
 
-set jdk_version=10.0.2
+set jdk_version=11.0.2
 set jdk_filename=openjdk-%jdk_version%_windows-x64_bin
-set jdk_url=https://download.java.net/java/GA/jdk10/%jdk_version%/19aef61b38124481863b1413dce1855f/13/%jdk_filename%.tar.gz
+set jdk_url=https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip
 
 if exist "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%" (
     echo %PROGRAMFILES%\Java\openjdk\jdk-%jdk_version% already exists, skipping install
@@ -35,26 +35,16 @@ if exist "%PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%" (
 )
 
 echo Downloading required files to %TEMP%
-powershell -Command "Invoke-WebRequest %jdk_url% -OutFile $env:temp\%jdk_filename%.tar.gz"
-if not exist "%TEMP%\7za920\7za.exe" (
-    :: Download 7zip ^(command line version^) in order to extract the tar.gz file since there is no native support in Windows
-    powershell -Command "Invoke-WebRequest https://www.7-zip.org/a/7za920.zip -OutFile $env:temp\7za920.zip"
-    powershell -Command "Expand-Archive $env:temp\7za920.zip -DestinationPath $env:temp\7za920 -Force"
-)
+powershell -Command "Invoke-WebRequest %jdk_url% -OutFile $env:temp\%jdk_filename%.zip"
 
 echo Extracting and installing JDK to %PROGRAMFILES%\Java\openjdk\jdk-%jdk_version%
-"%TEMP%\7za920\7za.exe" x "%TEMP%\%jdk_filename%.tar.gz" -o"%TEMP%" -r -y
-"%TEMP%\7za920\7za.exe" x "%TEMP%\%jdk_filename%.tar" -o"%TEMP%\openjdk-%jdk_version%" -r -y
+powershell -Command "Expand-Archive $env:temp\%jdk_filename%.zip -DestinationPath %TEMP%\openjdk-%jdk_version% -Force"
 md "%PROGRAMFILES%\Java\openjdk"
 move "%TEMP%\openjdk-%jdk_version%\jdk-%jdk_version%" "%PROGRAMFILES%\Java\openjdk"
 
 echo Removing downloaded files
-if exist "%TEMP%\7za920.zip" (
-    del /Q %TEMP%\7za920.zip
-)
 rmdir /S /Q %TEMP%\openjdk-%jdk_version%
-del /Q %TEMP%\%jdk_filename%.tar
-del /Q %TEMP%\%jdk_filename%.tar.gz
+del /Q %TEMP%\%jdk_filename%.zip
 
 :SetEnvVars
 echo Setting environment variables

--- a/scripts/install_java.sh
+++ b/scripts/install_java.sh
@@ -15,9 +15,9 @@ set -e
 unameOut="$(uname -s)"
 case "${unameOut}" in
     Linux*)
-        JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
-        JDK_FILENAME=openjdk-10.0.2_linux-x64_bin.tar.gz
-        JDK_URL=https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz
+        JAVA_HOME=/usr/lib/jvm/openjdk-11.0.2
+        JDK_FILENAME=openjdk-11.0.2_linux-x64_bin.tar.gz
+        JDK_URL=https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
 
         # Determine which package manager to use depending on the distribution
         declare -A osInfo;
@@ -52,13 +52,13 @@ case "${unameOut}" in
         update-alternatives --set javac $JAVA_HOME/bin/javac
         ;;
     Darwin*)
-        JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-10.0.2.jdk/Contents/Home
-        JDK_FILENAME=openjdk-10.0.2_osx-x64_bin.tar.gz
-        JDK_URL=https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_osx-x64_bin.tar.gz
+        JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home
+        JDK_FILENAME=openjdk-11.0.2_osx-x64_bin.tar.gz
+        JDK_URL=https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_osx-x64_bin.tar.gz
         if [ ! -d "$JAVA_HOME" ]; then
             if [[ $(command -v brew) == "" ]]; then
-                echo "Installing Hombrew"
-                /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+                echo "Installing Homebrew"
+                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             else
                 echo "Updating Homebrew"
                 brew update
@@ -66,10 +66,10 @@ case "${unameOut}" in
 
             brew install curl
             curl -L -O $JDK_URL
-            sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-10.0.2.jdk | sudo bash
+            sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk | sudo bash
             gunzip -c $JDK_FILENAME | tar xopf -
-            sudo mv jdk-10.0.2.jdk/* /Library/Java/JavaVirtualMachines/openjdk-10.0.2.jdk
-            sudo rmdir jdk-10.0.2.jdk
+            sudo mv jdk-11.0.2.jdk/* /Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk
+            sudo rmdir jdk-11.0.2.jdk
             rm $JDK_FILENAME
         fi
 
@@ -80,4 +80,3 @@ case "${unameOut}" in
     *)
 esac
 java -version
-


### PR DESCRIPTION
As https://github.com/bisq-network/bisq/pull/5431 just got merged, Java 11 is the only supported Java version. 

Updated docs references to reflect this change.
