### PR TITLE
Fix incorrect start height for block request

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/BsqNode.java
+++ b/core/src/main/java/bisq/core/dao/node/BsqNode.java
@@ -182,26 +182,6 @@ public abstract class BsqNode implements DaoSetupService {
         p2PService.removeP2PServiceListener(p2PServiceListener);
     }
 
-    @SuppressWarnings("WeakerAccess")
-    protected int getStartBlockHeight() {
-        int chainHeight = daoStateService.getChainHeight();
-        int startBlockHeight = chainHeight;
-        if (chainHeight > genesisBlockHeight)
-            startBlockHeight = chainHeight + 1;
-
-        log.info("getStartBlockHeight:\n" +
-                        "   Start block height={}\n" +
-                        "   Genesis txId={}\n" +
-                        "   Genesis block height={}\n" +
-                        "   Block height={}\n",
-                startBlockHeight,
-                genesisTxId,
-                genesisBlockHeight,
-                chainHeight);
-
-        return startBlockHeight;
-    }
-
     protected abstract void startParseBlocks();
 
     protected void onParseBlockChainComplete() {

--- a/core/src/main/java/bisq/core/dao/node/full/FullNode.java
+++ b/core/src/main/java/bisq/core/dao/node/full/FullNode.java
@@ -107,8 +107,7 @@ public class FullNode extends BsqNode {
 
     @Override
     protected void startParseBlocks() {
-        int startBlockHeight = getStartBlockHeight();
-
+        int startBlockHeight = daoStateService.getChainHeight();
         log.info("startParseBlocks: startBlockHeight={}", startBlockHeight);
         rpcService.requestChainHeadHeight(chainHeight -> {
                     // If our persisted block is equal to the chain height we have startBlockHeight 1 block higher,

--- a/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/LiteNode.java
@@ -182,7 +182,14 @@ public class LiteNode extends BsqNode {
     // First we request the blocks from a full node
     @Override
     protected void startParseBlocks() {
-        liteNodeNetworkService.requestBlocks(getStartBlockHeight());
+        if (daoStateChainHeightBelowWalletChainHeight()) {
+            liteNodeNetworkService.requestBlocks(daoStateService.getChainHeight() + 1);
+        } else {
+            log.info("No block request needed as we have already the most recent block. " +
+                            "daoStateService.getChainHeight()={}, bsqWalletService.getBestChainHeight()={}",
+                    daoStateService.getChainHeight(), bsqWalletService.getBestChainHeight());
+            onParseBlockChainComplete();
+        }
     }
 
 
@@ -221,9 +228,8 @@ public class LiteNode extends BsqNode {
                             MathUtils.roundDouble(duration / blockList.size(), 2));
                     // We only request again if wallet is synced, otherwise we would get repeated calls we want to avoid.
                     // We deal with that case at the setupWalletBestBlockListener method above.
-                    if (walletsSetup.isDownloadComplete() &&
-                            daoStateService.getChainHeight() < bsqWalletService.getBestChainHeight()) {
-                        liteNodeNetworkService.requestBlocks(getStartBlockHeight());
+                    if (daoStateChainHeightBelowWalletChainHeight()) {
+                        liteNodeNetworkService.requestBlocks(daoStateService.getChainHeight() + 1);
                     } else {
                         onParsingComplete.run();
                         onParseBlockChainComplete();
@@ -265,5 +271,9 @@ public class LiteNode extends BsqNode {
         }
 
         maybeExportToJson();
+    }
+
+    private boolean daoStateChainHeightBelowWalletChainHeight() {
+        return walletsSetup.isDownloadComplete() && daoStateService.getChainHeight() < bsqWalletService.getBestChainHeight();
     }
 }


### PR DESCRIPTION
We added 1 as with the lite monitor mode we persist the most recent block,
thus we request with the start height for the next block.
But that cause a problem at a DAO full mode which has lite monitor mode set
as then the block parsing would not be triggered.

We refactor it so that we take the chainHeight from the dao state
directly and add 1 at the requests.
We add a check if we are at chain tip, and if so we skip requests
and call the onParseBlockChainComplete directly.

How to test it?
Use a DAO full node and set lite mode for monitoring in setting. 
Create a new block. Restart. Now there is no BSQ and no monitoring data as block parsing did not get triggered.
With the PR this does not happen. 