### PR TITLE
OfferBook: Show Complete Text Of Action Button If Enough Space Available

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -1087,7 +1087,7 @@ public class OfferBookView extends ActivatableViewAndModel<GridPane, OfferBookVi
                             {
                                 button.setGraphic(iconView);
                                 button.setMinWidth(200);
-                                button.setMaxWidth(200);
+                                button.setMaxWidth(Double.MAX_VALUE);
                                 button.setGraphicTextGap(10);
                             }
 


### PR DESCRIPTION
Even if the app is maximized it does not show the full text of the
action button if the text is long. Switching Bisq to German and
maximizing the window reveals the problem.

Fixes #5862 