### PR TITLE
Block API attempt to swap BSQ with insufficient funds

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/trade/AbstractTradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/AbstractTradeTest.java
@@ -43,10 +43,16 @@ public class AbstractTradeTest extends AbstractOfferTest {
     @Getter
     protected static String tradeId;
 
-    protected final Supplier<Integer> maxTradeStateAndPhaseChecks = () -> isLongRunningTest ? 10 : 2;
+    protected final Supplier<Integer> maxTradeStateAndPhaseChecks = () ->
+            isLongRunningTest
+                    ? 10
+                    : 2;
     protected final Function<TradeInfo, String> toTradeDetailTable = (trade) ->
             new TableBuilder(TRADE_DETAIL_TBL, trade).build().toString();
-    protected final Function<GrpcClient, String> toUserName = (client) -> client.equals(aliceClient) ? "Alice" : "Bob";
+    protected final Function<GrpcClient, String> toUserName = (client) ->
+            client.equals(aliceClient)
+                    ? "Alice"
+                    : "Bob";
 
     @BeforeAll
     public static void initStaticFixtures() {
@@ -87,17 +93,17 @@ public class AbstractTradeTest extends AbstractOfferTest {
         return trade;
     }
 
-    protected final void waitForDepositConfirmation(Logger log,
-                                                    TestInfo testInfo,
-                                                    GrpcClient grpcClient,
-                                                    String tradeId) {
+    protected final void waitForTakerDepositConfirmation(Logger log,
+                                                         TestInfo testInfo,
+                                                         GrpcClient takerClient,
+                                                         String tradeId) {
         Predicate<TradeInfo> isTradeInDepositConfirmedStateAndPhase = (t) ->
                 t.getState().equals(DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN.name())
                         && t.getPhase().equals(DEPOSIT_CONFIRMED.name());
 
-        String userName = toUserName.apply(grpcClient);
+        String userName = toUserName.apply(takerClient);
         for (int i = 1; i <= maxTradeStateAndPhaseChecks.get(); i++) {
-            TradeInfo trade = grpcClient.getTrade(tradeId);
+            TradeInfo trade = takerClient.getTrade(tradeId);
             if (!isTradeInDepositConfirmedStateAndPhase.test(trade)) {
                 log.warn("{} still waiting on trade {} tx {}: DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN, attempt # {}",
                         userName,

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
@@ -101,7 +101,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
             alicesBsqOffers = aliceClient.getMyOffersSortedByDate(BSQ);
             assertEquals(0, alicesBsqOffers.size());
 
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
             genBtcBlocksThenWait(1, 2_500);
 
             trade = bobClient.getTrade(tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBSQOfferTest.java
@@ -46,6 +46,7 @@ import bisq.apitest.method.offer.AbstractOfferTest;
 
 // https://github.com/ghubstan/bisq/blob/master/cli/src/main/java/bisq/cli/TradeFormat.java
 
+@Deprecated // Bisq v1 protocol BSQ trades have been replaced by BSQ Swaps.
 @Disabled
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -122,7 +123,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
             genBtcBlocksThenWait(1, 2_500);
             bobClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             logTrade(log, testInfo, "Alice's Maker/Buyer View (Payment Sent)", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View (Payment Sent)", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -134,7 +135,7 @@ public class TakeBuyBSQOfferTest extends AbstractTradeTest {
     @Order(3)
     public void testAlicesConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             sleep(2_000);
             var trade = aliceClient.getTrade(tradeId);
             verifyBsqPaymentHasBeenReceived(log, aliceClient, trade);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
@@ -42,6 +42,7 @@ import static protobuf.OfferDirection.BUY;
 import static protobuf.OpenOffer.State.AVAILABLE;
 
 @Disabled
+@SuppressWarnings("ConstantConditions")
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TakeBuyBTCOfferTest extends AbstractTradeTest {
@@ -82,11 +83,9 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
             sleep(2_500);  // Allow available offer to be removed from offer book.
             alicesUsdOffers = aliceClient.getMyOffersSortedByDate(BUY.name(), USD);
             assertEquals(0, alicesUsdOffers.size());
-            genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
 
             trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
+            verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -96,13 +95,23 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(2)
-    public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
+    public void testPaymentMessagingPreconditions(final TestInfo testInfo) {
         try {
-            var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
-            aliceClient.confirmPaymentStarted(trade.getTradeId());
-            sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            // Alice is maker / btc buyer, Bob is taker / btc seller.
+            // Verify payment sent and rcvd msgs are sent by the right peers:  buyer and seller.
+            verifyPaymentSentMsgIsFromBtcBuyerPrecondition(log, bobClient);
+            verifyPaymentReceivedMsgIsFromBtcSellerPrecondition(log, aliceClient);
+
+            // Verify fiat payment sent and rcvd msgs cannot be sent before trade deposit tx is confirmed.
+            verifyPaymentSentMsgDepositTxConfirmedPrecondition(log, aliceClient);
+            verifyPaymentReceivedMsgDepositTxConfirmedPrecondition(log, bobClient);
+
+            // Now generate the BTC block to confirm the taker deposit tx.
+            genBtcBlocksThenWait(1, 2_500);
+            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+
+            // Verify the seller can only send a payment rcvd msg after the payment started msg.
+            verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, bobClient);
         } catch (StatusRuntimeException e) {
             fail(e);
         }
@@ -110,9 +119,23 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(3)
+    public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
+        try {
+            var trade = aliceClient.getTrade(tradeId);
+            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            aliceClient.confirmPaymentStarted(trade.getTradeId());
+            sleep(6_000);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
+        } catch (StatusRuntimeException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    @Order(4)
     public void testBobsConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             var trade = bobClient.getTrade(tradeId);
             bobClient.confirmPaymentReceived(trade.getTradeId());
             sleep(3_000);
@@ -131,7 +154,7 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testCloseTrade(final TestInfo testInfo) {
         try {
             genBtcBlocksThenWait(1, 1_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
@@ -108,7 +108,7 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, bobClient);
@@ -122,7 +122,7 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
             waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
@@ -145,7 +145,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
             alicesOffers = aliceClient.getMyOffersSortedByDate(BUY.name(), BRL);
             assertEquals(0, alicesOffers.size());
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
 
             trade = bobClient.getTrade(tradeId);
             verifyTakerDepositConfirmed(trade);
@@ -182,7 +182,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
             waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
@@ -185,7 +185,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
             waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             trade = aliceClient.getTrade(tradeId);
             assertEquals(OFFER_FEE_PAID.name(), trade.getOffer().getState());
             logTrade(log, testInfo, "Alice's Maker/Buyer View (Payment Sent)", aliceClient.getTrade(tradeId));
@@ -199,7 +199,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
     @Order(4)
     public void testBobsConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             var trade = bobClient.getTrade(tradeId);
             bobClient.confirmPaymentReceived(trade.getTradeId());
             sleep(3_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
@@ -115,7 +115,7 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
@@ -47,6 +47,7 @@ import bisq.apitest.method.offer.AbstractOfferTest;
 import bisq.cli.table.builder.TableBuilder;
 
 @Disabled
+@SuppressWarnings("ConstantConditions")
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TakeBuyXMROfferTest extends AbstractTradeTest {
@@ -89,11 +90,9 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
             var trade = takeAlicesOffer(offerId, bobsXmrAcct.getId(), TRADE_FEE_CURRENCY_CODE);
             alicesXmrOffers = aliceClient.getMyOffersSortedByDate(XMR);
             assertEquals(0, alicesXmrOffers.size());
-            genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
 
             trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
+            verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -103,15 +102,39 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
 
     @Test
     @Order(2)
+    public void testPaymentMessagingPreconditions(final TestInfo testInfo) {
+        try {
+            // Alice is maker / xmr buyer (btc seller), Bob is taker / xmr seller (btc buyer).
+            // Verify payment sent and rcvd msgs are sent by the right peers:  buyer and seller.
+            verifyPaymentSentMsgIsFromBtcBuyerPrecondition(log, aliceClient);
+            verifyPaymentReceivedMsgIsFromBtcSellerPrecondition(log, bobClient);
+
+            // Verify xmr payment sent and rcvd msgs cannot be sent before trade deposit tx is confirmed.
+            verifyPaymentSentMsgDepositTxConfirmedPrecondition(log, bobClient);
+            verifyPaymentReceivedMsgDepositTxConfirmedPrecondition(log, aliceClient);
+
+            // Now generate the BTC block to confirm the taker deposit tx.
+            genBtcBlocksThenWait(1, 2_500);
+            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+
+            // Verify the seller can only send a payment rcvd msg after the payment started msg.
+            verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);
+        } catch (StatusRuntimeException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    @Order(3)
     public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = bobClient.getTrade(tradeId);
 
             verifyTakerDepositConfirmed(trade);
-            log.debug("Bob sends XMR payment to Alice for trade {}", trade.getTradeId());
-            bobClient.confirmPaymentStarted(trade.getTradeId());
+            log.debug("Bob sends XMR payment to Alice for trade {}", tradeId);
+            bobClient.confirmPaymentStarted(tradeId);
             sleep(3500);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
 
             logTrade(log, testInfo, "Alice's Maker/Buyer View (Payment Sent)", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View (Payment Sent)", bobClient.getTrade(tradeId));
@@ -121,18 +144,18 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     public void testAlicesConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
 
             sleep(2_000);
             var trade = aliceClient.getTrade(tradeId);
             // If we were trading BSQ, Alice would verify payment has been sent to her
             // Bisq / BSQ wallet, but we can do no such checks for XMR payments.
             // All XMR transfers are done outside Bisq.
-            log.debug("Alice verifies XMR payment was received from Bob, for trade {}", trade.getTradeId());
-            aliceClient.confirmPaymentReceived(trade.getTradeId());
+            log.debug("Alice verifies XMR payment was received from Bob, for trade {}", tradeId);
+            aliceClient.confirmPaymentReceived(tradeId);
             sleep(3_000);
 
             trade = aliceClient.getTrade(tradeId);
@@ -150,7 +173,7 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testCloseTrade(final TestInfo testInfo) {
         try {
             genBtcBlocksThenWait(1, 1_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
@@ -46,6 +46,7 @@ import static protobuf.OfferDirection.BUY;
 import bisq.apitest.method.offer.AbstractOfferTest;
 import bisq.cli.table.builder.TableBuilder;
 
+@Deprecated // Bisq v1 protocol BSQ trades have been replaced by BSQ Swaps.
 @Disabled
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -114,7 +115,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
             genBtcBlocksThenWait(1, 2_500);
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             logTrade(log, testInfo, "Alice's Maker/Seller View (Payment Sent)", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Buyer View (Payment Sent)", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -126,7 +127,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
     @Order(3)
     public void testBobsConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
 
             sleep(2_000);
             var trade = bobClient.getTrade(tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBSQOfferTest.java
@@ -82,7 +82,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
                     alicesLegacyBsqAcct.getId(),
                     TRADE_FEE_CURRENCY_CODE);
             log.debug("Alice's SELL BSQ (BUY BTC) Offer:\n{}", new TableBuilder(OFFER_TBL, alicesOffer).build());
-            genBtcBlocksThenWait(1, 4_000);
+            genBtcBlocksThenWait(1, 2_500);
             var offerId = alicesOffer.getId();
             assertTrue(alicesOffer.getIsCurrencyForMakerFeeBtc());
             var alicesBsqOffers = aliceClient.getMyOffers(btcTradeDirection, BSQ);
@@ -95,7 +95,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
             alicesBsqOffers = aliceClient.getMyOffersSortedByDate(BSQ);
             assertEquals(0, alicesBsqOffers.size());
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
             trade = bobClient.getTrade(tradeId);
             verifyTakerDepositConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Seller View", aliceClient.getTrade(tradeId));
@@ -110,7 +110,7 @@ public class TakeSellBSQOfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             sendBsqPayment(log, aliceClient, trade);
             genBtcBlocksThenWait(1, 2_500);
             aliceClient.confirmPaymentStarted(trade.getTradeId());

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
@@ -112,7 +112,7 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
@@ -43,6 +43,7 @@ import static protobuf.Offer.State.OFFER_FEE_PAID;
 import static protobuf.OfferDirection.SELL;
 
 @Disabled
+@SuppressWarnings("ConstantConditions")
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TakeSellBTCOfferTest extends AbstractTradeTest {
@@ -86,10 +87,9 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
             sleep(2_500);  // Allow available offer to be removed from offer book.
             var takeableUsdOffers = bobClient.getOffersSortedByDate(SELL.name(), USD);
             assertEquals(0, takeableUsdOffers.size());
-            genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, trade.getTradeId());
+
             trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
+            verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
         } catch (StatusRuntimeException e) {
@@ -99,13 +99,23 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(2)
-    public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
+    public void testPaymentMessagingPreconditions(final TestInfo testInfo) {
         try {
-            var trade = bobClient.getTrade(tradeId);
-            verifyTakerDepositConfirmed(trade);
-            bobClient.confirmPaymentStarted(tradeId);
-            sleep(6_000);
-            waitForBuyerSeesPaymentInitiatedMessage(log, testInfo, bobClient, tradeId);
+            // Alice is maker / btc seller, Bob is taker / btc buyer.
+            // Verify payment sent and rcvd msgs are sent by the right peers:  buyer and seller.
+            verifyPaymentSentMsgIsFromBtcBuyerPrecondition(log, aliceClient);
+            verifyPaymentReceivedMsgIsFromBtcSellerPrecondition(log, bobClient);
+
+            // Verify fiat payment sent and rcvd msgs cannot be sent before trade deposit tx is confirmed.
+            verifyPaymentSentMsgDepositTxConfirmedPrecondition(log, bobClient);
+            verifyPaymentReceivedMsgDepositTxConfirmedPrecondition(log, aliceClient);
+
+            // Now generate the BTC block to confirm the taker deposit tx.
+            genBtcBlocksThenWait(1, 2_500);
+            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+
+            // Verify the seller can only send a payment rcvd msg after the payment started msg.
+            verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, aliceClient);
         } catch (StatusRuntimeException e) {
             fail(e);
         }
@@ -113,9 +123,23 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
 
     @Test
     @Order(3)
+    public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
+        try {
+            var trade = bobClient.getTrade(tradeId);
+            verifyTakerDepositConfirmed(trade);
+            bobClient.confirmPaymentStarted(tradeId);
+            sleep(6_000);
+            waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
+        } catch (StatusRuntimeException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    @Order(4)
     public void testAlicesConfirmPaymentReceived(final TestInfo testInfo) {
         try {
-            waitForSellerSeesPaymentInitiatedMessage(log, testInfo, aliceClient, tradeId);
+            waitUntilSellerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
 
             var trade = aliceClient.getTrade(tradeId);
             aliceClient.confirmPaymentReceived(trade.getTradeId());
@@ -134,7 +158,7 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testBobsBtcWithdrawalToExternalAddress(final TestInfo testInfo) {
         try {
             genBtcBlocksThenWait(1, 1_000);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
@@ -118,7 +118,7 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
 
             // Now generate the BTC block to confirm the taker deposit tx.
             genBtcBlocksThenWait(1, 2_500);
-            waitForDepositConfirmation(log, testInfo, bobClient, tradeId);
+            waitForTakerDepositConfirmation(log, testInfo, bobClient, tradeId);
 
             // Verify the seller can only send a payment rcvd msg after the payment started msg.
             verifyPaymentReceivedMsgAfterPaymentSentMsgPrecondition(log, bobClient);
@@ -132,10 +132,10 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
-            waitForDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
+            waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             log.debug("Alice sends XMR payment to Bob for trade {}", trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
-            sleep(3500);
+            sleep(3_500);
 
             waitUntilBuyerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
             logTrade(log, testInfo, "Alice's Maker/Seller View (Payment Sent)", aliceClient.getTrade(tradeId));

--- a/apitest/src/test/java/bisq/apitest/method/wallet/GetNetworkTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/GetNetworkTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.apitest.method.wallet;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.apitest.config.BisqAppConfig.alicedaemon;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+
+
+
+import bisq.apitest.method.MethodTest;
+
+@SuppressWarnings("ConstantConditions")
+@Disabled
+@Slf4j
+@TestMethodOrder(OrderAnnotation.class)
+public class GetNetworkTest extends MethodTest {
+
+    @BeforeAll
+    public static void setUp() {
+        try {
+            setUpScaffold(alicedaemon);
+        } catch (Exception ex) {
+            fail(ex);
+        }
+    }
+
+    @Test
+    @Order(1)
+    public void testGetNetwork() {
+        var network = aliceClient.getNetwork();
+        assertEquals("regtest", network);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        tearDownScaffold();
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/scenario/LongRunningTradesTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/LongRunningTradesTest.java
@@ -78,6 +78,7 @@ public class LongRunningTradesTest extends AbstractTradeTest {
         TakeSellBTCOfferTest test = new TakeSellBTCOfferTest();
         setLongRunningTest(true);
         test.testTakeAlicesSellOffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
         test.testAlicesConfirmPaymentReceived(testInfo);
         test.testBobsBtcWithdrawalToExternalAddress(testInfo);

--- a/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
@@ -44,6 +44,7 @@ import bisq.apitest.method.GetMethodHelpTest;
 import bisq.apitest.method.GetVersionTest;
 import bisq.apitest.method.MethodTest;
 import bisq.apitest.method.RegisterDisputeAgentsTest;
+import bisq.apitest.method.wallet.GetNetworkTest;
 
 
 @Slf4j
@@ -88,6 +89,13 @@ public class StartupTest extends MethodTest {
 
     @Test
     @Order(3)
+    public void testGetNetwork() {
+        GetNetworkTest test = new GetNetworkTest();
+        test.testGetNetwork();
+    }
+
+    @Test
+    @Order(4)
     public void testRegisterDisputeAgents() {
         RegisterDisputeAgentsTest test = new RegisterDisputeAgentsTest();
         test.testRegisterArbitratorShouldThrowException();
@@ -98,7 +106,7 @@ public class StartupTest extends MethodTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testGetCreateOfferHelp() {
         GetMethodHelpTest test = new GetMethodHelpTest();
         test.testGetCreateOfferHelp();

--- a/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
@@ -44,7 +44,6 @@ import bisq.apitest.method.GetMethodHelpTest;
 import bisq.apitest.method.GetVersionTest;
 import bisq.apitest.method.MethodTest;
 import bisq.apitest.method.RegisterDisputeAgentsTest;
-import bisq.apitest.method.wallet.GetNetworkTest;
 
 
 @Slf4j
@@ -89,13 +88,6 @@ public class StartupTest extends MethodTest {
 
     @Test
     @Order(3)
-    public void testGetNetwork() {
-        GetNetworkTest test = new GetNetworkTest();
-        test.testGetNetwork();
-    }
-
-    @Test
-    @Order(4)
     public void testRegisterDisputeAgents() {
         RegisterDisputeAgentsTest test = new RegisterDisputeAgentsTest();
         test.testRegisterArbitratorShouldThrowException();
@@ -106,7 +98,7 @@ public class StartupTest extends MethodTest {
     }
 
     @Test
-    @Order(5)
+    @Order(4)
     public void testGetCreateOfferHelp() {
         GetMethodHelpTest test = new GetMethodHelpTest();
         test.testGetCreateOfferHelp();

--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -20,6 +20,7 @@ package bisq.apitest.scenario;
 import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,7 @@ public class TradeTest extends AbstractTradeTest {
         test.testBobsBtcWithdrawalToExternalAddress(testInfo);
     }
 
+    @Disabled
     @Test
     @Order(3)
     public void testTakeBuyBSQOffer(final TestInfo testInfo) {
@@ -91,6 +93,7 @@ public class TradeTest extends AbstractTradeTest {
         test.testCloseTrade(testInfo);
     }
 
+    @Disabled
     @Test
     @Order(5)
     public void testTakeSellBSQOffer(final TestInfo testInfo) {

--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -56,6 +56,7 @@ public class TradeTest extends AbstractTradeTest {
     public void testTakeBuyBTCOffer(final TestInfo testInfo) {
         TakeBuyBTCOfferTest test = new TakeBuyBTCOfferTest();
         test.testTakeAlicesBuyOffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testAlicesConfirmPaymentStarted(testInfo);
         test.testBobsConfirmPaymentReceived(testInfo);
         test.testCloseTrade(testInfo);
@@ -66,6 +67,7 @@ public class TradeTest extends AbstractTradeTest {
     public void testTakeSellBTCOffer(final TestInfo testInfo) {
         TakeSellBTCOfferTest test = new TakeSellBTCOfferTest();
         test.testTakeAlicesSellOffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
         test.testAlicesConfirmPaymentReceived(testInfo);
         test.testBobsBtcWithdrawalToExternalAddress(testInfo);
@@ -110,6 +112,7 @@ public class TradeTest extends AbstractTradeTest {
         TakeBuyXMROfferTest test = new TakeBuyXMROfferTest();
         TakeBuyXMROfferTest.createXmrPaymentAccounts();
         test.testTakeAlicesSellBTCForXMROffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
         test.testAlicesConfirmPaymentReceived(testInfo);
         test.testCloseTrade(testInfo);
@@ -121,6 +124,7 @@ public class TradeTest extends AbstractTradeTest {
         TakeSellXMROfferTest test = new TakeSellXMROfferTest();
         TakeBuyXMROfferTest.createXmrPaymentAccounts();
         test.testTakeAlicesBuyBTCForXMROffer(testInfo);
+        test.testPaymentMessagingPreconditions(testInfo);
         test.testAlicesConfirmPaymentStarted(testInfo);
         test.testBobsConfirmPaymentReceived(testInfo);
         test.testAlicesBtcWithdrawalToExternalAddress(testInfo);

--- a/apitest/src/test/java/bisq/apitest/scenario/WalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/WalletTest.java
@@ -39,6 +39,7 @@ import bisq.apitest.method.MethodTest;
 import bisq.apitest.method.wallet.BsqWalletTest;
 import bisq.apitest.method.wallet.BtcTxFeeRateTest;
 import bisq.apitest.method.wallet.BtcWalletTest;
+import bisq.apitest.method.wallet.GetNetworkTest;
 import bisq.apitest.method.wallet.WalletProtectionTest;
 
 @Slf4j
@@ -62,6 +63,13 @@ public class WalletTest extends MethodTest {
 
     @Test
     @Order(1)
+    public void testGetNetwork() {
+        GetNetworkTest test = new GetNetworkTest();
+        test.testGetNetwork();
+    }
+
+    @Test
+    @Order(2)
     public void testBtcWalletFunding(final TestInfo testInfo) {
         BtcWalletTest btcWalletTest = new BtcWalletTest();
 
@@ -71,7 +79,7 @@ public class WalletTest extends MethodTest {
     }
 
     @Test
-    @Order(2)
+    @Order(3)
     public void testBsqWalletFunding(final TestInfo testInfo) {
         BsqWalletTest bsqWalletTest = new BsqWalletTest();
 
@@ -82,7 +90,7 @@ public class WalletTest extends MethodTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     public void testWalletProtection() {
         WalletProtectionTest walletProtectionTest = new WalletProtectionTest();
 
@@ -99,7 +107,7 @@ public class WalletTest extends MethodTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testTxFeeRateMethods(final TestInfo testInfo) {
         BtcTxFeeRateTest test = new BtcTxFeeRateTest();
 

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -164,6 +164,15 @@ public class CliMain {
                     out.println(version);
                     return;
                 }
+                case getnetwork: {
+                    if (new SimpleMethodOptionParser(args).parse().isForHelp()) {
+                        out.println(client.getMethodHelp(method));
+                        return;
+                    }
+                    var network = client.getNetwork();
+                    out.println(network);
+                    return;
+                }
                 case getbalance: {
                     var opts = new GetBalanceOptionParser(args).parse();
                     if (opts.isForHelp()) {
@@ -821,6 +830,8 @@ public class CliMain {
             stream.format(rowFormat, "Method", "Params", "Description");
             stream.format(rowFormat, "------", "------", "------------");
             stream.format(rowFormat, getversion.name(), "", "Get server version");
+            stream.println();
+            stream.format(rowFormat, getnetwork.name(), "", "Get BTC network:  mainnet, testnet3, or regtest");
             stream.println();
             stream.format(rowFormat, getbalance.name(), "[--currency-code=<bsq|btc>]", "Get server wallet balances");
             stream.println();

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -17,6 +17,7 @@
 
 package bisq.cli;
 
+import bisq.proto.grpc.AverageBsqTradePrice;
 import bisq.proto.grpc.OfferInfo;
 import bisq.proto.grpc.TradeInfo;
 
@@ -63,6 +64,7 @@ import bisq.cli.opts.CreateOfferOptionParser;
 import bisq.cli.opts.CreatePaymentAcctOptionParser;
 import bisq.cli.opts.EditOfferOptionParser;
 import bisq.cli.opts.GetAddressBalanceOptionParser;
+import bisq.cli.opts.GetAvgBsqPriceOptionParser;
 import bisq.cli.opts.GetBTCMarketPriceOptionParser;
 import bisq.cli.opts.GetBalanceOptionParser;
 import bisq.cli.opts.GetOffersOptionParser;
@@ -208,6 +210,21 @@ public class CliMain {
                     var address = opts.getAddress();
                     var addressBalance = client.getAddressBalance(address);
                     new TableBuilder(ADDRESS_BALANCE_TBL, addressBalance).build().print(out);
+                    return;
+                }
+                case getavgbsqprice: {
+                    var opts = new GetAvgBsqPriceOptionParser(args).parse();
+                    if (opts.isForHelp()) {
+                        out.println(client.getMethodHelp(method));
+                        return;
+                    }
+                    var days = opts.getDays();
+                    AverageBsqTradePrice price = client.getAverageBsqTradePrice(days);
+                    out.println(format("avg %d day btc price: %s    avg %d day usd price: %s",
+                            days,
+                            price.getBtcPrice(),
+                            days,
+                            price.getUsdPrice()));
                     return;
                 }
                 case getbtcprice: {
@@ -836,6 +853,8 @@ public class CliMain {
             stream.format(rowFormat, getbalance.name(), "[--currency-code=<bsq|btc>]", "Get server wallet balances");
             stream.println();
             stream.format(rowFormat, getaddressbalance.name(), "--address=<btc-address>", "Get server wallet address balance");
+            stream.println();
+            stream.format(rowFormat, getavgbsqprice.name(), "--days=<days>", "Get volume weighted average bsq trade price");
             stream.println();
             stream.format(rowFormat, getbtcprice.name(), "--currency-code=<currency-code>", "Get current market btc price");
             stream.println();

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -18,9 +18,11 @@
 package bisq.cli;
 
 import bisq.proto.grpc.AddressBalanceInfo;
+import bisq.proto.grpc.AverageBsqTradePrice;
 import bisq.proto.grpc.BalancesInfo;
 import bisq.proto.grpc.BsqBalanceInfo;
 import bisq.proto.grpc.BtcBalanceInfo;
+import bisq.proto.grpc.GetAverageBsqTradePriceRequest;
 import bisq.proto.grpc.GetMethodHelpRequest;
 import bisq.proto.grpc.GetTradesRequest;
 import bisq.proto.grpc.GetVersionRequest;
@@ -96,6 +98,13 @@ public final class GrpcClient {
 
     public AddressBalanceInfo getAddressBalance(String address) {
         return walletsServiceRequest.getAddressBalance(address);
+    }
+
+    public AverageBsqTradePrice getAverageBsqTradePrice(int days) {
+        var request = GetAverageBsqTradePriceRequest.newBuilder()
+                .setDays(days)
+                .build();
+        return grpcStubs.priceService.getAverageBsqTradePrice(request).getPrice();
     }
 
     public double getBtcPrice(String currencyCode) {

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -22,6 +22,7 @@ import bisq.proto.grpc.BalancesInfo;
 import bisq.proto.grpc.BsqBalanceInfo;
 import bisq.proto.grpc.BtcBalanceInfo;
 import bisq.proto.grpc.GetMethodHelpRequest;
+import bisq.proto.grpc.GetNetworkRequest;
 import bisq.proto.grpc.GetTradesRequest;
 import bisq.proto.grpc.GetVersionRequest;
 import bisq.proto.grpc.OfferInfo;
@@ -72,6 +73,11 @@ public final class GrpcClient {
     public String getVersion() {
         var request = GetVersionRequest.newBuilder().build();
         return grpcStubs.versionService.getVersion(request).getVersion();
+    }
+
+    public String getNetwork() {
+        var request = GetNetworkRequest.newBuilder().build();
+        return grpcStubs.walletsService.getNetwork(request).getNetwork();
     }
 
     public BalancesInfo getBalances() {
@@ -386,6 +392,7 @@ public final class GrpcClient {
                 tradeInstant);
     }
 
+    @SuppressWarnings("unused")
     public List<PaymentMethod> getCryptoPaymentMethods() {
         return paymentAccountsServiceRequest.getCryptoPaymentMethods();
     }

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -22,7 +22,6 @@ import bisq.proto.grpc.BalancesInfo;
 import bisq.proto.grpc.BsqBalanceInfo;
 import bisq.proto.grpc.BtcBalanceInfo;
 import bisq.proto.grpc.GetMethodHelpRequest;
-import bisq.proto.grpc.GetNetworkRequest;
 import bisq.proto.grpc.GetTradesRequest;
 import bisq.proto.grpc.GetVersionRequest;
 import bisq.proto.grpc.OfferInfo;
@@ -76,8 +75,7 @@ public final class GrpcClient {
     }
 
     public String getNetwork() {
-        var request = GetNetworkRequest.newBuilder().build();
-        return grpcStubs.walletsService.getNetwork(request).getNetwork();
+        return walletsServiceRequest.getNetwork();
     }
 
     public BalancesInfo getBalances() {

--- a/cli/src/main/java/bisq/cli/Method.java
+++ b/cli/src/main/java/bisq/cli/Method.java
@@ -29,6 +29,7 @@ public enum Method {
     editoffer,
     createpaymentacct,
     createcryptopaymentacct,
+    getavgbsqprice,
     getaddressbalance,
     getbalance,
     getbtcprice,

--- a/cli/src/main/java/bisq/cli/Method.java
+++ b/cli/src/main/java/bisq/cli/Method.java
@@ -36,6 +36,7 @@ public enum Method {
     @Deprecated // Since 27-Dec-2021.
     getmyoffer, // Endpoint to be removed from future version.  Use getoffer instead.
     getmyoffers,
+    getnetwork,
     getoffer,
     getoffers,
     getpaymentacctform,

--- a/cli/src/main/java/bisq/cli/opts/GetAvgBsqPriceOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/GetAvgBsqPriceOptionParser.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.cli.opts;
+
+
+import joptsimple.OptionSpec;
+
+import static bisq.cli.opts.OptLabel.OPT_DAYS;
+
+public class GetAvgBsqPriceOptionParser extends AbstractMethodOptionParser implements MethodOpts {
+
+    final OptionSpec<Integer> daysOpt = parser.accepts(OPT_DAYS,
+                    "number of days in average bsq price calculation")
+            .withRequiredArg()
+            .ofType(Integer.class)
+            .defaultsTo(30);
+
+    public GetAvgBsqPriceOptionParser(String[] args) {
+        super(args);
+    }
+
+    public GetAvgBsqPriceOptionParser parse() {
+        super.parse();
+
+        // Short circuit opt validation if user just wants help.
+        if (options.has(helpOpt))
+            return this;
+
+        if (!options.has(daysOpt) || options.valueOf(daysOpt) <= 0)
+            throw new IllegalArgumentException("no # of days specified");
+
+        return this;
+    }
+
+    public int getDays() {
+        return options.valueOf(daysOpt);
+    }
+}

--- a/cli/src/main/java/bisq/cli/opts/OptLabel.java
+++ b/cli/src/main/java/bisq/cli/opts/OptLabel.java
@@ -26,6 +26,7 @@ public class OptLabel {
     public final static String OPT_AMOUNT = "amount";
     public final static String OPT_CATEGORY = "category";
     public final static String OPT_CURRENCY_CODE = "currency-code";
+    public final static String OPT_DAYS = "days";
     public final static String OPT_DIRECTION = "direction";
     public final static String OPT_DISPUTE_AGENT_TYPE = "dispute-agent-type";
     public final static String OPT_ENABLE = "enable";

--- a/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
+++ b/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
@@ -24,6 +24,7 @@ import bisq.proto.grpc.BtcBalanceInfo;
 import bisq.proto.grpc.GetAddressBalanceRequest;
 import bisq.proto.grpc.GetBalancesRequest;
 import bisq.proto.grpc.GetFundingAddressesRequest;
+import bisq.proto.grpc.GetNetworkRequest;
 import bisq.proto.grpc.GetTransactionRequest;
 import bisq.proto.grpc.GetTxFeeRateRequest;
 import bisq.proto.grpc.GetUnusedBsqAddressRequest;
@@ -52,6 +53,11 @@ public class WalletsServiceRequest {
 
     public WalletsServiceRequest(GrpcStubs grpcStubs) {
         this.grpcStubs = grpcStubs;
+    }
+
+    public String getNetwork() {
+        var request = GetNetworkRequest.newBuilder().build();
+        return grpcStubs.walletsService.getNetwork(request).getNetwork();
     }
 
     public BalancesInfo getBalances() {

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -21,6 +21,7 @@ import bisq.core.api.model.AddressBalanceInfo;
 import bisq.core.api.model.BalancesInfo;
 import bisq.core.api.model.TxFeeRateInfo;
 import bisq.core.btc.wallet.TxBroadcaster;
+import bisq.core.monetary.Price;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OpenOffer;
 import bisq.core.payment.PaymentAccount;
@@ -36,6 +37,7 @@ import bisq.common.app.Version;
 import bisq.common.config.Config;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
+import bisq.common.util.Tuple2;
 
 import bisq.proto.grpc.GetTradesRequest;
 
@@ -280,6 +282,10 @@ public class CoreApi {
 
     public void getMarketPrice(String currencyCode, Consumer<Double> resultHandler) {
         corePriceService.getMarketPrice(currencyCode, resultHandler);
+    }
+
+    public Tuple2<Price, Price> getAverageBsqTradePrice(int days) {
+        return corePriceService.getAverageBsqTradePrice(days);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -360,6 +360,10 @@ public class CoreApi {
     // Wallets
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    public String getNetworkName() {
+        return walletsService.getNetworkName();
+    }
+
     public BalancesInfo getBalances(String currencyCode) {
         return walletsService.getBalances(currencyCode);
     }

--- a/core/src/main/java/bisq/core/api/CoreTradesService.java
+++ b/core/src/main/java/bisq/core/api/CoreTradesService.java
@@ -124,6 +124,12 @@ class CoreTradesService {
         bsqSwapTakeOfferModel.initWithData(offer);
         bsqSwapTakeOfferModel.applyAmount(offer.getAmount());
 
+        // Block attempt to take swap offer if there are insufficient funds for the trade.
+        var missingCoin = bsqSwapTakeOfferModel.getMissingFundsAsCoin();
+        if (missingCoin.value > 0)
+            throw new NotAvailableException(
+                    format("wallet has insufficient funds to take offer with id '%s'", offer.getId()));
+
         log.info("Initiating take {} offer, {}",
                 offer.isBuyOffer() ? "buy" : "sell",
                 bsqSwapTakeOfferModel);
@@ -155,6 +161,7 @@ class CoreTradesService {
                 offer.isBuyOffer() ? "buy" : "sell",
                 takeOfferModel);
 
+        // Block attempt to take swap offer if there are insufficient funds for the trade.
         if (!takeOfferModel.isBtcWalletFunded())
             throw new NotAvailableException(
                     format("wallet has insufficient btc to take offer with id '%s'", offer.getId()));

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -91,6 +91,8 @@ import static bisq.core.util.ParsingUtils.parseToCoin;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_REGTEST;
+import static org.bitcoinj.core.NetworkParameters.PAYMENT_PROTOCOL_ID_TESTNET;
 
 @Singleton
 @Slf4j
@@ -149,6 +151,18 @@ class CoreWalletsService {
 
     NetworkParameters getNetworkParameters() {
         return btcWalletService.getWallet().getContext().getParams();
+    }
+
+    String getNetworkName() {
+        var networkParameters = getNetworkParameters();
+        switch (networkParameters.getPaymentProtocolId()) {
+            case PAYMENT_PROTOCOL_ID_TESTNET:
+                return "testnet3";
+            case PAYMENT_PROTOCOL_ID_REGTEST:
+                return "regtest";
+            default:
+                return "mainnet";
+        }
     }
 
     BalancesInfo getBalances(String currencyCode) {
@@ -642,7 +656,7 @@ class CoreWalletsService {
                         .filter(e -> addressString.equals(e.getAddressString()))
                         .findFirst();
 
-        if (!addressEntry.isPresent())
+        if (addressEntry.isEmpty())
             throw new NotFoundException(format("address %s not found in wallet", addressString));
 
         return addressEntry.get();

--- a/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferModel.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferModel.java
@@ -54,6 +54,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static org.bitcoinj.core.Coin.ZERO;
+
 @Slf4j
 public class BsqSwapOfferModel {
     public final static String BSQ = "BSQ";
@@ -90,7 +92,7 @@ public class BsqSwapOfferModel {
     @Getter
     private final ObjectProperty<Coin> payoutAmountAsCoin = new SimpleObjectProperty<>();
     @Getter
-    private final ObjectProperty<Coin> missingFunds = new SimpleObjectProperty<>(Coin.ZERO);
+    private final ObjectProperty<Coin> missingFunds = new SimpleObjectProperty<>(ZERO);
     @Nullable
     private Coin txFee;
     @Getter
@@ -380,6 +382,10 @@ public class BsqSwapOfferModel {
         return PaymentMethod.BSQ_SWAP.getMaxTradeLimitAsCoin(BSQ).getValue();
     }
 
+    public Coin getMissingFundsAsCoin() {
+        // This extra getter is needed for API CoreTradesService, which avoids importing JFX dependencies.
+        return missingFunds.get().isPositive() ? missingFunds.get() : ZERO;
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Utils
@@ -398,6 +404,6 @@ public class BsqSwapOfferModel {
 
     private void resetTxFeeAndMissingFunds() {
         txFee = null;
-        missingFunds.set(Coin.ZERO);
+        missingFunds.set(ZERO);
     }
 }

--- a/core/src/main/resources/help/getavgbsqprice-help.txt
+++ b/core/src/main/resources/help/getavgbsqprice-help.txt
@@ -2,7 +2,7 @@ getavgbsqprice
 
 NAME
 ----
-getavgbsqprice - get average BSQ price in btc and usd
+getavgbsqprice - get average bsq price in btc and usd
 
 SYNOPSIS
 --------

--- a/core/src/main/resources/help/getavgbsqprice-help.txt
+++ b/core/src/main/resources/help/getavgbsqprice-help.txt
@@ -1,0 +1,19 @@
+getavgbsqprice
+
+NAME
+----
+getavgbsqprice - get average BSQ price in btc and usd
+
+SYNOPSIS
+--------
+getavgbsqprice
+    --days=<30|90>
+
+DESCRIPTION
+-----------
+Returns the volume weighted average BSQ trade price over n days,
+in BTC and USD.
+
+EXAMPLES
+--------
+$ ./bisq-cli --password=xyz --port=9998 getavgbsqprice --days=30

--- a/core/src/main/resources/help/getnetwork-help.txt
+++ b/core/src/main/resources/help/getnetwork-help.txt
@@ -1,0 +1,18 @@
+getnetwork
+
+NAME
+----
+getnetwork - get BTC network name
+
+SYNOPSIS
+--------
+getnetwork
+
+DESCRIPTION
+-----------
+Returns the name of the BTC network the API daemon is connected to:
+mainnet, testnet3, or regtest.
+
+EXAMPLES
+--------
+$ ./bisq-cli --password=xyz --port=9998 getnetwork

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPriceService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPriceService.java
@@ -88,17 +88,7 @@ class GrpcPriceService extends PriceImplBase {
         try {
             var days = req.getDays();
             Tuple2<Price, Price> prices = coreApi.getAverageBsqTradePrice(days);
-            var usdPrice = new BigDecimal(prices.first.toString())
-                    .setScale(Fiat.SMALLEST_UNIT_EXPONENT, RoundingMode.HALF_UP);
-            var btcPrice = new BigDecimal(prices.second.toString())
-                    .setScale(Altcoin.SMALLEST_UNIT_EXPONENT, RoundingMode.HALF_UP);
-            var proto = AverageBsqTradePrice.newBuilder()
-                    .setUsdPrice(usdPrice.toString())
-                    .setBtcPrice(btcPrice.toString())
-                    .build();
-            var reply = GetAverageBsqTradePriceReply.newBuilder()
-                    .setPrice(proto)
-                    .build();
+            var reply = buildGetAverageBsqTradePriceReply(prices);
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         } catch (Throwable cause) {
@@ -120,5 +110,19 @@ class GrpcPriceService extends PriceImplBase {
                             put(getGetAverageBsqTradePriceMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));
                         }}
                 )));
+    }
+
+    private GetAverageBsqTradePriceReply buildGetAverageBsqTradePriceReply(Tuple2<Price, Price> prices) {
+        var usdPrice = new BigDecimal(prices.first.toString())
+                .setScale(Fiat.SMALLEST_UNIT_EXPONENT, RoundingMode.HALF_UP);
+        var btcPrice = new BigDecimal(prices.second.toString())
+                .setScale(Altcoin.SMALLEST_UNIT_EXPONENT, RoundingMode.HALF_UP);
+        var proto = AverageBsqTradePrice.newBuilder()
+                .setUsdPrice(usdPrice.toString())
+                .setBtcPrice(btcPrice.toString())
+                .build();
+        return GetAverageBsqTradePriceReply.newBuilder()
+                .setPrice(proto)
+                .build();
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -29,6 +29,8 @@ import bisq.proto.grpc.GetBalancesReply;
 import bisq.proto.grpc.GetBalancesRequest;
 import bisq.proto.grpc.GetFundingAddressesReply;
 import bisq.proto.grpc.GetFundingAddressesRequest;
+import bisq.proto.grpc.GetNetworkReply;
+import bisq.proto.grpc.GetNetworkRequest;
 import bisq.proto.grpc.GetTransactionReply;
 import bisq.proto.grpc.GetTransactionRequest;
 import bisq.proto.grpc.GetTxFeeRateReply;
@@ -93,6 +95,20 @@ class GrpcWalletsService extends WalletsImplBase {
     public GrpcWalletsService(CoreApi coreApi, GrpcExceptionHandler exceptionHandler) {
         this.coreApi = coreApi;
         this.exceptionHandler = exceptionHandler;
+    }
+
+    @Override
+    public void getNetwork(GetNetworkRequest req, StreamObserver<GetNetworkReply> responseObserver) {
+        try {
+            var network = coreApi.getNetworkName();
+            var reply = GetNetworkReply.newBuilder()
+                    .setNetwork(network)
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
     }
 
     @Override

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -385,6 +385,7 @@ class GrpcWalletsService extends WalletsImplBase {
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
                 .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
                         new HashMap<>() {{
+                            put(getGetNetworkMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));
                             put(getGetBalancesMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));
                             put(getGetAddressBalanceMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));
                             put(getGetFundingAddressesMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -491,7 +491,7 @@ service Trades {
 
 message TakeOfferRequest {
     string offer_id = 1;                    // The unique identifier of the offer being taken.
-    string payment_account_id = 2;          // The unique identifier of the payment account used to take offer..
+    string payment_account_id = 2;          // The unique identifier of the payment account used to take offer.
     string taker_fee_currency_code = 3;     // The code of the currency (BSQ or BTC) used to pay the taker's Bisq trade fee.
 }
 
@@ -695,6 +695,9 @@ message TxInfo {
 * an encryption password on a a wallet, and unlocking / locking an encrypted wallet.
 */
 service Wallets {
+    // Get the name of the BTC / BSQ network (mainnet, testnet3, or regtest).
+    rpc GetNetwork (GetNetworkRequest) returns (GetNetworkReply) {
+    }
     // Get the Bisq wallet's current BSQ and BTC balances.
     rpc GetBalances (GetBalancesRequest) returns (GetBalancesReply) {
     }
@@ -718,7 +721,7 @@ service Wallets {
     // Get the Bisq network's most recently available bitcoin miner transaction fee rate, or custom fee rate if set.
     rpc GetTxFeeRate (GetTxFeeRateRequest) returns (GetTxFeeRateReply) {
     }
-    // Set the Bisq daemon's custom bitcoin miner transaction fee rate, in sats/byte..
+    // Set the Bisq daemon's custom bitcoin miner transaction fee rate, in sats/byte.
     rpc SetTxFeeRatePreference (SetTxFeeRatePreferenceRequest) returns (SetTxFeeRatePreferenceReply) {
     }
     // Remove the custom bitcoin miner transaction fee rate;  revert to the Bisq network's bitcoin miner transaction fee rate.
@@ -745,6 +748,13 @@ service Wallets {
     // setting can be overridden by subsequent UnlockWallet calls.
     rpc UnlockWallet (UnlockWalletRequest) returns (UnlockWalletReply) {
     }
+}
+
+message GetNetworkRequest {
+}
+
+message GetNetworkReply {
+    string network = 1;         // The BTC network name (mainnet, testnet3, or regtest).
 }
 
 message GetBalancesRequest {
@@ -885,7 +895,6 @@ message BalancesInfo {
     BtcBalanceInfo btc = 2;     // BTC wallet balance information.
 }
 
-// TODO Thoroughly review field descriptions.
 message BsqBalanceInfo {
     // The BSQ amount currently available to send to other addresses at the user's discretion, in satoshis.
     uint64 available_confirmed_balance = 1;
@@ -904,7 +913,6 @@ message BsqBalanceInfo {
     uint64 unlocking_bonds_balance = 6;
 }
 
-// TODO Thoroughly review field descriptions.
 message BtcBalanceInfo {
     // The BTC amount currently available to send to other addresses at the user's discretion, in satoshis.
     uint64 available_balance = 1;

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -434,6 +434,10 @@ service Price {
     // Get the current market price for a crypto currency.
     rpc GetMarketPrice (MarketPriceRequest) returns (MarketPriceReply) {
     }
+    // Get the volume weighted average trade price for BSQ, calculated over N days.
+    // The response contains the average BSQ trade price in USD to 4 decimal places, and in BTC to 8 decimal places.
+    rpc GetAverageBsqTradePrice (GetAverageBsqTradePriceRequest) returns (GetAverageBsqTradePriceReply) {
+    }
 }
 
 message MarketPriceRequest {
@@ -442,6 +446,21 @@ message MarketPriceRequest {
 
 message MarketPriceReply {
     double price = 1;   // The most recently available market price.
+}
+
+message GetAverageBsqTradePriceRequest {
+    sint32 days = 1;    // The number of days used in the average BSQ trade price calculations.
+}
+
+message GetAverageBsqTradePriceReply {
+    // The average BSQ trade price in USD to 4 decimal places, and in BTC to 8 decimal places.
+    AverageBsqTradePrice price = 1;
+}
+
+// The average BSQ trade price in USD and BTC.
+message AverageBsqTradePrice {
+    string usdPrice = 1;   // The average BSQ trade price in USD to 4 decimal places.
+    string btcPrice = 2;   // The average BSQ trade price in BTC to 8 decimal places.
 }
 
 service ShutdownServer {


### PR DESCRIPTION
This API bug was relying on the UI purposed `TaskRunner` to bubble up an insufficient funds error to the client, but it cannot do that.  This change blocks the `takeoffer` attempt if sufficient funds are not found after the swap model calculates the taker's trade amounts.

Related: https://github.com/bisq-network/bisq/pull/6221
Based on https://github.com/bisq-network/bisq/pull/6250, branch `add-api-price-service-getaverageprice`.