### PR TITLE
Prevent NPE in NetworkSettingsView when no connected peers are found

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -502,9 +502,10 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
         bitcoinNetworkListItems.setAll(walletsSetup.getPeerGroup().getConnectedPeers().stream()
                 .map(BitcoinNetworkListItem::new)
                 .collect(Collectors.toList()));
+        int bitcoinPeersChainHeight = walletsSetup.connectedPeersProperty().get() != null ?
+                PeerGroup.getMostCommonChainHeight(walletsSetup.connectedPeersProperty().get()) : 0;
         chainHeightTextField.textProperty().setValue(Res.get("settings.net.chainHeight",
-                walletsSetup.chainHeightProperty().get(),
-                PeerGroup.getMostCommonChainHeight(walletsSetup.connectedPeersProperty().get())));
+                walletsSetup.chainHeightProperty().get(), bitcoinPeersChainHeight));
     }
 }
 


### PR DESCRIPTION
Fixes #6390

To reproduce (not always, for some reason):

1. Start one Bisq instance (Bob) without deploying a complete localnet
2. Navigate to Settings > NETWORK INFO

While trying to set the value of `chainHeightTextField` it will pass a null list of peers to `getMostCommonChainHeight` which will throw the NPE. Sometimes it passes a non-null empty list instead, so it doesn't throw any NPE.
