### PR TITLE
Fix API CLI gettrades bug: category param can be uppercase

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -516,7 +516,7 @@ public class CliMain {
                             ? client.getOpenTrades()
                             : client.getTradeHistory(category);
                     if (trades.isEmpty()) {
-                        out.printf("no %s trades found%n", category.name().toLowerCase());
+                        out.printf("no %s trades found%n", category.name());
                     } else {
                         var tableType = category.equals(OPEN)
                                 ? OPEN_TRADES_TBL

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -516,7 +516,7 @@ public class CliMain {
                             ? client.getOpenTrades()
                             : client.getTradeHistory(category);
                     if (trades.isEmpty()) {
-                        out.printf("no %s trades found%n", category.name());
+                        out.printf("no %s trades found%n", category.name().toLowerCase());
                     } else {
                         var tableType = category.equals(OPEN)
                                 ? OPEN_TRADES_TBL

--- a/cli/src/main/java/bisq/cli/opts/GetTradesOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/GetTradesOptionParser.java
@@ -78,7 +78,7 @@ public class GetTradesOptionParser extends AbstractMethodOptionParser implements
     }
 
     public GetTradesRequest.Category getCategory() {
-        String cliOpt = options.valueOf(categoryOpt);
-        return CATEGORY.valueOf(cliOpt).grpcRequestCategory;
+        String categoryOpt = options.valueOf(this.categoryOpt).toLowerCase();
+        return CATEGORY.valueOf(categoryOpt).grpcRequestCategory;
     }
 }


### PR DESCRIPTION
When category param value was uppercase, e.g.,  `$ ./bisq-cli --password=xyz --port=9998 gettrades --category=OPEN`,
CLI validation failed:  `Error: No enum constant bisq.cli.opts.GetTradesOptionParser.CATEGORY.OPEN`.
(`gRPC` java/python clients were OK because they have to use the protobuf enum instead of a string parameter value.)
    
This fixes the bug, and `--category=open|closed|failed` now passes CLI validation.
    
Based on `master`.
