### PR TITLE
Preserve shadow plugin name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url "https://jitpack.io" }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.0'
-        classpath 'com.github.johnrengelman:shadow:5.2.0'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
         classpath files('gradle/witness/gradle-witness.jar')
         classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.10.RELEASE'
     }


### PR DESCRIPTION
Include plugins.gradle.org repository, which contains the shadow plugin of the same artefact group and name as used before in jcenter.

Addresses issue with plugin name mentioned in https://github.com/bisq-network/bisq/pull/5497#issuecomment-842226991