### PR TITLE
[WIP] Provide API trading statistics

### DIFF
--- a/apitest/src/main/java/bisq/apitest/config/ApiTestConfig.java
+++ b/apitest/src/main/java/bisq/apitest/config/ApiTestConfig.java
@@ -76,6 +76,7 @@ public class ApiTestConfig {
     static final String CONFIG_FILE = "configFile";
     static final String ROOT_APP_DATA_DIR = "rootAppDataDir";
     static final String API_PASSWORD = "apiPassword";
+    static final String DUMP_STATISTICS = "dumpStatistics";
     static final String RUN_SUBPROJECT_JARS = "runSubprojectJars";
     static final String BISQ_APP_INIT_TIME = "bisqAppInitTime";
     static final String SKIP_TESTS = "skipTests";
@@ -109,6 +110,7 @@ public class ApiTestConfig {
     public final String bitcoinRpcPassword;
     // Daemon instances can use same gRPC password, but each needs a different apiPort.
     public final String apiPassword;
+    public final boolean dumpStatistics;
     public final boolean runSubprojectJars;
     public final long bisqAppInitTime;
     public final boolean skipTests;
@@ -206,6 +208,12 @@ public class ApiTestConfig {
                 parser.accepts(API_PASSWORD, "gRPC API password")
                         .withRequiredArg()
                         .defaultsTo("xyz");
+
+        ArgumentAcceptingOptionSpec<Boolean> dumpStatisticsOpt =
+                parser.accepts(DUMP_STATISTICS, "Dump node statistics")
+                        .withRequiredArg()
+                        .ofType(Boolean.class)
+                        .defaultsTo(false);
 
         ArgumentAcceptingOptionSpec<Boolean> runSubprojectJarsOpt =
                 parser.accepts(RUN_SUBPROJECT_JARS,
@@ -311,6 +319,7 @@ public class ApiTestConfig {
             this.bitcoinRpcUser = options.valueOf(bitcoinRpcUserOpt);
             this.bitcoinRpcPassword = options.valueOf(bitcoinRpcPasswordOpt);
             this.apiPassword = options.valueOf(apiPasswordOpt);
+            this.dumpStatistics = options.valueOf(dumpStatisticsOpt);
             this.runSubprojectJars = options.valueOf(runSubprojectJarsOpt);
             this.bisqAppInitTime = options.valueOf(bisqAppInitTimeOpt);
             this.skipTests = options.valueOf(skipTestsOpt);

--- a/apitest/src/main/java/bisq/apitest/linux/BisqProcess.java
+++ b/apitest/src/main/java/bisq/apitest/linux/BisqProcess.java
@@ -242,6 +242,7 @@ public class BisqProcess extends AbstractLinuxProcess implements LinuxProcess {
                     add("--genesisBlockHeight=" + genesisBlockHeight);
                     add("--genesisTxId=" + genesisTxId);
                     if (bisqAppConfig.mainClassName.equals(BisqDaemonMain.class.getName())) {
+                        add("--dumpStatistics=" + config.dumpStatistics);
                         add("--apiPassword=" + config.apiPassword);
                         add("--apiPort=" + bisqAppConfig.apiPort);
                     }

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -76,7 +76,8 @@ public class MethodTest extends ApiTestCase {
             setUpScaffold(new String[]{
                     "--supportingApps", toNameList.apply(supportingApps),
                     "--callRateMeteringConfigPath", callRateMeteringConfigFile.getAbsolutePath(),
-                    "--enableBisqDebugging", startSupportingAppsInDebugMode ? "true" : "false"
+                    "--enableBisqDebugging", startSupportingAppsInDebugMode ? "true" : "false",
+                    "--dumpStatistics", "true"
             });
             doPostStartup(generateBtcBlock);
         } catch (Exception ex) {
@@ -93,7 +94,8 @@ public class MethodTest extends ApiTestCase {
             setUpScaffold(new String[]{
                     "--supportingApps", toNameList.apply(supportingApps),
                     "--callRateMeteringConfigPath", callRateMeteringConfigFile.getAbsolutePath(),
-                    "--enableBisqDebugging", startSupportingAppsInDebugMode ? "true" : "false"
+                    "--enableBisqDebugging", startSupportingAppsInDebugMode ? "true" : "false",
+                    "--dumpStatistics", "true"
             });
             doPostStartup(generateBtcBlock);
         } catch (Exception ex) {

--- a/apitest/src/test/java/bisq/apitest/method/trade/BsqSwapBuyBtcTradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/BsqSwapBuyBtcTradeTest.java
@@ -47,7 +47,6 @@ import static protobuf.BsqSwapTrade.State.PREPARATION;
 
 
 
-import bisq.apitest.method.offer.AbstractOfferTest;
 import bisq.cli.GrpcClient;
 
 @Disabled
@@ -61,7 +60,7 @@ public class BsqSwapBuyBtcTradeTest extends AbstractTradeTest {
 
     @BeforeAll
     public static void setUp() {
-        AbstractOfferTest.setUp();
+        setUp(false);
     }
 
     @BeforeEach
@@ -95,12 +94,14 @@ public class BsqSwapBuyBtcTradeTest extends AbstractTradeTest {
         assertEquals(1_000_000L, mySwapOffer.getMinAmount());
         assertEquals(BSQ, mySwapOffer.getBaseCurrencyCode());
         assertEquals(BTC, mySwapOffer.getCounterCurrencyCode());
+        assertTrue(mySwapOffer.getIsMakerApiUser());
 
         genBtcBlocksThenWait(1, 2_500);
 
         mySwapOffer = aliceClient.getOffer(newOfferId);
         log.debug("My fetched BsqSwap SELL BSQ (BUY BTC) Offer:\n{}", toOfferTable.apply(mySwapOffer));
         assertNotEquals(0, mySwapOffer.getMakerFee());
+        assertTrue(mySwapOffer.getIsMakerApiUser());
 
         runCliGetOffer(newOfferId);
     }
@@ -124,6 +125,8 @@ public class BsqSwapBuyBtcTradeTest extends AbstractTradeTest {
         tradeId = swapTrade.getTradeId(); // Cache the tradeId for following test case(s).
         log.debug("BsqSwap Trade at PREPARATION:\n{}", toTradeDetailTable.apply(swapTrade));
         assertEquals(PREPARATION.name(), swapTrade.getState());
+        assertTrue(swapTrade.getOffer().getIsMakerApiUser());
+        assertTrue(swapTrade.getIsTakerApiUser());
         genBtcBlocksThenWait(1, 3_000);
 
         swapTrade = getBsqSwapTrade(bobClient, tradeId);
@@ -141,10 +144,14 @@ public class BsqSwapBuyBtcTradeTest extends AbstractTradeTest {
         var alicesTrade = getBsqSwapTrade(aliceClient, tradeId);
         log.debug("Alice's BsqSwap Trade at COMPLETION:\n{}", toTradeDetailTable.apply(alicesTrade));
         assertEquals(1, alicesTrade.getBsqSwapTradeInfo().getNumConfirmations());
+        assertTrue(alicesTrade.getOffer().getIsMakerApiUser());
+        assertTrue(alicesTrade.getIsTakerApiUser());
 
         var bobsTrade = getBsqSwapTrade(bobClient, tradeId);
         log.debug("Bob's BsqSwap Trade at COMPLETION:\n{}", toTradeDetailTable.apply(bobsTrade));
         assertEquals(1, bobsTrade.getBsqSwapTradeInfo().getNumConfirmations());
+        assertTrue(bobsTrade.getOffer().getIsMakerApiUser());
+        assertTrue(bobsTrade.getIsTakerApiUser());
 
         genBtcBlocksThenWait(1, 2_000);
 

--- a/apitest/src/test/java/bisq/apitest/method/trade/BsqSwapSellBtcTradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/BsqSwapSellBtcTradeTest.java
@@ -45,7 +45,6 @@ import static protobuf.BsqSwapTrade.State.PREPARATION;
 
 
 
-import bisq.apitest.method.offer.AbstractOfferTest;
 import bisq.cli.GrpcClient;
 
 @Disabled
@@ -59,7 +58,7 @@ public class BsqSwapSellBtcTradeTest extends AbstractTradeTest {
 
     @BeforeAll
     public static void setUp() {
-        AbstractOfferTest.setUp();
+        setUp(false);
     }
 
     @BeforeEach
@@ -93,12 +92,14 @@ public class BsqSwapSellBtcTradeTest extends AbstractTradeTest {
         assertEquals(1_000_000L, mySwapOffer.getMinAmount());
         assertEquals(BSQ, mySwapOffer.getBaseCurrencyCode());
         assertEquals(BTC, mySwapOffer.getCounterCurrencyCode());
+        assertTrue(mySwapOffer.getIsMakerApiUser());
 
         genBtcBlocksThenWait(1, 2_500);
 
         mySwapOffer = aliceClient.getOffer(newOfferId);
         log.debug("My fetched BsqSwap Buy BSQ (Sell BTC) OFFER:\n{}", toOfferTable.apply(mySwapOffer));
         assertNotEquals(0, mySwapOffer.getMakerFee());
+        assertTrue(mySwapOffer.getIsMakerApiUser());
 
         runCliGetOffer(newOfferId);
     }
@@ -122,6 +123,8 @@ public class BsqSwapSellBtcTradeTest extends AbstractTradeTest {
         tradeId = swapTrade.getTradeId(); // Cache the tradeId for following test case(s).
         log.debug("BsqSwap Trade at PREPARATION:\n{}", toTradeDetailTable.apply(swapTrade));
         assertEquals(PREPARATION.name(), swapTrade.getState());
+        assertTrue(swapTrade.getOffer().getIsMakerApiUser());
+        assertTrue(swapTrade.getIsTakerApiUser());
         genBtcBlocksThenWait(1, 3_000);
 
         swapTrade = getBsqSwapTrade(bobClient, tradeId);
@@ -139,10 +142,14 @@ public class BsqSwapSellBtcTradeTest extends AbstractTradeTest {
         var alicesTrade = getBsqSwapTrade(aliceClient, tradeId);
         log.debug("Alice's BsqSwap Trade at COMPLETION:\n{}", toTradeDetailTable.apply(alicesTrade));
         assertEquals(1, alicesTrade.getBsqSwapTradeInfo().getNumConfirmations());
+        assertTrue(alicesTrade.getOffer().getIsMakerApiUser());
+        assertTrue(alicesTrade.getIsTakerApiUser());
 
         var bobsTrade = getBsqSwapTrade(bobClient, tradeId);
         log.debug("Bob's BsqSwap Trade at COMPLETION:\n{}", toTradeDetailTable.apply(bobsTrade));
         assertEquals(1, bobsTrade.getBsqSwapTradeInfo().getNumConfirmations());
+        assertTrue(bobsTrade.getOffer().getIsMakerApiUser());
+        assertTrue(bobsTrade.getIsTakerApiUser());
 
         genBtcBlocksThenWait(1, 2_000);
 

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
@@ -37,6 +37,7 @@ import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_RECEIVED_PAYOUT_TX
 import static bisq.core.trade.model.bisq_v1.Trade.State.SELLER_SAW_ARRIVED_PAYOUT_TX_PUBLISHED_MSG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static protobuf.OfferDirection.BUY;
 import static protobuf.OpenOffer.State.AVAILABLE;
@@ -68,6 +69,7 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
                     NO_TRIGGER_PRICE);
             var offerId = alicesOffer.getId();
             assertFalse(alicesOffer.getIsCurrencyForMakerFeeBtc());
+            assertTrue(alicesOffer.getIsMakerApiUser());
 
             // Wait for Alice's AddToOfferBook task.
             // Wait times vary;  my logs show >= 2-second delay.
@@ -88,6 +90,9 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
 
             trade = bobClient.getTrade(tradeId);
             assertEquals(alicesOffer.getAmount(), trade.getTradeAmountAsLong());
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
+
             verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
@@ -125,6 +130,8 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
@@ -140,6 +147,8 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
         try {
             waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             var trade = bobClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             bobClient.confirmPaymentReceived(trade.getTradeId());
             sleep(3_000);
             trade = bobClient.getTrade(tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
@@ -106,6 +106,7 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
                     NO_TRIGGER_PRICE);
             var offerId = alicesOffer.getId();
             assertFalse(alicesOffer.getIsCurrencyForMakerFeeBtc());
+            assertTrue(alicesOffer.getIsMakerApiUser());
 
             // Wait for Alice's AddToOfferBook task.
             // Wait times vary;  my logs show >= 2 second delay.
@@ -119,6 +120,8 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
                     0L,
                     false);
             assertEquals(alicesOffer.getAmount(), trade.getTradeAmountAsLong());
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
 
             // Before generating a blk and confirming deposit tx, make sure there
             // are no bank acct details in the either side's contract.
@@ -182,6 +185,8 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
             sleep(6_000);
@@ -201,6 +206,8 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
         try {
             waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
             var trade = bobClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             bobClient.confirmPaymentReceived(trade.getTradeId());
             sleep(3_000);
             trade = bobClient.getTrade(tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
@@ -35,6 +35,7 @@ import static bisq.cli.table.builder.TableType.OFFER_TBL;
 import static bisq.core.trade.model.bisq_v1.Trade.Phase.PAYOUT_PUBLISHED;
 import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_RECEIVED_PAYOUT_TX_PUBLISHED_MSG;
 import static bisq.core.trade.model.bisq_v1.Trade.State.SELLER_SAW_ARRIVED_PAYOUT_TX_PUBLISHED_MSG;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -81,6 +82,7 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
                     alicesXmrAcct.getId(),
                     TRADE_FEE_CURRENCY_CODE);
             log.debug("Alice's BUY XMR (SELL BTC) Offer:\n{}", new TableBuilder(OFFER_TBL, alicesOffer).build());
+            assertTrue(alicesOffer.getIsMakerApiUser());
             genBtcBlocksThenWait(1, 5000);
             var offerId = alicesOffer.getId();
             assertFalse(alicesOffer.getIsCurrencyForMakerFeeBtc());
@@ -98,6 +100,8 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
 
             trade = bobClient.getTrade(tradeId);
             assertEquals(intendedTradeAmount, trade.getTradeAmountAsLong());
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
@@ -135,6 +139,8 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
     public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = bobClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
 
             verifyTakerDepositConfirmed(trade);
             log.debug("Bob sends XMR payment to Alice for trade {}", tradeId);
@@ -157,6 +163,8 @@ public class TakeBuyXMROfferTest extends AbstractTradeTest {
 
             sleep(2_000);
             var trade = aliceClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             // If we were trading BSQ, Alice would verify payment has been sent to her
             // Bisq / BSQ wallet, but we can do no such checks for XMR payments.
             // All XMR transfers are done outside Bisq.

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
@@ -71,6 +71,7 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
                     NO_TRIGGER_PRICE);
             var offerId = alicesOffer.getId();
             assertTrue(alicesOffer.getIsCurrencyForMakerFeeBtc());
+            assertTrue(alicesOffer.getIsMakerApiUser());
 
             // Wait for Alice's AddToOfferBook task.
             // Wait times vary;  my logs show >= 2-second delay, but taking sell offers
@@ -91,6 +92,9 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
 
             trade = bobClient.getTrade(tradeId);
             assertEquals(alicesOffer.getAmount(), trade.getTradeAmountAsLong());
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
+
             verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Buyer View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Seller View", bobClient.getTrade(tradeId));
@@ -128,6 +132,8 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
     public void testBobsConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = bobClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             verifyTakerDepositConfirmed(trade);
             bobClient.confirmPaymentStarted(tradeId);
             sleep(6_000);
@@ -144,6 +150,8 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
             waitUntilSellerSeesPaymentStartedMessage(log, testInfo, aliceClient, tradeId);
 
             var trade = aliceClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             aliceClient.confirmPaymentReceived(trade.getTradeId());
             sleep(3_000);
             trade = aliceClient.getTrade(tradeId);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
@@ -43,7 +43,6 @@ import static protobuf.OfferDirection.BUY;
 
 
 
-import bisq.apitest.method.offer.AbstractOfferTest;
 import bisq.cli.table.builder.TableBuilder;
 
 @Disabled
@@ -60,7 +59,7 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
 
     @BeforeAll
     public static void setUp() {
-        AbstractOfferTest.setUp(false);
+        setUp(false);
         createXmrPaymentAccounts();
         EXPECTED_PROTOCOL_STATUS.init();
     }
@@ -84,6 +83,7 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
                     TRADE_FEE_CURRENCY_CODE,
                     NO_TRIGGER_PRICE);
             log.debug("Alice's SELL XMR (BUY BTC) Offer:\n{}", new TableBuilder(OFFER_TBL, alicesOffer).build());
+            assertTrue(alicesOffer.getIsMakerApiUser());
             genBtcBlocksThenWait(1, 4000);
             var offerId = alicesOffer.getId();
             assertTrue(alicesOffer.getIsCurrencyForMakerFeeBtc());
@@ -101,6 +101,8 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
 
             trade = bobClient.getTrade(tradeId);
             assertEquals(intendedTradeAmount, trade.getTradeAmountAsLong());
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             verifyTakerDepositNotConfirmed(trade);
             logTrade(log, testInfo, "Alice's Maker/Seller View", aliceClient.getTrade(tradeId));
             logTrade(log, testInfo, "Bob's Taker/Buyer View", bobClient.getTrade(tradeId));
@@ -138,6 +140,8 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
     public void testAlicesConfirmPaymentStarted(final TestInfo testInfo) {
         try {
             var trade = aliceClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             waitForTakerDepositConfirmation(log, testInfo, aliceClient, trade.getTradeId());
             log.debug("Alice sends XMR payment to Bob for trade {}", trade.getTradeId());
             aliceClient.confirmPaymentStarted(trade.getTradeId());
@@ -158,6 +162,8 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
             waitUntilSellerSeesPaymentStartedMessage(log, testInfo, bobClient, tradeId);
 
             var trade = bobClient.getTrade(tradeId);
+            assertTrue(trade.getIsTakerApiUser());
+            assertTrue(trade.getOffer().getIsMakerApiUser());
             sleep(2_000);
             // If we were trading BSQ, Bob would verify payment has been sent to his
             // Bisq / BSQ wallet, but we can do no such checks for XMR payments.

--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -19,6 +19,7 @@ package bisq.apitest.scenario;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
@@ -46,6 +47,11 @@ import bisq.apitest.method.trade.TakeSellXMROfferTest;
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TradeTest extends AbstractTradeTest {
+
+    @BeforeAll
+    public static void setUp() {
+        setUp(false);
+    }
 
     @BeforeEach
     public void init() {

--- a/build.gradle
+++ b/build.gradle
@@ -404,10 +404,18 @@ configure(project(':core')) {
         testImplementation "com.natpryce:make-it-easy:$easyVersion"
         testImplementation "org.hamcrest:hamcrest-all:$hamcrestVersion"
         testImplementation "org.mockito:mockito-core:$mockitoVersion"
+
+        testImplementation "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
+        testImplementation "org.junit.jupiter:junit-jupiter-params:$jupiterVersion"
+        testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
     }
 
     test {
+        useJUnitPlatform()
         systemProperty 'jdk.attach.allowAttachSelf', true
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
     }
 }
 

--- a/common/src/main/java/bisq/common/app/Capability.java
+++ b/common/src/main/java/bisq/common/app/Capability.java
@@ -43,5 +43,6 @@ public enum Capability {
     TRADE_STATISTICS_HASH_UPDATE,       // We changed the hash method in 1.2.0 and that requires update to 1.2.2 for handling it correctly, otherwise the seed nodes have to process too much data.
     NO_ADDRESS_PRE_FIX,                 // At 1.4.0 we removed the prefix filter for mailbox messages. If a peer has that capability we do not sent the prefix.
     TRADE_STATISTICS_3,                 // We used a new reduced trade statistics model from v1.4.0 on
-    BSQ_SWAP_OFFER                     // Supports new message type BsqSwapOffer
+    BSQ_SWAP_OFFER,                     // Supports new message type BsqSwapOffer
+    API_TRADE_STATISTICS                // We use API trade statistics model since v1.9.6
 }

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -31,6 +31,7 @@ import bisq.core.trade.model.Tradable;
 import bisq.core.trade.model.TradeModel;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
+import bisq.core.trade.statistics.ApiTradeStatisticsManager;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 
 import bisq.common.app.Version;
@@ -76,6 +77,7 @@ public class CoreApi {
     private final CoreTradesService coreTradesService;
     private final CoreWalletsService walletsService;
     private final TradeStatisticsManager tradeStatisticsManager;
+    private final ApiTradeStatisticsManager apiTradeStatisticsManager;
 
     @Inject
     public CoreApi(Config config,
@@ -86,7 +88,8 @@ public class CoreApi {
                    CorePriceService corePriceService,
                    CoreTradesService coreTradesService,
                    CoreWalletsService walletsService,
-                   TradeStatisticsManager tradeStatisticsManager) {
+                   TradeStatisticsManager tradeStatisticsManager,
+                   ApiTradeStatisticsManager apiTradeStatisticsManager) {
         this.config = config;
         this.coreDisputeAgentsService = coreDisputeAgentsService;
         this.coreHelpService = coreHelpService;
@@ -96,6 +99,7 @@ public class CoreApi {
         this.corePriceService = corePriceService;
         this.walletsService = walletsService;
         this.tradeStatisticsManager = tradeStatisticsManager;
+        this.apiTradeStatisticsManager = apiTradeStatisticsManager;
     }
 
     @SuppressWarnings("SameReturnValue")

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -63,6 +63,7 @@ import static bisq.proto.grpc.EditOfferRequest.EditType;
  * Provides high level interface to functionality of core Bisq features.
  * E.g. useful for different APIs to access data of different domains of Bisq.
  */
+@SuppressWarnings("unused")
 @Singleton
 @Slf4j
 public class CoreApi {

--- a/core/src/main/java/bisq/core/api/model/OfferInfo.java
+++ b/core/src/main/java/bisq/core/api/model/OfferInfo.java
@@ -78,6 +78,7 @@ public class OfferInfo implements Payload {
     private final String pubKeyRing;
     private final String versionNumber;
     private final int protocolVersion;
+    private final boolean isMakerApiUser;
 
     public OfferInfo(OfferInfoBuilder builder) {
         this.id = builder.getId();
@@ -111,6 +112,7 @@ public class OfferInfo implements Payload {
         this.pubKeyRing = builder.getPubKeyRing();
         this.versionNumber = builder.getVersionNumber();
         this.protocolVersion = builder.getProtocolVersion();
+        this.isMakerApiUser = builder.isMakerApiUser();
     }
 
     public static OfferInfo toMyInactiveOfferInfo(Offer offer) {
@@ -193,7 +195,8 @@ public class OfferInfo implements Payload {
                 .withOwnerNodeAddress(offer.getOfferPayloadBase().getOwnerNodeAddress().getFullAddress())
                 .withPubKeyRing(offer.getOfferPayloadBase().getPubKeyRing().toString())
                 .withVersionNumber(offer.getOfferPayloadBase().getVersionNr())
-                .withProtocolVersion(offer.getOfferPayloadBase().getProtocolVersion());
+                .withProtocolVersion(offer.getOfferPayloadBase().getProtocolVersion())
+                .withIsMakerApiUser(offer.getOfferPayloadBase().isMakerApiUser());
     }
 
     private static long getMakerFee(Offer offer, boolean isMyOffer) {
@@ -245,6 +248,7 @@ public class OfferInfo implements Payload {
                 .setPubKeyRing(pubKeyRing)
                 .setVersionNr(versionNumber)
                 .setProtocolVersion(protocolVersion)
+                .setIsMakerApiUser(isMakerApiUser)
                 .build();
     }
 
@@ -282,6 +286,7 @@ public class OfferInfo implements Payload {
                 .withPubKeyRing(proto.getPubKeyRing())
                 .withVersionNumber(proto.getVersionNr())
                 .withProtocolVersion(proto.getProtocolVersion())
+                .withIsMakerApiUser(proto.getIsMakerApiUser())
                 .build();
     }
 }

--- a/core/src/main/java/bisq/core/api/model/TradeInfo.java
+++ b/core/src/main/java/bisq/core/api/model/TradeInfo.java
@@ -95,6 +95,7 @@ public class TradeInfo implements Payload {
     private final ContractInfo contract;
     // Optional BSQ swap trade protocol details (post v1).
     private BsqSwapTradeInfo bsqSwapTradeInfo;
+    private final boolean isTakerApiUser;
     private final String closingStatus;
 
     public TradeInfo(TradeInfoV1Builder builder) {
@@ -125,6 +126,7 @@ public class TradeInfo implements Payload {
         this.contractAsJson = builder.getContractAsJson();
         this.contract = builder.getContract();
         this.bsqSwapTradeInfo = null;
+        this.isTakerApiUser = builder.isTakerApiUser();
         this.closingStatus = builder.getClosingStatus();
     }
 
@@ -185,6 +187,7 @@ public class TradeInfo implements Payload {
                 // N/A for bsq-swaps: tradePeriodState, isDepositPublished, isDepositConfirmed
                 // N/A for bsq-swaps: isPaymentStartedMessageSent, isPaymentReceivedMessageSent, isPayoutPublished
                 // N/A for bsq-swaps: isCompleted, contractAsJson, contract
+                .withIsTakerApiUser(bsqSwapTrade.isTakerApiUser())
                 .withClosingStatus(closingStatus)
                 .build();
         tradeInfo.bsqSwapTradeInfo = toBsqSwapTradeInfo(bsqSwapTrade, isMyOffer, numConfirmations);
@@ -242,6 +245,7 @@ public class TradeInfo implements Payload {
                 .withIsCompleted(trade.isWithdrawn())
                 .withContractAsJson(trade.getContractAsJson())
                 .withContract(contractInfo)
+                .withIsTakerApiUser(trade.isTakerApiUser())
                 .withClosingStatus(closingStatus)
                 .build();
     }
@@ -278,6 +282,7 @@ public class TradeInfo implements Payload {
                         .setIsPaymentReceivedMessageSent(isPaymentReceivedMessageSent)
                         .setIsPayoutPublished(isPayoutPublished)
                         .setIsCompleted(isCompleted)
+                        .setIsTakerApiUser(isTakerApiUser)
                         .setClosingStatus(closingStatus);
         if (offer.isBsqSwapOffer()) {
             protoBuilder.setBsqSwapTradeInfo(bsqSwapTradeInfo.toProtoMessage());
@@ -317,6 +322,7 @@ public class TradeInfo implements Payload {
                 .withIsCompleted(proto.getIsCompleted())
                 .withContractAsJson(proto.getContractAsJson())
                 .withContract((ContractInfo.fromProto(proto.getContract())))
+                .withIsTakerApiUser(proto.getIsTakerApiUser())
                 .withClosingStatus(proto.getClosingStatus())
                 .build();
 
@@ -356,6 +362,7 @@ public class TradeInfo implements Payload {
                 ", contractAsJson=" + contractAsJson + "\n" +
                 ", contract=" + contract + "\n" +
                 ", bsqSwapTradeInfo=" + bsqSwapTradeInfo + "\n" +
+                ", isTakerApiUser=" + isTakerApiUser + "\n" +
                 ", closingStatus=" + closingStatus + "\n" +
                 '}';
     }

--- a/core/src/main/java/bisq/core/api/model/builder/OfferInfoBuilder.java
+++ b/core/src/main/java/bisq/core/api/model/builder/OfferInfoBuilder.java
@@ -61,6 +61,7 @@ public final class OfferInfoBuilder {
     private String pubKeyRing;
     private String versionNumber;
     private int protocolVersion;
+    private boolean isMakerApiUser;
 
     public OfferInfoBuilder withId(String id) {
         this.id = id;
@@ -214,6 +215,11 @@ public final class OfferInfoBuilder {
 
     public OfferInfoBuilder withProtocolVersion(int protocolVersion) {
         this.protocolVersion = protocolVersion;
+        return this;
+    }
+
+    public OfferInfoBuilder withIsMakerApiUser(boolean isMakerApiUser) {
+        this.isMakerApiUser = isMakerApiUser;
         return this;
     }
 

--- a/core/src/main/java/bisq/core/api/model/builder/TradeInfoV1Builder.java
+++ b/core/src/main/java/bisq/core/api/model/builder/TradeInfoV1Builder.java
@@ -58,6 +58,7 @@ public final class TradeInfoV1Builder {
     private boolean isCompleted;
     private String contractAsJson;
     private ContractInfo contract;
+    private boolean isTakerApiUser;
     private String closingStatus;
 
     public TradeInfoV1Builder withOffer(OfferInfo offer) {
@@ -187,6 +188,11 @@ public final class TradeInfoV1Builder {
 
     public TradeInfoV1Builder withContract(ContractInfo contract) {
         this.contract = contract;
+        return this;
+    }
+
+    public TradeInfoV1Builder withIsTakerApiUser(boolean isTakerApiUser) {
+        this.isTakerApiUser = isTakerApiUser;
         return this;
     }
 

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -28,6 +28,7 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.setup.CorePersistedDataHost;
 import bisq.core.setup.CoreSetup;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
+import bisq.core.trade.statistics.ApiTradeStatisticsManager;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.trade.txproof.xmr.XmrTxProofService;
 
@@ -252,6 +253,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
             injector.getInstance(PriceFeedService.class).shutDown();
             injector.getInstance(ArbitratorManager.class).shutDown();
             injector.getInstance(TradeStatisticsManager.class).shutDown();
+            injector.getInstance(ApiTradeStatisticsManager.class).shutDown();
             injector.getInstance(XmrTxProofService.class).shutDown();
             injector.getInstance(RpcService.class).shutDown();
             injector.getInstance(DaoSetup.class).shutDown();

--- a/core/src/main/java/bisq/core/app/DomainInitialisation.java
+++ b/core/src/main/java/bisq/core/app/DomainInitialisation.java
@@ -53,6 +53,7 @@ import bisq.core.trade.ClosedTradableManager;
 import bisq.core.trade.TradeManager;
 import bisq.core.trade.bisq_v1.FailedTradesManager;
 import bisq.core.trade.bsq_swap.BsqSwapTradeManager;
+import bisq.core.trade.statistics.ApiTradeStatisticsManager;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.trade.txproof.xmr.XmrTxProofService;
 import bisq.core.user.User;
@@ -100,6 +101,7 @@ public class DomainInitialisation {
     private final FeeService feeService;
     private final DaoSetup daoSetup;
     private final TradeStatisticsManager tradeStatisticsManager;
+    private final ApiTradeStatisticsManager apiTradeStatisticsManager;
     private final AccountAgeWitnessService accountAgeWitnessService;
     private final SignedWitnessService signedWitnessService;
     private final PriceFeedService priceFeedService;
@@ -140,6 +142,7 @@ public class DomainInitialisation {
                                 FeeService feeService,
                                 DaoSetup daoSetup,
                                 TradeStatisticsManager tradeStatisticsManager,
+                                ApiTradeStatisticsManager apiTradeStatisticsManager,
                                 AccountAgeWitnessService accountAgeWitnessService,
                                 SignedWitnessService signedWitnessService,
                                 PriceFeedService priceFeedService,
@@ -178,6 +181,7 @@ public class DomainInitialisation {
         this.feeService = feeService;
         this.daoSetup = daoSetup;
         this.tradeStatisticsManager = tradeStatisticsManager;
+        this.apiTradeStatisticsManager = apiTradeStatisticsManager;
         this.accountAgeWitnessService = accountAgeWitnessService;
         this.signedWitnessService = signedWitnessService;
         this.priceFeedService = priceFeedService;
@@ -255,6 +259,7 @@ public class DomainInitialisation {
         }
 
         tradeStatisticsManager.onAllServicesInitialized();
+        apiTradeStatisticsManager.onAllServicesInitialized();
 
         accountAgeWitnessService.onAllServicesInitialized();
         signedWitnessService.onAllServicesInitialized();

--- a/core/src/main/java/bisq/core/app/misc/AppSetupWithP2P.java
+++ b/core/src/main/java/bisq/core/app/misc/AppSetupWithP2P.java
@@ -20,6 +20,7 @@ package bisq.core.app.misc;
 import bisq.core.account.sign.SignedWitnessService;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.filter.FilterManager;
+import bisq.core.trade.statistics.ApiTradeStatisticsManager;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 
 import bisq.network.p2p.P2PService;
@@ -52,6 +53,7 @@ public class AppSetupWithP2P extends AppSetup {
     private final P2PDataStorage p2PDataStorage;
     private final PeerManager peerManager;
     protected final TradeStatisticsManager tradeStatisticsManager;
+    protected final ApiTradeStatisticsManager apiTradeStatisticsManager;
     protected ArrayList<PersistedDataHost> persistedDataHosts;
     protected BooleanProperty p2pNetWorkReady;
 
@@ -60,6 +62,7 @@ public class AppSetupWithP2P extends AppSetup {
                            P2PDataStorage p2PDataStorage,
                            PeerManager peerManager,
                            TradeStatisticsManager tradeStatisticsManager,
+                           ApiTradeStatisticsManager apiTradeStatisticsManager,
                            AccountAgeWitnessService accountAgeWitnessService,
                            SignedWitnessService signedWitnessService,
                            FilterManager filterManager,
@@ -69,6 +72,7 @@ public class AppSetupWithP2P extends AppSetup {
         this.p2PDataStorage = p2PDataStorage;
         this.peerManager = peerManager;
         this.tradeStatisticsManager = tradeStatisticsManager;
+        this.apiTradeStatisticsManager = apiTradeStatisticsManager;
         this.accountAgeWitnessService = accountAgeWitnessService;
         this.signedWitnessService = signedWitnessService;
         this.filterManager = filterManager;
@@ -188,6 +192,7 @@ public class AppSetupWithP2P extends AppSetup {
         p2PService.onAllServicesInitialized();
 
         tradeStatisticsManager.onAllServicesInitialized();
+        apiTradeStatisticsManager.onAllServicesInitialized();
 
         accountAgeWitnessService.onAllServicesInitialized();
         signedWitnessService.onAllServicesInitialized();

--- a/core/src/main/java/bisq/core/app/misc/AppSetupWithP2PAndDAO.java
+++ b/core/src/main/java/bisq/core/app/misc/AppSetupWithP2PAndDAO.java
@@ -27,6 +27,7 @@ import bisq.core.dao.governance.myvote.MyVoteListService;
 import bisq.core.dao.governance.proofofburn.MyProofOfBurnListService;
 import bisq.core.dao.governance.proposal.MyProposalListService;
 import bisq.core.filter.FilterManager;
+import bisq.core.trade.statistics.ApiTradeStatisticsManager;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 
@@ -50,6 +51,7 @@ public class AppSetupWithP2PAndDAO extends AppSetupWithP2P {
                                  P2PDataStorage p2PDataStorage,
                                  PeerManager peerManager,
                                  TradeStatisticsManager tradeStatisticsManager,
+                                 ApiTradeStatisticsManager apiTradeStatisticsManager,
                                  AccountAgeWitnessService accountAgeWitnessService,
                                  SignedWitnessService signedWitnessService,
                                  FilterManager filterManager,
@@ -66,6 +68,7 @@ public class AppSetupWithP2PAndDAO extends AppSetupWithP2P {
                 p2PDataStorage,
                 peerManager,
                 tradeStatisticsManager,
+                apiTradeStatisticsManager,
                 accountAgeWitnessService,
                 signedWitnessService,
                 filterManager,

--- a/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
@@ -64,6 +64,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
     protected transient byte[] hash;
     @Nullable
     protected final Map<String, String> extraDataMap;
+    protected final boolean isMakerApiUser;
 
     public OfferPayloadBase(String id,
                             long date,
@@ -78,6 +79,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
                             String paymentMethodId,
                             String makerPaymentAccountId,
                             @Nullable Map<String, String> extraDataMap,
+                            boolean isMakerApiUser,
                             String versionNr,
                             int protocolVersion) {
         this.id = id;
@@ -93,6 +95,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
         this.paymentMethodId = paymentMethodId;
         this.makerPaymentAccountId = makerPaymentAccountId;
         this.extraDataMap = extraDataMap;
+        this.isMakerApiUser = isMakerApiUser;
         this.versionNr = versionNr;
         this.protocolVersion = protocolVersion;
     }
@@ -142,6 +145,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
                 ",\r\n     pubKeyRing=" + pubKeyRing +
                 ",\r\n     hash=" + (hash != null ? Hex.encode(hash) : "null") +
                 ",\r\n     extraDataMap=" + extraDataMap +
+                ",\r\n     isMakerApiUser=" + isMakerApiUser +
                 "\r\n}";
     }
 }

--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -452,6 +452,7 @@ public class OfferUtil {
                 original.isPrivateOffer(),
                 original.getHashOfChallenge(),
                 mutableOfferPayloadFields.getExtraDataMap(),
+                original.isMakerApiUser(),
                 original.getProtocolVersion());
     }
 

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -898,6 +898,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                         original.isPrivateOffer(),
                         original.getHashOfChallenge(),
                         updatedExtraDataMap,
+                        original.isMakerApiUser(),
                         protocolVersion);
 
                 // Save states from original data to use for the updated

--- a/core/src/main/java/bisq/core/offer/bisq_v1/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/CreateOfferService.java
@@ -17,6 +17,7 @@
 
 package bisq.core.offer.bisq_v1;
 
+import bisq.core.api.CoreContext;
 import bisq.core.btc.TxFeeEstimationService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.Restrictions;
@@ -67,6 +68,7 @@ public class CreateOfferService {
     private final PubKeyRing pubKeyRing;
     private final User user;
     private final BtcWalletService btcWalletService;
+    private final CoreContext coreContext;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -80,7 +82,8 @@ public class CreateOfferService {
                               P2PService p2PService,
                               PubKeyRing pubKeyRing,
                               User user,
-                              BtcWalletService btcWalletService) {
+                              BtcWalletService btcWalletService,
+                              CoreContext coreContext) {
         this.offerUtil = offerUtil;
         this.txFeeEstimationService = txFeeEstimationService;
         this.priceFeedService = priceFeedService;
@@ -88,6 +91,7 @@ public class CreateOfferService {
         this.pubKeyRing = pubKeyRing;
         this.user = user;
         this.btcWalletService = btcWalletService;
+        this.coreContext = coreContext;
     }
 
 
@@ -216,6 +220,7 @@ public class CreateOfferService {
                 isPrivateOffer,
                 hashOfChallenge,
                 extraDataMap,
+                coreContext.isApiUser(),
                 Version.TRADE_PROTOCOL_VERSION);
         Offer offer = new Offer(offerPayload);
         offer.setPriceFeedService(priceFeedService);

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
@@ -171,6 +171,7 @@ public final class OfferPayload extends OfferPayloadBase {
                         boolean isPrivateOffer,
                         @Nullable String hashOfChallenge,
                         @Nullable Map<String, String> extraDataMap,
+                        boolean isMakerApiUser,
                         int protocolVersion) {
         super(id,
                 date,
@@ -185,6 +186,7 @@ public final class OfferPayload extends OfferPayloadBase {
                 paymentMethodId,
                 makerPaymentAccountId,
                 extraDataMap,
+                isMakerApiUser,
                 versionNr,
                 protocolVersion);
 
@@ -265,7 +267,8 @@ public final class OfferPayload extends OfferPayloadBase {
                 .setLowerClosePrice(lowerClosePrice)
                 .setUpperClosePrice(upperClosePrice)
                 .setIsPrivateOffer(isPrivateOffer)
-                .setProtocolVersion(protocolVersion);
+                .setProtocolVersion(protocolVersion)
+                .setIsMakerApiUser(isMakerApiUser);
 
         builder.setOfferFeePaymentTxId(checkNotNull(offerFeePaymentTxId,
                 "OfferPayload is in invalid state: offerFeePaymentTxID is not set when adding to P2P network."));
@@ -331,6 +334,7 @@ public final class OfferPayload extends OfferPayloadBase {
                 proto.getIsPrivateOffer(),
                 hashOfChallenge,
                 extraDataMapMap,
+                proto.getIsMakerApiUser(),
                 proto.getProtocolVersion());
     }
 
@@ -359,6 +363,7 @@ public final class OfferPayload extends OfferPayloadBase {
                 ",\r\n     lowerClosePrice=" + lowerClosePrice +
                 ",\r\n     upperClosePrice=" + upperClosePrice +
                 ",\r\n     isPrivateOffer=" + isPrivateOffer +
+                ",\r\n     isMakerApiUser=" + isMakerApiUser +
                 ",\r\n     hashOfChallenge='" + hashOfChallenge + '\'' +
                 "\r\n} " + super.toString();
     }
@@ -400,6 +405,8 @@ public final class OfferPayload extends OfferPayloadBase {
             object.add("lowerClosePrice", context.serialize(offerPayload.getLowerClosePrice()));
             object.add("upperClosePrice", context.serialize(offerPayload.getUpperClosePrice()));
             object.add("isPrivateOffer", context.serialize(offerPayload.isPrivateOffer()));
+            // TODO? isMakerApiUser (not backward compatible?)
+            //  @chimp1984, can you review these changes?
             object.add("extraDataMap", context.serialize(offerPayload.getExtraDataMap()));
             object.add("protocolVersion", context.serialize(offerPayload.getProtocolVersion()));
             return object;

--- a/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
@@ -127,6 +127,7 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 .setAmount(amount)
                 .setMinAmount(minAmount)
                 .setProofOfWork(proofOfWork.toProtoMessage())
+                .setIsMakerApiUser(isMakerApiUser)
                 .setVersionNr(versionNr)
                 .setProtocolVersion(protocolVersion);
 

--- a/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
@@ -61,6 +61,7 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 original.getMinAmount(),
                 proofOfWork,
                 original.getExtraDataMap(),
+                original.isMakerApiUser(),
                 original.getVersionNr(),
                 original.getProtocolVersion()
         );
@@ -78,6 +79,7 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                                long minAmount,
                                ProofOfWork proofOfWork,
                                @Nullable Map<String, String> extraDataMap,
+                               boolean isMakerApiUser,
                                String versionNr,
                                int protocolVersion) {
         super(id,
@@ -93,6 +95,7 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 PaymentMethod.BSQ_SWAP_ID,
                 BsqSwapAccount.ID,
                 extraDataMap,
+                isMakerApiUser,
                 versionNr,
                 protocolVersion);
 
@@ -145,6 +148,7 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 proto.getMinAmount(),
                 ProofOfWork.fromProto(proto.getProofOfWork()),
                 extraDataMapMap,
+                proto.getIsMakerApiUser(),
                 proto.getVersionNr(),
                 proto.getProtocolVersion()
         );

--- a/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
@@ -17,6 +17,7 @@
 
 package bisq.core.offer.bsq_swap;
 
+import bisq.core.api.CoreContext;
 import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.dao.DaoFacade;
@@ -83,6 +84,7 @@ public class OpenBsqSwapOfferService {
     private final OfferUtil offerUtil;
     private final FilterManager filterManager;
     private final PubKeyRing pubKeyRing;
+    private final CoreContext coreContext;
 
     private final Map<String, OpenBsqSwapOffer> openBsqSwapOffersById = new HashMap<>();
     private final ListChangeListener<OpenOffer> offerListChangeListener;
@@ -100,7 +102,8 @@ public class OpenBsqSwapOfferService {
                                    OfferBookService offerBookService,
                                    OfferUtil offerUtil,
                                    FilterManager filterManager,
-                                   PubKeyRing pubKeyRing) {
+                                   PubKeyRing pubKeyRing,
+                                   CoreContext coreContext) {
         this.openOfferManager = openOfferManager;
         this.btcWalletService = btcWalletService;
         this.bsqWalletService = bsqWalletService;
@@ -111,6 +114,7 @@ public class OpenBsqSwapOfferService {
         this.offerUtil = offerUtil;
         this.filterManager = filterManager;
         this.pubKeyRing = pubKeyRing;
+        this.coreContext = coreContext;
 
         offerListChangeListener = c -> {
             c.next();
@@ -219,6 +223,7 @@ public class OpenBsqSwapOfferService {
                                 minAmount.getValue(),
                                 proofOfWork,
                                 null,
+                                coreContext.isApiUser(),
                                 Version.VERSION,
                                 Version.TRADE_PROTOCOL_VERSION);
                         resultHandler.accept(new Offer(bsqSwapOfferPayload));

--- a/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -79,6 +79,7 @@ import bisq.core.payment.payload.VenmoAccountPayload;
 import bisq.core.payment.payload.VerseAccountPayload;
 import bisq.core.payment.payload.WeChatPayAccountPayload;
 import bisq.core.payment.payload.WesternUnionAccountPayload;
+import bisq.core.trade.statistics.ApiTradeStatistics;
 import bisq.core.trade.statistics.TradeStatistics2;
 import bisq.core.trade.statistics.TradeStatistics3;
 
@@ -267,6 +268,8 @@ public class CoreProtoResolver implements ProtoResolver {
                     return SignedWitness.fromProto(proto.getSignedWitness());
                 case TRADE_STATISTICS3:
                     return TradeStatistics3.fromProto(proto.getTradeStatistics3());
+                case API_TRADE_STATISTICS:
+                    return ApiTradeStatistics.fromProto(proto.getApiTradeStatistics());
                 default:
                     throw new ProtobufferRuntimeException("Unknown proto message case (PB.PersistableNetworkPayload). messageCase=" + proto.getMessageCase());
             }

--- a/core/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
@@ -39,6 +39,7 @@ import bisq.core.support.dispute.arbitration.ArbitrationDisputeList;
 import bisq.core.support.dispute.mediation.MediationDisputeList;
 import bisq.core.support.dispute.refund.RefundDisputeList;
 import bisq.core.trade.model.TradableList;
+import bisq.core.trade.statistics.ApiTradeStatisticsStore;
 import bisq.core.trade.statistics.TradeStatistics2Store;
 import bisq.core.trade.statistics.TradeStatistics3Store;
 import bisq.core.user.PreferencesPayload;
@@ -141,6 +142,8 @@ public class CorePersistenceProtoResolver extends CoreProtoResolver implements P
                     return RemovedPayloadsMap.fromProto(proto.getRemovedPayloadsMap());
                 case BSQ_BLOCK_STORE:
                     return BsqBlockStore.fromProto(proto.getBsqBlockStore());
+                case API_TRADE_STATISTICS_STORE:
+                    return ApiTradeStatisticsStore.fromProto(proto.getApiTradeStatisticsStore());
                 default:
                     throw new ProtobufferRuntimeException("Unknown proto message case(PB.PersistableEnvelope). " +
                             "messageCase=" + proto.getMessageCase() + "; proto raw data=" + proto.toString());

--- a/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
+++ b/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
@@ -42,7 +42,8 @@ public class CoreNetworkCapabilities {
                 Capability.TRADE_STATISTICS_HASH_UPDATE,
                 Capability.NO_ADDRESS_PRE_FIX,
                 Capability.TRADE_STATISTICS_3,
-                Capability.BSQ_SWAP_OFFER
+                Capability.BSQ_SWAP_OFFER,
+                Capability.API_TRADE_STATISTICS
         );
 
         if (config.daoActivated) {

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade;
 
+import bisq.core.api.CoreContext;
 import bisq.core.btc.exceptions.AddressEntryException;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BsqWalletService;
@@ -166,6 +167,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     @Getter
     private final LongProperty numPendingTrades = new SimpleLongProperty();
     private final ReferralIdService referralIdService;
+    private final CoreContext coreContext;
     private final CorePersistenceProtoResolver corePersistenceProtoResolver;
     private final DumpDelayedPayoutTx dumpDelayedPayoutTx;
     @Getter
@@ -195,6 +197,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                         ClockWatcher clockWatcher,
                         PersistenceManager<TradableList<Trade>> persistenceManager,
                         ReferralIdService referralIdService,
+                        CoreContext coreContext,
                         CorePersistenceProtoResolver corePersistenceProtoResolver,
                         DumpDelayedPayoutTx dumpDelayedPayoutTx,
                         @Named(Config.ALLOW_FAULTY_DELAYED_TXS) boolean allowFaultyDelayedTxs) {
@@ -215,6 +218,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         this.provider = provider;
         this.clockWatcher = clockWatcher;
         this.referralIdService = referralIdService;
+        this.coreContext = coreContext;
         this.corePersistenceProtoResolver = corePersistenceProtoResolver;
         this.dumpDelayedPayoutTx = dumpDelayedPayoutTx;
         this.allowFaultyDelayedTxs = allowFaultyDelayedTxs;
@@ -295,6 +299,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                     openOffer.getRefundAgentNodeAddress(),
                     btcWalletService,
                     getNewProcessModel(offer),
+                    coreContext.isApiUser(),
                     UUID.randomUUID().toString());
         } else {
             trade = new SellerAsMakerTrade(offer,
@@ -306,6 +311,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                     openOffer.getRefundAgentNodeAddress(),
                     btcWalletService,
                     getNewProcessModel(offer),
+                    coreContext.isApiUser(),
                     UUID.randomUUID().toString());
         }
 
@@ -347,7 +353,8 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                     request.getTxFeePerVbyte(),
                     request.getMakerFee(),
                     request.getTakerFee(),
-                    bsqSwapProtocolModel);
+                    bsqSwapProtocolModel,
+                    coreContext.isApiUser());
         } else {
             checkArgument(request instanceof SellersBsqSwapRequest);
             checkArgument(offer.isBuyOffer(),
@@ -360,7 +367,8 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                     request.getTxFeePerVbyte(),
                     request.getMakerFee(),
                     request.getTakerFee(),
-                    bsqSwapProtocolModel);
+                    bsqSwapProtocolModel,
+                    coreContext.isApiUser());
         }
 
         TradeProtocol tradeProtocol = createTradeProtocol(bsqSwapTrade);
@@ -529,6 +537,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                                     model.getSelectedRefundAgent(),
                                     btcWalletService,
                                     getNewProcessModel(offer),
+                                    coreContext.isApiUser(),
                                     UUID.randomUUID().toString());
                         } else {
                             trade = new BuyerAsTakerTrade(offer,
@@ -543,6 +552,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                                     model.getSelectedRefundAgent(),
                                     btcWalletService,
                                     getNewProcessModel(offer),
+                                    coreContext.isApiUser(),
                                     UUID.randomUUID().toString());
                         }
                         trade.getProcessModel().setUseSavingsWallet(useSavingsWallet);
@@ -589,7 +599,8 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                                     txFeePerVbyte,
                                     makerFee,
                                     takerFee,
-                                    bsqSwapProtocolModel);
+                                    bsqSwapProtocolModel,
+                                    coreContext.isApiUser());
                         } else {
                             bsqSwapTrade = new BsqSwapBuyerAsTakerTrade(
                                     offer,
@@ -598,7 +609,8 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                                     txFeePerVbyte,
                                     makerFee,
                                     takerFee,
-                                    bsqSwapProtocolModel);
+                                    bsqSwapProtocolModel,
+                                    coreContext.isApiUser());
                         }
 
                         TradeProtocol tradeProtocol = createTradeProtocol(bsqSwapTrade);

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/BuyerAsMakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/BuyerAsMakerTrade.java
@@ -52,6 +52,7 @@ public final class BuyerAsMakerTrade extends BuyerTrade implements MakerTrade {
                              @Nullable NodeAddress refundAgentNodeAddress,
                              BtcWalletService btcWalletService,
                              ProcessModel processModel,
+                             boolean isTakerApiUser,
                              String uid) {
         super(offer,
                 txFee,
@@ -62,6 +63,7 @@ public final class BuyerAsMakerTrade extends BuyerTrade implements MakerTrade {
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 
@@ -96,6 +98,7 @@ public final class BuyerAsMakerTrade extends BuyerTrade implements MakerTrade {
                 proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                 btcWalletService,
                 processModel,
+                proto.getIsTakerApiUser(),
                 uid);
 
         trade.setAmountAsLong(proto.getTradeAmountAsLong());

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/BuyerAsTakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/BuyerAsTakerTrade.java
@@ -55,6 +55,7 @@ public final class BuyerAsTakerTrade extends BuyerTrade implements TakerTrade {
                              @Nullable NodeAddress refundAgentNodeAddress,
                              BtcWalletService btcWalletService,
                              ProcessModel processModel,
+                             boolean isTakerApiUser,
                              String uid) {
         super(offer,
                 tradeAmount,
@@ -68,6 +69,7 @@ public final class BuyerAsTakerTrade extends BuyerTrade implements TakerTrade {
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 
@@ -106,6 +108,7 @@ public final class BuyerAsTakerTrade extends BuyerTrade implements TakerTrade {
                         proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                         btcWalletService,
                         processModel,
+                        proto.getIsTakerApiUser(),
                         uid),
                 proto,
                 coreProtoResolver);

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/BuyerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/BuyerTrade.java
@@ -45,6 +45,7 @@ public abstract class BuyerTrade extends Trade {
                @Nullable NodeAddress refundAgentNodeAddress,
                BtcWalletService btcWalletService,
                ProcessModel processModel,
+               boolean isTakerApiUser,
                String uid) {
         super(offer,
                 tradeAmount,
@@ -58,6 +59,7 @@ public abstract class BuyerTrade extends Trade {
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 
@@ -70,6 +72,7 @@ public abstract class BuyerTrade extends Trade {
                @Nullable NodeAddress refundAgentNodeAddress,
                BtcWalletService btcWalletService,
                ProcessModel processModel,
+               boolean isTakerApiUser,
                String uid) {
         super(offer,
                 txFee,
@@ -80,6 +83,7 @@ public abstract class BuyerTrade extends Trade {
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/SellerAsMakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/SellerAsMakerTrade.java
@@ -52,6 +52,7 @@ public final class SellerAsMakerTrade extends SellerTrade implements MakerTrade 
                               @Nullable NodeAddress refundAgentNodeAddress,
                               BtcWalletService btcWalletService,
                               ProcessModel processModel,
+                              boolean isTakerApiUser,
                               String uid) {
         super(offer,
                 txFee,
@@ -62,6 +63,7 @@ public final class SellerAsMakerTrade extends SellerTrade implements MakerTrade 
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 
@@ -97,6 +99,7 @@ public final class SellerAsMakerTrade extends SellerTrade implements MakerTrade 
                 proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                 btcWalletService,
                 processModel,
+                proto.getIsTakerApiUser(),
                 uid);
 
         trade.setAmountAsLong(proto.getTradeAmountAsLong());

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/SellerAsTakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/SellerAsTakerTrade.java
@@ -55,6 +55,7 @@ public final class SellerAsTakerTrade extends SellerTrade implements TakerTrade 
                               @Nullable NodeAddress refundAgentNodeAddress,
                               BtcWalletService btcWalletService,
                               ProcessModel processModel,
+                              boolean isTakerApiUser,
                               String uid) {
         super(offer,
                 tradeAmount,
@@ -68,6 +69,7 @@ public final class SellerAsTakerTrade extends SellerTrade implements TakerTrade 
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 
@@ -106,6 +108,7 @@ public final class SellerAsTakerTrade extends SellerTrade implements TakerTrade 
                         proto.hasRefundAgentNodeAddress() ? NodeAddress.fromProto(proto.getRefundAgentNodeAddress()) : null,
                         btcWalletService,
                         processModel,
+                        proto.getIsTakerApiUser(),
                         uid),
                 proto,
                 coreProtoResolver);

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/SellerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/SellerTrade.java
@@ -45,6 +45,7 @@ public abstract class SellerTrade extends Trade {
                 @Nullable NodeAddress refundAgentNodeAddress,
                 BtcWalletService btcWalletService,
                 ProcessModel processModel,
+                boolean isTakerApiUser,
                 String uid) {
         super(offer,
                 tradeAmount,
@@ -58,6 +59,7 @@ public abstract class SellerTrade extends Trade {
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 
@@ -70,6 +72,7 @@ public abstract class SellerTrade extends Trade {
                 @Nullable NodeAddress refundAgentNodeAddress,
                 BtcWalletService btcWalletService,
                 ProcessModel processModel,
+                boolean isTakerApiUser,
                 String uid) {
         super(offer,
                 txFee,
@@ -80,6 +83,7 @@ public abstract class SellerTrade extends Trade {
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
     }
 

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/Trade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/Trade.java
@@ -441,6 +441,9 @@ public abstract class Trade extends TradeModel {
     @Getter
     transient final private IntegerProperty assetTxProofResultUpdateProperty = new SimpleIntegerProperty();
 
+    // Added at v1.9.6
+    @Getter
+    private final boolean isTakerApiUser;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor, initialization
@@ -456,6 +459,7 @@ public abstract class Trade extends TradeModel {
                     @Nullable NodeAddress refundAgentNodeAddress,
                     BtcWalletService btcWalletService,
                     ProcessModel processModel,
+                    boolean isTakerApiUser,
                     String uid) {
         super(uid, offer);
         this.tradeTxFee = tradeTxFee;
@@ -466,6 +470,7 @@ public abstract class Trade extends TradeModel {
         this.refundAgentNodeAddress = refundAgentNodeAddress;
         this.btcWalletService = btcWalletService;
         this.processModel = processModel;
+        this.isTakerApiUser = isTakerApiUser;
 
         tradeTxFeeAsLong = tradeTxFee.value;
         takerFeeAsLong = takerFee.value;
@@ -486,6 +491,7 @@ public abstract class Trade extends TradeModel {
                     @Nullable NodeAddress refundAgentNodeAddress,
                     BtcWalletService btcWalletService,
                     ProcessModel processModel,
+                    boolean isTakerApiUser,
                     String uid) {
 
         this(offer,
@@ -497,6 +503,7 @@ public abstract class Trade extends TradeModel {
                 refundAgentNodeAddress,
                 btcWalletService,
                 processModel,
+                isTakerApiUser,
                 uid);
         this.priceAsLong = priceAsLong;
 
@@ -518,6 +525,7 @@ public abstract class Trade extends TradeModel {
                 .setTakerFeeAsLong(takerFeeAsLong)
                 .setTakeOfferDate(takeOfferDate)
                 .setProcessModel(processModel.toProtoMessage())
+                .setIsTakerApiUser(isTakerApiUser)
                 .setTradeAmountAsLong(amountAsLong)
                 .setTradePrice(priceAsLong)
                 .setState(Trade.State.toProtoMessage(state))
@@ -1178,6 +1186,7 @@ public abstract class Trade extends TradeModel {
                 ",\n     refundAgentPubKeyRing=" + refundAgentPubKeyRing +
                 ",\n     refundResultState=" + refundResultState +
                 ",\n     refundResultStateProperty=" + refundResultStateProperty +
+                ",\n     isTakerApiUser=" + isTakerApiUser +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapBuyerAsMakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapBuyerAsMakerTrade.java
@@ -43,7 +43,8 @@ public final class BsqSwapBuyerAsMakerTrade extends BsqSwapBuyerTrade implements
                                     long txFeePerVbyte,
                                     long makerFee,
                                     long takerFee,
-                                    BsqSwapProtocolModel bsqSwapProtocolModel) {
+                                    BsqSwapProtocolModel bsqSwapProtocolModel,
+                                    boolean isTakerApiUser) {
 
 
         super(UUID.randomUUID().toString(),
@@ -55,6 +56,7 @@ public final class BsqSwapBuyerAsMakerTrade extends BsqSwapBuyerTrade implements
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 null,
                 BsqSwapTrade.State.PREPARATION,
                 null);
@@ -74,6 +76,7 @@ public final class BsqSwapBuyerAsMakerTrade extends BsqSwapBuyerTrade implements
                                      long makerFee,
                                      long takerFee,
                                      BsqSwapProtocolModel bsqSwapProtocolModel,
+                                     boolean isTakerApiUser,
                                      @Nullable String errorMessage,
                                      State state,
                                      @Nullable String txId) {
@@ -86,6 +89,7 @@ public final class BsqSwapBuyerAsMakerTrade extends BsqSwapBuyerTrade implements
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 errorMessage,
                 state,
                 txId);
@@ -115,6 +119,7 @@ public final class BsqSwapBuyerAsMakerTrade extends BsqSwapBuyerTrade implements
                 proto.getMakerFee(),
                 proto.getTakerFee(),
                 BsqSwapProtocolModel.fromProto(proto.getBsqSwapProtocolModel()),
+                proto.getIsTakerApiUser(),
                 ProtoUtil.stringOrNullFromProto(proto.getErrorMessage()),
                 State.fromProto(proto.getState()),
                 ProtoUtil.stringOrNullFromProto(proto.getTxId()));

--- a/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapBuyerAsTakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapBuyerAsTakerTrade.java
@@ -43,7 +43,8 @@ public final class BsqSwapBuyerAsTakerTrade extends BsqSwapBuyerTrade implements
                                     long txFeePerVbyte,
                                     long makerFee,
                                     long takerFee,
-                                    BsqSwapProtocolModel bsqSwapProtocolModel) {
+                                    BsqSwapProtocolModel bsqSwapProtocolModel,
+                                    boolean isTakerApiUser) {
 
 
         super(UUID.randomUUID().toString(),
@@ -55,6 +56,7 @@ public final class BsqSwapBuyerAsTakerTrade extends BsqSwapBuyerTrade implements
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 null,
                 BsqSwapTrade.State.PREPARATION,
                 null);
@@ -74,6 +76,7 @@ public final class BsqSwapBuyerAsTakerTrade extends BsqSwapBuyerTrade implements
                                      long makerFee,
                                      long takerFee,
                                      BsqSwapProtocolModel bsqSwapProtocolModel,
+                                     boolean isTakerApiUser,
                                      @Nullable String errorMessage,
                                      State state,
                                      @Nullable String txId) {
@@ -86,6 +89,7 @@ public final class BsqSwapBuyerAsTakerTrade extends BsqSwapBuyerTrade implements
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 errorMessage,
                 state,
                 txId);
@@ -115,6 +119,7 @@ public final class BsqSwapBuyerAsTakerTrade extends BsqSwapBuyerTrade implements
                 proto.getMakerFee(),
                 proto.getTakerFee(),
                 BsqSwapProtocolModel.fromProto(proto.getBsqSwapProtocolModel()),
+                proto.getIsTakerApiUser(),
                 ProtoUtil.stringOrNullFromProto(proto.getErrorMessage()),
                 State.fromProto(proto.getState()),
                 ProtoUtil.stringOrNullFromProto(proto.getTxId()));

--- a/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapBuyerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapBuyerTrade.java
@@ -40,6 +40,7 @@ public abstract class BsqSwapBuyerTrade extends BsqSwapTrade {
                              long makerFee,
                              long takerFee,
                              BsqSwapProtocolModel bsqSwapProtocolModel,
+                             boolean isTakerApiUser,
                              @Nullable String errorMessage,
                              State state,
                              @Nullable String txId) {
@@ -52,6 +53,7 @@ public abstract class BsqSwapBuyerTrade extends BsqSwapTrade {
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 errorMessage,
                 state,
                 txId);

--- a/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapSellerAsMakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapSellerAsMakerTrade.java
@@ -44,7 +44,8 @@ public final class BsqSwapSellerAsMakerTrade extends BsqSwapSellerTrade implemen
                                      long txFeePerVbyte,
                                      long makerFee,
                                      long takerFee,
-                                     BsqSwapProtocolModel bsqSwapProtocolModel) {
+                                     BsqSwapProtocolModel bsqSwapProtocolModel,
+                                     boolean isTakerApiUser) {
 
         super(UUID.randomUUID().toString(),
                 offer,
@@ -55,6 +56,7 @@ public final class BsqSwapSellerAsMakerTrade extends BsqSwapSellerTrade implemen
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 null,
                 BsqSwapTrade.State.PREPARATION,
                 null);
@@ -74,6 +76,7 @@ public final class BsqSwapSellerAsMakerTrade extends BsqSwapSellerTrade implemen
                                       long makerFee,
                                       long takerFee,
                                       BsqSwapProtocolModel bsqSwapProtocolModel,
+                                      boolean isTakerApiUser,
                                       @Nullable String errorMessage,
                                       State state,
                                       @Nullable String txId) {
@@ -86,6 +89,7 @@ public final class BsqSwapSellerAsMakerTrade extends BsqSwapSellerTrade implemen
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 errorMessage,
                 state,
                 txId);
@@ -115,6 +119,7 @@ public final class BsqSwapSellerAsMakerTrade extends BsqSwapSellerTrade implemen
                 proto.getMakerFee(),
                 proto.getTakerFee(),
                 BsqSwapProtocolModel.fromProto(proto.getBsqSwapProtocolModel()),
+                proto.getIsTakerApiUser(),
                 ProtoUtil.stringOrNullFromProto(proto.getErrorMessage()),
                 State.fromProto(proto.getState()),
                 ProtoUtil.stringOrNullFromProto(proto.getTxId()));

--- a/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapSellerAsTakerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapSellerAsTakerTrade.java
@@ -44,7 +44,8 @@ public final class BsqSwapSellerAsTakerTrade extends BsqSwapSellerTrade implemen
                                      long txFeePerVbyte,
                                      long makerFee,
                                      long takerFee,
-                                     BsqSwapProtocolModel bsqSwapProtocolModel) {
+                                     BsqSwapProtocolModel bsqSwapProtocolModel,
+                                     boolean isTakerApiUser) {
 
 
         super(UUID.randomUUID().toString(),
@@ -56,6 +57,7 @@ public final class BsqSwapSellerAsTakerTrade extends BsqSwapSellerTrade implemen
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 null,
                 BsqSwapTrade.State.PREPARATION,
                 null);
@@ -75,6 +77,7 @@ public final class BsqSwapSellerAsTakerTrade extends BsqSwapSellerTrade implemen
                                       long makerFee,
                                       long takerFee,
                                       BsqSwapProtocolModel bsqSwapProtocolModel,
+                                      boolean isTakerApiUser,
                                       @Nullable String errorMessage,
                                       State state,
                                       @Nullable String txId) {
@@ -87,6 +90,7 @@ public final class BsqSwapSellerAsTakerTrade extends BsqSwapSellerTrade implemen
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 errorMessage,
                 state,
                 txId);
@@ -116,6 +120,7 @@ public final class BsqSwapSellerAsTakerTrade extends BsqSwapSellerTrade implemen
                 proto.getMakerFee(),
                 proto.getTakerFee(),
                 BsqSwapProtocolModel.fromProto(proto.getBsqSwapProtocolModel()),
+                proto.getIsTakerApiUser(),
                 ProtoUtil.stringOrNullFromProto(proto.getErrorMessage()),
                 State.fromProto(proto.getState()),
                 ProtoUtil.stringOrNullFromProto(proto.getTxId()));

--- a/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapSellerTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapSellerTrade.java
@@ -37,6 +37,7 @@ public abstract class BsqSwapSellerTrade extends BsqSwapTrade {
                               long makerFee,
                               long takerFee,
                               BsqSwapProtocolModel bsqSwapProtocolModel,
+                              boolean isTakerApiUser,
                               @Nullable String errorMessage,
                               State state,
                               @Nullable String txId) {
@@ -49,6 +50,7 @@ public abstract class BsqSwapSellerTrade extends BsqSwapTrade {
                 makerFee,
                 takerFee,
                 bsqSwapProtocolModel,
+                isTakerApiUser,
                 errorMessage,
                 state,
                 txId);

--- a/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapTrade.java
+++ b/core/src/main/java/bisq/core/trade/model/bsq_swap/BsqSwapTrade.java
@@ -79,6 +79,8 @@ public abstract class BsqSwapTrade extends TradeModel {
     private final long takerFeeAsLong;
     @Getter
     private final BsqSwapProtocolModel bsqSwapProtocolModel;
+    @Getter
+    protected final boolean isTakerApiUser;
 
     @Getter
     private State state;
@@ -107,6 +109,7 @@ public abstract class BsqSwapTrade extends TradeModel {
                            long makerFeeAsLong,
                            long takerFeeAsLong,
                            BsqSwapProtocolModel bsqSwapProtocolModel,
+                           boolean isTakerApiUser,
                            @Nullable String errorMessage,
                            State state,
                            @Nullable String txId) {
@@ -116,6 +119,7 @@ public abstract class BsqSwapTrade extends TradeModel {
         this.makerFeeAsLong = makerFeeAsLong;
         this.takerFeeAsLong = takerFeeAsLong;
         this.bsqSwapProtocolModel = bsqSwapProtocolModel;
+        this.isTakerApiUser = isTakerApiUser;
         this.state = state;
         this.txId = txId;
 
@@ -138,6 +142,7 @@ public abstract class BsqSwapTrade extends TradeModel {
                 .setMakerFee(makerFeeAsLong)
                 .setTakerFee(takerFeeAsLong)
                 .setBsqSwapProtocolModel(bsqSwapProtocolModel.toProtoMessage())
+                .setIsTakerApiUser(isTakerApiUser)
                 .setState(State.toProtoMessage(state))
                 .setPeerNodeAddress(tradingPeerNodeAddress.toProtoMessage());
         Optional.ofNullable(errorMessage).ifPresent(builder::setErrorMessage);

--- a/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatistics.java
+++ b/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatistics.java
@@ -1,0 +1,241 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
+import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
+import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
+
+import bisq.common.app.Capabilities;
+import bisq.common.app.Capability;
+import bisq.common.util.Utilities;
+
+import protobuf.TradeStatistics3;
+
+import com.google.protobuf.ByteString;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.nio.ByteBuffer;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+
+/**
+ * Links to a TradeStatistics3 instance by joining on its hash field,
+ * to show if API was used by one or both sides of a trade.
+ * <p>
+ * The serialized protobuf is a 21 byte array.
+ * Bytes 0-19 are the TradeStatistics3 hash byte[20] (~ db join key).
+ * Byte 20 determines whether the API was used to make the trade's offer, take the
+ * offer, or both.
+ *
+ * Serialized protobuf size is 25 bytes.
+ */
+@Getter
+@Slf4j
+public final class ApiTradeStatistics implements ProcessOncePersistableNetworkPayload,
+        PersistableNetworkPayload, CapabilityRequiringPayload {
+
+    @VisibleForTesting
+    static final int RIPEMD160_HASH_LEN = 20;
+
+    // The proto is a one field byte array that might grow in size
+    // to hold more encoded info, and remain backward compatible.
+    @VisibleForTesting
+    static final int SERIALIZED_BYTE_ARRAY_LEN = 21;
+
+
+    // 0x00 means API was used to make the trade's offer.
+    private static final byte API_IS_MAKER = (byte) 0x00;
+    // 0x01 means API was used to take the trade's offer.
+    private static final byte API_IS_TAKER = (byte) 0x01;
+    // 0x02 means API was used to create and take the offer.
+    private static final byte API_IS_MAKER_AND_TAKER = (byte) 0x02;
+
+    private final byte[] tradeStatistics3Hash;  // Joins on TradeStatistics3.hash
+    private final boolean isMakerApiUser;
+    private final boolean isTakerApiUser;
+
+    // Is set while joining stores on tradeStatistics3.hash <--> this.tradeStatistics3Hash.
+    @Setter
+    @Nullable
+    private transient bisq.core.trade.statistics.TradeStatistics3 tradeStatistics3;
+
+    public ApiTradeStatistics(byte[] tradeStatistics3Hash,
+                              boolean isMakerApiUser,
+                              boolean isTakerApiUser) {
+        this.tradeStatistics3Hash = tradeStatistics3Hash;
+        this.isMakerApiUser = isMakerApiUser;
+        this.isTakerApiUser = isTakerApiUser;
+    }
+
+    public ApiTradeStatistics(byte[] bytes) {
+        var instance = decode(bytes);
+        this.tradeStatistics3Hash = instance.tradeStatistics3Hash;
+        this.isMakerApiUser = instance.isMakerApiUser;
+        this.isTakerApiUser = instance.isTakerApiUser;
+    }
+
+    @Override
+    public Capabilities getRequiredCapabilities() {
+        return new Capabilities(Capability.API_TRADE_STATISTICS);
+    }
+
+    @Override
+    public byte[] getHash() {
+        return this.tradeStatistics3Hash;
+    }
+
+    @Override
+    public boolean verifyHashSize() {
+        checkNotNull(tradeStatistics3Hash, "tradeStatistics3Hash must not be null");
+        return tradeStatistics3Hash.length == RIPEMD160_HASH_LEN;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ApiTradeStatistics)) return false;
+
+        ApiTradeStatistics that = (ApiTradeStatistics) o;
+
+        if (isMakerApiUser != that.isMakerApiUser) return false;
+        if (isTakerApiUser != that.isTakerApiUser) return false;
+        return Arrays.equals(tradeStatistics3Hash, that.tradeStatistics3Hash);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(tradeStatistics3Hash);
+        result = 31 * result + (isMakerApiUser ? 1 : 0);
+        result = 31 * result + (isTakerApiUser ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ApiTradeStatistics{" +
+                "tradeStatistics3Hash=" + Utilities.bytesAsHexString(tradeStatistics3Hash) +
+                ", isApiMaker=" + isMakerApiUser +
+                ", isApiTaker=" + isTakerApiUser +
+                ", tradeStatistics3=" + tradeStatistics3 +
+                '}';
+    }
+
+    public static ApiTradeStatistics from(TradeStatistics3 tradeStatisticsProto,
+                                          boolean isApiMaker,
+                                          boolean isApiTaker) {
+        byte[] tradeStatistics3Hash = tradeStatisticsProto.getHash().toByteArray();
+        if (tradeStatistics3Hash.length == 0) {
+            log.warn("Fake tradeStatistics3Hash! Fake tradeStatistics3Hash! Fake tradeStatistics3Hash!");
+            tradeStatistics3Hash = new byte[RIPEMD160_HASH_LEN];
+        }
+        return new ApiTradeStatistics(tradeStatistics3Hash, isApiMaker, isApiTaker);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public protobuf.ApiTradeStatistics toProtoApiTradeStatistics() {
+        return getBuilder().build();
+    }
+
+    @Override
+    public protobuf.PersistableNetworkPayload toProtoMessage() {
+        return protobuf.PersistableNetworkPayload.newBuilder().setApiTradeStatistics(getBuilder()).build();
+    }
+
+    @VisibleForTesting
+    public protobuf.ApiTradeStatistics.Builder getBuilder() {
+        var byteString = ByteString.copyFrom(encode(tradeStatistics3Hash, isMakerApiUser, isTakerApiUser));
+        protobuf.ApiTradeStatistics.Builder builder = protobuf.ApiTradeStatistics.newBuilder()
+                .setBytes(byteString);
+        return builder;
+    }
+
+    public static ApiTradeStatistics fromProto(protobuf.ApiTradeStatistics proto) {
+        return new ApiTradeStatistics(proto.getBytes().toByteArray());
+    }
+
+    private static byte[] encode(byte[] tradeStatistics3Hash,
+                                 boolean isApiMaker,
+                                 boolean isApiTaker) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(SERIALIZED_BYTE_ARRAY_LEN);
+        byteBuffer.put(tradeStatistics3Hash);                          // Bytes: 0->19
+        byteBuffer.put(encodeApiRoleByte(isApiMaker, isApiTaker));     // Byte: 20
+        return byteBuffer.array();
+    }
+
+    private static ApiTradeStatistics decode(byte[] bytes) {
+        if (bytes.length != SERIALIZED_BYTE_ARRAY_LEN) {
+            throw new IllegalStateException(
+                    format("Invalid byte[] length (%d), is not a serialized ApiTradeStatistics byte[%d] array.",
+                            bytes.length,
+                            SERIALIZED_BYTE_ARRAY_LEN));
+        }
+        // Bytes: 0->19
+        byte[] tradeStatistics3Hash = Arrays.copyOf(bytes, SERIALIZED_BYTE_ARRAY_LEN - 1);
+        // Byte: 20
+        byte apiRoleByte = bytes[SERIALIZED_BYTE_ARRAY_LEN - 1];
+        validateApiRoleByte(apiRoleByte);
+        if (isMakerApiUser(apiRoleByte)) {
+            return new ApiTradeStatistics(tradeStatistics3Hash, true, false);
+        } else if (isTakerApiUser(apiRoleByte)) {
+            return new ApiTradeStatistics(tradeStatistics3Hash, false, true);
+        } else {
+            return new ApiTradeStatistics(tradeStatistics3Hash, true, true);
+        }
+    }
+
+    private static byte encodeApiRoleByte(boolean isApiMaker, boolean isApiTaker) {
+        if (!isApiMaker && !isApiTaker) {
+            throw new IllegalStateException("API was not used for the trade.");
+        }
+        if (isApiMaker && !isApiTaker) {
+            return API_IS_MAKER;
+        } else if (!isApiMaker) {
+            return API_IS_TAKER;
+        } else {
+            return API_IS_MAKER_AND_TAKER;
+        }
+    }
+
+    private static void validateApiRoleByte(byte b) {
+        if (b != API_IS_MAKER && b != API_IS_TAKER && b != API_IS_MAKER_AND_TAKER) {
+            throw new IllegalStateException("API was not used for the trade.");
+        }
+    }
+
+    private static boolean isMakerApiUser(byte b) {
+        return b == API_IS_MAKER;
+    }
+
+    private static boolean isTakerApiUser(byte b) {
+        return b == API_IS_TAKER;
+    }
+}

--- a/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatisticsManager.java
@@ -1,0 +1,227 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
+
+import bisq.common.config.Config;
+import bisq.common.file.FileUtil;
+import bisq.common.util.Utilities;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import javax.inject.Named;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableSet;
+
+import java.nio.file.Paths;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Comparator.comparing;
+import static java.util.Objects.requireNonNull;
+
+@Singleton
+@Slf4j
+public class ApiTradeStatisticsManager {
+
+    private final P2PService p2PService;
+    private final ApiTradeStatisticsStorageService apiTradeStatisticsStorageService;
+    private final TradeStatistics3StorageService tradeStatistics3StorageService;
+    private final TradeStatisticsManager tradeStatisticsManager;
+    private final File storageDir;
+    private final boolean dumpStatistics;
+
+    @Getter
+    private final ObservableSet<ApiTradeStatistics> observableApiTradeStatisticsSet = FXCollections.observableSet();
+
+    @Inject
+    public ApiTradeStatisticsManager(P2PService p2PService,
+                                     ApiTradeStatisticsStorageService apiTradeStatisticsStorageService,
+                                     TradeStatistics3StorageService tradeStatistics3StorageService,
+                                     TradeStatisticsManager tradeStatisticsManager,
+                                     AppendOnlyDataStoreService appendOnlyDataStoreService,
+                                     @Named(Config.STORAGE_DIR) File storageDir,
+                                     @Named(Config.DUMP_STATISTICS) boolean dumpStatistics) {
+        this.p2PService = p2PService;
+        this.apiTradeStatisticsStorageService = apiTradeStatisticsStorageService;
+        this.tradeStatistics3StorageService = tradeStatistics3StorageService;
+        this.tradeStatisticsManager = tradeStatisticsManager;
+        this.storageDir = storageDir;
+        this.dumpStatistics = dumpStatistics;
+
+        appendOnlyDataStoreService.addService(apiTradeStatisticsStorageService);
+    }
+
+
+    public void onAllServicesInitialized() {
+        log.info("onAllServicesInitialized");
+
+        // First, set up a ApiTradeStatistics listener for new incoming stats.
+        // We do not try to join to the matching TradeStatistics3 payloads until
+        // we export statistics.
+        p2PService.getP2PDataStorage().addAppendOnlyDataStoreListener(payload -> {
+            if (payload instanceof ApiTradeStatistics) {
+                ApiTradeStatistics apiTradeStatistics = (ApiTradeStatistics) payload;
+                observableApiTradeStatisticsSet.add(apiTradeStatistics);
+                log.warn("Added api stats item # {} to set: {}",
+                        observableApiTradeStatisticsSet.size(),
+                        apiTradeStatistics);
+            }
+        });
+
+        // Load existing ApiTradeStatistics storage.
+        Set<ApiTradeStatistics> set = apiTradeStatisticsStorageService.getMapOfAllData().values().stream()
+                .filter(e -> e instanceof ApiTradeStatistics)
+                .map(e -> (ApiTradeStatistics) e)
+                .filter(s -> s.getTradeStatistics3().isValid())
+                .collect(Collectors.toSet());
+        observableApiTradeStatisticsSet.addAll(set);
+
+        maybeDumpStatistics();
+    }
+
+    // Try to keep JFX dependencies out of API.
+    public List<ApiTradeStatistics> getApiTradeStatistics() {
+        return Arrays.asList(observableApiTradeStatisticsSet.toArray(new ApiTradeStatistics[0]));
+    }
+
+    public void maybeRepublishApiTradeStatistics(String whatDoIDoNow) {
+        // See TradeManager L 449:
+        //  tradeStatisticsManager.maybeRepublishTradeStatistics(allTrades, referralId, isTorNetworkNode);
+    }
+
+    public void shutDown() {
+        log.info("shutDown");
+        maybeDumpStatistics();
+    }
+
+
+    private void maybeDumpStatistics() {
+        if (!dumpStatistics) {
+            return;
+        }
+        exportApiTradeStatisticsToCsv();
+    }
+
+    private void exportApiTradeStatisticsToCsv() {
+        List<ApiTradeStatistics> dateOrderedStats = getDateOrderedStats();
+
+        File tempFile = null;
+        File csvFile = Paths.get(storageDir.getAbsolutePath(), "api_trade_statistics.csv").toFile();
+        String header = "isMakerApiUser,isTakerApiUser,currency,price,amount,paymentMethod,date,mediator,refundAgent";
+        FileWriter fileWriter = null;
+        try {
+            tempFile = File.createTempFile("temp_api_trade_statistics", null, storageDir);
+            tempFile.deleteOnExit();
+
+            fileWriter = new FileWriter(requireNonNull(tempFile), UTF_8);
+            fileWriter.append(header).append("\n");
+            for (ApiTradeStatistics item : dateOrderedStats) {
+                var tradeStatistics3 = item.getTradeStatistics3();
+                item.setTradeStatistics3(tradeStatistics3);
+                fileWriter.append(String.valueOf(item.isMakerApiUser())).append(",");
+                fileWriter.append(String.valueOf(item.isTakerApiUser())).append(",");
+                fileWriter.append(tradeStatistics3.getCurrency()).append(",");
+                fileWriter.append(String.valueOf(tradeStatistics3.getPrice())).append(",");
+                fileWriter.append(String.valueOf(tradeStatistics3.getAmount())).append(",");
+                fileWriter.append(String.valueOf(tradeStatistics3.getPaymentMethodId())).append(",");
+                fileWriter.append(String.valueOf(tradeStatistics3.getDate())).append(",");
+                var mediator = tradeStatistics3.getMediator();
+                if (mediator == null) {
+                    fileWriter.append(",");
+                } else {
+                    fileWriter.append(mediator).append(",");
+                }
+                var refundAgent = tradeStatistics3.getRefundAgent();
+                if (refundAgent == null) {
+                    fileWriter.append("\n");
+                } else {
+                    fileWriter.append(refundAgent).append("\n");
+                }
+            }
+            log.info("Exported {} ApiTradeStatistics to {}.", dateOrderedStats.size(), csvFile.getAbsolutePath());
+        } catch (Exception ex) {
+            throw new RuntimeException("Fatal csv file write error.", ex);
+        } finally {
+            try {
+                requireNonNull(fileWriter).flush();
+                fileWriter.close();
+                FileUtil.renameFile(tempFile, csvFile);
+                if (tempFile.exists()) {
+                    tempFile.delete();
+                }
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    private List<ApiTradeStatistics> getDateOrderedStats() {
+        List<ApiTradeStatistics> orderedStats = new ArrayList<>();
+
+        // Find the matching TradeStatistics3 if missing (join on hash).
+        getApiTradeStatistics().stream()
+                .filter(apiStats -> apiStats.getTradeStatistics3() == null)
+                .forEach(apiStats -> {
+                    Optional<TradeStatistics3> tradeStatistics = tradeStatisticsManager.findTradeStatistics3WithHash(
+                            apiStats.getTradeStatistics3Hash());
+                    tradeStatistics.ifPresentOrElse(s -> {
+                        if (s.isValid()) {
+                            apiStats.setTradeStatistics3(s);
+                            orderedStats.add(apiStats);
+                        } else {
+                            log.error("Invalid tradeStatistics3: {}", s);
+                        }
+                    }, () -> {
+                        //  We cannot depend on the matching TradeStatistics3's arrival &
+                        //  storage before the arrival of this ApiTradeStatistics payload.
+                        log.error("TradeStatisticsManager could not find TradeStatistics3 with hash {}",
+                                Utilities.encodeToHex(apiStats.getTradeStatistics3Hash()));
+                    });
+                });
+
+        // Sort valid, complete API trading stats by trade creation date.
+        orderedStats.sort(comparing(apiTradeStatistics ->
+                apiTradeStatistics.getTradeStatistics3().getDateAsLong()));
+
+        if (observableApiTradeStatisticsSet.size() != orderedStats.size()) {
+            log.warn("Could not find {} matching TradeStatistics3 payloads in the set of"
+                            + " {} valid, complete ApiTradeStatistics payloads.",
+                    observableApiTradeStatisticsSet.size() - orderedStats.size(),
+                    orderedStats.size());
+        }
+        return orderedStats;
+    }
+}

--- a/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatisticsStorageService.java
+++ b/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatisticsStorageService.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+
+import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
+import bisq.network.p2p.storage.persistence.HistoricalDataStoreService;
+
+import bisq.common.config.Config;
+import bisq.common.persistence.PersistenceManager;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.File;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Singleton
+@Slf4j
+public class ApiTradeStatisticsStorageService extends HistoricalDataStoreService<ApiTradeStatisticsStore> {
+    private static final String FILE_NAME = "ApiTradeStatisticsStore";
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Constructor
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Inject
+    public ApiTradeStatisticsStorageService(@Named(Config.STORAGE_DIR) File storageDir,
+                                            PersistenceManager<ApiTradeStatisticsStore> persistenceManager) {
+        super(storageDir, persistenceManager);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public String getFileName() {
+        return FILE_NAME;
+    }
+
+    @Override
+    protected void initializePersistenceManager() {
+        persistenceManager.initialize(store, PersistenceManager.Source.NETWORK);
+    }
+
+    @Override
+    public boolean canHandle(PersistableNetworkPayload payload) {
+        return payload instanceof ApiTradeStatistics;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Protected
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    protected ApiTradeStatisticsStore createStore() {
+        return new ApiTradeStatisticsStore();
+    }
+
+    public void persistNow() {
+        persistenceManager.persistNow(() -> {
+        });
+    }
+}

--- a/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatisticsStore.java
+++ b/core/src/main/java/bisq/core/trade/statistics/ApiTradeStatisticsStore.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.network.p2p.storage.P2PDataStorage;
+import bisq.network.p2p.storage.persistence.PersistableNetworkPayloadStore;
+
+import com.google.protobuf.Message;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * We store only the payload in the PB file to save disc space. The hash of the payload
+ * can be created anyway and is only used as key in the map. So we have a hybrid data
+ * structure which is represented as list in the protobuffer definition and provide a
+ * hashMap for the domain access.
+ */
+public class ApiTradeStatisticsStore extends PersistableNetworkPayloadStore<ApiTradeStatistics> {
+
+    public ApiTradeStatisticsStore() {
+    }
+
+    private ApiTradeStatisticsStore(List<ApiTradeStatistics> list) {
+        list.forEach(item -> map.put(new P2PDataStorage.ByteArray(item.getHash()), item));
+    }
+
+    @Override
+    public Message toPersistableMessage() {
+        return super.toPersistableMessage();
+    }
+
+    @Override
+    public String getDefaultStorageFileName() {
+        return super.getDefaultStorageFileName();
+    }
+
+    public boolean containsKey(P2PDataStorage.ByteArray hash) {
+        return map.containsKey(hash);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public Message toProtoMessage() {
+        return protobuf.PersistableEnvelope.newBuilder()
+                .setApiTradeStatisticsStore(getBuilder())
+                .build();
+    }
+
+    private protobuf.ApiTradeStatisticsStore.Builder getBuilder() {
+        List<protobuf.ApiTradeStatistics> protoList = map.values().stream()
+                .map(payload -> (ApiTradeStatistics) payload)
+                .map(ApiTradeStatistics::toProtoApiTradeStatistics)
+                .collect(Collectors.toList());
+        return protobuf.ApiTradeStatisticsStore.newBuilder().addAllItems(protoList);
+    }
+
+
+    public static ApiTradeStatisticsStore fromProto(protobuf.ApiTradeStatisticsStore proto) {
+        List<ApiTradeStatistics> list = proto.getItemsList().stream()
+                .map(ApiTradeStatistics::fromProto)
+                .collect(Collectors.toList());
+        return new ApiTradeStatisticsStore(list);
+    }
+}

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -47,10 +47,12 @@ import java.time.Instant;
 import java.io.File;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -147,6 +149,12 @@ public class TradeStatisticsManager {
         return observableTradeStatisticsSet;
     }
 
+    public Optional<TradeStatistics3> findTradeStatistics3WithHash(byte[] hash) {
+        return observableTradeStatisticsSet.stream()
+                .filter(s -> Arrays.equals(s.getHash(), hash))
+                .findFirst();
+    }
+
     private void maybeDumpStatistics() {
         if (!dumpStatistics) {
             return;
@@ -170,7 +178,7 @@ public class TradeStatisticsManager {
             Instant yearAgo = Instant.ofEpochSecond(Instant.now().getEpochSecond() - TimeUnit.DAYS.toSeconds(365));
             Set<String> activeCurrencies = observableTradeStatisticsSet.stream()
                     .filter(e -> e.getDate().toInstant().isAfter(yearAgo))
-                    .map(p -> p.getCurrency())
+                    .map(TradeStatistics3::getCurrency)
                     .collect(Collectors.toSet());
 
             ArrayList<CurrencyTuple> activeFiatCurrencyList = fiatCurrencyList.stream()

--- a/core/src/test/java/bisq/core/offer/OfferMaker.java
+++ b/core/src/test/java/bisq/core/offer/OfferMaker.java
@@ -75,6 +75,7 @@ public class OfferMaker {
                     false,
                     null,
                     null,
+                    false,
                     0));
 
     public static final Maker<Offer> btcUsdOffer = a(Offer);

--- a/core/src/test/java/bisq/core/trade/statistics/ApiTradeStatisticsIntegrationTest.java
+++ b/core/src/test/java/bisq/core/trade/statistics/ApiTradeStatisticsIntegrationTest.java
@@ -1,0 +1,313 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.core.monetary.Price;
+import bisq.core.payment.payload.PaymentMethod;
+
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.Coin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiFunction;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.network.p2p.storage.P2PDataStorage.ByteArray;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Persisted store file sizes:
+ * <p>
+ * 10,000       ApiTradeStatistics:     245K
+ * 100,000      ApiTradeStatistics:     2.4M        ~ 5 minutes
+ * ~ 300,00  ~ 7.3M
+ * 395000    ~ 9.5M
+ * 449999    ~ 11M
+ * 529999    ~ 13M
+ * 599999    ~ 15M
+ * 669999    ~ 16M
+ * 724999    ~ 18M
+ * 739999    ~ 18M
+ * 879999    ~ 22M
+ * 1,000,000    ApiTradeStatistics:     ~ 25M
+ * Persisting 1,000,000 took 75324709 ms (20.92 hours, with artificial waits for file writes)
+ */
+@Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ApiTradeStatisticsIntegrationTest {
+
+    private static final int NUM_TEST_STATS = 100;
+    private static List<TradeStatistics3> tradeStatistics3List;
+    private static List<ApiTradeStatistics> apiTradeStatisticsList;
+    private static StatisticsTestBootstrapper app;  // For brevity, name it 'app'.
+
+    @BeforeAll
+    public static void bootstrap() {
+        tradeStatistics3List = genTradeStatistics3(NUM_TEST_STATS);
+        apiTradeStatisticsList = genApiTradeStatistics(tradeStatistics3List);
+
+        app = new StatisticsTestBootstrapper();
+        app.initializeServices();
+    }
+
+    @Order(1)
+    @Test
+    public void testPersistStatisticsStores() {
+        assertEquals(tradeStatistics3List.size(),
+                apiTradeStatisticsList.size(),
+                "Generated data set sizes do not match.");
+
+        log.info("Persisting {} {} & {} to {} ...",
+                tradeStatistics3List.size(),
+                TradeStatistics3.class.getSimpleName(),
+                ApiTradeStatistics.class.getSimpleName(),
+                app.getDbStorageDir().getAbsolutePath());
+
+        long ts = System.currentTimeMillis();
+        for (int listIdx = 0; listIdx < tradeStatistics3List.size(); listIdx++) {
+            TradeStatistics3 tradeStatistics3Object = tradeStatistics3List.get(listIdx);
+            ApiTradeStatistics apiTradeStatisticsObject = apiTradeStatisticsList.get(listIdx);
+            assertEquals(tradeStatistics3Object.getHash(), apiTradeStatisticsObject.getHash());
+
+            // Add payloads to the TradeStatistics3 & ApiTradeStatistics stores.
+            addOneTradeStatistics3Payload(tradeStatistics3Object);
+            addOneApiTradeStatisticsPayload(apiTradeStatisticsObject);
+
+            // Persist a batch of 5,000 payloads.
+            if ((listIdx != 0) && (listIdx % 5_000 == 0)) {
+                persistTradeStatistics3Payloads();
+                persistApiTradeStatisticsPayloads();
+                app.sleep(2_000); // Let disk writes finish.
+                log.info("Persisted {} {} & {} payloads ...",
+                        listIdx - 1,
+                        TradeStatistics3.class.getSimpleName(),
+                        ApiTradeStatistics.class.getSimpleName());
+            }
+        }
+
+        // Persist remaining batches of payloads.
+        persistTradeStatistics3Payloads();
+        persistApiTradeStatisticsPayloads();
+        app.sleep(2_000); // Let disk writes finish.
+
+        log.info("Done persisting {} {} & {} payloads to {} in ~ {} ms.",
+                apiTradeStatisticsList.size(),
+                TradeStatistics3.class.getSimpleName(),
+                ApiTradeStatistics.class.getSimpleName(),
+                app.getDbStorageDir().getAbsolutePath(),
+                System.currentTimeMillis() - ts);
+    }
+
+    @Order(2)
+    @Test
+    public void testReadTradeStatistics3StoreFile() {
+        var persistenceManager = app.createPersistenceManager(app.getDbStorageDir());
+        var persistedEnvelope = persistenceManager.getPersisted(app.getTradeStatistics3StorageService().getFileName());
+
+        var persistableNetworkPayloadByByteArrayMap = ((TradeStatistics3Store) persistedEnvelope).getMap();
+        assertEquals(NUM_TEST_STATS, persistableNetworkPayloadByByteArrayMap.size(), "Incorrect persisted payload count.");
+
+        persistableNetworkPayloadByByteArrayMap.forEach((k, v) -> {
+            assertTrue(tradeStatistics3List.contains(v), "Did not find persisted object in generated list.");
+        });
+
+        for (TradeStatistics3 expectedTradeStatistics3 : tradeStatistics3List) {
+            ByteArray expectedByteArray = new ByteArray(expectedTradeStatistics3.getHash());
+            var actualTradeStatistics3 = persistableNetworkPayloadByByteArrayMap.get(expectedByteArray);
+            assertNotNull(actualTradeStatistics3, "Did not find generated list entry in persisted payloads.");
+            assertEquals(expectedTradeStatistics3, actualTradeStatistics3, "Generated stats != persisted stats.");
+            ByteArray actualByteArray = new ByteArray(actualTradeStatistics3.getHash());
+            assertEquals(expectedByteArray, actualByteArray, "ByteArrays do not match.");
+        }
+    }
+
+    @Order(3)
+    @Test
+    public void testReadApiTradeStatisticsStoreFile() {
+        var persistenceManager = app.createPersistenceManager(app.getDbStorageDir());
+        var persistedEnvelope = persistenceManager.getPersisted(app.getApiTradeStatisticsStorageService().getFileName());
+
+        var persistableNetworkPayloadByByteArrayMap = ((ApiTradeStatisticsStore) persistedEnvelope).getMap();
+        assertEquals(NUM_TEST_STATS, persistableNetworkPayloadByByteArrayMap.size(), "Incorrect persisted payload count.");
+
+        persistableNetworkPayloadByByteArrayMap.forEach((k, v) -> {
+            assertTrue(apiTradeStatisticsList.contains(v), "Did not find persisted object in generated list.");
+        });
+
+        for (ApiTradeStatistics expectedApiTradeStatistics : apiTradeStatisticsList) {
+            ByteArray expectedByteArray = new ByteArray(expectedApiTradeStatistics.getTradeStatistics3Hash());
+            var actualApiTradeStatistics = persistableNetworkPayloadByByteArrayMap.get(expectedByteArray);
+            assertNotNull(actualApiTradeStatistics, "Did not find generated list entry in persisted payloads.");
+            assertEquals(expectedApiTradeStatistics, actualApiTradeStatistics, "Generated stats != persisted stats.");
+            ByteArray actualByteArray = new ByteArray(actualApiTradeStatistics.getHash());
+            assertEquals(expectedByteArray, actualByteArray, "ByteArrays do not match.");
+        }
+    }
+
+    @Order(4)
+    @Test
+    public void testMerge() {
+        BiFunction<byte[], List<TradeStatistics3>, TradeStatistics3> findTradeStatistics3 = (hash, list) ->
+                list.stream()
+                        .filter(s -> Arrays.equals(s.getHash(), hash))
+                        .findFirst().get();
+        // Set the transient ApiTradeStatistics.tradeStatistics3 fields in apiTradeStatisticsList.
+        apiTradeStatisticsList.stream()
+                .forEach(apiStats -> {
+                    TradeStatistics3 joinedStats = findTradeStatistics3.apply(apiStats.getTradeStatistics3Hash(), tradeStatistics3List);
+                    apiStats.setTradeStatistics3(joinedStats);
+                });
+        for (ApiTradeStatistics merged : apiTradeStatisticsList) {
+            assertNotNull(merged.getTradeStatistics3());
+            assertTrue(Arrays.equals(merged.getTradeStatistics3Hash(), merged.getTradeStatistics3().getHash()));
+        }
+    }
+
+    @Order(5)
+    @Test
+    public void testStatisticsCalculations() {
+        long countMakerApiUsers = apiTradeStatisticsList.stream()
+                .filter(s -> s.isMakerApiUser())
+                .count();
+        long countTakerApiUsers = apiTradeStatisticsList.stream()
+                .filter(s -> s.isTakerApiUser())
+                .count();
+        long countMakerAndTakerApiUsers = apiTradeStatisticsList.stream()
+                .filter(s -> s.isMakerApiUser() && s.isTakerApiUser())
+                .count();
+        log.info("countMakerApiUsers = {}, countTakerApiUsers = {} countMakerAndTakerApiUsers = {}",
+                countMakerApiUsers,
+                countTakerApiUsers,
+                countMakerAndTakerApiUsers);
+
+        // API Trade Amount Stats
+
+        var totalTradeAmountByApiMakers = apiTradeStatisticsList.stream()
+                .filter(apiStats -> apiStats.isMakerApiUser())
+                .mapToLong(apiStats -> apiStats.getTradeStatistics3().getAmount())
+                .sum();
+
+        var totalTradeAmountByApiTakers = apiTradeStatisticsList.stream()
+                .filter(apiStats -> apiStats.isTakerApiUser())
+                .mapToLong(apiStats -> apiStats.getTradeStatistics3().getAmount())
+                .sum();
+
+        var totalTradeAmountByApiMakerAndTakers = apiTradeStatisticsList.stream()
+                .filter(apiStats -> apiStats.isTakerApiUser() && apiStats.isMakerApiUser())
+                .mapToLong(apiStats -> apiStats.getTradeStatistics3().getAmount())
+                .sum();
+
+        var totalTradeAmount = apiTradeStatisticsList.stream()
+                .mapToLong(apiStats -> apiStats.getTradeStatistics3().getAmount())
+                .sum();
+
+        log.info("totalTradeAmountByApiMakers = {}, totalTradeAmountByApiTakers = {}, totalTradeAmountByApiMakerAndTakers = {}, totalTradeAmount = {}",
+                Coin.valueOf(totalTradeAmountByApiMakers).toFriendlyString(),
+                Coin.valueOf(totalTradeAmountByApiTakers).toFriendlyString(),
+                Coin.valueOf(totalTradeAmountByApiMakerAndTakers).toFriendlyString(),
+                Coin.valueOf(totalTradeAmount).toFriendlyString());
+
+        // TODO ? Look at GroupBy operations: https://dzone.com/articles/java-streams-groupingby-examples
+    }
+
+
+    @AfterAll
+    public static void shutdown() {
+        app.shutdown();
+    }
+
+    private void addOneTradeStatistics3Payload(TradeStatistics3 tradeStatistics3) {
+        app.getP2PDataStorage().addPersistableNetworkPayload(tradeStatistics3,
+                app.getNetworkNode().getNodeAddress(),
+                false,
+                false);
+    }
+
+    private void addOneApiTradeStatisticsPayload(ApiTradeStatistics apiTradeStatistics) {
+        app.getP2PDataStorage().addPersistableNetworkPayload(apiTradeStatistics,
+                app.getNetworkNode().getNodeAddress(),
+                false,
+                false);
+    }
+
+    private void persistTradeStatistics3Payloads() {
+        app.getTradeStatistics3StorageService().persistNow();
+    }
+
+    private void persistApiTradeStatisticsPayloads() {
+        app.getApiTradeStatisticsStorageService().persistNow();
+    }
+
+    private static List<TradeStatistics3> genTradeStatistics3(int numStats) {
+        List<TradeStatistics3> list = new ArrayList<>();
+        Random random = new Random();
+        Date now = new Date();
+        for (int i = 0; i < numStats; i++) {
+            var tradeDate = now.getTime() + 5;
+            var priceString = String.valueOf(20_000 + random.nextInt(20_000));
+            var tradePrice = Price.parse("EUR", priceString).getValue();
+            var tradeAmountString = String.valueOf(random.nextDouble()).substring(0, 10);
+            var tradeAmount = Coin.parseCoin(tradeAmountString).getValue();
+            list.add(new TradeStatistics3("EUR",
+                    tradePrice,
+                    tradeAmount,
+                    PaymentMethod.SEPA_ID,
+                    tradeDate,
+                    null,
+                    null,
+                    null,
+                    null));
+        }
+        assertEquals(numStats, list.size(), "Incorrect list size");
+        // Check the hashes are distinct.
+        // TODO This would not be necessary if we generated a Set instead of a List.
+        int countDistinctHashes = (int) list.stream()
+                .map(s -> Utilities.encodeToHex(s.getHash()))
+                .distinct()
+                .count();
+        assertEquals(list.size(), countDistinctHashes, "Generated duplicate hashes");
+        return list;
+    }
+
+    static List<ApiTradeStatistics> genApiTradeStatistics(List<TradeStatistics3> tradeStatistics3List) {
+        List<ApiTradeStatistics> stats = new ArrayList<>();
+        Random random = new Random();
+        for (TradeStatistics3 tradeStatistics3 : tradeStatistics3List) {
+            var isMakerApiUser = random.nextBoolean();
+            // Must be true when isMakerApiUser == false.
+            var isTakerApiUser = isMakerApiUser ? random.nextBoolean() : true;
+            stats.add(new ApiTradeStatistics(tradeStatistics3.getHash(), isMakerApiUser, isTakerApiUser));
+        }
+        return stats;
+    }
+}

--- a/core/src/test/java/bisq/core/trade/statistics/ApiTradeStatisticsTest.java
+++ b/core/src/test/java/bisq/core/trade/statistics/ApiTradeStatisticsTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.common.util.Utilities;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.core.trade.statistics.ApiTradeStatistics.RIPEMD160_HASH_LEN;
+import static bisq.core.trade.statistics.ApiTradeStatistics.SERIALIZED_BYTE_ARRAY_LEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ApiTradeStatisticsTest {
+
+    private static final int NUM_TEST_STATS = 1_000_000;
+    private static final int PERSISTABLE_NETWORK_PAYLOAD_SIZE = 25;
+    private static List<ApiTradeStatistics> apiTradeStatisticsList;
+
+    @BeforeAll
+    public static void genTestStatistics() {
+        apiTradeStatisticsList = genApiTradeStatistics(NUM_TEST_STATS);
+        verifyNoDuplicateTradeStatistics3Hashes(apiTradeStatisticsList);
+    }
+
+    @Order(1)
+    @Test
+    public void testApiTradeStatisticsSerialization() {
+        for (ApiTradeStatistics apiTradeStatistics : apiTradeStatisticsList) {
+            checkDeserialization(apiTradeStatistics);
+        }
+    }
+
+    @Order(2)
+    @Test
+    public void testPersistableNetworkPayloadProtosDeserialization() {
+        var persistableNetworkPayloadProtos = apiTradeStatisticsList.stream()
+                .map(ApiTradeStatistics::toProtoMessage)
+                .collect(Collectors.toList());
+        assertEquals(NUM_TEST_STATS, persistableNetworkPayloadProtos.size());
+        for (int i = 0; i < NUM_TEST_STATS; i++) {
+            protobuf.PersistableNetworkPayload persistableNetworkPayloadProto = persistableNetworkPayloadProtos.get(i);
+            ApiTradeStatistics expectedApiTradeStatistics = apiTradeStatisticsList.get(i);
+            checkDeserialization(expectedApiTradeStatistics, persistableNetworkPayloadProto);
+        }
+    }
+
+    private static void verifyNoDuplicateTradeStatistics3Hashes(List<ApiTradeStatistics> list) {
+        // Make sure there are no duplicate TradeStatistic3 hashes.
+        // TODO We would not have to do this if we generated a Set instead of a List.
+        int countDistinctHashes = (int) list.stream()
+                .map(s -> Utilities.encodeToHex(s.getHash()))
+                .distinct()
+                .count();
+        assertEquals(list.size(), countDistinctHashes, "Generated duplicate hashes");
+    }
+
+    private static List<ApiTradeStatistics> genApiTradeStatistics(int numStats) {
+        Random random = new Random();
+        List<ApiTradeStatistics> stats = new ArrayList<>();
+        for (int i = 0; i < numStats; i++) {
+            byte[] nextHash = new byte[RIPEMD160_HASH_LEN];
+            random.nextBytes(nextHash);
+            var isMakerApiUser = i % 2 != 0;
+            // Must be true if !isMakerApiUser.
+            var isTakerApiUser = !isMakerApiUser || i % 3 == 0;
+            stats.add(new ApiTradeStatistics(nextHash, isMakerApiUser, isTakerApiUser));
+        }
+        return stats;
+    }
+
+    // Private
+
+    private void checkDeserialization(ApiTradeStatistics expectedApiTradeStatistics) {
+        protobuf.PersistableNetworkPayload persistableNetworkPayloadProto = expectedApiTradeStatistics.toProtoMessage();
+        checkDeserialization(expectedApiTradeStatistics, persistableNetworkPayloadProto);
+    }
+
+    private void checkDeserialization(ApiTradeStatistics expectedApiTradeStatistics,
+                                      protobuf.PersistableNetworkPayload persistableNetworkPayloadProto) {
+        assertEquals(PERSISTABLE_NETWORK_PAYLOAD_SIZE, persistableNetworkPayloadProto.getSerializedSize());
+        assertEquals(PERSISTABLE_NETWORK_PAYLOAD_SIZE, persistableNetworkPayloadProto.toByteArray().length);
+
+        protobuf.ApiTradeStatistics apiTradeStatisticsProto = persistableNetworkPayloadProto.getApiTradeStatistics();
+        byte[] encodedApiStatisticsBytes = apiTradeStatisticsProto.getBytes().toByteArray();
+        assertEquals(SERIALIZED_BYTE_ARRAY_LEN, encodedApiStatisticsBytes.length);
+
+        ApiTradeStatistics actualApiTradeStatistics = new ApiTradeStatistics(encodedApiStatisticsBytes);
+        assertEquals(expectedApiTradeStatistics, actualApiTradeStatistics);
+    }
+}

--- a/core/src/test/java/bisq/core/trade/statistics/StatisticsTestBootstrapper.java
+++ b/core/src/test/java/bisq/core/trade/statistics/StatisticsTestBootstrapper.java
@@ -65,7 +65,7 @@ import lombok.extern.slf4j.Slf4j;
 import static bisq.network.utils.Utils.findFreeSystemPort;
 
 /**
- * P2P storage bootstrapper for testing storage file read & write.
+ * P2P storage bootstrapper for testing statistics storage file read & write.
  *
  * TODO Rename, refactor, and move to different pkg when needed by other core test cases.
  */
@@ -84,9 +84,7 @@ class StatisticsTestBootstrapper {
     private final P2PService p2PService;
     private final PriceFeedService priceFeedService;
     private final TradeStatistics3StorageService tradeStatistics3StorageService;
-    // private final TradeStatisticsManager tradeStatisticsManager; // Too hard to bootstrap
     private final ApiTradeStatisticsStorageService apiTradeStatisticsStorageService;
-    // private final ApiTradeStatisticsManager apiTradeStatisticsManager; // Too hard to bootstrap
     private final CorruptedStorageFileHandler corruptedStorageFileHandler;
     private final CoreNetworkProtoResolver coreNetworkProtoResolver;
     private final CorePersistenceProtoResolver corePersistenceProtoResolver;
@@ -188,30 +186,9 @@ class StatisticsTestBootstrapper {
                 keyRing,
                 mailboxMessageService);
 
-        // This is not going to work, statistics managers are too complicated to bootstrap here.
-        /*
-        this.tradeStatisticsManager = new TradeStatisticsManager(p2PService,
-                priceFeedService,
-                tradeStatistics3StorageService,
-                appendOnlyDataStoreService,
-                null,
-                dbStorageDir,
-                false);
-
-        this.apiTradeStatisticsManager = new ApiTradeStatisticsManager(p2PService,
-                apiTradeStatisticsStorageService,
-                tradeStatistics3StorageService,
-                tradeStatisticsManager,
-                appendOnlyDataStoreService,
-                dbStorageDir,
-                false);
-
-        // Set static INSTANCE for TradeStatistics3.isValid checks.
-        DaoState daoState = new DaoState();
-        DaoStateService daoStateService = new DaoStateService(daoState, null, new BsqFormatter());
-        TradeLimits tradeLimits = new TradeLimits(daoStateService, new PeriodService(null));
-        log.info(tradeLimits.toString());
-         */
+        // Wiring up the statistics managers is complicated from here, but
+        // the API test harness can make sure ApiStatisticsManager works
+        // as expected.
     }
 
     public void initializeServices() {

--- a/core/src/test/java/bisq/core/trade/statistics/StatisticsTestBootstrapper.java
+++ b/core/src/test/java/bisq/core/trade/statistics/StatisticsTestBootstrapper.java
@@ -1,0 +1,264 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.core.network.p2p.seed.DefaultSeedNodeRepository;
+import bisq.core.proto.network.CoreNetworkProtoResolver;
+import bisq.core.proto.persistable.CorePersistenceProtoResolver;
+import bisq.core.provider.PriceHttpClient;
+import bisq.core.provider.ProvidersRepository;
+import bisq.core.provider.price.PriceFeedService;
+import bisq.core.user.Preferences;
+
+import bisq.network.Socks5ProxyProvider;
+import bisq.network.crypto.EncryptionService;
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.mailbox.IgnoredMailboxService;
+import bisq.network.p2p.mailbox.MailboxMessageService;
+import bisq.network.p2p.network.LocalhostNetworkNode;
+import bisq.network.p2p.peers.Broadcaster;
+import bisq.network.p2p.peers.PeerManager;
+import bisq.network.p2p.peers.getdata.RequestDataManager;
+import bisq.network.p2p.peers.keepalive.KeepAliveManager;
+import bisq.network.p2p.peers.peerexchange.PeerExchangeManager;
+import bisq.network.p2p.storage.P2PDataStorage;
+import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
+import bisq.network.p2p.storage.persistence.ProtectedDataStoreService;
+import bisq.network.p2p.storage.persistence.RemovedPayloadsService;
+import bisq.network.p2p.storage.persistence.ResourceDataStoreService;
+
+import bisq.common.ClockWatcher;
+import bisq.common.config.Config;
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.KeyStorage;
+import bisq.common.file.CorruptedStorageFileHandler;
+import bisq.common.file.FileUtil;
+import bisq.common.persistence.PersistenceManager;
+
+import java.time.Clock;
+
+import java.nio.file.Files;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.ArrayList;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.network.utils.Utils.findFreeSystemPort;
+
+/**
+ * P2P storage bootstrapper for testing storage file read & write.
+ *
+ * TODO Rename, refactor, and move to different pkg when needed by other core test cases.
+ */
+@Slf4j
+@Getter
+class StatisticsTestBootstrapper {
+
+    private final File storageDir;
+    private final File dbStorageDir;
+    private final File keysStorageDir;
+    private final Config config;
+    private final String storeFilenamePostFix = "_TEST"; // or = "_" + config.baseCurrencyNetwork.name();
+    private final Clock clock;
+    private final LocalhostNetworkNode networkNode;
+    private final P2PDataStorage p2PDataStorage;
+    private final P2PService p2PService;
+    private final PriceFeedService priceFeedService;
+    private final TradeStatistics3StorageService tradeStatistics3StorageService;
+    // private final TradeStatisticsManager tradeStatisticsManager; // Too hard to bootstrap
+    private final ApiTradeStatisticsStorageService apiTradeStatisticsStorageService;
+    // private final ApiTradeStatisticsManager apiTradeStatisticsManager; // Too hard to bootstrap
+    private final CorruptedStorageFileHandler corruptedStorageFileHandler;
+    private final CoreNetworkProtoResolver coreNetworkProtoResolver;
+    private final CorePersistenceProtoResolver corePersistenceProtoResolver;
+    private final DefaultSeedNodeRepository seedNodeRepository;
+    private final PeerManager peerManager;
+    private final Broadcaster broadcaster;
+    private final AppendOnlyDataStoreService appendOnlyDataStoreService;
+    private final ProtectedDataStoreService protectedDataStoreService;
+    private final ResourceDataStoreService resourceDataStoreService;
+    private final RemovedPayloadsService removedPayloadsService;
+    private final int maxSequenceNumberBeforePurge = 5;
+
+    StatisticsTestBootstrapper() {
+        this.config = new Config();
+        this.clock = Clock.systemDefaultZone();
+        this.storageDir = createStorageDirs();
+        this.dbStorageDir = new File(storageDir.getAbsolutePath(), "db");
+        this.keysStorageDir = new File(storageDir.getAbsolutePath(), "keys");
+        this.corruptedStorageFileHandler = new CorruptedStorageFileHandler();
+        this.coreNetworkProtoResolver = new CoreNetworkProtoResolver(clock);
+        this.corePersistenceProtoResolver = new CorePersistenceProtoResolver(null, coreNetworkProtoResolver);
+        this.networkNode = new LocalhostNetworkNode(findFreeSystemPort(), coreNetworkProtoResolver, null);
+        this.seedNodeRepository = new DefaultSeedNodeRepository(config);
+        this.peerManager = new PeerManager(networkNode,
+                seedNodeRepository,
+                new ClockWatcher(),
+                new PersistenceManager<>(storageDir, corePersistenceProtoResolver, corruptedStorageFileHandler),
+                5);
+        this.broadcaster = new Broadcaster(networkNode, peerManager);
+        this.protectedDataStoreService = new ProtectedDataStoreService();
+        this.resourceDataStoreService = new ResourceDataStoreService();
+        this.removedPayloadsService = new RemovedPayloadsService(
+                new PersistenceManager<>(storageDir, corePersistenceProtoResolver, corruptedStorageFileHandler));
+
+        this.tradeStatistics3StorageService = new TradeStatistics3StorageService(dbStorageDir,
+                new PersistenceManager<>(dbStorageDir, corePersistenceProtoResolver, corruptedStorageFileHandler));
+        this.apiTradeStatisticsStorageService = new ApiTradeStatisticsStorageService(dbStorageDir,
+                new PersistenceManager<>(dbStorageDir, corePersistenceProtoResolver, corruptedStorageFileHandler));
+
+        this.appendOnlyDataStoreService = new AppendOnlyDataStoreService();
+        appendOnlyDataStoreService.addService(tradeStatistics3StorageService);
+        appendOnlyDataStoreService.addService(apiTradeStatisticsStorageService);
+
+        this.p2PDataStorage = new P2PDataStorage(networkNode,
+                broadcaster,
+                appendOnlyDataStoreService,
+                protectedDataStoreService,
+                resourceDataStoreService,
+                new PersistenceManager<>(dbStorageDir, corePersistenceProtoResolver, corruptedStorageFileHandler),
+                removedPayloadsService,
+                clock,
+                maxSequenceNumberBeforePurge);
+
+        KeyRing keyRing = new KeyRing(new KeyStorage(keysStorageDir));
+        RequestDataManager requestDataManager = new RequestDataManager(networkNode,
+                seedNodeRepository,
+                p2PDataStorage,
+                peerManager);
+        PeerExchangeManager peerExchangeManager = new PeerExchangeManager(networkNode,
+                seedNodeRepository,
+                peerManager);
+        KeepAliveManager keepAliveManager = new KeepAliveManager(networkNode, peerManager);
+        // config.socks5ProxyBtcAddress, config.socks5ProxyHttpAddress are null
+        Socks5ProxyProvider socks5ProxyProvider = new Socks5ProxyProvider(config.socks5ProxyBtcAddress, config.socks5ProxyHttpAddress);
+        EncryptionService encryptionService = new EncryptionService(keyRing, coreNetworkProtoResolver);
+        MailboxMessageService mailboxMessageService = new MailboxMessageService(networkNode,
+                peerManager,
+                p2PDataStorage,
+                encryptionService,
+                new IgnoredMailboxService(new PersistenceManager<>(dbStorageDir, corePersistenceProtoResolver, corruptedStorageFileHandler)),
+                new PersistenceManager<>(dbStorageDir, corePersistenceProtoResolver, corruptedStorageFileHandler),
+                keyRing,
+                clock,
+                false);
+
+        Preferences preferences = new Preferences(
+                new PersistenceManager<>(dbStorageDir, corePersistenceProtoResolver, corruptedStorageFileHandler),
+                config,
+                null,
+                null,
+                null,
+                null,
+                Config.DEFAULT_FULL_DAO_NODE,
+                null,
+                null,
+                Config.UNSPECIFIED_PORT);
+        ProvidersRepository providersRepository = new ProvidersRepository(config, new ArrayList<>(), true);
+        this.priceFeedService = new PriceFeedService(new PriceHttpClient(null), providersRepository, preferences);
+
+        this.p2PService = new P2PService(networkNode,
+                peerManager,
+                p2PDataStorage,
+                requestDataManager,
+                peerExchangeManager,
+                keepAliveManager,
+                broadcaster,
+                socks5ProxyProvider,
+                encryptionService,
+                keyRing,
+                mailboxMessageService);
+
+        // This is not going to work, statistics managers are too complicated to bootstrap here.
+        /*
+        this.tradeStatisticsManager = new TradeStatisticsManager(p2PService,
+                priceFeedService,
+                tradeStatistics3StorageService,
+                appendOnlyDataStoreService,
+                null,
+                dbStorageDir,
+                false);
+
+        this.apiTradeStatisticsManager = new ApiTradeStatisticsManager(p2PService,
+                apiTradeStatisticsStorageService,
+                tradeStatistics3StorageService,
+                tradeStatisticsManager,
+                appendOnlyDataStoreService,
+                dbStorageDir,
+                false);
+
+        // Set static INSTANCE for TradeStatistics3.isValid checks.
+        DaoState daoState = new DaoState();
+        DaoStateService daoStateService = new DaoStateService(daoState, null, new BsqFormatter());
+        TradeLimits tradeLimits = new TradeLimits(daoStateService, new PeriodService(null));
+        log.info(tradeLimits.toString());
+         */
+    }
+
+    public void initializeServices() {
+        appendOnlyDataStoreService.readFromResources(storeFilenamePostFix, () -> {
+        });
+        PersistenceManager.onAllServicesInitialized();
+        sleep(3_000); // Let service threads finish.  (TODO need a delay param?)
+    }
+
+    public PersistenceManager createPersistenceManager(File storageDir) {
+        return new PersistenceManager<>(storageDir, corePersistenceProtoResolver, corruptedStorageFileHandler);
+    }
+
+    public void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException ignored) {
+            // ignored
+        }
+    }
+
+    public void shutdown() {
+        log.info("Shutting down " + p2PDataStorage.getClass().getSimpleName());
+        // TODO Does anything else need to be explicitly shut down?
+        p2PDataStorage.shutDown();
+        log.info("Shut down");
+
+        try {
+            log.info("Deleting storage directory {}", storageDir.getAbsolutePath());
+            FileUtil.deleteDirectory(storageDir);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private File createStorageDirs() {
+        try {
+            File rootDir = Files.createTempDirectory("bisq-test-storage-").toFile();
+
+            File dbDir = new File(rootDir.getAbsolutePath(), "db");
+            dbDir.mkdir();
+            File keysDir = new File(rootDir.getAbsolutePath(), "keys");
+            keysDir.mkdir();
+
+            return rootDir;
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
@@ -100,6 +100,7 @@ public class TradesChartsViewModelTest {
             false,
             null,
             null,
+            false,
             1
     );
 

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -636,6 +636,7 @@ public class OfferBookViewModelTest {
                 false,
                 null,
                 null,
+                false,
                 1));
     }
 }

--- a/desktop/src/test/java/bisq/desktop/maker/OfferMaker.java
+++ b/desktop/src/test/java/bisq/desktop/maker/OfferMaker.java
@@ -118,6 +118,7 @@ public class OfferMaker {
                     false,
                     null,
                     null,
+                    false,
                     lookup.valueOf(protocolVersion, 0)));
 
     public static final Maker<Offer> btcUsdOffer = a(Offer);

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -644,6 +644,15 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     // Client API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    @VisibleForTesting
+    public boolean addPersistableNetworkPayload(PersistableNetworkPayload payload,
+                                                @Nullable NodeAddress sender,
+                                                boolean allowBroadcast,
+                                                boolean allowReBroadcast) {
+        return addPersistableNetworkPayload(
+                payload, sender, allowBroadcast, allowReBroadcast, false);
+    }
+
     /**
      * Adds a PersistableNetworkPayload to the local P2P data storage. If it does not already exist locally, it will
      * be broadcast to the P2P network.

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -350,6 +350,8 @@ message OfferInfo {
     string version_nr = 30;
     // The bitcoin protocol version used to create the offer.
     int32 protocol_version = 31;
+    // Whether the offer was created with the API or not.
+    bool is_maker_api_user = 32;
 }
 
 // An offer's current availability status.
@@ -653,6 +655,8 @@ message TradeInfo {
     BsqSwapTradeInfo bsq_swap_trade_info = 28;
     // Needed by open/closed/failed trade list items.
     string closing_status = 29;
+    // Whether the offer was taken with the API or not.
+    bool is_taker_api_user = 32;
 }
 
 message ContractInfo {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -613,6 +613,7 @@ message PersistableNetworkPayload {
         BlindVotePayload blind_vote_payload = 4;
         SignedWitness signed_witness = 5;
         TradeStatistics3 trade_statistics3 = 6;
+        ApiTradeStatistics api_trade_statistics = 7;
     }
 }
 
@@ -793,6 +794,10 @@ message TradeStatistics3 {
     map<string, string> extra_data = 9;
 }
 
+message ApiTradeStatistics {
+    bytes bytes = 1;
+}
+
 message MailboxStoragePayload {
     PrefixedSealedAndSignedMessage prefixed_sealed_and_signed_message = 1;
     bytes sender_pub_key_for_add_operation_bytes = 2;
@@ -841,6 +846,7 @@ message OfferPayload {
     string hash_of_challenge = 36;
     map<string, string> extra_data = 37;
     int32 protocol_version = 38;
+    bool is_maker_api_user = 39;
 }
 
 enum OfferDirection {
@@ -862,6 +868,7 @@ message BsqSwapOfferPayload {
     map<string, string> extra_data = 10;
     string version_nr = 11;
     int32 protocol_version = 12;
+    bool is_maker_api_user = 13;
 }
 
 message ProofOfWork {
@@ -1487,6 +1494,7 @@ message PersistableEnvelope {
         IgnoredMailboxMap ignored_mailbox_map = 33;
         RemovedPayloadsMap removed_payloads_map = 34;
         BsqBlockStore bsq_block_store = 35;
+        ApiTradeStatisticsStore api_trade_statistics_store = 36;
     }
 }
 
@@ -1531,6 +1539,10 @@ message TradeStatistics2Store {
 
 message TradeStatistics3Store {
     repeated TradeStatistics3 items = 1;
+}
+
+message ApiTradeStatisticsStore {
+    repeated ApiTradeStatistics items = 1;
 }
 
 message PeerList {
@@ -1731,6 +1743,7 @@ message Trade {
     string counter_currency_extra_data = 37;
     string asset_tx_proof_result = 38; // name of AssetTxProofResult enum
     string uid = 39;
+    bool is_taker_api_user = 40;
 }
 
 message BuyerAsMakerTrade {
@@ -1769,6 +1782,7 @@ message BsqSwapTrade {
     string tx_id = 10;
     string error_message = 11;
     State state = 12;
+    bool is_taker_api_user = 13;
 }
 
 message BsqSwapBuyerAsMakerTrade {


### PR DESCRIPTION

## Why API trading stats should be collected

The decision to approve the collection of API stats will weigh the cost of the coding, and network & memory overhead, against the need to know if the API is being used, and how much.  At the moment, we know little of API usage.

## Implementation summary

To summarize the impact of API stats collection: it adds two pieces of information to Bisq v1 storage and its network:

- Boolean field `is_maker_api_user` is added to Offer model and proto msg (was offer created by API).

- Boolean field `is_taker_api_user` is added to Trade model and proto msg (was offer taken by API).

- A new domain class `ApiTradeStatistics` was added to core, plus classes `ApiTradeStatisticsStore`,  `ApiTradeStatisticsStorageService`, and `ApiTradeStatisticsManager` (analogs of domain & store management classes for `TradeStatistics3`).

- Lifecyle for the new store and manager singletons is handled the same way as it is for `TradeStatistics3`.

## Who will use API trading stats

Bisq team members are the intended users of the first cut of this feature.  If the standard `--dumpStatistics=true` option is passed to the `bisq-daemon` and `bisq-desktop` startup scripts, API trading stats will be dumped to the appDataDir's db storage directory every time the API was used to by either side of a new trade, and the final dump during bisq shutdown.

### API trade statistics format

At this early stage, I chose to skip the work on dumping API stats as Json (and implementing code to consume it).  The dumped CSV data can be sliced and diced in many ways after importing them into spreadsheet apps, and this will give ideas on how to report API trading stats in API clients and the desktop.

When API stats are requested or dumped, `ApiTradeStatistics` is joined to `TradeStatistics3` (by `hash`), and the resulting CSV rows file will contain two flags: `is_maker_api_user`, `is_taker_api_user`, followed by the `TradeStatistics3` field values.

## How API stats are collected, stored, and broadcast

To summarize, just like `TradingStatistics3` are collected, stored, and broadcast, with the following differences:

- `ApiTradeStatistics` payloads are broadcast only after a BSQ swap buyer publishes a `TradeStatistics3` payload (see `PublishTradeStatistics`), and (a) the API was used to create the offer, (b) the API was used to take the offer, or (c) the API was used to make and take the offer.  Same is true for fiat and XMR trades (see `SellerPublishesTradeStatistics`).

- Each new `ApiTradeStatistics` instance contains the matching trade's `TradeStatistics3.hash` plus a byte determining how the API was used in the trade (by maker, taker, or both).

- When statistics are dumped, each `ApiTradeStatistics` object is _lazily_ joined to its matching `TradeStatistics3` on the hash, and each `TradeStatistics3`'s field values are written to CSV.

##  How much data is added to the network and storage

An `ApiTradeStatistics` payload on the wire is 25 bytes, roughly half that of a `TradeStatistics3` payload.

- 20 bytes are used for the hash used to join on its matching `TradeStatistics3`.
- 1 byte determines whether the offer was created by the API, taken by the API, or both.
- 4 bytes are protobuf object overhead

Any number of stored `ApiTradeStatistics` protos will be ~ 1/2 the size of an equal number of stored TradeStatistics3 protos.

## Testing

- `ApiTradeStatistics` serialization unit test:  `ApiTradeStatisticsTest`.

- API trade statistics store read/write (integration) test: `ApiTradeStatisticsIntegrationTest`.

- I am testing `ApiTradeStatisticsManager` via API regtest trade simulation runs, and `apitest` cases.

## TODO

- Implement `ApiTradeStatisticsManager.maybeRepublishApiTradeStatistics(...)`.

- Discuss how historical storage snapshots are created with @chimp1984 and/or @ripcurlx.  (It is still a bit magical to me.) 
 Implement what is needed to support it.

- Create a new API method `getapistats` with appropriate request params to dump stats to csv (and/or json?)

- Confer with @chimp1984 about a backward compatibility issue at the bottom of  core's `OfferPayload` class.  See its static class `JsonSerializer`.  The question is if the new field `isMakerApiUser` should NOT be serialized, to maintain backward compatibility.