### PR TITLE
Add custom bisq.properties to API test harness

### DIFF
--- a/apitest/src/main/resources/bisq.properties
+++ b/apitest/src/main/resources/bisq.properties
@@ -1,0 +1,7 @@
+# Bisq core properties file loaded by Bisq instances started by the test harness.
+# Normally, it would be left empty, but it is useful for ad-hoc testing with
+# Bisq Config options not configurable in test harness-specific apitest.properties
+# file.  This is where you might define Bisq options such as:
+#   dumpBlockchainData=true
+#   dumpDelayedPayoutTxs=true
+#   dumpStatistics=true


### PR DESCRIPTION
This change adds a `bisq.properties` file to `apitest/src/main/resources`, and makes sure it is copied to regtest/dev bisq instances' app data dirs before they are started.  By default it is empty, but can be used to override default BisqApp options during ad-hoc testing.

The change was necessary because the core's `bisq.properties` resource is not copied to test harness bisq instance's regtest data dirs during a normal build.

This PR's branch is based off `master`, is not part of any series of PRs requiring reviewing and merging in chronological order.

