### PR TITLE
Remove borders on separators in main nav Issue#5107

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -648,7 +648,7 @@ tree-table-view:focused {
 }
 
 .top-navigation .separator:vertical .line {
-    -fx-border-color: transparent transparent transparent -bs-rd-nav-border-color;
+    -fx-border-color: transparent transparent transparent transparent;
     -fx-border-width: 1;
     -fx-border-insets: 0 0 0 1;
 }


### PR DESCRIPTION
Changed color of vertical border separator of main navigation to transparent on line#651 of bisq.css, so that the navigation would look cleaner and modern on both light mode and dark mode.

Resolves #5107 

Light mode:
![image](https://user-images.githubusercontent.com/34779522/118730250-22dce980-b7ec-11eb-874d-d703bcd0334b.png)

Dark mode:
![image](https://user-images.githubusercontent.com/34779522/118730297-34be8c80-b7ec-11eb-8ec6-695f2e3e6af5.png)




