### PR TITLE
Fix snake_case field names

### DIFF
--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -459,8 +459,8 @@ message GetAverageBsqTradePriceReply {
 
 // The average BSQ trade price in USD and BTC.
 message AverageBsqTradePrice {
-    string usdPrice = 1;   // The average BSQ trade price in USD to 4 decimal places.
-    string btcPrice = 2;   // The average BSQ trade price in BTC to 8 decimal places.
+    string usd_price = 1;   // The average BSQ trade price in USD to 4 decimal places.
+    string btc_price = 2;   // The average BSQ trade price in BTC to 8 decimal places.
 }
 
 service ShutdownServer {


### PR DESCRIPTION
Be consistent, and x-language.

API reference doc needs snake_case proto msg field names (and so do non-java client devs who want to follow their language's field name conventions).

Based on `master`.