### PR TITLE
Remove jcenter repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
+        classpath 'com.github.johnrengelman:shadow:5.2.0'
         classpath files('gradle/witness/gradle-witness.jar')
         classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.10.RELEASE'
     }


### PR DESCRIPTION
Replace the jcenter repo with mavenCentral and jitpack.

One of the dependencies had a slightly different name in jcenter compared to jitpack (`com.github.jengelman.gradle.plugins:shadow` vs `com.github.johnrengelman:shadow`), so that was renamed as well.

Fixes #5496

