### PR TITLE
Json dump for Dao state refactoring

### DIFF
--- a/apitest/src/test/java/bisq/apitest/scenario/bot/script/BotScriptGenerator.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/bot/script/BotScriptGenerator.java
@@ -232,7 +232,7 @@ public class BotScriptGenerator {
         String json = generator.generateBotScriptTemplate();
         String destDir = getProperty("java.io.tmpdir");
         JsonFileManager jsonFileManager = new JsonFileManager(new File(destDir));
-        jsonFileManager.writeToDisc(json, "bot-script");
+        jsonFileManager.write(json, "bot-script");
         JsonFileManager.shutDownAllInstances();
         log.info("Saved {}/bot-script.json", destDir);
         log.info("bot-script.json contents\n{}", json);

--- a/common/src/main/java/bisq/common/file/JsonFileManager.java
+++ b/common/src/main/java/bisq/common/file/JsonFileManager.java
@@ -22,10 +22,13 @@ import bisq.common.util.Utilities;
 import java.nio.file.Paths;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -76,10 +79,26 @@ public class JsonFileManager {
     }
 
     public void writeToDiscThreaded(String json, String fileName) {
-        getExecutor().execute(() -> writeToDisc(json, fileName));
+        getExecutor().execute(() -> write(json, fileName));
     }
 
-    public void writeToDisc(String json, String fileName) {
+    public Optional<String> read(String fileName) {
+        File jsonFile = new File(Paths.get(dir.getAbsolutePath(), fileName + ".json").toString());
+        if (!jsonFile.exists()) {
+            return Optional.empty();
+        }
+        StringBuilder json = new StringBuilder();
+        try (Scanner scanner = new Scanner(jsonFile)) {
+            while (scanner.hasNext()) {
+                json.append(scanner.next());
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        return Optional.of(json.toString());
+    }
+
+    public void write(String json, String fileName) {
         File jsonFile = new File(Paths.get(dir.getAbsolutePath(), fileName + ".json").toString());
         File tempFile = null;
         PrintWriter printWriter = null;

--- a/common/src/main/java/bisq/common/file/JsonFileManager.java
+++ b/common/src/main/java/bisq/common/file/JsonFileManager.java
@@ -131,4 +131,9 @@ public class JsonFileManager {
                 printWriter.close();
         }
     }
+
+    public boolean delete(String fileName) {
+        File file = new File(Paths.get(dir.getAbsolutePath(), fileName + ".json").toString());
+        return file.delete();
+    }
 }

--- a/core/src/main/java/bisq/core/dao/node/BsqNode.java
+++ b/core/src/main/java/bisq/core/dao/node/BsqNode.java
@@ -214,9 +214,9 @@ public abstract class BsqNode implements DaoSetupService {
 
     @SuppressWarnings("WeakerAccess")
     protected void startReOrgFromLastSnapshot() {
+        exportJsonFilesService.onReOrg(daoStateSnapshotService.getChainHeightOfPersistedState());
         daoStateSnapshotService.applySnapshot(true);
     }
-
 
     protected Optional<Block> doParseBlock(RawBlock rawBlock) throws RequiredReorgFromSnapshotException {
         // We check if we have a block with that height. If so we return. We do not use the chainHeight as with genesis

--- a/core/src/main/java/bisq/core/dao/node/BsqNode.java
+++ b/core/src/main/java/bisq/core/dao/node/BsqNode.java
@@ -55,7 +55,7 @@ public abstract class BsqNode implements DaoSetupService {
     protected final DaoStateService daoStateService;
     private final String genesisTxId;
     private final int genesisBlockHeight;
-    private final ExportJsonFilesService exportJsonFilesService;
+    protected final ExportJsonFilesService exportJsonFilesService;
     private final DaoStateSnapshotService daoStateSnapshotService;
     private final P2PServiceListener p2PServiceListener;
     protected boolean parseBlockchainComplete;
@@ -209,7 +209,7 @@ public abstract class BsqNode implements DaoSetupService {
         parseBlockchainComplete = true;
         daoStateService.onParseBlockChainComplete();
 
-        maybeExportToJson();
+        exportJsonFilesService.onParseBlockChainComplete();
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -288,9 +288,5 @@ public abstract class BsqNode implements DaoSetupService {
             throw new RequiredReorgFromSnapshotException(rawBlock);
         }
         return Optional.empty();
-    }
-
-    protected void maybeExportToJson() {
-        exportJsonFilesService.maybeExportToJson();
     }
 }

--- a/core/src/main/java/bisq/core/dao/node/full/FullNode.java
+++ b/core/src/main/java/bisq/core/dao/node/full/FullNode.java
@@ -169,12 +169,12 @@ public class FullNode extends BsqNode {
     }
 
     private void onNewBlock(Block block) {
-        maybeExportToJson();
+        exportJsonFilesService.onNewBlock(block);
 
-        if (p2pNetworkReady && parseBlockchainComplete)
+        if (p2pNetworkReady && parseBlockchainComplete) {
             fullNodeNetworkService.publishNewBlock(block);
+        }
     }
-
 
     private void parseBlocksIfNewBlockAvailable(int chainHeight) {
         rpcService.requestChainHeadHeight(newChainHeight -> {

--- a/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
@@ -29,6 +29,7 @@ import bisq.core.dao.node.parser.BlockParser;
 import bisq.core.dao.node.parser.exceptions.RequiredReorgFromSnapshotException;
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.dao.state.DaoStateSnapshotService;
+import bisq.core.dao.state.model.blockchain.Block;
 
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.network.Connection;
@@ -42,6 +43,7 @@ import javafx.beans.value.ChangeListener;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -254,10 +256,10 @@ public class LiteNode extends BsqNode {
     }
 
     // We received a new block
-    private void onNewBlockReceived(RawBlock block) {
-        int blockHeight = block.getHeight();
+    private void onNewBlockReceived(RawBlock rawBlock) {
+        int blockHeight = rawBlock.getHeight();
         log.info("onNewBlockReceived: block at height {}, hash={}. Our DAO chainHeight={}",
-                blockHeight, block.getHash(), chainTipHeight);
+                blockHeight, rawBlock.getHash(), chainTipHeight);
 
         // We only update chainTipHeight if we get a newer block
         if (blockHeight > chainTipHeight) {
@@ -265,10 +267,9 @@ public class LiteNode extends BsqNode {
         }
 
         try {
-            doParseBlock(block);
+            Optional<Block> optionalBlock = doParseBlock(rawBlock);
+            optionalBlock.ifPresent(exportJsonFilesService::onNewBlock);
         } catch (RequiredReorgFromSnapshotException ignore) {
         }
-
-        maybeExportToJson();
     }
 }

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 
 import java.util.LinkedList;
+import java.util.Optional;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -120,6 +121,11 @@ public class DaoStateSnapshotService {
 
             log.debug("Cloned new snapshotCandidate at height {} took {} ms", chainHeight, System.currentTimeMillis() - ts);
         }
+    }
+
+    public Optional<Integer> getChainHeightOfPersistedState() {
+        DaoState state = daoStateStorageService.getPersistedBsqState();
+        return state != null ? Optional.of(state.getChainHeight()) : Optional.empty();
     }
 
     public void applySnapshot(boolean fromReorg) {

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -24,6 +24,7 @@ import bisq.core.dao.state.model.DaoState;
 import bisq.network.p2p.storage.persistence.ResourceDataStoreService;
 import bisq.network.p2p.storage.persistence.StoreService;
 
+import bisq.common.app.DevEnv;
 import bisq.common.config.Config;
 import bisq.common.file.FileUtil;
 import bisq.common.persistence.PersistenceManager;
@@ -63,7 +64,9 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
         this.daoState = daoState;
         this.daoStateMonitoringService = daoStateMonitoringService;
 
-        resourceDataStoreService.addService(this);
+        if (DevEnv.isDaoActivated()) {
+            resourceDataStoreService.addService(this);
+        }
     }
 
 

--- a/inventory/src/main/java/bisq/inventory/InventoryMonitor.java
+++ b/inventory/src/main/java/bisq/inventory/InventoryMonitor.java
@@ -242,7 +242,7 @@ public class InventoryMonitor implements SetupListener {
         inventoryWebServer.onNewRequestInfo(requestInfoListByNode, requestCounter);
 
         String json = Utilities.objectToJson(requestInfo);
-        jsonFileManagerByNodeAddress.get(nodeAddress).writeToDisc(json, String.valueOf(requestInfo.getRequestStartTime()));
+        jsonFileManagerByNodeAddress.get(nodeAddress).write(json, String.valueOf(requestInfo.getRequestStartTime()));
     }
 
     private void addJsonFileManagers(List<NodeAddress> seedNodes) {


### PR DESCRIPTION
- Write chainHeight
- Write on new blocks or on parse complete from last persisted block height
- Do not delete json dirs at start
- Write txs and txos from block/s to write
-  Add reorg handling to json dump
- Do not load daostate in case the DAO is disabled (not related to json dump aspect)

In case of a reorg we pass the block height of the last persisted snapshot
and delete all blocks and related tx/txos from that block height on.
In case we dont have a snapshot we delete the whole json dir.

It is not tested much yet. 
Will require adoption for the explorer nodes by @softsimon - should be either deployed to a branch or waited for merge to master until @softsimon signals readiness. 