### PR TITLE
Move volume formatting from DisplayUtils to VolumeUtil

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -30,7 +30,6 @@ import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.TxDetailsBsq;
 import bisq.desktop.main.overlays.windows.TxInputSelectionWindow;
 import bisq.desktop.main.overlays.windows.WalletPasswordWindow;
-import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.FormBuilder;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
@@ -54,6 +53,7 @@ import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.coin.CoinUtil;
@@ -256,7 +256,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
     }
 
     public void fillFromTradeData(Tuple2<Volume, String> tuple) {
-        amountInputTextField.setText(DisplayUtils.formatVolume(tuple.first));
+        amountInputTextField.setText(VolumeUtil.formatVolume(tuple.first));
         receiversAddressInputTextField.setText(tuple.second);
     }
 
@@ -528,7 +528,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
     private void doWithdraw(Transaction txWithBtcFee, TxType txType, TxBroadcaster.Callback callback) {
         if (btcWalletService.isEncrypted()) {
             UserThread.runAfter(() -> walletPasswordWindow.onAesKey(aesKey ->
-                    sendFunds(txWithBtcFee, txType, callback))
+                            sendFunds(txWithBtcFee, txType, callback))
                     .show(), 300, TimeUnit.MILLISECONDS);
         } else {
             sendFunds(txWithBtcFee, txType, callback);

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -39,6 +39,7 @@ import bisq.core.offer.OfferPayload;
 import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.trade.statistics.TradeStatistics3StorageService;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.util.Utilities;
@@ -198,7 +199,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                             .append("Market: ").append(CurrencyUtil.getCurrencyPair(tradeStatistics3.getCurrency())).append("\n")
                             .append("Price: ").append(FormattingUtils.formatPrice(tradeStatistics3.getTradePrice())).append("\n")
                             .append("Amount: ").append(formatter.formatCoin(tradeStatistics3.getTradeAmount())).append("\n")
-                            .append("Volume: ").append(DisplayUtils.formatVolume(tradeStatistics3.getTradeVolume())).append("\n")
+                            .append("Volume: ").append(VolumeUtil.formatVolume(tradeStatistics3.getTradeVolume())).append("\n")
                             .append("Payment method: ").append(Res.get(tradeStatistics3.getPaymentMethod())).append("\n")
                             .append("ReferralID: ").append(tradeStatistics3.getExtraDataMap().get(OfferPayload.REFERRAL_ID));
                     return sb.toString();

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -39,6 +39,7 @@ import bisq.core.locale.Res;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
@@ -88,10 +89,10 @@ import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
-import java.text.DecimalFormat;
-
 import javafx.util.Callback;
 import javafx.util.StringConverter;
+
+import java.text.DecimalFormat;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -140,7 +141,9 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    public OfferBookChartView(OfferBookChartViewModel model, Navigation navigation, @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
+    public OfferBookChartView(OfferBookChartViewModel model,
+                              Navigation navigation,
+                              @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                               @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
         super(model);
         this.navigation = navigation;
@@ -230,7 +233,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                             final double doubleValue = (double) object;
                             if (CurrencyUtil.isCryptoCurrency(model.getCurrencyCode())) {
                                 final String withCryptoPrecision = FormattingUtils.formatRoundedDoubleWithPrecision(doubleValue, cryptoPrecision);
-                                if (withCryptoPrecision.substring(0,3).equals("0.0")) {
+                                if (withCryptoPrecision.substring(0, 3).equals("0.0")) {
                                     return FormattingUtils.formatRoundedDoubleWithPrecision(doubleValue, 8).replaceFirst("0+$", "");
                                 } else {
                                     return withCryptoPrecision.replaceFirst("0+$", "");
@@ -398,7 +401,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     List<XYChart.Data<Number, Number>> filterOutliersBuy(List<XYChart.Data<Number, Number>> buy, boolean isCrypto) {
         List<Double> mnmx = isCrypto ? minMaxFilterRight(buy) : minMaxFilterLeft(buy);
         if (mnmx.get(0).doubleValue() == Double.MAX_VALUE ||
-            mnmx.get(1).doubleValue() == Double.MIN_VALUE) { // no filtering
+                mnmx.get(1).doubleValue() == Double.MIN_VALUE) { // no filtering
             return buy;
         }
         // apply filtering
@@ -408,7 +411,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     List<XYChart.Data<Number, Number>> filterOutliersSell(List<XYChart.Data<Number, Number>> sell, boolean isCrypto) {
         List<Double> mnmx = isCrypto ? minMaxFilterLeft(sell) : minMaxFilterRight(sell);
         if (mnmx.get(0).doubleValue() == Double.MAX_VALUE ||
-            mnmx.get(1).doubleValue() == Double.MIN_VALUE) { // no filtering
+                mnmx.get(1).doubleValue() == Double.MIN_VALUE) { // no filtering
             return sell;
         }
         // apply filtering
@@ -417,43 +420,43 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
 
     private List<Double> minMaxFilterLeft(List<XYChart.Data<Number, Number>> data) {
         double maxValue = data.stream()
-            .mapToDouble(o -> o.getXValue().doubleValue())
-            .max()
-            .orElse(Double.MIN_VALUE);
+                .mapToDouble(o -> o.getXValue().doubleValue())
+                .max()
+                .orElse(Double.MIN_VALUE);
         // Hide offers less than a div-factor of dataLimitFactor lower than the highest offer.
         double minValue = data.stream()
-            .mapToDouble(o -> o.getXValue().doubleValue())
-            .filter(o -> o > maxValue / dataLimitFactor)
-            .min()
-            .orElse(Double.MAX_VALUE);
+                .mapToDouble(o -> o.getXValue().doubleValue())
+                .filter(o -> o > maxValue / dataLimitFactor)
+                .min()
+                .orElse(Double.MAX_VALUE);
         return List.of(minValue, maxValue);
     }
 
     private List<Double> minMaxFilterRight(List<XYChart.Data<Number, Number>> data) {
         double minValue = data.stream()
-            .mapToDouble(o -> o.getXValue().doubleValue())
-            .min()
-            .orElse(Double.MAX_VALUE);
+                .mapToDouble(o -> o.getXValue().doubleValue())
+                .min()
+                .orElse(Double.MAX_VALUE);
 
         // Hide offers a dataLimitFactor factor higher than the lowest offer
         double maxValue = data.stream()
-            .mapToDouble(o -> o.getXValue().doubleValue())
-            .filter(o -> o < minValue * dataLimitFactor)
-            .max()
-            .orElse(Double.MIN_VALUE);
+                .mapToDouble(o -> o.getXValue().doubleValue())
+                .filter(o -> o < minValue * dataLimitFactor)
+                .max()
+                .orElse(Double.MIN_VALUE);
         return List.of(minValue, maxValue);
     }
 
     private List<XYChart.Data<Number, Number>> filterLeft(List<XYChart.Data<Number, Number>> data, double maxValue) {
         return data.stream()
-            .filter(o -> o.getXValue().doubleValue() > maxValue / dataLimitFactor)
-            .collect(Collectors.toList());
+                .filter(o -> o.getXValue().doubleValue() > maxValue / dataLimitFactor)
+                .collect(Collectors.toList());
     }
 
     private List<XYChart.Data<Number, Number>> filterRight(List<XYChart.Data<Number, Number>> data, double minValue) {
         return data.stream()
-            .filter(o -> o.getXValue().doubleValue() < minValue * dataLimitFactor)
-            .collect(Collectors.toList());
+                .filter(o -> o.getXValue().doubleValue() < minValue * dataLimitFactor)
+                .collect(Collectors.toList());
     }
 
     private Tuple4<TableView<OfferListItem>, VBox, Button, Label> getOfferTable(OfferPayload.Direction direction) {
@@ -479,7 +482,9 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                             private Offer offer;
                             final ChangeListener<Number> listener = new ChangeListener<>() {
                                 @Override
-                                public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+                                public void changed(ObservableValue<? extends Number> observable,
+                                                    Number oldValue,
+                                                    Number newValue) {
                                     if (offer != null && offer.getPrice() != null) {
                                         setText("");
                                         setGraphic(new ColoredDecimalPlacesWithZerosText(model.getPrice(offer),
@@ -529,7 +534,9 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                             private Offer offer;
                             final ChangeListener<Number> listener = new ChangeListener<>() {
                                 @Override
-                                public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+                                public void changed(ObservableValue<? extends Number> observable,
+                                                    Number oldValue,
+                                                    Number newValue) {
                                     if (offer != null && offer.getPrice() != null) {
                                         renderCellContentRange();
                                         model.priceFeedService.updateCounterProperty().removeListener(listener);
@@ -562,7 +569,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                              * Should not be called for empty cells
                              */
                             private void renderCellContentRange() {
-                                String volumeRange = DisplayUtils.formatVolume(offer, true, 2);
+                                String volumeRange = VolumeUtil.formatVolume(offer, true, 2);
 
                                 setText("");
                                 setGraphic(new ColoredDecimalPlacesWithZerosText(volumeRange,
@@ -711,8 +718,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                 if (buyOfferTableView.getHeight() != newTableViewHeight) {
                     buyOfferTableView.setMinHeight(newTableViewHeight);
                     sellOfferTableView.setMinHeight(newTableViewHeight);
-               }
+                }
             }
-       }, 100, TimeUnit.MILLISECONDS);
-   }
+        }, 100, TimeUnit.MILLISECONDS);
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -38,6 +38,7 @@ import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
+import bisq.core.util.VolumeUtil;
 
 import com.google.inject.Inject;
 
@@ -232,15 +233,20 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     }
 
     public Optional<CurrencyListItem> getSelectedCurrencyListItem() {
-        return currencyListItems.getObservableList().stream().filter(e -> e.tradeCurrency.equals(selectedTradeCurrencyProperty.get())).findAny();
+        return currencyListItems.getObservableList().stream()
+                .filter(e -> e.tradeCurrency.equals(selectedTradeCurrencyProperty.get())).findAny();
     }
 
     public int getMaxNumberOfPriceZeroDecimalsToColorize(Offer offer) {
-        return CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ? GUIUtil.FIAT_DECIMALS_WITH_ZEROS : GUIUtil.ALTCOINS_DECIMALS_WITH_ZEROS;
+        return CurrencyUtil.isFiatCurrency(offer.getCurrencyCode())
+                ? GUIUtil.FIAT_DECIMALS_WITH_ZEROS
+                : GUIUtil.ALTCOINS_DECIMALS_WITH_ZEROS;
     }
 
     public int getZeroDecimalsForPrice(Offer offer) {
-        return CurrencyUtil.isFiatCurrency(offer.getCurrencyCode()) ? GUIUtil.FIAT_PRICE_DECIMALS_WITH_ZEROS : GUIUtil.ALTCOINS_DECIMALS_WITH_ZEROS;
+        return CurrencyUtil.isFiatCurrency(offer.getCurrencyCode())
+                ? GUIUtil.FIAT_PRICE_DECIMALS_WITH_ZEROS
+                : GUIUtil.ALTCOINS_DECIMALS_WITH_ZEROS;
     }
 
     public String getPrice(Offer offer) {
@@ -248,7 +254,9 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     }
 
     private String formatPrice(Offer offer, boolean decimalAligned) {
-        return DisplayUtils.formatPrice(offer.getPrice(), decimalAligned, offer.isBuyOffer() ? maxPlacesForBuyPrice.get() : maxPlacesForSellPrice.get());
+        return DisplayUtils.formatPrice(offer.getPrice(), decimalAligned, offer.isBuyOffer()
+                ? maxPlacesForBuyPrice.get()
+                : maxPlacesForSellPrice.get());
     }
 
     public String getVolume(Offer offer) {
@@ -256,7 +264,10 @@ class OfferBookChartViewModel extends ActivatableViewModel {
     }
 
     private String formatVolume(Offer offer, boolean decimalAligned) {
-        return DisplayUtils.formatVolume(offer, decimalAligned, offer.isBuyOffer() ? maxPlacesForBuyVolume.get() : maxPlacesForSellVolume.get(), false);
+        return VolumeUtil.formatVolume(offer,
+                decimalAligned,
+                offer.isBuyOffer() ? maxPlacesForBuyVolume.get() : maxPlacesForSellVolume.get(),
+                false);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
@@ -23,6 +23,7 @@ import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import lombok.experimental.Delegate;
@@ -73,8 +74,8 @@ public class TradeStatistics3ListItem {
     public String getVolumeString() {
         if (volumeString == null) {
             volumeString = tradeStatistics3 != null ? showAllTradeCurrencies ?
-                    DisplayUtils.formatVolumeWithCode(tradeStatistics3.getTradeVolume()) :
-                    DisplayUtils.formatVolume(tradeStatistics3.getTradeVolume())
+                    VolumeUtil.formatVolumeWithCode(tradeStatistics3.getTradeVolume()) :
+                    VolumeUtil.formatVolume(tradeStatistics3.getTradeVolume())
                     : "";
         }
         return volumeString;

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -38,6 +38,7 @@ import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.user.CookieKey;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.UserThread;
@@ -570,7 +571,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             public String toString(Number volume) {
                 return currency.equals("BTC") ?
                         coinFormatter.formatCoin(Coin.valueOf(MathUtils.doubleToLong((double) volume))) :
-                        DisplayUtils.formatLargeFiatWithUnitPostFix((double) volume, "USD");
+                        VolumeUtil.formatLargeFiatWithUnitPostFix((double) volume, "USD");
             }
 
             @Override

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeBar.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/charts/volume/VolumeBar.java
@@ -18,9 +18,9 @@
 package bisq.desktop.main.market.trades.charts.volume;
 
 import bisq.desktop.main.market.trades.charts.CandleData;
-import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.Res;
+import bisq.core.util.VolumeUtil;
 
 import javafx.scene.Group;
 import javafx.scene.control.Tooltip;
@@ -57,7 +57,7 @@ public class VolumeBar extends Group {
     public void update(double height, double candleWidth, CandleData candleData) {
         bar.resizeRelocate(-candleWidth / 2, 0, candleWidth, height);
         String volumeInBtc = volumeStringConverter.toString(candleData.accumulatedAmount);
-        String volumeInUsd = DisplayUtils.formatLargeFiat(candleData.volumeInUsd, "USD");
+        String volumeInUsd = VolumeUtil.formatLargeFiat(candleData.volumeInUsd, "USD");
         tooltip.setText(Res.get("market.trades.tooltip.volumeBar", volumeInBtc, volumeInUsd, candleData.numTrades, candleData.date));
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/FeeUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/FeeUtil.java
@@ -23,6 +23,7 @@ import bisq.desktop.util.GUIUtil;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.OfferUtil;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.app.DevEnv;
@@ -65,9 +66,9 @@ public class FeeUtil {
                         " " + Res.get("guiUtil.ofTradeAmount");
             }
             return offerUtil.getFeeInUserFiatCurrency(tradeFee,
-                    isCurrencyForMakerFeeBtc,
-                    formatter)
-                    .map(DisplayUtils::formatAverageVolumeWithCode)
+                            isCurrencyForMakerFeeBtc,
+                            formatter)
+                    .map(VolumeUtil::formatAverageVolumeWithCode)
                     .map(feeInFiat -> Res.get("feeOptionWindow.btcFeeWithFiatAndPercentage", feeAsBtc, feeInFiat, percentage))
                     .orElseGet(() -> Res.get("feeOptionWindow.btcFeeWithPercentage", feeAsBtc, percentage));
         } else {

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -471,7 +471,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         volumeListener = (ov, oldValue, newValue) -> {
             ignoreVolumeStringListener = true;
             if (newValue != null)
-                volume.set(DisplayUtils.formatVolume(newValue));
+                volume.set(VolumeUtil.formatVolume(newValue));
             else
                 volume.set("");
 
@@ -758,7 +758,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
                 if (dataModel.getMinVolume().get() != null) {
                     InputValidator.ValidationResult minVolumeResult = isVolumeInputValid(
-                            DisplayUtils.formatVolume(dataModel.getMinVolume().get()));
+                            VolumeUtil.formatVolume(dataModel.getMinVolume().get()));
 
                     volumeValidationResult.set(minVolumeResult);
 
@@ -883,7 +883,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                     else if (CurrencyUtil.isFiatCurrency(tradeCurrencyCode.get()))
                         volume = VolumeUtil.getRoundedFiatVolume(volume);
 
-                    this.volume.set(DisplayUtils.formatVolume(volume));
+                    this.volume.set(VolumeUtil.formatVolume(volume));
                 }
 
                 ignoreVolumeStringListener = false;
@@ -1303,7 +1303,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 dataModel.getPrice().get() != null &&
                 dataModel.getPrice().get().getValue() != 0 &&
                 isVolumeInputValid(volume.get()).isValid &&
-                isVolumeInputValid(DisplayUtils.formatVolume(dataModel.getMinVolume().get())).isValid &&
+                isVolumeInputValid(VolumeUtil.formatVolume(dataModel.getMinVolume().get())).isValid &&
                 dataModel.isMinAmountLessOrEqualAmount();
 
         if (dataModel.useMarketBasedPrice.get() && dataModel.isMarketPriceAvailable()) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -50,6 +50,7 @@ import bisq.core.trade.closed.ClosedTradableManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 
@@ -435,7 +436,7 @@ class OfferBookViewModel extends ActivatableViewModel {
         if (offerVolume != null && minOfferVolume != null) {
             String postFix = showAllTradeCurrenciesProperty.get() ? " " + offer.getCurrencyCode() : "";
             decimalAligned = decimalAligned && !showAllTradeCurrenciesProperty.get();
-            return DisplayUtils.formatVolume(offer, decimalAligned, maxPlacesForVolume.get()) + postFix;
+            return VolumeUtil.formatVolume(offer, decimalAligned, maxPlacesForVolume.get()) + postFix;
         } else {
             return Res.get("shared.na");
         }

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -43,6 +43,7 @@ import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.trade.Trade;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.coin.CoinUtil;
@@ -475,7 +476,7 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void addBindings() {
-        volume.bind(createStringBinding(() -> DisplayUtils.formatVolume(dataModel.volume.get()), dataModel.volume));
+        volume.bind(createStringBinding(() -> VolumeUtil.formatVolume(dataModel.volume.get()), dataModel.volume));
 
         if (dataModel.getDirection() == OfferPayload.Direction.SELL) {
             volumeDescriptionLabel.set(Res.get("createOffer.amountPriceBox.buy.volumeDescription", dataModel.getCurrencyCode()));

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
@@ -39,6 +39,7 @@ import bisq.core.support.dispute.mediation.MediationManager;
 import bisq.core.support.dispute.refund.RefundManager;
 import bisq.core.trade.Contract;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
@@ -162,8 +163,10 @@ public class ContractWindow extends Overlay<ContractWindow> {
                 FormattingUtils.formatPrice(contract.getTradePrice()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradeAmount"),
                 formatter.formatCoinWithCode(contract.getTradeAmount()));
-        addConfirmationLabelLabel(gridPane, ++rowIndex, DisplayUtils.formatVolumeLabel(currencyCode, ":"),
-                DisplayUtils.formatVolumeWithCode(contract.getTradeVolume()));
+        addConfirmationLabelLabel(gridPane,
+                ++rowIndex,
+                VolumeUtil.formatVolumeLabel(currencyCode, ":"),
+                VolumeUtil.formatVolumeWithCode(contract.getTradeVolume()));
         String securityDeposit = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(offer.getBuyerSecurityDeposit()) +
@@ -172,28 +175,43 @@ public class ContractWindow extends Overlay<ContractWindow> {
                 " " +
                 formatter.formatCoinWithCode(offer.getSellerSecurityDeposit());
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.securityDeposit"), securityDeposit);
-        addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("contractWindow.btcAddresses"),
-                contract.getBuyerPayoutAddressString() + " / " +
-                        contract.getSellerPayoutAddressString()).second.setMouseTransparent(false);
-        addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("contractWindow.onions"),
+        addConfirmationLabelTextFieldWithCopyIcon(gridPane,
+                ++rowIndex,
+                Res.get("contractWindow.btcAddresses"),
+                contract.getBuyerPayoutAddressString() + " / " + contract.getSellerPayoutAddressString()).second.setMouseTransparent(false);
+        addConfirmationLabelTextFieldWithCopyIcon(gridPane,
+                ++rowIndex,
+                Res.get("contractWindow.onions"),
                 contract.getBuyerNodeAddress().getFullAddress() + " / " + contract.getSellerNodeAddress().getFullAddress());
 
-        addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("contractWindow.accountAge"),
-                getAccountAge(contract.getBuyerPaymentAccountPayload(), contract.getBuyerPubKeyRing(), offer.getCurrencyCode()) + " / " +
-                        getAccountAge(contract.getSellerPaymentAccountPayload(), contract.getSellerPubKeyRing(), offer.getCurrencyCode()));
+        addConfirmationLabelTextFieldWithCopyIcon(gridPane,
+                ++rowIndex,
+                Res.get("contractWindow.accountAge"),
+                getAccountAge(contract.getBuyerPaymentAccountPayload(),
+                        contract.getBuyerPubKeyRing(),
+                        offer.getCurrencyCode()) + " / " + getAccountAge(contract.getSellerPaymentAccountPayload(), contract.getSellerPubKeyRing(), offer.getCurrencyCode()));
 
         DisputeManager<? extends DisputeList<Dispute>> disputeManager = getDisputeManager(dispute);
         String nrOfDisputesAsBuyer = disputeManager != null ? disputeManager.getNrOfDisputes(true, contract) : "";
         String nrOfDisputesAsSeller = disputeManager != null ? disputeManager.getNrOfDisputes(false, contract) : "";
-        addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("contractWindow.numDisputes"),
+        addConfirmationLabelTextFieldWithCopyIcon(gridPane,
+                ++rowIndex,
+                Res.get("contractWindow.numDisputes"),
                 nrOfDisputesAsBuyer + " / " + nrOfDisputesAsSeller);
-
-        addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("shared.paymentDetails", Res.get("shared.buyer")),
-                contract.getBuyerPaymentAccountPayload() != null ?
-                        contract.getBuyerPaymentAccountPayload().getPaymentDetails() : "NA").second.setMouseTransparent(false);
-        addConfirmationLabelTextFieldWithCopyIcon(gridPane, ++rowIndex, Res.get("shared.paymentDetails", Res.get("shared.seller")),
-                sellerPaymentAccountPayload != null ?
-                        sellerPaymentAccountPayload.getPaymentDetails() : "NA").second.setMouseTransparent(false);
+        addConfirmationLabelTextFieldWithCopyIcon(gridPane,
+                ++rowIndex,
+                Res.get("shared.paymentDetails", Res.get("shared.buyer")),
+                contract.getBuyerPaymentAccountPayload() != null
+                        ? contract.getBuyerPaymentAccountPayload().getPaymentDetails()
+                        : "NA")
+                .second.setMouseTransparent(false);
+        addConfirmationLabelTextFieldWithCopyIcon(gridPane,
+                ++rowIndex,
+                Res.get("shared.paymentDetails", Res.get("shared.seller")),
+                sellerPaymentAccountPayload != null
+                        ? sellerPaymentAccountPayload.getPaymentDetails()
+                        : "NA")
+                .second.setMouseTransparent(false);
 
         String title = "";
         String agentKeyBaseUserName = "";
@@ -232,7 +250,10 @@ public class ContractWindow extends Overlay<ContractWindow> {
                 countries = CountryUtil.getCodesString(acceptedCountryCodes);
                 tooltip = new Tooltip(CountryUtil.getNamesByCodesString(acceptedCountryCodes));
             }
-            Label acceptedCountries = addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.acceptedTakerCountries"), countries).second;
+            Label acceptedCountries = addConfirmationLabelLabel(gridPane,
+                    ++rowIndex,
+                    Res.get("shared.acceptedTakerCountries"),
+                    countries).second;
             if (tooltip != null) acceptedCountries.setTooltip(new Tooltip());
         }
 
@@ -242,7 +263,10 @@ public class ContractWindow extends Overlay<ContractWindow> {
             } else if (offer.getPaymentMethod().equals(PaymentMethod.SPECIFIC_BANKS)) {
                 String value = Joiner.on(", ").join(acceptedBanks);
                 Tooltip tooltip = new Tooltip(Res.get("shared.acceptedBanks") + value);
-                Label acceptedBanksTextField = addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.acceptedBanks"), value).second;
+                Label acceptedBanksTextField = addConfirmationLabelLabel(gridPane,
+                        ++rowIndex,
+                        Res.get("shared.acceptedBanks"),
+                        value).second;
                 acceptedBanksTextField.setMouseTransparent(false);
                 acceptedBanksTextField.setTooltip(tooltip);
             }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -50,6 +50,7 @@ import bisq.core.trade.Contract;
 import bisq.core.trade.TradeDataValidation;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.coin.CoinUtil;
 
@@ -295,7 +296,7 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradePrice"),
                 FormattingUtils.formatPrice(contract.getTradePrice()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradeVolume"),
-                DisplayUtils.formatVolumeWithCode(contract.getTradeVolume()));
+                VolumeUtil.formatVolumeWithCode(contract.getTradeVolume()));
         String securityDeposit = Res.getWithColAndCap("shared.buyer") +
                 " " +
                 formatter.formatCoinWithCode(contract.getOfferPayload().getBuyerSecurityDeposit()) +

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/OfferDetailsWindow.java
@@ -28,7 +28,6 @@ import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
 
 import bisq.core.btc.wallet.BtcWalletService;
-import bisq.core.locale.BankUtil;
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Price;
@@ -39,6 +38,7 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.common.crypto.KeyRing;
@@ -208,20 +208,25 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
         if (takeOfferHandlerOptional.isPresent()) {
             addConfirmationLabelLabel(gridPane, ++rowIndex, btcAmount + btcDirectionInfo,
                     formatter.formatCoinWithCode(tradeAmount));
-            addConfirmationLabelLabel(gridPane, ++rowIndex, DisplayUtils.formatVolumeLabel(currencyCode) + fiatDirectionInfo,
-                    DisplayUtils.formatVolumeWithCode(offer.getVolumeByAmount(tradeAmount)));
+            addConfirmationLabelLabel(gridPane,
+                    ++rowIndex,
+                    VolumeUtil.formatVolumeLabel(currencyCode) + fiatDirectionInfo,
+                    VolumeUtil.formatVolumeWithCode(offer.getVolumeByAmount(tradeAmount)));
         } else {
             addConfirmationLabelLabel(gridPane, ++rowIndex, btcAmount + btcDirectionInfo,
                     formatter.formatCoinWithCode(offer.getAmount()));
             addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("offerDetailsWindow.minBtcAmount"),
                     formatter.formatCoinWithCode(offer.getMinAmount()));
-            String volume = DisplayUtils.formatVolumeWithCode(offer.getVolume());
+            String volume = VolumeUtil.formatVolumeWithCode(offer.getVolume());
             String minVolume = "";
             if (offer.getVolume() != null && offer.getMinVolume() != null &&
                     !offer.getVolume().equals(offer.getMinVolume()))
-                minVolume = " " + Res.get("offerDetailsWindow.min", DisplayUtils.formatVolumeWithCode(offer.getMinVolume()));
-            addConfirmationLabelLabel(gridPane, ++rowIndex,
-                    DisplayUtils.formatVolumeLabel(currencyCode) + fiatDirectionInfo, volume + minVolume);
+                minVolume = " " + Res.get("offerDetailsWindow.min",
+                        VolumeUtil.formatVolumeWithCode(offer.getMinVolume()));
+            addConfirmationLabelLabel(gridPane,
+                    ++rowIndex,
+                    VolumeUtil.formatVolumeLabel(currencyCode) + fiatDirectionInfo,
+                    volume + minVolume);
         }
 
         String priceLabel = Res.get("shared.price");

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SwiftPaymentDetails.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SwiftPaymentDetails.java
@@ -18,14 +18,15 @@
 package bisq.desktop.main.overlays.windows;
 
 import bisq.desktop.main.overlays.Overlay;
-import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.CountryUtil;
 import bisq.core.locale.Res;
 import bisq.core.payment.payload.SwiftAccountPayload;
 import bisq.core.trade.Trade;
+import bisq.core.util.VolumeUtil;
 
 import javafx.scene.control.Label;
+
 import javafx.geometry.Insets;
 
 import java.util.ArrayList;
@@ -72,7 +73,8 @@ public class SwiftPaymentDetails extends Overlay<SwiftPaymentDetails> {
         addTitledGroupBg(gridPane, ++rowIndex, rows, Res.get("payment.swift.headline"));
 
         gridPane.add(new Label(""), 0, ++rowIndex);  // spacer
-        addLabelsAndCopy(Res.get("portfolio.pending.step2_buyer.amountToTransfer"), DisplayUtils.formatVolumeWithCode(trade.getTradeVolume()));
+        addLabelsAndCopy(Res.get("portfolio.pending.step2_buyer.amountToTransfer"),
+                VolumeUtil.formatVolumeWithCode(trade.getTradeVolume()));
         addLabelsAndCopy(Res.get(SWIFT_CODE + BANKPOSTFIX), payload.getBankSwiftCode());
         addLabelsAndCopy(Res.get(SNAME + BANKPOSTFIX), payload.getBankName());
         addLabelsAndCopy(Res.get(BRANCH + BANKPOSTFIX), payload.getBankBranch());
@@ -85,7 +87,8 @@ public class SwiftPaymentDetails extends Overlay<SwiftPaymentDetails> {
             addLabelsAndCopy(Res.get(SNAME + INTERMEDIARYPOSTFIX), payload.getIntermediaryName());
             addLabelsAndCopy(Res.get(BRANCH + INTERMEDIARYPOSTFIX), payload.getIntermediaryBranch());
             addLabelsAndCopy(Res.get(ADDRESS + INTERMEDIARYPOSTFIX), cleanString(payload.getIntermediaryAddress()));
-            addLabelsAndCopy(Res.get(COUNTRY + INTERMEDIARYPOSTFIX), CountryUtil.getNameAndCode(payload.getIntermediaryCountryCode()));
+            addLabelsAndCopy(Res.get(COUNTRY + INTERMEDIARYPOSTFIX),
+                    CountryUtil.getNameAndCode(payload.getIntermediaryCountryCode()));
         }
 
         gridPane.add(new Label(""), 0, ++rowIndex);  // spacer

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -39,6 +39,7 @@ import bisq.core.trade.Trade;
 import bisq.core.trade.TradeManager;
 import bisq.core.trade.txproof.AssetTxProofResult;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
@@ -168,8 +169,8 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.btcAmount") + btcDirectionInfo,
                 formatter.formatCoinWithCode(trade.getTradeAmount()));
         addConfirmationLabelLabel(gridPane, ++rowIndex,
-                DisplayUtils.formatVolumeLabel(offer.getCurrencyCode()) + fiatDirectionInfo,
-                DisplayUtils.formatVolumeWithCode(trade.getTradeVolume()));
+                VolumeUtil.formatVolumeLabel(offer.getCurrencyCode()) + fiatDirectionInfo,
+                VolumeUtil.formatVolumeWithCode(trade.getTradeVolume()));
         addConfirmationLabelLabel(gridPane, ++rowIndex, Res.get("shared.tradePrice"),
                 FormattingUtils.formatPrice(trade.getTradePrice()));
         String paymentMethodText = Res.get(offer.getPaymentMethod().getId());

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesViewModel.java
@@ -32,6 +32,7 @@ import bisq.core.offer.OpenOffer;
 import bisq.core.trade.Tradable;
 import bisq.core.trade.Trade;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 
@@ -115,7 +116,7 @@ public class ClosedTradesViewModel extends ActivatableWithDataModel<ClosedTrades
         }
 
         Trade trade = (Trade) item.getTradable();
-        return DisplayUtils.formatVolume(trade.getTradeVolume(), appendCode);
+        return VolumeUtil.formatVolume(trade.getTradeVolume(), appendCode);
     }
 
     String getVolumeCurrency(ClosedTradableListItem item) {
@@ -289,7 +290,7 @@ public class ClosedTradesViewModel extends ActivatableWithDataModel<ClosedTrades
                 .map(volume -> {
                     return Res.get("closedTradesSummaryWindow.totalAmount.value",
                             btcFormatter.formatCoin(totalTradeAmount, true),
-                            DisplayUtils.formatVolumeWithCode(volume));
+                            VolumeUtil.formatVolumeWithCode(volume));
                 })
                 .orElse("");
     }
@@ -305,7 +306,7 @@ public class ClosedTradesViewModel extends ActivatableWithDataModel<ClosedTrades
                             } else {
                                 monetary = Fiat.valueOf(currencyCode, entry.getValue());
                             }
-                            return DisplayUtils.formatVolumeWithCode(new Volume(monetary));
+                            return VolumeUtil.formatVolumeWithCode(new Volume(monetary));
                         }
                 ));
     }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesViewModel.java
@@ -24,6 +24,7 @@ import bisq.desktop.util.DisplayUtils;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import com.google.inject.Inject;
@@ -37,7 +38,8 @@ class FailedTradesViewModel extends ActivatableWithDataModel<FailedTradesDataMod
 
 
     @Inject
-    public FailedTradesViewModel(FailedTradesDataModel dataModel, @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
+    public FailedTradesViewModel(FailedTradesDataModel dataModel,
+                                 @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
         super(dataModel);
 
         this.formatter = formatter;
@@ -64,7 +66,7 @@ class FailedTradesViewModel extends ActivatableWithDataModel<FailedTradesDataMod
 
     String getVolume(FailedTradesListItem item) {
         if (item != null && item.getTrade() != null)
-            return DisplayUtils.formatVolumeWithCode(item.getTrade().getTradeVolume());
+            return VolumeUtil.formatVolumeWithCode(item.getTrade().getTradeVolume());
         else
             return "";
     }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
@@ -29,6 +29,7 @@ import bisq.core.monetary.Price;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OpenOffer;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 
@@ -125,7 +126,9 @@ class OpenOffersViewModel extends ActivatableWithDataModel<OpenOffersDataModel> 
     }
 
     String getVolume(OpenOfferListItem item) {
-        return (item != null) ? DisplayUtils.formatVolume(item.getOffer(), false, 0) + " " + item.getOffer().getCurrencyCode() : "";
+        return (item != null) ?
+                VolumeUtil.formatVolume(item.getOffer(), false, 0) + " " + item.getOffer().getCurrencyCode()
+                : "";
     }
 
     String getDirectionLabel(OpenOfferListItem item) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersViewModel.java
@@ -126,8 +126,8 @@ class OpenOffersViewModel extends ActivatableWithDataModel<OpenOffersDataModel> 
     }
 
     String getVolume(OpenOfferListItem item) {
-        return (item != null) ?
-                VolumeUtil.formatVolume(item.getOffer(), false, 0) + " " + item.getOffer().getCurrencyCode()
+        return (item != null)
+                ? VolumeUtil.formatVolume(item.getOffer(), false, 0) + " " + item.getOffer().getCurrencyCode()
                 : "";
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -44,6 +44,7 @@ import bisq.core.trade.Contract;
 import bisq.core.trade.Trade;
 import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
 import bisq.network.p2p.NodeAddress;
@@ -388,7 +389,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
 
     private void onShowInfoForInvalidTrade(Trade trade) {
         new Popup().width(900).attention(Res.get("portfolio.pending.failedTrade.info.popup",
-                getInvalidTradeDetails(trade)))
+                        getInvalidTradeDetails(trade)))
                 .show();
     }
 
@@ -736,7 +737,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                                 super.updateItem(item, empty);
                                 if (item != null && !empty) {
                                     try {
-                                        String volume = DisplayUtils.formatVolumeWithCode(item.getTrade().getTradeVolume());
+                                        String volume = VolumeUtil.formatVolumeWithCode(item.getTrade().getTradeVolume());
                                         setGraphic(new AutoTooltipLabel(volume));
                                     } catch (Throwable ignore) {
                                         log.debug(ignore.toString()); // Stupidity to make Codacy happy

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -38,6 +38,7 @@ import bisq.core.trade.TradeUtil;
 import bisq.core.trade.closed.ClosedTradableManager;
 import bisq.core.user.User;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.BtcAddressValidator;
@@ -309,7 +310,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
 
     public String getFiatVolume() {
         return dataModel.getTrade() != null
-                ? DisplayUtils.formatVolumeWithCode(dataModel.getTrade().getTradeVolume())
+                ? VolumeUtil.formatVolumeWithCode(dataModel.getTrade().getTradeVolume())
                 : "";
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -70,7 +70,6 @@ import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.SetXmrTxKeyWindow;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import bisq.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
-import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.Layout;
 import bisq.desktop.util.Transitions;
 
@@ -95,6 +94,7 @@ import bisq.core.payment.payload.WesternUnionAccountPayload;
 import bisq.core.trade.Trade;
 import bisq.core.trade.TradeDataValidation;
 import bisq.core.user.DontShowAgainLookup;
+import bisq.core.util.VolumeUtil;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
@@ -601,7 +601,7 @@ public class BuyerStep2View extends TradeStepView {
             String refTextWarn = Res.get("portfolio.pending.step2_buyer.refTextWarn");
             String fees = Res.get("portfolio.pending.step2_buyer.fees");
             String id = trade.getShortId();
-            String amount = DisplayUtils.formatVolumeWithCode(trade.getTradeVolume());
+            String amount = VolumeUtil.formatVolumeWithCode(trade.getTradeVolume());
             if (paymentAccountPayload instanceof AssetsAccountPayload) {
                 message += Res.get("portfolio.pending.step2_buyer.altcoin",
                         getCurrencyName(trade),

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -24,9 +24,7 @@ import bisq.desktop.components.indicator.TxConfidenceIndicator;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import bisq.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
-import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
-import bisq.desktop.util.Layout;
 
 import bisq.core.locale.Res;
 import bisq.core.payment.PaymentAccount;
@@ -48,6 +46,7 @@ import bisq.core.trade.Contract;
 import bisq.core.trade.Trade;
 import bisq.core.trade.txproof.AssetTxProofResult;
 import bisq.core.user.DontShowAgainLookup;
+import bisq.core.util.VolumeUtil;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
@@ -75,6 +74,9 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import static bisq.desktop.util.FormBuilder.*;
+import static bisq.desktop.util.Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE;
+import static bisq.desktop.util.Layout.COMPACT_GROUP_DISTANCE;
+import static bisq.desktop.util.Layout.FLOATING_LABEL_DISTANCE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SellerStep3View extends TradeStepView {
@@ -195,11 +197,11 @@ public class SellerStep3View extends TradeStepView {
         addTradeInfoBlock();
 
         addTitledGroupBg(gridPane, ++gridRow, 3,
-                Res.get("portfolio.pending.step3_seller.confirmPaymentReceipt"), Layout.COMPACT_GROUP_DISTANCE);
+                Res.get("portfolio.pending.step3_seller.confirmPaymentReceipt"), COMPACT_GROUP_DISTANCE);
 
         TextFieldWithCopyIcon field = addTopLabelTextFieldWithCopyIcon(gridPane, gridRow,
                 Res.get("portfolio.pending.step3_seller.amountToReceive"),
-                model.getFiatVolume(), Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE).second;
+                model.getFiatVolume(), COMPACT_FIRST_ROW_AND_GROUP_DISTANCE).second;
         field.setCopyWithoutCurrencyPostFix(true);
 
         String myPaymentDetails = "";
@@ -250,7 +252,7 @@ public class SellerStep3View extends TradeStepView {
             assetTxConfidenceIndicator.setTooltip(new Tooltip());
             assetTxProofResultField.setContentForInfoPopOver(createPopoverLabel(Res.get("setting.info.msg")));
 
-            HBox.setMargin(assetTxConfidenceIndicator, new Insets(Layout.FLOATING_LABEL_DISTANCE, 0, 0, 0));
+            HBox.setMargin(assetTxConfidenceIndicator, new Insets(FLOATING_LABEL_DISTANCE, 0, 0, 0));
 
             HBox hBox = new HBox();
             HBox.setHgrow(vBox, Priority.ALWAYS);
@@ -259,7 +261,10 @@ public class SellerStep3View extends TradeStepView {
 
             GridPane.setRowIndex(hBox, gridRow);
             GridPane.setColumnIndex(hBox, 1);
-            GridPane.setMargin(hBox, new Insets(Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE + Layout.FLOATING_LABEL_DISTANCE, 0, 0, 0));
+            GridPane.setMargin(hBox, new Insets(COMPACT_FIRST_ROW_AND_GROUP_DISTANCE + FLOATING_LABEL_DISTANCE,
+                    0,
+                    0,
+                    0));
             gridPane.getChildren().add(hBox);
         }
 
@@ -397,7 +402,7 @@ public class SellerStep3View extends TradeStepView {
         PaymentAccountPayload paymentAccountPayload = model.dataModel.getSellersPaymentAccountPayload();
         String key = "confirmPayment" + trade.getId();
         String message = "";
-        String tradeVolumeWithCode = DisplayUtils.formatVolumeWithCode(trade.getTradeVolume());
+        String tradeVolumeWithCode = VolumeUtil.formatVolumeWithCode(trade.getTradeVolume());
         String currencyName = getCurrencyName(trade);
         String part1 = Res.get("portfolio.pending.step3_seller.part", currencyName);
         if (paymentAccountPayload instanceof AssetsAccountPayload) {
@@ -405,12 +410,17 @@ public class SellerStep3View extends TradeStepView {
             String explorerOrWalletString = isXmrTrade() ?
                     Res.get("portfolio.pending.step3_seller.altcoin.wallet", currencyName) :
                     Res.get("portfolio.pending.step3_seller.altcoin.explorer", currencyName);
-            message = Res.get("portfolio.pending.step3_seller.altcoin", part1, explorerOrWalletString, address, tradeVolumeWithCode, currencyName);
+            message = Res.get("portfolio.pending.step3_seller.altcoin",
+                    part1,
+                    explorerOrWalletString,
+                    address,
+                    tradeVolumeWithCode,
+                    currencyName);
         } else {
             if (paymentAccountPayload instanceof USPostalMoneyOrderAccountPayload) {
                 message = Res.get("portfolio.pending.step3_seller.postal", part1, tradeVolumeWithCode);
             } else if (paymentAccountPayload instanceof CashByMailAccountPayload) {
-                    message = Res.get("portfolio.pending.step3_seller.cashByMail", part1, tradeVolumeWithCode);
+                message = Res.get("portfolio.pending.step3_seller.cashByMail", part1, tradeVolumeWithCode);
             } else if (!(paymentAccountPayload instanceof WesternUnionAccountPayload) &&
                     !(paymentAccountPayload instanceof HalCashAccountPayload) &&
                     !(paymentAccountPayload instanceof F2FAccountPayload) &&

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -54,6 +54,7 @@ import bisq.core.user.Preferences;
 import bisq.core.user.User;
 import bisq.core.user.UserPayload;
 import bisq.core.util.FormattingUtils;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.coin.CoinUtil;
@@ -224,7 +225,7 @@ public class GUIUtil {
                 persistenceManager.persistNow(() -> {
                     persistenceManager.shutdown();
                     new Popup().feedback(Res.get("guiUtil.accountExport.savedToPath",
-                            Paths.get(directory, fileName).toAbsolutePath()))
+                                    Paths.get(directory, fileName).toAbsolutePath()))
                             .show();
                 });
             }
@@ -801,7 +802,7 @@ public class GUIUtil {
                     .dontShowAgainId(key)
                     .actionButtonTextWithGoTo("navigation.dao.networkMonitor")
                     .onAction(() -> {
-                            navigation.navigateTo(MainView.class, DaoView.class, MonitorView.class, DaoStateMonitorView.class);
+                        navigation.navigateTo(MainView.class, DaoView.class, MonitorView.class, DaoStateMonitorView.class);
                     })
                     .show(), 5, TimeUnit.SECONDS);
         }
@@ -1172,7 +1173,7 @@ public class GUIUtil {
         Volume bsqAmountAsVolume = Volume.parse(bsqAmountAsString, "BSQ");
         Coin requiredBtc = bsqPrice.getAmountByVolume(bsqAmountAsVolume);
         Volume volumeByAmount = usdPrice.getVolumeByAmount(requiredBtc);
-        return DisplayUtils.formatAverageVolumeWithCode(volumeByAmount);
+        return VolumeUtil.formatAverageVolumeWithCode(volumeByAmount);
     }
 
     public static MaterialDesignIcon getIconForSignState(AccountAgeWitnessService.SignState state) {

--- a/desktop/src/test/java/bisq/desktop/util/DisplayUtilsTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/DisplayUtilsTest.java
@@ -4,8 +4,9 @@ import bisq.core.locale.Res;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferPayload;
-import bisq.core.util.coin.ImmutableCoinFormatter;
+import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
+import bisq.core.util.coin.ImmutableCoinFormatter;
 
 import bisq.common.config.Config;
 
@@ -49,9 +50,9 @@ public class DisplayUtilsTest {
 
     @Test
     public void testFormatVolume() {
-        assertEquals("1", DisplayUtils.formatVolume(make(btcUsdOffer), true, 4));
-        assertEquals("100", DisplayUtils.formatVolume(make(usdVolume)));
-        assertEquals("1775", DisplayUtils.formatVolume(make(usdVolume.but(with(volumeString, "1774.62")))));
+        assertEquals("1", VolumeUtil.formatVolume(make(btcUsdOffer), true, 4));
+        assertEquals("100", VolumeUtil.formatVolume(make(usdVolume)));
+        assertEquals("1775", VolumeUtil.formatVolume(make(usdVolume.but(with(volumeString, "1774.62")))));
     }
 
     @Test
@@ -61,7 +62,7 @@ public class DisplayUtilsTest {
         when(offer.getMinVolume()).thenReturn(btc);
         when(offer.getVolume()).thenReturn(btc);
 
-        assertEquals("0.10000000", DisplayUtils.formatVolume(offer.getVolume()));
+        assertEquals("0.10000000", VolumeUtil.formatVolume(offer.getVolume()));
     }
 
     @Test
@@ -73,7 +74,7 @@ public class DisplayUtilsTest {
         when(offer.getMinVolume()).thenReturn(btcMin);
         when(offer.getVolume()).thenReturn(btcMax);
 
-        assertEquals("0.10000000 - 0.25000000", DisplayUtils.formatVolume(offer, false, 0));
+        assertEquals("0.10000000 - 0.25000000", VolumeUtil.formatVolume(offer, false, 0));
     }
 
     @Test
@@ -82,7 +83,7 @@ public class DisplayUtilsTest {
         when(offer.getMinVolume()).thenReturn(null);
         when(offer.getVolume()).thenReturn(null);
 
-        assertEquals("", DisplayUtils.formatVolume(offer.getVolume()));
+        assertEquals("", VolumeUtil.formatVolume(offer.getVolume()));
     }
 
     @Test


### PR DESCRIPTION
In practice, presentation/display logic should be kept in UIs, but the core api will need to duplicate a very small part of the code in `DisplayUtils` if a very small part of this refactoring is not done.  Instead of moving a tiny bit of the volume formatting methods, all of them are moved to core's `VolumeUtil`.

This PR's branch is based off `master`, and is not part of any PR chain requiring review/merge of any parent PRs.