### PR TITLE
Exclude persistedAccountName from API payment acct json forms

### DIFF
--- a/core/src/main/java/bisq/core/api/model/PaymentAccountForm.java
+++ b/core/src/main/java/bisq/core/api/model/PaymentAccountForm.java
@@ -135,6 +135,7 @@ public class PaymentAccountForm {
             "paymentAccountPayload",
             "paymentMethod",
             "paymentMethodId",          // Will be included, but handled differently.
+            "persistedAccountName",     // Automatically set in PaymentAccount.onPersistChanges().
             "selectedTradeCurrency",    // May be included, but handled differently.
             "tradeCurrencies",          // May be included, but handled differently.
             "HOLDER_NAME",


### PR DESCRIPTION
This recently added field  (1da71f6c66e790b8124e226467e78d68e7c5452a) is automatically set inside `PaymentAccount`.  It should not be included in the payment acct json forms used by API clients.

Based on branch `master`.