### PR TITLE
Prevent NPE when editing offer while not fully connected

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -733,7 +733,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
 
     private void onEditOpenOffer(Offer offer) {
         OpenOffer openOffer = model.getOpenOffer(offer);
-        if (openOffer != null) {
+        if (model.isBootstrappedOrShowPopup() && openOffer != null) {
             navigation.navigateToWithData(openOffer, MainView.class, PortfolioView.class, EditOfferView.class);
         }
     }


### PR DESCRIPTION
To reproduce:

1. Ensure you have an activated open offer

2. Start Bisq, go to BUY or SELL, find your offer and click on EDIT

4. NetworkNotReadyException

From then on it is impossible to edit the offer even after you're fully connected unless you restart the application. Trying to edit either from `BUY/SELL` or `PORTFOLIO > OPEN OFFERS` will result in NPEs