### PR TITLE
Update matching account toggle state when tab is selected

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -609,7 +609,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         if (isSelected) {
             updateCurrencyComboBoxFromModel();
             root.requestFocus();
-            updateCreateOfferButton();
+            matchingOffersToggle.setSelected(model.useOffersMatchingMyAccountsFilter);
         }
         updateCreateOfferButton();
     }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -231,10 +231,7 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     protected void activate() {
         filteredItems.addListener(filterItemsListener);
 
-        if (user != null) {
-            disableMatchToggle.set(user.getPaymentAccounts() == null || user.getPaymentAccounts().isEmpty());
-        }
-        useOffersMatchingMyAccountsFilter = !disableMatchToggle.get() && isShowOffersMatchingMyAccounts();
+        updateMatchingAccountToggleState();
 
         fillCurrencies();
         updateSelectedTradeCurrency();
@@ -268,6 +265,7 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
         if (isTabSelected) {
             updateSelectedTradeCurrency();
             filterOffers();
+            updateMatchingAccountToggleState();
         }
     }
 
@@ -559,6 +557,13 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
         allCurrencies.clear();
 
         fillCurrencies(tradeCurrencies, allCurrencies);
+    }
+
+    private void updateMatchingAccountToggleState() {
+        if (user != null) {
+            disableMatchToggle.set(user.getPaymentAccounts() == null || user.getPaymentAccounts().isEmpty());
+        }
+        useOffersMatchingMyAccountsFilter = !disableMatchToggle.get() && isShowOffersMatchingMyAccounts();
     }
 
     abstract void fillCurrencies(ObservableList<TradeCurrency> tradeCurrencies,


### PR DESCRIPTION
Fixes #6199.

This PR re-creates the same behavior as before, that the matching account toggle is a state that is shared across different offer books.