### PR TITLE
Optimize DaoState snapshot behaviour

### DIFF
--- a/common/src/main/java/bisq/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/bisq/common/persistence/PersistenceManager.java
@@ -26,6 +26,7 @@ import bisq.common.file.FileUtil;
 import bisq.common.handlers.ResultHandler;
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
+import bisq.common.util.GcUtil;
 import bisq.common.util.Utilities;
 
 import com.google.inject.Inject;
@@ -319,7 +320,11 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         new Thread(() -> {
             T persisted = getPersisted(fileName);
             if (persisted != null) {
-                UserThread.execute(() -> resultHandler.accept(persisted));
+                UserThread.execute(() -> {
+                    resultHandler.accept(persisted);
+
+                    GcUtil.maybeReleaseMemory();
+                });
             } else {
                 UserThread.execute(orElse);
             }
@@ -496,6 +501,8 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             if (completeHandler != null) {
                 UserThread.execute(completeHandler);
             }
+
+            GcUtil.maybeReleaseMemory();
         }
     }
 

--- a/common/src/main/java/bisq/common/setup/CommonSetup.java
+++ b/common/src/main/java/bisq/common/setup/CommonSetup.java
@@ -23,6 +23,7 @@ import bisq.common.app.DevEnv;
 import bisq.common.app.Log;
 import bisq.common.app.Version;
 import bisq.common.config.Config;
+import bisq.common.util.GcUtil;
 import bisq.common.util.Profiler;
 import bisq.common.util.Utilities;
 
@@ -54,15 +55,14 @@ public class CommonSetup {
         Version.printVersion();
         maybePrintPathOfCodeSource();
         Profiler.printSystemLoad();
+        Profiler.printSystemLoadPeriodically(10, TimeUnit.MINUTES);
+
+        GcUtil.autoReleaseMemory();
 
         setSystemProperties();
         setupSigIntHandlers(gracefulShutDownHandler);
 
         DevEnv.setup(config);
-    }
-
-    public static void printSystemLoadPeriodically(int delayMin) {
-        UserThread.runPeriodically(Profiler::printSystemLoad, delayMin, TimeUnit.MINUTES);
     }
 
     public static void setupUncaughtExceptionHandler(UncaughtExceptionHandler uncaughtExceptionHandler) {

--- a/common/src/main/java/bisq/common/util/GcUtil.java
+++ b/common/src/main/java/bisq/common/util/GcUtil.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.util;
+
+import bisq.common.UserThread;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GcUtil {
+    public static void autoReleaseMemory() {
+        autoReleaseMemory(1000);
+    }
+
+    /**
+     * @param trigger  Threshold for free memory in MB when we invoke the garbage collector
+     */
+    public static void autoReleaseMemory(long trigger) {
+        UserThread.runPeriodically(() -> maybeReleaseMemory(trigger), 60);
+    }
+
+    public static void maybeReleaseMemory() {
+        maybeReleaseMemory(3000);
+    }
+
+    /**
+     * @param trigger  Threshold for free memory in MB when we invoke the garbage collector
+     */
+    public static void maybeReleaseMemory(long trigger) {
+        long totalMemory = Runtime.getRuntime().totalMemory();
+        if (totalMemory > trigger * 1024 * 1024) {
+            log.info("Invoke garbage collector. Total memory: {} {} {}", Utilities.readableFileSize(totalMemory), totalMemory, trigger * 1024 * 1024);
+            System.gc();
+            log.info("Total memory after gc() call: {}", Utilities.readableFileSize(Runtime.getRuntime().totalMemory()));
+        }
+    }
+}

--- a/common/src/main/java/bisq/common/util/Profiler.java
+++ b/common/src/main/java/bisq/common/util/Profiler.java
@@ -17,18 +17,30 @@
 
 package bisq.common.util;
 
+import bisq.common.UserThread;
+
+import java.util.concurrent.TimeUnit;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class Profiler {
+    public static void printSystemLoadPeriodically(long delay, TimeUnit timeUnit) {
+        UserThread.runPeriodically(Profiler::printSystemLoad, delay, timeUnit);
+    }
+
     public static void printSystemLoad() {
         Runtime runtime = Runtime.getRuntime();
-        long free = runtime.freeMemory() / 1024 / 1024;
-        long total = runtime.totalMemory() / 1024 / 1024;
+        long free = runtime.freeMemory();
+        long total = runtime.totalMemory();
         long used = total - free;
 
-        log.info("System report: Used memory: {} MB; Free memory: {} MB; Total memory: {} MB; No. of threads: {}",
-                used, free, total, Thread.activeCount());
+        log.info("Total memory: {}; Used memory: {}; Free memory: {}; Max memory: {}; No. of threads: {}",
+                Utilities.readableFileSize(total),
+                Utilities.readableFileSize(used),
+                Utilities.readableFileSize(free),
+                Utilities.readableFileSize(runtime.maxMemory()),
+                Thread.activeCount());
     }
 
     public static long getUsedMemoryInMB() {

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -130,7 +130,6 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
     // Headless versions can call inside launchApplication the onApplicationLaunched() manually
     protected void onApplicationLaunched() {
         configUserThread();
-        CommonSetup.printSystemLoadPeriodically(10);
         // As the handler method might be overwritten by subclasses and they use the application as handler
         // we need to setup the handler after the application is created.
         CommonSetup.setupUncaughtExceptionHandler(this);

--- a/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
@@ -40,6 +40,7 @@ import bisq.common.UserThread;
 import bisq.common.config.Config;
 import bisq.common.crypto.Hash;
 import bisq.common.file.FileUtil;
+import bisq.common.util.GcUtil;
 import bisq.common.util.Utilities;
 
 import javax.inject.Inject;
@@ -59,7 +60,6 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -304,10 +304,10 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
                     height, daoStateBlockChain.getLast().getHeight());
             prevHash = daoStateBlockChain.getLast().getHash();
         }
-        byte[] stateHash = daoStateService.getSerializedStateForHashChain();
+        byte[] stateAsBytes = daoStateService.getSerializedStateForHashChain();
         // We include the prev. hash in our new hash so we can be sure that if one hash is matching all the past would
         // match as well.
-        byte[] combined = ArrayUtils.addAll(prevHash, stateHash);
+        byte[] combined = ArrayUtils.addAll(prevHash, stateAsBytes);
         byte[] hash = Hash.getSha256Ripemd160hash(combined);
 
         DaoStateHash myDaoStateHash = new DaoStateHash(height, hash, prevHash);
@@ -334,10 +334,10 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
         numCalls++;
     }
 
-    private boolean processPeersDaoStateHash(DaoStateHash daoStateHash, Optional<NodeAddress> peersNodeAddress,
+    private boolean processPeersDaoStateHash(DaoStateHash daoStateHash,
+                                             Optional<NodeAddress> peersNodeAddress,
                                              boolean notifyListeners) {
-        // No guarantee that it runs but helps to lower memory allocation before we get heavier load
-        System.gc();
+        GcUtil.maybeReleaseMemory();
 
         AtomicBoolean changed = new AtomicBoolean(false);
         AtomicBoolean inConflictWithNonSeedNode = new AtomicBoolean(this.isInConflictWithNonSeedNode);
@@ -378,13 +378,11 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
                 log.debug("Conflict with non-seed nodes: {}", conflictMsg);
         }
 
-
         if (notifyListeners && changed.get()) {
             listeners.forEach(Listener::onChangeAfterBatchProcessing);
         }
 
-        // No guarantee that it runs but helps to lower memory allocation before we get heavier load
-        UserThread.runAfter(System::gc, 300, TimeUnit.MILLISECONDS);
+        GcUtil.maybeReleaseMemory();
 
         return changed.get();
     }

--- a/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -335,6 +336,9 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
 
     private boolean processPeersDaoStateHash(DaoStateHash daoStateHash, Optional<NodeAddress> peersNodeAddress,
                                              boolean notifyListeners) {
+        // No guarantee that it runs but helps to lower memory allocation before we get heavier load
+        System.gc();
+
         AtomicBoolean changed = new AtomicBoolean(false);
         AtomicBoolean inConflictWithNonSeedNode = new AtomicBoolean(this.isInConflictWithNonSeedNode);
         AtomicBoolean inConflictWithSeedNode = new AtomicBoolean(this.isInConflictWithSeedNode);
@@ -378,6 +382,9 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
         if (notifyListeners && changed.get()) {
             listeners.forEach(Listener::onChangeAfterBatchProcessing);
         }
+
+        // No guarantee that it runs but helps to lower memory allocation before we get heavier load
+        UserThread.runAfter(System::gc, 300, TimeUnit.MILLISECONDS);
 
         return changed.get();
     }

--- a/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
+++ b/core/src/main/java/bisq/core/dao/node/explorer/ExportJsonFilesService.java
@@ -26,10 +26,10 @@ import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.dao.state.model.blockchain.TxOutput;
 import bisq.core.dao.state.model.blockchain.TxType;
 
-import bisq.common.UserThread;
 import bisq.common.config.Config;
 import bisq.common.file.FileUtil;
 import bisq.common.file.JsonFileManager;
+import bisq.common.util.GcUtil;
 import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Utils;
@@ -52,7 +52,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -146,8 +145,7 @@ public class ExportJsonFilesService implements DaoSetupService {
                         return jsonTx;
                     }).collect(Collectors.toList());
 
-            // No guarantee that it runs but helps to lower memory allocation before we get heavier load
-            System.gc();
+            GcUtil.maybeReleaseMemory();
 
             DaoState daoState = daoStateService.getClone();
             List<JsonBlock> jsonBlockList = daoState.getBlocks().stream()
@@ -160,8 +158,7 @@ public class ExportJsonFilesService implements DaoSetupService {
                 allJsonTxOutputs.forEach(jsonTxOutput -> txOutputFileManager.writeToDisc(Utilities.objectToJson(jsonTxOutput), jsonTxOutput.getId()));
                 jsonTxs.forEach(jsonTx -> txFileManager.writeToDisc(Utilities.objectToJson(jsonTx), jsonTx.getId()));
 
-                // No guarantee that it runs but helps to lower memory allocation before we get heavier load
-                UserThread.runAfter(System::gc, 300, TimeUnit.MILLISECONDS);
+                GcUtil.maybeReleaseMemory();
 
                 return null;
             });

--- a/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
+++ b/core/src/main/java/bisq/core/dao/node/parser/BlockParser.java
@@ -24,6 +24,7 @@ import bisq.core.dao.state.DaoStateService;
 import bisq.core.dao.state.model.blockchain.Block;
 
 import bisq.common.app.DevEnv;
+import bisq.common.util.GcUtil;
 
 import org.bitcoinj.core.Coin;
 
@@ -114,6 +115,8 @@ public class BlockParser {
         daoStateService.onParseBlockComplete(block);
         log.info("Parsing {} transactions at block height {} took {} ms", rawBlock.getRawTxs().size(),
                 blockHeight, System.currentTimeMillis() - startTs);
+
+        GcUtil.maybeReleaseMemory();
         return block;
     }
 

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -281,7 +281,6 @@ public class DaoStateService implements DaoSetupService {
         daoStateListeners.forEach(DaoStateListener::onParseBlockChainComplete);
     }
 
-
     public List<Block> getBlocks() {
         return daoState.getBlocks();
     }
@@ -535,9 +534,7 @@ public class DaoStateService implements DaoSetupService {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private Set<TxOutput> getTxOutputsByTxOutputType(TxOutputType txOutputType) {
-        return getUnorderedTxOutputStream()
-                .filter(txOutput -> txOutput.getTxOutputType() == txOutputType)
-                .collect(Collectors.toSet());
+        return daoState.getTxOutputByTxOutputType(txOutputType);
     }
 
     public boolean isBsqTxOutputType(TxOutput txOutput) {

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -114,6 +114,9 @@ public class DaoStateSnapshotService {
                 return;
             }
 
+            // No guarantee that it runs but helps to lower memory allocation before we get heavier load
+            System.gc();
+
             // At trigger event we store the latest snapshotCandidate to disc
             long ts = System.currentTimeMillis();
             requestPersistenceCalled = true;
@@ -126,6 +129,9 @@ public class DaoStateSnapshotService {
                                 System.currentTimeMillis() - ts);
 
                         long ts2 = System.currentTimeMillis();
+
+                        // No guarantee that it runs but helps to lower memory allocation before we get heavier load
+                        System.gc();
 
                         // Now we clone and keep it in memory for the next trigger event
                         daoStateSnapshotCandidate = daoStateService.getClone();

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -24,6 +24,7 @@ import bisq.core.dao.state.model.blockchain.Block;
 import bisq.core.dao.state.storage.DaoStateStorageService;
 
 import bisq.common.config.Config;
+import bisq.common.util.GcUtil;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -114,8 +115,7 @@ public class DaoStateSnapshotService {
                 return;
             }
 
-            // No guarantee that it runs but helps to lower memory allocation before we get heavier load
-            System.gc();
+            GcUtil.maybeReleaseMemory();
 
             // At trigger event we store the latest snapshotCandidate to disc
             long ts = System.currentTimeMillis();
@@ -130,8 +130,7 @@ public class DaoStateSnapshotService {
 
                         long ts2 = System.currentTimeMillis();
 
-                        // No guarantee that it runs but helps to lower memory allocation before we get heavier load
-                        System.gc();
+                        GcUtil.maybeReleaseMemory();
 
                         // Now we clone and keep it in memory for the next trigger event
                         daoStateSnapshotCandidate = daoStateService.getClone();
@@ -139,6 +138,7 @@ public class DaoStateSnapshotService {
 
                         log.info("Cloned new snapshotCandidate at height {} took {} ms", chainHeight, System.currentTimeMillis() - ts2);
                         requestPersistenceCalled = false;
+                        GcUtil.maybeReleaseMemory();
                     });
         }
     }

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -63,6 +63,7 @@ public class DaoStateSnapshotService {
     @Setter
     @Nullable
     private Runnable daoRequiresRestartHandler;
+    private boolean requestPersistenceCalled;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -101,24 +102,38 @@ public class DaoStateSnapshotService {
                 !daoStateService.getBlocks().isEmpty() &&
                 isValidHeight(daoStateService.getBlockHeightOfLastBlock()) &&
                 noSnapshotCandidateOrDifferentHeight) {
-            // At trigger event we store the latest snapshotCandidate to disc
-            long ts = System.currentTimeMillis();
-            if (daoStateSnapshotCandidate != null) {
-                // Serialisation happens on the userThread so we do not need to clone the data. Write to disk happens
-                // in a thread but does not interfere with our objects as they got already serialized when passed to the
-                // write thread. We use requestPersistence so we do not write immediately but at next scheduled interval.
-                // This avoids frequent write at dao sync and better performance.
-                daoStateStorageService.requestPersistence(daoStateSnapshotCandidate, daoStateHashChainSnapshotCandidate);
-                log.info("Serializing snapshotCandidate for writing to Disc with height {} at height {} took {} ms",
-                        daoStateSnapshotCandidate.getChainHeight(), chainHeight, System.currentTimeMillis() - ts);
+
+            // We protect to get called while we are not completed with persisting the daoState. This can take about
+            // 20 seconds and it is not expected that we get triggered another snapshot event in that period, but this
+            // check guards that we would skip such calls..
+            if (requestPersistenceCalled) {
+                log.warn("We try to persist a daoState but the previous call has not completed yet. " +
+                        "We ignore that call and skip that snapshot. " +
+                        "Snapshot will be created at next snapshot height again. This is not to be expected with live " +
+                        "blockchain data.");
+                return;
             }
 
-            ts = System.currentTimeMillis();
-            // Now we clone and keep it in memory for the next trigger event
-            daoStateSnapshotCandidate = daoStateService.getClone();
-            daoStateHashChainSnapshotCandidate = new LinkedList<>(daoStateMonitoringService.getDaoStateHashChain());
+            // At trigger event we store the latest snapshotCandidate to disc
+            long ts = System.currentTimeMillis();
+            requestPersistenceCalled = true;
+            daoStateStorageService.requestPersistence(daoStateSnapshotCandidate,
+                    daoStateHashChainSnapshotCandidate,
+                    () -> {
+                        log.info("Serializing snapshotCandidate for writing to Disc with height {} at height {} took {} ms",
+                                daoStateSnapshotCandidate != null ? daoStateSnapshotCandidate.getChainHeight() : "N/A",
+                                chainHeight,
+                                System.currentTimeMillis() - ts);
 
-            log.debug("Cloned new snapshotCandidate at height {} took {} ms", chainHeight, System.currentTimeMillis() - ts);
+                        long ts2 = System.currentTimeMillis();
+
+                        // Now we clone and keep it in memory for the next trigger event
+                        daoStateSnapshotCandidate = daoStateService.getClone();
+                        daoStateHashChainSnapshotCandidate = new LinkedList<>(daoStateMonitoringService.getDaoStateHashChain());
+
+                        log.info("Cloned new snapshotCandidate at height {} took {} ms", chainHeight, System.currentTimeMillis() - ts2);
+                        requestPersistenceCalled = false;
+                    });
         }
     }
 

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -92,9 +92,8 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
         new Thread(() -> {
             Thread.currentThread().setName("Serialize and write DaoState");
             persistenceManager.persistNow(() -> {
-                // After we have written to disk we remove the reference to the daoState. We have in the meantime
-                // already cloned the next daoState and if we would not release the reference we would have 3 times
-                // the daoState data in memory.
+                // After we have written to disk we remove the the daoState in the store to avoid that it stays in
+                // memory there until the next persist call.
                 store.setDaoState(null);
 
                 completeHandler.run();

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -97,8 +97,6 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
                 // the daoState data in memory.
                 store.setDaoState(null);
 
-                // Hint the system for garbage collection. No guarantee if and when it will be executed...
-                System.gc();
                 completeHandler.run();
             });
         }).start();

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -76,10 +76,32 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
         return FILE_NAME;
     }
 
-    public void requestPersistence(DaoState daoState, LinkedList<DaoStateHash> daoStateHashChain) {
+    public void requestPersistence(DaoState daoState,
+                                   LinkedList<DaoStateHash> daoStateHashChain,
+                                   Runnable completeHandler) {
+        if (daoState == null) {
+            completeHandler.run();
+            return;
+        }
+
         store.setDaoState(daoState);
         store.setDaoStateHashChain(daoStateHashChain);
-        persistenceManager.requestPersistence();
+
+        // We let the persistence run in a thread to avoid the slow protobuf serialisation to happen on the user
+        // thread. We also call it immediately to get notified about the completion event.
+        new Thread(() -> {
+            Thread.currentThread().setName("Serialize and write DaoState");
+            persistenceManager.persistNow(() -> {
+                // After we have written to disk we remove the reference to the daoState. We have in the meantime
+                // already cloned the next daoState and if we would not release the reference we would have 3 times
+                // the daoState data in memory.
+                store.setDaoState(null);
+
+                // Hint the system for garbage collection. No guarantee if and when it will be executed...
+                System.gc();
+                completeHandler.run();
+            });
+        }).start();
     }
 
     public DaoState getPersistedBsqState() {
@@ -125,7 +147,7 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
 
     @Override
     protected DaoStateStore createStore() {
-        return new DaoStateStore(DaoState.getClone(daoState), new LinkedList<>(daoStateMonitoringService.getDaoStateHashChain()));
+        return new DaoStateStore(null, new LinkedList<>(daoStateMonitoringService.getDaoStateHashChain()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStore.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStore.java
@@ -31,6 +31,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 
@@ -40,12 +42,13 @@ public class DaoStateStore implements PersistableEnvelope {
     // the snapshot!
     @Getter
     @Setter
+    @Nullable
     private DaoState daoState;
     @Getter
     @Setter
     private LinkedList<DaoStateHash> daoStateHashChain;
 
-    DaoStateStore(DaoState daoState, LinkedList<DaoStateHash> daoStateHashChain) {
+    DaoStateStore(@Nullable DaoState daoState, LinkedList<DaoStateHash> daoStateHashChain) {
         this.daoState = daoState;
         this.daoStateHashChain = daoStateHashChain;
     }

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -247,7 +247,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
         map.put(hashOfPayload, protectedStorageEntry);
-        log.trace("## addProtectedMailboxStorageEntryToMap hashOfPayload={}, map={}", hashOfPayload, printMap());
+        //log.trace("## addProtectedMailboxStorageEntryToMap hashOfPayload={}, map={}", hashOfPayload, printMap());
     }
 
 
@@ -280,14 +280,14 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
 
         Map<ByteArray, PersistableNetworkPayload> mapForDataRequest = getMapForDataRequest();
         Set<byte[]> excludedKeys = getKeysAsByteSet(mapForDataRequest);
-        log.trace("## getKnownPayloadHashes map of PersistableNetworkPayloads={}, excludedKeys={}",
+       /* log.trace("## getKnownPayloadHashes map of PersistableNetworkPayloads={}, excludedKeys={}",
                 printPersistableNetworkPayloadMap(mapForDataRequest),
-                excludedKeys.stream().map(Utilities::encodeToHex).toArray());
+                excludedKeys.stream().map(Utilities::encodeToHex).toArray());*/
 
         Set<byte[]> excludedKeysFromProtectedStorageEntryMap = getKeysAsByteSet(map);
-        log.trace("## getKnownPayloadHashes map of ProtectedStorageEntrys={}, excludedKeys={}",
+        /*log.trace("## getKnownPayloadHashes map of ProtectedStorageEntrys={}, excludedKeys={}",
                 printMap(),
-                excludedKeysFromProtectedStorageEntryMap.stream().map(Utilities::encodeToHex).toArray());
+                excludedKeysFromProtectedStorageEntryMap.stream().map(Utilities::encodeToHex).toArray());*/
 
         excludedKeys.addAll(excludedKeysFromProtectedStorageEntryMap);
         return excludedKeys;
@@ -742,7 +742,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
 
-        log.trace("## call addProtectedStorageEntry hash={}, map={}", hashOfPayload, printMap());
+        //log.trace("## call addProtectedStorageEntry hash={}, map={}", hashOfPayload, printMap());
 
         // We do that check early as it is a very common case for returning, so we return early
         // If we have seen a more recent operation for this payload and we have a payload locally, ignore it
@@ -795,7 +795,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         sequenceNumberMap.put(hashOfPayload, new MapValue(protectedStorageEntry.getSequenceNumber(), this.clock.millis()));
         requestPersistence();
 
-        log.trace("## ProtectedStorageEntry added to map. hash={}, map={}", hashOfPayload, printMap());
+        //log.trace("## ProtectedStorageEntry added to map. hash={}, map={}", hashOfPayload, printMap());
 
         // Optionally, broadcast the add/update depending on the calling environment
         if (allowBroadcast) {
@@ -823,7 +823,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         ProtectedStoragePayload protectedStoragePayload = protectedMailboxStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
 
-        log.trace("## call republishProtectedStorageEntry hash={}, map={}", hashOfPayload, printMap());
+        //log.trace("## call republishProtectedStorageEntry hash={}, map={}", hashOfPayload, printMap());
 
         if (hasAlreadyRemovedAddOncePayload(protectedStoragePayload, hashOfPayload)) {
             log.trace("## We have already removed that AddOncePayload by a previous removeDataMessage. " +
@@ -1023,9 +1023,9 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
             ByteArray hashOfPayload = entry.getKey();
             ProtectedStorageEntry protectedStorageEntry = entry.getValue();
 
-            log.trace("## removeFromMapAndDataStore: hashOfPayload={}, map before remove={}", hashOfPayload, printMap());
+            //log.trace("## removeFromMapAndDataStore: hashOfPayload={}, map before remove={}", hashOfPayload, printMap());
             map.remove(hashOfPayload);
-            log.trace("## removeFromMapAndDataStore: map after remove={}", printMap());
+            //log.trace("## removeFromMapAndDataStore: map after remove={}", printMap());
 
             // We inform listeners even the entry was not found in our map
             removedProtectedStorageEntries.add(protectedStorageEntry);


### PR DESCRIPTION
- Run persistence call in thread instead of user thread (serialisation is very slow and had blocked user thread)
- Create new snapshot only after persistence is completed to avoid to have 3 daoState objects in memory
- Set DaoState in store to null to let gc remove the old reference (was left there before so we had 3 instances of daoStates in memory)

This change results in about 70 mb less memory usage (10% of about 700 mb normal memory usage).
With vm arguments:
```
-XX:+UseG1GC
-XX:MaxHeapFreeRatio=10
-XX:MinHeapFreeRatio=5
-XX:+UseStringDeduplication
```
memory reduction is about 30% and total memory gets released (not the case with defaults). In my tests I got about 496 MB instead of about 700 with the master version and no vm arguments.

During parsing or other heavier load the total memory will go up again to about 2GB but gets released after some GC rounds once the load is reduced again.

As those gc settings have impact on performance we should observe it first to see if it works well or continue to fine tune it (or add/find other options).

To test the difference one need to wait either enough blocks to get a snapshot (every 20 blocks but I guess one need to wait > 40 blocks to see the full effect) or to hack the code a bit to create the daostate clones at each block (thats how I got my numbers - but I will let it running in both versions, master and the PR over night to see if the improvement really gets confirmed).

I also added that debugging code to the Profiler class to trigger gc fast and to get fast updates about memory usage:
```
 static {
        UserThread.runPeriodically(() -> {
            log.error("UsedMemoryInMB={}, totalMemory={}, freeMemory={}, maxMemory={}",
                    Profiler.getUsedMemoryInMB(),
                    Utilities.readableFileSize(Runtime.getRuntime().totalMemory()),
                    Utilities.readableFileSize(Runtime.getRuntime().freeMemory()),
                    Utilities.readableFileSize(Runtime.getRuntime().maxMemory())
            );
        }, 2);

        UserThread.runPeriodically(() -> {
            System.gc();
        }, 30);
    }
```

I used https://heaphero.io/ for a memory analysis. Here are the results:
[heaphero_results_PR.pdf](https://github.com/bisq-network/bisq/files/6772730/heaphero_results_PR.pdf)
[heap_hero_results_master.pdf](https://github.com/bisq-network/bisq/files/6772731/heap_hero_results_master.pdf)

It shows clearly the lower memory use for the daostate and for strings. Most strings are also from the daostate data (address, pubkeyashex, asm,...) 


