### PR TITLE
Remove apitest's create bsq-swap account method

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/offer/AbstractOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/AbstractOfferTest.java
@@ -52,8 +52,11 @@ public abstract class AbstractOfferTest extends MethodTest {
     @Setter
     protected static boolean isLongRunningTest;
 
-    protected static PaymentAccount alicesBsqAcct;
-    protected static PaymentAccount bobsBsqAcct;
+    protected static PaymentAccount alicesBsqSwapAcct;
+    protected static PaymentAccount bobsBsqSwapAcct;
+    // TODO Deprecate legacy BSQ accounts when no longer in use.
+    protected static PaymentAccount alicesLegacyBsqAcct;
+    protected static PaymentAccount bobsLegacyBsqAcct;
 
     @BeforeAll
     public static void setUp() {
@@ -64,17 +67,8 @@ public abstract class AbstractOfferTest extends MethodTest {
                 arbdaemon,
                 alicedaemon,
                 bobdaemon);
-    }
 
-    public static void createBsqSwapBsqPaymentAccounts() {
-        alicesBsqAcct = aliceClient.createCryptoCurrencyPaymentAccount("Alice's BsqSwap Account",
-                BSQ,
-                aliceClient.getUnusedBsqAddress(), // TODO refactor, bsq address not needed for atom acct
-                false);
-        bobsBsqAcct = bobClient.createCryptoCurrencyPaymentAccount("Bob's BsqSwap Account",
-                BSQ,
-                bobClient.getUnusedBsqAddress(),   // TODO refactor, bsq address not needed for atom acct
-                false);
+        initSwapPaymentAccounts();
     }
 
     // Mkt Price Margin value of offer returned from server is scaled down by 10^-2.
@@ -105,13 +99,20 @@ public abstract class AbstractOfferTest extends MethodTest {
         return priceAsBigDecimal.toPlainString();
     };
 
+    public static void initSwapPaymentAccounts() {
+        // A bot may not know what the default 'BSQ Swap' account name is,
+        // but API test cases do:  the value of the i18n property 'BSQ_SWAP'.
+        alicesBsqSwapAcct = aliceClient.getPaymentAccount("BSQ Swap");
+        bobsBsqSwapAcct = bobClient.getPaymentAccount("BSQ Swap");
+    }
+
     @SuppressWarnings("ConstantConditions")
-    public static void createBsqPaymentAccounts() {
-        alicesBsqAcct = aliceClient.createCryptoCurrencyPaymentAccount("Alice's BSQ Account",
+    public static void createLegacyBsqPaymentAccounts() {
+        alicesLegacyBsqAcct = aliceClient.createCryptoCurrencyPaymentAccount("Alice's Legacy BSQ Account",
                 BSQ,
                 aliceClient.getUnusedBsqAddress(),
                 false);
-        bobsBsqAcct = bobClient.createCryptoCurrencyPaymentAccount("Bob's BSQ Account",
+        bobsLegacyBsqAcct = bobClient.createCryptoCurrencyPaymentAccount("Bob's Legacy BSQ Account",
                 BSQ,
                 bobClient.getUnusedBsqAddress(),
                 false);

--- a/apitest/src/test/java/bisq/apitest/method/offer/BsqSwapOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/BsqSwapOfferTest.java
@@ -46,7 +46,6 @@ public class BsqSwapOfferTest extends AbstractOfferTest {
     @BeforeAll
     public static void setUp() {
         AbstractOfferTest.setUp();
-        createBsqSwapBsqPaymentAccounts();
     }
 
     @BeforeEach
@@ -115,7 +114,7 @@ public class BsqSwapOfferTest extends AbstractOfferTest {
                 1_000_000L,
                 1_000_000L,
                 "0.00005",
-                alicesBsqAcct.getId());
+                alicesBsqSwapAcct.getId());
         log.debug("BsqSwap Sell BSQ (Buy BTC) OFFER:\n{}", bsqSwapOffer);
         var newOfferId = bsqSwapOffer.getId();
         assertNotEquals("", newOfferId);

--- a/apitest/src/test/java/bisq/apitest/method/offer/CreateBSQOffersTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/CreateBSQOffersTest.java
@@ -53,7 +53,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
     @BeforeAll
     public static void setUp() {
         AbstractOfferTest.setUp();
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
     }
 
     @Test
@@ -68,7 +68,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
                 100_000_000L,
                 "0.00005",   // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 MAKER_FEE_CURRENCY_CODE);
         log.info("Sell BSQ (Buy BTC) OFFER:\n{}", formatOfferTable(singletonList(newOffer), BSQ));
         assertTrue(newOffer.getIsMyOffer());
@@ -82,7 +82,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(100_000_000L, newOffer.getAmount());
         assertEquals(100_000_000L, newOffer.getMinAmount());
         assertEquals(15_000_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());
@@ -99,7 +99,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(100_000_000L, newOffer.getAmount());
         assertEquals(100_000_000L, newOffer.getMinAmount());
         assertEquals(15_000_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());
@@ -115,7 +115,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
                 100_000_000L,
                 "0.00005",   // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 MAKER_FEE_CURRENCY_CODE);
         log.info("SELL 20K BSQ OFFER:\n{}", formatOfferTable(singletonList(newOffer), BSQ));
         assertTrue(newOffer.getIsMyOffer());
@@ -129,7 +129,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(100_000_000L, newOffer.getAmount());
         assertEquals(100_000_000L, newOffer.getMinAmount());
         assertEquals(15_000_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());
@@ -146,7 +146,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(100_000_000L, newOffer.getAmount());
         assertEquals(100_000_000L, newOffer.getMinAmount());
         assertEquals(15_000_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());
@@ -162,7 +162,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
                 5_000_000L,
                 "0.00005",   // FIXED PRICE IN BTC sats FOR 1 BSQ
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 MAKER_FEE_CURRENCY_CODE);
         log.info("BUY 1-2K BSQ OFFER:\n{}", formatOfferTable(singletonList(newOffer), BSQ));
         assertTrue(newOffer.getIsMyOffer());
@@ -176,7 +176,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(10_000_000L, newOffer.getAmount());
         assertEquals(5_000_000L, newOffer.getMinAmount());
         assertEquals(1_500_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());
@@ -193,7 +193,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(10_000_000L, newOffer.getAmount());
         assertEquals(5_000_000L, newOffer.getMinAmount());
         assertEquals(1_500_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());
@@ -209,7 +209,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
                 25_000_000L,
                 "0.00005",   // FIXED PRICE IN BTC sats FOR 1 BSQ
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 MAKER_FEE_CURRENCY_CODE);
         log.info("SELL 5-10K BSQ OFFER:\n{}", formatOfferTable(singletonList(newOffer), BSQ));
         assertTrue(newOffer.getIsMyOffer());
@@ -223,7 +223,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(50_000_000L, newOffer.getAmount());
         assertEquals(25_000_000L, newOffer.getMinAmount());
         assertEquals(7_500_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());
@@ -240,7 +240,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
         assertEquals(50_000_000L, newOffer.getAmount());
         assertEquals(25_000_000L, newOffer.getMinAmount());
         assertEquals(7_500_000, newOffer.getBuyerSecurityDeposit());
-        assertEquals(alicesBsqAcct.getId(), newOffer.getPaymentAccountId());
+        assertEquals(alicesLegacyBsqAcct.getId(), newOffer.getPaymentAccountId());
         assertEquals(BSQ, newOffer.getBaseCurrencyCode());
         assertEquals(BTC, newOffer.getCounterCurrencyCode());
         assertFalse(newOffer.getIsCurrencyForMakerFeeBtc());

--- a/apitest/src/test/java/bisq/apitest/method/offer/EditOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/EditOfferTest.java
@@ -427,14 +427,14 @@ public class EditOfferTest extends AbstractOfferTest {
     @Test
     @Order(13)
     public void testChangeFixedPricedBsqOfferToPriceMarginBasedOfferShouldThrowException() {
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
         OfferInfo originalOffer = aliceClient.createFixedPricedOffer(BUY.name(),
                 BSQ,
                 100_000_000L,
                 100_000_000L,
                 "0.00005",   // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 BSQ);
         log.info("ORIGINAL BSQ OFFER:\n{}", formatOfferTable(singletonList(originalOffer), "BSQ"));
         genBtcBlocksThenWait(1, 2500); // Wait for offer book entry.
@@ -455,14 +455,14 @@ public class EditOfferTest extends AbstractOfferTest {
     @Test
     @Order(14)
     public void testEditTriggerPriceOnFixedPriceBsqOfferShouldThrowException() {
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
         OfferInfo originalOffer = aliceClient.createFixedPricedOffer(BUY.name(),
                 BSQ,
                 100_000_000L,
                 100_000_000L,
                 "0.00005",   // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 BSQ);
         log.info("ORIGINAL BSQ OFFER:\n{}", formatOfferTable(singletonList(originalOffer), "BSQ"));
         genBtcBlocksThenWait(1, 2500); // Wait for offer book entry.
@@ -484,7 +484,7 @@ public class EditOfferTest extends AbstractOfferTest {
     @Test
     @Order(15)
     public void testEditFixedPriceOnBsqOffer() {
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
         String fixedPriceAsString = "0.00005"; // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
         final OfferInfo originalOffer = aliceClient.createFixedPricedOffer(BUY.name(),
                 BSQ,
@@ -492,7 +492,7 @@ public class EditOfferTest extends AbstractOfferTest {
                 100_000_000L,
                 fixedPriceAsString,
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 BSQ);
         log.info("ORIGINAL BSQ OFFER:\n{}", formatOfferTable(singletonList(originalOffer), "BSQ"));
         genBtcBlocksThenWait(1, 2500); // Wait for offer book entry.
@@ -518,7 +518,7 @@ public class EditOfferTest extends AbstractOfferTest {
     @Test
     @Order(16)
     public void testDisableBsqOffer() {
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
         String fixedPriceAsString = "0.00005"; // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
         final OfferInfo originalOffer = aliceClient.createFixedPricedOffer(BUY.name(),
                 BSQ,
@@ -526,7 +526,7 @@ public class EditOfferTest extends AbstractOfferTest {
                 100_000_000L,
                 fixedPriceAsString,
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 BSQ);
         log.info("ORIGINAL BSQ OFFER:\n{}", formatOfferTable(singletonList(originalOffer), "BSQ"));
         genBtcBlocksThenWait(1, 2500); // Wait for offer book entry.
@@ -551,7 +551,7 @@ public class EditOfferTest extends AbstractOfferTest {
     @Test
     @Order(17)
     public void testEditFixedPriceAndDisableBsqOffer() {
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
         String fixedPriceAsString = "0.00005"; // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
         final OfferInfo originalOffer = aliceClient.createFixedPricedOffer(BUY.name(),
                 BSQ,
@@ -559,7 +559,7 @@ public class EditOfferTest extends AbstractOfferTest {
                 100_000_000L,
                 fixedPriceAsString,
                 getDefaultBuyerSecurityDepositAsPercent(),
-                alicesBsqAcct.getId(),
+                alicesLegacyBsqAcct.getId(),
                 BSQ);
         log.info("ORIGINAL BSQ OFFER:\n{}", formatOfferTable(singletonList(originalOffer), "BSQ"));
         genBtcBlocksThenWait(1, 2500); // Wait for offer book entry.

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
@@ -72,7 +72,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
     @BeforeAll
     public static void setUp() {
         AbstractOfferTest.setUp();
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
         EXPECTED_PROTOCOL_STATUS.init();
     }
 
@@ -90,7 +90,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
                     7_500_000L,
                     "0.000035",   // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
                     getDefaultBuyerSecurityDepositAsPercent(),
-                    alicesBsqAcct.getId(),
+                    alicesLegacyBsqAcct.getId(),
                     TRADE_FEE_CURRENCY_CODE);
             log.info("ALICE'S BUY BSQ (SELL BTC) OFFER:\n{}", formatOfferTable(singletonList(alicesOffer), BSQ));
             genBtcBlocksThenWait(1, 5000);
@@ -100,7 +100,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
             var alicesBsqOffers = aliceClient.getMyCryptoCurrencyOffers(btcTradeDirection, BSQ);
             assertEquals(1, alicesBsqOffers.size());
 
-            var trade = takeAlicesOffer(offerId, bobsBsqAcct.getId(), TRADE_FEE_CURRENCY_CODE);
+            var trade = takeAlicesOffer(offerId, bobsLegacyBsqAcct.getId(), TRADE_FEE_CURRENCY_CODE);
             assertNotNull(trade);
             assertEquals(offerId, trade.getTradeId());
             assertFalse(trade.getIsCurrencyForTakerFeeBtc());

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
@@ -73,7 +73,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
     @BeforeAll
     public static void setUp() {
         AbstractOfferTest.setUp();
-        createBsqPaymentAccounts();
+        createLegacyBsqPaymentAccounts();
         EXPECTED_PROTOCOL_STATUS.init();
     }
 
@@ -91,7 +91,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
                     7_500_000L,
                     "0.000035",   // FIXED PRICE IN BTC (satoshis) FOR 1 BSQ
                     getDefaultBuyerSecurityDepositAsPercent(),
-                    alicesBsqAcct.getId(),
+                    alicesLegacyBsqAcct.getId(),
                     TRADE_FEE_CURRENCY_CODE);
             log.info("ALICE'S SELL BSQ (BUY BTC) OFFER:\n{}", formatOfferTable(singletonList(alicesOffer), BSQ));
             genBtcBlocksThenWait(1, 4000);
@@ -101,7 +101,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
             var alicesBsqOffers = aliceClient.getMyCryptoCurrencyOffers(btcTradeDirection, BSQ);
             assertEquals(1, alicesBsqOffers.size());
 
-            var trade = takeAlicesOffer(offerId, bobsBsqAcct.getId(), TRADE_FEE_CURRENCY_CODE);
+            var trade = takeAlicesOffer(offerId, bobsLegacyBsqAcct.getId(), TRADE_FEE_CURRENCY_CODE);
             assertNotNull(trade);
             assertEquals(offerId, trade.getTradeId());
             assertTrue(trade.getIsCurrencyForTakerFeeBtc());

--- a/apitest/src/test/java/bisq/apitest/scenario/LongRunningBsqSwapTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/LongRunningBsqSwapTest.java
@@ -43,7 +43,6 @@ public class LongRunningBsqSwapTest extends AbstractOfferTest {
     @BeforeAll
     public static void setUp() {
         AbstractOfferTest.setUp();
-        createBsqSwapBsqPaymentAccounts();
     }
 
     @Test

--- a/apitest/src/test/java/bisq/apitest/scenario/OfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/OfferTest.java
@@ -80,7 +80,7 @@ public class OfferTest extends AbstractOfferTest {
     @Order(5)
     public void testCreateBSQOffers() {
         CreateBSQOffersTest test = new CreateBSQOffersTest();
-        CreateBSQOffersTest.createBsqPaymentAccounts();
+        CreateBSQOffersTest.createLegacyBsqPaymentAccounts();
         test.testCreateBuy1BTCFor20KBSQOffer();
         test.testCreateSell1BTCFor20KBSQOffer();
         test.testCreateBuyBTCWith1To2KBSQOffer();
@@ -93,7 +93,6 @@ public class OfferTest extends AbstractOfferTest {
     @Order(6)
     public void testCreateBSQSwapOffers() {
         BsqSwapOfferTest test = new BsqSwapOfferTest();
-        BsqSwapOfferTest.createBsqSwapBsqPaymentAccounts();
         test.testAliceCreateBsqSwapBuyOffer1();
         test.testAliceCreateBsqSwapBuyOffer2();
         test.testAliceCreateBsqSwapBuyOffer3();

--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -70,7 +70,7 @@ public class TradeTest extends AbstractTradeTest {
     @Order(3)
     public void testTakeBuyBSQOffer(final TestInfo testInfo) {
         TakeBuyBSQOfferTest test = new TakeBuyBSQOfferTest();
-        TakeBuyBSQOfferTest.createBsqPaymentAccounts();
+        TakeBuyBSQOfferTest.createLegacyBsqPaymentAccounts();
         test.testTakeAlicesSellBTCForBSQOffer(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
         test.testAlicesConfirmPaymentReceived(testInfo);
@@ -92,7 +92,7 @@ public class TradeTest extends AbstractTradeTest {
     @Order(5)
     public void testTakeSellBSQOffer(final TestInfo testInfo) {
         TakeSellBSQOfferTest test = new TakeSellBSQOfferTest();
-        TakeSellBSQOfferTest.createBsqPaymentAccounts();
+        TakeSellBSQOfferTest.createLegacyBsqPaymentAccounts();
         test.testTakeAlicesBuyBTCForBSQOffer(testInfo);
         test.testAlicesConfirmPaymentStarted(testInfo);
         test.testBobsConfirmPaymentReceived(testInfo);
@@ -103,7 +103,6 @@ public class TradeTest extends AbstractTradeTest {
     @Order(6)
     public void testBsqSwapTradeTest(final TestInfo testInfo) {
         BsqSwapTradeTest test = new BsqSwapTradeTest();
-        test.createBsqSwapBsqPaymentAccounts();
         test.testAliceCreateBsqSwapBuyOffer();
         test.testBobTakesBsqSwapOffer();
     }

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -414,6 +414,10 @@ public final class GrpcClient {
         return paymentAccountsServiceRequest.getPaymentAccounts();
     }
 
+    public PaymentAccount getPaymentAccount(String accountName) {
+        return paymentAccountsServiceRequest.getPaymentAccount(accountName);
+    }
+
     public PaymentAccount createCryptoCurrencyPaymentAccount(String accountName,
                                                              String currencyCode,
                                                              String address,

--- a/cli/src/main/java/bisq/cli/opts/CreateCryptoCurrencyPaymentAcctOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/CreateCryptoCurrencyPaymentAcctOptionParser.java
@@ -20,7 +20,10 @@ package bisq.cli.opts;
 
 import joptsimple.OptionSpec;
 
-import static bisq.cli.opts.OptLabel.*;
+import static bisq.cli.opts.OptLabel.OPT_ACCOUNT_NAME;
+import static bisq.cli.opts.OptLabel.OPT_ADDRESS;
+import static bisq.cli.opts.OptLabel.OPT_CURRENCY_CODE;
+import static bisq.cli.opts.OptLabel.OPT_TRADE_INSTANT;
 
 public class CreateCryptoCurrencyPaymentAcctOptionParser extends AbstractMethodOptionParser implements MethodOpts {
 
@@ -34,11 +37,6 @@ public class CreateCryptoCurrencyPaymentAcctOptionParser extends AbstractMethodO
             .withRequiredArg();
 
     final OptionSpec<Boolean> tradeInstantOpt = parser.accepts(OPT_TRADE_INSTANT, "create trade instant account")
-            .withOptionalArg()
-            .ofType(boolean.class)
-            .defaultsTo(Boolean.FALSE);
-
-    final OptionSpec<Boolean> tradeBsqSwapOpt = parser.accepts(OPT_TRADE_BSQ_SWAP, "create trade bsq swap account")
             .withOptionalArg()
             .ofType(boolean.class)
             .defaultsTo(Boolean.FALSE);
@@ -83,9 +81,5 @@ public class CreateCryptoCurrencyPaymentAcctOptionParser extends AbstractMethodO
 
     public boolean getIsTradeInstant() {
         return options.valueOf(tradeInstantOpt);
-    }
-
-    public boolean getIsTradeBsqSwap() {
-        return options.valueOf(tradeBsqSwapOpt);
     }
 }

--- a/cli/src/main/java/bisq/cli/opts/OptLabel.java
+++ b/cli/src/main/java/bisq/cli/opts/OptLabel.java
@@ -44,7 +44,6 @@ public class OptLabel {
     public final static String OPT_REGISTRATION_KEY = "registration-key";
     public final static String OPT_SECURITY_DEPOSIT = "security-deposit";
     public final static String OPT_SHOW_CONTRACT = "show-contract";
-    public final static String OPT_TRADE_BSQ_SWAP = "trade-bsq-swap";
     public final static String OPT_TRADE_ID = "trade-id";
     public final static String OPT_TRADE_INSTANT = "trade-instant";
     public final static String OPT_TIMEOUT = "timeout";

--- a/cli/src/main/java/bisq/cli/request/PaymentAccountsServiceRequest.java
+++ b/cli/src/main/java/bisq/cli/request/PaymentAccountsServiceRequest.java
@@ -29,6 +29,8 @@ import protobuf.PaymentMethod;
 
 import java.util.List;
 
+import static java.lang.String.format;
+
 
 
 import bisq.cli.GrpcStubs;
@@ -63,6 +65,22 @@ public class PaymentAccountsServiceRequest {
     public List<PaymentAccount> getPaymentAccounts() {
         var request = GetPaymentAccountsRequest.newBuilder().build();
         return grpcStubs.paymentAccountsService.getPaymentAccounts(request).getPaymentAccountsList();
+    }
+
+    /**
+     * Returns the first PaymentAccount found with the given name, or throws an
+     * IllegalArgumentException if not found.  This method should be used with care;
+     * it will only return one PaymentAccount, and the account name must be an exact
+     * match on the name argument.
+     * @param accountName the name of the stored PaymentAccount to retrieve
+     * @return PaymentAccount with given name
+     */
+    public PaymentAccount getPaymentAccount(String accountName) {
+        return getPaymentAccounts().stream()
+                .filter(a -> a.getAccountName().equals(accountName)).findFirst()
+                .orElseThrow(() ->
+                        new IllegalArgumentException(format("payment account with name '%s' not found",
+                                accountName)));
     }
 
     public PaymentAccount createCryptoCurrencyPaymentAccount(String accountName,

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -240,13 +240,11 @@ public class CoreApi {
     public PaymentAccount createCryptoCurrencyPaymentAccount(String accountName,
                                                              String currencyCode,
                                                              String address,
-                                                             boolean tradeInstant,
-                                                             boolean isBsqSwap) {
+                                                             boolean tradeInstant) {
         return paymentAccountsService.createCryptoCurrencyPaymentAccount(accountName,
                 currencyCode,
                 address,
-                tradeInstant,
-                isBsqSwap);
+                tradeInstant);
     }
 
     public List<PaymentMethod> getCryptoCurrencyPaymentMethods() {

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -103,8 +103,7 @@ class CorePaymentAccountsService {
     PaymentAccount createCryptoCurrencyPaymentAccount(String accountName,
                                                       String currencyCode,
                                                       String address,
-                                                      boolean tradeInstant,
-                                                      boolean isBsqSwap) {
+                                                      boolean tradeInstant) {
         String bsqCode = currencyCode.toUpperCase();
         if (!bsqCode.equals("BSQ"))
             throw new IllegalArgumentException("api does not currently support " + currencyCode + " accounts");
@@ -112,21 +111,12 @@ class CorePaymentAccountsService {
         // Validate the BSQ address string but ignore the return value.
         coreWalletsService.getValidBsqAddress(address);
 
-        // TODO Split into 2 methods: createAtomicPaymentAccount(), createCryptoCurrencyPaymentAccount().
-        PaymentAccount cryptoCurrencyAccount;
-        if (isBsqSwap) {
-            cryptoCurrencyAccount = PaymentAccountFactory.getPaymentAccount(PaymentMethod.BSQ_SWAP);
-        } else {
-            cryptoCurrencyAccount = tradeInstant
-                    ? (InstantCryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS_INSTANT)
-                    : (CryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS);
-        }
+        AssetAccount cryptoCurrencyAccount = tradeInstant
+                ? (InstantCryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS_INSTANT)
+                : (CryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS);
         cryptoCurrencyAccount.init();
         cryptoCurrencyAccount.setAccountName(accountName);
-        if (!isBsqSwap) {
-            ((AssetAccount) cryptoCurrencyAccount).setAddress(address);
-        }
-
+        cryptoCurrencyAccount.setAddress(address);
         Optional<CryptoCurrency> cryptoCurrency = getCryptoCurrency(bsqCode);
         cryptoCurrency.ifPresent(cryptoCurrencyAccount::setSingleTradeCurrency);
         user.addPaymentAccount(cryptoCurrencyAccount);

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -130,7 +130,6 @@ class CorePaymentAccountsService {
         Optional<CryptoCurrency> cryptoCurrency = getCryptoCurrency(bsqCode);
         cryptoCurrency.ifPresent(cryptoCurrencyAccount::setSingleTradeCurrency);
         user.addPaymentAccount(cryptoCurrencyAccount);
-        accountAgeWitnessService.publishMyAccountAgeWitness(cryptoCurrencyAccount.getPaymentAccountPayload());
         log.info("Saved crypto payment account with id {} and payment method {}.",
                 cryptoCurrencyAccount.getId(),
                 cryptoCurrencyAccount.getPaymentAccountPayload().getPaymentMethodId());

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
@@ -136,8 +136,7 @@ class GrpcPaymentAccountsService extends PaymentAccountsImplBase {
             PaymentAccount paymentAccount = coreApi.createCryptoCurrencyPaymentAccount(req.getAccountName(),
                     req.getCurrencyCode(),
                     req.getAddress(),
-                    req.getTradeInstant(),
-                    req.getIsBsqSwap());
+                    req.getTradeInstant());
             var reply = CreateCryptoCurrencyPaymentAccountReply.newBuilder()
                     .setPaymentAccount(paymentAccount.toProtoMessage())
                     .build();

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -311,7 +311,6 @@ message CreateCryptoCurrencyPaymentAccountRequest {
     string currencyCode = 2;
     string address = 3;
     bool tradeInstant = 4;
-    bool isBsqSwap = 5;
 }
 
 message CreateCryptoCurrencyPaymentAccountReply {


### PR DESCRIPTION
If not present, a default BSQ swap account is saved when a `User` object is initialized.  Use the existing default account in API bsq-swap test cases, and rename the legacy BSQ payment account fixtures to distinguish them from the new default 'BSQ Swap' payment account.
