### PR TITLE
Send pretty payment details to API clients

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
@@ -41,6 +41,7 @@ import io.grpc.StatusRuntimeException;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -75,6 +76,11 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
 
     private static PaymentAccount alicesPaymentAccount;
     private static PaymentAccount bobsPaymentAccount;
+
+    @BeforeAll
+    public static void setUp() {
+        setUp(false);
+    }
 
     @Test
     @Order(1)
@@ -156,13 +162,19 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
         assertNotNull(alicesPaymentAccount);
         assertNotNull(bobsPaymentAccount);
 
-        var alicesContract = aliceClient.getTrade(tradeId).getContractAsJson();
-        verifyJsonContractIncludesBankAccountDetails(alicesContract, alicesPaymentAccount);
-        verifyJsonContractIncludesBankAccountDetails(alicesContract, bobsPaymentAccount);
+        var alicesTrade = aliceClient.getTrade(tradeId);
+        assertNotEquals("", alicesTrade.getContract().getMakerPaymentAccountPayload().getPaymentDetails());
+        assertNotEquals("", alicesTrade.getContract().getTakerPaymentAccountPayload().getPaymentDetails());
+        var alicesContractJson = alicesTrade.getContractAsJson();
+        verifyJsonContractIncludesBankAccountDetails(alicesContractJson, alicesPaymentAccount);
+        verifyJsonContractIncludesBankAccountDetails(alicesContractJson, bobsPaymentAccount);
 
-        var bobsContract = bobClient.getTrade(tradeId).getContractAsJson();
-        verifyJsonContractIncludesBankAccountDetails(bobsContract, alicesPaymentAccount);
-        verifyJsonContractIncludesBankAccountDetails(bobsContract, bobsPaymentAccount);
+        var bobsTrade = bobClient.getTrade(tradeId);
+        assertNotEquals("", bobsTrade.getContract().getMakerPaymentAccountPayload().getPaymentDetails());
+        assertNotEquals("", bobsTrade.getContract().getTakerPaymentAccountPayload().getPaymentDetails());
+        var bobsContractJson = bobsTrade.getContractAsJson();
+        verifyJsonContractIncludesBankAccountDetails(bobsContractJson, alicesPaymentAccount);
+        verifyJsonContractIncludesBankAccountDetails(bobsContractJson, bobsPaymentAccount);
     }
 
     @Test
@@ -207,7 +219,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
 
     @Test
     @Order(5)
-    public void testKeepFunds(final TestInfo testInfo) {
+    public void testCloseTrade(final TestInfo testInfo) {
         try {
             genBtcBlocksThenWait(1, 1_000);
 

--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -88,7 +88,7 @@ public class TradeTest extends AbstractTradeTest {
         test.testBankAcctDetailsIncludedInContracts(testInfo);
         test.testAlicesConfirmPaymentStarted(testInfo);
         test.testBobsConfirmPaymentReceived(testInfo);
-        test.testKeepFunds(testInfo);
+        test.testCloseTrade(testInfo);
     }
 
     @Test

--- a/core/src/main/java/bisq/core/api/model/PaymentAccountPayloadInfo.java
+++ b/core/src/main/java/bisq/core/api/model/PaymentAccountPayloadInfo.java
@@ -37,13 +37,17 @@ public class PaymentAccountPayloadInfo implements Payload {
     private final String paymentMethodId;
     @Nullable
     private final String address;
+    @Nullable
+    private final String paymentDetails;
 
     public PaymentAccountPayloadInfo(String id,
                                      String paymentMethodId,
-                                     @Nullable String address) {
+                                     @Nullable String address,
+                                     @Nullable String paymentDetails) {
         this.id = id;
         this.paymentMethodId = paymentMethodId;
         this.address = address;
+        this.paymentDetails = paymentDetails;
     }
 
     public static PaymentAccountPayloadInfo toPaymentAccountPayloadInfo(
@@ -57,21 +61,30 @@ public class PaymentAccountPayloadInfo implements Payload {
         else if (paymentAccountPayload instanceof InstantCryptoCurrencyPayload)
             address = Optional.of(((InstantCryptoCurrencyPayload) paymentAccountPayload).getAddress());
 
+        String prettyPaymentDetails = paymentAccountPayload.getPaymentDetailsForTradePopup();
+        Optional<String> paymentDetails = prettyPaymentDetails.isBlank()
+                ? Optional.empty()
+                : Optional.of(prettyPaymentDetails);
+
         return new PaymentAccountPayloadInfo(paymentAccountPayload.getId(),
                 paymentAccountPayload.getPaymentMethodId(),
-                address.orElse(""));
+                address.orElse(""),
+                paymentDetails.orElse(""));
     }
 
     // For transmitting TradeInfo messages when the contract or the contract's payload is not yet available.
     public static Supplier<PaymentAccountPayloadInfo> emptyPaymentAccountPayload = () ->
-            new PaymentAccountPayloadInfo("", "", "");
+            new PaymentAccountPayloadInfo("", "", "", "");
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static PaymentAccountPayloadInfo fromProto(bisq.proto.grpc.PaymentAccountPayloadInfo proto) {
-        return new PaymentAccountPayloadInfo(proto.getId(), proto.getPaymentMethodId(), proto.getAddress());
+        return new PaymentAccountPayloadInfo(proto.getId(),
+                proto.getPaymentMethodId(),
+                proto.getAddress(),
+                proto.getPaymentDetails());
     }
 
     @Override
@@ -80,6 +93,7 @@ public class PaymentAccountPayloadInfo implements Payload {
                 .setId(id)
                 .setPaymentMethodId(paymentMethodId)
                 .setAddress(address != null ? address : "")
+                .setPaymentDetails(paymentDetails != null ? paymentDetails : "")
                 .build();
     }
 }

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -667,6 +667,7 @@ message PaymentAccountPayloadInfo {
     string id = 1;                  // The unique identifier of the payment account.
     string payment_method_id = 2;   // The unique identifier of the payment method.
     string address = 3;             // The optional altcoin wallet address associated with the (altcoin) payment account.
+    string payment_details = 4;     // The optional payment details, if available.
 }
 
 message TxFeeRateInfo {


### PR DESCRIPTION
Non-CLI clients need a better way of accessing payment details than a contract json string.

- Add `grpc.proto` `PaymentAccountPayloadInfo` field: payment_details.
- Adjust proto wrapper `PaymentAccountPayloadInfo` to new field.
- Add test asserts to verify payment details are sent to client.
- Fix a test name: `testKeepFunds` -> `testCloseTrade`.

Based on branch `master` @ Sat 12 Mar 2022 01:42 PM -03,  commit c6293b52730e59c675953fc8cff9238d0efd7edc
