### PR TITLE
Conditionally block API's send payment sent/rcvd msgs

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/trade/AbstractTradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/AbstractTradeTest.java
@@ -43,10 +43,16 @@ public class AbstractTradeTest extends AbstractOfferTest {
     @Getter
     protected static String tradeId;
 
-    protected final Supplier<Integer> maxTradeStateAndPhaseChecks = () -> isLongRunningTest ? 10 : 2;
+    protected final Supplier<Integer> maxTradeStateAndPhaseChecks = () ->
+            isLongRunningTest
+                    ? 10
+                    : 2;
     protected final Function<TradeInfo, String> toTradeDetailTable = (trade) ->
             new TableBuilder(TRADE_DETAIL_TBL, trade).build().toString();
-    protected final Function<GrpcClient, String> toUserName = (client) -> client.equals(aliceClient) ? "Alice" : "Bob";
+    protected final Function<GrpcClient, String> toUserName = (client) ->
+            client.equals(aliceClient)
+                    ? "Alice"
+                    : "Bob";
 
     @BeforeAll
     public static void initStaticFixtures() {
@@ -87,17 +93,17 @@ public class AbstractTradeTest extends AbstractOfferTest {
         return trade;
     }
 
-    protected final void waitForDepositConfirmation(Logger log,
-                                                    TestInfo testInfo,
-                                                    GrpcClient grpcClient,
-                                                    String tradeId) {
+    protected final void waitForTakerDepositConfirmation(Logger log,
+                                                         TestInfo testInfo,
+                                                         GrpcClient takerClient,
+                                                         String tradeId) {
         Predicate<TradeInfo> isTradeInDepositConfirmedStateAndPhase = (t) ->
                 t.getState().equals(DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN.name())
                         && t.getPhase().equals(DEPOSIT_CONFIRMED.name());
 
-        String userName = toUserName.apply(grpcClient);
+        String userName = toUserName.apply(takerClient);
         for (int i = 1; i <= maxTradeStateAndPhaseChecks.get(); i++) {
-            TradeInfo trade = grpcClient.getTrade(tradeId);
+            TradeInfo trade = takerClient.getTrade(tradeId);
             if (!isTradeInDepositConfirmedStateAndPhase.test(trade)) {
                 log.warn("{} still waiting on trade {} tx {}: DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN, attempt # {}",
                         userName,

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
@@ -101,7 +101,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
             alicesBsqOffers = aliceClient.getMyOffersSortedByDate(BSQ);
             assertEquals(0, alicesBsqOffers.size());
 
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
             genBtcBlocksThenWait(1, 2_500);
 
             trade = bobClient.getTrade(tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
@@ -46,6 +46,7 @@ import bisq.apitest.method.offer.AbstractOfferTest;
 
 // https://github.com/ghubstan/bisq/blob/master/cli/src/main/java/bisq/cli/TradeFormat.java
 
+@Deprecated // Bisq v1 protocol BSQ trades have been replaced by BSQ Swaps.
 @Disabled
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -122,7 +123,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
             genBtcBlocksThenWait(1, 2_500);
             bobClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             logTrade(log, testInfo, "Alice's Maker/Buyer View (Payment Sent)", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View (Payment Sent)", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -134,7 +135,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
     @Order(3)
     public void testAlicesConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             sleep(2_000);
             var trade = aliceClient.getTrade(tradeId);
             verifyBsqPaymentHasBeenReceived(log, aliceClient, trade);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
@@ -42,6 +42,7 @@ import static protobuf.OfferDirection.BUY;
 import static protobuf.OpenOffer.State.AVAILABLE;
 
 @Disabled
+@SuppressWarnings("ConstantConditions")
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TakeBuyBTCOfferTest extends AbstractTradeTest {
@@ -82,11 +83,9 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
             sleep(2_500);  // Allow available offer to be removed from offer book.
             alicesUsdOffers = aliceClient.getMyOffersSortedByDate(BUY.name(), USD);
             assertEquals(0, alicesUsdOffers.size());
-            genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
 
             trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
+            verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -96,13 +95,23 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(2)
-    public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
+    public void testPaymentMessagingPreconditions(final TestInfo testInfo) {
         try {
-            var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
-            aliceClient.confirmPaymentStarted(trade.getTradeId());
-            sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            // Alice is maker / btc buyer, Bob is taker / btc seller.
+            // Verify payment sent and rcvd msgs are sent by the right peers:  buyer and seller.
+            verifyPaymentSentMsgIsFromBtcBuyerPrecondition(log, bobClient);
+            verifyPaymentReceivedMsgIsFromBtcSellerPrecondition(log, aliceClient);
+
+            // Verify fiat payment sent and rcvd msgs cannot be sent before trade deposit tx is confirmed.
+            verifyPaymentSentMsgDepositTxConfirmedPrecondition(log, aliceClient);
+            verifyPaymentReceivedMsgDepositTxConfirmedPrecondition(log, bobClient);
+
+            // Now generate the BTC block to confirm the taker deposit tx.
+            genBtcBlocksThenWait(1, 2_500);
+            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+
+            // Verify the seller can only send a payment rcvd msg after the payment started msg.
+            verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, bobClient);
         } catch (StatusRuntimeException e) {
             fail(e);
         }
@@ -110,9 +119,23 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(3)
+    public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
+        try {
+            var trade = aliceClient.getTrade(tradeId);
+            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            aliceClient.confirmPaymentStarted(trade.getTradeId());
+            sleep(6_000);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
+        } catch (StatusRuntimeException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    @Order(4)
     public void testBobsConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             var trade = bobClient.getTrade(tradeId);
             bobClient.confirmPaymentReceived(trade.getTradeId());
             sleep(3_000);
@@ -131,7 +154,7 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testCloseTrade(final TestInfo testInfo) {
         try {
             genBtcBlocksThenWait(1, 1_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
@@ -108,7 +108,7 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, bobClient);
@@ -122,7 +122,7 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
             waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
@@ -145,7 +145,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
             alicesOffers = aliceClient.getMyOffersSortedByDate(BUY.name(), BRL);
             assertEquals(0, alicesOffers.size());
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
 
             trade = bobClient.getTrade(tradeId);
             verifyTakerDepositConfirmed(trade);
@@ -182,7 +182,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
             waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
@@ -185,7 +185,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
             waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             trade = aliceClient.getTrade(tradeId);
             assertEquals(OFFER_FEE_PAID.name(), trade.getOffer().getState());
             logTrade(log, testInfo, "Alice's Maker/Buyer View (Payment Sent)", aliceClient.getTrade(tradeId));
@@ -199,7 +199,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
     @Order(4)
     public void testBobsConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             var trade = bobClient.getTrade(tradeId);
             bobClient.confirmPaymentReceived(trade.getTradeId());
             sleep(3_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
@@ -115,7 +115,7 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
@@ -47,6 +47,7 @@ import bisq.apitest.method.offer.AbstractOfferTest;
 import bisq.cli.table.builder.TableBuilder;
 
 @Disabled
+@SuppressWarnings("ConstantConditions")
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TakeBuyXMROfferTest extends AbstractTradeTest {
@@ -89,11 +90,9 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
             var trade = takeAlicesOffer(offerId, bobsXmrAcct.getId(), TRADE_FEE_CURRENCY_CODE);
             alicesXmrOffers = aliceClient.getMyOffersSortedByDate(XMR);
             assertEquals(0, alicesXmrOffers.size());
-            genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
 
             trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
+            verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -103,15 +102,39 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
 
     @Test
     @Order(2)
+    public void testPaymentMessagingPreconditions(final TestInfo testInfo) {
+        try {
+            // Alice is maker / xmr buyer (btc seller), Bob is taker / xmr seller (btc buyer).
+            // Verify payment sent and rcvd msgs are sent by the right peers:  buyer and seller.
+            verifyPaymentSentMsgIsFromBtcBuyerPrecondition(log, aliceClient);
+            verifyPaymentReceivedMsgIsFromBtcSellerPrecondition(log, bobClient);
+
+            // Verify xmr payment sent and rcvd msgs cannot be sent before trade deposit tx is confirmed.
+            verifyPaymentSentMsgDepositTxConfirmedPrecondition(log, bobClient);
+            verifyPaymentReceivedMsgDepositTxConfirmedPrecondition(log, aliceClient);
+
+            // Now generate the BTC block to confirm the taker deposit tx.
+            genBtcBlocksThenWait(1, 2_500);
+            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+
+            // Verify the seller can only send a payment rcvd msg after the payment started msg.
+            verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);
+        } catch (StatusRuntimeException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    @Order(3)
     public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = bobClient.getTrade(tradeId);
 
             verifyTakerDepositConfirmed(trade);
-            log.debug("Bob sends XMR payment to Alice for trade {}", trade.getTradeId());
-            bobClient.confirmPaymentStarted(trade.getTradeId());
+            log.debug("Bob sends XMR payment to Alice for trade {}", tradeId);
+            bobClient.confirmPaymentStarted(tradeId);
             sleep(3500);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
 
             logTrade(log, testInfo, "Alice's Maker/Buyer View (Payment Sent)", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View (Payment Sent)", bobClient.getTrade(tradeId));
@@ -121,18 +144,18 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     public void testAlicesConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
 
             sleep(2_000);
             var trade = aliceClient.getTrade(tradeId);
             // If we were trading BSQ, Alice would verify payment has been sent to her
             // Bisq / BSQ wallet, but we can do no such checks for XMR payments.
             // All XMR transfers are done outside Bisq.
-            log.debug("Alice verifies XMR payment was received from Bob, for trade {}", trade.getTradeId());
-            aliceClient.confirmPaymentReceived(trade.getTradeId());
+            log.debug("Alice verifies XMR payment was received from Bob, for trade {}", tradeId);
+            aliceClient.confirmPaymentReceived(tradeId);
             sleep(3_000);
 
             trade = aliceClient.getTrade(tradeId);
@@ -150,7 +173,7 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testCloseTrade(final TestInfo testInfo) {
         try {
             genBtcBlocksThenWait(1, 1_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
@@ -46,6 +46,7 @@ import static protobuf.OfferDirection.BUY;
 import bisq.apitest.method.offer.AbstractOfferTest;
 import bisq.cli.table.builder.TableBuilder;
 
+@Deprecated // Bisq v1 protocol BSQ trades have been replaced by BSQ Swaps.
 @Disabled
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -114,7 +115,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
             genBtcBlocksThenWait(1, 2_500);
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             logTrade(log, testInfo, "Alice's Maker/Seller View (Payment Sent)", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Buyer View (Payment Sent)", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -126,7 +127,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
     @Order(3)
     public void testBobsConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
 
             sleep(2_000);
             var trade = bobClient.getTrade(tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
@@ -82,7 +82,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
                     alicesLegacyBsqAcct.getId(),
                     TRADE_FEE_CURRENCY_CODE);
             log.debug("Alice's SELL BSQ (BUY BTC) Offer:\n{}", new TableBuilder(OFFER_TBL, alicesOffer).build());
-            genBtcBlocksThenWait(1, 4_000);
+            genBtcBlocksThenWait(1, 2_500);
             var offerId = alicesOffer.getId();
             assertTrue(alicesOffer.getIsCurrencyForMakerFeeBtc());
             var alicesBsqOffers = aliceClient.getMyOffers(btcTradeDirection, BSQ);
@@ -95,7 +95,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
             alicesBsqOffers = aliceClient.getMyOffersSortedByDate(BSQ);
             assertEquals(0, alicesBsqOffers.size());
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
             trade = bobClient.getTrade(tradeId);
             verifyTakerDepositConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Seller View", aliceClient.getTrade(tradeId));
@@ -110,7 +110,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             sendBsqPayment(log, aliceClient, trade);
             genBtcBlocksThenWait(1, 2_500);
             aliceClient.confirmPaymentStarted(trade.getTradeId());

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
@@ -112,7 +112,7 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
@@ -43,6 +43,7 @@ import static protobuf.Offer.State.OFFER_FEE_PAID;
 import static protobuf.OfferDirection.SELL;
 
 @Disabled
+@SuppressWarnings("ConstantConditions")
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TakeSellBTCOfferTest extends AbstractTradeTest {
@@ -86,10 +87,9 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
             sleep(2_500);  // Allow available offer to be removed from offer book.
             var takeableUsdOffers = bobClient.getOffersSortedByDate(SELL.name(), USD);
             assertEquals(0, takeableUsdOffers.size());
-            genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+
             trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
+            verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -99,13 +99,23 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(2)
-    public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
+    public void testPaymentMessagingPreconditions(final TestInfo testInfo) {
         try {
-            var trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
-            bobClient.confirmPaymentStarted(tradeId);
-            sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            // Alice is maker / btc seller, Bob is taker / btc buyer.
+            // Verify payment sent and rcvd msgs are sent by the right peers:  buyer and seller.
+            verifyPaymentSentMsgIsFromBtcBuyerPrecondition(log, aliceClient);
+            verifyPaymentReceivedMsgIsFromBtcSellerPrecondition(log, bobClient);
+
+            // Verify fiat payment sent and rcvd msgs cannot be sent before trade deposit tx is confirmed.
+            verifyPaymentSentMsgDepositTxConfirmedPrecondition(log, bobClient);
+            verifyPaymentReceivedMsgDepositTxConfirmedPrecondition(log, aliceClient);
+
+            // Now generate the BTC block to confirm the taker deposit tx.
+            genBtcBlocksThenWait(1, 2_500);
+            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+
+            // Verify the seller can only send a payment rcvd msg after the payment started msg.
+            verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);
         } catch (StatusRuntimeException e) {
             fail(e);
         }
@@ -113,9 +123,23 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(3)
+    public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
+        try {
+            var trade = bobClient.getTrade(tradeId);
+            verifyTakerDepositConfirmed(trade);
+            bobClient.confirmPaymentStarted(tradeId);
+            sleep(6_000);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
+        } catch (StatusRuntimeException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    @Order(4)
     public void testAlicesConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
 
             var trade = aliceClient.getTrade(tradeId);
             aliceClient.confirmPaymentReceived(trade.getTradeId());
@@ -134,7 +158,7 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testBobsBtcWithdrawalToExternalAddress(final TestInfo testInfo) {
         try {
             genBtcBlocksThenWait(1, 1_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
@@ -118,7 +118,7 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, bobClient);
@@ -132,10 +132,10 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             log.debug("Alice sends XMR payment to Bob for trade {}", trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
-            sleep(3500);
+            sleep(3_500);
 
             waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             logTrade(log, testInfo, "Alice's Maker/Seller View (Payment Sent)", aliceClient.getTrade(tradeId));

--- a/apitest/src/test/java/bisq/apitest/scenario/LongRunningTradesTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/LongRunningTradesTest.java
@@ -78,6 +78,7 @@ public class LongRunningTradesTest extends AbstractTradeTest {
         TakeSellBTCOfferTest test = new TakeSellBTCOfferTest();
         setLongRunningTest(true);
         test.testTakeAlicesSellOffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
         test.testAlicesConfirmPaymentReceived(testInfo);
         test.testBobsBtcWithdrawalToExternalAddress(testInfo);

--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -20,6 +20,7 @@ package bisq.apitest.scenario;
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,7 @@ public class TradeTest extends AbstractTradeTest {
         test.testBobsBtcWithdrawalToExternalAddress(testInfo);
     }
 
+    @Disabled
     @Test
     @Order(3)
     public void testTakeBuyBSQOffer(final TestInfo testInfo) {
@@ -91,6 +93,7 @@ public class TradeTest extends AbstractTradeTest {
         test.testCloseTrade(testInfo);
     }
 
+    @Disabled
     @Test
     @Order(5)
     public void testTakeSellBSQOffer(final TestInfo testInfo) {

--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -56,6 +56,7 @@ public class TradeTest extends AbstractTradeTest {
     public void testTakeBuyBTCOffer(final TestInfo testInfo) {
         TakeBuyBTCOfferTest test = new TakeBuyBTCOfferTest();
         test.testTakeAlicesBuyOffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testAlicesConfirmPaymentStarted(testInfo);
         test.testBobsConfirmPaymentReceived(testInfo);
         test.testCloseTrade(testInfo);
@@ -66,6 +67,7 @@ public class TradeTest extends AbstractTradeTest {
     public void testTakeSellBTCOffer(final TestInfo testInfo) {
         TakeSellBTCOfferTest test = new TakeSellBTCOfferTest();
         test.testTakeAlicesSellOffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
         test.testAlicesConfirmPaymentReceived(testInfo);
         test.testBobsBtcWithdrawalToExternalAddress(testInfo);
@@ -110,6 +112,7 @@ public class TradeTest extends AbstractTradeTest {
         TakeBuyXMROfferTest test = new TakeBuyXMROfferTest();
         TakeBuyXMROfferTest.createXmrPaymentAccounts();
         test.testTakeAlicesSellBTCForXMROffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
         test.testAlicesConfirmPaymentReceived(testInfo);
         test.testCloseTrade(testInfo);
@@ -121,6 +124,7 @@ public class TradeTest extends AbstractTradeTest {
         TakeSellXMROfferTest test = new TakeSellXMROfferTest();
         TakeBuyXMROfferTest.createXmrPaymentAccounts();
         test.testTakeAlicesBuyBTCForXMROffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testAlicesConfirmPaymentStarted(testInfo);
         test.testBobsConfirmPaymentReceived(testInfo);
         test.testAlicesBtcWithdrawalToExternalAddress(testInfo);


### PR DESCRIPTION
Fixes API bug incorrectly permitting payment sent / received msgs before trade deposit tx is confirmed.  Also blocks payment rcvd confirmation msgs from being sent if payment sent msgs have not been sent (yet).  API cannot depend on silent, UI purposed task runner errors if `confirmpaymentstarted` or `confirmpaymentreceived` msgs are sent outside the proper context.  Throw a FailedPreconditionException instead, to be  translated into the proper gPRC `StatusRuntimeException` before being sent to client.

The important change is in `bisq.core.api.CoreTradesService`:

- For BTC buyers and sellers, block the messaging attempt if the taker deposit tx has not been confirmed.
- For BTC sellers, block an attempt to send a `confirmpaymentreceived` message until after receiving a `confirmpaymentstarted` message has been sent from the buyer.

Also apitest send payment sent/rcvd precondition checks:

- verifyPaymentSentMsgIsFromBtcBuyerPrecondition
- verifyPaymentReceivedMsgIsFromBtcSellerPrecondition
- verifyPaymentSentMsgDepositTxConfirmedPrecondition
- verifyPaymentReceivedMsgDepositTxConfirmedPrecondition
- verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition 

Based on 'master'.
