### PR TITLE
[v1.9.6] Resize action column if it contains own offers

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -143,6 +143,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
     private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> depositColumn;
     private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> signingStateColumn;
     private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> avatarColumn;
+    private TableColumn<OfferBookListItem, OfferBookListItem> actionColumn;
     private TableView<OfferBookListItem> tableView;
 
     private int gridRow = 0;
@@ -261,8 +262,9 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         tableView.getColumns().add(depositColumn);
         signingStateColumn = getSigningStateColumn();
         tableView.getColumns().add(signingStateColumn);
+        actionColumn = getActionColumn();
+        tableView.getColumns().add(actionColumn);
         avatarColumn = getAvatarColumn();
-        tableView.getColumns().add(getActionColumn());
         tableView.getColumns().add(avatarColumn);
 
         tableView.getSortOrder().add(priceColumn);
@@ -437,6 +439,8 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
 
         currencySelectionSubscriber = currencySelectionBinding.subscribe((observable, oldValue, newValue) -> {
         });
+
+        updateActionColumn();
 
         tableView.setItems(model.getOfferList());
 
@@ -1307,6 +1311,11 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         createOfferButton.setText(Res.get("offerbook.createNewOffer",
                 model.getDirection() == OfferDirection.BUY ? Res.get("shared.buy") : Res.get("shared.sell"),
                 getTradeCurrencyCode()).toUpperCase());
+    }
+
+    private void updateActionColumn() {
+        boolean hasOwnOffers = model.getOfferList().stream().anyMatch(offerBookListItem -> model.isMyOffer(offerBookListItem.getOffer()));
+        actionColumn.setMinWidth(hasOwnOffers ? 180 : 90);
     }
 
     abstract String getTradeCurrencyCode();


### PR DESCRIPTION
I think it would be better not to have truncation with our default with when having own offers.

![Bildschirmfoto 2022-10-19 um 13 24 45](https://user-images.githubusercontent.com/170962/196678380-f21343f3-807b-40c6-bd2a-dd476e4d9723.png)
![Bildschirmfoto 2022-10-19 um 13 24 54](https://user-images.githubusercontent.com/170962/196678412-aca1e77a-572d-472e-a5ba-bd136a75a8cc.png)
