### PR TITLE
Fix issue with offers getting disabled for no apparent reason

### DIFF
--- a/core/src/main/java/bisq/core/offer/OpenOffer.java
+++ b/core/src/main/java/bisq/core/offer/OpenOffer.java
@@ -187,6 +187,10 @@ public final class OpenOffer implements Tradable {
         return state == State.DEACTIVATED;
     }
 
+    public boolean isCanceled() {
+        return state == State.CANCELED;
+    }
+
     public BsqSwapOfferPayload getBsqSwapOfferPayload() {
         checkArgument(getOffer().getBsqSwapOfferPayload().isPresent(),
                 "getBsqSwapOfferPayload must be called only when BsqSwapOfferPayload is the expected payload");

--- a/core/src/main/java/bisq/core/offer/bisq_v1/TriggerPriceService.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/TriggerPriceService.java
@@ -202,7 +202,7 @@ public class TriggerPriceService {
             String currencyCode = openOffer.getOffer().getCurrencyCode();
             if (openOffersByCurrency.containsKey(currencyCode)) {
                 Set<OpenOffer> set = openOffersByCurrency.get(currencyCode);
-                set.remove(openOffer);
+                set.removeIf(OpenOffer::isCanceled);
                 if (set.isEmpty()) {
                     openOffersByCurrency.remove(currencyCode);
                 }


### PR DESCRIPTION
See comments by Droidus (me) in [this ](https://bisq.community/t/offer-keeps-getting-disabled/11629) forum thread.

Steps to reproduce:

1. Create an offer (suppose that current market price is 20.000$)

2. Set a price trigger (say, 20.200$) and confirm

3. Change your mind and re-edit the offer, set a different price trigger (say, 21.000$) and confirm

4. You now unknowingly have two trigger prices waiting in a queue instead of one, and the first to be triggered is not the last one that you've set. If you wait a while and assuming the market price will go up, your offer will be "disabled" way before the market price reaches 21.000$ and will leave you wondering why that has happened.

I put "disabled" inside quotes because the offer is not exactly getting disabled but is definitely thrown off the offerbook, and the log states the following:

```
Market price exceeded the trigger price of the open offer.
We deactivate the open offer with ID XXXXX.
Currency: XXX;
Offer direction: XXX;
Market price: XXXXX.XXX;
Trigger price: <PREVIOUS_TRIGGER_PRICE>
```

However if you go to PORTFOLIO > OPEN OFFERS you will see that the offer is still "enabled", but the only way to really bring it back is by manually disabling and re-enabling it (assuming the market price has not yet reached the next in line price trigger).

If you keep editing the price trigger then your offer will keep getting randomly deactivated for no apparent reason at all. This is a real life scenario and a very frustrating one by the way because it was happening to my own offers lately (as the market price was fluctuating I kept changing the price trigger but without realizing what was happening under the hood, so I ended up with problematic offers that couldn't stay up for long).

`set.remove` does not work in this case, `onRemovedOpenOffers` method does nothing and `openOffersByCurrency` keeps getting larger after every modification of an open offer. So when `onPriceFeedChanged` is triggered it iterates through all `openOffersByCurrency` and since it finds all the canceled ones as well, a previous trigger price is used instead of the current one.

Tested live (I haven't setup regtest yet)
