### PR TITLE
Clean tor directory at startup

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -147,6 +147,7 @@ public class BisqSetup {
     private final MediationManager mediationManager;
     private final RefundManager refundManager;
     private final ArbitrationManager arbitrationManager;
+    private final TorSetup torSetup;
 
     @Setter
     @Nullable
@@ -234,7 +235,8 @@ public class BisqSetup {
                      Socks5ProxyProvider socks5ProxyProvider,
                      MediationManager mediationManager,
                      RefundManager refundManager,
-                     ArbitrationManager arbitrationManager) {
+                     ArbitrationManager arbitrationManager,
+                     TorSetup torSetup) {
         this.domainInitialisation = domainInitialisation;
         this.p2PNetworkSetup = p2PNetworkSetup;
         this.walletAppSetup = walletAppSetup;
@@ -257,6 +259,7 @@ public class BisqSetup {
         this.mediationManager = mediationManager;
         this.refundManager = refundManager;
         this.arbitrationManager = arbitrationManager;
+        this.torSetup = torSetup;
 
         MemPoolSpaceTxBroadcaster.init(socks5ProxyProvider, preferences, localBitcoinNode);
     }
@@ -314,7 +317,7 @@ public class BisqSetup {
     }
 
     private void step3() {
-        startP2pNetworkAndWallet(this::step4);
+        cleanupTorFiles(() -> startP2pNetworkAndWallet(this::step4));
     }
 
     private void step4() {
@@ -367,6 +370,13 @@ public class BisqSetup {
     private void readMapsFromResources(Runnable completeHandler) {
         String postFix = "_" + config.baseCurrencyNetwork.name();
         p2PService.getP2PDataStorage().readFromResources(postFix, completeHandler);
+    }
+
+    // 6,7 sec
+    // Tor started after 28671 ms
+    private void cleanupTorFiles(Runnable nextStep) {
+        torSetup.cleanupTorFiles(nextStep, null);
+        // nextStep.run();
     }
 
     private void startP2pNetworkAndWallet(Runnable nextStep) {


### PR DESCRIPTION
This PR is an intent to fight the messaging issues. We had in the past sometimes issues that Tor became instable and deleting the tor directory (excluding the hidden service dir) solved that. So it might be worth to see if it helps if we reset at each startup the tor directory. 
The startup time for Tor is a bit slower as it need to download about 10MB of data. 

Tests showed that it takes about 8 seconds longer. On a slow internet connection its about  15-25 sec slower.

I dont have a very strong opinion if we should use that PR as the chances that it fixes the problem are not super high, but its a relatively cheap attempt which comes with only a small delay at startup. Give a thumbs up/down if you support that PR.
I researched also to find if there are reported bugs with corrupted/outdated tor data but could not find much beside that at shutdown the decriptor files might get corrupted, but I assume that would lead to problems as starting Tor.

Normal:
```
bisq.log:Tor started after 6736 ms. Start publishing hidden service.
bisq.log:Tor started after 6182 ms. Start publishing hidden service.
bisq.log:Tor started after 5802 ms. Start publishing hidden service.
bisq.log:Tor started after 6286 ms. Start publishing hidden service.
bisq.log:Tor started after 6303 ms. Start publishing hidden service.
```

With that PR:
```
bisq.log:Tor started after 14819 ms. Start publishing hidden service.
bisq.log:Tor started after 13833 ms. Start publishing hidden service.
bisq.log:Tor started after 12840 ms. Start publishing hidden service.
bisq.log:Tor started after 13760 ms. Start publishing hidden service.
```