### PR TITLE
Don't ask for SEPA Instant payment when buyer has SEPA account

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -101,6 +101,8 @@ import bisq.core.payment.payload.HalCashAccountPayload;
 import bisq.core.payment.payload.MoneyGramAccountPayload;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.payment.payload.SepaAccountPayload;
+import bisq.core.payment.payload.SepaInstantAccountPayload;
 import bisq.core.payment.payload.SwiftAccountPayload;
 import bisq.core.payment.payload.USPostalMoneyOrderAccountPayload;
 import bisq.core.payment.payload.WesternUnionAccountPayload;
@@ -243,9 +245,17 @@ public class BuyerStep2View extends TradeStepView {
         int rowSpanStart = gridRow;
 
         PaymentAccountPayload paymentAccountPayload = model.dataModel.getSellersPaymentAccountPayload();
+        PaymentAccountPayload buyersPaymentAccountPayload = model.dataModel.getBuyersPaymentAccountPayload();
         String paymentMethodId = paymentAccountPayload != null ? paymentAccountPayload.getPaymentMethodId() : "";
+
+        // consider special case where we might need to show buyer's (instead of seller's) payment method ID
+        String paymentMethodIdToDisplay = buyersPaymentAccountPayload instanceof SepaAccountPayload
+                && paymentAccountPayload instanceof SepaInstantAccountPayload ?
+                buyersPaymentAccountPayload.getPaymentMethodId() :
+                paymentMethodId;
+
         TitledGroupBg accountTitledGroupBg = addTitledGroupBg(gridPane, ++gridRow, 4,
-                Res.get("portfolio.pending.step2_buyer.startPaymentUsing", Res.get(paymentMethodId)),
+                Res.get("portfolio.pending.step2_buyer.startPaymentUsing", Res.get(paymentMethodIdToDisplay)),
                 Layout.COMPACT_GROUP_DISTANCE);
         GridPane.setColumnSpan(accountTitledGroupBg, 2);
 
@@ -425,7 +435,6 @@ public class BuyerStep2View extends TradeStepView {
             Offer offer = trade.getOffer();
             List<PaymentAccount> possiblePaymentAccounts = PaymentAccountUtil.getPossiblePaymentAccounts(offer,
                     model.getUser().getPaymentAccounts(), model.dataModel.getAccountAgeWitnessService());
-            PaymentAccountPayload buyersPaymentAccountPayload = model.dataModel.getBuyersPaymentAccountPayload();
             if (buyersPaymentAccountPayload != null && possiblePaymentAccounts.size() > 1) {
                 String id = buyersPaymentAccountPayload.getId();
                 possiblePaymentAccounts.stream()


### PR DESCRIPTION
Fixes #5919

How to reproduce:

1. Bob creates an offer to buy BTC with his **SEPA** account
2. Alice takes Bob's offer with her **SEPA Instant** account
3. Bob is then prompted to pay using SEPA Instant Payments instead of simple SEPA

Current code always decides which payment method to request from the buyer based on the seller's account type, so I added a special case for when maker/buyer has SEPA but taker/seller is using SEPA Instant.

Tested on localnet (after it happened to me on mainnet).