### PR TITLE
Fix custom fee rate field when custom inputs are used

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -740,6 +740,17 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                                             inputsToggleGroup.selectedToggleProperty().removeListener(inputsToggleGroupListener);
                                             inputsToggleGroup.selectToggle(useCustomInputsRadioButton);
                                             useAllInputs.set(false);
+
+                                            useCustomFee.setSelected(false);
+
+                                            transactionFeeInputTextField.setEditable(false);
+                                            transactionFeeInputTextField.setPromptText(Res.get("funds.withdrawal.useCustomFeeValueInfo"));
+                                            transactionFeeInputTextField.setText(String.valueOf(feeService.getTxFeePerVbyte().value));
+                                            transactionFeeInputTextField.focusedProperty().addListener(transactionFeeFocusedListener);
+
+                                            feeService.feeUpdateCounterProperty().addListener(transactionFeeChangeListener);
+                                            useCustomFee.selectedProperty().addListener(useCustomFeeCheckboxListener);
+
                                             inputsToggleGroup.selectedToggleProperty().addListener(inputsToggleGroupListener);
                                         }
                                     });

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -744,12 +744,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                                             useCustomFee.setSelected(false);
 
                                             transactionFeeInputTextField.setEditable(false);
-                                            transactionFeeInputTextField.setPromptText(Res.get("funds.withdrawal.useCustomFeeValueInfo"));
                                             transactionFeeInputTextField.setText(String.valueOf(feeService.getTxFeePerVbyte().value));
-                                            transactionFeeInputTextField.focusedProperty().addListener(transactionFeeFocusedListener);
-
-                                            feeService.feeUpdateCounterProperty().addListener(transactionFeeChangeListener);
-                                            useCustomFee.selectedProperty().addListener(useCustomFeeCheckboxListener);
 
                                             inputsToggleGroup.selectedToggleProperty().addListener(inputsToggleGroupListener);
                                         }

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -190,6 +190,16 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
         inputsToggleGroupListener = (observable, oldValue, newValue) -> {
             useAllInputs.set(newValue == useAllInputsRadioButton);
 
+            useCustomFee.setSelected(false);
+
+            transactionFeeInputTextField.setEditable(false);
+            transactionFeeInputTextField.setPromptText(Res.get("funds.withdrawal.useCustomFeeValueInfo"));
+            transactionFeeInputTextField.setText(String.valueOf(feeService.getTxFeePerVbyte().value));
+            transactionFeeInputTextField.focusedProperty().addListener(transactionFeeFocusedListener);
+
+            feeService.feeUpdateCounterProperty().addListener(transactionFeeChangeListener);
+            useCustomFee.selectedProperty().addListener(useCustomFeeCheckboxListener);
+
             updateInputSelection();
         };
 
@@ -612,9 +622,6 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
 
         withdrawMemoTextField.setText("");
         withdrawMemoTextField.setPromptText(Res.get("funds.withdrawal.memo"));
-
-        transactionFeeInputTextField.setText("");
-        transactionFeeInputTextField.setPromptText(Res.get("funds.withdrawal.useCustomFeeValueInfo"));
 
         selectedItems.clear();
         tableView.getSelectionModel().clearSelection();


### PR DESCRIPTION
If a user chooses to use custom inputs in Funds menu, custom fee rate field is wrongly blanked and this leads to _NumberFormatException_.

Fixed by updating _inputsToggleGroupListener_

Thanks @jmacxx for having pointed out this.