### PR TITLE
Remove create CHASE_QUICK_PAY apitest case

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/payment/CreatePaymentAccountTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/payment/CreatePaymentAccountTest.java
@@ -22,7 +22,6 @@ import bisq.core.payment.AdvancedCashAccount;
 import bisq.core.payment.AliPayAccount;
 import bisq.core.payment.AustraliaPayid;
 import bisq.core.payment.CashDepositAccount;
-import bisq.core.payment.ChaseQuickPayAccount;
 import bisq.core.payment.ClearXchangeAccount;
 import bisq.core.payment.F2FAccount;
 import bisq.core.payment.FasterPaymentsAccount;
@@ -250,28 +249,6 @@ public class CreatePaymentAccountTest extends AbstractPaymentAccountTest {
         assertEquals(COMPLETED_FORM_MAP.get(PROPERTY_NAME_HOLDER_TAX_ID), payload.getHolderTaxId());
         assertEquals(COMPLETED_FORM_MAP.get(PROPERTY_NAME_NATIONAL_ACCOUNT_ID), payload.getNationalAccountId());
         assertEquals(COMPLETED_FORM_MAP.get(PROPERTY_NAME_SALT), paymentAccount.getSaltAsHex());
-        print(paymentAccount);
-    }
-
-    @Test
-    public void testCreateChaseQuickPayAccount(TestInfo testInfo) {
-        File emptyForm = getEmptyForm(testInfo, CHASE_QUICK_PAY_ID);
-        verifyEmptyForm(emptyForm,
-                CHASE_QUICK_PAY_ID,
-                PROPERTY_NAME_EMAIL,
-                PROPERTY_NAME_HOLDER_NAME);
-        COMPLETED_FORM_MAP.put(PROPERTY_NAME_PAYMENT_METHOD_ID, CHASE_QUICK_PAY_ID);
-        COMPLETED_FORM_MAP.put(PROPERTY_NAME_ACCOUNT_NAME, "Quick Pay Acct");
-        COMPLETED_FORM_MAP.put(PROPERTY_NAME_EMAIL, "johndoe@quickpay.com");
-        COMPLETED_FORM_MAP.put(PROPERTY_NAME_HOLDER_NAME, "John Doe");
-        COMPLETED_FORM_MAP.put(PROPERTY_NAME_SALT, "");
-        String jsonString = getCompletedFormAsJsonString();
-        ChaseQuickPayAccount paymentAccount = (ChaseQuickPayAccount) createPaymentAccount(aliceClient, jsonString);
-        verifyUserPayloadHasPaymentAccountWithId(aliceClient, paymentAccount.getId());
-        verifyAccountSingleTradeCurrency("USD", paymentAccount);
-        verifyCommonFormEntries(paymentAccount);
-        assertEquals(COMPLETED_FORM_MAP.get(PROPERTY_NAME_EMAIL), paymentAccount.getEmail());
-        assertEquals(COMPLETED_FORM_MAP.get(PROPERTY_NAME_HOLDER_NAME), paymentAccount.getHolderName());
         print(paymentAccount);
     }
 

--- a/apitest/src/test/java/bisq/apitest/scenario/PaymentAccountTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/PaymentAccountTest.java
@@ -51,7 +51,6 @@ public class PaymentAccountTest extends AbstractPaymentAccountTest {
         test.testCreateAustraliaPayidAccount(testInfo);
         test.testCreateCashDepositAccount(testInfo);
         test.testCreateBrazilNationalBankAccount(testInfo);
-        test.testCreateChaseQuickPayAccount(testInfo);
         test.testCreateClearXChangeAccount(testInfo);
         test.testCreateF2FAccount(testInfo);
         test.testCreateFasterPaymentsAccount(testInfo);

--- a/core/src/test/java/bisq/core/payment/PaymentAccountsTest.java
+++ b/core/src/test/java/bisq/core/payment/PaymentAccountsTest.java
@@ -41,23 +41,6 @@ public class PaymentAccountsTest {
         assertNull(actual);
     }
 
-//    @Test
-//    public void testGetOldestPaymentAccountForOffer() {
-//        AccountAgeWitnessService service = mock(AccountAgeWitnessService.class);
-//
-//        PaymentAccount oldest = createAccountWithAge(service, 3);
-//        Set<PaymentAccount> accounts = Sets.newHashSet(
-//                oldest,
-//                createAccountWithAge(service, 2),
-//                createAccountWithAge(service, 1));
-//
-//        BiFunction<Offer, PaymentAccount, Boolean> dummyValidator = (offer, account) -> true;
-//        PaymentAccounts testedEntity = new PaymentAccounts(accounts, service, dummyValidator);
-//
-//        PaymentAccount actual = testedEntity.getOldestPaymentAccountForOffer(mock(Offer.class));
-//        assertEquals(oldest, actual);
-//    }
-
     private static PaymentAccount createAccountWithAge(AccountAgeWitnessService service, long age) {
         PaymentAccountPayload payload = mock(PaymentAccountPayload.class);
 


### PR DESCRIPTION
And remove commented core test.

PaymentMethod `CHASE_QUICK_PAY` is no[ longer supported](https://github.com/bisq-network/bisq/pull/5556).

This is the 1st in a short series of PRs to add an `editoffer` api method.