### PR TITLE
Payment account factory test

### DIFF
--- a/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
@@ -19,73 +19,72 @@ package bisq.core.payment;
 
 import bisq.core.payment.payload.PaymentMethod;
 
-// comment
 public class PaymentAccountFactory {
     public static PaymentAccount getPaymentAccount(PaymentMethod paymentMethod) {
         switch (paymentMethod.getId()) {
-            case PaymentMethod.UPHOLD_ID:
+            case PaymentMethod.UPHOLD_ID: //done
                 return new UpholdAccount();
-            case PaymentMethod.MONEY_BEAM_ID:
+            case PaymentMethod.MONEY_BEAM_ID: //done
                 return new MoneyBeamAccount();
-            case PaymentMethod.POPMONEY_ID:
+            case PaymentMethod.POPMONEY_ID: //done
                 return new PopmoneyAccount();
-            case PaymentMethod.REVOLUT_ID:
+            case PaymentMethod.REVOLUT_ID: //done
                 return new RevolutAccount();
-            case PaymentMethod.PERFECT_MONEY_ID:
+            case PaymentMethod.PERFECT_MONEY_ID: //done
                 return new PerfectMoneyAccount();
-            case PaymentMethod.SEPA_ID:
+            case PaymentMethod.SEPA_ID: //done
                 return new SepaAccount();
-            case PaymentMethod.SEPA_INSTANT_ID:
+            case PaymentMethod.SEPA_INSTANT_ID: //done
                 return new SepaInstantAccount();
-            case PaymentMethod.FASTER_PAYMENTS_ID:
+            case PaymentMethod.FASTER_PAYMENTS_ID: //done
                 return new FasterPaymentsAccount();
-            case PaymentMethod.NATIONAL_BANK_ID:
+            case PaymentMethod.NATIONAL_BANK_ID: //done
                 return new NationalBankAccount();
-            case PaymentMethod.SAME_BANK_ID:
+            case PaymentMethod.SAME_BANK_ID: //done
                 return new SameBankAccount();
-            case PaymentMethod.SPECIFIC_BANKS_ID:
+            case PaymentMethod.SPECIFIC_BANKS_ID: //done
                 return new SpecificBanksAccount();
-            case PaymentMethod.JAPAN_BANK_ID:
+            case PaymentMethod.JAPAN_BANK_ID://done
                 return new JapanBankAccount();
-            case PaymentMethod.AUSTRALIA_PAYID_ID:
+            case PaymentMethod.AUSTRALIA_PAYID_ID: //done
                 return new AustraliaPayid();
-            case PaymentMethod.ALI_PAY_ID:
+            case PaymentMethod.ALI_PAY_ID: //done
                 return new AliPayAccount();
-            case PaymentMethod.WECHAT_PAY_ID:
+            case PaymentMethod.WECHAT_PAY_ID: // done
                 return new WeChatPayAccount();
-            case PaymentMethod.SWISH_ID:
+            case PaymentMethod.SWISH_ID: //done
                 return new SwishAccount();
-            case PaymentMethod.CLEAR_X_CHANGE_ID:
+            case PaymentMethod.CLEAR_X_CHANGE_ID:// done
                 return new ClearXchangeAccount();
-            case PaymentMethod.CHASE_QUICK_PAY_ID:
+            case PaymentMethod.CHASE_QUICK_PAY_ID: // done
                 return new ChaseQuickPayAccount();
-            case PaymentMethod.INTERAC_E_TRANSFER_ID:
+            case PaymentMethod.INTERAC_E_TRANSFER_ID://done
                 return new InteracETransferAccount();
-            case PaymentMethod.US_POSTAL_MONEY_ORDER_ID:
+            case PaymentMethod.US_POSTAL_MONEY_ORDER_ID: //done
                 return new USPostalMoneyOrderAccount();
-            case PaymentMethod.CASH_DEPOSIT_ID:
+            case PaymentMethod.CASH_DEPOSIT_ID: //done
                 return new CashDepositAccount();
-            case PaymentMethod.BLOCK_CHAINS_ID:
+            case PaymentMethod.BLOCK_CHAINS_ID://done
                 return new CryptoCurrencyAccount();
-            case PaymentMethod.MONEY_GRAM_ID:
+            case PaymentMethod.MONEY_GRAM_ID: // done
                 return new MoneyGramAccount();
-            case PaymentMethod.WESTERN_UNION_ID:
+            case PaymentMethod.WESTERN_UNION_ID:// done
                 return new WesternUnionAccount();
-            case PaymentMethod.HAL_CASH_ID:
+            case PaymentMethod.HAL_CASH_ID: //done
                 return new HalCashAccount();
-            case PaymentMethod.F2F_ID:
+            case PaymentMethod.F2F_ID: // done
                 return new F2FAccount();
-            case PaymentMethod.CASH_BY_MAIL_ID:
+            case PaymentMethod.CASH_BY_MAIL_ID: //done
                 return new CashByMailAccount();
-            case PaymentMethod.PROMPT_PAY_ID:
+            case PaymentMethod.PROMPT_PAY_ID: // done
                 return new PromptPayAccount();
-            case PaymentMethod.ADVANCED_CASH_ID:
+            case PaymentMethod.ADVANCED_CASH_ID: //done
                 return new AdvancedCashAccount();
-            case PaymentMethod.TRANSFERWISE_ID:
+            case PaymentMethod.TRANSFERWISE_ID: // done
                 return new TransferwiseAccount();
-            case PaymentMethod.AMAZON_GIFT_CARD_ID:
+            case PaymentMethod.AMAZON_GIFT_CARD_ID: //done
                 return new AmazonGiftCardAccount();
-            case PaymentMethod.BLOCK_CHAINS_INSTANT_ID:
+            case PaymentMethod.BLOCK_CHAINS_INSTANT_ID: //done
                 return new InstantCryptoCurrencyAccount();
 
             // Cannot be deleted as it would break old trade history entries

--- a/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
@@ -22,69 +22,69 @@ import bisq.core.payment.payload.PaymentMethod;
 public class PaymentAccountFactory {
     public static PaymentAccount getPaymentAccount(PaymentMethod paymentMethod) {
         switch (paymentMethod.getId()) {
-            case PaymentMethod.UPHOLD_ID: //done
+            case PaymentMethod.UPHOLD_ID:
                 return new UpholdAccount();
-            case PaymentMethod.MONEY_BEAM_ID: //done
+            case PaymentMethod.MONEY_BEAM_ID:
                 return new MoneyBeamAccount();
-            case PaymentMethod.POPMONEY_ID: //done
+            case PaymentMethod.POPMONEY_ID:
                 return new PopmoneyAccount();
-            case PaymentMethod.REVOLUT_ID: //done
+            case PaymentMethod.REVOLUT_ID:
                 return new RevolutAccount();
-            case PaymentMethod.PERFECT_MONEY_ID: //done
+            case PaymentMethod.PERFECT_MONEY_ID:
                 return new PerfectMoneyAccount();
-            case PaymentMethod.SEPA_ID: //done
+            case PaymentMethod.SEPA_ID:
                 return new SepaAccount();
-            case PaymentMethod.SEPA_INSTANT_ID: //done
+            case PaymentMethod.SEPA_INSTANT_ID:
                 return new SepaInstantAccount();
-            case PaymentMethod.FASTER_PAYMENTS_ID: //done
+            case PaymentMethod.FASTER_PAYMENTS_ID:
                 return new FasterPaymentsAccount();
-            case PaymentMethod.NATIONAL_BANK_ID: //done
+            case PaymentMethod.NATIONAL_BANK_ID:
                 return new NationalBankAccount();
-            case PaymentMethod.SAME_BANK_ID: //done
+            case PaymentMethod.SAME_BANK_ID:
                 return new SameBankAccount();
-            case PaymentMethod.SPECIFIC_BANKS_ID: //done
+            case PaymentMethod.SPECIFIC_BANKS_ID:
                 return new SpecificBanksAccount();
-            case PaymentMethod.JAPAN_BANK_ID://done
+            case PaymentMethod.JAPAN_BANK_ID:
                 return new JapanBankAccount();
-            case PaymentMethod.AUSTRALIA_PAYID_ID: //done
+            case PaymentMethod.AUSTRALIA_PAYID_ID:
                 return new AustraliaPayid();
-            case PaymentMethod.ALI_PAY_ID: //done
+            case PaymentMethod.ALI_PAY_ID:
                 return new AliPayAccount();
-            case PaymentMethod.WECHAT_PAY_ID: // done
+            case PaymentMethod.WECHAT_PAY_ID:
                 return new WeChatPayAccount();
-            case PaymentMethod.SWISH_ID: //done
+            case PaymentMethod.SWISH_ID:
                 return new SwishAccount();
-            case PaymentMethod.CLEAR_X_CHANGE_ID:// done
+            case PaymentMethod.CLEAR_X_CHANGE_ID:
                 return new ClearXchangeAccount();
-            case PaymentMethod.CHASE_QUICK_PAY_ID: // done
+            case PaymentMethod.CHASE_QUICK_PAY_ID:
                 return new ChaseQuickPayAccount();
-            case PaymentMethod.INTERAC_E_TRANSFER_ID://done
+            case PaymentMethod.INTERAC_E_TRANSFER_ID:
                 return new InteracETransferAccount();
-            case PaymentMethod.US_POSTAL_MONEY_ORDER_ID: //done
+            case PaymentMethod.US_POSTAL_MONEY_ORDER_ID:
                 return new USPostalMoneyOrderAccount();
-            case PaymentMethod.CASH_DEPOSIT_ID: //done
+            case PaymentMethod.CASH_DEPOSIT_ID:
                 return new CashDepositAccount();
-            case PaymentMethod.BLOCK_CHAINS_ID://done
+            case PaymentMethod.BLOCK_CHAINS_ID:
                 return new CryptoCurrencyAccount();
-            case PaymentMethod.MONEY_GRAM_ID: // done
+            case PaymentMethod.MONEY_GRAM_ID:
                 return new MoneyGramAccount();
-            case PaymentMethod.WESTERN_UNION_ID:// done
+            case PaymentMethod.WESTERN_UNION_ID:
                 return new WesternUnionAccount();
-            case PaymentMethod.HAL_CASH_ID: //done
+            case PaymentMethod.HAL_CASH_ID:
                 return new HalCashAccount();
-            case PaymentMethod.F2F_ID: // done
+            case PaymentMethod.F2F_ID:
                 return new F2FAccount();
-            case PaymentMethod.CASH_BY_MAIL_ID: //done
+            case PaymentMethod.CASH_BY_MAIL_ID:
                 return new CashByMailAccount();
-            case PaymentMethod.PROMPT_PAY_ID: // done
+            case PaymentMethod.PROMPT_PAY_ID:
                 return new PromptPayAccount();
-            case PaymentMethod.ADVANCED_CASH_ID: //done
+            case PaymentMethod.ADVANCED_CASH_ID:
                 return new AdvancedCashAccount();
-            case PaymentMethod.TRANSFERWISE_ID: // done
+            case PaymentMethod.TRANSFERWISE_ID:
                 return new TransferwiseAccount();
-            case PaymentMethod.AMAZON_GIFT_CARD_ID: //done
+            case PaymentMethod.AMAZON_GIFT_CARD_ID:
                 return new AmazonGiftCardAccount();
-            case PaymentMethod.BLOCK_CHAINS_INSTANT_ID: //done
+            case PaymentMethod.BLOCK_CHAINS_INSTANT_ID:
                 return new InstantCryptoCurrencyAccount();
 
             // Cannot be deleted as it would break old trade history entries

--- a/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccountFactory.java
@@ -19,6 +19,7 @@ package bisq.core.payment;
 
 import bisq.core.payment.payload.PaymentMethod;
 
+// comment
 public class PaymentAccountFactory {
     public static PaymentAccount getPaymentAccount(PaymentMethod paymentMethod) {
         switch (paymentMethod.getId()) {

--- a/core/src/test/java/bisq/core/payment/PaymentAccountFactoryTest.java
+++ b/core/src/test/java/bisq/core/payment/PaymentAccountFactoryTest.java
@@ -1,0 +1,109 @@
+package bisq.core.payment;
+
+import bisq.core.payment.payload.PaymentMethod;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PaymentAccountFactoryTest {
+
+    @Test
+    public void testGetPaymentAccount() {
+        PaymentMethod uphold = PaymentMethod.UPHOLD;
+        Assert.assertEquals(new UpholdAccount(), PaymentAccountFactory.getPaymentAccount(uphold));
+
+        PaymentMethod moneyBeam = PaymentMethod.MONEY_BEAM;
+        Assert.assertEquals(new MoneyBeamAccount(), PaymentAccountFactory.getPaymentAccount(moneyBeam));
+
+        PaymentMethod popMoney = PaymentMethod.POPMONEY;
+        Assert.assertEquals(new PopmoneyAccount(), PaymentAccountFactory.getPaymentAccount(popMoney));
+
+        PaymentMethod revolut = PaymentMethod.REVOLUT;
+        Assert.assertEquals(new RevolutAccount(), PaymentAccountFactory.getPaymentAccount(revolut));
+
+        PaymentMethod perfectMoney = PaymentMethod.PERFECT_MONEY;
+        Assert.assertEquals(new PerfectMoneyAccount(), PaymentAccountFactory.getPaymentAccount(perfectMoney));
+
+//        PaymentMethod sepa = PaymentMethod.SEPA;
+//        Assert.assertEquals(new SepaAccount(), PaymentAccountFactory.getPaymentAccount(sepa));
+
+//        PaymentMethod sepaInstant = PaymentMethod.SEPA_INSTANT;
+//        Assert.assertEquals(new SepaInstantAccount(), PaymentAccountFactory.getPaymentAccount(sepaInstant));
+
+        PaymentMethod fpi = PaymentMethod.FASTER_PAYMENTS;
+        Assert.assertEquals(new FasterPaymentsAccount(), PaymentAccountFactory.getPaymentAccount(fpi));
+
+//        PaymentMethod nationalBank = PaymentMethod.NATIONAL_BANK;
+//        Assert.assertEquals(new NationalBankAccount(), PaymentAccountFactory.getPaymentAccount(nationalBank));
+
+//        PaymentMethod sameBank = PaymentMethod.SAME_BANK;
+//        Assert.assertEquals(new SameBankAccount(), PaymentAccountFactory.getPaymentAccount(sameBank));
+
+//        PaymentMethod specBanc = PaymentMethod.SPECIFIC_BANKS;
+//        Assert.assertEquals(new SpecificBanksAccount(), PaymentAccountFactory.getPaymentAccount(specBanc));
+
+        PaymentMethod jpnBank = PaymentMethod.JAPAN_BANK;
+        Assert.assertEquals(new JapanBankAccount(),PaymentAccountFactory.getPaymentAccount(jpnBank));
+
+        PaymentMethod australia = PaymentMethod.AUSTRALIA_PAYID;
+        Assert.assertEquals(new AustraliaPayid(), PaymentAccountFactory.getPaymentAccount(australia));
+
+        PaymentMethod aliPay = PaymentMethod.ALI_PAY;
+        Assert.assertEquals(new AliPayAccount(), PaymentAccountFactory.getPaymentAccount(aliPay));
+
+        PaymentMethod wechat = PaymentMethod.WECHAT_PAY;
+        Assert.assertEquals(new WeChatPayAccount(), PaymentAccountFactory.getPaymentAccount(wechat));
+
+        PaymentMethod swishPay = PaymentMethod.SWISH;
+        Assert.assertEquals(new SwishAccount(), PaymentAccountFactory.getPaymentAccount(swishPay));
+
+        PaymentMethod clearXChange = PaymentMethod.CLEAR_X_CHANGE;
+        Assert.assertEquals(new ClearXchangeAccount(), PaymentAccountFactory.getPaymentAccount(clearXChange));
+
+        PaymentMethod chase = PaymentMethod.CHASE_QUICK_PAY;
+        Assert.assertEquals(new ChaseQuickPayAccount(), PaymentAccountFactory.getPaymentAccount(chase));
+
+        PaymentMethod interacETransfer = PaymentMethod.INTERAC_E_TRANSFER;
+        Assert.assertEquals(new InteracETransferAccount(), PaymentAccountFactory.getPaymentAccount(interacETransfer));
+
+        PaymentMethod usPostal = PaymentMethod.US_POSTAL_MONEY_ORDER;
+        Assert.assertEquals(new USPostalMoneyOrderAccount(), PaymentAccountFactory.getPaymentAccount(usPostal));
+
+//        PaymentMethod cashDeposit = PaymentMethod.CASH_DEPOSIT;
+//        Assert.assertEquals(new CashDepositAccount(), PaymentAccountFactory.getPaymentAccount(cashDeposit));
+
+        PaymentMethod blockChain = PaymentMethod.BLOCK_CHAINS;
+        Assert.assertEquals(new CryptoCurrencyAccount(), PaymentAccountFactory.getPaymentAccount(blockChain));
+
+//        PaymentMethod moneygram = PaymentMethod.MONEY_GRAM;
+//        Assert.assertEquals(new MoneyGramAccount(), PaymentAccountFactory.getPaymentAccount(moneygram));
+
+//        PaymentMethod westernAccount = PaymentMethod.WESTERN_UNION;
+//        Assert.assertEquals(new WesternUnionAccount(), PaymentAccountFactory.getPaymentAccount(westernAccount));
+
+        PaymentMethod halCash = PaymentMethod.HAL_CASH;
+        Assert.assertEquals(new HalCashAccount(), PaymentAccountFactory.getPaymentAccount(halCash));
+
+//        PaymentMethod f2f = PaymentMethod.F2F;
+//        Assert.assertEquals(new F2FAccount(), PaymentAccountFactory.getPaymentAccount(f2f));
+
+        PaymentMethod cashByMail = PaymentMethod.CASH_BY_MAIL;
+        Assert.assertEquals(new CashByMailAccount(), PaymentAccountFactory.getPaymentAccount(cashByMail));
+
+//        PaymentMethod prompt = PaymentMethod.PROMPT_PAY;
+//        Assert.assertEquals(new PromptPayAccount(), prompt);
+
+        PaymentMethod advancedCash = PaymentMethod.ADVANCED_CASH;
+        Assert.assertEquals(new AdvancedCashAccount(), PaymentAccountFactory.getPaymentAccount(advancedCash));
+
+        PaymentMethod transferwise = PaymentMethod.TRANSFERWISE;
+        Assert.assertEquals(new TransferwiseAccount(), PaymentAccountFactory.getPaymentAccount(transferwise));
+
+        PaymentMethod amazonGiftCard = PaymentMethod.AMAZON_GIFT_CARD;
+        Assert.assertEquals(new AmazonGiftCardAccount(), PaymentAccountFactory.getPaymentAccount(amazonGiftCard));
+
+        PaymentMethod blockChainsInstant = PaymentMethod.BLOCK_CHAINS_INSTANT;
+        Assert.assertEquals(new InstantCryptoCurrencyAccount(), PaymentAccountFactory.getPaymentAccount(blockChainsInstant));
+
+    }
+}

--- a/core/src/test/java/bisq/core/payment/PaymentAccountFactoryTest.java
+++ b/core/src/test/java/bisq/core/payment/PaymentAccountFactoryTest.java
@@ -90,8 +90,8 @@ public class PaymentAccountFactoryTest {
         PaymentMethod cashByMail = PaymentMethod.CASH_BY_MAIL;
         Assert.assertEquals(new CashByMailAccount(), PaymentAccountFactory.getPaymentAccount(cashByMail));
 
-//        PaymentMethod prompt = PaymentMethod.PROMPT_PAY;
-//        Assert.assertEquals(new PromptPayAccount(), prompt);
+        PaymentMethod prompt = PaymentMethod.PROMPT_PAY;
+        Assert.assertEquals(new PromptPayAccount(), PaymentAccountFactory.getPaymentAccount(prompt));
 
         PaymentMethod advancedCash = PaymentMethod.ADVANCED_CASH;
         Assert.assertEquals(new AdvancedCashAccount(), PaymentAccountFactory.getPaymentAccount(advancedCash));


### PR DESCRIPTION
Added a new test class called PaymentAccountFactoryTest.java under bisq/core/src/test/java/bisq.core/payment

I noticed that there are currently no test cases for the PaymentAccountFactory, so I added some test cases to make sure the returned accounts are correct.

You will notice that there are some commented out PaymentMethods, these payment methods do not pass the test.

I noticed that the failing payment methods extend CountryBasedPaymentAccount, which is something to look into.