### PR TITLE
Minor inclusions in deploy & undeploy targets (Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,8 @@ localnet: .localnet
 # user, you'll need to manually run each of the targets listed below
 # commands manually in a separate terminal or as background jobs.
 deploy: setup
+	# ensure localnet is not already deployed
+	if screen -ls localnet | grep Detached; then false; fi
 	# create a new screen session named 'localnet'
 	screen -dmS localnet
 	# deploy each node in its own named screen window
@@ -175,6 +177,8 @@ undeploy:
 	screen -S localnet -X at "#" stuff "^C"
 	# quit all screen windows which results in killing the session
 	screen -S localnet -X at "#" kill
+	# remove dead screens
+	screen -wipe || true
 
 bitcoind: .localnet
 	bitcoind \


### PR DESCRIPTION
If one wants to undeploy but accidentally makes the mistake to run `make deploy` while the localnet is already deployed, `make undeploy` will not work anymore. Instead of having to manually kill the detached screens (and also having to figuring out how to do it if you're not a screen user), I added a line in the `deploy` target to first check if the localnet is already deployed.

In the `undeploy` target I added a line to remove the dead screen(s) that are hanging around after `make undeploy` (they keep increasing in number after more deploying and undeploying).