### PR TITLE
Apply Localized Number Formatting To Transaction Details

### DIFF
--- a/core/src/main/java/bisq/core/locale/GlobalSettings.java
+++ b/core/src/main/java/bisq/core/locale/GlobalSettings.java
@@ -39,6 +39,7 @@ public class GlobalSettings {
     }
 
     public static void setLocale(Locale locale) {
+        Locale.setDefault(locale);
         GlobalSettings.locale = locale;
         localeProperty.set(locale);
     }

--- a/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
@@ -52,11 +52,6 @@ import lombok.extern.slf4j.Slf4j;
 public class BsqFormatter implements CoinFormatter {
     private final ImmutableCoinFormatter immutableCoinFormatter;
 
-    // We don't support localized formatting. Format is always using "." as decimal mark and no grouping separator.
-    // Input of "," as decimal mark (like in German locale) will be replaced with ".".
-    // Input of a group separator (1,123,45) leads to a validation error.
-    // Note: BtcFormat was intended to be used, but it leads to many problems (automatic format to mBit,
-    // no way to remove grouping separator). It seems to be not optimal for user input formatting.
     @Getter
     private MonetaryFormat monetaryFormat;
 

--- a/core/src/main/java/bisq/core/util/coin/ImmutableCoinFormatter.java
+++ b/core/src/main/java/bisq/core/util/coin/ImmutableCoinFormatter.java
@@ -30,11 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ImmutableCoinFormatter implements CoinFormatter {
 
-    // We don't support localized formatting. Format is always using "." as decimal mark and no grouping separator.
-    // Input of "," as decimal mark (like in german locale) will be replaced with ".".
-    // Input of a group separator (1,123,45) lead to an validation error.
-    // Note: BtcFormat was intended to be used, but it lead to many problems (automatic format to mBit,
-    // no way to remove grouping separator). It seems to be not optimal for user input formatting.
     @Getter
     private MonetaryFormat monetaryFormat;
 

--- a/desktop/src/test/java/bisq/desktop/main/offer/bisq_v1/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/bisq_v1/createoffer/CreateOfferViewModelTest.java
@@ -56,6 +56,8 @@ import javafx.collections.FXCollections;
 
 import java.time.Instant;
 
+import java.util.Locale;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -76,6 +78,8 @@ public class CreateOfferViewModelTest {
 
     @Before
     public void setUp() {
+        GlobalSettings.setLocale(Locale.US);
+
         final CryptoCurrency btc = new CryptoCurrency("BTC", "bitcoin");
         GlobalSettings.setDefaultTradeCurrency(btc);
         Res.setup();

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -59,6 +59,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Locale;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,6 +89,7 @@ public class OfferBookViewModelTest {
 
     @Before
     public void setUp() {
+        GlobalSettings.setLocale(Locale.US);
         GlobalSettings.setDefaultTradeCurrency(usd);
         Res.setBaseCurrencyCode(usd.getCode());
         Res.setBaseCurrencyName(usd.getName());


### PR DESCRIPTION
Fixes #3145

By default all amounts are separated by a "." In some locales that is
not the correct separator. This change formats all amounts and
percentages using the correct locale.