### PR TITLE
Include option for non-URI addresses in QR codes

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -830,6 +830,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         requestPersistence();
     }
 
+    public void setUseBitcoinUrisInQrCodes(boolean value) {
+        prefPayload.setUseBitcoinUrisInQrCodes(value);
+        requestPersistence();
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Getter
@@ -1147,6 +1152,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         void setNotifyOnPreRelease(boolean value);
 
         void setUseFullModeDaoMonitor(boolean value);
+
+        void setUseBitcoinUrisInQrCodes(boolean value);
 
         void setClearDataAfterDays(int value);
 

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -140,6 +140,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
     private boolean denyApiTaker;
     private boolean notifyOnPreRelease;
     private boolean useFullModeDaoMonitor;
+    private boolean useBitcoinUrisInQrCodes = true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -209,7 +210,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .setShowOffersMatchingMyAccounts(showOffersMatchingMyAccounts)
                 .setDenyApiTaker(denyApiTaker)
                 .setNotifyOnPreRelease(notifyOnPreRelease)
-                .setUseFullModeDaoMonitor(useFullModeDaoMonitor);
+                .setUseFullModeDaoMonitor(useFullModeDaoMonitor)
+                .setUseBitcoinUrisInQrCodes(useBitcoinUrisInQrCodes);
 
         Optional.ofNullable(backupDirectory).ifPresent(builder::setBackupDirectory);
         Optional.ofNullable(preferredTradeCurrency).ifPresent(e -> builder.setPreferredTradeCurrency((protobuf.TradeCurrency) e.toProtoMessage()));
@@ -313,7 +315,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.getShowOffersMatchingMyAccounts(),
                 proto.getDenyApiTaker(),
                 proto.getNotifyOnPreRelease(),
-                proto.getUseFullModeDaoMonitor()
+                proto.getUseFullModeDaoMonitor(),
+                proto.getUseBitcoinUrisInQrCodes()
         );
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1327,6 +1327,11 @@ setting.preferences.txFeeTooLarge=Your input is above any reasonable value (>500
 setting.preferences.ignorePeers=Ignored peers [onion address:port]
 setting.preferences.ignoreDustThreshold=Min. non-dust output value
 setting.preferences.clearDataAfterDays=Clear sensitive data after (days)
+setting.preferences.useBitcoinUris=Use bitcoin URIs in QR codes
+setting.preferences.useBitcoinUris.tooltip=Bisq's QR codes can either store bitcoin URIs containing the address along\n\
+  with some extra parameters (amount & label) or plain bitcoin addresses\n\
+  with no additional data. Disable this option if your external wallet's\n\
+  scanner cannot handle the bitcoin URI scheme format.
 setting.preferences.currenciesInList=Currencies in market price feed list
 setting.preferences.prefCurrency=Preferred currency
 setting.preferences.displayFiat=Display national currencies

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -847,7 +847,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         missingCoinListener = (observable, oldValue, newValue) -> {
             if (!newValue.toString().equals("")) {
                 final byte[] imageBytes = QRCode
-                        .from(getBitcoinURI())
+                        .from(getStringToEncode())
                         .withSize(98, 98) // code has 41 elements 8 px is border with 98 we get double scale and min. border
                         .to(ImageType.PNG)
                         .stream()
@@ -1231,7 +1231,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         Tooltip.install(qrCodeImageView, new Tooltip(Res.get("shared.openLargeQRWindow")));
         qrCodeImageView.setOnMouseClicked(e -> GUIUtil.showFeeInfoBeforeExecute(
                 () -> UserThread.runAfter(
-                        () -> new QRCodeWindow(getBitcoinURI()).show(),
+                        () -> new QRCodeWindow(getStringToEncode()).show(),
                         200, TimeUnit.MILLISECONDS)));
         GridPane.setRowIndex(qrCodeImageView, gridRow);
         GridPane.setColumnIndex(qrCodeImageView, 1);
@@ -1338,6 +1338,14 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private String getBitcoinURI() {
         return GUIUtil.getBitcoinURI(addressTextField.getAddress(), model.getDataModel().getMissingCoin().get(),
                 model.getPaymentLabel());
+    }
+
+    @NotNull
+    private String getStringToEncode() {
+        String address = addressTextField.getAddress() != null ?
+                addressTextField.getAddress() : "";
+        return GUIUtil.getPreferences().isUseBitcoinUrisInQrCodes() ?
+                getBitcoinURI() : address;
     }
 
     private void addAmountPriceFields() {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferView.java
@@ -555,7 +555,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         }
 
         final byte[] imageBytes = QRCode
-                .from(getBitcoinURI())
+                .from(getStringToEncode())
                 .withSize(98, 98) // code has 41 elements 8 px is border with 98 we get double scale and min. border
                 .to(ImageType.PNG)
                 .stream()
@@ -973,7 +973,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         Tooltip.install(qrCodeImageView, new Tooltip(Res.get("shared.openLargeQRWindow")));
         qrCodeImageView.setOnMouseClicked(e -> GUIUtil.showFeeInfoBeforeExecute(
                 () -> UserThread.runAfter(
-                        () -> new QRCodeWindow(getBitcoinURI()).show(),
+                        () -> new QRCodeWindow(getStringToEncode()).show(),
                         200, TimeUnit.MILLISECONDS)));
         GridPane.setRowIndex(qrCodeImageView, gridRow);
         GridPane.setColumnIndex(qrCodeImageView, 1);
@@ -1077,6 +1077,14 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         return GUIUtil.getBitcoinURI(model.dataModel.getAddressEntry().getAddressString(),
                 model.dataModel.getMissingCoin().get(),
                 model.getPaymentLabel());
+    }
+
+    @NotNull
+    private String getStringToEncode() {
+        String address = addressTextField.getAddress() != null ?
+                addressTextField.getAddress() : "";
+        return GUIUtil.getPreferences().isUseBitcoinUrisInQrCodes() ?
+                getBitcoinURI() : address;
     }
 
     private void addAmountPriceFields() {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/QRCodeWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/QRCodeWindow.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.overlays.windows;
 
-import bisq.desktop.components.AutoTooltipLabel;
 import bisq.desktop.main.overlays.Overlay;
 
 import bisq.core.locale.Res;
@@ -25,14 +24,11 @@ import bisq.core.locale.Res;
 import net.glxn.qrgen.QRCode;
 import net.glxn.qrgen.image.ImageType;
 
-import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Priority;
 
 import javafx.geometry.HPos;
-import javafx.geometry.Insets;
 
 import java.io.ByteArrayInputStream;
 
@@ -42,12 +38,12 @@ import org.slf4j.LoggerFactory;
 public class QRCodeWindow extends Overlay<QRCodeWindow> {
     private static final Logger log = LoggerFactory.getLogger(QRCodeWindow.class);
     private final ImageView qrCodeImageView;
-    private final String bitcoinURI;
+    private final String bitcoinAddressOrURI;
 
-    public QRCodeWindow(String bitcoinURI) {
-        this.bitcoinURI = bitcoinURI;
+    public QRCodeWindow(String bitcoinAddressOrURI) {
+        this.bitcoinAddressOrURI = bitcoinAddressOrURI;
         final byte[] imageBytes = QRCode
-                .from(bitcoinURI)
+                .from(bitcoinAddressOrURI)
                 .withSize(250, 250)
                 .to(ImageType.PNG)
                 .stream()
@@ -71,10 +67,11 @@ public class QRCodeWindow extends Overlay<QRCodeWindow> {
         GridPane.setHalignment(qrCodeImageView, HPos.CENTER);
         gridPane.getChildren().add(qrCodeImageView);
 
-        message = bitcoinURI.replace("%20", " ").replace("?", "\n?").replace("&", "\n&");
+        message = bitcoinAddressOrURI.replace("%20", " ").replace("?", "\n?").replace("&", "\n&");
         setTruncatedMessage();
-
         addMessage();
+        GridPane.setHalignment(messageLabel, HPos.CENTER);
+
         addButtons();
         applyStyles();
         display();

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -80,6 +80,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.control.Separator;
 import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleButton;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
@@ -97,6 +98,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import javafx.util.Callback;
+import javafx.util.Duration;
 import javafx.util.StringConverter;
 
 import java.io.File;
@@ -122,7 +124,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
     private ToggleButton showOwnOffersInOfferBook, useAnimations, useDarkMode, sortMarketCurrenciesNumerically,
             avoidStandbyMode, useCustomFee, autoConfirmXmrToggle, hideNonAccountPaymentMethodsToggle, denyApiTakerToggle,
-            notifyOnPreReleaseToggle, isDaoFullNodeToggleButton, fullModeDaoMonitorToggleButton;
+            notifyOnPreReleaseToggle, isDaoFullNodeToggleButton, fullModeDaoMonitorToggleButton, useBitcoinUrisToggle;
     private int gridRow = 0;
     private int displayCurrenciesGridRowIndex = 0;
     private InputTextField transactionFeeInputTextField, ignoreTradersListInputTextField, ignoreDustThresholdInputTextField,
@@ -263,7 +265,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void initializeGeneralOptions() {
-        int titledGroupBgRowSpan = displayStandbyModeFeature ? 10 : 9;
+        int titledGroupBgRowSpan = displayStandbyModeFeature ? 11 : 10;
         TitledGroupBg titledGroupBg = addTitledGroupBg(root, gridRow, titledGroupBgRowSpan, Res.get("setting.preferences.general"));
         GridPane.setColumnSpan(titledGroupBg, 1);
 
@@ -416,6 +418,13 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             avoidStandbyMode = addSlideToggleButton(root, ++gridRow,
                     Res.get("setting.preferences.avoidStandbyMode"));
         }
+
+        useBitcoinUrisToggle = addSlideToggleButton(root, ++gridRow, Res.get("setting.preferences.useBitcoinUris"));
+        Tooltip tooltip = new Tooltip(Res.get("setting.preferences.useBitcoinUris.tooltip"));
+        tooltip.setShowDuration(Duration.millis(8000));
+        tooltip.setShowDelay(Duration.millis(300));
+        tooltip.setHideDelay(Duration.millis(0));
+        Tooltip.install(useBitcoinUrisToggle, tooltip);
     }
 
     private void initializeSeparator() {
@@ -904,6 +913,10 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             }
         });
 
+        useBitcoinUrisToggle.setSelected(preferences.isUseBitcoinUrisInQrCodes());
+        useBitcoinUrisToggle.setOnAction(e ->
+                preferences.setUseBitcoinUrisInQrCodes(useBitcoinUrisToggle.isSelected()));
+
         btcExplorerTextField.setText(preferences.getBlockChainExplorer().name);
         bsqExplorerTextField.setText(preferences.getBsqBlockChainExplorer().name);
 
@@ -1172,6 +1185,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         userCountryComboBox.setOnAction(null);
         editCustomBtcExplorer.setOnAction(null);
         editCustomBsqExplorer.setOnAction(null);
+        useBitcoinUrisToggle.setOnAction(null);
         deviationInputTextField.textProperty().removeListener(deviationListener);
         deviationInputTextField.focusedProperty().removeListener(deviationFocusedListener);
         transactionFeeInputTextField.focusedProperty().removeListener(transactionFeeFocusedListener);

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -147,6 +147,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.jetbrains.annotations.NotNull;
@@ -173,14 +175,12 @@ public class GUIUtil {
     public static TradeCurrency TOP_ALTCOIN = CurrencyUtil.getTradeCurrency("XMR").get();
 
     private static FeeService feeService;
+    @Getter
+    @Setter
     private static Preferences preferences;
 
     public static void setFeeService(FeeService feeService) {
         GUIUtil.feeService = feeService;
-    }
-
-    public static void setPreferences(Preferences preferences) {
-        GUIUtil.preferences = preferences;
     }
 
     public static String getUserLanguage() {
@@ -788,6 +788,9 @@ public class GUIUtil {
     }
 
     public static String getBitcoinURI(String address, Coin amount, String label) {
+        if (amount.isZero()) {
+            amount = null;
+        }
         return address != null ?
                 BitcoinURI.convertToBitcoinURI(Address.fromString(Config.baseCurrencyNetworkParameters(),
                         address), amount, label, null) :

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1956,6 +1956,7 @@ message PreferencesPayload {
     int32 clear_data_after_days = 63;
     string buy_screen_crypto_currency_code = 64;
     string sell_screen_crypto_currency_code = 65;
+    bool use_bitcoin_uris_in_qr_codes = 66;
 }
 
 message AutoConfirmSettings {


### PR DESCRIPTION
Resolves #6377

Includes an option in Preferences to control the way bitcoin addresses are encoded (either in bitcoin URI format or in plain non-URI format) and affects all views that generate/display a QR code.

- When the bitcoin URI format is selected (default), addresses are encoded like before: `bitcoin:address?amount=<AMOUNT>&label=<LABEL>`. In DepositView however the `amount` parameter will only be included if the amount is larger than zero. This will fix the particular issue mentioned above (`amount=0` is probably wrong because it can be interpreted as a request for 0 BTCs, so literally a request for no transaction). It won't make any difference in other views like TakeOfferView where the `amount` parameter is present because it's always greater than 0.

- When the plain format is selected, addresses are encoded simply as: `address`. This will allow all external wallets to read the generated QRs if they're facing issues (some can only read simple `bitcoin:address` URIs without any extra parameters, some cannot handle the URI scheme format altogether even when not having parameters, but all can read plain addresses).

I also added a simple text formatter to the amount text field in DepositView, mainly to prevent the exception-like message that pops up when you input a negative number:

![negative](https://user-images.githubusercontent.com/76814540/196497206-8139fb49-f213-45f8-86c7-4eb017b34cea.jpg)

The textfield will now only accept positive integer or positive dot-decimal numerical values.

### NOTE
After reading through BIP21 and on the topic of coin control, in my opinion a more "correct" format of Bisq's bitcoin URIs (ie. one that strictly adheres to the standard) would be the following:

For URIs generated in DepositView:
`bitcoin:<ADDRESS>?amount=<AMOUNT>&label=Bisq&message=Fund wallet` (instead of `&label=Fund Bisq wallet`)

For URIs generated when creating/taking offer:
`bitcoin:<ADDRESS>?amount=<AMOUNT>&label=Bisq&message=Trade with ID XXXXX` (instead of `&label=Bisq trade with ID X`)

Because the `label` of BIP21 seems to denote names/entities instead of payment reasons. This would allow the transactions to be tagged as intended by the few wallets that can parse the `label` parameter and that can also apply coin control.

I didn't change the format, just noting this here.