### PR TITLE
Reduce # of hash calculations in UI OfferBook view

### DIFF
--- a/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
+++ b/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
@@ -32,8 +32,6 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
 
-import bisq.network.p2p.storage.P2PDataStorage;
-
 import bisq.common.crypto.KeyRing;
 import bisq.common.util.MathUtils;
 
@@ -74,12 +72,12 @@ public class MarketAlerts {
     public void onAllServicesInitialized() {
         offerBookService.addOfferBookChangedListener(new OfferBookService.OfferBookChangedListener() {
             @Override
-            public void onAdded(Offer offer, P2PDataStorage.ByteArray hashOfPayload) {
+            public void onAdded(Offer offer) {
                 onOfferAdded(offer);
             }
 
             @Override
-            public void onRemoved(Offer offer, P2PDataStorage.ByteArray hashOfPayload) {
+            public void onRemoved(Offer offer) {
             }
         });
         applyFilterOnAllOffers();

--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -24,7 +24,6 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.network.p2p.BootstrapListener;
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.storage.HashMapChangedListener;
-import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 
 import bisq.common.UserThread;
@@ -49,8 +48,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
-import static bisq.network.p2p.storage.P2PDataStorage.get32ByteHashAsByteArray;
-
 /**
  * Handles storage and retrieval of offers.
  * Uses an invalidation flag to only request the full offer map in case there was a change (anyone has added or removed an offer).
@@ -59,9 +56,9 @@ import static bisq.network.p2p.storage.P2PDataStorage.get32ByteHashAsByteArray;
 public class OfferBookService {
 
     public interface OfferBookChangedListener {
-        void onAdded(Offer offer, P2PDataStorage.ByteArray hashOfPayload);
+        void onAdded(Offer offer);
 
-        void onRemoved(Offer offer, P2PDataStorage.ByteArray hashOfPayload);
+        void onRemoved(Offer offer);
     }
 
     private final P2PService p2PService;
@@ -94,8 +91,7 @@ public class OfferBookService {
                         OfferPayload offerPayload = (OfferPayload) protectedStorageEntry.getProtectedStoragePayload();
                         Offer offer = new Offer(offerPayload);
                         offer.setPriceFeedService(priceFeedService);
-                        P2PDataStorage.ByteArray hashOfPayload = get32ByteHashAsByteArray(offerPayload);
-                        listener.onAdded(offer, hashOfPayload);
+                        listener.onAdded(offer);
                     }
                 }));
             }
@@ -107,8 +103,7 @@ public class OfferBookService {
                         OfferPayload offerPayload = (OfferPayload) protectedStorageEntry.getProtectedStoragePayload();
                         Offer offer = new Offer(offerPayload);
                         offer.setPriceFeedService(priceFeedService);
-                        P2PDataStorage.ByteArray hashOfPayload = get32ByteHashAsByteArray(offerPayload);
-                        listener.onRemoved(offer, hashOfPayload);
+                        listener.onRemoved(offer);
                     }
                 }));
             }
@@ -120,12 +115,12 @@ public class OfferBookService {
                 public void onUpdatedDataReceived() {
                     addOfferBookChangedListener(new OfferBookChangedListener() {
                         @Override
-                        public void onAdded(Offer offer, P2PDataStorage.ByteArray hashOfPayload) {
+                        public void onAdded(Offer offer) {
                             doDumpStatistics();
                         }
 
                         @Override
-                        public void onRemoved(Offer offer, P2PDataStorage.ByteArray hashOfPayload) {
+                        public void onRemoved(Offer offer) {
                             doDumpStatistics();
                         }
                     });

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookListItem.java
@@ -42,8 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nullable;
-
 @Slf4j
 public class OfferBookListItem {
     @Getter
@@ -58,11 +56,7 @@ public class OfferBookListItem {
      * envelope bundles.  It can happen when the API is used to edit an offer because
      * the remove/add msgs are received in the same envelope bundle, then processed in
      * unpredictable order.
-     *
-     * A null value indicates the item's payload hash has not been set by onAdded or
-     * onRemoved since the most recent OfferBook view refresh.
      */
-    @Nullable
     @Getter
     P2PDataStorage.ByteArray hashOfPayload;
 
@@ -71,12 +65,8 @@ public class OfferBookListItem {
     private WitnessAgeData witnessAgeData;
 
     public OfferBookListItem(Offer offer) {
-        this(offer, null);
-    }
-
-    public OfferBookListItem(Offer offer, @Nullable P2PDataStorage.ByteArray hashOfPayload) {
         this.offer = offer;
-        this.hashOfPayload = hashOfPayload;
+        this.hashOfPayload = new P2PDataStorage.ByteArray(offer.getOfferPayload().getHash());
     }
 
     public WitnessAgeData getWitnessAgeData(AccountAgeWitnessService accountAgeWitnessService,
@@ -124,7 +114,7 @@ public class OfferBookListItem {
     public String toString() {
         return "OfferBookListItem{" +
                 "offerId=" + offer.getId() +
-                ", hashOfPayload=" + (hashOfPayload == null ? "null" : hashOfPayload.getHex()) +
+                ", hashOfPayload=" + hashOfPayload.getHex() +
                 ", witnessAgeData=" + (witnessAgeData == null ? "null" : witnessAgeData.displayString) +
                 '}';
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferDataModel.java
@@ -298,7 +298,7 @@ class TakeOfferDataModel extends OfferDataModel {
         // only local effect. Other trader might see the offer for a few seconds
         // still (but cannot take it).
         if (removeOffer) {
-            offerBook.removeOffer(checkNotNull(offer), null);
+            offerBook.removeOffer(checkNotNull(offer));
         }
 
         btcWalletService.resetAddressEntriesForOpenOffer(offer.getId());

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -77,6 +77,7 @@ import static com.natpryce.makeiteasy.MakeItEasy.make;
 import static com.natpryce.makeiteasy.MakeItEasy.with;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -391,12 +392,19 @@ public class OfferBookViewModelTest {
         when(priceFeedService.updateCounterProperty()).thenReturn(new SimpleIntegerProperty());
 
         final OfferBookListItem item1 = make(item);
+        assertNotNull(item1.getHashOfPayload());
         item1.getOffer().setPriceFeedService(priceFeedService);
+
         final OfferBookListItem item2 = make(item.but(with(marketPriceMargin, 0.0197)));
+        assertNotNull(item2.getHashOfPayload());
         item2.getOffer().setPriceFeedService(priceFeedService);
+
         final OfferBookListItem item3 = make(item.but(with(marketPriceMargin, 0.1)));
+        assertNotNull(item3.getHashOfPayload());
         item3.getOffer().setPriceFeedService(priceFeedService);
+
         final OfferBookListItem item4 = make(item.but(with(marketPriceMargin, -0.1)));
+        assertNotNull(item4.getHashOfPayload());
         item4.getOffer().setPriceFeedService(priceFeedService);
         offerBookListItems.addAll(item1, item2);
 
@@ -427,12 +435,15 @@ public class OfferBookViewModelTest {
         final OfferBookListItem item = make(btcBuyItem.but(
                 with(useMarketBasedPrice, true),
                 with(marketPriceMargin, -0.12)));
+        assertNotNull(item.getHashOfPayload());
 
         final OfferBookListItem lowItem = make(btcBuyItem.but(
                 with(useMarketBasedPrice, true),
                 with(marketPriceMargin, 0.01)));
+        assertNotNull(lowItem.getHashOfPayload());
 
         final OfferBookListItem fixedItem = make(btcBuyItem);
+        assertNotNull(fixedItem.getHashOfPayload());
 
         item.getOffer().setPriceFeedService(priceFeedService);
         lowItem.getOffer().setPriceFeedService(priceFeedService);

--- a/desktop/src/test/java/bisq/desktop/maker/OfferMaker.java
+++ b/desktop/src/test/java/bisq/desktop/maker/OfferMaker.java
@@ -20,30 +20,64 @@ package bisq.desktop.maker;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.crypto.Encryption;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.Sig;
+
+import java.net.UnknownHostException;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import com.natpryce.makeiteasy.Instantiator;
 import com.natpryce.makeiteasy.Maker;
 import com.natpryce.makeiteasy.Property;
 
 import static com.natpryce.makeiteasy.MakeItEasy.a;
 import static com.natpryce.makeiteasy.MakeItEasy.with;
+import static com.natpryce.makeiteasy.Property.newProperty;
+import static java.lang.System.currentTimeMillis;
+import static java.net.InetAddress.getLocalHost;
 
+@SuppressWarnings("InstantiationOfUtilityClass")
 public class OfferMaker {
 
-    public static final Property<Offer, Long> price = new Property<>();
-    public static final Property<Offer, Long> minAmount = new Property<>();
-    public static final Property<Offer, Long> amount = new Property<>();
-    public static final Property<Offer, String> baseCurrencyCode = new Property<>();
-    public static final Property<Offer, String> counterCurrencyCode = new Property<>();
-    public static final Property<Offer, OfferPayload.Direction> direction = new Property<>();
-    public static final Property<Offer, Boolean> useMarketBasedPrice = new Property<>();
-    public static final Property<Offer, Double> marketPriceMargin = new Property<>();
-    public static final Property<Offer, String> id = new Property<>();
+    public static final Property<Offer, String> id = newProperty();
+    public static final Property<Offer, String> paymentMethodId = newProperty();
+    public static final Property<Offer, String> paymentAccountId = newProperty();
+    public static final Property<Offer, String> offerFeePaymentTxId = newProperty();
+    public static final Property<Offer, String> countryCode = newProperty();
+    public static final Property<Offer, List<String>> countryCodes = newProperty();
+    public static final Property<Offer, Long> date = newProperty();
+    public static final Property<Offer, Long> price = newProperty();
+    public static final Property<Offer, Long> minAmount = newProperty();
+    public static final Property<Offer, Long> amount = newProperty();
+    public static final Property<Offer, String> baseCurrencyCode = newProperty();
+    public static final Property<Offer, String> counterCurrencyCode = newProperty();
+    public static final Property<Offer, OfferPayload.Direction> direction = newProperty();
+    public static final Property<Offer, Boolean> useMarketBasedPrice = newProperty();
+    public static final Property<Offer, Double> marketPriceMargin = newProperty();
+    public static final Property<Offer, NodeAddress> nodeAddress = newProperty();
+    public static final Property<Offer, List<NodeAddress>> nodeAddresses = newProperty();
+    public static final Property<Offer, PubKeyRing> pubKeyRing = newProperty();
+    public static final Property<Offer, Long> blockHeight = newProperty();
+    public static final Property<Offer, Long> txFee = newProperty();
+    public static final Property<Offer, Long> makerFee = newProperty();
+    public static final Property<Offer, Long> buyerSecurityDeposit = newProperty();
+    public static final Property<Offer, Long> sellerSecurityDeposit = newProperty();
+    public static final Property<Offer, Long> tradeLimit = newProperty();
+    public static final Property<Offer, Long> maxTradePeriod = newProperty();
+    public static final Property<Offer, Long> lowerClosePrice = newProperty();
+    public static final Property<Offer, Long> upperClosePrice = newProperty();
+    public static final Property<Offer, Integer> protocolVersion = newProperty();
 
     public static final Instantiator<Offer> Offer = lookup -> new Offer(
             new OfferPayload(lookup.valueOf(id, "1234"),
-                    0L,
-                    null,
-                    null,
+                    lookup.valueOf(date, currentTimeMillis()),
+                    lookup.valueOf(nodeAddress, getLocalHostNodeWithPort(10000)),
+                    lookup.valueOf(pubKeyRing, genPubKeyRing()),
                     lookup.valueOf(direction, OfferPayload.Direction.BUY),
                     lookup.valueOf(price, 100000L),
                     lookup.valueOf(marketPriceMargin, 0.0),
@@ -52,33 +86,51 @@ public class OfferMaker {
                     lookup.valueOf(minAmount, 100000L),
                     lookup.valueOf(baseCurrencyCode, "BTC"),
                     lookup.valueOf(counterCurrencyCode, "USD"),
+                    lookup.valueOf(nodeAddresses, new ArrayList<>() {{
+                        add(getLocalHostNodeWithPort(10001));
+                    }}),
+                    lookup.valueOf(nodeAddresses, new ArrayList<>() {{
+                        add(getLocalHostNodeWithPort(10002));
+                    }}),
+                    lookup.valueOf(paymentMethodId, "SEPA"),
+                    lookup.valueOf(paymentAccountId, "00002c4d-1ffc-4208-8ff3-e669817b0000"),
+                    lookup.valueOf(offerFeePaymentTxId, "0000dcd1d388b95714c96ce13f5cb000090c41a1faf89e4ce7680938cc170000"),
+                    lookup.valueOf(countryCode, "FR"),
+                    lookup.valueOf(countryCodes, new ArrayList<>() {{
+                        add("FR");
+                    }}),
                     null,
                     null,
-                    "SEPA",
-                    "",
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    "",
-                    0L,
-                    0L,
-                    0L,
+                    "2",
+                    lookup.valueOf(blockHeight, 700000L),
+                    lookup.valueOf(txFee, 250L),
+                    lookup.valueOf(makerFee, 1000L),
                     false,
-                    0L,
-                    0L,
-                    0L,
-                    0L,
+                    lookup.valueOf(buyerSecurityDeposit, 10000L),
+                    lookup.valueOf(sellerSecurityDeposit, 10000L),
+                    lookup.valueOf(tradeLimit, 0L),
+                    lookup.valueOf(maxTradePeriod, 0L),
                     false,
                     false,
-                    0L,
-                    0L,
+                    lookup.valueOf(lowerClosePrice, 0L),
+                    lookup.valueOf(upperClosePrice, 0L),
                     false,
                     null,
                     null,
-                    0));
+                    lookup.valueOf(protocolVersion, 0)));
 
     public static final Maker<Offer> btcUsdOffer = a(Offer);
     public static final Maker<Offer> btcBCHCOffer = a(Offer).but(with(counterCurrencyCode, "BCHC"));
+
+    static NodeAddress getLocalHostNodeWithPort(int port) {
+        try {
+            return new NodeAddress(getLocalHost().getHostAddress(), port);
+        } catch (UnknownHostException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static PubKeyRing genPubKeyRing() {
+        return new PubKeyRing(Sig.generateKeyPair().getPublic(), Encryption.generateKeyPair().getPublic());
+    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -1182,17 +1182,25 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         // That object is saved to disc. We need to take care of changes to not break deserialization.
         public final byte[] bytes;
 
+        public ByteArray(byte[] bytes) {
+            this.bytes = bytes;
+            verifyBytesNotEmpty();
+        }
+
+        public void verifyBytesNotEmpty() {
+            if (this.bytes == null)
+                throw new IllegalArgumentException("Cannot create P2PDataStorage.ByteArray with null byte[] array argument.");
+
+            if (this.bytes.length == 0)
+                throw new IllegalArgumentException("Cannot create P2PDataStorage.ByteArray with empty byte[] array argument.");
+        }
+
         @Override
         public String toString() {
             return "ByteArray{" +
                     "bytes as Hex=" + Hex.encode(bytes) +
                     '}';
         }
-
-        public ByteArray(byte[] bytes) {
-            this.bytes = bytes;
-        }
-
 
         ///////////////////////////////////////////////////////////////////////////////////////////
         // Protobuffer


### PR DESCRIPTION
We can cache an offer payload hash as soon as its `offerFeePaymentTxId`is set.  (The payload hash cannot be calculated until the object can be transformed into a protobuf message, which requires a non-null `offerFeePaymentTxId`.)

Another benefit is removal of the payload hash argument from the`OfferBookListItem` constructor.

Changes include

- `OfferPayload` Added `transient byte[] hash` field + getter method (where hash is calculated and cached).

- `OfferBookService` Removed `P2PDataStorage.ByteArray hashOfPayload` parameter from `OfferBookChangedListener` listener methods `onAdded` & `onRemoved`.  (Hash is cached in `OfferPayload`.)

- `P2PDataStorage` Added null check to `ByteArray` class constructor.

- `OfferBook` Adjusted for change to `OfferBookChangedListener`, and removed redundant payload hash null checks.

- `TakeOfferDataModel` and `MarketAlerts` Adjusted for change to `OfferBookChangedListener`.

- `OfferBookListItem` Removed overloaded constructor with `@Nullable P2PDataStorage.ByteArray hashOfPayload` parameter.  (Field value is set from cached offer payload hash.)

- `OfferBookViewModelTest` and `OfferMaker`  Adjusted test and test fixture:  do not attempt to create offer payloads without an `offerFeePaymentTxId`.


_Follow up to the [last PR in series](https://github.com/bisq-network/bisq/pull/5666)  to support API `editoffer` method._