### PR TITLE
Substitute Unconfirmed for Processing BSQ swap

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -576,7 +576,7 @@ takeOffer.success.info=You can see the status of your trade at \"Portfolio/Open 
 takeOffer.error.message=An error occurred when taking the offer.\n\n{0}
 
 takeOffer.bsqSwap.success.headline=Your BSQ swap trade is completed
-takeOffer.bsqSwap.success.info=You can see your completed trade at \"Portfolio/Unconfirmed BSQ Swaps\"
+takeOffer.bsqSwap.success.info=You can see your completed trade at \"Portfolio/Processing BSQ Swaps\"
 
 # new entries
 takeOffer.takeOfferButton=Review: Take offer to {0} bitcoin
@@ -652,7 +652,7 @@ bsqSwapOffer.feeHandling=Fee handling for BSQ swaps is different from normal Bis
 portfolio.tab.openOffers=My open offers
 portfolio.tab.pendingTrades=Open trades
 portfolio.tab.history=History
-portfolio.tab.bsqSwap=Unconfirmed BSQ swaps
+portfolio.tab.bsqSwap=Processing BSQ swaps
 portfolio.tab.failed=Failed
 portfolio.tab.editOpenOffer=Edit offer
 portfolio.tab.duplicateOffer=Duplicate offer
@@ -2454,8 +2454,8 @@ dao.tx.bsqSwapTx=BSQ Swap transaction
 dao.tx.bsqSwapTrade=BSQ Swap trade: {0}
 
 
-dao.proposal.create.missingBsqFunds=You don''t have sufficient BSQ funds for creating the proposal. If you have an \
-  unconfirmed BSQ transaction you need to wait for a blockchain confirmation because BSQ is validated only if it is \
+dao.proposal.create.missingBsqFunds=You don''t have sufficient BSQ funds for creating the proposal. If you have a \
+  processing BSQ transaction you need to wait for a blockchain confirmation because BSQ is validated only if it is \
   included in a block.\n\
   Missing: {0}
 
@@ -3252,8 +3252,8 @@ navigation.funds.availableForWithdrawal=\"Funds/Send funds\"
 navigation.portfolio.myOpenOffers=\"Portfolio/My open offers\"
 navigation.portfolio.pending=\"Portfolio/Open trades\"
 navigation.portfolio.closedTrades=\"Portfolio/History\"
-navigation.portfolio.bsqSwapTrades=\"Portfolio/Unconfirmed BSQ Swaps\"
-navigation.portfolio.bsqSwapTrades.short=\"Unconfirmed BSQ Swaps\"
+navigation.portfolio.bsqSwapTrades=\"Portfolio/Processing BSQ Swaps\"
+navigation.portfolio.bsqSwapTrades.short=\"Processing BSQ Swaps\"
 navigation.funds.depositFunds=\"Funds/Receive funds\"
 navigation.settings.preferences=\"Settings/Preferences\"
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -576,7 +576,7 @@ takeOffer.success.info=You can see the status of your trade at \"Portfolio/Open 
 takeOffer.error.message=An error occurred when taking the offer.\n\n{0}
 
 takeOffer.bsqSwap.success.headline=Your BSQ swap trade is completed
-takeOffer.bsqSwap.success.info=You can see your completed trade at \"Portfolio/Processing BSQ Swaps\"
+takeOffer.bsqSwap.success.info=Until your trade is included in a block you can see your completed trade at \"Portfolio/Unconfirmed BSQ Swaps\"
 
 # new entries
 takeOffer.takeOfferButton=Review: Take offer to {0} bitcoin
@@ -652,7 +652,7 @@ bsqSwapOffer.feeHandling=Fee handling for BSQ swaps is different from normal Bis
 portfolio.tab.openOffers=My open offers
 portfolio.tab.pendingTrades=Open trades
 portfolio.tab.history=History
-portfolio.tab.bsqSwap=Processing BSQ swaps
+portfolio.tab.bsqSwap=Unconfirmed BSQ swaps
 portfolio.tab.failed=Failed
 portfolio.tab.editOpenOffer=Edit offer
 portfolio.tab.duplicateOffer=Duplicate offer
@@ -2454,8 +2454,8 @@ dao.tx.bsqSwapTx=BSQ Swap transaction
 dao.tx.bsqSwapTrade=BSQ Swap trade: {0}
 
 
-dao.proposal.create.missingBsqFunds=You don''t have sufficient BSQ funds for creating the proposal. If you have a \
-  processing BSQ transaction you need to wait for a blockchain confirmation because BSQ is validated only if it is \
+dao.proposal.create.missingBsqFunds=You don''t have sufficient BSQ funds for creating the proposal. If you have an \
+  unconfirmed BSQ transaction you need to wait for a blockchain confirmation because BSQ is validated only if it is \
   included in a block.\n\
   Missing: {0}
 
@@ -3252,8 +3252,8 @@ navigation.funds.availableForWithdrawal=\"Funds/Send funds\"
 navigation.portfolio.myOpenOffers=\"Portfolio/My open offers\"
 navigation.portfolio.pending=\"Portfolio/Open trades\"
 navigation.portfolio.closedTrades=\"Portfolio/History\"
-navigation.portfolio.bsqSwapTrades=\"Portfolio/Processing BSQ Swaps\"
-navigation.portfolio.bsqSwapTrades.short=\"Processing BSQ Swaps\"
+navigation.portfolio.bsqSwapTrades=\"Portfolio/Unconfirmed BSQ Swaps\"
+navigation.portfolio.bsqSwapTrades.short=\"Unconfirmed BSQ Swaps\"
 navigation.funds.depositFunds=\"Funds/Receive funds\"
 navigation.settings.preferences=\"Settings/Preferences\"
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
*Unconfirmed* BSQ swap seems like something failed, while *Processing* is used by some wallets for unconfirmed transactions and has no negative implications.

![Bildschirmfoto 2021-12-01 um 11 10 50](https://user-images.githubusercontent.com/50149324/144220923-91abc8f4-2330-40fe-b43b-b2e8ce0a8099.png)
![Bildschirmfoto 2021-12-01 um 11 10 58](https://user-images.githubusercontent.com/50149324/144220927-a47fd3c2-7191-45f8-b441-789908e27b0b.png)


<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->