### PR TITLE
Fix BSQ swap buyer tx fee theft vulnerability

### DIFF
--- a/core/src/main/java/bisq/core/btc/model/RawTransactionInput.java
+++ b/core/src/main/java/bisq/core/btc/model/RawTransactionInput.java
@@ -144,6 +144,11 @@ public final class RawTransactionInput implements NetworkPayload, PersistablePay
         long outputValue = tx.getOutput(index).getValue().value;
         checkArgument(value == outputValue,
                 "Input value (%s) mismatches connected tx output value (%s).", value, outputValue);
+        var scriptPubKey = tx.getOutput(index).getScriptPubKey();
+        var scriptType = scriptPubKey != null ? scriptPubKey.getScriptType() : null;
+        checkArgument(scriptTypeId <= 0 || scriptType != null && scriptType.id == scriptTypeId,
+                "Input scriptTypeId (%s) mismatches connected tx output scriptTypeId (%s.id = %s).",
+                scriptTypeId, scriptType, scriptType != null ? scriptType.id : 0);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/btc/model/RawTransactionInput.java
+++ b/core/src/main/java/bisq/core/btc/model/RawTransactionInput.java
@@ -17,7 +17,7 @@
 
 package bisq.core.btc.model;
 
-import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.WalletService;
 
 import bisq.common.proto.network.NetworkPayload;
 import bisq.common.proto.persistable.PersistablePayload;
@@ -35,6 +35,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import javax.annotation.concurrent.Immutable;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode
 @Immutable
@@ -56,7 +60,7 @@ public final class RawTransactionInput implements NetworkPayload, PersistablePay
                 input.getConnectedOutput() != null &&
                         input.getConnectedOutput().getScriptPubKey() != null &&
                         input.getConnectedOutput().getScriptPubKey().getScriptType() != null ?
-                        input.getConnectedOutput().getScriptPubKey().getScriptType().id : -1);
+                        input.getConnectedOutput().getScriptPubKey().getScriptType().id : 0);
     }
 
     // Does not set the scriptTypeId. Use RawTransactionInput(TransactionInput input) for any new code.
@@ -129,8 +133,17 @@ public final class RawTransactionInput implements NetworkPayload, PersistablePay
         return scriptTypeId == Script.ScriptType.P2WSH.id;
     }
 
-    public String getParentTxId(BtcWalletService btcWalletService) {
-        return btcWalletService.getTxFromSerializedTx(parentTransaction).getTxId().toString();
+    public String getParentTxId(WalletService walletService) {
+        return walletService.getTxFromSerializedTx(parentTransaction).getTxId().toString();
+    }
+
+    public void validate(WalletService walletService) {
+        Transaction tx = walletService.getTxFromSerializedTx(checkNotNull(parentTransaction));
+        checkArgument(index == (int) index, "Input index out of range.");
+        checkElementIndex((int) index, tx.getOutputs().size(), "Input index");
+        long outputValue = tx.getOutput(index).getValue().value;
+        checkArgument(value == outputValue,
+                "Input value (%s) mismatches connected tx output value (%s).", value, outputValue);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerification.java
+++ b/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerification.java
@@ -77,7 +77,7 @@ public class BsqSwapTakeOfferRequestVerification {
             checkArgument(isDateInTolerance(request), "Trade date is out of tolerance");
             checkArgument(isTxFeeInTolerance(request, feeService), "Miner fee from taker not in tolerance");
             checkArgument(request.getMakerFee() == Objects.requireNonNull(CoinUtil.getMakerFee(false, amountAsCoin)).value);
-            checkArgument(request.getTakerFee() == CoinUtil.getTakerFee(false, amountAsCoin).value);
+            checkArgument(request.getTakerFee() == Objects.requireNonNull(CoinUtil.getTakerFee(false, amountAsCoin)).value);
         } catch (Exception e) {
             log.error("BsqSwapTakeOfferRequestVerification failed. Request={}, peer={}, error={}", request, peer, e.toString());
             return false;
@@ -93,9 +93,9 @@ public class BsqSwapTakeOfferRequestVerification {
     private static boolean isTxFeeInTolerance(BsqSwapRequest request, FeeService feeService) {
         double myFee = (double) feeService.getTxFeePerVbyte().getValue();
         double peersFee = (double) Coin.valueOf(request.getTxFeePerVbyte()).getValue();
-        // Allow for 10% diff in mining fee, ie, maker will accept taker fee that's 10%
-        // off their own fee from service. Both parties will use the same fee while
-        // creating the bsq swap tx
+        // Allow for 50% diff in mining fee, ie, maker will accept taker fee that's less
+        // than 50% off their own fee from service (that is, 100% higher or 50% lower).
+        // Both parties will use the same fee while creating the bsq swap tx.
         double diff = abs(1 - myFee / peersFee);
         boolean isInTolerance = diff < 0.5;
         if (!isInTolerance) {

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/seller/ProcessTxInputsMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/seller/ProcessTxInputsMessage.java
@@ -62,8 +62,11 @@ public abstract class ProcessTxInputsMessage extends BsqSwapTask {
             TxInputsMessage message = checkNotNull((TxInputsMessage) protocolModel.getTradeMessage());
             checkNotNull(message);
 
+            BtcWalletService btcWalletService = protocolModel.getBtcWalletService();
+
             List<RawTransactionInput> inputs = message.getBsqInputs();
             checkArgument(!inputs.isEmpty(), "Buyers BSQ inputs must not be empty");
+            inputs.forEach(input -> input.validate(btcWalletService));
 
             long sumInputs = inputs.stream().mapToLong(rawTransactionInput -> rawTransactionInput.value).sum();
             long buyersBsqInputAmount = BsqSwapCalculation.getBuyersBsqInputValue(trade, getBuyersTradeFee()).getValue();
@@ -71,7 +74,6 @@ public abstract class ProcessTxInputsMessage extends BsqSwapTask {
                     "Buyers BSQ input amount do not match our calculated required BSQ input amount");
 
             DaoFacade daoFacade = protocolModel.getDaoFacade();
-            BtcWalletService btcWalletService = protocolModel.getBtcWalletService();
 
             long sumValidBsqInputValue = inputs.stream()
                     .mapToLong(input -> daoFacade.getUnspentTxOutputValue(


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Prevent the seller from stealing the combined tx fee as change by lying about the value of one or more of his BTC inputs, which are passed to the buyer as raw inputs in the `BsqSwapFinalizeTxRequest` message.

To this end, add a `RawTransactionInput::validate` method to check the `value` field against the output value of the respective spending tx and run it on every raw seller input in `ProcessBsqSwapFinalizeTxRequest`, so that the buyer is no longer just trusting those numbers.

Additionally, check that the spending txIds from the raw BTC inputs supplied by the seller actually match those of his signed inputs in the accompanying partially signed tx, thus tying the raw input values to the seller's tx.

--

This should block an attack by the BTC seller that I was able to carry out on regtest. If the seller is the taker, the attack can be made worse by creating a swap trade with the tx fee set at just under twice that seen by the maker, so that it is still within tolerance. So the seller-as-taker could wait until the tx fee spikes to, say, 50 sat/vbyte (but the mempool is not too full) and then take an offer with the tx fee set to 99 sat/vbyte. In this way, they could steal around 12000 sat or so as change and still leave 1 sat/vbyte for the fee so that the transaction eventually confirms. The attack is made worse the more inputs the maker uses or the higher the broadcast tx fee.
