### PR TITLE
Fix bsq wallet & tx fee rate test cases (api)

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
@@ -25,8 +25,8 @@ import static bisq.apitest.method.wallet.WalletTestUtil.BOBS_INITIAL_BSQ_BALANCE
 import static bisq.apitest.method.wallet.WalletTestUtil.bsqBalanceModel;
 import static bisq.apitest.method.wallet.WalletTestUtil.verifyBsqBalances;
 import static bisq.cli.TableFormat.formatBsqBalanceInfoTbl;
+import static org.bitcoinj.core.NetworkParameters.ID_REGTEST;
 import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_REGTEST;
-import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_TESTNET;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -61,11 +61,10 @@ public class BsqWalletTest extends MethodTest {
         String addressString = aliceClient.getUnusedBsqAddress();
         assertFalse(addressString.isEmpty());
         assertTrue(addressString.startsWith("B"));
-        Address address = Address.fromString(NetworkParameters.fromID(PAYMENT_PROTOCOL_ID_REGTEST), addressString.substring(1));
+        Address address = Address.fromString(NetworkParameters.fromID(ID_REGTEST), addressString.substring(1));
         NetworkParameters networkParameters = address.getParameters();
         String addressNetwork = networkParameters.getPaymentProtocolId();
-        log.warn("TODO Fix bug causing the regtest bsq address network being set to 'testnet'.");
-        assertTrue(addressNetwork.equals(PAYMENT_PROTOCOL_ID_TESTNET));
+        assertTrue(addressNetwork.equals(PAYMENT_PROTOCOL_ID_REGTEST));
     }
 
     @Test

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
@@ -2,7 +2,7 @@ package bisq.apitest.method.wallet;
 
 import bisq.proto.grpc.BsqBalanceInfo;
 
-import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.Address;
 import org.bitcoinj.core.NetworkParameters;
 
 import lombok.extern.slf4j.Slf4j;
@@ -25,11 +25,9 @@ import static bisq.apitest.method.wallet.WalletTestUtil.BOBS_INITIAL_BSQ_BALANCE
 import static bisq.apitest.method.wallet.WalletTestUtil.bsqBalanceModel;
 import static bisq.apitest.method.wallet.WalletTestUtil.verifyBsqBalances;
 import static bisq.cli.TableFormat.formatBsqBalanceInfoTbl;
-import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_MAINNET;
 import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_REGTEST;
 import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_TESTNET;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
@@ -48,8 +46,8 @@ public class BsqWalletTest extends MethodTest {
 
     @BeforeAll
     public static void setUp() {
-        startSupportingApps(false,
-                true,
+        startSupportingApps(true,
+                false,
                 bitcoind,
                 seednode,
                 arbdaemon,
@@ -60,16 +58,14 @@ public class BsqWalletTest extends MethodTest {
     @Test
     @Order(1)
     public void testGetUnusedBsqAddress() {
-        var address = aliceClient.getUnusedBsqAddress();
-        assertFalse(address.isEmpty());
-        assertTrue(address.startsWith("B"));
-
-        NetworkParameters networkParameters = LegacyAddress.getParametersFromAddress(address.substring(1));
+        String addressString = aliceClient.getUnusedBsqAddress();
+        assertFalse(addressString.isEmpty());
+        assertTrue(addressString.startsWith("B"));
+        Address address = Address.fromString(NetworkParameters.fromID(PAYMENT_PROTOCOL_ID_REGTEST), addressString.substring(1));
+        NetworkParameters networkParameters = address.getParameters();
         String addressNetwork = networkParameters.getPaymentProtocolId();
-        assertNotEquals(PAYMENT_PROTOCOL_ID_MAINNET, addressNetwork);
-        // TODO Fix bug causing the regtest bsq address network to be evaluated as 'testnet' here.
-        assertTrue(addressNetwork.equals(PAYMENT_PROTOCOL_ID_TESTNET)
-                || addressNetwork.equals(PAYMENT_PROTOCOL_ID_REGTEST));
+        log.warn("TODO Fix bug causing the regtest bsq address network being set to 'testnet'.");
+        assertTrue(addressNetwork.equals(PAYMENT_PROTOCOL_ID_TESTNET));
     }
 
     @Test

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BtcTxFeeRateTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BtcTxFeeRateTest.java
@@ -56,8 +56,7 @@ public class BtcTxFeeRateTest extends MethodTest {
     @Order(2)
     public void testSetInvalidTxFeeRateShouldThrowException(final TestInfo testInfo) {
         var currentTxFeeRateInfo = TxFeeRateInfo.fromProto(aliceClient.getTxFeeRate());
-        Throwable exception = assertThrows(StatusRuntimeException.class, () ->
-                aliceClient.setTxFeeRate(10));
+        Throwable exception = assertThrows(StatusRuntimeException.class, () -> aliceClient.setTxFeeRate(1));
         String expectedExceptionMessage =
                 format("UNKNOWN: tx fee rate preference must be >= %d sats/byte",
                         currentTxFeeRateInfo.getMinFeeServiceRate());


### PR DESCRIPTION
- `BsqWalletTest`  Regtest btc block being generated with this fix, and chain download triggered.   Also adjusted testGetUnusedBsqAddress() for upcoming SegWit BSQ changes.

- `BtcTxFeeRateTest` Minimum tx fee rates move fast, sometimes so low the validation test fails.  This change tries to consistently force validation error by setting fee rate=1.
