### PR TITLE
CI Security: Use Github actions via sha1 (not tags) and keep them updated via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,14 @@ jobs:
             java: [ '11', '11.0.3', '15', '15.0.5']
     name: Test Java ${{ matrix.Java }}, ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
         lfs: true
 
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@5f00602cd1b2819185d88dc7a1b1985f598c6705
       with:
         java-version: ${{ matrix.java }}
         distribution: 'zulu'
@@ -31,7 +31,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Validate Gradle Wrapper JAR files
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
 
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Tags are mutable and can change unexpectedly. Referencing actions via sha1 is more secure in that regard. Dependabot helps to automatically update to newer versions without the need to manually deal with sha1s.

Merging the PR opens update PRs similar to those shown here https://github.com/dbast/bisq/pulls 

Each update PR lists the according changes to each action and allows giving instructions to dependabot via e.g. `@dependabot ignore this major version`.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
