### PR TITLE
Add I2P as enum entry

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/full/rpc/dto/DtoNetworkInfo.java
+++ b/core/src/main/java/bisq/core/dao/node/full/rpc/dto/DtoNetworkInfo.java
@@ -91,7 +91,7 @@ public class DtoNetworkInfo {
 
     @RequiredArgsConstructor
     public enum NetworkType {
-        IPV4("ipv4"), IPV6("ipv6"), ONION("onion");
+        IPV4("ipv4"), IPV6("ipv6"), ONION("onion"), I2P("i2p");
 
         @Getter(onMethod_ = @JsonValue)
         private final String name;


### PR DESCRIPTION
After a seed node has updated Bitcoin Core to v22 he got the error posted below.
It seems I2P was added as enum value and our json parsing does not tolerate newly added values.
I think it would be good to add some error handling to not cause a fatal failure in such cases, but I am not familiar with that part of the code and with the used json library. This PR should at least fixe quickly the issue.

```
Nov-18 16:53:32.739 [RpcService] ERROR b.c.d.n.f.RpcService: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `bisq.core.dao.node.full.rpc.dto.DtoNetworkInfo$NetworkType` from String "i2p": not one of the values accepted for Enum class: [onion, ipv4, ipv6] at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: bisq.core.dao.node.full.rpc.dto.DtoNetworkInfo["networks"]->
java.util.ArrayList[3]->bisq.core.dao.node.full.rpc.dto.DtoNetworkInfo$Network["name"]) 
Nov-18 16:53:32.741 [SeedNodeMain] ERROR b.c.d.n.f.FullNode: An error occurred:Error=bisq.core.dao.node.full.RpcException: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `bisq.core.dao.node.full.rpc.dto.DtoNetworkI
nfo$NetworkType` from String "i2p": not one of the values accepted for Enum class: [onion, ipv4, ipv6] at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: bisq.core.dao.node.full.rpc.dto.DtoNetworkInfo["networks"]->
java.util.ArrayList[3]->bisq.core.dao.node.full.rpc.dto.DtoNetworkInfo$Network["name"]) 
Nov-18 16:53:32.742 [SeedNodeMain] ERROR b.c.a.m.AppSetupWithP2PAndDAO: An error occurred: Error=bisq.core.dao.node.full.RpcExcept
ion: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `bisq.core.dao.node.full.rpc.dto.
DtoNetworkInfo$NetworkType` from String "i2p": not one of the values accepted for Enum class: [onion, ipv4, ipv6]
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: bisq.core.dao.node.full.rpc.dto.DtoNetworkInfo["networks"]->
java.util.ArrayList[3]->bisq.core.dao.node.full.rpc.dto.DtoNetworkInfo$Network["name"]) 
```