### PR TITLE
Show Peer Info window only when left-clicking on avatar

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -36,6 +36,7 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 
@@ -170,23 +171,27 @@ public class PeerInfoIcon extends Group {
                         Res.get("peerInfo.unknownAge") :
                 null;
 
-        setOnMouseClicked(e -> new PeerInfoWithTagEditor(privateNotificationManager, tradeModel, offer, preferences, useDevPrivilegeKeys)
-                .fullAddress(fullAddress)
-                .numTrades(numTrades)
-                .accountAge(accountAgeFormatted)
-                .signAge(signAgeFormatted)
-                .accountAgeInfo(peersAccountAgeInfo)
-                .signAgeInfo(peersSignAgeInfo)
-                .accountSigningState(accountSigningState)
-                .position(localToScene(new Point2D(0, 0)))
-                .onSave(newTag -> {
-                    preferences.setTagForPeer(fullAddress, newTag);
-                    updatePeerInfoIcon();
-                    if (callback != null) {
-                        callback.avatarTagUpdated();
-                    }
-                })
-                .show());
+        setOnMouseClicked(e -> {
+            if (e.getButton().equals(MouseButton.PRIMARY)) {
+                new PeerInfoWithTagEditor(privateNotificationManager, tradeModel, offer, preferences, useDevPrivilegeKeys)
+                        .fullAddress(fullAddress)
+                        .numTrades(numTrades)
+                        .accountAge(accountAgeFormatted)
+                        .signAge(signAgeFormatted)
+                        .accountAgeInfo(peersAccountAgeInfo)
+                        .signAgeInfo(peersSignAgeInfo)
+                        .accountSigningState(accountSigningState)
+                        .position(localToScene(new Point2D(0, 0)))
+                        .onSave(newTag -> {
+                            preferences.setTagForPeer(fullAddress, newTag);
+                            updatePeerInfoIcon();
+                            if (callback != null) {
+                                callback.avatarTagUpdated();
+                            }
+                        })
+                        .show();
+            }
+        });
     }
 
     protected double getScaleFactor() {


### PR DESCRIPTION
Fixes minor glitch when right-clicking on a peer's avatar in PORTFOLIO

Steps to reproduce:

- PORTFOLIO > HISTORY > Right-click on a peer's avatar > will show both PeerInfoWithTagEditor window and the "Create new offer like this..." context menu overlapping:

![1](https://user-images.githubusercontent.com/76814540/182619450-745c6b7f-812b-4763-87bc-4b1830f50c1e.jpg)

- Click on "Create new offer like this..." > if you were maker, this will open the duplicate offer tab while still keeping the PeerInfoWithTagEditor popup visible:

![2](https://user-images.githubusercontent.com/76814540/182619786-bbef18ef-c00f-4bf6-8fec-c99a9f830b88.jpg)

- Right-clicking to another avatar instead > will show a duplicate "Create new offer like this..." context menu without closing the previous one:

![3](https://user-images.githubusercontent.com/76814540/182619808-e2d8849a-231c-427c-91e5-d380875ad529.jpg)

