### PR TITLE
Add hint to upgrade to tor v3

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessApp.java
@@ -102,6 +102,7 @@ public class BisqHeadlessApp implements HeadlessApp {
             gracefulShutDownHandler.gracefulShutDown(() -> {
             });
         });
+        bisqSetup.setTorAddressUpgradeHandler(() -> log.info("setTorAddressUpgradeHandler"));
 
         corruptedStorageFileHandler.getFiles().ifPresent(files -> log.warn("getCorruptedDatabaseFiles. files={}", files));
         tradeManager.setTakeOfferRequestErrorMessageHandler(errorMessage -> log.error("onTakeOfferRequestErrorMessageHandler"));

--- a/core/src/main/java/bisq/core/offer/OfferRestrictions.java
+++ b/core/src/main/java/bisq/core/offer/OfferRestrictions.java
@@ -19,6 +19,7 @@ package bisq.core.offer;
 
 import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
+import bisq.common.config.Config;
 import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Coin;
@@ -33,7 +34,7 @@ public class OfferRestrictions {
     private static final Date REQUIRE_TOR_NODE_ADDRESS_V3_DATE = Utilities.getUTCDate(2021, GregorianCalendar.AUGUST, 15);
 
     public static boolean requiresNodeAddressUpdate() {
-        return new Date().after(REQUIRE_TOR_NODE_ADDRESS_V3_DATE);
+        return Config.baseCurrencyNetwork().isRegtest() || new Date().after(REQUIRE_TOR_NODE_ADDRESS_V3_DATE);
     }
 
     public static Coin TOLERATED_SMALL_TRADE_AMOUNT = Coin.parseCoin("0.01");

--- a/core/src/main/java/bisq/core/offer/OfferRestrictions.java
+++ b/core/src/main/java/bisq/core/offer/OfferRestrictions.java
@@ -28,12 +28,12 @@ import java.util.GregorianCalendar;
 import java.util.Map;
 
 public class OfferRestrictions {
-    // The date when traders who have not updated cannot take offers from updated clients and their offers become
-    // invisible for updated clients.
-    private static final Date REQUIRE_UPDATE_DATE = Utilities.getUTCDate(2019, GregorianCalendar.SEPTEMBER, 19);
+    // The date when traders who have not upgraded to a Tor v3 Node Address cannot take offers and their offers become
+    // invisible.
+    private static final Date REQUIRE_TOR_NODE_ADDRESS_V3_DATE = Utilities.getUTCDate(2021, GregorianCalendar.AUGUST, 15);
 
-    static boolean requiresUpdate() {
-        return new Date().after(REQUIRE_UPDATE_DATE);
+    public static boolean requiresNodeAddressUpdate() {
+        return new Date().after(REQUIRE_TOR_NODE_ADDRESS_V3_DATE);
     }
 
     public static Coin TOLERATED_SMALL_TRADE_AMOUNT = Coin.parseCoin("0.01");

--- a/core/src/main/java/bisq/core/offer/OfferRestrictions.java
+++ b/core/src/main/java/bisq/core/offer/OfferRestrictions.java
@@ -34,7 +34,7 @@ public class OfferRestrictions {
     private static final Date REQUIRE_TOR_NODE_ADDRESS_V3_DATE = Utilities.getUTCDate(2021, GregorianCalendar.AUGUST, 15);
 
     public static boolean requiresNodeAddressUpdate() {
-        return Config.baseCurrencyNetwork().isRegtest() || new Date().after(REQUIRE_TOR_NODE_ADDRESS_V3_DATE);
+        return new Date().after(REQUIRE_TOR_NODE_ADDRESS_V3_DATE) && !Config.baseCurrencyNetwork().isRegtest();
     }
 
     public static Coin TOLERATED_SMALL_TRADE_AMOUNT = Coin.parseCoin("0.01");

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -52,6 +52,7 @@ import bisq.network.p2p.P2PService;
 import bisq.network.p2p.SendDirectMessageListener;
 import bisq.network.p2p.peers.Broadcaster;
 import bisq.network.p2p.peers.PeerManager;
+import bisq.network.utils.Utils;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
@@ -597,6 +598,13 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
         boolean result = false;
         String errorMessage = null;
+
+        if (OfferRestrictions.requiresNodeAddressUpdate() && !Utils.isV3Address(peer.getHostName())) {
+            errorMessage = "We got a handleOfferAvailabilityRequest from a Tor node v2 address where a Tor node v3 address is required.";
+            log.info(errorMessage);
+            sendAckMessage(request, peer, false, errorMessage);
+            return;
+        }
 
         if (!p2PService.isBootstrapped()) {
             errorMessage = "We got a handleOfferAvailabilityRequest but we have not bootstrapped yet.";

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2994,7 +2994,8 @@ popup.accountSigning.unsignedPubKeys.signed=Pubkeys were signed
 popup.accountSigning.unsignedPubKeys.result.signed=Signed pubkeys
 popup.accountSigning.unsignedPubKeys.result.failed=Failed to sign
 
-popup.info.torMigration.msg=You won't be able to use your Tor v2 address anymore starting from October 15th, 2021 [HYPERLINK:https://blog.torproject.org/v2-deprecation-timeline]. \
+popup.info.torMigration.msg=You won't be able to use your Tor v2 address anymore starting from October 15th, 2021 [HYPERLINK:https://blog.torproject.org/v2-deprecation-timeline].\n\
+  To provide a graceful upgrade process for everyone, nodes with Tor v2 addresses won't be able to participate in any trading activity starting from August 15th, 2021.\n\n\
   Your client is right now in a state that allows you to generate a new Tor v3 address [HYPERLINK:https://bisq.wiki/Changing_your_onion_address] \
   Please make a full back up of your data directory first before you proceed to switch to a Tor v3 address \
   following the guide in the bisq.wiki. Also be aware as Bisq's "reputation" is bound to onion addresses that former \

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2994,13 +2994,12 @@ popup.accountSigning.unsignedPubKeys.signed=Pubkeys were signed
 popup.accountSigning.unsignedPubKeys.result.signed=Signed pubkeys
 popup.accountSigning.unsignedPubKeys.result.failed=Failed to sign
 
-popup.info.torMigration.msg=You won't be able to use your Tor v2 address anymore starting from October 15th, 2021 [HYPERLINK:https://blog.torproject.org/v2-deprecation-timeline].\n\
-  To provide a graceful upgrade process for everyone, nodes with Tor v2 addresses won't be able to participate in any trading activity starting from August 15th, 2021.\n\n\
-  Your client is right now in a state that allows you to generate a new Tor v3 address [HYPERLINK:https://bisq.wiki/Changing_your_onion_address] \
-  Please make a full back up of your data directory first before you proceed to switch to a Tor v3 address \
-  following the guide in the bisq.wiki. Also be aware as Bisq's "reputation" is bound to onion addresses that former \
-  trading partners won't be able to recognize you anymore. You'll not loose your signed account status with upgrading \
-  to a new onion address.
+popup.info.torMigration.msg=Your Bisq node is currently using a Tor v2 address. Tor v2 is being deprecated soon \
+  [HYPERLINK:https://blog.torproject.org/v2-deprecation-timeline], and \
+  Bisq nodes with Tor v2 addresses will no longer be able to trade on August 15th, 2021.\n\n\
+  Please switch your Bisq node to a Tor v3 address. It's quick and simple -- see details in this doc \
+  [HYPERLINK:https://bisq.wiki/Changing_your_onion_address] or in this video [HYPERLINK:https://bitcointv.com/videos/watch/f96adc20-4092-4253-84c0-1b18088b4b95]. \n\n\
+  Make sure to back up your data directory beforehand.
 
 ####################################################################
 # Notifications

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2994,6 +2994,13 @@ popup.accountSigning.unsignedPubKeys.signed=Pubkeys were signed
 popup.accountSigning.unsignedPubKeys.result.signed=Signed pubkeys
 popup.accountSigning.unsignedPubKeys.result.failed=Failed to sign
 
+popup.info.torMigration.msg=You won't be able to use your Tor v2 address anymore starting from October 15th, 2021 [HYPERLINK:https://blog.torproject.org/v2-deprecation-timeline]. \
+  Your client is right now in a state that allows you to generate a new Tor v3 address [HYPERLINK:https://bisq.wiki/Changing_your_onion_address] \
+  Please make a full back up of your data directory first before you proceed to switch to a Tor v3 address \
+  following the guide in the bisq.wiki. Also be aware as Bisq's "reputation" is bound to onion addresses that former \
+  trading partners won't be able to recognize you anymore. You'll not loose your signed account status with upgrading \
+  to a new onion address.
+
 ####################################################################
 # Notifications
 ####################################################################
@@ -3109,7 +3116,7 @@ txIdTextField.missingTx.warning.tooltip=Missing required transaction
 ####################################################################
 
 navigation.account=\"Account\"
-navigation.account.walletSeed=\"Account/Wallet seed\"
+navigation.account.backup=\"Account/Backup\"
 navigation.funds.availableForWithdrawal=\"Funds/Send funds\"
 navigation.portfolio.myOpenOffers=\"Portfolio/My open offers\"
 navigation.portfolio.pending=\"Portfolio/Open trades\"

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1111,6 +1111,7 @@ support.sigCheck.popup.failed=Signature verification failed
 support.sigCheck.popup.invalidFormat=Message is not of expected format. Copy & paste summary message from dispute.
 
 support.reOpenByTrader.prompt=Are you sure you want to re-open the dispute?
+support.reOpenByTrader.failed=Failed to re-open the dispute.
 support.reOpenButton.label=Re-open
 support.sendNotificationButton.label=Private notification
 support.reportButton.label=Report

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -980,6 +980,7 @@ portfolio.pending.failedTrade.txChainValid.moveToFailed=The trade protocol encou
 portfolio.pending.failedTrade.moveTradeToFailedIcon.tooltip=Move trade to failed trades
 portfolio.pending.failedTrade.warningIcon.tooltip=Click to open details about the issues of this trade
 portfolio.failed.revertToPending.popup=Do you want to move this trade to open trades?
+portfolio.failed.revertToPending.failed=Failed to move this trade to open trades.
 portfolio.failed.revertToPending=Move trade to open trades
 
 portfolio.closed.completed=Completed

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -17,9 +17,12 @@
 
 package bisq.desktop.main;
 
+import bisq.desktop.Navigation;
 import bisq.desktop.app.BisqApp;
 import bisq.desktop.common.model.ViewModel;
 import bisq.desktop.components.TxIdTextField;
+import bisq.desktop.main.account.AccountView;
+import bisq.desktop.main.account.content.backup.BackupView;
 import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.notifications.NotificationCenter;
 import bisq.desktop.main.overlays.popups.Popup;
@@ -135,6 +138,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
     @Getter
     private final TorNetworkSettingsWindow torNetworkSettingsWindow;
     private final CorruptedStorageFileHandler corruptedStorageFileHandler;
+    private final Navigation navigation;
 
     @Getter
     private final BooleanProperty showAppScreen = new SimpleBooleanProperty();
@@ -178,7 +182,8 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                          LocalBitcoinNode localBitcoinNode,
                          AccountAgeWitnessService accountAgeWitnessService,
                          TorNetworkSettingsWindow torNetworkSettingsWindow,
-                         CorruptedStorageFileHandler corruptedStorageFileHandler) {
+                         CorruptedStorageFileHandler corruptedStorageFileHandler,
+                         Navigation navigation) {
         this.bisqSetup = bisqSetup;
         this.walletsSetup = walletsSetup;
         this.user = user;
@@ -203,6 +208,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         this.accountAgeWitnessService = accountAgeWitnessService;
         this.torNetworkSettingsWindow = torNetworkSettingsWindow;
         this.corruptedStorageFileHandler = corruptedStorageFileHandler;
+        this.navigation = navigation;
 
         TxIdTextField.setPreferences(preferences);
 
@@ -414,6 +420,13 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                 .useShutDownButton()
                 .hideCloseButton()
                 .show());
+
+        bisqSetup.setTorAddressUpgradeHandler(() -> new Popup().information(Res.get("popup.info.torMigration.msg"))
+                .actionButtonTextWithGoTo("navigation.account.backup")
+                .onAction(() -> {
+                    navigation.setReturnPath(navigation.getCurrentPath());
+                    navigation.navigateTo(MainView.class, AccountView.class, BackupView.class);
+                }).show());
 
         corruptedStorageFileHandler.getFiles().ifPresent(files -> new Popup()
                 .warning(Res.get("popup.warning.incompatibleDB", files.toString(), config.appDataDir))

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
@@ -20,7 +20,10 @@ package bisq.desktop.main.offer.offerbook;
 import bisq.core.filter.FilterManager;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferBookService;
+import bisq.core.offer.OfferRestrictions;
 import bisq.core.trade.TradeManager;
+
+import bisq.network.utils.Utils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -75,6 +78,11 @@ public class OfferBook {
                     return;
                 }
 
+                if (OfferRestrictions.requiresNodeAddressUpdate() && !Utils.isV3Address(offer.getMakerNodeAddress().getHostName())) {
+                    log.debug("Ignored offer with Tor v2 node address. ID={}", offer.getId());
+                    return;
+                }
+
                 boolean hasSameOffer = offerBookListItems.stream()
                         .anyMatch(item -> item.getOffer().equals(offer));
                 if (!hasSameOffer) {
@@ -126,6 +134,7 @@ public class OfferBook {
             offerBookListItems.clear();
             offerBookListItems.addAll(offerBookService.getOffers().stream()
                     .filter(o -> !filterManager.isOfferIdBanned(o.getId()))
+                    .filter(o -> !OfferRestrictions.requiresNodeAddressUpdate() || Utils.isV3Address(o.getMakerNodeAddress().getHostName()))
                     .map(OfferBookListItem::new)
                     .collect(Collectors.toList()));
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
@@ -91,13 +91,13 @@ class FailedTradesDataModel extends ActivatableDataModel {
     }
 
     public boolean onMoveTradeToPendingTrades(Trade trade) {
-        if (isTradeWithSameCurrentNodeAddress(trade)) {
-            failedTradesManager.removeTrade(trade);
-            tradeManager.addFailedTradeToPendingTrades(trade);
-            return true;
-        } else {
+        if (!isTradeWithSameCurrentNodeAddress(trade)) {
             return false;
         }
+
+        failedTradesManager.removeTrade(trade);
+        tradeManager.addFailedTradeToPendingTrades(trade);
+        return true;
     }
 
     private boolean isTradeWithSameCurrentNodeAddress(Trade trade) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesDataModel.java
@@ -25,26 +25,39 @@ import bisq.core.trade.Trade;
 import bisq.core.trade.TradeManager;
 import bisq.core.trade.failed.FailedTradesManager;
 
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
+
+import bisq.common.crypto.KeyRing;
+
 import com.google.inject.Inject;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 class FailedTradesDataModel extends ActivatableDataModel {
 
     private final FailedTradesManager failedTradesManager;
     private final TradeManager tradeManager;
+    private final P2PService p2PService;
+    private final KeyRing keyRing;
 
     private final ObservableList<FailedTradesListItem> list = FXCollections.observableArrayList();
     private final ListChangeListener<Trade> tradesListChangeListener;
 
     @Inject
-    public FailedTradesDataModel(FailedTradesManager failedTradesManager, TradeManager tradeManager) {
+    public FailedTradesDataModel(FailedTradesManager failedTradesManager,
+                                 TradeManager tradeManager,
+                                 P2PService p2PService,
+                                 KeyRing keyRing) {
         this.failedTradesManager = failedTradesManager;
         this.tradeManager = tradeManager;
+        this.p2PService = p2PService;
+        this.keyRing = keyRing;
 
         tradesListChangeListener = change -> applyList();
     }
@@ -77,9 +90,19 @@ class FailedTradesDataModel extends ActivatableDataModel {
         list.sort((o1, o2) -> o2.getTrade().getDate().compareTo(o1.getTrade().getDate()));
     }
 
-    public void onMoveTradeToPendingTrades(Trade trade) {
-        failedTradesManager.removeTrade(trade);
-        tradeManager.addFailedTradeToPendingTrades(trade);
+    public boolean onMoveTradeToPendingTrades(Trade trade) {
+        if (isTradeWithSameCurrentNodeAddress(trade)) {
+            failedTradesManager.removeTrade(trade);
+            tradeManager.addFailedTradeToPendingTrades(trade);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isTradeWithSameCurrentNodeAddress(Trade trade) {
+        NodeAddress tradeNodeAddress = trade.getContract().getMyNodeAddress(keyRing.getPubKeyRing());
+        return Objects.equals(p2PService.getNetworkNode().getNodeAddress(), tradeNodeAddress);
     }
 
     public void unfailTrade(Trade trade) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -334,14 +334,18 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
 
     private void onRevertTrade(Trade trade) {
         new Popup().attention(Res.get("portfolio.failed.revertToPending.popup"))
-                .onAction(() -> onMoveTradeToPendingTrades(trade))
+                .onAction(() -> {
+                    if (!onMoveTradeToPendingTrades(trade)) {
+                        new Popup().warning(Res.get("portfolio.failed.revertToPending.failed")).show();
+                    }
+                })
                 .actionButtonText(Res.get("shared.yes"))
                 .closeButtonText(Res.get("shared.no"))
                 .show();
     }
 
-    private void onMoveTradeToPendingTrades(Trade trade) {
-        model.dataModel.onMoveTradeToPendingTrades(trade);
+    private boolean onMoveTradeToPendingTrades(Trade trade) {
+       return model.dataModel.onMoveTradeToPendingTrades(trade);
     }
 
     private void setTradeIdColumnCellFactory() {

--- a/desktop/src/main/java/bisq/desktop/main/presentation/SettingsPresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/SettingsPresentation.java
@@ -58,6 +58,5 @@ public class SettingsPresentation {
     }
 
     public void setup() {
-        showNotification.set(preferences.showAgain(SETTINGS_NEWS));
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -38,6 +38,7 @@ import bisq.core.alert.PrivateNotificationManager;
 import bisq.core.dao.DaoFacade;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
+import bisq.core.offer.OfferRestrictions;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.DisputeList;
@@ -58,6 +59,7 @@ import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
+import bisq.network.utils.Utils;
 
 import bisq.common.UserThread;
 import bisq.common.crypto.KeyRing;
@@ -542,6 +544,11 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
     private boolean isDisputeWithSameCurrentNodeAddress(Dispute dispute, boolean isMediator) {
         NodeAddress disputeNodeAddress = isMediator ? dispute.getContract().getMediatorNodeAddress() :
                 dispute.getContract().getMyNodeAddress(keyRing.getPubKeyRing());
+
+        if (OfferRestrictions.requiresNodeAddressUpdate() && !Utils.isV3Address(disputeNodeAddress.getHostName())) {
+            return false;
+        }
+
         return Objects.equals(p2PService.getNetworkNode().getNodeAddress(), disputeNodeAddress);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -528,7 +528,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
     protected boolean reOpenDispute() {
         if (selectedDispute != null &&
                 selectedDispute.isClosed() &&
-                isDisputeWithSameCurrentNodeAddress(selectedDispute,
+                isNodeAddressOk(selectedDispute,
                         !disputeManager.isTrader(selectedDispute))) {
             selectedDispute.reOpen();
             handleOnProcessDispute(selectedDispute);
@@ -541,7 +541,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
         }
     }
 
-    private boolean isDisputeWithSameCurrentNodeAddress(Dispute dispute, boolean isMediator) {
+    private boolean isNodeAddressOk(Dispute dispute, boolean isMediator) {
         NodeAddress disputeNodeAddress = isMediator ? dispute.getContract().getMediatorNodeAddress() :
                 dispute.getContract().getMyNodeAddress(keyRing.getPubKeyRing());
 

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -57,6 +57,7 @@ import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
 
 import bisq.common.UserThread;
 import bisq.common.crypto.KeyRing;
@@ -108,6 +109,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -149,6 +151,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
 
     protected final DisputeManager<? extends DisputeList<Dispute>> disputeManager;
     protected final KeyRing keyRing;
+    private final P2PService p2PService;
     private final TradeManager tradeManager;
     protected final CoinFormatter formatter;
     protected final Preferences preferences;
@@ -192,6 +195,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
 
     public DisputeView(DisputeManager<? extends DisputeList<Dispute>> disputeManager,
                        KeyRing keyRing,
+                       P2PService p2PService,
                        TradeManager tradeManager,
                        CoinFormatter formatter,
                        Preferences preferences,
@@ -206,6 +210,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
                        boolean useDevPrivilegeKeys) {
         this.disputeManager = disputeManager;
         this.keyRing = keyRing;
+        this.p2PService = p2PService;
         this.tradeManager = tradeManager;
         this.formatter = formatter;
         this.preferences = preferences;
@@ -495,8 +500,9 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
     // a derived version in the ClientView for users pops up an "Are you sure" box first.
     // this version includes the sending of an automatic message to the user, see addMediationReOpenedMessage
     protected void reOpenDisputeFromButton() {
-        reOpenDispute();
-        disputeManager.addMediationReOpenedMessage(selectedDispute, false);
+        if (reOpenDispute()) {
+            disputeManager.addMediationReOpenedMessage(selectedDispute, false);
+        }
     }
 
     // only applicable to traders
@@ -517,13 +523,26 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> {
         // overridden by clients that use it (dispute agents)
     }
 
-    protected void reOpenDispute() {
-        if (selectedDispute != null && selectedDispute.isClosed()) {
+    protected boolean reOpenDispute() {
+        if (selectedDispute != null &&
+                selectedDispute.isClosed() &&
+                isDisputeWithSameCurrentNodeAddress(selectedDispute,
+                        !disputeManager.isTrader(selectedDispute))) {
             selectedDispute.reOpen();
             handleOnProcessDispute(selectedDispute);
             disputeManager.requestPersistence();
             onSelectDispute(selectedDispute);
+            return true;
+        } else {
+            new Popup().warning(Res.get("support.reOpenByTrader.failed")).show();
+            return false;
         }
+    }
+
+    private boolean isDisputeWithSameCurrentNodeAddress(Dispute dispute, boolean isMediator) {
+        NodeAddress disputeNodeAddress = isMediator ? dispute.getContract().getMediatorNodeAddress() :
+                dispute.getContract().getMyNodeAddress(keyRing.getPubKeyRing());
+        return Objects.equals(p2PService.getNetworkNode().getNodeAddress(), disputeNodeAddress);
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/DisputeAgentView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/DisputeAgentView.java
@@ -74,7 +74,8 @@ public abstract class DisputeAgentView extends DisputeView implements MultipleHo
 
     public DisputeAgentView(DisputeManager<? extends DisputeList<Dispute>> disputeManager,
                             KeyRing keyRing,
-                            P2PService p2PService, TradeManager tradeManager,
+                            P2PService p2PService,
+                            TradeManager tradeManager,
                             CoinFormatter formatter,
                             Preferences preferences,
                             DisputeSummaryWindow disputeSummaryWindow,

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/DisputeAgentView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/DisputeAgentView.java
@@ -40,6 +40,8 @@ import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
 import bisq.core.util.coin.CoinFormatter;
 
+import bisq.network.p2p.P2PService;
+
 import bisq.common.crypto.KeyRing;
 import bisq.common.util.Utilities;
 
@@ -72,7 +74,7 @@ public abstract class DisputeAgentView extends DisputeView implements MultipleHo
 
     public DisputeAgentView(DisputeManager<? extends DisputeList<Dispute>> disputeManager,
                             KeyRing keyRing,
-                            TradeManager tradeManager,
+                            P2PService p2PService, TradeManager tradeManager,
                             CoinFormatter formatter,
                             Preferences preferences,
                             DisputeSummaryWindow disputeSummaryWindow,
@@ -86,6 +88,7 @@ public abstract class DisputeAgentView extends DisputeView implements MultipleHo
                             boolean useDevPrivilegeKeys) {
         super(disputeManager,
                 keyRing,
+                p2PService,
                 tradeManager,
                 formatter,
                 preferences,

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/arbitration/ArbitratorView.java
@@ -40,6 +40,8 @@ import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
+import bisq.network.p2p.P2PService;
+
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
 
@@ -52,6 +54,7 @@ public class ArbitratorView extends DisputeAgentView {
     @Inject
     public ArbitratorView(ArbitrationManager arbitrationManager,
                           KeyRing keyRing,
+                          P2PService p2PService,
                           TradeManager tradeManager,
                           @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                           Preferences preferences,
@@ -66,6 +69,7 @@ public class ArbitratorView extends DisputeAgentView {
                           @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
         super(arbitrationManager,
                 keyRing,
+                p2PService,
                 tradeManager,
                 formatter,
                 preferences,

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/mediation/MediatorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/mediation/MediatorView.java
@@ -38,6 +38,8 @@ import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
+import bisq.network.p2p.P2PService;
+
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
 
@@ -50,6 +52,7 @@ public class MediatorView extends DisputeAgentView {
     @Inject
     public MediatorView(MediationManager mediationManager,
                         KeyRing keyRing,
+                        P2PService p2PService,
                         TradeManager tradeManager,
                         @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                         Preferences preferences,
@@ -64,6 +67,7 @@ public class MediatorView extends DisputeAgentView {
                         @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
         super(mediationManager,
                 keyRing,
+                p2PService,
                 tradeManager,
                 formatter,
                 preferences,

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/refund/RefundAgentView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/agent/refund/RefundAgentView.java
@@ -40,6 +40,8 @@ import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
+import bisq.network.p2p.P2PService;
+
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
 
@@ -52,6 +54,7 @@ public class RefundAgentView extends DisputeAgentView {
     @Inject
     public RefundAgentView(RefundManager refundManager,
                            KeyRing keyRing,
+                           P2PService p2PService,
                            TradeManager tradeManager,
                            @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                            Preferences preferences,
@@ -66,6 +69,7 @@ public class RefundAgentView extends DisputeAgentView {
                            @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
         super(refundManager,
                 keyRing,
+                p2PService,
                 tradeManager,
                 formatter,
                 preferences,

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/client/DisputeClientView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/client/DisputeClientView.java
@@ -34,11 +34,14 @@ import bisq.core.trade.TradeManager;
 import bisq.core.user.Preferences;
 import bisq.core.util.coin.CoinFormatter;
 
+import bisq.network.p2p.P2PService;
+
 import bisq.common.crypto.KeyRing;
 
 public abstract class DisputeClientView extends DisputeView {
     public DisputeClientView(DisputeManager<? extends DisputeList<Dispute>> DisputeManager,
                              KeyRing keyRing,
+                             P2PService p2PService,
                              TradeManager tradeManager,
                              CoinFormatter formatter,
                              Preferences preferences,
@@ -51,9 +54,9 @@ public abstract class DisputeClientView extends DisputeView {
                              RefundAgentManager refundAgentManager,
                              DaoFacade daoFacade,
                              boolean useDevPrivilegeKeys) {
-        super(DisputeManager, keyRing, tradeManager, formatter, preferences, disputeSummaryWindow, privateNotificationManager,
-                contractWindow, tradeDetailsWindow, accountAgeWitnessService,
-                mediatorManager, refundAgentManager, daoFacade, useDevPrivilegeKeys);
+        super(DisputeManager, keyRing, p2PService, tradeManager, formatter, preferences, disputeSummaryWindow,
+                privateNotificationManager, contractWindow, tradeDetailsWindow,
+                accountAgeWitnessService, mediatorManager, refundAgentManager, daoFacade, useDevPrivilegeKeys);
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/client/arbitration/ArbitrationClientView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/client/arbitration/ArbitrationClientView.java
@@ -38,6 +38,8 @@ import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
+import bisq.network.p2p.P2PService;
+
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
 
@@ -49,6 +51,7 @@ public class ArbitrationClientView extends DisputeClientView {
     @Inject
     public ArbitrationClientView(ArbitrationManager arbitrationManager,
                                  KeyRing keyRing,
+                                 P2PService p2PService,
                                  TradeManager tradeManager,
                                  @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                                  Preferences preferences,
@@ -61,7 +64,7 @@ public class ArbitrationClientView extends DisputeClientView {
                                  RefundAgentManager refundAgentManager,
                                  DaoFacade daoFacade,
                                  @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
-        super(arbitrationManager, keyRing, tradeManager, formatter, preferences, disputeSummaryWindow,
+        super(arbitrationManager, keyRing, p2PService, tradeManager, formatter, preferences, disputeSummaryWindow,
                 privateNotificationManager, contractWindow, tradeDetailsWindow, accountAgeWitnessService,
                 mediatorManager, refundAgentManager, daoFacade, useDevPrivilegeKeys);
     }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/client/mediation/MediationClientView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/client/mediation/MediationClientView.java
@@ -42,6 +42,7 @@ import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
 
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
@@ -54,6 +55,7 @@ public class MediationClientView extends DisputeClientView {
     @Inject
     public MediationClientView(MediationManager mediationManager,
                                KeyRing keyRing,
+                               P2PService p2PService,
                                TradeManager tradeManager,
                                @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                                Preferences preferences,
@@ -66,7 +68,7 @@ public class MediationClientView extends DisputeClientView {
                                RefundAgentManager refundAgentManager,
                                DaoFacade daoFacade,
                                @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
-        super(mediationManager, keyRing, tradeManager, formatter, preferences, disputeSummaryWindow,
+        super(mediationManager, keyRing, p2PService, tradeManager, formatter, preferences, disputeSummaryWindow,
                 privateNotificationManager, contractWindow, tradeDetailsWindow, accountAgeWitnessService,
                 mediatorManager, refundAgentManager, daoFacade, useDevPrivilegeKeys);
     }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/client/refund/RefundClientView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/client/refund/RefundClientView.java
@@ -40,6 +40,7 @@ import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
 
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
@@ -52,6 +53,7 @@ public class RefundClientView extends DisputeClientView {
     @Inject
     public RefundClientView(RefundManager refundManager,
                             KeyRing keyRing,
+                            P2PService p2PService,
                             TradeManager tradeManager,
                             @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                             Preferences preferences,
@@ -64,7 +66,7 @@ public class RefundClientView extends DisputeClientView {
                             RefundAgentManager refundAgentManager,
                             DaoFacade daoFacade,
                             @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
-        super(refundManager, keyRing, tradeManager, formatter, preferences, disputeSummaryWindow,
+        super(refundManager, keyRing, p2PService, tradeManager, formatter, preferences, disputeSummaryWindow,
                 privateNotificationManager, contractWindow, tradeDetailsWindow, accountAgeWitnessService,
                 mediatorManager, refundAgentManager, daoFacade, useDevPrivilegeKeys);
     }

--- a/p2p/src/test/java/bisq/network/utils/UtilsTest.java
+++ b/p2p/src/test/java/bisq/network/utils/UtilsTest.java
@@ -17,25 +17,20 @@
 
 package bisq.network.utils;
 
-import java.net.ServerSocket;
+import org.junit.Test;
 
-import java.io.IOException;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.util.Random;
+public class UtilsTest {
 
-public class Utils {
-    public static int findFreeSystemPort() {
-        try {
-            ServerSocket server = new ServerSocket(0);
-            int port = server.getLocalPort();
-            server.close();
-            return port;
-        } catch (IOException ignored) {
-            return new Random().nextInt(10000) + 50000;
-        }
+    @Test
+    public void checkV2Address() {
+        assertFalse(Utils.isV3Address("xmh57jrzrnw6insl.onion"));
     }
 
-    public static boolean isV3Address(String address) {
-        return address.matches("[a-z2-7]{56}.onion");
+    @Test
+    public void checkV3Address() {
+        assertTrue(Utils.isV3Address("vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion"));
     }
 }


### PR DESCRIPTION
If the node is in a state where an upgrade to a Tor v3 address can be done it displays a informational prompt.

![Bildschirmfoto 2021-06-14 um 17 18 33](https://user-images.githubusercontent.com/170962/121916821-c90d0800-cd34-11eb-8177-542869f3b10c.png)

@m52go ☝️ This needs some native speaker love.

I'll check this state on application start and when the last open trade is completed. I wanted to do this for closed disputes as well, but the data structure in place would force me to scatter check codes on multiple places which would make it burdensome to remove after the transition is complete.

To have a graceful upgrade proces nodes with a Tor v2 address won't be able to take offers anymore starting with August 15, 2020 (2 months before the Tor v2 support is dropped). Also their offers won't be visible to anyone else at that point.

I also added some unrelated checks to this upgrade process, that you can only reopen trades and disputes if you have the same local onion address to prevent communication issues that would go by without notice.

This fixes https://github.com/bisq-network/bisq/issues/5558.