### PR TITLE
Update API test-guide and gRPC method docs

### DIFF
--- a/apitest/docs/api-beta-test-guide.md
+++ b/apitest/docs/api-beta-test-guide.md
@@ -43,6 +43,14 @@ $ ./gradlew clean build :apitest:installDaoSetup            # if you want to run
 
 ## Running Api Test Harness
 
+#### Warning:  Never run an API daemon and the [Bisq GUI](https://bisq.network) on the same host at the same time.
+
+The API daemon and the GUI share the same default wallet and connection ports.  Beyond inevitable failures due to
+fighting over the wallet and ports, doing so will probably corrupt your wallet.  Before starting the API daemon, make
+sure your GUI is shut down, and vice-versa.  Please back up your mainnet wallet early and often with the GUI.
+
+### Configuration And Start Command
+
 If your bitcoin-core binaries are in your system `PATH`, start bitcoind in regtest-mode, Bisq seednode and arbitration
 node daemons, plus Bob & Alice daemons in a bash terminal with the following bash command:
 ```

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -66,7 +66,8 @@ service Offers {
     // Get the available BSQ swap offer with offer-id.
     rpc GetBsqSwapOffer (GetOfferRequest) returns (GetBsqSwapOfferReply) {
     }
-    // Get the v1 protocol offer with offer-id.
+    // Get the v1 protocol offer with an offer-id.  Your node must have a payment account with the same
+    // payment method as the offer's associated payment method, e,g., ACH_TRANSFER, CASH_DEPOSIT, etc.
     rpc GetOffer (GetOfferRequest) returns (GetOfferReply) {
     }
     // Get user's BSQ swap offer with offer-id.
@@ -78,7 +79,9 @@ service Offers {
     // Get all available BSQ swap offers with a BUY (BTC) or SELL (BTC) direction.
     rpc GetBsqSwapOffers (GetBsqSwapOffersRequest) returns (GetBsqSwapOffersReply) {
     }
-    // Get all available v1 protocol offers with a BUY (BTC) or SELL (BTC) direction.
+    // Get all available v1 protocol offers with a BUY (BTC) or SELL (BTC) direction.  The returned offers
+    // are restricted to those associated with payment methods matching the payment methods you have set up
+    // on your node, e,g., NATIONAL_BANK, US_POSTAL_MONEY_ORDER, etc.
     rpc GetOffers (GetOffersRequest) returns (GetOffersReply) {
     }
     // Get all user's BSQ swap offers with a BUY (BTC) or SELL (BTC) direction.
@@ -485,7 +488,8 @@ service Trades {
     // Get currently open, or historical trades (closed or failed).
     rpc GetTrades (GetTradesRequest) returns (GetTradesReply) {
     }
-    // Take an open offer.
+    // Take an available offer.  Your node must have a payment account with the same payment method as
+    // the offer's payment method, e.g., NATIONAL_BANK, SEPA, SWIFT, etc.
     rpc TakeOffer (TakeOfferRequest) returns (TakeOfferReply) {
     }
     // Send a 'payment started' message to a trading peer (the BTC seller).


### PR DESCRIPTION
A warning was added to the API test guide:  "Warn user not to run API daemon and GUI at same time".

The grpc.proto `takeoffer` and `getoffer(s)`  rpc method comments were updated to explain that they only work as expected when the user's node has payment account/methods matching the available offers' own payment methods.
    
- `getoffers` returns only the offers with payment methods matching those set up on the user's node
    
- `getoffer` will only return the offer if the user's node has a payment method matching the payment method associated with the requested offer
    
- `takeoffer` will fail if the user's node does not have a matching payment method


Based on `master`.
