### PR TITLE
Improve TradeStatistics validation

### DIFF
--- a/apitest/src/test/java/bisq/apitest/scenario/bot/AbstractBotTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/bot/AbstractBotTest.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.locale.CountryUtil.findCountryByCode;
 import static bisq.core.payment.payload.PaymentMethod.CLEAR_X_CHANGE_ID;
-import static bisq.core.payment.payload.PaymentMethod.getPaymentMethodById;
+import static bisq.core.payment.payload.PaymentMethod.getPaymentMethod;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
 import static java.nio.file.Files.readAllBytes;
@@ -74,7 +74,7 @@ public abstract class AbstractBotTest extends MethodTest {
             } else {
                 throw new UnsupportedOperationException(
                         format("This test harness bot does not work with %s payment accounts yet.",
-                                getPaymentMethodById(paymentMethodId).getDisplayString()));
+                                getPaymentMethod(paymentMethodId).getDisplayString()));
             }
         } else {
             String countryCode = botScript.getCountryCode();

--- a/apitest/src/test/java/bisq/apitest/scenario/bot/Bot.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/bot/Bot.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.locale.CountryUtil.findCountryByCode;
 import static bisq.core.payment.payload.PaymentMethod.CLEAR_X_CHANGE_ID;
-import static bisq.core.payment.payload.PaymentMethod.getPaymentMethodById;
+import static bisq.core.payment.payload.PaymentMethod.getPaymentMethod;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -62,7 +62,7 @@ class Bot {
             } else {
                 throw new UnsupportedOperationException(
                         format("This bot test does not work with %s payment accounts yet.",
-                                getPaymentMethodById(paymentMethodId).getDisplayString()));
+                                getPaymentMethod(paymentMethodId).getDisplayString()));
             }
         } else {
             Country country = findCountry(botScript.getCountryCode());

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -773,7 +773,7 @@ public class AccountAgeWitnessService {
                 filterManager.isNodeAddressBanned(dispute.getContract().getSellerNodeAddress()) ||
                 filterManager.isCurrencyBanned(dispute.getContract().getOfferPayload().getCurrencyCode()) ||
                 filterManager.isPaymentMethodBanned(
-                        PaymentMethod.getPaymentMethodById(dispute.getContract().getPaymentMethodId())) ||
+                        PaymentMethod.getPaymentMethod(dispute.getContract().getPaymentMethodId())) ||
                 filterManager.arePeersPaymentAccountDataBanned(dispute.getContract().getBuyerPaymentAccountPayload()) ||
                 filterManager.arePeersPaymentAccountDataBanned(
                         dispute.getContract().getSellerPaymentAccountPayload()) ||

--- a/core/src/main/java/bisq/core/api/model/PaymentAccountForm.java
+++ b/core/src/main/java/bisq/core/api/model/PaymentAccountForm.java
@@ -47,7 +47,7 @@ import java.lang.reflect.Type;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static bisq.core.payment.payload.PaymentMethod.getPaymentMethodById;
+import static bisq.core.payment.payload.PaymentMethod.getPaymentMethod;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
@@ -148,7 +148,7 @@ public class PaymentAccountForm {
      * @return A uniquely named tmp file used to define new payment account details.
      */
     public File getPaymentAccountForm(String paymentMethodId) {
-        PaymentMethod paymentMethod = getPaymentMethodById(paymentMethodId);
+        PaymentMethod paymentMethod = getPaymentMethod(paymentMethodId);
         File file = getTmpJsonFile(paymentMethodId);
         try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(checkNotNull(file), false), UTF_8)) {
             PaymentAccount paymentAccount = PaymentAccountFactory.getPaymentAccount(paymentMethod);
@@ -244,7 +244,7 @@ public class PaymentAccountForm {
     }
 
     private Class<? extends PaymentAccount> getPaymentAccountClass(String paymentMethodId) {
-        PaymentMethod paymentMethod = getPaymentMethodById(paymentMethodId);
+        PaymentMethod paymentMethod = getPaymentMethod(paymentMethodId);
         return PaymentAccountFactory.getPaymentAccount(paymentMethod).getClass();
     }
 }

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -347,7 +347,7 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     public PaymentMethod getPaymentMethod() {
-        return PaymentMethod.getPaymentMethodById(offerPayloadBase.getPaymentMethodId());
+        return PaymentMethod.getPaymentMethod(offerPayloadBase.getPaymentMethodId());
     }
 
     // utils

--- a/core/src/main/java/bisq/core/payment/PaymentAccount.java
+++ b/core/src/main/java/bisq/core/payment/PaymentAccount.java
@@ -42,7 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 import static bisq.core.payment.payload.PaymentMethod.TRANSFERWISE_ID;
-import static bisq.core.payment.payload.PaymentMethod.getPaymentMethodById;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode
@@ -113,7 +112,7 @@ public abstract class PaymentAccount implements PersistablePayload {
         ngnTwOptional.ifPresent(tradeCurrencies::remove);
 
         try {
-            PaymentAccount account = PaymentAccountFactory.getPaymentAccount(getPaymentMethodById(paymentMethodId));
+            PaymentAccount account = PaymentAccountFactory.getPaymentAccount(PaymentMethod.getPaymentMethod(paymentMethodId));
             account.getTradeCurrencies().clear();
             account.setId(proto.getId());
             account.setCreationDate(proto.getCreationDate());

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -29,6 +29,7 @@ import org.bitcoinj.core.Coin;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import lombok.EqualsAndHashCode;
@@ -364,10 +365,15 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static PaymentMethod getPaymentMethodById(String id) {
+        return getActivePaymentMethodById(id)
+                .orElseGet(() -> new PaymentMethod(Res.get("shared.na")));
+    }
+
+    // We look up only our active payment methods not retired ones.
+    public static Optional<PaymentMethod> getActivePaymentMethodById(String id) {
         return paymentMethods.stream()
                 .filter(e -> e.getId().equals(id))
-                .findFirst()
-                .orElseGet(() -> new PaymentMethod(Res.get("shared.na")));
+                .findFirst();
     }
 
     public Coin getMaxTradeLimitAsCoin(String currencyCode) {
@@ -391,7 +397,9 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
             riskFactor = 8;
         else {
             riskFactor = 8;
-            log.error("maxTradeLimit is not matching one of our default values. maxTradeLimit=" + Coin.valueOf(maxTradeLimit).toFriendlyString());
+            log.warn("maxTradeLimit is not matching one of our default values. We use highest risk factor. " +
+                            "maxTradeLimit={}. PaymentMethod={}",
+                    Coin.valueOf(maxTradeLimit).toFriendlyString(), this);
         }
 
         TradeLimits tradeLimits = TradeLimits.getINSTANCE();

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -365,12 +365,12 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static PaymentMethod getPaymentMethodById(String id) {
-        return getActivePaymentMethodById(id)
+        return getActivePaymentMethod(id)
                 .orElseGet(() -> new PaymentMethod(Res.get("shared.na")));
     }
 
     // We look up only our active payment methods not retired ones.
-    public static Optional<PaymentMethod> getActivePaymentMethodById(String id) {
+    public static Optional<PaymentMethod> getActivePaymentMethod(String id) {
         return paymentMethods.stream()
                 .filter(e -> e.getId().equals(id))
                 .findFirst();

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -364,7 +364,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public static PaymentMethod getPaymentMethodById(String id) {
+    public static PaymentMethod getPaymentMethod(String id) {
         return getActivePaymentMethod(id)
                 .orElseGet(() -> new PaymentMethod(Res.get("shared.na")));
     }

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -437,7 +437,12 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         }
         long maxTradeLimit = Coin.COIN.multiply(2).value;
         try {
-            maxTradeLimit = PaymentMethod.getPaymentMethodById(getPaymentMethod()).getMaxTradeLimitAsCoin(currency).value;
+            // We cover only active payment methods. Retired ones will not be found by getActivePaymentMethodById.
+            String paymentMethod = getPaymentMethod();
+            Optional<PaymentMethod> optionalPaymentMethodById = PaymentMethod.getActivePaymentMethodById(paymentMethod);
+            if (optionalPaymentMethodById.isPresent()) {
+                maxTradeLimit = optionalPaymentMethodById.get().getMaxTradeLimitAsCoin(currency).value;
+            }
         } catch (Exception ignore) {
         }
         return amount > 0 &&

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -398,7 +398,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         refundAgent = null;
     }
 
-    public String getPaymentMethod() {
+    public String getPaymentMethodId() {
         try {
             return PaymentMethodMapper.values()[Integer.parseInt(paymentMethod)].name();
         } catch (Throwable ignore) {
@@ -438,7 +438,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         long maxTradeLimit = Coin.COIN.multiply(2).value;
         try {
             // We cover only active payment methods. Retired ones will not be found by getActivePaymentMethodById.
-            String paymentMethodId = getPaymentMethod();
+            String paymentMethodId = getPaymentMethodId();
             Optional<PaymentMethod> optionalPaymentMethod = PaymentMethod.getActivePaymentMethod(paymentMethodId);
             if (optionalPaymentMethod.isPresent()) {
                 maxTradeLimit = optionalPaymentMethod.get().getMaxTradeLimitAsCoin(currency).value;

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -443,7 +443,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
             if (optionalPaymentMethodById.isPresent()) {
                 maxTradeLimit = optionalPaymentMethodById.get().getMaxTradeLimitAsCoin(currency).value;
             }
-        } catch (Exception ignore) {
+        } catch (Exception e) {
+            log.warn("Error at isValid(). " + e.toString(), e);
         }
         return amount > 0 &&
                 amount <= maxTradeLimit &&

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -438,10 +438,10 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         long maxTradeLimit = Coin.COIN.multiply(2).value;
         try {
             // We cover only active payment methods. Retired ones will not be found by getActivePaymentMethodById.
-            String paymentMethod = getPaymentMethod();
-            Optional<PaymentMethod> optionalPaymentMethodById = PaymentMethod.getActivePaymentMethodById(paymentMethod);
-            if (optionalPaymentMethodById.isPresent()) {
-                maxTradeLimit = optionalPaymentMethodById.get().getMaxTradeLimitAsCoin(currency).value;
+            String paymentMethodId = getPaymentMethod();
+            Optional<PaymentMethod> optionalPaymentMethod = PaymentMethod.getActivePaymentMethod(paymentMethodId);
+            if (optionalPaymentMethod.isPresent()) {
+                maxTradeLimit = optionalPaymentMethod.get().getMaxTradeLimitAsCoin(currency).value;
             }
         } catch (Exception e) {
             log.warn("Error at isValid(). " + e.toString(), e);

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -444,7 +444,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                 maxTradeLimit = optionalPaymentMethod.get().getMaxTradeLimitAsCoin(currency).value;
             }
         } catch (Exception e) {
-            log.warn("Error at isValid(). " + e.toString(), e);
+            log.warn("Error at isValid().", e);
         }
         return amount > 0 &&
                 amount <= maxTradeLimit &&

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsForJson.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsForJson.java
@@ -52,7 +52,7 @@ public final class TradeStatisticsForJson {
 
     public TradeStatisticsForJson(TradeStatistics3 tradeStatistics) {
         this.currency = tradeStatistics.getCurrency();
-        this.paymentMethod = tradeStatistics.getPaymentMethod();
+        this.paymentMethod = tradeStatistics.getPaymentMethodId();
         this.tradePrice = tradeStatistics.getPrice();
         this.tradeAmount = tradeStatistics.getAmount();
         this.tradeDate = tradeStatistics.getDateAsLong();

--- a/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
@@ -65,7 +65,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static bisq.core.payment.payload.PaymentMethod.getPaymentMethodById;
+import static bisq.core.payment.payload.PaymentMethod.getPaymentMethod;
 import static bisq.core.support.dispute.DisputeResult.PayoutSuggestion.UNKNOWN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -232,7 +232,7 @@ public class AccountAgeWitnessServiceTest {
         when(contract.getBuyerPaymentAccountPayload()).thenReturn(buyerPaymentAccountPayload);
         when(contract.getSellerPaymentAccountPayload()).thenReturn(sellerPaymentAccountPayload);
         when(contract.getOfferPayload()).thenReturn(mock(OfferPayload.class));
-        List<TraderDataItem> items = service.getTraderPaymentAccounts(now, getPaymentMethodById(PaymentMethod.SEPA_ID), disputes);
+        List<TraderDataItem> items = service.getTraderPaymentAccounts(now, getPaymentMethod(PaymentMethod.SEPA_ID), disputes);
         assertEquals(2, items.size());
 
         // Setup a mocked arbitrator key

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -200,7 +200,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                             .append("Price: ").append(FormattingUtils.formatPrice(tradeStatistics3.getTradePrice())).append("\n")
                             .append("Amount: ").append(formatter.formatCoin(tradeStatistics3.getTradeAmount())).append("\n")
                             .append("Volume: ").append(VolumeUtil.formatVolume(tradeStatistics3.getTradeVolume())).append("\n")
-                            .append("Payment method: ").append(Res.get(tradeStatistics3.getPaymentMethod())).append("\n")
+                            .append("Payment method: ").append(Res.get(tradeStatistics3.getPaymentMethodId())).append("\n")
                             .append("ReferralID: ").append(tradeStatistics3.getExtraDataMap().get(OfferPayload.REFERRAL_ID));
                     return sb.toString();
                 })

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
@@ -83,7 +83,7 @@ public class TradeStatistics3ListItem {
 
     public String getPaymentMethodString() {
         if (paymentMethodString == null) {
-            paymentMethodString = tradeStatistics3 != null ? Res.get(tradeStatistics3.getPaymentMethod()) : "";
+            paymentMethodString = tradeStatistics3 != null ? Res.get(tradeStatistics3.getPaymentMethodId()) : "";
         }
         return paymentMethodString;
     }


### PR DESCRIPTION
Only apply maxTradeLimit from PaymentMethod if the PaymentMethod is found in the active list. Otherwise the 2 BTC default is used.
We get TradeStatistics3 objects from old retired PaymentMethods
which are not found in the active list.
