### PR TITLE
Increase seednode RAM limit from 4G to 8G, and BISQ_MAX_MEMORY to match

### DIFF
--- a/seednode/bisq.env
+++ b/seednode/bisq.env
@@ -5,7 +5,7 @@
 JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
 
 # java memory and remote management options
-JAVA_OPTS="-Xms4096M -Xmx4096M"
+JAVA_OPTS="-Xms8192M -Xmx8192M"
 
 # bitcoin rpc credentials
 BITCOIN_RPC_USER=__BITCOIN_RPC_USER__
@@ -30,7 +30,7 @@ BISQ_BASE_CURRENCY=btc_mainnet
 # bisq node settings
 BISQ_NODE_PORT=8000
 BISQ_MAX_CONNECTIONS=20
-BISQ_MAX_MEMORY=4000
+BISQ_MAX_MEMORY=8000
 
 # set to true for BSQ seednode
 BISQ_DAO_FULLNODE=true


### PR DESCRIPTION
It seems my Bisq seednode `wizseeds` has crashed due to OOM:
```
[InputHandler] ERROR b.c.s.CommonSetup: Stack trace: java.lang.OutOfMemoryError: Java heap space
```

I suppose it is time to increase our RAM limits from 4G to 8G @Emzy @chimp1984 @ripcurlx 