### PR TITLE
Override/disable gRPC call rate meters in test harness driver

### DIFF
--- a/apitest/dao-setup.gradle
+++ b/apitest/dao-setup.gradle
@@ -79,5 +79,10 @@ task cleanDaoSetup {
         delete file(buildResourcesDir + '/bisq-BTC_REGTEST_Arb_dao')
         delete file(buildResourcesDir + '/bisq-BTC_REGTEST_Alice_dao')
         delete file(buildResourcesDir + '/bisq-BTC_REGTEST_Bob_dao')
+
+        def mainResourcesDir = layout.projectDirectory.dir('src/main/resources').asFile.path
+        println "Deleting test call rate metering config files in src main resources dir $mainResourcesDir ..."
+        delete file(mainResourcesDir + '/dao-setup/bisq-BTC_REGTEST_Alice_dao/ratemeters.json')
+        delete file(mainResourcesDir + '/dao-setup/bisq-BTC_REGTEST_Bob_dao/ratemeters.json')
     }
 }

--- a/apitest/src/main/java/bisq/apitest/Scaffold.java
+++ b/apitest/src/main/java/bisq/apitest/Scaffold.java
@@ -191,7 +191,7 @@ public class Scaffold {
                     MILLISECONDS.sleep(1000);
                     if (p.hasShutdownExceptions()) {
                         // We log shutdown exceptions, but do not throw any from here
-                        // because all of the background instances must be shut down.
+                        // because all the background instances must be shut down.
                         p.logExceptions(p.getShutdownExceptions(), log);
 
                         // We cache only the 1st shutdown exception and move on to the
@@ -227,27 +227,28 @@ public class Scaffold {
                 throw new IllegalStateException("Could not install bitcoin regtest dir");
 
             String aliceDataDir = daoSetupDir + "/" + alicedaemon.appName;
+            if (!config.callRateMeteringConfigPath.isEmpty()) {
+                installCallRateMeteringConfiguration(aliceDataDir);
+            }
             BashCommand copyAliceDataDir = new BashCommand(
                     "cp -rf " + aliceDataDir + " " + config.rootAppDataDir);
             if (copyAliceDataDir.run().getExitStatus() != 0)
                 throw new IllegalStateException("Could not install alice data dir");
 
             String bobDataDir = daoSetupDir + "/" + bobdaemon.appName;
+            if (!config.callRateMeteringConfigPath.isEmpty()) {
+                installCallRateMeteringConfiguration(bobDataDir);
+            }
             BashCommand copyBobDataDir = new BashCommand(
                     "cp -rf " + bobDataDir + " " + config.rootAppDataDir);
             if (copyBobDataDir.run().getExitStatus() != 0)
                 throw new IllegalStateException("Could not install bob data dir");
 
-            log.info("Installed dao-setup files into {}", buildDataDir);
-
-            if (!config.callRateMeteringConfigPath.isEmpty()) {
-                installCallRateMeteringConfiguration(aliceDataDir);
-                installCallRateMeteringConfiguration(bobDataDir);
-            }
+            log.info("Copied all dao-setup files to {}", buildDataDir);
 
             // Copy the blocknotify script from the src resources dir to the build
             // resources dir.  Users may want to edit comment out some lines when all
-            // of the default block notifcation ports being will not be used (to avoid
+            // the default block notifcation ports being will not be used (to avoid
             // seeing rpc notifcation warnings in log files).
             installBitcoinBlocknotify();
 

--- a/apitest/src/main/java/bisq/apitest/config/ApiTestConfig.java
+++ b/apitest/src/main/java/bisq/apitest/config/ApiTestConfig.java
@@ -149,7 +149,7 @@ public class ApiTestConfig {
 
         ArgumentAcceptingOptionSpec<String> configFileOpt =
                 parser.accepts(CONFIG_FILE, format("Specify configuration file. " +
-                        "Relative paths will be prefixed by %s location.", userDir))
+                                "Relative paths will be prefixed by %s location.", userDir))
                         .withRequiredArg()
                         .ofType(String.class)
                         .defaultsTo(DEFAULT_CONFIG_FILE_NAME);
@@ -206,55 +206,55 @@ public class ApiTestConfig {
 
         ArgumentAcceptingOptionSpec<Boolean> runSubprojectJarsOpt =
                 parser.accepts(RUN_SUBPROJECT_JARS,
-                        "Run subproject build jars instead of full build jars")
+                                "Run subproject build jars instead of full build jars")
                         .withRequiredArg()
                         .ofType(Boolean.class)
                         .defaultsTo(false);
 
         ArgumentAcceptingOptionSpec<Long> bisqAppInitTimeOpt =
                 parser.accepts(BISQ_APP_INIT_TIME,
-                        "Amount of time (ms) to wait on a Bisq instance's initialization")
+                                "Amount of time (ms) to wait on a Bisq instance's initialization")
                         .withRequiredArg()
                         .ofType(Long.class)
                         .defaultsTo(5000L);
 
         ArgumentAcceptingOptionSpec<Boolean> skipTestsOpt =
                 parser.accepts(SKIP_TESTS,
-                        "Start apps, but skip tests")
+                                "Start apps, but skip tests")
                         .withRequiredArg()
                         .ofType(Boolean.class)
                         .defaultsTo(false);
 
         ArgumentAcceptingOptionSpec<Boolean> shutdownAfterTestsOpt =
                 parser.accepts(SHUTDOWN_AFTER_TESTS,
-                        "Terminate all processes after tests")
+                                "Terminate all processes after tests")
                         .withRequiredArg()
                         .ofType(Boolean.class)
                         .defaultsTo(true);
 
         ArgumentAcceptingOptionSpec<String> supportingAppsOpt =
                 parser.accepts(SUPPORTING_APPS,
-                        "Comma delimited list of supporting apps (bitcoind,seednode,arbdaemon,...")
+                                "Comma delimited list of supporting apps (bitcoind,seednode,arbdaemon,...")
                         .withRequiredArg()
                         .ofType(String.class)
                         .defaultsTo("bitcoind,seednode,arbdaemon,alicedaemon,bobdaemon");
 
         ArgumentAcceptingOptionSpec<String> callRateMeteringConfigPathOpt =
                 parser.accepts(CALL_RATE_METERING_CONFIG_PATH,
-                        "Install a ratemeters.json file to configure call rate metering interceptors")
+                                "Install a ratemeters.json file to configure call rate metering interceptors")
                         .withRequiredArg()
                         .defaultsTo(EMPTY);
 
         ArgumentAcceptingOptionSpec<Boolean> enableBisqDebuggingOpt =
                 parser.accepts(ENABLE_BISQ_DEBUGGING,
-                        "Start Bisq apps with remote debug options")
+                                "Start Bisq apps with remote debug options")
                         .withRequiredArg()
                         .ofType(Boolean.class)
                         .defaultsTo(false);
 
         ArgumentAcceptingOptionSpec<Boolean> registerDisputeAgentsOpt =
                 parser.accepts(REGISTER_DISPUTE_AGENTS,
-                        "Register dispute agents in arbitration daemon")
+                                "Register dispute agents in arbitration daemon")
                         .withRequiredArg()
                         .ofType(Boolean.class)
                         .defaultsTo(true);

--- a/apitest/src/main/java/bisq/apitest/config/ApiTestRateMeterInterceptorConfig.java
+++ b/apitest/src/main/java/bisq/apitest/config/ApiTestRateMeterInterceptorConfig.java
@@ -1,0 +1,70 @@
+package bisq.apitest.config;
+
+import java.io.File;
+
+import static bisq.apitest.config.ApiTestConfig.CALL_RATE_METERING_CONFIG_PATH;
+import static bisq.proto.grpc.DisputeAgentsGrpc.getRegisterDisputeAgentMethod;
+import static bisq.proto.grpc.GetVersionGrpc.getGetVersionMethod;
+import static java.lang.System.arraycopy;
+import static java.util.Arrays.stream;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+
+import bisq.daemon.grpc.GrpcVersionService;
+import bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig;
+
+public class ApiTestRateMeterInterceptorConfig {
+
+    public static File getTestRateMeterInterceptorConfig() {
+        GrpcServiceRateMeteringConfig.Builder builder = new GrpcServiceRateMeteringConfig.Builder();
+        builder.addCallRateMeter(GrpcVersionService.class.getSimpleName(),
+                getGetVersionMethod().getFullMethodName(),
+                1,
+                SECONDS);
+        // Only GrpcVersionService is @VisibleForTesting, so we need to
+        // hardcode other grpcServiceClassName parameter values used in
+        // builder.addCallRateMeter(...).
+        builder.addCallRateMeter("GrpcDisputeAgentsService",
+                getRegisterDisputeAgentMethod().getFullMethodName(),
+                10, // Same as default.
+                SECONDS);
+        // Define rate meters for non-existent method 'disabled', to override other grpc
+        // services' default rate meters -- defined in their rateMeteringInterceptor()
+        // methods.
+        String[] serviceClassNames = new String[]{
+                "GrpcGetTradeStatisticsService",
+                "GrpcHelpService",
+                "GrpcOffersService",
+                "GrpcPaymentAccountsService",
+                "GrpcPriceService",
+                "GrpcTradesService",
+                "GrpcWalletsService"
+        };
+        for (String service : serviceClassNames) {
+            builder.addCallRateMeter(service, "disabled", 1, MILLISECONDS);
+        }
+        File file = builder.build();
+        file.deleteOnExit();
+        return file;
+    }
+
+    public static boolean hasCallRateMeteringConfigPathOpt(String[] args) {
+        return stream(args).anyMatch(a -> a.contains("--" + CALL_RATE_METERING_CONFIG_PATH));
+    }
+
+    public static String[] appendCallRateMeteringConfigPathOpt(String[] args, File rateMeterInterceptorConfig) {
+        String[] rateMeteringConfigPathOpt = new String[]{
+                "--" + CALL_RATE_METERING_CONFIG_PATH + "=" + rateMeterInterceptorConfig.getAbsolutePath()
+        };
+        if (args.length == 0) {
+            return rateMeteringConfigPathOpt;
+        } else {
+            String[] appendedOpts = new String[args.length + 1];
+            arraycopy(args, 0, appendedOpts, 0, args.length);
+            arraycopy(rateMeteringConfigPathOpt, 0, appendedOpts, args.length, rateMeteringConfigPathOpt.length);
+            return appendedOpts;
+        }
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -31,6 +31,7 @@ import java.io.PrintWriter;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static bisq.apitest.config.ApiTestRateMeterInterceptorConfig.getTestRateMeterInterceptorConfig;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.stream;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -49,15 +50,6 @@ public class MethodTest extends ApiTestCase {
 
     public static void startSupportingApps(File callRateMeteringConfigFile,
                                            boolean generateBtcBlock,
-                                           Enum<?>... supportingApps) {
-        startSupportingApps(callRateMeteringConfigFile,
-                generateBtcBlock,
-                false,
-                supportingApps);
-    }
-
-    public static void startSupportingApps(File callRateMeteringConfigFile,
-                                           boolean generateBtcBlock,
                                            boolean startSupportingAppsInDebugMode,
                                            Enum<?>... supportingApps) {
         try {
@@ -73,18 +65,11 @@ public class MethodTest extends ApiTestCase {
     }
 
     public static void startSupportingApps(boolean generateBtcBlock,
-                                           Enum<?>... supportingApps) {
-        startSupportingApps(generateBtcBlock,
-                false,
-                supportingApps);
-    }
-
-    public static void startSupportingApps(boolean generateBtcBlock,
                                            boolean startSupportingAppsInDebugMode,
                                            Enum<?>... supportingApps) {
         try {
             // Disable call rate metering where there is no callRateMeteringConfigFile.
-            File callRateMeteringConfigFile = defaultRateMeterInterceptorConfig();
+            File callRateMeteringConfigFile = getTestRateMeterInterceptorConfig();
             setUpScaffold(new String[]{
                     "--supportingApps", toNameList.apply(supportingApps),
                     "--callRateMeteringConfigPath", callRateMeteringConfigFile.getAbsolutePath(),

--- a/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static bisq.apitest.Scaffold.BitcoinCoreApp.bitcoind;
+import static bisq.apitest.config.ApiTestRateMeterInterceptorConfig.getTestRateMeterInterceptorConfig;
 import static bisq.apitest.config.BisqAppConfig.alicedaemon;
 import static bisq.apitest.config.BisqAppConfig.arbdaemon;
 import static bisq.apitest.config.BisqAppConfig.seednode;
@@ -54,7 +55,7 @@ public class StartupTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         try {
-            callRateMeteringConfigFile = defaultRateMeterInterceptorConfig();
+            callRateMeteringConfigFile = getTestRateMeterInterceptorConfig();
             startSupportingApps(callRateMeteringConfigFile,
                     false,
                     false,


### PR DESCRIPTION
Ad-hoc API testers need to be able to run the test harness without interference from the production api method call rate meters.  This change overrides and disables most call rate meters when the test harness is run from the `ApiTestMain` driver (no jupiter tests).