### PR TITLE
Add bitcoinj Tor v3 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ configure(subprojects) {
 
     ext { // in alphabetical order
         bcVersion = '1.63'
-        bitcoinjVersion = '2a80db4'
+        bitcoinjVersion = '44d038d'
         codecVersion = '1.13'
         easybindVersion = '1.0.3'
         easyVersion = '4.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ configure(subprojects) {
 
     ext { // in alphabetical order
         bcVersion = '1.63'
-        bitcoinjVersion = '44d038d'
+        bitcoinjVersion = '3186b20'
         codecVersion = '1.13'
         easybindVersion = '1.0.3'
         easyVersion = '4.0.1'

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -29,7 +29,7 @@ dependencyVerification {
         'com.github.bisq-network.tor-binary:tor-binary-linux64:d5c1d54b2c2323ac1124435be633c7822a28e6fe9160486d03102cc2b444df24',
         'com.github.bisq-network.tor-binary:tor-binary-macos:6216d66241e020fec1a55648d7176ef64959e094c493df8f49e7e8e8f62fe1e1',
         'com.github.bisq-network.tor-binary:tor-binary-windows:28a1031d7610863f774eedbd00b83b06b132781c31077b805033299de3e3a263',
-        'com.github.bisq-network:bitcoinj:6ee51c893d97eae6d548bd34c738028511f31a0f472fcb71a0ec5cfed5c6f035',
+        'com.github.bisq-network:bitcoinj:59e4d2370fcbfe38f9f3f01f0830f4b5c0448cd27c867ea4eb23457a79d83c0b',
         'com.github.bisq-network:jsonrpc4j:842b4a660440ef53cd436da2e21c3e1fed939b620a3fc7542307deb3e77fdeb6',
         'com.github.ravn:jsocks:3c71600af027b2b6d4244e4ad14d98ff2352a379410daebefff5d8cd48d742a4',
         'com.google.android:annotations:ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15',

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -29,7 +29,7 @@ dependencyVerification {
         'com.github.bisq-network.tor-binary:tor-binary-linux64:d5c1d54b2c2323ac1124435be633c7822a28e6fe9160486d03102cc2b444df24',
         'com.github.bisq-network.tor-binary:tor-binary-macos:6216d66241e020fec1a55648d7176ef64959e094c493df8f49e7e8e8f62fe1e1',
         'com.github.bisq-network.tor-binary:tor-binary-windows:28a1031d7610863f774eedbd00b83b06b132781c31077b805033299de3e3a263',
-        'com.github.bisq-network:bitcoinj:65ed08fa5777ea4a08599bdd575e7dc1f4ba2d4d5835472551439d6f6252e68a',
+        'com.github.bisq-network:bitcoinj:6ee51c893d97eae6d548bd34c738028511f31a0f472fcb71a0ec5cfed5c6f035',
         'com.github.bisq-network:jsonrpc4j:842b4a660440ef53cd436da2e21c3e1fed939b620a3fc7542307deb3e77fdeb6',
         'com.github.ravn:jsocks:3c71600af027b2b6d4244e4ad14d98ff2352a379410daebefff5d8cd48d742a4',
         'com.google.android:annotations:ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15',


### PR DESCRIPTION
This is atm only for those who want to help with testing our new bitcoinj fork on Regtest. If you want to test Tor v3 addresses against Mainnet only do it with a fresh data directory and DO NOT try to use it for real transactions as we haven't done intensive testing yet (only automated Regtest testing)

If you need a Bitcoin Core Node Tor v3 address for testing you can use mine (this is one of the federated Bitcoin core ndoes): `catlnkpdm454ecngktyo4z22m5dlcvfvgzz4nt5l36eeczecrafslkqd.onion`

e.g. use `--btcNodes=catlnkpdm454ecngktyo4z22m5dlcvfvgzz4nt5l36eeczecrafslkqd.onion` as startup argument.

Afterwards you should see following in your Network Info Tab

![Bildschirmfoto 2021-09-09 um 11 40 16](https://user-images.githubusercontent.com/170962/132663501-2d8fb995-922f-4243-980e-212ac1120f4b.png)


