### PR TITLE
Replace bisq.network/faq links with bisq.wiki

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -436,7 +436,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             String key = "securityDepositInfo";
             new Popup().backgroundInfo(Res.get("popup.info.securityDepositInfo"))
                     .actionButtonText(Res.get("shared.faq"))
-                    .onAction(() -> GUIUtil.openWebPage("https://bisq.network/faq#6"))
+                    .onAction(() -> GUIUtil.openWebPage("https://bisq.wiki/Frequently_asked_questions#Why_does_Bisq_require_a_security_deposit_in_BTC.3F"))
                     .useIUnderstandButton()
                     .dontShowAgainId(key)
                     .show();

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -512,7 +512,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
             String key = "securityDepositInfo";
             new Popup().backgroundInfo(Res.get("popup.info.securityDepositInfo"))
                     .actionButtonText(Res.get("shared.faq"))
-                    .onAction(() -> GUIUtil.openWebPage("https://bisq.network/faq#6"))
+                    .onAction(() -> GUIUtil.openWebPage("https://bisq.wiki/Frequently_asked_questions#Why_does_Bisq_require_a_security_deposit_in_BTC.3F"))
                     .useIUnderstandButton()
                     .dontShowAgainId(key)
                     .show();


### PR DESCRIPTION
Will be moving FAQs from the website to the wiki, so this pull request replaces bisq.network/faq links in the software with bisq.wiki links.

FYI the [wiki page is already done](https://bisq.wiki/Frequently_asked_questions), but the old FAQ page hasn't been removed from the website yet ([PR made though](https://github.com/bisq-network/bisq-website/pull/432)).