### PR TITLE
Reduce mempool fee suggestion from high to medium priority

### DIFF
--- a/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
+++ b/pricenode/src/main/java/bisq/price/mining/providers/MempoolFeeRateProvider.java
@@ -91,7 +91,7 @@ abstract class MempoolFeeRateProvider extends FeeRateProvider {
     private FeeRate getEstimatedFeeRate() {
         Set<Map.Entry<String, Long>> feeRatePredictions = getFeeRatePredictions();
         long estimatedFeeRate = feeRatePredictions.stream()
-                .filter(p -> p.getKey().equalsIgnoreCase("fastestFee"))
+                .filter(p -> p.getKey().equalsIgnoreCase("halfHourFee"))
                 .map(Map.Entry::getValue)
                 .findFirst()
                 .map(r -> Math.max(r, MIN_FEE_RATE))


### PR DESCRIPTION
After discussion on Keybase, the pricenode operators decided the high priority was no longer necessary.

This reverts commit 087e160f6bde515ea7c74abdb335775b6efc1e36.