### PR TITLE
Fix resync BSQ blocks from resources

### DIFF
--- a/common/src/main/java/bisq/common/file/FileUtil.java
+++ b/common/src/main/java/bisq/common/file/FileUtil.java
@@ -24,6 +24,11 @@ import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -32,10 +37,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -166,6 +175,42 @@ public class FileUtil {
                 IOUtils.copy(inputStream, fileOutputStream);
             }
         }
+    }
+
+    // adapted from https://stackoverflow.com/questions/3923129/get-a-list-of-resources-from-classpath-directory/48190582#48190582
+    public static List<String> listResourceDirectory(String directoryName) throws IOException, ResourceNotFoundException {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(directoryName);
+        if (url == null) {
+            throw new ResourceNotFoundException(directoryName);
+        }
+        if (url.getProtocol().equals("file")) {
+            try {
+                File dir = new File(url.toURI());
+                String[] filenames = dir.list();
+                if (filenames != null) {
+                    return List.of(filenames);
+                }
+            } catch (URISyntaxException e) {
+                throw new IOException(e);
+            }
+        } else if (url.getProtocol().equals("jar")) {
+            List<String> filenames = new ArrayList<>();
+            String dirname = directoryName + "/";
+            String path = url.getPath();
+            String jarPath = path.substring(5, path.indexOf("!"));
+            try (JarFile jar = new JarFile(URLDecoder.decode(jarPath, StandardCharsets.UTF_8.name()))) {
+                Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    String name = entry.getName();
+                    if (name.startsWith(dirname) && !dirname.equals(name)) {
+                        filenames.add(name.substring(dirname.length()));
+                    }
+                }
+            }
+            return filenames;
+        }
+        throw new IOException("Failed to list resource directory: " + directoryName);
     }
 
     public static void renameFile(File oldFile, File newFile) throws IOException {

--- a/core/src/main/java/bisq/core/dao/state/storage/BsqBlocksStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/BsqBlocksStorageService.java
@@ -21,6 +21,7 @@ import bisq.core.dao.state.GenesisTxInfo;
 import bisq.core.dao.state.model.blockchain.Block;
 
 import bisq.common.config.Config;
+import bisq.common.file.FileUtil;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
 
 import protobuf.BaseBlock;
@@ -28,10 +29,6 @@ import protobuf.BaseBlock;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-
-import org.apache.commons.io.FileUtils;
-
-import java.net.URL;
 
 import java.io.File;
 
@@ -116,27 +113,19 @@ public class BsqBlocksStorageService {
                 return;
             }
 
-            URL dirUrl = getClass().getClassLoader().getResource(resourceDir);
-            if (dirUrl == null) {
-                log.info("Directory {} in resources does not exist.", resourceDir);
-                return;
-            }
-            File dir = new File(dirUrl.toURI());
-            String[] fileNames = dir.list();
-            if (fileNames == null) {
-                log.info("No files in directory. {}", dir.getAbsolutePath());
+            List<String> fileNames = FileUtil.listResourceDirectory(resourceDir);
+            if (fileNames.isEmpty()) {
+                log.info("No files in directory. {}", resourceDir);
                 return;
             }
             if (!storageDir.exists()) {
                 storageDir.mkdir();
             }
             for (String fileName : fileNames) {
-                URL url = getClass().getClassLoader().getResource(resourceDir + File.separator + fileName);
-                File resourceFile = new File(url.toURI());
                 File destinationFile = new File(storageDir, fileName);
-                FileUtils.copyFile(resourceFile, destinationFile);
+                FileUtil.resourceToFile(resourceDir + "/" + fileName, destinationFile);
             }
-            log.info("Copying {} resource files took {} ms", fileNames.length, System.currentTimeMillis() - ts);
+            log.info("Copying {} resource files took {} ms", fileNames.size(), System.currentTimeMillis() - ts);
         } catch (Throwable e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Prevent a _"URI is not hierarchical"_ `IllegalArgumentException` from the expression, `new File(dirUrl.toURI())`, which occurs on Linux & Windows when listing the resource directory of BSQ blocks. Adapt a solution from StackOverflow (together with the earlier `java.nio.file.FileSystem`-based approach in #5898), which uses two separate code paths depending on the environment, into the new method `FileUtil::listResourceDirectory`.

The issue is caused by the resource URL taking one of the two forms:

1.  file:/Users/[USER]/Java/bisq/bisq/p2p/out/production/resources/BsqBlocks_BTC_MAINNET
2.  jar:file:...p2p.jar!/BsqBlocks_BTC_MAINNET

depending on whether the system is OSX or not.

--

I tested the PR on Linux & Windows, but have not been able to test the absence of a regression on OSX (though I don't expect this, as it should use a similar code path to the original).