### PR TITLE
Avoid creating more than one refund payout

### DIFF
--- a/core/src/main/java/bisq/core/support/dispute/Dispute.java
+++ b/core/src/main/java/bisq/core/support/dispute/Dispute.java
@@ -148,6 +148,8 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
     private transient String uid;
     @Setter
     private transient long payoutTxConfirms = -1;
+    @Setter
+    private transient boolean payoutDone = false;
 
     private transient final BooleanProperty isClosedProperty = new SimpleBooleanProperty();
     private transient final IntegerProperty badgeCountProperty = new SimpleIntegerProperty();

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2626,6 +2626,9 @@ disputeSummaryWindow.close.txDetails=Spending: {0}\n\
 disputeSummaryWindow.close.noPayout.headline=Close without any payout
 disputeSummaryWindow.close.noPayout.text=Do you want to close without doing any payout?
 
+disputeSummaryWindow.close.alreadyPaid.headline=Payout already done
+disputeSummaryWindow.close.alreadyPaid.text=Restart the client to do another payout for this dispute
+
 emptyWalletWindow.headline={0} emergency wallet tool
 emptyWalletWindow.info=Please use that only in emergency case if you cannot access your fund from the UI.\n\n\
 Please note that all open offers will be closed automatically when using this tool.\n\n\

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -673,6 +673,13 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
     }
 
     private void showPayoutTxConfirmation(Contract contract, DisputeResult disputeResult, ResultHandler resultHandler) {
+        if (dispute.isPayoutDone()) {
+            new Popup().headLine(Res.get("disputeSummaryWindow.close.alreadyPaid.headline"))
+                    .confirmation(Res.get("disputeSummaryWindow.close.alreadyPaid.text"))
+                    .closeButtonText(Res.get("shared.cancel"))
+                    .show();
+        }
+
         Coin buyerPayoutAmount = disputeResult.getBuyerPayoutAmount();
         String buyerPayoutAddressString = contract.getBuyerPayoutAddressString();
         Coin sellerPayoutAmount = disputeResult.getSellerPayoutAmount();
@@ -734,6 +741,12 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
                           String buyerPayoutAddressString,
                           String sellerPayoutAddressString,
                           ResultHandler resultHandler) {
+        if (dispute.isPayoutDone()) {
+            log.error("Payout already processed, returning to avoid double payout for dispute of trade {}",
+                    dispute.getTradeId());
+            return;
+        }
+        dispute.setPayoutDone(true);
         try {
             Transaction tx = btcWalletService.createRefundPayoutTx(buyerPayoutAmount,
                     sellerPayoutAmount,


### PR DESCRIPTION
Double clicking the close ticketbutton creates two payout transactions.
This fix makes sure only one payout transaction is created for the
dispute.

Restarting the client allows for creating another refund transaction
for the dispute if needed.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Refund agent reported a case of a refund being done twice. This PR makes sure that two transactions are not created for the same refund during one session. It's still possible to restart the client to make another refund for an already closed ticket if needed.

I managed to reproduce at least one case of double refund transactions by double clicking the close ticket button, there might be other ways to trigger the refund payout twice, but with this fix it will only create one refund transaction no matter which way the payout was triggered.