### PR TITLE
Add missing check if tx was in correct phase

### DIFF
--- a/core/src/main/java/bisq/core/dao/monitoring/BlindVoteStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/BlindVoteStateMonitoringService.java
@@ -257,8 +257,8 @@ public class BlindVoteStateMonitoringService implements DaoSetupService, DaoStat
 
         periodService.getCycle(blockHeight).ifPresent(cycle -> {
             List<BlindVote> blindVotes = blindVoteListService.getConfirmedBlindVotes().stream()
-                    .filter(e -> periodService.isTxInPhaseAndCycle(e.getTxId(), DaoPhase.Phase.BLIND_VOTE, blockHeight))
                     .filter(e -> e.getTxId() != null)
+                    .filter(e -> periodService.isTxInPhaseAndCycle(e.getTxId(), DaoPhase.Phase.BLIND_VOTE, blockHeight))
                     .sorted(Comparator.comparing(BlindVote::getTxId))
                     .collect(Collectors.toList());
 

--- a/core/src/main/java/bisq/core/dao/monitoring/BlindVoteStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/BlindVoteStateMonitoringService.java
@@ -257,8 +257,10 @@ public class BlindVoteStateMonitoringService implements DaoSetupService, DaoStat
 
         periodService.getCycle(blockHeight).ifPresent(cycle -> {
             List<BlindVote> blindVotes = blindVoteListService.getConfirmedBlindVotes().stream()
-                    .filter(e -> periodService.isTxInCorrectCycle(e.getTxId(), blockHeight))
-                    .sorted(Comparator.comparing(BlindVote::getTxId)).collect(Collectors.toList());
+                    .filter(e -> periodService.isTxInPhaseAndCycle(e.getTxId(), DaoPhase.Phase.BLIND_VOTE, blockHeight))
+                    .filter(e -> e.getTxId() != null)
+                    .sorted(Comparator.comparing(BlindVote::getTxId))
+                    .collect(Collectors.toList());
 
             // We use MyBlindVoteList to get the serialized bytes from the blindVotes list
             byte[] serializedBlindVotes = new MyBlindVoteList(blindVotes).toProtoMessage().toByteArray();

--- a/core/src/main/java/bisq/core/dao/monitoring/ProposalStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/ProposalStateMonitoringService.java
@@ -259,8 +259,8 @@ public class ProposalStateMonitoringService implements DaoSetupService, DaoState
 
         periodService.getCycle(blockHeight).ifPresent(cycle -> {
             List<Proposal> proposals = proposalService.getValidatedProposals().stream()
-                    .filter(e -> periodService.isTxInPhaseAndCycle(e.getTxId(), DaoPhase.Phase.PROPOSAL, blockHeight))
                     .filter(e -> e.getTxId() != null)
+                    .filter(e -> periodService.isTxInPhaseAndCycle(e.getTxId(), DaoPhase.Phase.PROPOSAL, blockHeight))
                     .sorted(Comparator.comparing(Proposal::getTxId))
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
There have been 1 tx in cycle 17 and 2 txs in cycle 23 which have been confirmed outside of the phase.
The vote result had excluded it correctly but for the hash calculation for the blind vote monitor the
phase check was missing which results in an incorrect hash.
By fixing that the past hashes back to cycle 17 are all invalid. Once all seed nodes are running that
patch nodes should be in sync again. As it did not affect consensus but only the monitoring it is not
critical.

We see currently 2 different hashes on seeds. I am not sure why but probably some have filtered those invalid txs already out.
