### PR TITLE
Fix the formula used to calculate BSQ amount needed to avoid dust

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BsqWalletService.java
@@ -684,7 +684,7 @@ public class BsqWalletService extends WalletService implements DaoStateListener 
                 log.warn("We increased required input as change output was zero or dust: New change value={}", change);
                 String info = "Available BSQ balance=" + coinSelection.valueGathered.value / 100 + " BSQ. " +
                         "Intended fee to burn=" + fee.value / 100 + " BSQ. " +
-                        "Please increase your balance to at least " + (coinSelection.valueGathered.value + minDustThreshold.value) / 100 + " BSQ.";
+                        "Please increase your balance to at least " + (fee.value + minDustThreshold.value) / 100 + " BSQ.";
                 checkArgument(coinSelection.valueGathered.compareTo(fee) > 0,
                         "This transaction require a change output of at least " + minDustThreshold.value / 100 + " BSQ (dust limit). " +
                                 info);


### PR DESCRIPTION
The formula used to calculate the BSQ needed to avoid dust was incorrect.

For example, this was before:

![paste](https://user-images.githubusercontent.com/79100296/117420997-65661280-af1e-11eb-9508-932148b5555a.png)

The BSQ amount needed should be 8, not 13. Now it is fixed.
