### PR TITLE
[WIP] Configure gradle submodule publication in jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,18 @@ configure(rootProject) {
 configure(subprojects) {
     apply plugin: 'java'
     apply plugin: 'com.google.osdetector'
+    apply plugin: 'maven-publish'
 
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 
-    ext { // in alphabetical order
+    ext {
+        // Desktop application version, accessible to subprojects being published to jitpack.
+        // Submodules with their own version numbers (like pricenode) will be split out into their
+        // own repos, and will import needed submodule from jitpack libs published by this build.
+        desktopVersion = '1.9.2-SNAPSHOT'
+
+        // Dependency Version Constraints
         bcVersion = '1.63'
         bitcoinjVersion = '42bbae9'
         codecVersion = '1.13'
@@ -94,8 +101,18 @@ configure(subprojects) {
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }
-}
 
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                groupId project.group
+                artifactId project.name
+                version "${desktopVersion}"
+                from components.java
+            }
+        }
+    }
+}
 
 configure([project(':cli'),
            project(':daemon'),
@@ -464,7 +481,7 @@ configure(project(':desktop')) {
         modules = ['javafx.controls', 'javafx.fxml']
     }
 
-    version = '1.9.2-SNAPSHOT'
+    version = desktopVersion
 
     jar.manifest.attributes(
         "Implementation-Title": project.name,

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,7 @@
+before_install:
+  - echo "Checking git-lfs version..."
+  - git-lfs --version
+  - echo "Running git lfs pull..."
+  - git lfs pull
+  - echo "Checking java version..."
+  - java -version


### PR DESCRIPTION
**Goal**:  reduce size of bisq repo's dependency chain by moving some of its sub-modules into their own repos.  The first sub-module to be moved will be `pricenode` -> `bisq-pricenode` (todo).  The current `pricenode` sub-module depends on `assets`, `common`, and `core`, and the new `bisq-pricenode` will need to declare dependencies on these three sub-modules.   These changes can be used to publish all of the bisq repo's sub-modules as libraries in jitpack, so the new `bisq-pricenode` repo can use just the `assets`, `common`, and `core` libs it will need.

**Changes**:

- Define ext property `desktopVersion` above dependency version defs.  Each published bisq library needs a version, and this configures them to be the desktop app's version.  Sub-modules with their own version numbers (like pricenode) will be moved out into their own repos, and will import needed bisq sub-modules as jitpack libs published by this build.
  
- Apply plugin 'maven-publish' in configure(subprojects).

- Define submodule publication properties at end of configure(subprojects).

- Add jitpack.yml with before_install instruction to run 'git lfs pull'.
  Jitpack's current default version of git-lfs works, but this yaml file may need to download, install, and specify jitpack build's LFS version in the future.

  By default, jitpack is able to build bisq with OpenJDK 11.0.2, but this yaml file may be to download, install, and specify jitpack build's JDK in the future (if/when jitpack doesn't have the required JDK).


To publish the bisq libraries to your local maven repo (~/.m2/repository/bisq):

  `$ ./gradlew publishToMavenLocal`

**Risks**: 

Security risks are unknown at this time (by me).   

There may be issues with GitHub download bandwidth quotas, possibly forcing GitHub account upgrades for dev(s).  I am being warned about reaching my monthly download quota after going through several publishing & downloading (all of bisq) cycles to see how this will work on both sides:  uploading to jitack from GitHub, downloading from jitpack to dev machine.  It may not be a problem since bisq releases are usually < 1x / month, and I don't need to delete my gradle dependency cache very often -- far less than 1x / month.


Based on `master`.