### PR TITLE
Remove legacy bitcoind txindex param from apitest harness

### DIFF
--- a/apitest/src/main/java/bisq/apitest/linux/BitcoinDaemon.java
+++ b/apitest/src/main/java/bisq/apitest/linux/BitcoinDaemon.java
@@ -52,7 +52,6 @@ public class BitcoinDaemon extends AbstractLinuxProcess implements LinuxProcess 
                 + " -daemon"
                 + " -regtest=1"
                 + " -server=1"
-                + " -txindex=1"
                 + " -peerbloomfilters=1"
                 + " -debug=net"
                 + " -fallbackfee=0.0002"


### PR DESCRIPTION
It was put there thinking it would be needed by the test harness and suites, which work fine without it, and it must be removed before API test harness can run against bitcoin-core v23.

See https://github.com/bitcoin/bitcoin/pull/22626#issuecomment-893220371

Based on `master`.