### PR TITLE
Fix cli test that blocks building on Windows

### DIFF
--- a/cli/src/test/java/bisq/cli/opt/OptionParsersTest.java
+++ b/cli/src/test/java/bisq/cli/opt/OptionParsersTest.java
@@ -176,8 +176,12 @@ public class OptionParsersTest {
         };
         Throwable exception = assertThrows(RuntimeException.class, () ->
                 new CreatePaymentAcctOptionParser(args).parse());
-        assertEquals("json payment account form '/tmp/milkyway/solarsystem/mars' could not be found",
+        if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0)
+            assertEquals("json payment account form '\\tmp\\milkyway\\solarsystem\\mars' could not be found",
                 exception.getMessage());
+        else
+            assertEquals("json payment account form '/tmp/milkyway/solarsystem/mars' could not be found",
+                    exception.getMessage());
     }
 
     // createcryptopaymentacct parser tests


### PR DESCRIPTION
This fix a path issue that was blocking users to build Bisq on Windows from terminal when using a command like _gradlew.bat build_

Fix tested on Windows and Linux/macOS.

The error was:
```
Task :cli:test FAILED

bisq.cli.opt.OptionParsersTest > testCreatePaymentAcctOptParserWithInvalidPaymentFormOptValueShouldThrowException() FAILED
    org.opentest4j.AssertionFailedError at OptionParsersTest.java:179
```

Due to:
```
testCreatePaymentAcctOptParserWithInvalidPaymentFormOptValueShouldThrowException()

org.opentest4j.AssertionFailedError: expected: <json payment account form '/tmp/milkyway/solarsystem/mars' could not be found> but was: <json payment account form '\tmp\milkyway\solarsystem\mars' could not be found>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
	at bisq.cli.opt.OptionParsersTest.testCreatePaymentAcctOptParserWithInvalidPaymentFormOptValueShouldThrowException(OptionParsersTest.java:179)
```
