### PR TITLE
Fix API FeeService NPE (Alternate)

### DIFF
--- a/core/src/main/java/bisq/core/provider/fee/FeeService.java
+++ b/core/src/main/java/bisq/core/provider/fee/FeeService.java
@@ -82,7 +82,7 @@ public class FeeService {
 
     private static Coin getFilterFromParamAsCoin(Param param) {
         Coin filterVal = Coin.ZERO;
-        if (filterManager != null) {
+        if (filterManager != null && filterManager.getFilter() != null) {
             if (param == Param.DEFAULT_MAKER_FEE_BTC) {
                 filterVal = Coin.valueOf(filterManager.getFilter().getMakerFeeBtc());
             } else if (param == Param.DEFAULT_TAKER_FEE_BTC) {


### PR DESCRIPTION
Return fee from dao state service if JFX property filterManager.getFilter() == null.

JFX property `filterManager.getFilter()` is null in apitest cases.

This is change may be preferred over https://github.com/bisq-network/bisq/pull/6051.

Related to 1e4e7c52846ab4b6f2171ad6d6f4ff82e960e25d.

Based on `master`.