### PR TITLE
Reset the icon color properly for market price margin information

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/InfoInputTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/InfoInputTextField.java
@@ -98,6 +98,7 @@ public class InfoInputTextField extends AnchorPane {
     public void setContentForPopOver(Node node, AwesomeIcon awesomeIcon, @Nullable String style) {
         this.node = node;
         AwesomeDude.setIcon(icon, awesomeIcon);
+        icon.getStyleClass().removeAll("icon", "info", "warning", style);
         icon.getStyleClass().addAll("icon", style == null ? "info" : style);
         icon.setManaged(true);
         icon.setVisible(true);


### PR DESCRIPTION
Instead of 
<img width="345" alt="Bildschirmfoto 2021-12-21 um 13 28 59" src="https://user-images.githubusercontent.com/170962/146930436-bdca378b-0d6e-4fe7-99fa-5d14e67abac7.png">
it should be like this after the price is within a certain threshold again.
<img width="329" alt="Bildschirmfoto 2021-12-21 um 13 28 04" src="https://user-images.githubusercontent.com/170962/146930437-ec1cc71f-2ec9-4ab8-b0ce-cfdcf08d3f75.png">
