### PR TITLE
Dont log error if BSQ blocks directory does not exist in resources

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/storage/BsqBlocksStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/BsqBlocksStorageService.java
@@ -22,6 +22,7 @@ import bisq.core.dao.state.model.blockchain.Block;
 
 import bisq.common.config.Config;
 import bisq.common.file.FileUtil;
+import bisq.common.file.ResourceNotFoundException;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
 
 import protobuf.BaseBlock;
@@ -104,10 +105,9 @@ public class BsqBlocksStorageService {
 
     void copyFromResources(String postFix) {
         long ts = System.currentTimeMillis();
+        String dirName = BsqBlocksStorageService.NAME;
+        String resourceDir = dirName + postFix;
         try {
-            String dirName = BsqBlocksStorageService.NAME;
-            String resourceDir = dirName + postFix;
-
             if (storageDir.exists()) {
                 log.info("No resource directory was copied. {} exists already.", dirName);
                 return;
@@ -123,9 +123,11 @@ public class BsqBlocksStorageService {
             }
             for (String fileName : fileNames) {
                 File destinationFile = new File(storageDir, fileName);
-                FileUtil.resourceToFile(resourceDir + "/" + fileName, destinationFile);
+                FileUtil.resourceToFile(resourceDir + File.separator + fileName, destinationFile);
             }
             log.info("Copying {} resource files took {} ms", fileNames.size(), System.currentTimeMillis() - ts);
+        } catch (ResourceNotFoundException ignore) {
+            log.info("Directory {} in resources does not exist.", resourceDir);
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/core/src/main/java/bisq/core/dao/state/storage/BsqBlocksStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/BsqBlocksStorageService.java
@@ -123,7 +123,9 @@ public class BsqBlocksStorageService {
             }
             for (String fileName : fileNames) {
                 File destinationFile = new File(storageDir, fileName);
-                FileUtil.resourceToFile(resourceDir + File.separator + fileName, destinationFile);
+                //  File.separator doesn't appear to work on Windows. It has to be "/", not "\".
+                // See: https://github.com/bisq-network/bisq/pull/5909#pullrequestreview-827992563
+                FileUtil.resourceToFile(resourceDir + "/" + fileName, destinationFile);
             }
             log.info("Copying {} resource files took {} ms", fileNames.size(), System.currentTimeMillis() - ts);
         } catch (ResourceNotFoundException ignore) {


### PR DESCRIPTION
In case the BSQ blocks directory does not exist in resources (as in case of REG_TEST)

we do not want to log an error stacktrace but just an info message.

Use `File.separator` instead of "/"

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.
