### PR TITLE
Fix setting of buyer security deposit

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferDataModel.java
@@ -714,7 +714,7 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
         return getBoundedSellerSecurityDepositAsCoin(percentOfAmountAsCoin);
     }
 
-    private Coin getBoundedBuyerSecurityDepositAsCoin(Coin value) {
+    protected Coin getBoundedBuyerSecurityDepositAsCoin(Coin value) {
         // We need to ensure that for small amount values we don't get a too low BTC amount. We limit it with using the
         // MinBuyerSecurityDepositAsCoin from Restrictions.
         return Coin.valueOf(Math.max(Restrictions.getMinBuyerSecurityDepositAsCoin().value, value.value));

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -481,8 +481,10 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         securityDepositAsDoubleListener = (ov, oldValue, newValue) -> {
             if (newValue != null) {
                 buyerSecurityDeposit.set(FormattingUtils.formatToPercent((double) newValue));
-                if (dataModel.getAmount().get() != null)
+                if (dataModel.getAmount().get() != null) {
                     buyerSecurityDepositInBTC.set(btcFormatter.formatCoinWithCode(dataModel.getBuyerSecurityDepositAsCoin()));
+                }
+                updateBuyerSecurityDeposit();
             } else {
                 buyerSecurityDeposit.set("");
                 buyerSecurityDepositInBTC.set("");

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/duplicateoffer/DuplicateOfferDataModel.java
@@ -40,6 +40,8 @@ import bisq.core.util.coin.CoinUtil;
 
 import bisq.network.p2p.P2PService;
 
+import org.bitcoinj.core.Coin;
+
 import com.google.inject.Inject;
 
 import javax.inject.Named;
@@ -88,14 +90,18 @@ class DuplicateOfferDataModel extends MutableOfferDataModel {
         setVolume(offer.getVolume());
         setUseMarketBasedPrice(offer.isUseMarketBasedPrice());
 
-        if (offer.getBuyerSecurityDeposit().value == Restrictions.getMinBuyerSecurityDepositAsCoin().getValue()) {
-            setBuyerSecurityDeposit(Restrictions.getMinBuyerSecurityDepositAsPercent());
-        } else {
-            setBuyerSecurityDeposit(CoinUtil.getAsPercentPerBtc(offer.getBuyerSecurityDeposit(), offer.getAmount()));
-        }
+        setBuyerSecurityDeposit(getBuyerSecurityAsPercent(offer));
 
         if (offer.isUseMarketBasedPrice()) {
             setMarketPriceMargin(offer.getMarketPriceMargin());
         }
+    }
+
+    private double getBuyerSecurityAsPercent(Offer offer) {
+        Coin offerBuyerSecurityDeposit = getBoundedBuyerSecurityDepositAsCoin(offer.getBuyerSecurityDeposit());
+        double offerBuyerSecurityDepositAsPercent = CoinUtil.getAsPercentPerBtc(offerBuyerSecurityDeposit,
+                offer.getAmount());
+        return Math.min(offerBuyerSecurityDepositAsPercent,
+                Restrictions.getMaxBuyerSecurityDepositAsPercent());
     }
 }


### PR DESCRIPTION
The existing code failed if an offer was duplicated that had
a different minimum security deposit set. It is changed so that
it makes sure that the it never falls below the minimum buyer
security deposit and never exceeds the maximum security deposit
percentage.