### PR TITLE
Add a placeholder on the "Search Disputes" field

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -229,12 +229,13 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
         HBox.setHgrow(label, Priority.NEVER);
 
         filterTextField = new InputTextField();
+        filterTextField.setPromptText(Res.get("support.filter.prompt"));
         Tooltip tooltip = new Tooltip();
         tooltip.setShowDelay(Duration.millis(100));
         tooltip.setShowDuration(Duration.seconds(10));
         filterTextField.setTooltip(tooltip);
         filterTextFieldListener = (observable, oldValue, newValue) -> applyFilteredListPredicate(filterTextField.getText());
-        HBox.setHgrow(filterTextField, Priority.NEVER);
+        HBox.setHgrow(filterTextField, Priority.ALWAYS);
 
         alertIconLabel = new Label();
         Text icon = getIconForLabel(MaterialDesignIcon.ALERT_CIRCLE_OUTLINE, "2em", alertIconLabel);


### PR DESCRIPTION
Added a hint for "search disputes" text input and changed the box size to accommodate the hint.
resolved #5105 
![image](https://user-images.githubusercontent.com/34779522/121104245-78d2fa80-c7b6-11eb-909b-8a44886b4c7b.png)
