### PR TITLE
Prepare Bisq for bitcoin-core v23 compatiblity

### DIFF
--- a/apitest/src/main/java/bisq/apitest/linux/BitcoinDaemon.java
+++ b/apitest/src/main/java/bisq/apitest/linux/BitcoinDaemon.java
@@ -52,7 +52,6 @@ public class BitcoinDaemon extends AbstractLinuxProcess implements LinuxProcess 
                 + " -daemon"
                 + " -regtest=1"
                 + " -server=1"
-                + " -txindex=1"
                 + " -peerbloomfilters=1"
                 + " -debug=net"
                 + " -fallbackfee=0.0002"

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BtcWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BtcWalletTest.java
@@ -41,7 +41,7 @@ public class BtcWalletTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         startSupportingApps(false,
-                true,
+                false,
                 bitcoind,
                 seednode,
                 alicedaemon,

--- a/core/src/main/java/bisq/core/dao/node/full/rpc/dto/DtoNetworkInfo.java
+++ b/core/src/main/java/bisq/core/dao/node/full/rpc/dto/DtoNetworkInfo.java
@@ -91,7 +91,11 @@ public class DtoNetworkInfo {
 
     @RequiredArgsConstructor
     public enum NetworkType {
-        IPV4("ipv4"), IPV6("ipv6"), ONION("onion"), I2P("i2p");
+        IPV4("ipv4"),
+        IPV6("ipv6"),
+        ONION("onion"),
+        I2P("i2p"),
+        CJDNS("cjdns");
 
         @Getter(onMethod_ = @JsonValue)
         private final String name;

--- a/seednode/bitcoin.conf
+++ b/seednode/bitcoin.conf
@@ -2,6 +2,7 @@ server=1
 daemon=1
 listen=1
 discover=1
+txindex=1
 dbcache=1337
 maxconnections=1337
 peerbloomfilters=1

--- a/seednode/bitcoin.conf
+++ b/seednode/bitcoin.conf
@@ -2,7 +2,6 @@ server=1
 daemon=1
 listen=1
 discover=1
-txindex=1
 dbcache=1337
 maxconnections=1337
 peerbloomfilters=1


### PR DESCRIPTION
There seem to be at least two minor adjustments we have to make for bitcoin v23:

- Add a `CJDNS` enum to `DtoNetworkInfo.NetworkType`, or json parsing will fail.
- Remove `-txindex=1` from seednode's `bitcoin.conf`.
  This change needs special attention from reviewers.
  
More detail about these two changes are in the commits.  

The API test suites work with these changes, against both bitcoin-core v22 and v23, but have not been tested against bitcoin-core v21, 20, 19.

This PR needs more thorough testing with the desktop UI before merging.

Based on https://github.com/bisq-network/bisq/pull/6214, branch `remove-bitcoind-txindex-param`.