### PR TITLE
Reduce the number of connected BTC nodes from 9 to 7

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -129,7 +129,8 @@ public class Config {
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
     public static final String DEFAULT_REGTEST_HOST = "localhost";
-    public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC = 9; // down from BitcoinJ default of 12
+    public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC = 7; // down from BitcoinJ default of 12
+    public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC_PUBLIC = 9;
     public static final boolean DEFAULT_FULL_DAO_NODE = false;
     static final String DEFAULT_CONFIG_FILE_NAME = "bisq.properties";
 

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -129,7 +129,7 @@ public class Config {
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
     public static final String DEFAULT_REGTEST_HOST = "localhost";
-    public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC = 7; // down from BitcoinJ default of 12
+    public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC_PROVIDED = 7; // down from BitcoinJ default of 12
     public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC_PUBLIC = 9;
     public static final boolean DEFAULT_FULL_DAO_NODE = false;
     static final String DEFAULT_CONFIG_FILE_NAME = "bisq.properties";
@@ -551,7 +551,7 @@ public class Config {
                 parser.accepts(NUM_CONNECTIONS_FOR_BTC, "Number of connections to the Bitcoin network")
                         .withRequiredArg()
                         .ofType(int.class)
-                        .defaultsTo(DEFAULT_NUM_CONNECTIONS_FOR_BTC);
+                        .defaultsTo(DEFAULT_NUM_CONNECTIONS_FOR_BTC_PROVIDED);
 
         ArgumentAcceptingOptionSpec<String> rpcUserOpt =
                 parser.accepts(RPC_USER, "Bitcoind rpc username")

--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
@@ -22,6 +22,8 @@ import bisq.core.user.Preferences;
 import bisq.common.config.Config;
 import bisq.common.util.Utilities;
 
+import javax.inject.Named;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -34,9 +36,12 @@ public class BtcNodesSetupPreferences {
     private static final Logger log = LoggerFactory.getLogger(BtcNodesSetupPreferences.class);
 
     private final Preferences preferences;
+    private final int numConnectionsForBtc;
 
-    public BtcNodesSetupPreferences(Preferences preferences) {
+    public BtcNodesSetupPreferences(Preferences preferences,
+                                    int numConnectionsForBtc) {
         this.preferences = preferences;
+        this.numConnectionsForBtc = numConnectionsForBtc;
     }
 
     public List<BtcNodes.BtcNode> selectPreferredNodes(BtcNodes nodes) {
@@ -83,7 +88,7 @@ public class BtcNodesSetupPreferences {
                 break;
             case PUBLIC:
                 // We keep the empty nodes
-                result = (int) Math.floor(Config.DEFAULT_NUM_CONNECTIONS_FOR_BTC * 0.8);
+                result = (int) Math.floor(numConnectionsForBtc * 0.8);
                 break;
             case PROVIDED:
             default:

--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
@@ -19,10 +19,7 @@ package bisq.core.btc.nodes;
 
 import bisq.core.user.Preferences;
 
-import bisq.common.config.Config;
 import bisq.common.util.Utilities;
-
-import javax.inject.Named;
 
 import java.util.Collections;
 import java.util.List;

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -396,7 +396,8 @@ public class WalletsSetup {
     }
 
     private void configPeerNodes(@Nullable Socks5Proxy proxy) {
-        BtcNodesSetupPreferences btcNodesSetupPreferences = new BtcNodesSetupPreferences(preferences);
+        BtcNodesSetupPreferences btcNodesSetupPreferences = new BtcNodesSetupPreferences(preferences,
+                numConnectionsForBtc);
 
         List<BtcNode> nodes = btcNodesSetupPreferences.selectPreferredNodes(btcNodes);
         int minBroadcastConnections = btcNodesSetupPreferences.calculateMinBroadcastConnections(nodes);

--- a/core/src/test/java/bisq/core/btc/nodes/BtcNodesSetupPreferencesTest.java
+++ b/core/src/test/java/bisq/core/btc/nodes/BtcNodesSetupPreferencesTest.java
@@ -20,6 +20,8 @@ package bisq.core.btc.nodes;
 import bisq.core.btc.nodes.BtcNodes.BtcNode;
 import bisq.core.user.Preferences;
 
+import bisq.common.config.Config;
+
 import java.util.List;
 
 import org.junit.Test;
@@ -37,7 +39,7 @@ public class BtcNodesSetupPreferencesTest {
         Preferences delegate = mock(Preferences.class);
         when(delegate.getBitcoinNodesOptionOrdinal()).thenReturn(PUBLIC.ordinal());
 
-        BtcNodesSetupPreferences preferences = new BtcNodesSetupPreferences(delegate);
+        BtcNodesSetupPreferences preferences = new BtcNodesSetupPreferences(delegate, Config.DEFAULT_NUM_CONNECTIONS_FOR_BTC_PUBLIC);
         List<BtcNode> nodes = preferences.selectPreferredNodes(mock(BtcNodes.class));
 
         assertTrue(nodes.isEmpty());
@@ -49,7 +51,7 @@ public class BtcNodesSetupPreferencesTest {
         when(delegate.getBitcoinNodesOptionOrdinal()).thenReturn(CUSTOM.ordinal());
         when(delegate.getBitcoinNodes()).thenReturn("aaa.onion,bbb.onion");
 
-        BtcNodesSetupPreferences preferences = new BtcNodesSetupPreferences(delegate);
+        BtcNodesSetupPreferences preferences = new BtcNodesSetupPreferences(delegate, Config.DEFAULT_NUM_CONNECTIONS_FOR_BTC_PUBLIC);
         List<BtcNode> nodes = preferences.selectPreferredNodes(mock(BtcNodes.class));
 
         assertEquals(2, nodes.size());

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -44,6 +44,8 @@ import bisq.network.p2p.network.Statistic;
 
 import bisq.common.ClockWatcher;
 import bisq.common.UserThread;
+import bisq.common.config.Config;
+import bisq.common.config.ConfigFileEditor;
 
 import org.bitcoinj.core.PeerGroup;
 
@@ -118,6 +120,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
     private final ClockWatcher clockWatcher;
     private final WalletsSetup walletsSetup;
     private final P2PService p2PService;
+    private final ConfigFileEditor configFileEditor;
 
     private final ObservableList<P2pNetworkListItem> p2pNetworkListItems = FXCollections.observableArrayList();
     private final SortedList<P2pNetworkListItem> p2pSortedList = new SortedList<>(p2pNetworkListItems);
@@ -144,7 +147,8 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                                FilterManager filterManager,
                                LocalBitcoinNode localBitcoinNode,
                                TorNetworkSettingsWindow torNetworkSettingsWindow,
-                               ClockWatcher clockWatcher) {
+                               ClockWatcher clockWatcher,
+                               Config config) {
         super();
         this.walletsSetup = walletsSetup;
         this.p2PService = p2PService;
@@ -154,6 +158,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         this.localBitcoinNode = localBitcoinNode;
         this.torNetworkSettingsWindow = torNetworkSettingsWindow;
         this.clockWatcher = clockWatcher;
+        this.configFileEditor = new ConfigFileEditor(config.configFile);
     }
 
     public void initialize() {
@@ -413,6 +418,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                         && btcNodesInputTextField.validate()
                         && currentBitcoinNodesOption != BtcNodes.BitcoinNodesOption.CUSTOM) {
                     preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                    configFileEditor.clearOption(Config.NUM_CONNECTIONS_FOR_BTC);
                     if (calledFromUser) {
                         if (isPreventPublicBtcNetwork()) {
                             new Popup().warning(Res.get("settings.net.warn.useCustomNodes.B2XWarning"))
@@ -428,6 +434,8 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                 btcNodesLabel.setDisable(true);
                 if (currentBitcoinNodesOption != BtcNodes.BitcoinNodesOption.PUBLIC) {
                     preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                    configFileEditor.setOption(Config.NUM_CONNECTIONS_FOR_BTC,
+                            String.valueOf(Config.DEFAULT_NUM_CONNECTIONS_FOR_BTC_PUBLIC));
                     if (calledFromUser) {
                         new Popup()
                                 .warning(Res.get("settings.net.warn.usePublicNodes"))
@@ -435,6 +443,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                                 .onAction(() -> UserThread.runAfter(() -> {
                                     selectedBitcoinNodesOption = BtcNodes.BitcoinNodesOption.PROVIDED;
                                     preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                                    configFileEditor.clearOption(Config.NUM_CONNECTIONS_FOR_BTC);
                                     selectBitcoinPeersToggle();
                                     onBitcoinPeersToggleSelected(false);
                                 }, 300, TimeUnit.MILLISECONDS))
@@ -451,6 +460,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                     btcNodesLabel.setDisable(true);
                     if (currentBitcoinNodesOption != BtcNodes.BitcoinNodesOption.PROVIDED) {
                         preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                        configFileEditor.clearOption(Config.NUM_CONNECTIONS_FOR_BTC);
                         if (calledFromUser) {
                             showShutDownPopup();
                         }
@@ -458,6 +468,8 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
                 } else {
                     selectedBitcoinNodesOption = BtcNodes.BitcoinNodesOption.PUBLIC;
                     preferences.setBitcoinNodesOptionOrdinal(selectedBitcoinNodesOption.ordinal());
+                    configFileEditor.setOption(Config.NUM_CONNECTIONS_FOR_BTC,
+                            String.valueOf(Config.DEFAULT_NUM_CONNECTIONS_FOR_BTC_PUBLIC));
                     selectBitcoinPeersToggle();
                     onBitcoinPeersToggleSelected(false);
                 }


### PR DESCRIPTION
After a discussion on #ops on keybase with @chimp1984 @Emzy and @wiz it was decided to reduce the number of connected BTC nodes, in case the provided nodes are used, from 9 to 7. This should reduce unnecessary load on our federated nodes.