### PR TITLE
Fix text overlapping in Wallet Info menu

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1446,7 +1446,7 @@ account.menu.walletInfo.path.info=If you import seed words into another wallet (
   path. This should only be done in emergency cases when you lose access to the Bisq wallet and data directory.\n\
   Keep in mind that spending funds from a non-Bisq wallet can bungle the internal Bisq data structures associated with the wallet \
   data, which can lead to failed trades.\n\n\
-  NEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.
+  NEVER send BSQ from a non-Bisq wallet, as it will probably lead to an invalid BSQ transaction and losing your BSQ.\n\n\
 
 account.menu.walletInfo.openDetails=Show raw wallet details and private keys
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/walletinfo/WalletInfoView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/walletinfo/WalletInfoView.java
@@ -92,10 +92,11 @@ public class WalletInfoView extends ActivatableView<GridPane, Void> {
         btcTextField = addTopLabelTextField(root, ++gridRow, "BTC", -Layout.FLOATING_LABEL_DISTANCE).second;
         bsqTextField = addTopLabelTextField(root, ++gridRow, "BSQ", -Layout.FLOATING_LABEL_DISTANCE).second;
 
-        addTitledGroupBg(root, ++gridRow, 3, Res.get("account.menu.walletInfo.xpub.headLine"), Layout.GROUP_DISTANCE);
+        addTitledGroupBg(root, ++gridRow, 4, Res.get("account.menu.walletInfo.xpub.headLine"), Layout.GROUP_DISTANCE);
         addXpubKeys(btcWalletService, "BTC", gridRow, Layout.FIRST_ROW_AND_GROUP_DISTANCE);
         ++gridRow; // update gridRow
         addXpubKeys(bsqWalletService, "BSQ", ++gridRow, -Layout.FLOATING_LABEL_DISTANCE);
+        ++gridRow; // update gridRow
 
         addTitledGroupBg(root, ++gridRow, 4, Res.get("account.menu.walletInfo.path.headLine"), Layout.GROUP_DISTANCE);
         addMultilineLabel(root, gridRow, Res.get("account.menu.walletInfo.path.info"), Layout.FIRST_ROW_AND_GROUP_DISTANCE, Double.MAX_VALUE);


### PR DESCRIPTION
Fixes #5491 

Now it looks like this:
<img width="1061" alt="walletinfo" src="https://user-images.githubusercontent.com/79100296/118131205-820eb880-b3fe-11eb-81f8-a55c080c82ff.png">



