### PR TITLE
Set gradle java src & target compat =  VERSION_11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ configure(subprojects) {
     apply plugin: 'java'
     apply plugin: 'com.google.osdetector'
 
-    sourceCompatibility = 1.10
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 
     ext { // in alphabetical order
         bcVersion = '1.63'


### PR DESCRIPTION
This change sets java source and class generation version targets to 11.  The Bisq distribution is built with JDK 11, but the build file's source target has remained at 1.10.  Upgrading allows devs to use java syntax features and apis available `@since 11`, and it might help anyone building the src avoid confusion over which JDK they should use:  the minimum is JDK 11, but the old `sourceCompatibility` was 1.10, implying JDK 10 might work.

See https://docs.gradle.org/current/userguide/java_plugin.html#sec:java-extension
