### PR TITLE
Remove references to keybase and switch to Matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,7 @@ about: Report a bug or a technical issue
 <!--
    SUPPORT REQUESTS: This is for reporting bugs in the Bisq app.
    If you have a support request, please join #support on Bisq's
-   Keybase team over at https://keybase.io/team/Bisq
+   Matrix Space over at https://bisq.chat
 -->
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/bisq-network/bisq/discussions
     about: Request new features or upgrades to existing tools
   - name: 💬 Community Support Chat
-    url: https://keybase.io/team/bisq
+    url: https://bisq.chat
     about: Ask general questions and get community support

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,7 @@ Anyone is welcome to contribute to Bisq. This document provides an overview of h
 
 ## Communication Channels
 
-Most communication about Bisq happens on [Keybase](https://keybase.io).
-
-Install Keybase and enter "bisq" from the teams tab. This is an "open" team, which means the admins will auto-accept any request to join, and you can get in fast.
+Most communication about Bisq happens on [Matrix](https://bisq.chat), follow [instructions in the wiki](https://bisq.wiki/Matrix_bisq.chat) to join the Bisq space; there is also a [forum](https://bisq.community/) and a [subreddit](https://www.reddit.com/r/bisq/).
 
 Discussion about code changes happens in GitHub issues and pull requests.
 

--- a/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/BondedRoleType.java
@@ -44,7 +44,7 @@ public enum BondedRoleType {
     GITHUB_ADMIN(50, 110, "https://bisq.network/roles/16", true),
     FORUM_ADMIN(20, 110, "https://bisq.network/roles/19", true),
     TWITTER_ADMIN(20, 110, "https://bisq.network/roles/21", true),
-    ROCKET_CHAT_ADMIN(20, 110, "https://bisq.network/roles/79", true),// Now Keybase Admin
+    ROCKET_CHAT_ADMIN(20, 110, "https://bisq.network/roles/79", true),
     YOUTUBE_ADMIN(10, 110, "https://bisq.network/roles/56", true),
 
     // maintainers

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentLookupMap.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentLookupMap.java
@@ -28,7 +28,7 @@ public class DisputeAgentLookupMap {
 
     // See also: https://bisq.wiki/Finding_your_mediator
     @Nullable
-    public static String getKeyBaseUserName(String fullAddress) {
+    public static String getMatrixUserName(String fullAddress) {
         if (fullAddress.matches("localhost(.*)")) {
             return fullAddress; // on regtest, agent displays as localhost
         }
@@ -44,18 +44,18 @@ public class DisputeAgentLookupMap {
             case "3z5jnirlccgxzoxc6zwkcgwj66bugvqplzf6z2iyd5oxifiaorhnanqd.onion:9999":
                 return "refundagent2";
             case "6c4cim7h7t3bm4bnchbf727qrhdfrfr6lhod25wjtizm2sifpkktvwad.onion:9999":
-                return "pazza";
+                return "pazza83";
             default:
                 log.warn("No user name for dispute agent with address {} found.", fullAddress);
                 return Res.get("shared.na");
         }
     }
 
-    public static String getKeybaseLinkForAgent(String onion) {
+    public static String getMatrixLinkForAgent(String onion) {
         // when a new mediator starts or an onion address changes, mediator name won't be known until
         // the table above is updated in the software.
-        // as a stopgap measure, replace unknonwn ones with a link to the bisq team
-        String agentName = getKeyBaseUserName(onion).replaceAll(Res.get("shared.na"), "bisq");
-        return "https://keybase.io/" + agentName;
+        // as a stopgap measure, replace unknown ones with a link to the Bisq team
+        String agentName = getMatrixUserName(onion).replaceAll(Res.get("shared.na"), "bisq");
+        return "https://matrix.to/#/@" + agentName + ":matrix.org";
     }
 }

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -151,7 +151,7 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
         NodeAddress agentNodeAddress = getAgentNodeAddress(dispute);
         checkNotNull(agentNodeAddress, "Agent node address must not be null");
         String roleContextMsg = Res.get("support.initialMediatorMsg",
-                DisputeAgentLookupMap.getKeybaseLinkForAgent(agentNodeAddress.getFullAddress()));
+                DisputeAgentLookupMap.getMatrixLinkForAgent(agentNodeAddress.getFullAddress()));
         String link = "https://bisq.wiki/Dispute_resolution#Level_2:_Mediation";
         return Res.get("support.initialInfo", role, roleContextMsg, role, link);
     }

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -135,7 +135,7 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
     protected String getDisputeInfo(Dispute dispute) {
         String role = Res.get("shared.refundAgent").toLowerCase();
         String roleContextMsg = Res.get("support.initialArbitratorMsg",
-                DisputeAgentLookupMap.getKeybaseLinkForAgent(getAgentNodeAddress(dispute).getFullAddress()));
+                DisputeAgentLookupMap.getMatrixLinkForAgent(getAgentNodeAddress(dispute).getFullAddress()));
         String link = "https://bisq.wiki/Dispute_resolution#Level_3:_Arbitration";
         return Res.get("support.initialInfo", role, roleContextMsg, role, link);
     }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -666,7 +666,7 @@ portfolio.pending.unconfirmedTooLong=Security deposit transaction on trade {0} i
   as confirmed in Bisq: \n\
   ● Make a data backup [HYPERLINK:https://bisq.wiki/Backing_up_application_data] \n\
   ● Do an SPV resync. [HYPERLINK:https://bisq.wiki/Resyncing_SPV_file]\n\n\
-  Contact Bisq support [HYPERLINK:https://keybase.io/team/bisq] if you have doubts or the issue persists.
+  Contact Bisq support [HYPERLINK:https://bisq.chat] if you have doubts or the issue persists.
 
 portfolio.pending.step1.waitForConf=Wait for blockchain confirmation
 portfolio.pending.step2_buyer.startPayment=Start payment
@@ -935,14 +935,14 @@ portfolio.pending.openSupportTicket.msg=Please use this function only in emergen
 portfolio.pending.timeLockNotOver=You have to wait until ≈{0} ({1} more blocks) before you can open an arbitration dispute.
 portfolio.pending.error.depositTxNull=The deposit transaction is null. You cannot open a dispute \
   without a valid deposit transaction. Please go to \"Settings/Network info\" and do a SPV resync.\n\n\
-  For further help please contact the Bisq support channel at the Bisq Keybase team.
+  For further help please contact the Bisq support channel at the Bisq Matrix Space.
 portfolio.pending.mediationResult.error.depositTxNull=The deposit transaction is null. You can move the \
   trade to failed trades.
 portfolio.pending.mediationResult.error.delayedPayoutTxNull=The delayed payout transaction is null. You can move the \
   trade to failed trades.
 portfolio.pending.error.depositTxNotConfirmed=The deposit transaction is not confirmed. You can not open an arbitration dispute \
   with an unconfirmed deposit transaction. Please wait until it is confirmed or go to \"Settings/Network info\" and do a SPV resync.\n\n\
-  For further help please contact the Bisq support channel at the Bisq Keybase team.
+  For further help please contact the Bisq support channel at the Bisq Matrix Space.
 
 portfolio.pending.support.headline.getHelp=Need help?
 portfolio.pending.support.text.getHelp=If you have any problems you can try to contact the trade peer in the trade \
@@ -1270,12 +1270,12 @@ support.initialInfo=Please enter a description of your problem in the text field
 \t● You accepted the rules outlined in the dispute document in the user agreement when you first started the application.\n\n\
 You can read more about the dispute process at: {3}
 support.initialMediatorMsg=Mediators will generally reply to you within 24 hours.\n\
-  \t  If you have not had a reply after 48 hours please feel free to reach out to your mediator on Keybase.\n\
-  \t  Mediators usernames on Keybase are the same as their usernames within the Bisq app.\n\
+  \t  If you have not had a reply after 48 hours please feel free to reach out to your mediator on Matrix.\n\
+  \t  Mediators usernames on Matrix are the same as their usernames within the Bisq app.\n\
   \t  Your mediator is: {0}
 support.initialArbitratorMsg=Arbitrators will generally reply to you within 5 days.\n\
-  \t  If you have not had a reply after 7 days please feel free to reach out to your arbitrator on Keybase.\n\
-  \t  Arbitrators usernames on Keybase are the same as their usernames within the Bisq app.\n\
+  \t  If you have not had a reply after 7 days please feel free to reach out to your arbitrator on Matrix.\n\
+  \t  Arbitrators usernames on Matrix are the same as their usernames within the Bisq app.\n\
   \t  Your arbitrator is: {0}
 support.systemMsg=System message: {0}
 support.youOpenedTicket=You opened a request for support.\n\n{0}\n\nBisq version: {1}
@@ -3031,7 +3031,7 @@ popup.warning.openOffer.makerFeeTxRejected=The maker fee transaction for offer w
   Transaction ID={1}.\n\
   The offer has been removed to avoid further problems.\n\
   Please go to \"Settings/Network info\" and do a SPV resync.\n\
-  For further help please contact the Bisq support channel at the Bisq Keybase team.
+  For further help please contact the Bisq support channel at the Bisq Matrix Space.
 
 popup.warning.trade.txRejected.tradeFee=trade fee
 popup.warning.trade.txRejected.deposit=deposit
@@ -3039,12 +3039,12 @@ popup.warning.trade.txRejected=The {0} transaction for trade with ID {1} was rej
   Transaction ID={2}\n\
   The trade has been moved to failed trades.\n\
   Please go to \"Settings/Network info\" and do a SPV resync.\n\
-  For further help please contact the Bisq support channel at the Bisq Keybase team.
+  For further help please contact the Bisq support channel at the Bisq Matrix Space.
 
 popup.warning.openOfferWithInvalidMakerFeeTx=The maker fee transaction for offer with ID {0} is invalid.\n\
   Transaction ID={1}.\n\
   Please go to \"Settings/Network info\" and do a SPV resync.\n\
-  For further help please contact the Bisq support channel at the Bisq Keybase team.
+  For further help please contact the Bisq support channel at the Bisq Matrix Space.
 
 popup.info.securityDepositInfo=To ensure both traders follow the trade protocol, both traders need to pay a security \
 deposit.\n\nThis deposit is kept in your trade wallet until your trade has been successfully completed, and then it's \
@@ -3325,7 +3325,7 @@ password.deriveKey=Derive key from password
 password.walletDecrypted=Wallet successfully decrypted and password protection removed.
 password.wrongPw=You entered the wrong password.\n\nPlease try entering your password again, carefully checking for typos or spelling errors.
 password.walletEncrypted=Wallet successfully encrypted and password protection enabled.
-password.walletEncryptionFailed=Wallet password could not be set. You may have imported seed words which do not match the wallet database. Please contact the developers on Keybase ([HYPERLINK:https://keybase.io/team/bisq]).
+password.walletEncryptionFailed=Wallet password could not be set. You may have imported seed words which do not match the wallet database. Please contact the developers on Matrix ([HYPERLINK:https://bisq.chat]).
 password.passwordsDoNotMatch=The 2 passwords you entered don't match.
 password.forgotPassword=Forgot password?
 password.backupReminder=Please note that when setting a wallet password all automatically created backups from the unencrypted wallet will be deleted.\n\n\

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
@@ -211,20 +211,20 @@ public class ContractWindow extends Overlay<ContractWindow> {
                         : "NA");
 
         String title = "";
-        String agentKeyBaseUserName = "";
+        String agentMatrixUserName = "";
         if (dispute.getSupportType() != null) {
             switch (dispute.getSupportType()) {
                 case ARBITRATION:
                     title = Res.get("shared.selectedArbitrator");
                     break;
                 case MEDIATION:
-                    agentKeyBaseUserName = DisputeAgentLookupMap.getKeyBaseUserName(contract.getMediatorNodeAddress().getFullAddress());
+                    agentMatrixUserName = DisputeAgentLookupMap.getMatrixUserName(contract.getMediatorNodeAddress().getFullAddress());
                     title = Res.get("shared.selectedMediator");
                     break;
                 case TRADE:
                     break;
                 case REFUND:
-                    agentKeyBaseUserName = DisputeAgentLookupMap.getKeyBaseUserName(contract.getRefundAgentNodeAddress().getFullAddress());
+                    agentMatrixUserName = DisputeAgentLookupMap.getMatrixUserName(contract.getRefundAgentNodeAddress().getFullAddress());
                     title = Res.get("shared.selectedRefundAgent");
                     break;
             }
@@ -233,7 +233,7 @@ public class ContractWindow extends Overlay<ContractWindow> {
         if (disputeManager != null) {
             NodeAddress agentNodeAddress = disputeManager.getAgentNodeAddress(dispute);
             if (agentNodeAddress != null) {
-                String value = agentKeyBaseUserName + " (" + agentNodeAddress.getFullAddress() + ")";
+                String value = agentMatrixUserName + " (" + agentNodeAddress.getFullAddress() + ")";
                 addConfirmationLabelTextField(gridPane, ++rowIndex, title, value);
             }
         }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -358,8 +358,8 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
                     data += "\n\nRaw deposit transaction as hex:\n" + depositTxAsHex;
                 }
 
-                data += "\n\nSelected mediator: " + DisputeAgentLookupMap.getKeyBaseUserName(contract.getMediatorNodeAddress().getFullAddress());
-                data += "\nSelected arbitrator (refund agent): " + DisputeAgentLookupMap.getKeyBaseUserName(contract.getRefundAgentNodeAddress().getFullAddress());
+                data += "\n\nSelected mediator: " + DisputeAgentLookupMap.getMatrixUserName(contract.getMediatorNodeAddress().getFullAddress());
+                data += "\nSelected arbitrator (refund agent): " + DisputeAgentLookupMap.getMatrixUserName(contract.getRefundAgentNodeAddress().getFullAddress());
 
                 textArea.setText(data);
                 textArea.setPrefHeight(50);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -467,7 +467,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
     }
 
     private void doOpenDispute(boolean isSupportTicket, Transaction depositTx) {
-        // We do not support opening a dispute if the deposit tx is null. Traders have to use the support channel at keybase
+        // We do not support opening a dispute if the deposit tx is null. Traders have to use the support channel at Matrix
         // in such cases. The mediators or arbitrators could not help anyway with a payout in such cases.
         if (depositTx == null) {
             log.error("Deposit tx must not be null");

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -1369,8 +1369,8 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> implements
                                         return;
                                     }
 
-                                    String keyBaseUserName = DisputeAgentLookupMap.getKeyBaseUserName(agentNodeAddress.getFullAddress());
-                                    setText(keyBaseUserName);
+                                    String MatrixUserName = DisputeAgentLookupMap.getMatrixUserName(agentNodeAddress.getFullAddress());
+                                    setText(MatrixUserName);
                                 } else {
                                     setText("");
                                 }

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -236,7 +236,7 @@ If all was successful:
 
 * Forum
 
-* Keybase (#general channel)
+* Matrix space (_General_ room)
 
 * Twitter
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,7 +12,7 @@ In order to take part in the testing process, you will need to do the following:
 
 ## Communication Channels
 
-If you would like to discuss and/or contribute to Bisq's testing effort, join us in the #testing channel within the [Bisq Keybase team](https://keybase.io/team/bisq).
+If you would like to discuss and/or contribute to Bisq's testing effort, join us in the #testing channel within the [Bisq Matrix Space](https://bisq.chat).
 Here you could also request access to TestPad (https://bisq.ontestpad.com).
 
 ## Compensation

--- a/pricenode/README.md
+++ b/pricenode/README.md
@@ -57,7 +57,7 @@ If you run a main pricenode, you also are obliged to activate the monitoring fee
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/bisq-network/bisq/master/monitor/install_collectd_debian.sh)
 ```
-Follow the instruction given by the script and report your certificate to the [@bisq-network/monitoring](https://github.com/orgs/bisq-network/teams/monitoring-operators) team or via the [Keybase](https://keybase.io/team/bisq) `#monitoring` channel!
+Follow the instruction given by the script and report your certificate to the [@bisq-network/monitoring](https://github.com/orgs/bisq-network/teams/monitoring-operators) team.
 
 Furthermore, you are obliged to provide network size data to the monitor by running
 ```bash


### PR DESCRIPTION
Except `dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN` which refers to an
unused role, every other instance of `keybase` has been contextually
updated to Matrix (bisq.chat); functions to display moderator name
and profile address on keybase have been updated to work with Matrix
usernames and urls.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.
