### PR TITLE
Enforce inclusion of TradeLimits for headless apps

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqHeadlessAppMain.java
+++ b/core/src/main/java/bisq/core/app/BisqHeadlessAppMain.java
@@ -17,6 +17,8 @@
 
 package bisq.core.app;
 
+import bisq.core.payment.TradeLimits;
+
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
 import bisq.common.app.Version;
@@ -31,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BisqHeadlessAppMain extends BisqExecutable {
     protected HeadlessApp headlessApp;
+    private TradeLimits tradeLimits;
 
     public BisqHeadlessAppMain() {
         super("Bisq Daemon", "bisqd", "Bisq", Version.VERSION);
@@ -108,6 +111,9 @@ public class BisqHeadlessAppMain extends BisqExecutable {
 
     @Override
     protected void startApplication() {
+        // Pin that as it is used in PaymentMethods and verification in TradeStatistics
+        tradeLimits = injector.getInstance(TradeLimits.class);
+
         // We need to be in user thread! We mapped at launchApplication already...
         headlessApp.startApplication();
 

--- a/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
@@ -25,6 +25,7 @@ import bisq.core.dao.DaoSetup;
 import bisq.core.dao.node.full.RpcService;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.offer.bsq_swap.OpenBsqSwapOfferService;
+import bisq.core.payment.TradeLimits;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 
 import bisq.network.p2p.NodeAddress;
@@ -62,6 +63,7 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable {
     private static final long SHUTDOWN_INTERVAL = TimeUnit.HOURS.toMillis(24);
     private volatile boolean stopped;
     private final long startTime = System.currentTimeMillis();
+    private TradeLimits tradeLimits;
 
     public ExecutableForAppWithP2p(String fullName, String scriptName, String appName, String version) {
         super(fullName, scriptName, appName, version);
@@ -74,6 +76,12 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable {
                 .setDaemon(true)
                 .build();
         UserThread.setExecutor(Executors.newSingleThreadExecutor(threadFactory));
+    }
+
+    @Override
+    protected void startApplication() {
+        // Pin that as it is used in PaymentMethods and verification in TradeStatistics
+        tradeLimits = injector.getInstance(TradeLimits.class);
     }
 
     @Override

--- a/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
+++ b/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
@@ -91,13 +91,6 @@ public class BisqDaemonMain extends BisqHeadlessAppMain implements BisqSetup.Bis
     @Override
     protected void startApplication() {
         super.startApplication();
-
-        // We need to be in user thread! We mapped at launchApplication already...
-        headlessApp.startApplication();
-
-        // In headless mode we don't have an async behaviour so we trigger the setup by
-        // calling onApplicationStarted.
-        onApplicationStarted();
     }
 
     @Override

--- a/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
+++ b/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
@@ -90,6 +90,8 @@ public class BisqDaemonMain extends BisqHeadlessAppMain implements BisqSetup.Bis
 
     @Override
     protected void startApplication() {
+        super.startApplication();
+
         // We need to be in user thread! We mapped at launchApplication already...
         headlessApp.startApplication();
 

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -137,6 +137,8 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
 
     @Override
     protected void startApplication() {
+        super.startApplication();
+
         Cookie cookie = injector.getInstance(User.class).getCookie();
         cookie.getAsOptionalBoolean(CookieKey.CLEAN_TOR_DIR_AT_RESTART).ifPresent(wasCleanTorDirSet -> {
             if (wasCleanTorDirSet) {

--- a/statsnode/src/main/java/bisq/statistics/StatisticsMain.java
+++ b/statsnode/src/main/java/bisq/statistics/StatisticsMain.java
@@ -88,6 +88,8 @@ public class StatisticsMain extends ExecutableForAppWithP2p {
 
     @Override
     protected void startApplication() {
+        super.startApplication();
+
         statistics.startApplication();
     }
 }


### PR DESCRIPTION
PaymentMethod use an instance of TradeLimits and expect that it
has been injected, which is the case for desktop but not for
headless apps, so we enforce injection in the app base classes
used for headless apps.

The validation of trade statistics use a method in PaymentMethod where that
dependency is required.

Tha hack how the PaymentMethod use TradeLimits is not nice, but
would require more effort for refactoring.
