### PR TITLE
Pricenode: Add JVM flag ExitOnOutOfMemoryError

### DIFF
--- a/pricenode/bisq-pricenode.env
+++ b/pricenode/bisq-pricenode.env
@@ -1,1 +1,1 @@
-JAVA_OPTS=""
+JAVA_OPTS="-XX:+ExitOnOutOfMemoryError"

--- a/seednode/bisq.env
+++ b/seednode/bisq.env
@@ -5,7 +5,7 @@
 JAVA_HOME=/usr/lib/jvm/openjdk-10.0.2
 
 # java memory and remote management options
-JAVA_OPTS="-Xms4096M -Xmx4096M"
+JAVA_OPTS="-Xms4096M -Xmx4096M -XX:+ExitOnOutOfMemoryError"
 
 # bitcoin rpc credentials
 BITCOIN_RPC_USER=__BITCOIN_RPC_USER__


### PR DESCRIPTION
Add flag that causes the JVM to exit with exit code 3 whenever there is an OutOfMemory exception for the pricenode service, which causes the systemd bisq-pricenode service to restart.

Can be tested by running the pricenode on a VM with very little memory, or by artificially limiting the JVM memory in addition to this flag: `-Xmx10m -XX:+ExitOnOutOfMemoryError`. The tests should result in an endless restart cycle for the pricenode service (`sudo systemctl status bisq-pricenode` should show service uptime of max 1-2 seconds each time it's called).

Fixes #6225