### PR TITLE
Cleanup blockchain explorer URL code & add tests

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/ExplorerAddressTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/ExplorerAddressTextField.java
@@ -102,8 +102,8 @@ public class ExplorerAddressTextField extends AnchorPane {
         }
 
         textField.setText(address);
-        textField.setOnMouseClicked(mouseEvent -> GUIUtil.openAddressInBlockExplorer(address, isBsq));
-        blockExplorerIcon.setOnMouseClicked(mouseEvent -> GUIUtil.openAddressInBlockExplorer(address, isBsq));
+        textField.setOnMouseClicked(mouseEvent -> openBlockExplorer(address));
+        blockExplorerIcon.setOnMouseClicked(mouseEvent -> openBlockExplorer(address));
         copyIcon.setOnMouseClicked(e -> Utilities.copyToClipboard(address));
     }
 
@@ -112,5 +112,17 @@ public class ExplorerAddressTextField extends AnchorPane {
         blockExplorerIcon.setOnMouseClicked(null);
         copyIcon.setOnMouseClicked(null);
         textField.setText("");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Private
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private void openBlockExplorer(String address) {
+        if (isBsq) {
+            GUIUtil.openAddressInBsqBlockExplorer(address);
+        } else {
+            GUIUtil.openAddressInBlockExplorer(address);
+        }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/ExplorerAddressTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/ExplorerAddressTextField.java
@@ -20,8 +20,6 @@ package bisq.desktop.components;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.locale.Res;
-import bisq.core.user.BlockChainExplorer;
-import bisq.core.user.Preferences;
 
 import bisq.common.util.Utilities;
 
@@ -41,9 +39,6 @@ import lombok.Setter;
 import javax.annotation.Nullable;
 
 public class ExplorerAddressTextField extends AnchorPane {
-    @Setter
-    private static Preferences preferences;
-
     @Getter
     private final TextField textField;
     private final Label copyIcon, blockExplorerIcon, missingAddressWarningIcon;
@@ -107,8 +102,8 @@ public class ExplorerAddressTextField extends AnchorPane {
         }
 
         textField.setText(address);
-        textField.setOnMouseClicked(mouseEvent -> openBlockExplorer(address));
-        blockExplorerIcon.setOnMouseClicked(mouseEvent -> openBlockExplorer(address));
+        textField.setOnMouseClicked(mouseEvent -> GUIUtil.openAddressInBlockExplorer(address, isBsq));
+        blockExplorerIcon.setOnMouseClicked(mouseEvent -> GUIUtil.openAddressInBlockExplorer(address, isBsq));
         copyIcon.setOnMouseClicked(e -> Utilities.copyToClipboard(address));
     }
 
@@ -117,18 +112,5 @@ public class ExplorerAddressTextField extends AnchorPane {
         blockExplorerIcon.setOnMouseClicked(null);
         copyIcon.setOnMouseClicked(null);
         textField.setText("");
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Private
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-    private void openBlockExplorer(String address) {
-        if (preferences != null) {
-            BlockChainExplorer blockChainExplorer = isBsq ?
-                    preferences.getBsqBlockChainExplorer() :
-                    preferences.getBlockChainExplorer();
-            GUIUtil.openWebPage(blockChainExplorer.addressUrl + address, false);
-        }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/TxIdTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/TxIdTextField.java
@@ -138,8 +138,8 @@ public class TxIdTextField extends AnchorPane {
         updateConfidence(walletService.getConfidenceForTxId(txId));
 
         textField.setText(txId);
-        textField.setOnMouseClicked(mouseEvent -> GUIUtil.openTxInBlockExplorer(txId, isBsq));
-        blockExplorerIcon.setOnMouseClicked(mouseEvent -> GUIUtil.openTxInBlockExplorer(txId, isBsq));
+        textField.setOnMouseClicked(mouseEvent -> openBlockExplorer(txId));
+        blockExplorerIcon.setOnMouseClicked(mouseEvent -> openBlockExplorer(txId));
         copyIcon.setOnMouseClicked(e -> Utilities.copyToClipboard(txId));
     }
 
@@ -156,6 +156,14 @@ public class TxIdTextField extends AnchorPane {
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private void openBlockExplorer(String txId) {
+        if (isBsq) {
+            GUIUtil.openTxInBsqBlockExplorer(txId);
+        } else {
+            GUIUtil.openTxInBlockExplorer(txId);
+        }
+    }
 
     private void updateConfidence(TransactionConfidence confidence) {
         GUIUtil.updateConfidence(confidence, progressIndicatorTooltip, txConfidenceIndicator);

--- a/desktop/src/main/java/bisq/desktop/components/TxIdTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/TxIdTextField.java
@@ -23,8 +23,6 @@ import bisq.desktop.util.GUIUtil;
 import bisq.core.btc.listeners.TxConfidenceListener;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.locale.Res;
-import bisq.core.user.BlockChainExplorer;
-import bisq.core.user.Preferences;
 
 import bisq.common.util.Utilities;
 
@@ -46,8 +44,6 @@ import lombok.Setter;
 import javax.annotation.Nullable;
 
 public class TxIdTextField extends AnchorPane {
-    @Setter
-    private static Preferences preferences;
     @Setter
     private static BtcWalletService walletService;
 
@@ -142,8 +138,8 @@ public class TxIdTextField extends AnchorPane {
         updateConfidence(walletService.getConfidenceForTxId(txId));
 
         textField.setText(txId);
-        textField.setOnMouseClicked(mouseEvent -> openBlockExplorer(txId));
-        blockExplorerIcon.setOnMouseClicked(mouseEvent -> openBlockExplorer(txId));
+        textField.setOnMouseClicked(mouseEvent -> GUIUtil.openTxInBlockExplorer(txId, isBsq));
+        blockExplorerIcon.setOnMouseClicked(mouseEvent -> GUIUtil.openTxInBlockExplorer(txId, isBsq));
         copyIcon.setOnMouseClicked(e -> Utilities.copyToClipboard(txId));
     }
 
@@ -160,15 +156,6 @@ public class TxIdTextField extends AnchorPane {
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////
-
-    private void openBlockExplorer(String txId) {
-        if (preferences != null) {
-            BlockChainExplorer blockChainExplorer = isBsq ?
-                    preferences.getBsqBlockChainExplorer() :
-                    preferences.getBlockChainExplorer();
-            GUIUtil.openWebPage(blockChainExplorer.txUrl + txId, false);
-        }
-    }
 
     private void updateConfidence(TransactionConfidence confidence) {
         GUIUtil.updateConfidence(confidence, progressIndicatorTooltip, txConfidenceIndicator);

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -20,7 +20,6 @@ package bisq.desktop.main;
 import bisq.desktop.Navigation;
 import bisq.desktop.app.BisqApp;
 import bisq.desktop.common.model.ViewModel;
-import bisq.desktop.components.ExplorerAddressTextField;
 import bisq.desktop.components.TxIdTextField;
 import bisq.desktop.main.account.AccountView;
 import bisq.desktop.main.account.content.backup.BackupView;
@@ -232,9 +231,6 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         this.corruptedStorageFileHandler = corruptedStorageFileHandler;
         this.clockWatcher = clockWatcher;
         this.navigation = navigation;
-
-        TxIdTextField.setPreferences(preferences);
-        ExplorerAddressTextField.setPreferences(preferences);
 
         TxIdTextField.setWalletService(btcWalletService);
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
@@ -32,7 +32,6 @@ import bisq.core.dao.governance.bond.reputation.BondedReputationRepository;
 import bisq.core.dao.governance.bond.role.BondedRole;
 import bisq.core.dao.governance.bond.role.BondedRolesRepository;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
 
 import javax.inject.Inject;
@@ -68,7 +67,6 @@ public class BondsView extends ActivatableView<GridPane, Void> {
     private final BsqFormatter bsqFormatter;
     private final BondedRolesRepository bondedRolesRepository;
     private final BondedReputationRepository bondedReputationRepository;
-    private final Preferences preferences;
 
     private int gridRow = 0;
 
@@ -87,12 +85,10 @@ public class BondsView extends ActivatableView<GridPane, Void> {
     @Inject
     private BondsView(BsqFormatter bsqFormatter,
                       BondedRolesRepository bondedRolesRepository,
-                      BondedReputationRepository bondedReputationRepository,
-                      Preferences preferences) {
+                      BondedReputationRepository bondedReputationRepository) {
         this.bsqFormatter = bsqFormatter;
         this.bondedRolesRepository = bondedRolesRepository;
         this.bondedReputationRepository = bondedReputationRepository;
-        this.preferences = preferences;
     }
 
     @Override
@@ -330,7 +326,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
                                 if (item != null && !empty) {
                                     String lockupTxId = item.getLockupTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(lockupTxId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(lockupTxId, preferences));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(lockupTxId, true));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", lockupTxId)));
                                     if (item.getLockupDateString().equals("-")) hyperlinkWithIcon.hideIcon();
                                     setGraphic(hyperlinkWithIcon);

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
@@ -326,7 +326,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
                                 if (item != null && !empty) {
                                     String lockupTxId = item.getLockupTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(lockupTxId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(lockupTxId, true));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(lockupTxId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", lockupTxId)));
                                     if (item.getLockupDateString().equals("-")) hyperlinkWithIcon.hideIcon();
                                     setGraphic(hyperlinkWithIcon);

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
@@ -393,7 +393,7 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(transactionId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
@@ -37,7 +37,6 @@ import bisq.core.dao.governance.bond.BondConsensus;
 import bisq.core.dao.governance.bond.BondState;
 import bisq.core.dao.governance.bond.reputation.MyBondedReputation;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.ParsingUtils;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.validation.HexStringValidator;
@@ -90,7 +89,6 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
     private final HexStringValidator hexStringValidator;
     private final BsqValidator bsqValidator;
     private final DaoFacade daoFacade;
-    private final Preferences preferences;
 
     private final IntegerValidator timeInputTextFieldValidator;
 
@@ -114,15 +112,13 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
                              BondingViewUtils bondingViewUtils,
                              HexStringValidator hexStringValidator,
                              BsqValidator bsqValidator,
-                             DaoFacade daoFacade,
-                             Preferences preferences) {
+                             DaoFacade daoFacade) {
         this.bsqFormatter = bsqFormatter;
         this.bsqWalletService = bsqWalletService;
         this.bondingViewUtils = bondingViewUtils;
         this.hexStringValidator = hexStringValidator;
         this.bsqValidator = bsqValidator;
         this.daoFacade = daoFacade;
-        this.preferences = preferences;
 
         timeInputTextFieldValidator = new IntegerValidator();
         timeInputTextFieldValidator.setMinValue(BondConsensus.getMinLockTime());
@@ -397,7 +393,7 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(item.getTxId(), preferences));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
@@ -33,7 +33,6 @@ import bisq.core.dao.DaoFacade;
 import bisq.core.dao.SignVerifyService;
 import bisq.core.dao.governance.bond.role.BondedRole;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
 
 import javax.inject.Inject;
@@ -68,7 +67,6 @@ public class RolesView extends ActivatableView<GridPane, Void> {
     private final SignVerifyService signVerifyService;
     private final BsqFormatter bsqFormatter;
     private final DaoFacade daoFacade;
-    private final Preferences preferences;
 
     private final ObservableList<RolesListItem> observableList = FXCollections.observableArrayList();
     private final SortedList<RolesListItem> sortedList = new SortedList<>(observableList);
@@ -84,13 +82,11 @@ public class RolesView extends ActivatableView<GridPane, Void> {
     private RolesView(BsqFormatter bsqFormatter,
                       BondingViewUtils bondingViewUtils,
                       SignVerifyService signVerifyService,
-                      DaoFacade daoFacade,
-                      Preferences preferences) {
+                      DaoFacade daoFacade) {
         this.bsqFormatter = bsqFormatter;
         this.bondingViewUtils = bondingViewUtils;
         this.signVerifyService = signVerifyService;
         this.daoFacade = daoFacade;
-        this.preferences = preferences;
     }
 
     @Override
@@ -245,7 +241,7 @@ public class RolesView extends ActivatableView<GridPane, Void> {
                                     String lockupTxId = item.getLockupTxId();
                                     if (lockupTxId != null) {
                                         hyperlinkWithIcon = new ExternalHyperlink(lockupTxId);
-                                        hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(lockupTxId, preferences));
+                                        hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(lockupTxId, true));
                                         hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", lockupTxId)));
                                         setGraphic(hyperlinkWithIcon);
                                     } else {

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/roles/RolesView.java
@@ -241,7 +241,7 @@ public class RolesView extends ActivatableView<GridPane, Void> {
                                     String lockupTxId = item.getLockupTxId();
                                     if (lockupTxId != null) {
                                         hyperlinkWithIcon = new ExternalHyperlink(lockupTxId);
-                                        hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(lockupTxId, true));
+                                        hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(lockupTxId));
                                         hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", lockupTxId)));
                                         setGraphic(hyperlinkWithIcon);
                                     } else {

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
@@ -39,7 +39,6 @@ import bisq.core.dao.governance.proofofburn.MyProofOfBurnListService;
 import bisq.core.dao.governance.proofofburn.ProofOfBurnService;
 import bisq.core.dao.governance.proposal.TxException;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
 import bisq.core.util.coin.BsqFormatter;
@@ -86,7 +85,6 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
     private final ProofOfBurnService proofOfBurnService;
     private final SignVerifyService signVerifyService;
     private final MyProofOfBurnListService myProofOfBurnListService;
-    private final Preferences preferences;
     private final CoinFormatter btcFormatter;
     private final BsqFormatter bsqFormatter;
     private final BsqWalletService bsqWalletService;
@@ -122,7 +120,6 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                             ProofOfBurnService proofOfBurnService,
                             SignVerifyService signVerifyService,
                             MyProofOfBurnListService myProofOfBurnListService,
-                            Preferences preferences,
                             @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter) {
         this.bsqFormatter = bsqFormatter;
         this.bsqWalletService = bsqWalletService;
@@ -130,7 +127,6 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
         this.proofOfBurnService = proofOfBurnService;
         this.signVerifyService = signVerifyService;
         this.myProofOfBurnListService = myProofOfBurnListService;
-        this.preferences = preferences;
         this.btcFormatter = btcFormatter;
     }
 
@@ -417,7 +413,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(item.getTxId(), preferences));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {
@@ -580,7 +576,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(item.getTxId(), preferences));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/proofofburn/ProofOfBurnView.java
@@ -413,7 +413,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(transactionId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {
@@ -576,7 +576,7 @@ public class ProofOfBurnView extends ActivatableView<GridPane, Void> implements 
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(transactionId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/transactions/BSQTransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/transactions/BSQTransactionsView.java
@@ -21,6 +21,7 @@ import bisq.desktop.common.view.ActivatableView;
 import bisq.desktop.common.view.FxmlView;
 import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.components.TitledGroupBg;
+import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
 
 import bisq.core.dao.DaoFacade;
@@ -28,7 +29,6 @@ import bisq.core.dao.state.DaoStateListener;
 import bisq.core.dao.state.model.blockchain.Block;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 
 import bisq.common.util.Tuple3;
 
@@ -48,7 +48,6 @@ import static bisq.desktop.util.FormBuilder.addTopLabelReadOnlyTextField;
 public class BSQTransactionsView extends ActivatableView<GridPane, Void> implements DaoStateListener {
 
     private final DaoFacade daoFacade;
-    private final Preferences preferences;
 
     private int gridRow = 0;
     private TextField allTxTextField, burntFeeTxsTextField,
@@ -60,10 +59,8 @@ public class BSQTransactionsView extends ActivatableView<GridPane, Void> impleme
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    private BSQTransactionsView(DaoFacade daoFacade,
-                                Preferences preferences) {
+    private BSQTransactionsView(DaoFacade daoFacade) {
         this.daoFacade = daoFacade;
-        this.preferences = preferences;
     }
 
     @Override
@@ -71,7 +68,7 @@ public class BSQTransactionsView extends ActivatableView<GridPane, Void> impleme
         addTitledGroupBg(root, gridRow, 2, Res.get("dao.factsAndFigures.transactions.genesis"));
         String genTxHeight = String.valueOf(daoFacade.getGenesisBlockHeight());
         String genesisTxId = daoFacade.getGenesisTxId();
-        String url = preferences.getBsqBlockChainExplorer().txUrl + genesisTxId;
+        String url = GUIUtil.getTxUrl(genesisTxId, true);
 
         GridPane.setColumnSpan(addTopLabelReadOnlyTextField(root, gridRow, Res.get("dao.factsAndFigures.transactions.genesisBlockHeight"),
                 genTxHeight, Layout.FIRST_ROW_DISTANCE).third, 2);

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/transactions/BSQTransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/transactions/BSQTransactionsView.java
@@ -68,7 +68,7 @@ public class BSQTransactionsView extends ActivatableView<GridPane, Void> impleme
         addTitledGroupBg(root, gridRow, 2, Res.get("dao.factsAndFigures.transactions.genesis"));
         String genTxHeight = String.valueOf(daoFacade.getGenesisBlockHeight());
         String genesisTxId = daoFacade.getGenesisTxId();
-        String url = GUIUtil.getTxUrl(genesisTxId, true);
+        String url = GUIUtil.getBsqTxUrl(genesisTxId);
 
         GridPane.setColumnSpan(addTopLabelReadOnlyTextField(root, gridRow, Res.get("dao.factsAndFigures.transactions.genesisBlockHeight"),
                 genTxHeight, Layout.FIRST_ROW_DISTANCE).third, 2);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
@@ -56,7 +56,6 @@ import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.dao.state.model.governance.Vote;
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.validation.InputValidator;
 import bisq.core.util.validation.RegexValidator;
@@ -110,7 +109,6 @@ public class ProposalDisplay {
     @Nullable
     private final ChangeParamValidator changeParamValidator;
     private final Navigation navigation;
-    private final Preferences preferences;
 
     @Nullable
     private TextField proposalFeeTextField, comboBoxValueTextField, requiredBondForRoleTextField;
@@ -152,14 +150,12 @@ public class ProposalDisplay {
                            BsqFormatter bsqFormatter,
                            DaoFacade daoFacade,
                            @Nullable ChangeParamValidator changeParamValidator,
-                           Navigation navigation,
-                           @Nullable Preferences preferences) {
+                           Navigation navigation) {
         this.gridPane = gridPane;
         this.bsqFormatter = bsqFormatter;
         this.daoFacade = daoFacade;
         this.changeParamValidator = changeParamValidator;
         this.navigation = navigation;
-        this.preferences = preferences;
 
         // focusOutListener = observable -> inputChangedListeners.forEach(Runnable::run);
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -461,7 +461,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
 
     private void addProposalDisplay() {
         if (selectedProposalType != null) {
-            proposalDisplay = new ProposalDisplay(root, bsqFormatter, daoFacade, changeParamValidator, navigation, null);
+            proposalDisplay = new ProposalDisplay(root, bsqFormatter, daoFacade, changeParamValidator, navigation);
 
             proposalDisplay.createAllFields(Res.get("dao.proposal.create.new"), alwaysVisibleGridRowIndex, Layout.GROUP_DISTANCE_WITHOUT_SEPARATOR,
                     selectedProposalType, true);

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -50,7 +50,6 @@ import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Volume;
 import bisq.core.user.DontShowAgainLookup;
-import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
 import bisq.core.util.VolumeUtil;
@@ -104,7 +103,6 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
     private final BtcValidator btcValidator;
     private final BsqAddressValidator bsqAddressValidator;
     private final BtcAddressValidator btcAddressValidator;
-    private final Preferences preferences;
     private final WalletPasswordWindow walletPasswordWindow;
 
     private int gridRow = 0;
@@ -138,7 +136,6 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
                         BtcValidator btcValidator,
                         BsqAddressValidator bsqAddressValidator,
                         BtcAddressValidator btcAddressValidator,
-                        Preferences preferences,
                         WalletPasswordWindow walletPasswordWindow) {
         this.bsqWalletService = bsqWalletService;
         this.btcWalletService = btcWalletService;
@@ -153,7 +150,6 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
         this.btcValidator = btcValidator;
         this.bsqAddressValidator = bsqAddressValidator;
         this.btcAddressValidator = btcAddressValidator;
-        this.preferences = preferences;
         this.walletPasswordWindow = walletPasswordWindow;
     }
 
@@ -347,7 +343,6 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
         }
         TxInputSelectionWindow txInputSelectionWindow = new TxInputSelectionWindow(unspentTransactionOutputs,
                 bsqUtxoCandidates,
-                preferences,
                 bsqFormatter);
         txInputSelectionWindow.onAction(() -> setBsqUtxoCandidates(txInputSelectionWindow.getCandidates()))
                 .show();
@@ -410,7 +405,6 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
         }
         TxInputSelectionWindow txInputSelectionWindow = new TxInputSelectionWindow(unspentTransactionOutputs,
                 btcUtxoCandidates,
-                preferences,
                 btcFormatter);
         txInputSelectionWindow.onAction(() -> setBtcUtxoCandidates(txInputSelectionWindow.getCandidates())).
                 show();

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -43,7 +43,6 @@ import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.locale.Res;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
 
 import bisq.common.Timer;
@@ -105,7 +104,6 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
     private final BsqWalletService bsqWalletService;
     private final BtcWalletService btcWalletService;
     private final BsqBalanceUtil bsqBalanceUtil;
-    private final Preferences preferences;
     private final TradableRepository tradableRepository;
     private final BsqTradeDetailsWindow bsqTradeDetailsWindow;
 
@@ -130,7 +128,6 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
     private BsqTxView(DaoFacade daoFacade,
                       DaoStateService daoStateService,
                       BsqWalletService bsqWalletService,
-                      Preferences preferences,
                       BtcWalletService btcWalletService,
                       BsqBalanceUtil bsqBalanceUtil,
                       BsqFormatter bsqFormatter,
@@ -140,7 +137,6 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
         this.daoStateService = daoStateService;
         this.bsqFormatter = bsqFormatter;
         this.bsqWalletService = bsqWalletService;
-        this.preferences = preferences;
         this.btcWalletService = btcWalletService;
         this.bsqBalanceUtil = bsqBalanceUtil;
         this.tradableRepository = tradableRepository;
@@ -458,7 +454,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> openTxInBlockExplorer(item));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {
@@ -538,7 +534,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                             String addressString = item.getAddress();
                                             field = new AddressWithIconAndDirection(item.getDirection(), addressString,
                                                     item.isReceived());
-                                            field.setOnAction(event -> openAddressInBlockExplorer(item));
+                                            field.setOnAction(event -> GUIUtil.openAddressInBlockExplorer(addressString, true));
                                             field.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForAddress", addressString)));
                                             setGraphic(field);
                                         }
@@ -773,17 +769,6 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                 });
 
         tableView.getColumns().add(column);
-    }
-
-    private void openTxInBlockExplorer(BsqTxListItem item) {
-        if (item.getTxId() != null)
-            GUIUtil.openWebPage(preferences.getBsqBlockChainExplorer().txUrl + item.getTxId(), false);
-    }
-
-    private void openAddressInBlockExplorer(BsqTxListItem item) {
-        if (item.getAddress() != null) {
-            GUIUtil.openWebPage(preferences.getBsqBlockChainExplorer().addressUrl + item.getAddress(), false);
-        }
     }
 }
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -454,7 +454,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(transactionId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {
@@ -534,7 +534,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                             String addressString = item.getAddress();
                                             field = new AddressWithIconAndDirection(item.getDirection(), addressString,
                                                     item.isReceived());
-                                            field.setOnAction(event -> GUIUtil.openAddressInBlockExplorer(addressString, true));
+                                            field.setOnAction(event -> GUIUtil.openAddressInBsqBlockExplorer(addressString));
                                             field.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForAddress", addressString)));
                                             setGraphic(field);
                                         }

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
@@ -35,7 +35,6 @@ import bisq.core.btc.listeners.BalanceListener;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.ParsingUtils;
 import bisq.core.util.coin.CoinFormatter;
@@ -117,7 +116,6 @@ public class DepositView extends ActivatableView<VBox, Void> {
     private InputTextField amountTextField;
 
     private final BtcWalletService walletService;
-    private final Preferences preferences;
     private final CoinFormatter formatter;
     private String paymentLabelString;
     private final ObservableList<DepositListItem> observableList = FXCollections.observableArrayList();
@@ -134,10 +132,8 @@ public class DepositView extends ActivatableView<VBox, Void> {
 
     @Inject
     private DepositView(BtcWalletService walletService,
-                        Preferences preferences,
                         @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter) {
         this.walletService = walletService;
-        this.preferences = preferences;
         this.formatter = formatter;
     }
 
@@ -313,11 +309,6 @@ public class DepositView extends ActivatableView<VBox, Void> {
         }
     }
 
-    private void openBlockExplorer(DepositListItem item) {
-        if (item.getAddressString() != null)
-            GUIUtil.openWebPage(preferences.getBlockChainExplorer().addressUrl + item.getAddressString(), false);
-    }
-
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -390,7 +381,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
                                     String address = item.getAddressString();
                                     field = new ExternalHyperlink(address);
                                     field.setOnAction(event -> {
-                                        openBlockExplorer(item);
+                                        GUIUtil.openAddressInBlockExplorer(address);
                                         tableView.getSelectionModel().select(item);
                                     });
                                     field.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForAddress", address)));

--- a/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
@@ -37,7 +37,6 @@ import bisq.core.offer.OpenOfferManager;
 import bisq.core.trade.TradeManager;
 import bisq.core.trade.model.Tradable;
 import bisq.core.trade.model.bisq_v1.Trade;
-import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
@@ -101,7 +100,6 @@ public class LockedView extends ActivatableView<VBox, Void> {
     private final BtcWalletService btcWalletService;
     private final TradeManager tradeManager;
     private final OpenOfferManager openOfferManager;
-    private final Preferences preferences;
     private final CoinFormatter formatter;
     private final OfferDetailsWindow offerDetailsWindow;
     private final TradeDetailsWindow tradeDetailsWindow;
@@ -121,14 +119,12 @@ public class LockedView extends ActivatableView<VBox, Void> {
     private LockedView(BtcWalletService btcWalletService,
                        TradeManager tradeManager,
                        OpenOfferManager openOfferManager,
-                       Preferences preferences,
                        @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                        OfferDetailsWindow offerDetailsWindow,
                        TradeDetailsWindow tradeDetailsWindow) {
         this.btcWalletService = btcWalletService;
         this.tradeManager = tradeManager;
         this.openOfferManager = openOfferManager;
-        this.preferences = preferences;
         this.formatter = formatter;
         this.offerDetailsWindow = offerDetailsWindow;
         this.tradeDetailsWindow = tradeDetailsWindow;
@@ -244,10 +240,6 @@ public class LockedView extends ActivatableView<VBox, Void> {
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
-    }
-
-    private void openBlockExplorer(LockedListItem item) {
-        GUIUtil.openWebPage(preferences.getBlockChainExplorer().addressUrl + item.getAddressString(), false);
     }
 
     private Optional<Tradable> getTradable(LockedListItem item) {
@@ -387,7 +379,7 @@ public class LockedView extends ActivatableView<VBox, Void> {
                                 if (item != null && !empty) {
                                     String address = item.getAddressString();
                                     hyperlinkWithIcon = new ExternalHyperlink(address);
-                                    hyperlinkWithIcon.setOnAction(event -> openBlockExplorer(item));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openAddressInBlockExplorer(address));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForAddress", address)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
@@ -37,7 +37,6 @@ import bisq.core.offer.OpenOfferManager;
 import bisq.core.trade.TradeManager;
 import bisq.core.trade.model.Tradable;
 import bisq.core.trade.model.bisq_v1.Trade;
-import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
@@ -101,7 +100,6 @@ public class ReservedView extends ActivatableView<VBox, Void> {
     private final BtcWalletService btcWalletService;
     private final TradeManager tradeManager;
     private final OpenOfferManager openOfferManager;
-    private final Preferences preferences;
     private final CoinFormatter formatter;
     private final OfferDetailsWindow offerDetailsWindow;
     private final TradeDetailsWindow tradeDetailsWindow;
@@ -121,14 +119,12 @@ public class ReservedView extends ActivatableView<VBox, Void> {
     private ReservedView(BtcWalletService btcWalletService,
                          TradeManager tradeManager,
                          OpenOfferManager openOfferManager,
-                         Preferences preferences,
                          @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
                          OfferDetailsWindow offerDetailsWindow,
                          TradeDetailsWindow tradeDetailsWindow) {
         this.btcWalletService = btcWalletService;
         this.tradeManager = tradeManager;
         this.openOfferManager = openOfferManager;
-        this.preferences = preferences;
         this.formatter = formatter;
         this.offerDetailsWindow = offerDetailsWindow;
         this.tradeDetailsWindow = tradeDetailsWindow;
@@ -243,10 +239,6 @@ public class ReservedView extends ActivatableView<VBox, Void> {
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
-    }
-
-    private void openBlockExplorer(ReservedListItem item) {
-        GUIUtil.openWebPage(preferences.getBlockChainExplorer().addressUrl + item.getAddressString(), false);
     }
 
     private Optional<Tradable> getTradable(ReservedListItem item) {
@@ -385,7 +377,7 @@ public class ReservedView extends ActivatableView<VBox, Void> {
                                 if (item != null && !empty) {
                                     String address = item.getAddressString();
                                     hyperlinkWithIcon = new ExternalHyperlink(address);
-                                    hyperlinkWithIcon.setOnAction(event -> openBlockExplorer(item));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openAddressInBlockExplorer(address));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForAddress", address)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -330,17 +330,6 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         observableList.setAll(transactionsListItems);
     }
 
-    private void openTxInBlockExplorer(TransactionsListItem item) {
-        if (item.getTxId() != null)
-            GUIUtil.openWebPage(preferences.getBlockChainExplorer().txUrl + item.getTxId(), false);
-    }
-
-    private void openAddressInBlockExplorer(TransactionsListItem item) {
-        if (item.getAddressString() != null) {
-            GUIUtil.openWebPage(preferences.getBlockChainExplorer().addressUrl + item.getAddressString(), false);
-        }
-    }
-
     private void openDetailPopup(TransactionsListItem item) {
         if (item.getTradable() instanceof OpenOffer) {
             offerDetailsWindow.show(item.getTradable().getOffer());
@@ -473,7 +462,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                                     String addressString = item.getAddressString();
                                     field = new AddressWithIconAndDirection(item.getDirection(), addressString,
                                             item.getReceived());
-                                    field.setOnAction(event -> openAddressInBlockExplorer(item));
+                                    field.setOnAction(event -> GUIUtil.openAddressInBlockExplorer(addressString));
                                     field.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForAddress", addressString)));
                                     setGraphic(field);
                                 } else {
@@ -506,7 +495,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                                 if (item != null && !empty) {
                                     String transactionId = item.getTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> openTxInBlockExplorer(item));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -547,11 +547,6 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
         }
     }
 
-    private void openBlockExplorer(WithdrawalListItem item) {
-        if (item.getAddressString() != null)
-            GUIUtil.openWebPage(preferences.getBlockChainExplorer().addressUrl + item.getAddressString(), false);
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
@@ -676,7 +671,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
                                 if (item != null && !empty) {
                                     String address = item.getAddressString();
                                     hyperlinkWithIcon = new ExternalHyperlink(address);
-                                    hyperlinkWithIcon.setOnAction(event -> openBlockExplorer(item));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openAddressInBlockExplorer(address));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForAddress", address)));
                                     setAlignment(Pos.CENTER);
                                     setGraphic(hyperlinkWithIcon);

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
@@ -313,8 +313,9 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
         AwesomeDude.setIcon(blockExplorerIcon, AwesomeIcon.EXTERNAL_LINK);
         blockExplorerIcon.setMinWidth(20);
         blockExplorerIcon.setOnMouseClicked(mouseEvent -> {
-            if (depositTxHex.getText().length() == HEX_HASH_LENGTH)
+            if (depositTxHex.getText().length() == HEX_HASH_LENGTH) {
                 GUIUtil.openTxInBlockExplorer(depositTxHex.getText());
+            }
         });
         depositTxHex = addInputTextField(inputsGridPane, rowIndexA, "depositTxId");
         HBox hBoxTx = new HBox(12, depositTxHex, blockExplorerIcon);

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ManualPayoutTxWindow.java
@@ -36,8 +36,6 @@ import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.locale.Res;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.mediation.MediationManager;
-import bisq.core.user.BlockChainExplorer;
-import bisq.core.user.Preferences;
 
 import bisq.network.p2p.P2PService;
 
@@ -110,7 +108,6 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
     private final TradeWalletService tradeWalletService;
     private final P2PService p2PService;
     private final MediationManager mediationManager;
-    private final Preferences preferences;
     private final WalletsSetup walletsSetup;
     private final WalletsManager walletsManager;
     GridPane inputsGridPane;
@@ -149,13 +146,11 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
     public ManualPayoutTxWindow(TradeWalletService tradeWalletService,
                                 P2PService p2PService,
                                 MediationManager mediationManager,
-                                Preferences preferences,
                                 WalletsSetup walletsSetup,
                                 WalletsManager walletsManager) {
         this.tradeWalletService = tradeWalletService;
         this.p2PService = p2PService;
         this.mediationManager = mediationManager;
-        this.preferences = preferences;
         this.walletsSetup = walletsSetup;
         this.walletsManager = walletsManager;
         type = Type.Attention;
@@ -317,7 +312,10 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
         blockExplorerIcon.setTooltip(tooltip);
         AwesomeDude.setIcon(blockExplorerIcon, AwesomeIcon.EXTERNAL_LINK);
         blockExplorerIcon.setMinWidth(20);
-        blockExplorerIcon.setOnMouseClicked(mouseEvent -> openBlockExplorer(depositTxHex.getText()));
+        blockExplorerIcon.setOnMouseClicked(mouseEvent -> {
+            if (depositTxHex.getText().length() == HEX_HASH_LENGTH)
+                GUIUtil.openTxInBlockExplorer(depositTxHex.getText());
+        });
         depositTxHex = addInputTextField(inputsGridPane, rowIndexA, "depositTxId");
         HBox hBoxTx = new HBox(12, depositTxHex, blockExplorerIcon);
         hBoxTx.setAlignment(Pos.BASELINE_LEFT);
@@ -623,15 +621,6 @@ public class ManualPayoutTxWindow extends Overlay<ManualPayoutTxWindow> {
             txFee.setText(txFeeValue.toPlainString());
             double feePercent = (double) txFeeValue.value / getInputFieldAsCoin(amountInMultisig).value;
             txFeePct.setText(String.format("%.2f", feePercent * 100));
-        }
-    }
-
-    private void openBlockExplorer(String txId) {
-        if (txId.length() != HEX_HASH_LENGTH)
-            return;
-        if (preferences != null) {
-            BlockChainExplorer blockChainExplorer = preferences.getBlockChainExplorer();
-            GUIUtil.openWebPage(blockChainExplorer.txUrl + txId, false);
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
@@ -266,7 +266,7 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
                                 if (item != null && !empty) {
                                     String transactionId = item.getBlindVoteTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(transactionId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
@@ -35,7 +35,6 @@ import bisq.core.dao.state.model.governance.Ballot;
 import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Proposal;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
 
 import bisq.common.util.Tuple2;
@@ -78,7 +77,6 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
     private final BsqFormatter bsqFormatter;
     private final DaoFacade daoFacade;
     private final Navigation navigation;
-    private final Preferences preferences;
     private boolean isVoteIncludedInResult;
     private SortedList<VoteListItem> sortedVotes;
     private Tab proposalTab, votesTab;
@@ -90,12 +88,10 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
     @Inject
     public ProposalResultsWindow(BsqFormatter bsqFormatter,
                                  DaoFacade daoFacade,
-                                 Navigation navigation,
-                                 Preferences preferences) {
+                                 Navigation navigation) {
         this.bsqFormatter = bsqFormatter;
         this.daoFacade = daoFacade;
         this.navigation = navigation;
-        this.preferences = preferences;
     }
 
     public void show(EvaluatedProposal evaluatedProposal, Ballot ballot,
@@ -147,8 +143,7 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
 
     private void addContent(EvaluatedProposal evaluatedProposal, Ballot ballot) {
         Proposal proposal = evaluatedProposal.getProposal();
-        ProposalDisplay proposalDisplay = new ProposalDisplay(gridPane, bsqFormatter, daoFacade, null,
-                navigation, preferences);
+        ProposalDisplay proposalDisplay = new ProposalDisplay(gridPane, bsqFormatter, daoFacade, null, navigation);
         proposalDisplay.createAllFields("", rowIndex, -Layout.FIRST_ROW_DISTANCE, proposal.getType(),
                 false, "last");
         proposalDisplay.setEditable(false);
@@ -271,7 +266,7 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
                                 if (item != null && !empty) {
                                     String transactionId = item.getBlindVoteTxId();
                                     hyperlinkWithIcon = new ExternalHyperlink(transactionId);
-                                    hyperlinkWithIcon.setOnAction(event -> openTxInBlockExplorer(item));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(transactionId, true));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", transactionId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {
@@ -395,10 +390,5 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
                 doClose();
             }
         });
-    }
-
-    private void openTxInBlockExplorer(VoteListItem item) {
-        if (item.getBlindVoteTxId() != null)
-            GUIUtil.openWebPage(preferences.getBsqBlockChainExplorer().txUrl + item.getBlindVoteTxId(), false);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/SelectProposalWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/SelectProposalWindow.java
@@ -14,7 +14,6 @@ import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Proposal;
 import bisq.core.dao.state.model.governance.Vote;
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
 
 import bisq.common.util.Tuple2;
@@ -44,7 +43,6 @@ public class SelectProposalWindow extends Overlay<SelectProposalWindow> {
     private final DaoFacade daoFacade;
     private final ChangeParamValidator changeParamValidator;
     private final Navigation navigation;
-    private final Preferences preferences;
     private Optional<Runnable> acceptHandlerOptional;
     private Optional<Runnable> rejectHandlerOptional;
     private Optional<Runnable> ignoreHandlerOptional;
@@ -60,13 +58,11 @@ public class SelectProposalWindow extends Overlay<SelectProposalWindow> {
 
     @Inject
     public SelectProposalWindow(BsqFormatter bsqFormatter, DaoFacade daoFacade,
-                                ChangeParamValidator changeParamValidator, Navigation navigation,
-                                Preferences preferences) {
+                                ChangeParamValidator changeParamValidator, Navigation navigation) {
         this.bsqFormatter = bsqFormatter;
         this.daoFacade = daoFacade;
         this.changeParamValidator = changeParamValidator;
         this.navigation = navigation;
-        this.preferences = preferences;
     }
 
     public void show(Proposal proposal, EvaluatedProposal evaluatedProposal, Ballot ballot) {
@@ -140,7 +136,7 @@ public class SelectProposalWindow extends Overlay<SelectProposalWindow> {
 
     private void addContent(Proposal proposal, EvaluatedProposal evaluatedProposal, Ballot ballot) {
         ProposalDisplay proposalDisplay = new ProposalDisplay(gridPane, bsqFormatter, daoFacade, changeParamValidator,
-                navigation, preferences);
+                navigation);
 
         proposalDisplay.onNavigate(this::doClose);
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TxInputSelectionWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TxInputSelectionWindow.java
@@ -29,7 +29,6 @@ import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.Layout;
 
 import bisq.core.locale.Res;
-import bisq.core.user.Preferences;
 import bisq.core.util.coin.CoinFormatter;
 
 import org.bitcoinj.core.Coin;
@@ -77,7 +76,6 @@ public class TxInputSelectionWindow extends Overlay<TxInputSelectionWindow> {
     private final List<TransactionOutput> spendableTransactionOutputs;
     @Getter
     private final Set<TransactionOutput> candidates;
-    private final Preferences preferences;
     private final CoinFormatter formatter;
 
     private BalanceTextField balanceTextField;
@@ -85,11 +83,9 @@ public class TxInputSelectionWindow extends Overlay<TxInputSelectionWindow> {
 
     public TxInputSelectionWindow(List<TransactionOutput> spendableTransactionOutputs,
                                   Set<TransactionOutput> candidates,
-                                  Preferences preferences,
                                   CoinFormatter formatter) {
         this.spendableTransactionOutputs = spendableTransactionOutputs;
         this.candidates = candidates;
-        this.preferences = preferences;
         this.formatter = formatter;
         type = Type.Attention;
     }
@@ -228,7 +224,7 @@ public class TxInputSelectionWindow extends Overlay<TxInputSelectionWindow> {
                                     TransactionOutput transactionOutput = item.getTransactionOutput();
                                     String txId = transactionOutput.getParentTransaction().getTxId().toString();
                                     hyperlinkWithIcon = new ExternalHyperlink(txId + ":" + transactionOutput.getIndex());
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openWebPage(preferences.getBsqBlockChainExplorer().txUrl + txId, false));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(txId, true));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", txId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TxInputSelectionWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TxInputSelectionWindow.java
@@ -224,7 +224,7 @@ public class TxInputSelectionWindow extends Overlay<TxInputSelectionWindow> {
                                     TransactionOutput transactionOutput = item.getTransactionOutput();
                                     String txId = transactionOutput.getParentTransaction().getTxId().toString();
                                     hyperlinkWithIcon = new ExternalHyperlink(txId + ":" + transactionOutput.getIndex());
-                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBlockExplorer(txId, true));
+                                    hyperlinkWithIcon.setOnAction(event -> GUIUtil.openTxInBsqBlockExplorer(txId));
                                     hyperlinkWithIcon.setTooltip(new Tooltip(Res.get("tooltip.openBlockchainForTx", txId)));
                                     setGraphic(hyperlinkWithIcon);
                                 } else {

--- a/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/MarketPricePresentation.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.presentation;
 
-import bisq.desktop.components.ExplorerAddressTextField;
 import bisq.desktop.components.TxIdTextField;
 import bisq.desktop.main.shared.PriceFeedComboBoxItem;
 import bisq.desktop.util.GUIUtil;
@@ -93,9 +92,6 @@ public class MarketPricePresentation {
                                    FeeService feeService) {
         this.priceFeedService = priceFeedService;
         this.preferences = preferences;
-
-        TxIdTextField.setPreferences(preferences);
-        ExplorerAddressTextField.setPreferences(preferences);
 
         // TODO
         TxIdTextField.setWalletService(btcWalletService);

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -49,6 +49,7 @@ import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.txproof.AssetTxProofResult;
+import bisq.core.user.BlockChainExplorer;
 import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
@@ -1168,9 +1169,42 @@ public class GUIUtil {
         };
     }
 
-    public static void openTxInBsqBlockExplorer(String txId, Preferences preferences) {
+    private static BlockChainExplorer getBlockExplorer(boolean isBsq) {
+        return isBsq ? preferences.getBsqBlockChainExplorer() : preferences.getBlockChainExplorer();
+    }
+
+    public static void openAddressInBlockExplorer(String address) {
+        openAddressInBlockExplorer(address, false);
+    }
+
+    public static void openAddressInBlockExplorer(String address, boolean isBsq) {
+        if (address != null)
+            openWebPage(getAddressUrl(address, isBsq), false);
+    }
+
+    public static void openTxInBlockExplorer(String txId) {
+        openTxInBlockExplorer(txId, false);
+    }
+
+    public static void openTxInBlockExplorer(String txId, boolean isBsq) {
         if (txId != null)
-            GUIUtil.openWebPage(preferences.getBsqBlockChainExplorer().txUrl + txId, false);
+            openWebPage(getTxUrl(txId, isBsq), false);
+    }
+
+    public static String getAddressUrl(String address) {
+        return getAddressUrl(address, false);
+    }
+
+    public static String getAddressUrl(String address, boolean isBsq) {
+        return getBlockExplorer(isBsq).addressUrl + address;
+    }
+
+    public static String getTxUrl(String txId) {
+        return getTxUrl(txId, false);
+    }
+
+    public static String getTxUrl(String txId, boolean isBsq) {
+        return getBlockExplorer(isBsq).txUrl + txId;
     }
 
     public static String getBsqInUsd(Price bsqPrice,

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -49,7 +49,6 @@ import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.txproof.AssetTxProofResult;
-import bisq.core.user.BlockChainExplorer;
 import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
@@ -1169,44 +1168,44 @@ public class GUIUtil {
         };
     }
 
-    private static BlockChainExplorer getBlockExplorer(boolean isBsq) {
-        return isBsq ? preferences.getBsqBlockChainExplorer() : preferences.getBlockChainExplorer();
-    }
-
     public static void openAddressInBlockExplorer(String address) {
-        openAddressInBlockExplorer(address, false);
+        if (address != null) {
+            openWebPage(getAddressUrl(address), false);
+        }
     }
 
-    public static void openAddressInBlockExplorer(String address, boolean isBsq) {
+    public static void openAddressInBsqBlockExplorer(String address) {
         if (address != null) {
-            openWebPage(getAddressUrl(address, isBsq), false);
+            openWebPage(getBsqAddressUrl(address), false);
         }
     }
 
     public static void openTxInBlockExplorer(String txId) {
-        openTxInBlockExplorer(txId, false);
+        if (txId != null) {
+            openWebPage(getTxUrl(txId), false);
+        }
     }
 
-    public static void openTxInBlockExplorer(String txId, boolean isBsq) {
+    public static void openTxInBsqBlockExplorer(String txId) {
         if (txId != null) {
-            openWebPage(getTxUrl(txId, isBsq), false);
+            openWebPage(getBsqTxUrl(txId), false);
         }
     }
 
     public static String getAddressUrl(String address) {
-        return getAddressUrl(address, false);
+        return preferences.getBlockChainExplorer().addressUrl + address;
     }
 
-    public static String getAddressUrl(String address, boolean isBsq) {
-        return getBlockExplorer(isBsq).addressUrl + address;
+    public static String getBsqAddressUrl(String address) {
+        return preferences.getBsqBlockChainExplorer().addressUrl + address;
     }
 
     public static String getTxUrl(String txId) {
-        return getTxUrl(txId, false);
+        return preferences.getBlockChainExplorer().txUrl + txId;
     }
 
-    public static String getTxUrl(String txId, boolean isBsq) {
-        return getBlockExplorer(isBsq).txUrl + txId;
+    public static String getBsqTxUrl(String txId) {
+        return preferences.getBsqBlockChainExplorer().txUrl + txId;
     }
 
     public static String getBsqInUsd(Price bsqPrice,

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -1178,8 +1178,9 @@ public class GUIUtil {
     }
 
     public static void openAddressInBlockExplorer(String address, boolean isBsq) {
-        if (address != null)
+        if (address != null) {
             openWebPage(getAddressUrl(address, isBsq), false);
+        }
     }
 
     public static void openTxInBlockExplorer(String txId) {
@@ -1187,8 +1188,9 @@ public class GUIUtil {
     }
 
     public static void openTxInBlockExplorer(String txId, boolean isBsq) {
-        if (txId != null)
+        if (txId != null) {
             openWebPage(getTxUrl(txId, isBsq), false);
+        }
     }
 
     public static String getAddressUrl(String address) {

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -23,6 +23,7 @@ import bisq.core.locale.TradeCurrency;
 import bisq.core.monetary.Price;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.user.BlockChainExplorer;
 import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
 import bisq.core.util.coin.BsqFormatter;
@@ -53,12 +54,27 @@ import static org.mockito.Mockito.when;
 
 public class GUIUtilTest {
 
+    private Preferences preferences;
+    private String explorerName;
+    private String bsqExplorerName;
+    private String txUrlPrefix;
+    private String bsqTxUrlPrefix;
+    private String addressUrlPrefix;
+    private String bsqAddressUrlPrefix;
+
     @Before
     public void setup() {
         Locale.setDefault(new Locale("en", "US"));
         GlobalSettings.setLocale(new Locale("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
+        preferences = mock(Preferences.class);
+        explorerName = "Blockstream.info";
+        bsqExplorerName = "mempool.space (@wiz)";
+        txUrlPrefix = "https://blockstream.info/tx/";
+        bsqTxUrlPrefix = "https://mempool.space/bisq/tx/";
+        addressUrlPrefix = "https://blockstream.info/address/";
+        bsqAddressUrlPrefix = "https://mempool.space/bisq/address/";
     }
 
     @Test
@@ -79,7 +95,6 @@ public class GUIUtilTest {
 
     @Test
     public void testOpenURLWithCampaignParameters() {
-        Preferences preferences = mock(Preferences.class);
         DontShowAgainLookup.setPreferences(preferences);
         GUIUtil.setPreferences(preferences);
         when(preferences.showAgain("warnOpenURLWhenTorEnabled")).thenReturn(false);
@@ -100,7 +115,6 @@ public class GUIUtilTest {
 
     @Test
     public void testOpenURLWithoutCampaignParameters() {
-        Preferences preferences = mock(Preferences.class);
         DontShowAgainLookup.setPreferences(preferences);
         GUIUtil.setPreferences(preferences);
         when(preferences.showAgain("warnOpenURLWhenTorEnabled")).thenReturn(false);
@@ -112,6 +126,38 @@ public class GUIUtilTest {
 
         assertEquals("https://www.github.com", captor.getValue().toString());
 */
+    }
+
+    @Test
+    public void testGetAddressUrl() {
+        GUIUtil.setPreferences(preferences);
+        when(preferences.getBlockChainExplorer()).thenReturn(new BlockChainExplorer(
+                explorerName, txUrlPrefix, addressUrlPrefix));
+        when(preferences.getBsqBlockChainExplorer()).thenReturn(new BlockChainExplorer(
+                bsqExplorerName, bsqTxUrlPrefix, bsqAddressUrlPrefix));
+
+        String address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+        assertEquals(addressUrlPrefix + address, GUIUtil.getAddressUrl(address));
+        assertEquals(addressUrlPrefix + address, GUIUtil.getAddressUrl(address, false));
+
+        String bsqAddress = "B17Q6zA7LbEt5je4mtkBtYBfvDfvEwkzde";
+        assertEquals(bsqAddressUrlPrefix + bsqAddress, GUIUtil.getAddressUrl(bsqAddress, true));
+    }
+
+    @Test
+    public void testGetTxUrl() {
+        GUIUtil.setPreferences(preferences);
+        when(preferences.getBlockChainExplorer()).thenReturn(new BlockChainExplorer(
+                explorerName, txUrlPrefix, addressUrlPrefix));
+        when(preferences.getBsqBlockChainExplorer()).thenReturn(new BlockChainExplorer(
+                bsqExplorerName, bsqTxUrlPrefix, bsqAddressUrlPrefix));
+
+        String txId = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b";
+        assertEquals(txUrlPrefix + txId, GUIUtil.getTxUrl(txId));
+        assertEquals(txUrlPrefix + txId, GUIUtil.getTxUrl(txId, false));
+
+        String bsqTxId = "4b5417ec5ab6112bedf539c3b4f5a806ed539542d8b717e1c4470aa3180edce5";
+        assertEquals(bsqTxUrlPrefix + bsqTxId, GUIUtil.getTxUrl(bsqTxId, true));
     }
 
     @Test

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -133,15 +133,17 @@ public class GUIUtilTest {
         GUIUtil.setPreferences(preferences);
         when(preferences.getBlockChainExplorer()).thenReturn(new BlockChainExplorer(
                 explorerName, txUrlPrefix, addressUrlPrefix));
-        when(preferences.getBsqBlockChainExplorer()).thenReturn(new BlockChainExplorer(
-                bsqExplorerName, bsqTxUrlPrefix, bsqAddressUrlPrefix));
-
         String address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
         assertEquals(addressUrlPrefix + address, GUIUtil.getAddressUrl(address));
-        assertEquals(addressUrlPrefix + address, GUIUtil.getAddressUrl(address, false));
+    }
 
+    @Test
+    public void testGetBsqAddressUrl() {
+        GUIUtil.setPreferences(preferences);
+        when(preferences.getBsqBlockChainExplorer()).thenReturn(new BlockChainExplorer(
+                bsqExplorerName, bsqTxUrlPrefix, bsqAddressUrlPrefix));
         String bsqAddress = "B17Q6zA7LbEt5je4mtkBtYBfvDfvEwkzde";
-        assertEquals(bsqAddressUrlPrefix + bsqAddress, GUIUtil.getAddressUrl(bsqAddress, true));
+        assertEquals(bsqAddressUrlPrefix + bsqAddress, GUIUtil.getBsqAddressUrl(bsqAddress));
     }
 
     @Test
@@ -149,15 +151,17 @@ public class GUIUtilTest {
         GUIUtil.setPreferences(preferences);
         when(preferences.getBlockChainExplorer()).thenReturn(new BlockChainExplorer(
                 explorerName, txUrlPrefix, addressUrlPrefix));
-        when(preferences.getBsqBlockChainExplorer()).thenReturn(new BlockChainExplorer(
-                bsqExplorerName, bsqTxUrlPrefix, bsqAddressUrlPrefix));
-
         String txId = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b";
         assertEquals(txUrlPrefix + txId, GUIUtil.getTxUrl(txId));
-        assertEquals(txUrlPrefix + txId, GUIUtil.getTxUrl(txId, false));
+    }
 
+    @Test
+    public void testGetBsqTxUrl() {
+        GUIUtil.setPreferences(preferences);
+        when(preferences.getBsqBlockChainExplorer()).thenReturn(new BlockChainExplorer(
+                bsqExplorerName, bsqTxUrlPrefix, bsqAddressUrlPrefix));
         String bsqTxId = "4b5417ec5ab6112bedf539c3b4f5a806ed539542d8b717e1c4470aa3180edce5";
-        assertEquals(bsqTxUrlPrefix + bsqTxId, GUIUtil.getTxUrl(bsqTxId, true));
+        assertEquals(bsqTxUrlPrefix + bsqTxId, GUIUtil.getBsqTxUrl(bsqTxId));
     }
 
     @Test


### PR DESCRIPTION
This is an attempt to handle blockchain URLs consistently across the application.

While trying to delve into the GUI code I noticed there isn't a uniform way for opening txIDs/addresses in a blockchain explorer and some code that can be reused is instead getting re-implemented in various places.