### PR TITLE
Increase trade protocol timeout from 60 sec to 120 sec

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsMakerProtocol.java
@@ -85,7 +85,7 @@ public class BuyerAsMakerProtocol extends BuyerProtocol implements MakerProtocol
                                     errorMessageHandler.handleErrorMessage(errorMessage);
                                     handleTaskRunnerFault(message, errorMessage);
                                 }))
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 
@@ -105,7 +105,7 @@ public class BuyerAsMakerProtocol extends BuyerProtocol implements MakerProtocol
                         BuyerSignsDelayedPayoutTx.class,
                         BuyerFinalizesDelayedPayoutTx.class,
                         BuyerSendsDelayedPayoutTxSignatureResponse.class)
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsTakerProtocol.java
@@ -82,7 +82,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         CreateTakerFeeTx.class,
                         BuyerAsTakerCreatesDepositTxInputs.class,
                         TakerSendInputsForDepositTxRequest.class)
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .run(() -> {
                     processModel.setTempTradingPeerNodeAddress(trade.getTradingPeerNodeAddress());
                     processModel.getTradeManager().requestPersistence();
@@ -106,7 +106,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         BuyerAsTakerSignsDepositTx.class,
                         BuyerSetupDepositTxListener.class,
                         BuyerAsTakerSendsDepositTxMessage.class)
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 
@@ -120,7 +120,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
                         BuyerSignsDelayedPayoutTx.class,
                         BuyerFinalizesDelayedPayoutTx.class,
                         BuyerSendsDelayedPayoutTxSignatureResponse.class)
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsMakerProtocol.java
@@ -85,7 +85,7 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
                                     errorMessageHandler.handleErrorMessage(errorMessage);
                                     handleTaskRunnerFault(message, errorMessage);
                                 }))
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 
@@ -105,7 +105,7 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
                         SellerCreatesDelayedPayoutTx.class,
                         SellerSignsDelayedPayoutTx.class,
                         SellerSendDelayedPayoutTxSignatureRequest.class)
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsTakerProtocol.java
@@ -77,7 +77,7 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
                         CreateTakerFeeTx.class,
                         SellerAsTakerCreatesDepositTxInputs.class,
                         TakerSendInputsForDepositTxRequest.class)
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 
@@ -99,7 +99,7 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
                         SellerCreatesDelayedPayoutTx.class,
                         SellerSignsDelayedPayoutTx.class,
                         SellerSendDelayedPayoutTxSignatureRequest.class)
-                        .withTimeout(60))
+                        .withTimeout(120))
                 .executeTasks();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerProtocol.java
@@ -97,7 +97,7 @@ public abstract class SellerProtocol extends DisputeProtocol {
                         VerifyPeersAccountAgeWitness.class))
                 .run(() -> {
                     // We stop timeout here and don't start a new one as the
-                    // SellerSendsDepositTxAndDelayedPayoutTxMessage repeats the send the message and has it's own
+                    // SellerSendsDepositTxAndDelayedPayoutTxMessage repeats to send the message and has it's own
                     // timeout if it never succeeds.
                     stopTimeout();
                 })


### PR DESCRIPTION
Another attempt to deal with the messaging issues....

At one investigated case we saw that a timeout got triggered followed by `Hidden Service xxx.onion has been announced to the Tor network.` log from the Netwlay lib which gets logged if the hidden service gets an `UPLOADED` event, which usually happen at startup. So it might be Tor related. Unfortunately the low level tor logs are not eabled by default so we cannot see more details.