### PR TITLE
Fix reorg handling

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/full/FullNode.java
+++ b/core/src/main/java/bisq/core/dao/node/full/FullNode.java
@@ -111,15 +111,6 @@ public class FullNode extends BsqNode {
     }
 
     @Override
-    protected void startReOrgFromLastSnapshot() {
-        super.startReOrgFromLastSnapshot();
-
-        int startBlockHeight = getStartBlockHeight();
-        rpcService.requestChainHeadHeight(chainHeight -> parseBlocksOnHeadHeight(startBlockHeight, chainHeight),
-                this::handleError);
-    }
-
-    @Override
     protected void onP2PNetworkReady() {
         super.onP2PNetworkReady();
 

--- a/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
@@ -185,15 +185,6 @@ public class LiteNode extends BsqNode {
         liteNodeNetworkService.requestBlocks(getStartBlockHeight());
     }
 
-    @Override
-    protected void startReOrgFromLastSnapshot() {
-        super.startReOrgFromLastSnapshot();
-
-        int startBlockHeight = getStartBlockHeight();
-        liteNodeNetworkService.reset();
-        liteNodeNetworkService.requestBlocks(startBlockHeight);
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private

--- a/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
@@ -243,7 +243,7 @@ public class LiteNode extends BsqNode {
                 doParseBlock(block);
                 runDelayedBatchProcessing(blocks, resultHandler);
             } catch (RequiredReorgFromSnapshotException e) {
-                resultHandler.run();
+                log.warn("Interrupt batch processing because if a blockchain reorg. {}", e.toString());
             }
         });
     }

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -25,9 +25,11 @@ import bisq.core.user.Cookie;
 import bisq.core.user.CookieKey;
 import bisq.core.user.User;
 
+import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.P2PServiceListener;
 import bisq.network.p2p.peers.PeerManager;
+import bisq.network.p2p.seed.SeedNodeRepository;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
@@ -41,6 +43,9 @@ import bisq.common.handlers.ResultHandler;
 
 import com.google.inject.Key;
 import com.google.inject.name.Names;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -108,9 +113,26 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
         seedNode.setInjector(injector);
 
         if (DevEnv.isDaoActivated()) {
-            injector.getInstance(DaoStateSnapshotService.class).setDaoRequiresRestartHandler(() -> gracefulShutDown(() -> {
-            }));
+            injector.getInstance(DaoStateSnapshotService.class).setDaoRequiresRestartHandler(
+                    // We shut down with a deterministic delay per seed to avoid that all seeds shut down at the
+                    // same time in case of a reorg. We use 30 sec. as distance delay between the seeds to be on the
+                    // safe side. We have 12 seeds so that's 6 minutes.
+                    () -> UserThread.runAfter(this::gracefulShutDown, 1 + (getMyIndex() * 30L))
+            );
         }
+    }
+
+    private int getMyIndex() {
+        P2PService p2PService = injector.getInstance(P2PService.class);
+        SeedNodeRepository seedNodeRepository = injector.getInstance(SeedNodeRepository.class);
+        List<NodeAddress> seedNodes = new ArrayList<>(seedNodeRepository.getSeedNodeAddresses());
+        NodeAddress myAddress = p2PService.getAddress();
+        for (int i = 0; i < seedNodes.size(); i++) {
+            if (seedNodes.get(i).equals(myAddress)) {
+                return i;
+            }
+        }
+        return 0;
     }
 
     @Override
@@ -195,6 +217,11 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
             }
         }, CHECK_CONNECTION_LOSS_SEC);
 
+    }
+
+    private void gracefulShutDown() {
+        gracefulShutDown(() -> {
+        });
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/5809

How to reproduce:
- Start a new regtest setup with a seed, a full node (Alice) and a lite node (Bob)
- Make a backup of that start setup version. Assume block height is 113 here.
- Create 1 block
- Create 1 tx 
- Create 1 block. Block height is 115.
- Stop BTC core replace the blocks and regtest folders in btc core data dir with the folders from the start setup backup. This is used for simulating a reorg. 
- Create 2 blocks. Still no reorg as fork chain has same height 115 as existing chain.
- Create 1 more block triggering the reorg at 116.

In master the Alice nad Bob nodes get caught in an endless loop requesting new blocks. The seed node is shut down automatically. Bob will start the endless loop only after the seed has restarted and the next block is propagated.

With the PR version there is just the shutdown at seed node and the shutdown popup at desktop apps but no loops.
The litenode will not recognize the new block as the full nodes are shut down or inactive. Only after restarting the seed and creating a new block the lite node will detect the reorg. The block propagation is delayed with a random delay so it can take a bit... 

To avoid that all seed nodes shut down at the same time when a reorg happens we add a detereministic delay derived from the index of the seed in the seed node list. So shut down is delayed by 30 sec * index, distributing the shutdown of 12 seeds over 6 minutes.