### PR TITLE
[v1.9.0] Fix incorrect volume binding for buy offers

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
@@ -270,9 +270,9 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         if (dataModel.getDirection() == OfferDirection.BUY) {
             volumeDescriptionLabel.bind(createStringBinding(
                     () -> Res.get(CurrencyUtil.isFiatCurrency(dataModel.getTradeCurrencyCode().get()) ?
-                                    "createOffer.amountPriceBox.buy.volumeDescription" :
-                                    "createOffer.amountPriceBox.buy.volumeDescriptionAltcoin", dataModel.getTradeCurrencyCode().get(),
-                            dataModel.getTradeCurrencyCode())));
+                            "createOffer.amountPriceBox.buy.volumeDescription" :
+                            "createOffer.amountPriceBox.buy.volumeDescriptionAltcoin", dataModel.getTradeCurrencyCode().get()),
+                    dataModel.getTradeCurrencyCode()));
         } else {
             volumeDescriptionLabel.bind(createStringBinding(
                     () -> Res.get(CurrencyUtil.isFiatCurrency(dataModel.getTradeCurrencyCode().get()) ?


### PR DESCRIPTION
Was not updated when switching between payment accounts with different default currency

<img width="1387" alt="Bildschirmfoto 2022-04-27 um 13 35 16" src="https://user-images.githubusercontent.com/170962/165510021-003c12c0-5e49-41e7-a096-524a313d881a.png">
