### PR TITLE
Fix security deposit in duplicate offer when minimum deposit is used

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -106,7 +106,6 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
     final String shortOfferId;
     private final AccountAgeWitnessService accountAgeWitnessService;
     private final FeeService feeService;
-    private final CoinFormatter btcFormatter;
     private final Navigation navigation;
     private final String offerId;
     private final BalanceListener btcBalanceListener;
@@ -121,9 +120,12 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
     protected final ObjectProperty<Price> price = new SimpleObjectProperty<>();
     protected final ObjectProperty<Volume> volume = new SimpleObjectProperty<>();
     protected final ObjectProperty<Volume> minVolume = new SimpleObjectProperty<>();
+    protected final CoinFormatter btcFormatter;
 
     // Percentage value of buyer security deposit. E.g. 0.01 means 1% of trade amount
     protected final DoubleProperty buyerSecurityDeposit = new SimpleDoubleProperty();
+
+    protected final StringProperty buyerSecurityDepositInBTC = new SimpleStringProperty();
 
     protected final ObservableList<PaymentAccount> paymentAccounts = FXCollections.observableArrayList();
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
@@ -89,9 +89,9 @@ class DuplicateOfferDataModel extends MutableOfferDataModel {
         setUseMarketBasedPrice(offer.isUseMarketBasedPrice());
 
         if (offer.getBuyerSecurityDeposit().value == Restrictions.getMinBuyerSecurityDepositAsCoin().getValue()) {
-            setBuyerSecurityDeposit(Restrictions.getMinBuyerSecurityDepositAsPercent());
+            buyerSecurityDepositInBTC.set(btcFormatter.formatCoinWithCode(Restrictions.getMinBuyerSecurityDepositAsCoin()));
         } else {
-            setBuyerSecurityDeposit(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount()));
+            buyerSecurityDeposit.set(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount()));
         }
 
         if (offer.isUseMarketBasedPrice()) {


### PR DESCRIPTION
This should fix the security deposit when a user duplicates an offer with a minimum security deposit set.

Please test that on Mainnet as I saw some differences between Regtest, but on Mainnet should be ok.
