### PR TITLE
Speed up "Synchronizing DAO" by ~30%

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
@@ -29,7 +29,7 @@ import org.bitcoinj.core.Coin;
 
 import javax.inject.Inject;
 
-import java.util.LinkedList;
+import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -118,16 +118,15 @@ public class BlockParser {
     }
 
     private void validateIfBlockIsConnecting(RawBlock rawBlock) throws BlockHashNotConnectingException, BlockHeightNotConnectingException {
-        LinkedList<Block> blocks = daoStateService.getBlocks();
+        List<Block> blocks = daoStateService.getBlocks();
 
         if (blocks.isEmpty())
             return;
 
-        Block last = blocks.getLast();
-        if (last.getHeight() + 1 != rawBlock.getHeight())
+        if (daoStateService.getBlockHeightOfLastBlock() + 1 != rawBlock.getHeight())
             throw new BlockHeightNotConnectingException(rawBlock);
 
-        if (!last.getHash().equals(rawBlock.getPreviousBlockHash()))
+        if (!daoStateService.getBlockHashOfLastBlock().equals(rawBlock.getPreviousBlockHash()))
             throw new BlockHashNotConnectingException(rawBlock);
     }
 

--- a/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
@@ -76,6 +76,7 @@ public class BlockParser {
      * @throws BlockHeightNotConnectingException If new block height is not current chain Height + 1
      */
     public Block parseBlock(RawBlock rawBlock) throws BlockHashNotConnectingException, BlockHeightNotConnectingException {
+        long startTs = System.currentTimeMillis();
         int blockHeight = rawBlock.getHeight();
         log.trace("Parse block at height={} ", blockHeight);
 
@@ -102,7 +103,6 @@ public class BlockParser {
         // There are some blocks with testing such dependency chains like block 130768 where at each iteration only
         // one get resolved.
         // Lately there is a patter with 24 iterations observed
-        long startTs = System.currentTimeMillis();
 
         rawBlock.getRawTxs().forEach(rawTx ->
                 txParser.findTx(rawTx,
@@ -111,10 +111,9 @@ public class BlockParser {
                         genesisTotalSupply)
                         .ifPresent(tx -> daoStateService.onNewTxForLastBlock(block, tx)));
 
+        daoStateService.onParseBlockComplete(block);
         log.info("Parsing {} transactions at block height {} took {} ms", rawBlock.getRawTxs().size(),
                 blockHeight, System.currentTimeMillis() - startTs);
-
-        daoStateService.onParseBlockComplete(block);
         return block;
     }
 

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -117,10 +117,7 @@ public class DaoStateService implements DaoSetupService {
 
         daoState.setTxCache(snapshot.getTxCache());
 
-        daoState.getBlocks().clear();
-        daoState.getBlocks().addAll(snapshot.getBlocks());
-        daoState.setBlockHashCache(snapshot.getBlockHashCache());
-        daoState.setBlockHeightCache(snapshot.getBlockHeightCache());
+        daoState.clearAndSetBlocks(snapshot.getBlocks());
 
         daoState.getCycles().clear();
         daoState.getCycles().addAll(snapshot.getCycles());
@@ -223,7 +220,7 @@ public class DaoStateService implements DaoSetupService {
                     "We ignore that block as the first block need to be the genesis block. " +
                     "That might happen in edge cases at reorgs. Received block={}", block);
         } else {
-            daoState.getBlocks().add(block);
+            daoState.addBlock(block);
 
             if (parseBlockChainComplete)
                 log.info("New Block added at blockHeight {}", block.getHeight());
@@ -285,7 +282,7 @@ public class DaoStateService implements DaoSetupService {
     }
 
 
-    public LinkedList<Block> getBlocks() {
+    public List<Block> getBlocks() {
         return daoState.getBlocks();
     }
 
@@ -297,12 +294,12 @@ public class DaoStateService implements DaoSetupService {
      * {@code false}.
      */
     public boolean isBlockHashKnown(String blockHash) {
-        return daoState.getBlockHashCache().contains(blockHash);
+        return daoState.getBlocksByHash().contains(blockHash);
     }
 
     public Optional<Block> getLastBlock() {
         if (!getBlocks().isEmpty())
-            return Optional.of(getBlocks().getLast());
+            return Optional.of(daoState.getLastBlock());
         else
             return Optional.empty();
     }
@@ -311,8 +308,12 @@ public class DaoStateService implements DaoSetupService {
         return getLastBlock().map(Block::getHeight).orElse(0);
     }
 
+    public String getBlockHashOfLastBlock() {
+        return getLastBlock().map(Block::getHash).orElse("");
+    }
+
     public Optional<Block> getBlockAtHeight(int height) {
-        return Optional.ofNullable(daoState.getBlockHeightCache().get(height));
+        return Optional.ofNullable(daoState.getBlocksByHeight().get(height));
     }
 
     public boolean containsBlock(Block block) {

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -120,6 +120,7 @@ public class DaoStateService implements DaoSetupService {
         daoState.getBlocks().clear();
         daoState.getBlocks().addAll(snapshot.getBlocks());
         daoState.setBlockHashCache(snapshot.getBlockHashCache());
+        daoState.setBlockHeightCache(snapshot.getBlockHeightCache());
 
         daoState.getCycles().clear();
         daoState.getCycles().addAll(snapshot.getCycles());
@@ -311,9 +312,7 @@ public class DaoStateService implements DaoSetupService {
     }
 
     public Optional<Block> getBlockAtHeight(int height) {
-        return getBlocks().stream()
-                .filter(block -> block.getHeight() == height)
-                .findAny();
+        return Optional.ofNullable(daoState.getBlockHeightCache().get(height));
     }
 
     public boolean containsBlock(Block block) {

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -119,6 +119,7 @@ public class DaoStateService implements DaoSetupService {
 
         daoState.getBlocks().clear();
         daoState.getBlocks().addAll(snapshot.getBlocks());
+        daoState.setBlockHashCache(snapshot.getBlockHashCache());
 
         daoState.getCycles().clear();
         daoState.getCycles().addAll(snapshot.getCycles());
@@ -295,7 +296,7 @@ public class DaoStateService implements DaoSetupService {
      * {@code false}.
      */
     public boolean isBlockHashKnown(String blockHash) {
-        return getBlocks().stream().anyMatch(block -> block.getHash().equals(blockHash));
+        return daoState.getBlockHashCache().contains(blockHash);
     }
 
     public Optional<Block> getLastBlock() {

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -294,7 +294,7 @@ public class DaoStateService implements DaoSetupService {
      * {@code false}.
      */
     public boolean isBlockHashKnown(String blockHash) {
-        return daoState.getBlocksByHash().contains(blockHash);
+        return daoState.getBlockHashes().contains(blockHash);
     }
 
     public Optional<Block> getLastBlock() {

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -320,10 +320,6 @@ public class DaoStateService implements DaoSetupService {
         return getBlocks().contains(block);
     }
 
-    public boolean containsBlockHash(String blockHash) {
-        return getBlocks().stream().anyMatch(block -> block.getHash().equals(blockHash));
-    }
-
     public long getBlockTime(int height) {
         return getBlockAtHeight(height).map(Block::getTime).orElse(0L);
     }

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -99,7 +99,7 @@ public class DaoStateSnapshotService {
                 daoStateSnapshotCandidate.getChainHeight() != chainHeight;
         if (isSnapshotHeight(chainHeight) &&
                 !daoStateService.getBlocks().isEmpty() &&
-                isValidHeight(daoStateService.getBlocks().getLast().getHeight()) &&
+                isValidHeight(daoStateService.getBlockHeightOfLastBlock()) &&
                 noSnapshotCandidateOrDifferentHeight) {
             // At trigger event we store the latest snapshotCandidate to disc
             long ts = System.currentTimeMillis();
@@ -126,10 +126,9 @@ public class DaoStateSnapshotService {
         DaoState persistedBsqState = daoStateStorageService.getPersistedBsqState();
         LinkedList<DaoStateHash> persistedDaoStateHashChain = daoStateStorageService.getPersistedDaoStateHashChain();
         if (persistedBsqState != null) {
-            LinkedList<Block> blocks = persistedBsqState.getBlocks();
             int chainHeightOfPersisted = persistedBsqState.getChainHeight();
-            if (!blocks.isEmpty()) {
-                int heightOfLastBlock = blocks.getLast().getHeight();
+            if (!persistedBsqState.getBlocks().isEmpty()) {
+                int heightOfLastBlock = persistedBsqState.getLastBlock().getHeight();
                 log.debug("applySnapshot from persistedBsqState daoState with height of last block {}", heightOfLastBlock);
                 if (isValidHeight(heightOfLastBlock)) {
                     if (chainHeightOfLastApplySnapshot != chainHeightOfPersisted) {

--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -109,6 +109,8 @@ public class DaoState implements PersistablePayload {
     @JsonExclude
     private transient final Map<String, Tx> txCache; // key is txId
     @JsonExclude
+    private transient final Map<Integer, Block> blockHeightCache; // key is block height
+    @JsonExclude
     private transient final Set<String> blockHashCache;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -165,6 +167,9 @@ public class DaoState implements PersistablePayload {
         blockHashCache = blocks.stream()
                 .map(Block::getHash)
                 .collect(Collectors.toSet());
+
+        blockHeightCache = blocks.stream()
+                .collect(Collectors.toMap(Block::getHeight, Function.identity(), (x, y) -> x, HashMap::new));
     }
 
     @Override
@@ -260,6 +265,11 @@ public class DaoState implements PersistablePayload {
         this.blockHashCache.addAll(blockHashCache);
     }
 
+    public void setBlockHeightCache(Map<Integer, Block> blockHeightCache) {
+        this.blockHeightCache.clear();
+        this.blockHeightCache.putAll(blockHeightCache);
+    }
+
     public Map<String, Tx> getTxCache() {
         return Collections.unmodifiableMap(txCache);
     }
@@ -267,6 +277,8 @@ public class DaoState implements PersistablePayload {
     public Set<String> getBlockHashCache() {
         return Collections.unmodifiableSet(blockHashCache);
     }
+
+    public Map<Integer, Block> getBlockHeightCache() { return Collections.unmodifiableMap(blockHeightCache); }
 
     @Override
     public String toString() {

--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -107,7 +108,8 @@ public class DaoState implements PersistablePayload {
     // Transient data used only as an index - must be kept in sync with the block list
     @JsonExclude
     private transient final Map<String, Tx> txCache; // key is txId
-
+    @JsonExclude
+    private transient final Set<String> blockHashCache;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -159,6 +161,10 @@ public class DaoState implements PersistablePayload {
         txCache = blocks.stream()
                 .flatMap(block -> block.getTxs().stream())
                 .collect(Collectors.toMap(Tx::getId, Function.identity(), (x, y) -> x, HashMap::new));
+
+        blockHashCache = blocks.stream()
+                .map(Block::getHash)
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -249,8 +255,17 @@ public class DaoState implements PersistablePayload {
         this.txCache.putAll(txCache);
     }
 
+    public void setBlockHashCache(Set<String> blockHashCache) {
+        this.blockHashCache.clear();
+        this.blockHashCache.addAll(blockHashCache);
+    }
+
     public Map<String, Tx> getTxCache() {
         return Collections.unmodifiableMap(txCache);
+    }
+
+    public Set<String> getBlockHashCache() {
+        return Collections.unmodifiableSet(blockHashCache);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -278,7 +278,9 @@ public class DaoState implements PersistablePayload {
         return Collections.unmodifiableSet(blockHashCache);
     }
 
-    public Map<Integer, Block> getBlockHeightCache() { return Collections.unmodifiableMap(blockHeightCache); }
+    public Map<Integer, Block> getBlockHeightCache() {
+        return Collections.unmodifiableMap(blockHeightCache);
+    }
 
     @Override
     public String toString() {

--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -113,7 +113,7 @@ public class DaoState implements PersistablePayload {
     @JsonExclude
     private transient final Map<Integer, Block> blocksByHeight; // Blocks indexed by height
     @JsonExclude
-    private transient final Set<String> blocksByHash; // Blocks indexed by hash
+    private transient final Set<String> blockHashes; // Cache of known block hashes
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -166,7 +166,7 @@ public class DaoState implements PersistablePayload {
                 .flatMap(block -> block.getTxs().stream())
                 .collect(Collectors.toMap(Tx::getId, Function.identity(), (x, y) -> x, HashMap::new));
 
-        blocksByHash = blocks.stream()
+        blockHashes = blocks.stream()
                 .map(Block::getHash)
                 .collect(Collectors.toSet());
 
@@ -266,8 +266,8 @@ public class DaoState implements PersistablePayload {
         return Collections.unmodifiableMap(txCache);
     }
 
-    public Set<String> getBlocksByHash() {
-        return Collections.unmodifiableSet(blocksByHash);
+    public Set<String> getBlockHashes() {
+        return Collections.unmodifiableSet(blockHashes);
     }
 
     public Map<Integer, Block> getBlocksByHeight() {
@@ -295,7 +295,7 @@ public class DaoState implements PersistablePayload {
 
     public void addBlock(Block block) {
         blocks.add(block);
-        blocksByHash.add(block.getHash());
+        blockHashes.add(block.getHash());
         blocksByHeight.put(block.getHeight(), block);
     }
 
@@ -310,7 +310,7 @@ public class DaoState implements PersistablePayload {
     public void clearAndSetBlocks(List<Block> newBlocks) {
         blocks.clear();
         blocksByHeight.clear();
-        blocksByHash.clear();
+        blockHashes.clear();
 
         addBlocks(newBlocks);
     }


### PR DESCRIPTION
`BlockParser.parseBlock()` normally takes about 300ms per block.

One part of it is checking if the new block hash is known, which was done by string-comparing it to the hashes of all known blocks. In my case, this was about 110 000 string-comparisons per `BlockParser.parseBlock()` call.

This commit adds a block hash cache in the `DaoState` and replaces the hash string-comparisons by one `HashSet` lookup.

With this change, `BlockParser.parseBlock()` takes around 200ms on my setup.