### PR TITLE
Disable GC calls if fullDaoNode is set (like in case of seed nodes)

### DIFF
--- a/common/src/main/java/bisq/common/setup/CommonSetup.java
+++ b/common/src/main/java/bisq/common/setup/CommonSetup.java
@@ -57,6 +57,9 @@ public class CommonSetup {
         Profiler.printSystemLoad();
         Profiler.printSystemLoadPeriodically(10, TimeUnit.MINUTES);
 
+        // Full DAO nodes (like seed nodes) do not use the GC triggers as it is expected they have sufficient RAM allocated.
+        GcUtil.setDISABLE_GC_CALLS(config.fullDaoNode);
+
         GcUtil.autoReleaseMemory();
 
         setSystemProperties();

--- a/common/src/main/java/bisq/common/util/GcUtil.java
+++ b/common/src/main/java/bisq/common/util/GcUtil.java
@@ -19,29 +19,41 @@ package bisq.common.util;
 
 import bisq.common.UserThread;
 
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class GcUtil {
-    public static void autoReleaseMemory() {
-        autoReleaseMemory(1000);
-    }
+    @Setter
+    private static boolean DISABLE_GC_CALLS = false;
+    private static int TRIGGER_MEM = 1000;
+    private static int TRIGGER_MAX_MEM = 3000;
 
-    /**
-     * @param trigger  Threshold for free memory in MB when we invoke the garbage collector
-     */
-    public static void autoReleaseMemory(long trigger) {
-        UserThread.runPeriodically(() -> maybeReleaseMemory(trigger), 60);
+    public static void autoReleaseMemory() {
+        if (DISABLE_GC_CALLS)
+            return;
+
+        autoReleaseMemory(TRIGGER_MEM);
     }
 
     public static void maybeReleaseMemory() {
-        maybeReleaseMemory(3000);
+        if (DISABLE_GC_CALLS)
+            return;
+
+        maybeReleaseMemory(TRIGGER_MAX_MEM);
     }
 
     /**
      * @param trigger  Threshold for free memory in MB when we invoke the garbage collector
      */
-    public static void maybeReleaseMemory(long trigger) {
+    private static void autoReleaseMemory(long trigger) {
+        UserThread.runPeriodically(() -> maybeReleaseMemory(trigger), 60);
+    }
+
+    /**
+     * @param trigger  Threshold for free memory in MB when we invoke the garbage collector
+     */
+    private static void maybeReleaseMemory(long trigger) {
         long totalMemory = Runtime.getRuntime().totalMemory();
         if (totalMemory > trigger * 1024 * 1024) {
             log.info("Invoke garbage collector. Total memory: {} {} {}", Utilities.readableFileSize(totalMemory), totalMemory, trigger * 1024 * 1024);


### PR DESCRIPTION
Seed nodes have 4 GB allocated so the attempt to reduce memory
footprint is not needed for those cases. We use the fullDaoNode
prog arg as its expected that any full node will have allocated
sufficient memory and thus the intended reduction of memory by
calling the GC is not required and counter productive.