### PR TITLE
GitHub build: Cache gradle dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'zulu'
+        cache: 'gradle'
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
Enable gradle cache to speed up builds and become less affected by various public repository issues.

See https://github.com/marketplace/actions/setup-java-jdk#caching-packages-dependencies
