### PR TITLE
[v1.9.3] Reduce toggle width to prevent horizontal scrollbar in min width

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/chart/ChartView.java
+++ b/desktop/src/main/java/bisq/desktop/components/chart/ChartView.java
@@ -372,7 +372,7 @@ public abstract class ChartView<T extends ChartViewModel<? extends ChartDataMode
         hBox.setSpacing(10);
         collection.forEach(series -> {
             AutoTooltipSlideToggleButton toggle = new AutoTooltipSlideToggleButton();
-            toggle.setMinWidth(200);
+            toggle.setMinWidth(180);
             toggle.setAlignment(Pos.TOP_LEFT);
             String seriesId = getSeriesId(series);
             legendToggleBySeriesName.put(seriesId, toggle);

--- a/desktop/src/main/java/bisq/desktop/components/chart/ChartView.java
+++ b/desktop/src/main/java/bisq/desktop/components/chart/ChartView.java
@@ -74,6 +74,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import lombok.Setter;
@@ -370,9 +371,11 @@ public abstract class ChartView<T extends ChartViewModel<? extends ChartDataMode
     protected HBox initLegendsAndGetLegendBox(Collection<XYChart.Series<Number, Number>> collection) {
         HBox hBox = new HBox();
         hBox.setSpacing(10);
+        AtomicInteger index = new AtomicInteger();
+        var mainColumns = 2;
         collection.forEach(series -> {
             AutoTooltipSlideToggleButton toggle = new AutoTooltipSlideToggleButton();
-            toggle.setMinWidth(180);
+            toggle.setMinWidth(index.getAndIncrement() < mainColumns ? 200 : 160);
             toggle.setAlignment(Pos.TOP_LEFT);
             String seriesId = getSeriesId(series);
             legendToggleBySeriesName.put(seriesId, toggle);


### PR DESCRIPTION
Before:
![Bildschirmfoto 2022-06-29 um 11 31 32](https://user-images.githubusercontent.com/170962/176403703-e741e772-fc25-445e-bccb-0c6e7cf826a0.png)

After:
![Bildschirmfoto 2022-06-29 um 11 22 12](https://user-images.githubusercontent.com/170962/176403370-d371d67e-eb94-45c8-a38e-534e4e6f465f.png)

It does break the alignment of the columns, but I think the horizontal scrollbar is more ugly IMO.

@chimp1984: WDYT?
