### PR TITLE
Fix raspi build

### DIFF
--- a/desktop/package/package.gradle
+++ b/desktop/package/package.gradle
@@ -469,6 +469,16 @@ task packageInstallers {
             rename { String fileName -> fileName.replace('-all.jar', "-all-" + os + ".jar") }
         }
 
+        // Checksum each file present in the binaries folder
+        ant.checksum(algorithm: 'SHA-256') {
+            ant.fileset(dir: "${binariesFolderPath}")
+        }
+
+        println "The binaries and checksums are ready:"
+        FileCollection collection = layout.files { binariesFolderPath.listFiles() }
+        collection.collect { it.path }.sort().each { println it }
+
+        // After binaries are ready, copy them to shared folder
         // Env variable can be set by calling "export BISQ_SHARED_FOLDER='Some value'"
         // This is to copy the final binary/ies to a shared folder for further processing if a VM is used.
         String envVariableSharedFolder = "$System.env.BISQ_SHARED_FOLDER"
@@ -481,17 +491,16 @@ task packageInstallers {
                 from binariesFolderPath
                 into envVariableSharedFolder
             }
-            executeCmd("open " + envVariableSharedFolder)
-        }
 
-        // Checksum each file present in the binaries folder
-        ant.checksum(algorithm: 'SHA-256') {
-            ant.fileset(dir: "${binariesFolderPath}")
+            // Try to open a native file explorer window at the shared folder location
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                executeCmd("start '${envVariableSharedFolder}'")
+            } else if (Os.isFamily(Os.FAMILY_MAC)) {
+                executeCmd("open '${envVariableSharedFolder}'")
+            } else {
+                executeCmd("nautilus '${envVariableSharedFolder}'")
+            }
         }
-
-        println "The binaries and checksums are ready:"
-        FileCollection collection = layout.files { binariesFolderPath.listFiles() }
-        collection.collect { it.path }.sort().each { println it }
     }
 }
 

--- a/desktop/package/package.gradle
+++ b/desktop/package/package.gradle
@@ -169,9 +169,8 @@ task retrieveAndExtractJavaBinaries {
 task packageInstallers {
     description 'Call jpackage to prepare platform-specific binaries for this platform'
     dependsOn 'retrieveAndExtractJavaBinaries'
-    // Clean all previous artefacts and create a fresh shadowJar for the installers
     dependsOn rootProject.clean
-    dependsOn ':desktop:shadowJar'
+    dependsOn ':desktop:build' // Full build needed for "desktop/build/app/lib", used for raspi package
 
     doLast {
         String jPackageFilePath = retrieveAndExtractJavaBinaries.property('jpackageFilePath')
@@ -211,8 +210,7 @@ task packageInstallers {
         String appVersion = version.replaceAll("-SNAPSHOT", "")
         println "Packaging Bisq version ${appVersion}"
 
-        // zip jar lib for Raspberry Pi only on macOS as there are path issues on Windows and it is only needed once
-        // for the release
+        // zip jar lib for Raspberry Pi only on macOS as it is only needed once for the release
         if (Os.isFamily(Os.FAMILY_MAC)) {
             println "Zipping jar lib for raspberry pi"
             ant.zip(basedir: "${project(':desktop').buildDir}/app/lib",


### PR DESCRIPTION
Fix packaging issue which sometimes caused issues with creating the raspi package on Windows (and other environments where a recent `./gradlew :desktop:build` was not run recently).

Builds on top of #5515