### PR TITLE
Fix horizontal centering of overlays on Windows

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/Overlay.java
@@ -727,7 +727,9 @@ public abstract class Overlay<T extends Overlay<T>> {
             double titleBarHeight = window.getHeight() - rootScene.getHeight();
             if (Utilities.isWindows())
                 titleBarHeight -= 9;
-            stage.setX(Math.round(window.getX() + (owner.getWidth() - stage.getWidth()) / 2));
+
+            double windowWidth = Utilities.isWindows() ? window.getWidth() : owner.getWidth();
+            stage.setX(Math.round(window.getX() + (windowWidth - stage.getWidth()) / 2));
 
             if (type.animationType == AnimationType.SlideDownFromCenterTop)
                 stage.setY(Math.round(window.getY() + titleBarHeight));


### PR DESCRIPTION
Horizontal centering of overlays is not accurate on Windows; this is more noticeable when the application window isn't maximized.

Linux is probably unaffected by this (I've confirmed this isn't an issue on a Debian GNOME system but I'm not sure about other flavors) and I don't know about MacOS, so for now this is meant to be a Windows-only fix.

Before/after examples:

![Center1a](https://user-images.githubusercontent.com/76814540/203065168-a8217a0f-baa3-42e3-9a7e-c91f46c93504.jpg)

![Center1b](https://user-images.githubusercontent.com/76814540/203065178-86304924-f78b-4ca8-82a4-4bbd55ec8711.jpg)

![Center2a](https://user-images.githubusercontent.com/76814540/203065190-0374cab0-2bfd-4c51-8cbe-87815b7cff8c.jpg)

![Center2b](https://user-images.githubusercontent.com/76814540/203065197-dcf29bb5-7a85-4593-86a5-a7ba06fb22a9.jpg)