### PR TITLE
Fix broken test for new build

### DIFF
--- a/desktop/src/test/java/bisq/desktop/util/DisplayUtilsTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/DisplayUtilsTest.java
@@ -1,5 +1,6 @@
 package bisq.desktop.util;
 
+import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
@@ -32,7 +33,8 @@ public class DisplayUtilsTest {
 
     @Before
     public void setUp() {
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.US);
+        GlobalSettings.setLocale(Locale.US);
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }


### PR DESCRIPTION
It seems that the new build process exposed a timing issue in the setting of the locale that wasn't existing before.
This PR sets the locale additionally in the GlobalSettings.
This bug only surfaces for non-english setups.