### PR TITLE
Build: Change default console to plain

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 systemProp.org.gradle.internal.http.connectionTimeout=120000
 systemProp.org.gradle.internal.http.socketTimeout=120000
+
+# Makes Y/N user prompts more readable during installer packaging
+org.gradle.console=plain


### PR DESCRIPTION
Change default gradle console style to plain. This makes y/n user prompts more readable during installer packaging, without having to specify `--console=plain`.

Now it packaging installers can be directly done with `./gradlew packageInstallers`