### PR TITLE
Fix API editoffer bug: set fixed-price=0 on margin offers

### DIFF
--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -420,7 +420,7 @@ public class OfferUtil {
                 original.getOwnerNodeAddress(),
                 original.getPubKeyRing(),
                 original.getDirection(),
-                mutableOfferPayloadFields.getPrice(),
+                mutableOfferPayloadFields.getFixedPrice(),
                 mutableOfferPayloadFields.getMarketPriceMargin(),
                 mutableOfferPayloadFields.isUseMarketBasedPrice(),
                 original.getAmount(),

--- a/core/src/main/java/bisq/core/offer/bisq_v1/MutableOfferPayloadFields.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/MutableOfferPayloadFields.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 @Setter
 public final class MutableOfferPayloadFields {
 
-    private final long price;
+    private final long fixedPrice; // Must be 0 when marketPriceMargin = true (on server).
     private final double marketPriceMargin;
     private final boolean useMarketBasedPrice;
     private final String baseCurrencyCode;
@@ -69,7 +69,7 @@ public final class MutableOfferPayloadFields {
                 offerPayload.getExtraDataMap());
     }
 
-    public MutableOfferPayloadFields(long price,
+    public MutableOfferPayloadFields(long fixedPrice,
                                      double marketPriceMargin,
                                      boolean useMarketBasedPrice,
                                      String baseCurrencyCode,
@@ -83,7 +83,7 @@ public final class MutableOfferPayloadFields {
                                      @Nullable String bankId,
                                      @Nullable List<String> acceptedBankIds,
                                      @Nullable Map<String, String> extraDataMap) {
-        this.price = price;
+        this.fixedPrice = fixedPrice;
         this.marketPriceMargin = marketPriceMargin;
         this.useMarketBasedPrice = useMarketBasedPrice;
         this.baseCurrencyCode = baseCurrencyCode;
@@ -102,7 +102,7 @@ public final class MutableOfferPayloadFields {
     @Override
     public String toString() {
         return "MutableOfferPayloadFields{" + "\n" +
-                "  price=" + price + "\n" +
+                "  fixedPrice=" + fixedPrice + "\n" +
                 ", marketPriceMargin=" + marketPriceMargin + "\n" +
                 ", useMarketBasedPrice=" + useMarketBasedPrice + "\n" +
                 ", baseCurrencyCode='" + baseCurrencyCode + '\'' + "\n" +


### PR DESCRIPTION
This is causing erroneous PRICE_OUT_OF_TOLERANCE errors when trying to take offers having (fixed) `price`!=0, and `isUsingMktPriceMargin`=true in the payload.

The API daemon `editoffer's` treatment of (fixed) `price` and `isUsingMktPriceMargin` flag in the API has been inconsistent with the UI.

With this change:  when isUsingMktPriceMargin=true, (fixed) price is set to 0 on the server.  API clients, however, still receive and must show the calculated `price` when isUsingMktPriceMargin=true, making this fix hard to test in the client.  The server will now throw an exception if (fixed) price and isUsingMktPriceMargin flag in the API are not properly set in the API server.

This fix is intended to prevent issues such as https://github.com/bisq-network/bisq/issues/6170 from happening for this reason.  The offer maker edited offers with API, creating inconsistent state described above.  It is hoped the user's offers can be fixed by editing them in the UI.

Based on `master`.

