### PR TITLE
Build: Include build platform in fat jar filename

### DIFF
--- a/desktop/package/package.gradle
+++ b/desktop/package/package.gradle
@@ -200,11 +200,8 @@ task packageInstallers {
         // We convert the fat jar into a deterministic one by stripping out comments with date, etc.
         // jar file created from https://github.com/ManfredKarrer/tools
         executeCmd("java -jar \"${project(':desktop').projectDir}/package/tools-1.0.jar\" ${fatJarFolderPath}/${mainJarName}")
-
-        // Store deterministic jar SHA-256
-        ant.checksum(file: "${fatJarFolderPath}/${mainJarName}", algorithm: 'SHA-256')
         copy {
-            from "${fatJarFolderPath}/${mainJarName}.SHA-256"
+            from "${fatJarFolderPath}/${mainJarName}"
             into binariesFolderPath
         }
 
@@ -483,10 +480,14 @@ task packageInstallers {
             executeCmd("open " + envVariableSharedFolder)
         }
 
-        println "The binaries are ready:"
-        binariesFolderPath.traverse {
-            println it.path
+        // Checksum each file in the resulting binaries folder
+        ant.checksum(algorithm: 'SHA-256') {
+            ant.fileset(dir: "${binariesFolderPath}")
         }
+
+        println "The binaries and checksums are ready:"
+        FileCollection collection = layout.files { binariesFolderPath.listFiles() }
+        collection.collect { it.path }.sort().each { println it }
     }
 }
 

--- a/desktop/package/package.gradle
+++ b/desktop/package/package.gradle
@@ -465,6 +465,8 @@ task packageInstallers {
         copy {
             from "${fatJarFolderPath}/${mainJarName}"
             into binariesFolderPath
+            // desktop-1.6.4-SNAPSHOT-all.jar => desktop-1.6.4-SNAPSHOT-all-mac.jar (or -win.jar, or -linux.jar)
+            rename { String fileName -> fileName.replace('-all.jar', "-all-" + os + ".jar") }
         }
 
         // Env variable can be set by calling "export BISQ_SHARED_FOLDER='Some value'"

--- a/desktop/package/package.gradle
+++ b/desktop/package/package.gradle
@@ -200,10 +200,6 @@ task packageInstallers {
         // We convert the fat jar into a deterministic one by stripping out comments with date, etc.
         // jar file created from https://github.com/ManfredKarrer/tools
         executeCmd("java -jar \"${project(':desktop').projectDir}/package/tools-1.0.jar\" ${fatJarFolderPath}/${mainJarName}")
-        copy {
-            from "${fatJarFolderPath}/${mainJarName}"
-            into binariesFolderPath
-        }
 
         // TODO For non-modular applications: use jlink to create a custom runtime containing only the modules required
 
@@ -465,6 +461,12 @@ task packageInstallers {
                     " --type rpm")
         }
 
+        // After binaries have been generated, copy the (deterministic, signed) fat jar to the binaries folder
+        copy {
+            from "${fatJarFolderPath}/${mainJarName}"
+            into binariesFolderPath
+        }
+
         // Env variable can be set by calling "export BISQ_SHARED_FOLDER='Some value'"
         // This is to copy the final binary/ies to a shared folder for further processing if a VM is used.
         String envVariableSharedFolder = "$System.env.BISQ_SHARED_FOLDER"
@@ -480,7 +482,7 @@ task packageInstallers {
             executeCmd("open " + envVariableSharedFolder)
         }
 
-        // Checksum each file in the resulting binaries folder
+        // Checksum each file present in the binaries folder
         ant.checksum(algorithm: 'SHA-256') {
             ant.fileset(dir: "${binariesFolderPath}")
         }


### PR DESCRIPTION
Depending on which platform it was built, the resulting fat jar (and its hash file) will include the platform in the name.

For example on mac:
- `desktop-1.6.5-all-mac.jar`
- `desktop-1.6.5-all-mac.jar.SHA-256`

Depends on #5487