### PR TITLE
Include penalty for exceeding transfer limits

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3700,24 +3700,24 @@ payment.nequi.info.account=Please make sure to include your phone number that is
 When users set up a Nequi account payment limits are set to a maximum of ~ 7,000,000 COP that can be sent per month.\n\n\
 If you intend to trade amount of over 7,000,000 COP per trade you will need to complete KYC with Bancolombia and pay a fee \
   of around 15,000 COP. After this all transactions will incur a 0.4% of tax. Please ensure you are aware of the latest taxes.\n\n\
-Users should also be aware of account limits. Trades above Nequi account limits will likely have to be cancelled.
+Users should also be aware of account limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
 payment.nequi.info.buyer=Please send payment only to the phone number provided in the BTC Seller's Bisq account.\n\n\
 When users set up a Nequi account, payment limits are set to a maximum of ~ 7,000,000 COP that can be sent per month.\n\n\
 If you intend to trade amount of over 7,000,000 COP per trade you will need to complete KYC with Bancolombia and pay a fee \
   of around 15,000 COP. After this all transactions will incur a 0.4% of tax. Please ensure you are aware of the latest taxes.\n\n\
-Users should also be aware of account limits. Trades above Nequi account limits will likely have to be cancelled.
+Users should also be aware of account limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
 payment.nequi.info.seller=Please check that the payment received matches the phone number provided in the BTC Buyer's Bisq account.\n\n\
 When users set up a Nequi account, payment limits are set to a maximum of ~ 7,000,000 COP that can be sent per month.\n\n\
 If you intend to trade amount of over 7,000,000 COP per trade you will need to complete KYC with Bancolombia and pay a fee \
   of around 15,000 COP. After this all transactions will incur a 0.4% of tax. Please ensure you are aware of the latest taxes.\n\n\
-Users should also be aware of account limits. Trades above Nequi account limits will likely have to be cancelled.
+Users should also be aware of account limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
 
 payment.bizum.info.account=To use Bizum you need a bank account (IBAN) in Spain and to be registered for the service.\n\n\
 Bizum can be used for trades between €0.50 and €1,000.\n\n\
 The maximum amount of transactions you can send/receive using Bizum is €2,000 Euros per day.\n\n\
 Bizum users can have a maximum of 150 operations per month.\n\n\
 Each bank however may establish its own limits, within the above limits, for its clients.\n\n\
-Traders on Bisq should be aware of their limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
+Users should also be aware of account limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
 payment.bizum.info.buyer=Please send payment only to the BTC Seller's mobile phone number as provided in Bisq.\n\n\
 The maximum trade size is €1,000 per payment. The maximum amount of transactions you can send using Bizum is €2,000 Euros per day.\n\n\
 If you trade over the above limits your trade might be cancelled and there could be a penalty.
@@ -3746,36 +3746,36 @@ payment.monese.info.seller=BTC Sellers should expect to receive payment from the
 
 payment.satispay.info.account=To use Satispay you need a bank account (IBAN) in Italy and to be registered for the service.\n\n\
 Satispay account limits are individually set. If you want to trade increased amounts you will need to contact Satispay \
-  support to increase your limits. Traders on Bisq should be aware of their limits. If you trade over the above limits \
+  support to increase your limits. Users should also be aware of account limits. If you trade over the above limits \
   your trade might be cancelled and there could be a penalty.
 payment.satispay.info.buyer=Please send payment only to the BTC Seller's mobile phone number as provided in Bisq.\n\n\
 Satispay account limits are individually set. If you want to trade increased amounts you will need to contact Satispay \
-  support to increase your limits. Traders on Bisq should be aware of their limits. If you trade over the above limits \
+  support to increase your limits. Users should also be aware of account limits. If you trade over the above limits \
   your trade might be cancelled and there could be a penalty.
 payment.satispay.info.seller=Please make sure your payment is received from the BTC Buyer's mobile phone number / name as provided in Bisq.\n\n\
 Satispay account limits are individually set. If you want to trade increased amounts you will need to contact Satispay \
-  support to increase your limits. Traders on Bisq should be aware of their limits. If you trade over the above limits \
+  support to increase your limits. Users should also be aware of account limits. If you trade over the above limits \
   your trade might be cancelled and there could be a penalty.
 
 payment.tikkie.info.account=To use Tikkie you need a bank account (IBAN) in The Netherlands and to be registered for the service.\n\n\
 When you send a Tikkie payment request to an individual person you can ask to receive a maximum of €750 per Tikkie \
   request. The maximum amount you can request within 24 hours is €2,500 per Tikkie account.\n\n\
 Each bank however may establish its own limits, within these limits, for its clients.\n\n\
-Traders on Bisq should be aware of their limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
+Users should also be aware of account limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
 payment.tikkie.info.buyer=Please request a payment link from the BTC Seller in trader chat. Once the BTC Seller has \
   sent you a payment link that matches the correct amount for the trade please proceed to payment.\n\n\
 When the BTC Seller requests a Tikkie payment the maximum they can ask to receive is €750 per Tikkie request. If the \
   trade is over that amount the BTC Seller will have to sent multiple requests to total the trade amount. The maximum \
   you can request in a day is €2,500.\n\n\
 Each bank however may establish its own limits, within these limits, for its clients.\n\n\
-Traders on Bisq should be aware of their limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
+Users should also be aware of account limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
 payment.tikkie.info.seller=Please send a payment link to the BTC Seller in trader chat. Once the BTC \
   Buyer has sent you payment please check their IBAN detail match the details they have in Bisq.\n\n\
 When the BTC Seller requests a Tikkie payment the maximum they can ask to receive is €750 per Tikkie request. If the \
   trade is over that amount the BTC Seller will have to sent multiple requests to total the trade amount. The maximum \
   you can request in a day is €2,500.\n\n\
 Each bank however may establish its own limits, within these limits, for its clients.\n\n\
-Traders on Bisq should be aware of their limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
+Users should also be aware of account limits. If you trade over the above limits your trade might be cancelled and there could be a penalty.
 
 payment.verse.info.account=Verse is a multiple currency payment method that can send and receive payment in EUR, SEK, HUF, DKK, PLN.\n\n\
 When setting up your Verse account in Bisq please make sure to include the username that matches your username in your \


### PR DESCRIPTION
Nequi payment method did not include that there might be a penalty for exceeding the transfer limits. I have used the same wording for every payment method where it's possible to incur in a penalty for having the trade cancelled because of exceeding transfer limits.

Please @pazza review.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
