### PR TITLE
CLI bug fix: show trade's contract volume, not moving offer volume

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -781,7 +781,7 @@ public class CliMain {
             stream.println();
             stream.format(rowFormat, editoffer.name(), "--offer-id=<offer-id> \\", "Edit offer with id");
             stream.format(rowFormat, "", "[--fixed-price=<price>] \\", "");
-            stream.format(rowFormat, "", "[--market-price=margin=<percent>] \\", "");
+            stream.format(rowFormat, "", "[--market-price-margin=<percent>] \\", "");
             stream.format(rowFormat, "", "[--trigger-price=<price>] \\", "");
             stream.format(rowFormat, "", "[--enabled=<true|false>]", "");
             stream.println();

--- a/cli/src/main/java/bisq/cli/TradeFormat.java
+++ b/cli/src/main/java/bisq/cli/TradeFormat.java
@@ -164,7 +164,7 @@ public class TradeFormat {
     private static final Function<TradeInfo, String> amountFormat = (t) ->
             t.getOffer().getBaseCurrencyCode().equals("BTC")
                     ? formatSatoshis(t.getTradeAmountAsLong())
-                    : formatCryptoCurrencyOfferVolume(t.getOffer().getVolume());
+                    : formatCryptoCurrencyOfferVolume(t.getTradeVolume());
 
     private static final BiFunction<TradeInfo, Boolean, String> makerTakerMinerTxFeeFormat = (t, isTaker) -> {
         if (isTaker) {

--- a/cli/src/main/java/bisq/cli/TradeFormat.java
+++ b/cli/src/main/java/bisq/cli/TradeFormat.java
@@ -159,7 +159,7 @@ public class TradeFormat {
     private static final Function<TradeInfo, String> priceFormat = (t) ->
             t.getOffer().getBaseCurrencyCode().equals("BTC")
                     ? formatPrice(t.getTradePrice())
-                    : formatCryptoCurrencyPrice(t.getOffer().getPrice());
+                    : formatCryptoCurrencyPrice(t.getTradePrice());
 
     private static final Function<TradeInfo, String> amountFormat = (t) ->
             t.getOffer().getBaseCurrencyCode().equals("BTC")

--- a/cli/src/main/java/bisq/cli/TradeFormat.java
+++ b/cli/src/main/java/bisq/cli/TradeFormat.java
@@ -188,7 +188,7 @@ public class TradeFormat {
 
     private static final Function<TradeInfo, String> tradeCostFormat = (t) ->
             t.getOffer().getBaseCurrencyCode().equals("BTC")
-                    ? formatOfferVolume(t.getOffer().getVolume())
+                    ? formatOfferVolume(t.getTradeVolume())
                     : formatSatoshis(t.getTradeAmountAsLong());
 
     private static final BiFunction<TradeInfo, Boolean, String> bsqReceiveAddress = (t, showBsqBuyerAddress) -> {

--- a/core/src/main/java/bisq/core/api/model/TradeInfo.java
+++ b/core/src/main/java/bisq/core/api/model/TradeInfo.java
@@ -51,6 +51,7 @@ public class TradeInfo implements Payload {
     private final String payoutTxId;
     private final long tradeAmountAsLong;
     private final long tradePrice;
+    private final long tradeVolume;
     private final String tradingPeerNodeAddress;
     private final String state;
     private final String phase;
@@ -78,6 +79,7 @@ public class TradeInfo implements Payload {
         this.payoutTxId = builder.payoutTxId;
         this.tradeAmountAsLong = builder.tradeAmountAsLong;
         this.tradePrice = builder.tradePrice;
+        this.tradeVolume = builder.tradeVolume;
         this.tradingPeerNodeAddress = builder.tradingPeerNodeAddress;
         this.state = builder.state;
         this.phase = builder.phase;
@@ -133,6 +135,7 @@ public class TradeInfo implements Payload {
                 .withPayoutTxId(trade.getPayoutTxId())
                 .withTradeAmountAsLong(trade.getTradeAmountAsLong())
                 .withTradePrice(trade.getTradePrice().getValue())
+                .withTradeVolume(trade.getTradeVolume() == null ? 0 : trade.getTradeVolume().getValue())
                 .withTradingPeerNodeAddress(Objects.requireNonNull(
                         trade.getTradingPeerNodeAddress()).getHostNameWithoutPostFix())
                 .withState(trade.getState().name())
@@ -169,6 +172,7 @@ public class TradeInfo implements Payload {
                 .setPayoutTxId(payoutTxId == null ? "" : payoutTxId)
                 .setTradeAmountAsLong(tradeAmountAsLong)
                 .setTradePrice(tradePrice)
+                .setTradeVolume(tradeVolume)
                 .setTradingPeerNodeAddress(tradingPeerNodeAddress)
                 .setState(state)
                 .setPhase(phase)
@@ -199,6 +203,7 @@ public class TradeInfo implements Payload {
                 .withPayoutTxId(proto.getPayoutTxId())
                 .withTradeAmountAsLong(proto.getTradeAmountAsLong())
                 .withTradePrice(proto.getTradePrice())
+                .withTradeVolume(proto.getTradeVolume())
                 .withTradePeriodState(proto.getTradePeriodState())
                 .withState(proto.getState())
                 .withPhase(proto.getPhase())
@@ -234,6 +239,7 @@ public class TradeInfo implements Payload {
         private String payoutTxId;
         private long tradeAmountAsLong;
         private long tradePrice;
+        private long tradeVolume;
         private String tradingPeerNodeAddress;
         private String state;
         private String phase;
@@ -309,6 +315,11 @@ public class TradeInfo implements Payload {
 
         public TradeInfoBuilder withTradePrice(long tradePrice) {
             this.tradePrice = tradePrice;
+            return this;
+        }
+
+        public TradeInfoBuilder withTradeVolume(long tradeVolume) {
+            this.tradeVolume = tradeVolume;
             return this;
         }
 
@@ -392,6 +403,7 @@ public class TradeInfo implements Payload {
                 ", payoutTxId='" + payoutTxId + '\'' + "\n" +
                 ", tradeAmountAsLong='" + tradeAmountAsLong + '\'' + "\n" +
                 ", tradePrice='" + tradePrice + '\'' + "\n" +
+                ", tradeVolume='" + tradeVolume + '\'' + "\n" +
                 ", tradingPeerNodeAddress='" + tradingPeerNodeAddress + '\'' + "\n" +
                 ", state='" + state + '\'' + "\n" +
                 ", phase='" + phase + '\'' + "\n" +

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -409,6 +409,7 @@ message TradeInfo {
     bool isWithdrawn = 23;
     string contractAsJson = 24;
     ContractInfo contract = 25;
+    uint64 tradeVolume = 26;
 }
 
 message ContractInfo {


### PR DESCRIPTION
This fixes a an API CLI `gettrade` bug that could have resulted in loss of funds (explained below).  
There are two minor changes:

- Show correct, frozen `Buyer Cost` (trade volume, not offer volume) in CLI console.
This corrects the CLI's displayed fiat trade cost value, which should be trade.volume, not offer.volume.  Offer volume varies with BTC volatility, and the CLI should be showing the trade.volume value instead, frozen when the contract was made.

- Show correct, frozen altcoin `Amount`  (trade volume, not offer volume) in CLI console.
This corrects the CLI's displayed altcoin trade amount value, which should be trade.volume, not offer.volume.  The bug has been hidden by the stability of the BSQ price, and exposed while testing API support for XMR trades.

**The bug could have resulted in loss of funds for traders who used the API to buy BTC in the following scenario:**

	(1) A trader made or took a market-price-margin based offer to buy BTC, using the API.
	
	(2) The BTC price was volatile between the time the trade was taken and the payment was sent.
	
	(3) The payer did not pay the amount shown by the API CLI at the time the trade was created.

		She waited, then returned to the API to find out how much to pay -- minutes to days 
		after the contract was created -- when the trade price (volume) was frozen.  The CLI
		would have shown her a different amount in the `Buyer Cost` column than it showed 
		immediately after the trade was created.

The CLI's `gettrade` command has been showing the moving offer volume in the `Buyer Cost` column -- how 
much the buyer pays.  This value varies with BTC price if the offer is market-price-margin based.

The CLI should be showing the constant trade volume, frozen at the time a trade contract is written.

This bug does not affect BSQ trading because all BSQ trades are at fixed prices.
This bug would have affected XMR trading if the fix was not applied before XMR trading support in the API is released.

To check to see if you paid too much or too little, you could use the desktop app to view your trade history,
and match the correct payment amounts to your bank transfer records.