### PR TITLE
Return correct security deposit percentage size/minimum deposit when cloning an offer

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -639,7 +639,7 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
         this.volume.set(volume);
     }
 
-    void setBuyerSecurityDeposit(double value) {
+    protected void setBuyerSecurityDeposit(double value) {
         this.buyerSecurityDeposit.set(value);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
@@ -86,11 +86,12 @@ class DuplicateOfferDataModel extends MutableOfferDataModel {
         setAmount(offer.getAmount());
         setPrice(offer.getPrice());
         setVolume(offer.getVolume());
+        setUseMarketBasedPrice(offer.isUseMarketBasedPrice());
+
         if (offer.getBuyerSecurityDeposit().value == Restrictions.getMinBuyerSecurityDepositAsCoin().getValue())
             setBuyerSecurityDeposit(Restrictions.getMinBuyerSecurityDepositAsPercent());
         else
             setBuyerSecurityDeposit(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount()));
-        setUseMarketBasedPrice(offer.isUseMarketBasedPrice());
 
         if (offer.isUseMarketBasedPrice()) {
             setMarketPriceMargin(offer.getMarketPriceMargin());

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
@@ -88,10 +88,11 @@ class DuplicateOfferDataModel extends MutableOfferDataModel {
         setVolume(offer.getVolume());
         setUseMarketBasedPrice(offer.isUseMarketBasedPrice());
 
-        if (offer.getBuyerSecurityDeposit().value == Restrictions.getMinBuyerSecurityDepositAsCoin().getValue())
+        if (offer.getBuyerSecurityDeposit().value == Restrictions.getMinBuyerSecurityDepositAsCoin().getValue()) {
             setBuyerSecurityDeposit(Restrictions.getMinBuyerSecurityDepositAsPercent());
-        else
+        } else {
             setBuyerSecurityDeposit(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount()));
+        }
 
         if (offer.isUseMarketBasedPrice()) {
             setMarketPriceMargin(offer.getMarketPriceMargin());

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
@@ -24,6 +24,7 @@ import bisq.desktop.main.offer.MutableOfferDataModel;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.Restrictions;
 import bisq.core.offer.CreateOfferService;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferUtil;
@@ -35,6 +36,7 @@ import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
+import bisq.core.util.coin.CoinUtil;
 
 import bisq.network.p2p.P2PService;
 
@@ -84,7 +86,12 @@ class DuplicateOfferDataModel extends MutableOfferDataModel {
         setAmount(offer.getAmount());
         setPrice(offer.getPrice());
         setVolume(offer.getVolume());
+        if (offer.getBuyerSecurityDeposit().value == Restrictions.getMinBuyerSecurityDepositAsCoin().getValue())
+            setBuyerSecurityDeposit(Restrictions.getMinBuyerSecurityDepositAsPercent());
+        else
+            setBuyerSecurityDeposit(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount()));
         setUseMarketBasedPrice(offer.isUseMarketBasedPrice());
+
         if (offer.isUseMarketBasedPrice()) {
             setMarketPriceMargin(offer.getMarketPriceMargin());
         }


### PR DESCRIPTION
Fixes #5470 as security deposit was not previously set.
It works both with minimum security deposit and arbitrary percentage.

Thanks to @jmacxx for letting me work on this.