### PR TITLE
Not create and publish account age witnesses for BSQ swap accounts

### DIFF
--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -26,6 +26,7 @@ import bisq.core.offer.Offer;
 import bisq.core.offer.OfferDirection;
 import bisq.core.offer.OfferRestrictions;
 import bisq.core.payment.AssetAccount;
+import bisq.core.payment.BsqSwapAccount;
 import bisq.core.payment.ChargeBackRisk;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentAccountPayload;
@@ -228,7 +229,7 @@ public class AccountAgeWitnessService {
     private void republishAllFiatAccounts() {
         if (user.getPaymentAccounts() != null)
             user.getPaymentAccounts().stream()
-                    .filter(account -> !(account instanceof AssetAccount))
+                    .filter(account -> !(account instanceof AssetAccount) && !(account instanceof BsqSwapAccount))
                     .forEach(account -> {
                         AccountAgeWitness myWitness = getMyWitness(account.getPaymentAccountPayload());
                         // We only publish if the date of our witness is inside the date tolerance.

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -25,8 +25,6 @@ import bisq.core.locale.Res;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferDirection;
 import bisq.core.offer.OfferRestrictions;
-import bisq.core.payment.AssetAccount;
-import bisq.core.payment.BsqSwapAccount;
 import bisq.core.payment.ChargeBackRisk;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentAccountPayload;
@@ -229,7 +227,7 @@ public class AccountAgeWitnessService {
     private void republishAllFiatAccounts() {
         if (user.getPaymentAccounts() != null)
             user.getPaymentAccounts().stream()
-                    .filter(account -> !(account instanceof AssetAccount) && !(account instanceof BsqSwapAccount))
+                    .filter(account -> account.getPaymentMethod().isFiat())
                     .forEach(account -> {
                         AccountAgeWitness myWitness = getMyWitness(account.getPaymentAccountPayload());
                         // We only publish if the date of our witness is inside the date tolerance.


### PR DESCRIPTION
While creating updated data stores I recognized that the amount of new daily account age witnesses increased by a factor of 10.
The bug was caused as BSQ swap accounts do not extend AssetAccount and are slipping through a re-publish check.