### PR TITLE
Increase mouse-wheel vertical scrolling speed in ScrollPane

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/BisqScrollPane.java
+++ b/desktop/src/main/java/bisq/desktop/components/BisqScrollPane.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components;
+
+import bisq.common.util.Utilities;
+
+import javafx.scene.Node;
+import javafx.scene.control.ScrollPane;
+
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+
+/**
+ * Custom scroll pane that uses a workaround to fix slow vertical scrolling.
+ */
+public class BisqScrollPane extends ScrollPane {
+
+    private final double BASE_DELTA_Y_MULTIPLIER = 0.8;
+    private double deltaYMultiplier = BASE_DELTA_Y_MULTIPLIER;
+
+    public BisqScrollPane() {
+        super();
+        if (Utilities.isLinux() || Utilities.isWindows()) {
+            if (getContent() == null) {
+                contentProperty().addListener(new ChangeListener<>() {
+                    @Override
+                    public void changed(ObservableValue<? extends Node> o, Node oldVal, Node newVal) {
+                        contentProperty().removeListener(this);
+                        changeScrollingSpeed();
+                    }
+                });
+            } else {
+                changeScrollingSpeed();
+            }
+        }
+    }
+
+    private void changeScrollingSpeed() {
+        getContent().setOnScroll(scrollEvent -> {
+            double deltaY = scrollEvent.getDeltaY() * deltaYMultiplier;
+            double fullHeight = getContent().getBoundsInLocal().getHeight();
+            double visibleHeight = getBoundsInLocal().getHeight();
+            double heightDiff = fullHeight - visibleHeight;
+            double diff = heightDiff > 1 ? heightDiff : 1;
+            setVvalue(getVvalue() - deltaY / diff);
+        });
+    }
+
+    /**
+     * Sets the vertical scroll amount's multiplier. Any value below BASE_DELTA_Y_MULTIPLIER
+     * will decrease the scrolling speed whereas any value above will accelerate it.
+     * @param deltaYMultiplier the value by which deltaY will be multiplied
+     */
+    public void setDeltaYMultiplier(double deltaYMultiplier) {
+        this.deltaYMultiplier = deltaYMultiplier;
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/account/AccountView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/account/AccountView.fxml
@@ -18,41 +18,41 @@
   -->
 
 <?import com.jfoenix.controls.JFXTabPane?>
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <JFXTabPane fx:id="root" fx:controller="bisq.desktop.main.account.AccountView"
             prefHeight="630.0" prefWidth="1000.0"
             AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
             AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0"
             xmlns:fx="http://javafx.com/fxml">
     <Tab fx:id="fiatAccountsTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    fitToHeight="true"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        fitToHeight="true"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="altcoinAccountsTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    fitToHeight="true"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        fitToHeight="true"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="notificationTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="passwordTab" closable="false"/>
     <Tab fx:id="seedWordsTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="walletInfoTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="backupTab" closable="false"/>
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingView.fxml
@@ -17,22 +17,22 @@
   ~ along with Bisq. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <AnchorPane fx:id="root" fx:controller="bisq.desktop.main.dao.bonding.BondingView"
             xmlns:fx="http://javafx.com/fxml">
 
     <VBox fx:id="leftVBox" prefWidth="240" spacing="5" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15"
           AnchorPane.topAnchor="15"/>
 
-    <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                fitToHeight="true"
-                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
-                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+    <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                    fitToHeight="true"
+                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <AnchorPane fx:id="content" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
                     AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
-    </ScrollPane>
+    </BisqScrollPane>
 
 </AnchorPane>
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/BurnBsqView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/BurnBsqView.fxml
@@ -17,22 +17,22 @@
   ~ along with Bisq. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <AnchorPane fx:id="root" fx:controller="bisq.desktop.main.dao.burnbsq.BurnBsqView"
             xmlns:fx="http://javafx.com/fxml">
 
     <VBox fx:id="leftVBox" prefWidth="240" spacing="5" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15"
           AnchorPane.topAnchor="15"/>
 
-    <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                fitToHeight="true"
-                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
-                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+    <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                    fitToHeight="true"
+                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <AnchorPane fx:id="content" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
                     AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
-    </ScrollPane>
+    </BisqScrollPane>
 
 </AnchorPane>
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/EconomyView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/EconomyView.fxml
@@ -17,20 +17,19 @@
   ~ along with Bisq. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <AnchorPane fx:id="root" fx:controller="bisq.desktop.main.dao.economy.EconomyView"
             xmlns:fx="http://javafx.com/fxml">
 
     <VBox fx:id="leftVBox" prefWidth="240" spacing="5" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15"
           AnchorPane.topAnchor="15"/>
 
-    <ScrollPane fitToWidth="true" fitToHeight="true"
-                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
-                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+    <BisqScrollPane fitToWidth="true" fitToHeight="true"
+                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <AnchorPane fx:id="content"/>
-    </ScrollPane>
+    </BisqScrollPane>
 
 </AnchorPane>

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/GovernanceView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/GovernanceView.fxml
@@ -17,20 +17,20 @@
   ~ along with Bisq. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <AnchorPane fx:id="root" fx:controller="bisq.desktop.main.dao.governance.GovernanceView"
             xmlns:fx="http://javafx.com/fxml">
 
     <VBox fx:id="leftVBox" prefWidth="240" spacing="5" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15"
           AnchorPane.topAnchor="15"/>
 
-    <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
-                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+    <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <AnchorPane fx:id="content" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
                     AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
-    </ScrollPane>
+    </BisqScrollPane>
 
 </AnchorPane>

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.dao.governance;
 
 import bisq.desktop.Navigation;
+import bisq.desktop.components.BisqScrollPane;
 import bisq.desktop.components.HyperlinkWithIcon;
 import bisq.desktop.components.InputTextField;
 import bisq.desktop.components.TitledGroupBg;
@@ -69,7 +70,6 @@ import org.bitcoinj.core.Coin;
 
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.layout.AnchorPane;
@@ -670,8 +670,8 @@ public class ProposalDisplay {
     }
 
     @SuppressWarnings("Duplicates")
-    public ScrollPane getView() {
-        ScrollPane scrollPane = new ScrollPane();
+    public BisqScrollPane getView() {
+        BisqScrollPane scrollPane = new BisqScrollPane();
         scrollPane.setFitToWidth(true);
         scrollPane.setFitToHeight(true);
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/MonitorView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/MonitorView.fxml
@@ -17,21 +17,21 @@
   ~ along with Bisq. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <AnchorPane fx:id="root" fx:controller="bisq.desktop.main.dao.monitor.MonitorView"
             xmlns:fx="http://javafx.com/fxml">
 
     <VBox fx:id="leftVBox" prefWidth="240" spacing="5" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15"
           AnchorPane.topAnchor="15"/>
 
-    <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                fitToHeight="true"
-                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
-                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+    <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                    fitToHeight="true"
+                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <AnchorPane fx:id="content" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
                     AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
-    </ScrollPane>
+    </BisqScrollPane>
 
 </AnchorPane>

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/BsqWalletView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/BsqWalletView.fxml
@@ -17,20 +17,19 @@
   ~ along with Bisq. If not, see <http://www.gnu.org/licenses/>.
   -->
 
-
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <AnchorPane fx:id="root" fx:controller="bisq.desktop.main.dao.wallet.BsqWalletView"
             xmlns:fx="http://javafx.com/fxml">
 
     <VBox fx:id="leftVBox" prefWidth="240" spacing="5" AnchorPane.bottomAnchor="20" AnchorPane.leftAnchor="15"
           AnchorPane.topAnchor="15"/>
 
-    <ScrollPane fitToWidth="true" fitToHeight="true"
-                AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
-                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+    <BisqScrollPane fitToWidth="true" fitToHeight="true"
+                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="270.0"
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <AnchorPane fx:id="content"/>
-    </ScrollPane>
+    </BisqScrollPane>
 
 </AnchorPane>

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.fxml
@@ -18,24 +18,24 @@
   -->
 
 <?import com.jfoenix.controls.JFXTabPane?>
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <JFXTabPane fx:id="root" fx:controller="bisq.desktop.main.market.MarketView"
             AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
             AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0"
             xmlns:fx="http://javafx.com/fxml">
 
     <Tab fx:id="offerBookTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="spreadTab" closable="false"/>
     <Tab fx:id="spreadTabPaymentMethod" closable="false"/>
     <Tab fx:id="tradesTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
 </JFXTabPane>

--- a/desktop/src/main/java/bisq/desktop/main/offer/bsq_swap/BsqSwapOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bsq_swap/BsqSwapOfferView.java
@@ -215,15 +215,7 @@ public abstract class BsqSwapOfferView<M extends BsqSwapOfferViewModel<?>> exten
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void addScrollPane() {
-        scrollPane = new ScrollPane();
-        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        scrollPane.setFitToWidth(true);
-        scrollPane.setFitToHeight(true);
-        AnchorPane.setLeftAnchor(scrollPane, 0d);
-        AnchorPane.setTopAnchor(scrollPane, 0d);
-        AnchorPane.setRightAnchor(scrollPane, 0d);
-        AnchorPane.setBottomAnchor(scrollPane, 0d);
+        scrollPane = GUIUtil.createScrollPane();
         root.getChildren().add(scrollPane);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.overlays.windows;
 
 import bisq.desktop.components.AutoTooltipButton;
+import bisq.desktop.components.BisqScrollPane;
 import bisq.desktop.components.InputTextField;
 import bisq.desktop.main.overlays.Overlay;
 import bisq.desktop.main.overlays.popups.Popup;
@@ -97,7 +98,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
 
         createGridPane();
 
-        scrollPane = new ScrollPane();
+        scrollPane = new BisqScrollPane();
         scrollPane.setContent(gridPane);
         scrollPane.setFitToWidth(true);
         scrollPane.setFitToHeight(true);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.portfolio.pendingtrades.steps;
 
+import bisq.desktop.components.BisqScrollPane;
 import bisq.desktop.components.InfoTextField;
 import bisq.desktop.components.TitledGroupBg;
 import bisq.desktop.components.TxIdTextField;
@@ -120,7 +121,7 @@ public abstract class TradeStepView extends AnchorPane {
         trade = model.dataModel.getTrade();
         checkNotNull(trade, "Trade must not be null at TradeStepView");
 
-        ScrollPane scrollPane = new ScrollPane();
+        ScrollPane scrollPane = new BisqScrollPane();
         scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
         scrollPane.setFitToHeight(true);

--- a/desktop/src/main/java/bisq/desktop/main/settings/SettingsView.fxml
+++ b/desktop/src/main/java/bisq/desktop/main/settings/SettingsView.fxml
@@ -18,27 +18,27 @@
   -->
 
 <?import com.jfoenix.controls.JFXTabPane?>
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import bisq.desktop.components.BisqScrollPane?>
 <JFXTabPane fx:id="root" fx:controller="bisq.desktop.main.settings.SettingsView"
             AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
             AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0"
             xmlns:fx="http://javafx.com/fxml">
 
     <Tab fx:id="preferencesTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="networkTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
     <Tab fx:id="aboutTab" closable="false">
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+        <BisqScrollPane fitToWidth="true" hbarPolicy="NEVER"
+                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </Tab>
 </JFXTabPane>

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -20,6 +20,7 @@ package bisq.desktop.util;
 import bisq.desktop.Navigation;
 import bisq.desktop.app.BisqApp;
 import bisq.desktop.components.AutoTooltipLabel;
+import bisq.desktop.components.BisqScrollPane;
 import bisq.desktop.components.BisqTextArea;
 import bisq.desktop.components.InfoAutoTooltipLabel;
 import bisq.desktop.components.indicator.TxConfidenceIndicator;
@@ -1264,8 +1265,8 @@ public class GUIUtil {
         }
     }
 
-    public static ScrollPane createScrollPane() {
-        ScrollPane scrollPane = new ScrollPane();
+    public static BisqScrollPane createScrollPane() {
+        BisqScrollPane scrollPane = new BisqScrollPane();
         scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         scrollPane.setFitToWidth(true);


### PR DESCRIPTION
Fixes #3017

This PR increases the mouse-wheel scrolling "speed" inside scrollpanes (as stated in the linked issue above the scrolling is slow only inside ScrollPane but not in other components like TableView). I believe that the speed now is more or less of the degree that is usually expected universally in any kind of application.

Apparently the scroll amount in a ScrollPane depends on the content's full height, so the speed usually differs between views. If the content's height is large enough then the scrolling speed will be faster, but if the content is only slightly larger than the viewable area then the scrolling speed is slower. Example: NetworkSettingsView, where the scrolling speed is painfully slow when the window is maximized. The technique used here makes it so the speed is almost (but not exactly) equal in all scrollable views.

Initally I made this to apply only on Windows machines but after testing on a Debian GNOME system there doesn't seem to be any difference, so I removed the OS check. **I have not tested this on MacOS.**

I'm using a custom `BisqScrollPane` component here, an alternative way would be to use helper methods like setFasterScrollSpeed in GUIUtil. I've tested that code too so I can switch to that approach if requested.

Before:

https://user-images.githubusercontent.com/76814540/203327741-87160f13-608e-4e05-8206-383cf62d3f9d.mp4

After:

https://user-images.githubusercontent.com/76814540/203327778-d1efdd5a-d91c-46ef-9af9-c3fc07437c93.mp4
