### PR TITLE
Move get (cryptocurrency) offer filter to daemon [No. 1]

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/offer/CreateBSQOffersTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/CreateBSQOffersTest.java
@@ -260,7 +260,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
     @Test
     @Order(5)
     public void testGetAllMyBsqOffers() {
-        List<OfferInfo> offers = aliceClient.getMyCryptoCurrencyOffersSortedByDate(BSQ);
+        List<OfferInfo> offers = aliceClient.getMyOffersSortedByDate(BSQ);
         log.debug("All Alice's BSQ Offers:\n{}", toOffersTable.apply(offers));
         assertEquals(4, offers.size());
         log.debug("ALICE'S BALANCES\n{}", formatBalancesTbls(aliceClient.getBalances()));
@@ -269,7 +269,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
     @Test
     @Order(6)
     public void testGetAvailableBsqOffers() {
-        List<OfferInfo> offers = bobClient.getCryptoCurrencyOffersSortedByDate(BSQ);
+        List<OfferInfo> offers = bobClient.getOffersSortedByDate(BSQ);
         log.debug("All Bob's Available BSQ Offers:\n{}", toOffersTable.apply(offers));
         assertEquals(4, offers.size());
         log.debug("BOB'S BALANCES\n{}", formatBalancesTbls(bobClient.getBalances()));

--- a/apitest/src/test/java/bisq/apitest/method/offer/CreateXMROffersTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/CreateXMROffersTest.java
@@ -257,7 +257,7 @@ public class CreateXMROffersTest extends AbstractOfferTest {
     @Test
     @Order(5)
     public void testGetAllMyXMROffers() {
-        List<OfferInfo> offers = aliceClient.getMyCryptoCurrencyOffersSortedByDate(XMR);
+        List<OfferInfo> offers = aliceClient.getMyOffersSortedByDate(XMR);
         log.debug("All of Alice's XMR offers:\n{}", toOffersTable.apply(offers));
         assertEquals(4, offers.size());
         log.debug("Alice's balances\n{}", formatBalancesTbls(aliceClient.getBalances()));
@@ -266,7 +266,7 @@ public class CreateXMROffersTest extends AbstractOfferTest {
     @Test
     @Order(6)
     public void testGetAvailableXMROffers() {
-        List<OfferInfo> offers = bobClient.getCryptoCurrencyOffersSortedByDate(XMR);
+        List<OfferInfo> offers = bobClient.getOffersSortedByDate(XMR);
         log.debug("All of Bob's available XMR offers:\n{}", toOffersTable.apply(offers));
         assertEquals(4, offers.size());
         log.debug("Bob's balances\n{}", formatBalancesTbls(bobClient.getBalances()));

--- a/apitest/src/test/java/bisq/apitest/method/trade/FailUnfailTradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/FailUnfailTradeTest.java
@@ -61,7 +61,7 @@ public class FailUnfailTradeTest extends AbstractTradeTest {
         TakeBuyBTCOfferTest test = new TakeBuyBTCOfferTest();
         test.testTakeAlicesBuyOffer(testInfo);
 
-        var tradeId = test.getTradeId();
+        var tradeId = AbstractTradeTest.getTradeId();
         aliceClient.failTrade(tradeId);
 
         Throwable exception = assertThrows(StatusRuntimeException.class, () -> aliceClient.getTrade(tradeId));
@@ -82,7 +82,7 @@ public class FailUnfailTradeTest extends AbstractTradeTest {
         TakeSellBTCOfferTest test = new TakeSellBTCOfferTest();
         test.testTakeAlicesSellOffer(testInfo);
 
-        var tradeId = test.getTradeId();
+        var tradeId = AbstractTradeTest.getTradeId();
         aliceClient.failTrade(tradeId);
 
         Throwable exception = assertThrows(StatusRuntimeException.class, () -> aliceClient.getTrade(tradeId));
@@ -101,10 +101,10 @@ public class FailUnfailTradeTest extends AbstractTradeTest {
     @Order(3)
     public void testFailAndUnFailBuyXmrTrade(final TestInfo testInfo) {
         TakeBuyXMROfferTest test = new TakeBuyXMROfferTest();
-        test.createXmrPaymentAccounts();
+        createXmrPaymentAccounts();
         test.testTakeAlicesSellBTCForXMROffer(testInfo);
 
-        var tradeId = test.getTradeId();
+        var tradeId = AbstractTradeTest.getTradeId();
         aliceClient.failTrade(tradeId);
 
         Throwable exception = assertThrows(StatusRuntimeException.class, () -> aliceClient.getTrade(tradeId));
@@ -123,10 +123,10 @@ public class FailUnfailTradeTest extends AbstractTradeTest {
     @Order(4)
     public void testFailAndUnFailTakeSellXMRTrade(final TestInfo testInfo) {
         TakeSellXMROfferTest test = new TakeSellXMROfferTest();
-        test.createXmrPaymentAccounts();
+        createXmrPaymentAccounts();
         test.testTakeAlicesBuyBTCForXMROffer(testInfo);
 
-        var tradeId = test.getTradeId();
+        var tradeId = AbstractTradeTest.getTradeId();
         aliceClient.failTrade(tradeId);
 
         Throwable exception = assertThrows(StatusRuntimeException.class, () -> aliceClient.getTrade(tradeId));

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
@@ -83,7 +83,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
             var offerId = alicesOffer.getId();
             assertFalse(alicesOffer.getIsCurrencyForMakerFeeBtc());
 
-            var alicesBsqOffers = aliceClient.getMyCryptoCurrencyOffers(btcTradeDirection, BSQ);
+            var alicesBsqOffers = aliceClient.getMyOffers(btcTradeDirection, BSQ);
             assertEquals(1, alicesBsqOffers.size());
 
             var trade = takeAlicesOffer(offerId,
@@ -97,7 +97,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
             tradeId = trade.getTradeId();
 
             genBtcBlocksThenWait(1, 2_500);
-            alicesBsqOffers = aliceClient.getMyCryptoCurrencyOffersSortedByDate(BSQ);
+            alicesBsqOffers = aliceClient.getMyOffersSortedByDate(BSQ);
             assertEquals(0, alicesBsqOffers.size());
 
             waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
@@ -84,10 +84,10 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
             var offerId = alicesOffer.getId();
             assertFalse(alicesOffer.getIsCurrencyForMakerFeeBtc());
 
-            var alicesXmrOffers = aliceClient.getMyCryptoCurrencyOffers(btcTradeDirection, XMR);
+            var alicesXmrOffers = aliceClient.getMyOffers(btcTradeDirection, XMR);
             assertEquals(1, alicesXmrOffers.size());
             var trade = takeAlicesOffer(offerId, bobsXmrAcct.getId(), TRADE_FEE_CURRENCY_CODE);
-            alicesXmrOffers = aliceClient.getMyCryptoCurrencyOffersSortedByDate(XMR);
+            alicesXmrOffers = aliceClient.getMyOffersSortedByDate(XMR);
             assertEquals(0, alicesXmrOffers.size());
             genBtcBlocksThenWait(1, 2_500);
             waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
@@ -84,14 +84,14 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
             genBtcBlocksThenWait(1, 4_000);
             var offerId = alicesOffer.getId();
             assertTrue(alicesOffer.getIsCurrencyForMakerFeeBtc());
-            var alicesBsqOffers = aliceClient.getMyCryptoCurrencyOffers(btcTradeDirection, BSQ);
+            var alicesBsqOffers = aliceClient.getMyOffers(btcTradeDirection, BSQ);
             assertEquals(1, alicesBsqOffers.size());
             var trade = takeAlicesOffer(offerId,
                     bobsLegacyBsqAcct.getId(),
                     TRADE_FEE_CURRENCY_CODE,
                     false);
             sleep(2_500);  // Allow available offer to be removed from offer book.
-            alicesBsqOffers = aliceClient.getMyCryptoCurrencyOffersSortedByDate(BSQ);
+            alicesBsqOffers = aliceClient.getMyOffersSortedByDate(BSQ);
             assertEquals(0, alicesBsqOffers.size());
             genBtcBlocksThenWait(1, 2_500);
             waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
@@ -88,10 +88,10 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
             var offerId = alicesOffer.getId();
             assertTrue(alicesOffer.getIsCurrencyForMakerFeeBtc());
 
-            var alicesXmrOffers = aliceClient.getMyCryptoCurrencyOffers(btcTradeDirection, XMR);
+            var alicesXmrOffers = aliceClient.getMyOffers(btcTradeDirection, XMR);
             assertEquals(1, alicesXmrOffers.size());
             var trade = takeAlicesOffer(offerId, bobsXmrAcct.getId(), TRADE_FEE_CURRENCY_CODE);
-            alicesXmrOffers = aliceClient.getMyCryptoCurrencyOffersSortedByDate(XMR);
+            alicesXmrOffers = aliceClient.getMyOffersSortedByDate(XMR);
             assertEquals(0, alicesXmrOffers.size());
             genBtcBlocksThenWait(1, 2_500);
 

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -27,7 +27,6 @@ import bisq.proto.grpc.GetVersionRequest;
 import bisq.proto.grpc.OfferInfo;
 import bisq.proto.grpc.RegisterDisputeAgentRequest;
 import bisq.proto.grpc.StopRequest;
-import bisq.proto.grpc.TakeOfferReply;
 import bisq.proto.grpc.TradeInfo;
 import bisq.proto.grpc.TxFeeRateInfo;
 import bisq.proto.grpc.TxInfo;
@@ -271,10 +270,6 @@ public final class GrpcClient {
         return offersServiceRequest.getOffer(offerId);
     }
 
-    public OfferInfo getMyBsqSwapOffer(String offerId) {
-        return offersServiceRequest.getMyBsqSwapOffer(offerId);
-    }
-
     @Deprecated // Since 5-Dec-2021.
     // Endpoint to be removed from future version.  Use getOffer service method instead.
     public OfferInfo getMyOffer(String offerId) {
@@ -289,10 +284,6 @@ public final class GrpcClient {
         return offersServiceRequest.getOffers(direction, currencyCode);
     }
 
-    public List<OfferInfo> getCryptoCurrencyOffers(String direction, String currencyCode) {
-        return offersServiceRequest.getCryptoCurrencyOffers(direction, currencyCode);
-    }
-
     public List<OfferInfo> getOffersSortedByDate(String currencyCode) {
         return offersServiceRequest.getOffersSortedByDate(currencyCode);
     }
@@ -301,56 +292,24 @@ public final class GrpcClient {
         return offersServiceRequest.getOffersSortedByDate(direction, currencyCode);
     }
 
-    public List<OfferInfo> getCryptoCurrencyOffersSortedByDate(String currencyCode) {
-        return offersServiceRequest.getCryptoCurrencyOffersSortedByDate(currencyCode);
-    }
-
     public List<OfferInfo> getBsqSwapOffersSortedByDate() {
         return offersServiceRequest.getBsqSwapOffersSortedByDate();
-    }
-
-    public List<OfferInfo> getMyBsqSwapOffers(String direction) {
-        return offersServiceRequest.getMyBsqSwapOffers(direction);
     }
 
     public List<OfferInfo> getMyOffers(String direction, String currencyCode) {
         return offersServiceRequest.getMyOffers(direction, currencyCode);
     }
 
-    public List<OfferInfo> getMyCryptoCurrencyOffers(String direction, String currencyCode) {
-        return offersServiceRequest.getMyCryptoCurrencyOffers(direction, currencyCode);
+    public List<OfferInfo> getMyOffersSortedByDate(String currencyCode) {
+        return offersServiceRequest.getMyOffersSortedByDate(currencyCode);
     }
 
     public List<OfferInfo> getMyOffersSortedByDate(String direction, String currencyCode) {
         return offersServiceRequest.getMyOffersSortedByDate(direction, currencyCode);
     }
 
-    public List<OfferInfo> getMyOffersSortedByDate(String currencyCode) {
-        return offersServiceRequest.getMyOffersSortedByDate(currencyCode);
-    }
-
-    public List<OfferInfo> getMyCryptoCurrencyOffersSortedByDate(String currencyCode) {
-        return offersServiceRequest.getMyCryptoCurrencyOffersSortedByDate(currencyCode);
-    }
-
     public List<OfferInfo> getMyBsqSwapBsqOffersSortedByDate() {
         return offersServiceRequest.getMyBsqSwapOffersSortedByDate();
-    }
-
-    public OfferInfo getMostRecentOffer(String direction, String currencyCode) {
-        return offersServiceRequest.getMostRecentOffer(direction, currencyCode);
-    }
-
-    public List<OfferInfo> sortBsqSwapOffersByDate(List<OfferInfo> offers) {
-        return offersServiceRequest.sortOffersByDate(offers);
-    }
-
-    public List<OfferInfo> sortOffersByDate(List<OfferInfo> offers) {
-        return offersServiceRequest.sortOffersByDate(offers);
-    }
-
-    public TakeOfferReply getTakeOfferReply(String offerId, String paymentAccountId, String takerFeeCurrencyCode) {
-        return tradesServiceRequest.getTakeOfferReply(offerId, paymentAccountId, takerFeeCurrencyCode);
     }
 
     public TradeInfo takeBsqSwapOffer(String offerId) {

--- a/cli/src/main/java/bisq/cli/request/OffersServiceRequest.java
+++ b/cli/src/main/java/bisq/cli/request/OffersServiceRequest.java
@@ -32,7 +32,6 @@ import bisq.proto.grpc.OfferInfo;
 import java.util.ArrayList;
 import java.util.List;
 
-import static bisq.cli.CryptoCurrencyUtil.apiDoesSupportCryptoCurrency;
 import static bisq.proto.grpc.EditOfferRequest.EditType.ACTIVATION_STATE_ONLY;
 import static bisq.proto.grpc.EditOfferRequest.EditType.FIXED_PRICE_ONLY;
 import static bisq.proto.grpc.EditOfferRequest.EditType.MKT_PRICE_MARGIN_ONLY;
@@ -217,13 +216,6 @@ public class OffersServiceRequest {
         return grpcStubs.offersService.getOffer(request).getOffer();
     }
 
-    public OfferInfo getMyBsqSwapOffer(String offerId) {
-        var request = GetMyOfferRequest.newBuilder()
-                .setId(offerId)
-                .build();
-        return grpcStubs.offersService.getMyBsqSwapOffer(request).getBsqSwapOffer();
-    }
-
     public OfferInfo getMyOffer(String offerId) {
         var request = GetMyOfferRequest.newBuilder()
                 .setId(offerId)
@@ -240,40 +232,23 @@ public class OffersServiceRequest {
     }
 
     public List<OfferInfo> getOffers(String direction, String currencyCode) {
-        if (apiDoesSupportCryptoCurrency(currencyCode)) {
-            return getCryptoCurrencyOffers(direction, currencyCode);
-        } else {
-            var request = GetOffersRequest.newBuilder()
-                    .setDirection(direction)
-                    .setCurrencyCode(currencyCode)
-                    .build();
-            return grpcStubs.offersService.getOffers(request).getOffersList();
-        }
-    }
-
-    public List<OfferInfo> getCryptoCurrencyOffers(String direction, String currencyCode) {
-        return getOffers(direction, "BTC").stream()
-                .filter(o -> o.getBaseCurrencyCode().equalsIgnoreCase(currencyCode))
-                .collect(toList());
+        var request = GetOffersRequest.newBuilder()
+                .setDirection(direction)
+                .setCurrencyCode(currencyCode)
+                .build();
+        return grpcStubs.offersService.getOffers(request).getOffersList();
     }
 
     public List<OfferInfo> getOffersSortedByDate(String currencyCode) {
         ArrayList<OfferInfo> offers = new ArrayList<>();
         offers.addAll(getOffers(BUY.name(), currencyCode));
         offers.addAll(getOffers(SELL.name(), currencyCode));
-        return sortOffersByDate(offers);
+        return offers.isEmpty() ? offers : sortOffersByDate(offers);
     }
 
     public List<OfferInfo> getOffersSortedByDate(String direction, String currencyCode) {
         var offers = getOffers(direction, currencyCode);
         return offers.isEmpty() ? offers : sortOffersByDate(offers);
-    }
-
-    public List<OfferInfo> getCryptoCurrencyOffersSortedByDate(String currencyCode) {
-        ArrayList<OfferInfo> offers = new ArrayList<>();
-        offers.addAll(getCryptoCurrencyOffers(BUY.name(), currencyCode));
-        offers.addAll(getCryptoCurrencyOffers(SELL.name(), currencyCode));
-        return sortOffersByDate(offers);
     }
 
     public List<OfferInfo> getBsqSwapOffersSortedByDate() {
@@ -291,40 +266,23 @@ public class OffersServiceRequest {
     }
 
     public List<OfferInfo> getMyOffers(String direction, String currencyCode) {
-        if (apiDoesSupportCryptoCurrency(currencyCode)) {
-            return getMyCryptoCurrencyOffers(direction, currencyCode);
-        } else {
-            var request = GetMyOffersRequest.newBuilder()
-                    .setDirection(direction)
-                    .setCurrencyCode(currencyCode)
-                    .build();
-            return grpcStubs.offersService.getMyOffers(request).getOffersList();
-        }
-    }
-
-    public List<OfferInfo> getMyCryptoCurrencyOffers(String direction, String currencyCode) {
-        return getMyOffers(direction, "BTC").stream()
-                .filter(o -> o.getBaseCurrencyCode().equalsIgnoreCase(currencyCode))
-                .collect(toList());
-    }
-
-    public List<OfferInfo> getMyOffersSortedByDate(String direction, String currencyCode) {
-        var offers = getMyOffers(direction, currencyCode);
-        return offers.isEmpty() ? offers : sortOffersByDate(offers);
+        var request = GetMyOffersRequest.newBuilder()
+                .setDirection(direction)
+                .setCurrencyCode(currencyCode)
+                .build();
+        return grpcStubs.offersService.getMyOffers(request).getOffersList();
     }
 
     public List<OfferInfo> getMyOffersSortedByDate(String currencyCode) {
         ArrayList<OfferInfo> offers = new ArrayList<>();
         offers.addAll(getMyOffers(BUY.name(), currencyCode));
         offers.addAll(getMyOffers(SELL.name(), currencyCode));
-        return sortOffersByDate(offers);
+        return offers.isEmpty() ? offers : sortOffersByDate(offers);
     }
 
-    public List<OfferInfo> getMyCryptoCurrencyOffersSortedByDate(String currencyCode) {
-        ArrayList<OfferInfo> offers = new ArrayList<>();
-        offers.addAll(getMyCryptoCurrencyOffers(BUY.name(), currencyCode));
-        offers.addAll(getMyCryptoCurrencyOffers(SELL.name(), currencyCode));
-        return sortOffersByDate(offers);
+    public List<OfferInfo> getMyOffersSortedByDate(String direction, String currencyCode) {
+        var offers = getMyOffers(direction, currencyCode);
+        return offers.isEmpty() ? offers : sortOffersByDate(offers);
     }
 
     public List<OfferInfo> getMyBsqSwapOffersSortedByDate() {

--- a/cli/src/test/java/bisq/cli/AbstractCliTest.java
+++ b/cli/src/test/java/bisq/cli/AbstractCliTest.java
@@ -135,7 +135,7 @@ public abstract class AbstractCliTest {
         CliMain.main(args);
         out.println("<<<<<");
 
-        return aliceClient.getMyCryptoCurrencyOffersSortedByDate(currencyCode);
+        return aliceClient.getMyOffersSortedByDate(currencyCode);
     }
 
     protected String[] getMyOffersCommand(String direction, String currencyCode) {

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -40,13 +40,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
 import static bisq.common.app.DevEnv.isDaoTradingActivated;
 import static bisq.common.config.Config.baseCurrencyNetwork;
+import static bisq.core.locale.CurrencyUtil.apiSupportsCryptoCurrency;
 import static bisq.core.locale.CurrencyUtil.findAsset;
 import static bisq.core.locale.CurrencyUtil.getCryptoCurrency;
 import static java.lang.String.format;
@@ -54,9 +54,6 @@ import static java.lang.String.format;
 @Singleton
 @Slf4j
 class CorePaymentAccountsService {
-
-    private final Predicate<String> apiDoesSupportCryptoCurrencyAccount = (c) ->
-            c.equals("BSQ") || c.equals("XMR");
 
     private final CoreWalletsService coreWalletsService;
     private final AccountAgeWitnessService accountAgeWitnessService;
@@ -159,7 +156,7 @@ class CorePaymentAccountsService {
     }
 
     private void verifyApiDoesSupportCryptoCurrencyAccount(String cryptoCurrencyCode) {
-        if (!apiDoesSupportCryptoCurrencyAccount.test(cryptoCurrencyCode))
+        if (!apiSupportsCryptoCurrency(cryptoCurrencyCode))
             throw new IllegalArgumentException(
                     format("api does not currently support %s accounts",
                             cryptoCurrencyCode.toLowerCase()));

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -793,4 +793,17 @@ public class CurrencyUtil {
     public static String getOfferVolumeCode(String currencyCode) {
         return Res.get("shared.offerVolumeCode", currencyCode);
     }
+
+    public static boolean apiSupportsCryptoCurrency(String currencyCode) {
+        // Although this method is only used by the core.api package, its
+        // presence here avoids creating a new util class just for this method.
+        if (isCryptoCurrency(currencyCode))
+            return currencyCode.equals("BTC")
+                    || currencyCode.equals("BSQ")
+                    || currencyCode.equals("XMR");
+        else
+            throw new IllegalArgumentException(
+                    format("Method requires a crypto currency code, but was given '%s'.",
+                            currencyCode));
+    }
 }


### PR DESCRIPTION
Some API reference & Python bot examples exposed an API bug the Java CLI has been hiding. Due due this Bisq v1 `Offer` entity design:

- In fiat offers, the `baseCurrencyCode`=BTC, `counterCurrencyCode`=FiatCode
- In altcoin offers, `baseCurrencyCode`=AltcoinCode, `counterCurrencyCode`=BTC,

new API examples were not doing what the CLI has been doing for several months, which is get (cryptocurrency) all BTC offers from the server, and filter on the altcoin code.  The CLI side filtering should have been done on the server, as it is in this commit.

A lot of dead gRPC client side offer filtering code is removed as well.

Based on `master`.
