### PR TITLE
Improve seednode monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ configure([project(':cli'),
     build.dependsOn installDist
     installDist.destinationDir = file('build/app')
     distZip.enabled = false
+    distTar.enabled = false
 
     // the 'installDist' and 'startScripts' blocks below configure bisq executables to put
     // generated shell scripts in the root project directory, such that users can easily

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ configure(project(':common')) {
     ext.getHash = {
         def p1 = 'git rev-parse HEAD'.execute()
         p1.waitFor()
-        return p1.text.substring(0,7)
+        return p1.text
     }
 
     jar.manifest.attributes(
@@ -515,6 +515,10 @@ configure(project(':desktop')) {
 
 configure(project(':seednode')) {
     apply plugin: 'com.github.johnrengelman.shadow'
+
+    jar.manifest.attributes(
+        "Implementation-Title": project.name,
+        "Implementation-Version": version)
 
     mainClassName = 'bisq.seednode.SeedNodeMain'
 

--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -21,6 +21,8 @@ import java.net.URL;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -140,14 +142,15 @@ public class Version {
                 '}');
     }
 
-    public String readCommitHash() {
+    public static Optional<String> findCommitHash() {
         try {
-            String pth = getClass().getResource(getClass().getSimpleName() + ".class").toString();
+            String pth = Objects.requireNonNull(Version.class.getResource(Version.class.getSimpleName() + ".class")).toString();
             String mnf = pth.substring(0, pth.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
             Attributes attr = new Manifest(new URL(mnf).openStream()).getMainAttributes();
-            return attr.getValue("Implementation-Version");
-        } catch (Exception ignored) { }
-        return "unknown";
+            return Optional.of(attr.getValue("Implementation-Version"));
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
     }
 
     public static final byte COMPENSATION_REQUEST = (byte) 0x01;

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -129,6 +129,7 @@ public class Config {
     public static final String BYPASS_MEMPOOL_VALIDATION = "bypassMempoolValidation";
     public static final String DAO_NODE_API_URL = "daoNodeApiUrl";
     public static final String DAO_NODE_API_PORT = "daoNodeApiPort";
+    public static final String SEED_NODE_REPORTING_SERVER_URL = "seedNodeReportingServerUrl";
 
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
@@ -220,6 +221,7 @@ public class Config {
     public final boolean bypassMempoolValidation;
     public final String daoNodeApiUrl;
     public final int daoNodeApiPort;
+    public final String seedNodeReportingServerUrl;
 
     // Properties derived from options but not exposed as options themselves
     public final File torDir;
@@ -679,6 +681,11 @@ public class Config {
                         .withRequiredArg()
                         .ofType(Integer.class)
                         .defaultsTo(8082);
+        ArgumentAcceptingOptionSpec<String> seedNodeReportingServerUrlOpt =
+                parser.accepts(SEED_NODE_REPORTING_SERVER_URL, "URL of seed node reporting server")
+                        .withRequiredArg()
+                        .ofType(String.class)
+                        .defaultsTo("");
 
         try {
             CompositeOptionSet options = new CompositeOptionSet();
@@ -799,6 +806,7 @@ public class Config {
             this.bypassMempoolValidation = options.valueOf(bypassMempoolValidationOpt);
             this.daoNodeApiUrl = options.valueOf(daoNodeApiUrlOpt);
             this.daoNodeApiPort = options.valueOf(daoNodeApiPortOpt);
+            this.seedNodeReportingServerUrl = options.valueOf(seedNodeReportingServerUrlOpt);
         } catch (OptionException ex) {
             throw new ConfigException("problem parsing option '%s': %s",
                     ex.options().get(0),

--- a/common/src/main/java/bisq/common/setup/CommonSetup.java
+++ b/common/src/main/java/bisq/common/setup/CommonSetup.java
@@ -98,6 +98,7 @@ public class CommonSetup {
     private static void setupLog(Config config) {
         String logPath = Paths.get(config.appDataDir.getPath(), "bisq").toString();
         Log.setup(logPath);
+        log.info("Log file at: {}.log", logPath);
         Utilities.printSysInfo();
         Log.setLevel(Level.toLevel(config.logLevel));
     }

--- a/common/src/main/java/bisq/common/util/CompletableFutureUtil.java
+++ b/common/src/main/java/bisq/common/util/CompletableFutureUtil.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+//todo
+public class CompletableFutureUtil {
+    public static <T> CompletableFuture<List<T>> allOf(Collection<CompletableFuture<T>> collection) {
+        //noinspection unchecked
+        return allOf(collection.toArray(new CompletableFuture[0]));
+    }
+
+    public static <T> CompletableFuture<List<T>> allOf(Stream<CompletableFuture<T>> stream) {
+        return allOf(stream.collect(Collectors.toList()));
+    }
+
+    public static <T> CompletableFuture<List<T>> allOf(CompletableFuture<T>... list) {
+        CompletableFuture<List<T>> result = CompletableFuture.allOf(list).thenApply(v ->
+                Stream.of(list)
+                        .map(future -> {
+                            // We want to return the results in list, not the futures. Once allOf call is complete
+                            // we know that all futures have completed (normally, exceptional or cancelled).
+                            // For exceptional and canceled cases we throw an exception.
+                            T res = future.join();
+                            if (future.isCompletedExceptionally()) {
+                                throw new RuntimeException((future.handle((r, throwable) -> throwable).join()));
+                            }
+                            if (future.isCancelled()) {
+                                throw new RuntimeException("Future got canceled");
+                            }
+                            return res;
+                        })
+                        .collect(Collectors.<T>toList())
+        );
+        return result;
+    }
+}

--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -64,6 +64,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -133,6 +134,12 @@ public class Utilities {
         executor.allowCoreThreadTimeOut(true);
         executor.setRejectedExecutionHandler((r, e) -> log.debug("RejectedExecutionHandler called"));
         return executor;
+    }
+
+    public static ExecutorService newCachedThreadPool(int maximumPoolSize) {
+        return new ThreadPoolExecutor(0, maximumPoolSize,
+                60, TimeUnit.SECONDS,
+                new SynchronousQueue<>());
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
@@ -85,6 +85,7 @@ public class ModuleForAppWithP2p extends AppModule {
         bindConstant().annotatedWith(named(USE_DEV_MODE_HEADER)).to(config.useDevModeHeader);
         bindConstant().annotatedWith(named(REFERRAL_ID)).to(config.referralId);
         bindConstant().annotatedWith(named(PREVENT_PERIODIC_SHUTDOWN_AT_SEED_NODE)).to(config.preventPeriodicShutdownAtSeedNode);
+        bindConstant().annotatedWith(named(SEED_NODE_REPORTING_SERVER_URL)).to(config.seedNodeReportingServerUrl);
 
         // ordering is used for shut down sequence
         install(new TradeModule(config));

--- a/core/src/main/java/bisq/core/monitor/DoubleValueItem.java
+++ b/core/src/main/java/bisq/core/monitor/DoubleValueItem.java
@@ -81,6 +81,6 @@ public enum DoubleValueItem implements ReportingItem {
 
     @Override
     public String toString() {
-        return name() + "= " + value;
+        return name() + "=" + value;
     }
 }

--- a/core/src/main/java/bisq/core/monitor/DoubleValueItem.java
+++ b/core/src/main/java/bisq/core/monitor/DoubleValueItem.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.monitor;
+
+import lombok.Getter;
+import lombok.Setter;
+
+
+public enum DoubleValueItem implements ReportingItem {
+    Unspecified("", "Unspecified"),
+    sentBytesPerSec("network", "sentBytesPerSec"),
+    receivedBytesPerSec("network", "receivedBytesPerSec"),
+    receivedMessagesPerSec("network", "receivedMessagesPerSec"),
+    sentMessagesPerSec("network", "sentMessagesPerSec");
+
+
+    @Getter
+    @Setter
+    private String key;
+    @Getter
+    @Setter
+    private String group;
+    @Getter
+    @Setter
+    private double value;
+
+    DoubleValueItem(String group, String key) {
+        this.group = group;
+        this.key = key;
+    }
+
+    public DoubleValueItem withValue(double value) {
+        setValue(value);
+        return this;
+    }
+
+    public static DoubleValueItem from(String key, double value) {
+        DoubleValueItem item;
+        try {
+            item = DoubleValueItem.valueOf(key);
+        } catch (Throwable t) {
+            item = DoubleValueItem.Unspecified;
+            item.setKey(key);
+        }
+
+        item.setValue(value);
+        return item;
+    }
+
+    @Override
+    public protobuf.ReportingItem toProtoMessage() {
+        return getBuilder().setDoubleValueItem(protobuf.DoubleValueItem.newBuilder()
+                        .setValue(value))
+                .build();
+    }
+
+    public static DoubleValueItem fromProto(protobuf.ReportingItem baseProto, protobuf.DoubleValueItem proto) {
+        return DoubleValueItem.from(baseProto.getKey(), proto.getValue());
+    }
+
+    @Override
+    public String getPath() {
+        return group + "." + key;
+    }
+
+
+    @Override
+    public String toString() {
+        return name() + "= " + value;
+    }
+}

--- a/core/src/main/java/bisq/core/monitor/IntegerValueItem.java
+++ b/core/src/main/java/bisq/core/monitor/IntegerValueItem.java
@@ -102,6 +102,6 @@ public enum IntegerValueItem implements ReportingItem {
 
     @Override
     public String toString() {
-        return name() + "= " + value;
+        return name() + "=" + value;
     }
 }

--- a/core/src/main/java/bisq/core/monitor/IntegerValueItem.java
+++ b/core/src/main/java/bisq/core/monitor/IntegerValueItem.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.monitor;
+
+import lombok.Getter;
+import lombok.Setter;
+
+
+public enum IntegerValueItem implements ReportingItem {
+    Unspecified("", "Unspecified"),
+    OfferPayload("data", "OfferPayload"),
+    MailboxStoragePayload("data", "MailboxStoragePayload"),
+    TradeStatistics3("data", "TradeStatistics3"),
+    AccountAgeWitness("data", "AccountAgeWitness"),
+    SignedWitness("data", "SignedWitness"),
+    Alert("data", "Alert"),
+    Filter("data", "Filter"),
+    Arbitrator("data", "Arbitrator"),
+    Mediator("data", "Mediator"),
+    RefundAgent("data", "RefundAgent"),
+
+    TempProposalPayload("dao", "TempProposalPayload"),
+    ProposalPayload("dao", "ProposalPayload"),
+    BlindVotePayload("dao", "BlindVotePayload"),
+    daoStateChainHeight("dao", "daoStateChainHeight"),
+    blockTimeIsSec("dao", "blockTimeIsSec"),
+
+    maxConnections("network", "maxConnections"),
+    numConnections("network", "numConnections"),
+    peakNumConnections("network", "peakNumConnections"),
+    numAllConnectionsLostEvents("network", "numAllConnectionsLostEvents"),
+    sentBytes("network", "sentBytes"),
+    receivedBytes("network", "receivedBytes"),
+
+    usedMemoryInMB("node", "usedMemoryInMB"),
+    totalMemoryInMB("node", "totalMemoryInMB"),
+    jvmStartTimeInSec("node", "jvmStartTimeInSec");
+
+    @Getter
+    @Setter
+    private String key;
+    @Getter
+    @Setter
+    private String group;
+    @Getter
+    @Setter
+    private int value;
+
+    IntegerValueItem(String group, String key) {
+        this.group = group;
+        this.key = key;
+    }
+
+    public IntegerValueItem withValue(int value) {
+        setValue(value);
+        return this;
+    }
+
+    public static IntegerValueItem from(String key, int value) {
+        IntegerValueItem item;
+        try {
+            item = IntegerValueItem.valueOf(key);
+        } catch (Throwable t) {
+            item = IntegerValueItem.Unspecified;
+            item.setKey(key);
+        }
+
+        item.setValue(value);
+        return item;
+    }
+
+    @Override
+    public protobuf.ReportingItem toProtoMessage() {
+        return getBuilder().setIntegerValueItem(protobuf.IntegerValueItem.newBuilder()
+                        .setValue(value))
+                .build();
+    }
+
+    public static IntegerValueItem fromProto(protobuf.ReportingItem baseProto, protobuf.IntegerValueItem proto) {
+        return IntegerValueItem.from(baseProto.getKey(), proto.getValue());
+    }
+
+    @Override
+    public String getPath() {
+        return group + "." + key;
+    }
+
+    @Override
+    public String toString() {
+        return name() + "= " + value;
+    }
+}

--- a/core/src/main/java/bisq/core/monitor/LongValueItem.java
+++ b/core/src/main/java/bisq/core/monitor/LongValueItem.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 
-public enum IntegerValueItem implements ReportingItem {
+public enum LongValueItem implements ReportingItem {
     Unspecified("", "Unspecified"),
     OfferPayload("data", "OfferPayload"),
     MailboxStoragePayload("data", "MailboxStoragePayload"),
@@ -59,24 +59,24 @@ public enum IntegerValueItem implements ReportingItem {
     private String group;
     @Getter
     @Setter
-    private int value;
+    private long value;
 
-    IntegerValueItem(String group, String key) {
+    LongValueItem(String group, String key) {
         this.group = group;
         this.key = key;
     }
 
-    public IntegerValueItem withValue(int value) {
+    public LongValueItem withValue(long value) {
         setValue(value);
         return this;
     }
 
-    public static IntegerValueItem from(String key, int value) {
-        IntegerValueItem item;
+    public static LongValueItem from(String key, long value) {
+        LongValueItem item;
         try {
-            item = IntegerValueItem.valueOf(key);
+            item = LongValueItem.valueOf(key);
         } catch (Throwable t) {
-            item = IntegerValueItem.Unspecified;
+            item = LongValueItem.Unspecified;
             item.setKey(key);
         }
 
@@ -86,13 +86,13 @@ public enum IntegerValueItem implements ReportingItem {
 
     @Override
     public protobuf.ReportingItem toProtoMessage() {
-        return getBuilder().setIntegerValueItem(protobuf.IntegerValueItem.newBuilder()
+        return getBuilder().setLongValueItem(protobuf.LongValueItem.newBuilder()
                         .setValue(value))
                 .build();
     }
 
-    public static IntegerValueItem fromProto(protobuf.ReportingItem baseProto, protobuf.IntegerValueItem proto) {
-        return IntegerValueItem.from(baseProto.getKey(), proto.getValue());
+    public static LongValueItem fromProto(protobuf.ReportingItem baseProto, protobuf.LongValueItem proto) {
+        return LongValueItem.from(baseProto.getKey(), proto.getValue());
     }
 
     @Override

--- a/core/src/main/java/bisq/core/monitor/ReportingItem.java
+++ b/core/src/main/java/bisq/core/monitor/ReportingItem.java
@@ -39,8 +39,8 @@ public interface ReportingItem extends NetworkPayload {
         switch (proto.getMessageCase()) {
             case STRING_VALUE_ITEM:
                 return StringValueItem.fromProto(proto, proto.getStringValueItem());
-            case INTEGER_VALUE_ITEM:
-                return IntegerValueItem.fromProto(proto, proto.getIntegerValueItem());
+            case LONG_VALUE_ITEM:
+                return LongValueItem.fromProto(proto, proto.getLongValueItem());
             case DOUBLE_VALUE_ITEM:
                 return DoubleValueItem.fromProto(proto, proto.getDoubleValueItem());
             case MESSAGE_NOT_SET:

--- a/core/src/main/java/bisq/core/monitor/ReportingItem.java
+++ b/core/src/main/java/bisq/core/monitor/ReportingItem.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.monitor;
+
+import bisq.common.proto.ProtobufferRuntimeException;
+import bisq.common.proto.network.NetworkPayload;
+
+public interface ReportingItem extends NetworkPayload {
+    String getKey();
+
+    String getGroup();
+
+    String getPath();
+
+    default protobuf.ReportingItem.Builder getBuilder() {
+        return protobuf.ReportingItem.newBuilder()
+                .setGroup(getGroup())
+                .setKey(getKey());
+    }
+
+    protobuf.ReportingItem toProtoMessage();
+
+    static ReportingItem fromProto(protobuf.ReportingItem proto) {
+        switch (proto.getMessageCase()) {
+            case STRING_VALUE_ITEM:
+                return StringValueItem.fromProto(proto, proto.getStringValueItem());
+            case INTEGER_VALUE_ITEM:
+                return IntegerValueItem.fromProto(proto, proto.getIntegerValueItem());
+            case DOUBLE_VALUE_ITEM:
+                return DoubleValueItem.fromProto(proto, proto.getDoubleValueItem());
+            case MESSAGE_NOT_SET:
+            default:
+                throw new ProtobufferRuntimeException("Unknown message case: " + proto);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/monitor/ReportingItems.java
+++ b/core/src/main/java/bisq/core/monitor/ReportingItems.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.monitor;
+
+import bisq.common.proto.network.NetworkPayload;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReportingItems extends ArrayList<ReportingItem> implements NetworkPayload {
+    @Getter
+    private final String address;
+
+    public ReportingItems(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public protobuf.ReportingItems toProtoMessage() {
+        return protobuf.ReportingItems.newBuilder()
+                .setAddress(address)
+                .addAllReportingItem(this.stream()
+                        .map(ReportingItem::toProtoMessage)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static ReportingItems fromProto(protobuf.ReportingItems proto) {
+        ReportingItems reportingItems = new ReportingItems(proto.getAddress());
+        reportingItems.addAll(proto.getReportingItemList().stream()
+                .map(ReportingItem::fromProto).collect(Collectors.toList()));
+        return reportingItems;
+    }
+
+    public byte[] toProtoMessageAsBytes() {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            toProtoMessage().writeDelimitedTo(outputStream);
+            return outputStream.toByteArray();
+        } catch (Throwable t) {
+            log.error("Error at ", t);
+            throw new RuntimeException(t);
+        }
+    }
+
+    public static ReportingItems fromProtoMessageAsBytes(byte[] protoAsBytes) {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(protoAsBytes)) {
+            protobuf.ReportingItems proto = protobuf.ReportingItems.parseDelimitedFrom(inputStream);
+            return fromProto(proto);
+        } catch (Throwable t) {
+            log.error("Error at ", t);
+            throw new RuntimeException(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/monitor/StringValueItem.java
+++ b/core/src/main/java/bisq/core/monitor/StringValueItem.java
@@ -82,6 +82,6 @@ public enum StringValueItem implements ReportingItem {
 
     @Override
     public String toString() {
-        return name() + "= " + value;
+        return name() + "=" + value;
     }
 }

--- a/core/src/main/java/bisq/core/monitor/StringValueItem.java
+++ b/core/src/main/java/bisq/core/monitor/StringValueItem.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.monitor;
+
+import lombok.Getter;
+import lombok.Setter;
+
+
+public enum StringValueItem implements ReportingItem {
+    Unspecified("", "Unspecified"),
+
+    daoStateHash("dao", "daoStateHash"),
+    proposalHash("dao", "proposalHash"),
+    blindVoteHash("dao", "blindVoteHash"),
+
+    version("node", "version"),
+    commitHash("node", "commitHash");
+
+    @Getter
+    @Setter
+    private String key;
+    @Getter
+    @Setter
+    private String group;
+    @Getter
+    @Setter
+    private String value;
+
+    StringValueItem(String group, String key) {
+        this.group = group;
+        this.key = key;
+    }
+
+    public StringValueItem withValue(String value) {
+        setValue(value);
+        return this;
+    }
+
+    public static StringValueItem from(String key, String value) {
+        StringValueItem item;
+        try {
+            item = StringValueItem.valueOf(key);
+        } catch (Throwable t) {
+            item = StringValueItem.Unspecified;
+            item.setKey(key);
+        }
+
+        item.setValue(value);
+        return item;
+    }
+
+    @Override
+    public String getPath() {
+        return group + "." + key;
+    }
+
+    @Override
+    public protobuf.ReportingItem toProtoMessage() {
+        return getBuilder().setStringValueItem(protobuf.StringValueItem.newBuilder()
+                        .setValue(value))
+                .build();
+    }
+
+    public static StringValueItem fromProto(protobuf.ReportingItem baseProto, protobuf.StringValueItem proto) {
+        return StringValueItem.from(baseProto.getKey(), proto.getValue());
+    }
+
+    @Override
+    public String toString() {
+        return name() + "= " + value;
+    }
+}

--- a/core/src/main/java/bisq/core/network/p2p/inventory/GetInventoryRequestHandler.java
+++ b/core/src/main/java/bisq/core/network/p2p/inventory/GetInventoryRequestHandler.java
@@ -150,7 +150,7 @@ public class GetInventoryRequestHandler implements MessageListener {
 
             // node
             inventory.put(InventoryItem.version, Version.VERSION);
-            inventory.put(InventoryItem.commitHash, new Version().readCommitHash());
+            Version.findCommitHash().ifPresent(commitHash -> inventory.put(InventoryItem.commitHash, commitHash));
             inventory.put(InventoryItem.usedMemory, String.valueOf(Profiler.getUsedMemoryInBytes()));
             inventory.put(InventoryItem.jvmStartTime, String.valueOf(ManagementFactory.getRuntimeMXBean().getStartTime()));
 

--- a/core/src/main/java/bisq/core/provider/ProvidersRepository.java
+++ b/core/src/main/java/bisq/core/provider/ProvidersRepository.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 
 @Slf4j
 public class ProvidersRepository {
-    private static final List<String> DEFAULT_NODES = Arrays.asList(
+    public static final List<String> DEFAULT_NODES = Arrays.asList(
             "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/", // @wiz
             "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/", // @emzy
             "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/", // @mrosseel

--- a/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
+++ b/core/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CoreNetworkCapabilities {
 
-    static void setSupportedCapabilities(Config config) {
+    public static void setSupportedCapabilities(Config config) {
         Capabilities.app.addAll(
                 Capability.TRADE_STATISTICS,
                 Capability.TRADE_STATISTICS_2,

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -463,7 +463,6 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
     }
 
     public void shutDown(CloseConnectionReason closeConnectionReason, @Nullable Runnable shutDownCompleteHandler) {
-        log.info("Connection shutdown started");
         log.debug("shutDown: peersNodeAddressOptional={}, closeConnectionReason={}",
                 peersNodeAddressOptional, closeConnectionReason);
 

--- a/p2p/src/main/java/bisq/network/p2p/network/Statistic.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Statistic.java
@@ -238,6 +238,30 @@ public class Statistic {
         return roundTripTime;
     }
 
+    public static long getTotalSentBytes() {
+        return totalSentBytes.get();
+    }
+
+    public static double getTotalSentBytesPerSec() {
+        return totalSentBytesPerSec.get();
+    }
+
+    public static long getTotalReceivedBytes() {
+        return totalReceivedBytes.get();
+    }
+
+    public static double getTotalReceivedBytesPerSec() {
+        return totalReceivedBytesPerSec.get();
+    }
+
+    public static double numTotalReceivedMessagesPerSec() {
+        return numTotalReceivedMessagesPerSec.get();
+    }
+
+    public static double getNumTotalSentMessagesPerSec() {
+        return numTotalSentMessagesPerSec.get();
+    }
+
     @Override
     public String toString() {
         return "Statistic{" +

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -380,7 +380,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
                         serviceMap = service.getMap();
                     }
                     map.putAll(serviceMap);
-                    log.info("We added {} entries from {} to the excluded key set of our request",
+                    log.debug("We added {} entries from {} to the excluded key set of our request",
                             serviceMap.size(), service.getClass().getSimpleName());
                 });
         return map;
@@ -489,6 +489,9 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         return new HashSet<>(filteredResults);
     }
 
+    public Collection<PersistableNetworkPayload> getPersistableNetworkPayloadCollection() {
+        return getMapForDataRequest().values();
+    }
 
     private Set<byte[]> getKeysAsByteSet(Map<ByteArray, ? extends PersistablePayload> map) {
         return map.keySet().stream()

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -2489,3 +2489,29 @@ message MockPayload {
     string message_version = 1;
     string message = 2;
 }
+
+message ReportingItem {
+    string key = 1;
+    string group = 2;
+    oneof message {
+        StringValueItem string_value_item = 3;
+        IntegerValueItem integer_value_item = 4;
+        DoubleValueItem double_value_item = 5;
+    }
+}
+message StringValueItem {
+    string value = 1;
+}
+
+message IntegerValueItem {
+    uint32 value = 1;
+}
+
+message DoubleValueItem {
+    double value = 1;
+}
+
+message ReportingItems {
+    string address = 1;
+    repeated ReportingItem reporting_item = 2;
+}

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -2495,7 +2495,7 @@ message ReportingItem {
     string group = 2;
     oneof message {
         StringValueItem string_value_item = 3;
-        IntegerValueItem integer_value_item = 4;
+        LongValueItem long_value_item = 4;
         DoubleValueItem double_value_item = 5;
     }
 }
@@ -2503,8 +2503,8 @@ message StringValueItem {
     string value = 1;
 }
 
-message IntegerValueItem {
-    uint32 value = 1;
+message LongValueItem {
+    uint64 value = 1;
 }
 
 message DoubleValueItem {

--- a/seednode/src/main/java/bisq/seednode/SeedNode.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNode.java
@@ -21,7 +21,11 @@ import bisq.core.app.misc.AppSetup;
 import bisq.core.app.misc.AppSetupWithP2PAndDAO;
 import bisq.core.network.p2p.inventory.GetInventoryRequestHandler;
 
+import bisq.common.config.Config;
+
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +36,7 @@ public class SeedNode {
     private Injector injector;
     private AppSetup appSetup;
     private GetInventoryRequestHandler getInventoryRequestHandler;
+    private SeedNodeReportingService seedNodeReportingService;
 
     public SeedNode() {
     }
@@ -41,9 +46,19 @@ public class SeedNode {
         appSetup.start();
 
         getInventoryRequestHandler = injector.getInstance(GetInventoryRequestHandler.class);
+
+        String seedNodeReportingServerUrl = injector.getInstance(Key.get(String.class, Names.named(Config.SEED_NODE_REPORTING_SERVER_URL)));
+        if (seedNodeReportingServerUrl != null && !seedNodeReportingServerUrl.trim().isEmpty()) {
+            seedNodeReportingService = injector.getInstance(SeedNodeReportingService.class);
+        }
     }
 
     public void shutDown() {
-        getInventoryRequestHandler.shutDown();
+        if (getInventoryRequestHandler != null) {
+            getInventoryRequestHandler.shutDown();
+        }
+        if (seedNodeReportingService != null) {
+            seedNodeReportingService.shutDown();
+        }
     }
 }

--- a/seednode/src/main/java/bisq/seednode/SeedNodeReportingService.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeReportingService.java
@@ -27,7 +27,7 @@ import bisq.core.dao.monitoring.model.ProposalStateBlock;
 import bisq.core.dao.state.DaoStateListener;
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.monitor.DoubleValueItem;
-import bisq.core.monitor.IntegerValueItem;
+import bisq.core.monitor.LongValueItem;
 import bisq.core.monitor.ReportingItems;
 import bisq.core.monitor.StringValueItem;
 
@@ -171,7 +171,7 @@ public class SeedNodeReportingService {
             return;
         }
         ReportingItems reportingItems = new ReportingItems(getMyAddress());
-        reportingItems.add(IntegerValueItem.usedMemoryInMB.withValue((int) Profiler.getUsedMemoryInMB()));
+        reportingItems.add(LongValueItem.usedMemoryInMB.withValue(Profiler.getUsedMemoryInMB()));
         sendReportingItems(reportingItems);
     }
 
@@ -182,9 +182,9 @@ public class SeedNodeReportingService {
 
         ReportingItems reportingItems = new ReportingItems(getMyAddress());
         int daoStateChainHeight = daoStateService.getChainHeight();
-        reportingItems.add(IntegerValueItem.daoStateChainHeight.withValue(daoStateChainHeight));
-        daoStateService.getLastBlock().map(block -> (int) (block.getTime() / 1000))
-                .ifPresent(blockTime -> reportingItems.add(IntegerValueItem.blockTimeIsSec.withValue(blockTime)));
+        reportingItems.add(LongValueItem.daoStateChainHeight.withValue(daoStateChainHeight));
+        daoStateService.getLastBlock().map(block -> (block.getTime() / 1000))
+                .ifPresent(blockTime -> reportingItems.add(LongValueItem.blockTimeIsSec.withValue(blockTime)));
         LinkedList<DaoStateBlock> daoStateBlockChain = daoStateMonitoringService.getDaoStateBlockChain();
         if (!daoStateBlockChain.isEmpty()) {
             String daoStateHash = Utilities.bytesAsHexString(daoStateBlockChain.getLast().getMyStateHash().getHash());
@@ -224,24 +224,24 @@ public class SeedNodeReportingService {
                     numItemsByType.putIfAbsent(className, 0);
                     numItemsByType.put(className, numItemsByType.get(className) + 1);
                 });
-        numItemsByType.forEach((key, value) -> reportingItems.add(IntegerValueItem.from(key, value)));
+        numItemsByType.forEach((key, value) -> reportingItems.add(LongValueItem.from(key, value)));
 
         // Network
-        reportingItems.add(IntegerValueItem.numConnections.withValue(networkNode.getAllConnections().size()));
-        reportingItems.add(IntegerValueItem.peakNumConnections.withValue(peerManager.getPeakNumConnections()));
-        reportingItems.add(IntegerValueItem.numAllConnectionsLostEvents.withValue(peerManager.getNumAllConnectionsLostEvents()));
-        reportingItems.add(IntegerValueItem.sentBytes.withValue((int) Statistic.getTotalSentBytes()));
-        reportingItems.add(IntegerValueItem.receivedBytes.withValue((int) Statistic.getTotalReceivedBytes()));
+        reportingItems.add(LongValueItem.numConnections.withValue(networkNode.getAllConnections().size()));
+        reportingItems.add(LongValueItem.peakNumConnections.withValue(peerManager.getPeakNumConnections()));
+        reportingItems.add(LongValueItem.numAllConnectionsLostEvents.withValue(peerManager.getNumAllConnectionsLostEvents()));
+        reportingItems.add(LongValueItem.sentBytes.withValue(Statistic.getTotalSentBytes()));
+        reportingItems.add(LongValueItem.receivedBytes.withValue(Statistic.getTotalReceivedBytes()));
         reportingItems.add(DoubleValueItem.sentBytesPerSec.withValue(Statistic.getTotalSentBytesPerSec()));
         reportingItems.add(DoubleValueItem.sentMessagesPerSec.withValue(Statistic.getNumTotalSentMessagesPerSec()));
         reportingItems.add(DoubleValueItem.receivedBytesPerSec.withValue(Statistic.getTotalReceivedBytesPerSec()));
         reportingItems.add(DoubleValueItem.receivedMessagesPerSec.withValue(Statistic.numTotalReceivedMessagesPerSec()));
 
         // Node
-        reportingItems.add(IntegerValueItem.usedMemoryInMB.withValue((int) Profiler.getUsedMemoryInMB()));
-        reportingItems.add(IntegerValueItem.totalMemoryInMB.withValue((int) Profiler.getTotalMemoryInMB()));
-        reportingItems.add(IntegerValueItem.jvmStartTimeInSec.withValue((int) (ManagementFactory.getRuntimeMXBean().getStartTime() / 1000)));
-        reportingItems.add(IntegerValueItem.maxConnections.withValue(maxConnections));
+        reportingItems.add(LongValueItem.usedMemoryInMB.withValue(Profiler.getUsedMemoryInMB()));
+        reportingItems.add(LongValueItem.totalMemoryInMB.withValue(Profiler.getTotalMemoryInMB()));
+        reportingItems.add(LongValueItem.jvmStartTimeInSec.withValue((ManagementFactory.getRuntimeMXBean().getStartTime() / 1000)));
+        reportingItems.add(LongValueItem.maxConnections.withValue(maxConnections));
         reportingItems.add(StringValueItem.version.withValue(Version.VERSION));
 
         // If no commit hash is found we use 0 in hex format

--- a/seednode/src/main/java/bisq/seednode/SeedNodeReportingService.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeReportingService.java
@@ -1,0 +1,281 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.seednode;
+
+import bisq.core.dao.DaoFacade;
+import bisq.core.dao.monitoring.BlindVoteStateMonitoringService;
+import bisq.core.dao.monitoring.DaoStateMonitoringService;
+import bisq.core.dao.monitoring.ProposalStateMonitoringService;
+import bisq.core.dao.monitoring.model.BlindVoteStateBlock;
+import bisq.core.dao.monitoring.model.DaoStateBlock;
+import bisq.core.dao.monitoring.model.ProposalStateBlock;
+import bisq.core.dao.state.DaoStateListener;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.monitor.DoubleValueItem;
+import bisq.core.monitor.IntegerValueItem;
+import bisq.core.monitor.ReportingItems;
+import bisq.core.monitor.StringValueItem;
+
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.network.NetworkNode;
+import bisq.network.p2p.network.Statistic;
+import bisq.network.p2p.peers.PeerManager;
+import bisq.network.p2p.storage.P2PDataStorage;
+import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
+
+import bisq.common.Timer;
+import bisq.common.UserThread;
+import bisq.common.app.Version;
+import bisq.common.config.Config;
+import bisq.common.util.Profiler;
+import bisq.common.util.Utilities;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.io.IOException;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import java.lang.management.ManagementFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Sends reporting data to monitoring server via clear net.
+ * The seed node is configured with nginx as proxy which takes care of TLS handling and provides the client key.
+ *
+ * We send on a regular interval every 60 seconds the used memory metric data which serves as a heartbeat to signal the
+ * monitor that the seed node is alive.
+ * We send every 5 minutes the network data, network load data and node specific data.
+ * At each new block we send the DAO hashes and block height.
+ */
+@Slf4j
+@Singleton
+public class SeedNodeReportingService {
+    private final static long REPORT_DELAY_SEC = TimeUnit.MINUTES.toSeconds(5);
+    private final static long HEART_BEAT_DELAY_SEC = TimeUnit.MINUTES.toSeconds(1);
+
+    private final P2PService p2PService;
+    private final NetworkNode networkNode;
+    private final PeerManager peerManager;
+    private final P2PDataStorage p2PDataStorage;
+    private final DaoStateService daoStateService;
+    private final DaoStateMonitoringService daoStateMonitoringService;
+    private final ProposalStateMonitoringService proposalStateMonitoringService;
+    private final BlindVoteStateMonitoringService blindVoteStateMonitoringService;
+    private final int maxConnections;
+    private final String seedNodeReportingServerUrl;
+    private final DaoStateListener daoStateListener;
+    private final HttpClient httpClient;
+
+    private Timer dataReportTimer;
+    private final Timer heartBeatTimer;
+    private final ThreadPoolExecutor executor;
+
+    @Inject
+    public SeedNodeReportingService(P2PService p2PService,
+                                    DaoFacade daoFacade,
+                                    NetworkNode networkNode,
+                                    PeerManager peerManager,
+                                    P2PDataStorage p2PDataStorage,
+                                    DaoStateService daoStateService,
+                                    DaoStateMonitoringService daoStateMonitoringService,
+                                    ProposalStateMonitoringService proposalStateMonitoringService,
+                                    BlindVoteStateMonitoringService blindVoteStateMonitoringService,
+                                    @Named(Config.MAX_CONNECTIONS) int maxConnections,
+                                    @Named(Config.SEED_NODE_REPORTING_SERVER_URL) String seedNodeReportingServerUrl) {
+        this.p2PService = p2PService;
+        this.networkNode = networkNode;
+        this.peerManager = peerManager;
+        this.p2PDataStorage = p2PDataStorage;
+        this.daoStateService = daoStateService;
+        this.daoStateMonitoringService = daoStateMonitoringService;
+        this.proposalStateMonitoringService = proposalStateMonitoringService;
+        this.blindVoteStateMonitoringService = blindVoteStateMonitoringService;
+        this.maxConnections = maxConnections;
+        this.seedNodeReportingServerUrl = seedNodeReportingServerUrl;
+
+        executor = Utilities.getThreadPoolExecutor("SeedNodeReportingService", 2, 4, 30);
+        httpClient = HttpClient.newHttpClient();
+
+        heartBeatTimer = UserThread.runPeriodically(this::sendHeartBeat, HEART_BEAT_DELAY_SEC);
+
+        // We send each time when a new block is received and the DAO hash has been provided (which
+        // takes a bit after the block arrives).
+        daoStateMonitoringService.addListener(new DaoStateMonitoringService.Listener() {
+            @Override
+            public void onDaoStateHashesChanged() {
+                sendBlockRelatedData();
+            }
+
+            @Override
+            public void onCheckpointFail() {
+            }
+        });
+
+        // Independent of the block
+        daoStateListener = new DaoStateListener() {
+            @Override
+            public void onParseBlockChainComplete() {
+                daoFacade.removeBsqStateListener(daoStateListener);
+                dataReportTimer = UserThread.runPeriodically(() -> sendDataReport(), REPORT_DELAY_SEC);
+                sendDataReport();
+
+                sendBlockRelatedData();
+            }
+        };
+        daoFacade.addBsqStateListener(daoStateListener);
+    }
+
+    public void shutDown() {
+        if (heartBeatTimer != null) {
+            heartBeatTimer.stop();
+        }
+        if (dataReportTimer != null) {
+            dataReportTimer.stop();
+        }
+
+        Utilities.shutdownAndAwaitTermination(executor, 2, TimeUnit.SECONDS);
+    }
+
+    private void sendHeartBeat() {
+        if (p2PService.getAddress() == null) {
+            return;
+        }
+        ReportingItems reportingItems = new ReportingItems(getMyAddress());
+        reportingItems.add(IntegerValueItem.usedMemoryInMB.withValue((int) Profiler.getUsedMemoryInMB()));
+        sendReportingItems(reportingItems);
+    }
+
+    private void sendBlockRelatedData() {
+        if (p2PService.getAddress() == null) {
+            return;
+        }
+
+        ReportingItems reportingItems = new ReportingItems(getMyAddress());
+        int daoStateChainHeight = daoStateService.getChainHeight();
+        reportingItems.add(IntegerValueItem.daoStateChainHeight.withValue(daoStateChainHeight));
+        daoStateService.getLastBlock().map(block -> (int) (block.getTime() / 1000))
+                .ifPresent(blockTime -> reportingItems.add(IntegerValueItem.blockTimeIsSec.withValue(blockTime)));
+        LinkedList<DaoStateBlock> daoStateBlockChain = daoStateMonitoringService.getDaoStateBlockChain();
+        if (!daoStateBlockChain.isEmpty()) {
+            String daoStateHash = Utilities.bytesAsHexString(daoStateBlockChain.getLast().getMyStateHash().getHash());
+            reportingItems.add(StringValueItem.daoStateHash.withValue(daoStateHash));
+        }
+
+        LinkedList<ProposalStateBlock> proposalStateBlockChain = proposalStateMonitoringService.getProposalStateBlockChain();
+        if (!proposalStateBlockChain.isEmpty()) {
+            String proposalHash = Utilities.bytesAsHexString(proposalStateBlockChain.getLast().getMyStateHash().getHash());
+            reportingItems.add(StringValueItem.proposalHash.withValue(proposalHash));
+        }
+
+        LinkedList<BlindVoteStateBlock> blindVoteStateBlockChain = blindVoteStateMonitoringService.getBlindVoteStateBlockChain();
+        if (!blindVoteStateBlockChain.isEmpty()) {
+            String blindVoteHash = Utilities.bytesAsHexString(blindVoteStateBlockChain.getLast().getMyStateHash().getHash());
+            reportingItems.add(StringValueItem.blindVoteHash.withValue(blindVoteHash));
+        }
+
+        sendReportingItems(reportingItems);
+    }
+
+    private void sendDataReport() {
+        if (p2PService.getAddress() == null) {
+            return;
+        }
+
+        ReportingItems reportingItems = new ReportingItems(getMyAddress());
+
+        // Data
+        Map<String, Integer> numItemsByType = new HashMap<>();
+        Stream.concat(p2PDataStorage.getPersistableNetworkPayloadCollection().stream()
+                                .map(payload -> payload.getClass().getSimpleName()),
+                        p2PDataStorage.getMap().values().stream()
+                                .map(ProtectedStorageEntry::getProtectedStoragePayload)
+                                .map(payload -> payload.getClass().getSimpleName()))
+                .forEach(className -> {
+                    numItemsByType.putIfAbsent(className, 0);
+                    numItemsByType.put(className, numItemsByType.get(className) + 1);
+                });
+        numItemsByType.forEach((key, value) -> reportingItems.add(IntegerValueItem.from(key, value)));
+
+        // Network
+        reportingItems.add(IntegerValueItem.numConnections.withValue(networkNode.getAllConnections().size()));
+        reportingItems.add(IntegerValueItem.peakNumConnections.withValue(peerManager.getPeakNumConnections()));
+        reportingItems.add(IntegerValueItem.numAllConnectionsLostEvents.withValue(peerManager.getNumAllConnectionsLostEvents()));
+        reportingItems.add(IntegerValueItem.sentBytes.withValue((int) Statistic.getTotalSentBytes()));
+        reportingItems.add(IntegerValueItem.receivedBytes.withValue((int) Statistic.getTotalReceivedBytes()));
+        reportingItems.add(DoubleValueItem.sentBytesPerSec.withValue(Statistic.getTotalSentBytesPerSec()));
+        reportingItems.add(DoubleValueItem.sentMessagesPerSec.withValue(Statistic.getNumTotalSentMessagesPerSec()));
+        reportingItems.add(DoubleValueItem.receivedBytesPerSec.withValue(Statistic.getTotalReceivedBytesPerSec()));
+        reportingItems.add(DoubleValueItem.receivedMessagesPerSec.withValue(Statistic.numTotalReceivedMessagesPerSec()));
+
+        // Node
+        reportingItems.add(IntegerValueItem.usedMemoryInMB.withValue((int) Profiler.getUsedMemoryInMB()));
+        reportingItems.add(IntegerValueItem.totalMemoryInMB.withValue((int) Profiler.getTotalMemoryInMB()));
+        reportingItems.add(IntegerValueItem.jvmStartTimeInSec.withValue((int) (ManagementFactory.getRuntimeMXBean().getStartTime() / 1000)));
+        reportingItems.add(IntegerValueItem.maxConnections.withValue(maxConnections));
+        reportingItems.add(StringValueItem.version.withValue(Version.VERSION));
+
+        // If no commit hash is found we use 0 in hex format
+        String commitHash = Version.findCommitHash().orElse("00");
+        reportingItems.add(StringValueItem.commitHash.withValue(commitHash));
+
+        sendReportingItems(reportingItems);
+    }
+
+    private void sendReportingItems(ReportingItems reportingItems) {
+        CompletableFuture.runAsync(() -> {
+            log.info("Send report to monitor server: {}", reportingItems.toString());
+            // We send the data as hex encoded protobuf data. We do not use the envelope as it is not part of the p2p system.
+            byte[] protoMessageAsBytes = reportingItems.toProtoMessageAsBytes();
+            try {
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(seedNodeReportingServerUrl))
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(protoMessageAsBytes))
+                        .header("User-Agent", getMyAddress())
+                        .build();
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() != 200) {
+                    log.error("Response error message: {}", response);
+                }
+            } catch (IOException e) {
+                log.warn("IOException at sending reporting. {}", e.getMessage());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }, executor);
+    }
+
+    private String getMyAddress() {
+        return p2PService.getAddress() != null ? p2PService.getAddress().getFullAddress() : "N/A";
+    }
+
+}

--- a/seednode/src/main/java/bisq/seednode/SeedNodeReportingService.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeReportingService.java
@@ -60,7 +60,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -98,7 +98,7 @@ public class SeedNodeReportingService {
 
     private Timer dataReportTimer;
     private final Timer heartBeatTimer;
-    private final ThreadPoolExecutor executor;
+    private final ExecutorService executor;
 
     @Inject
     public SeedNodeReportingService(P2PService p2PService,
@@ -123,7 +123,7 @@ public class SeedNodeReportingService {
         this.maxConnections = maxConnections;
         this.seedNodeReportingServerUrl = seedNodeReportingServerUrl;
 
-        executor = Utilities.getThreadPoolExecutor("SeedNodeReportingService", 2, 4, 30);
+        executor = Utilities.newCachedThreadPool(5);
         httpClient = HttpClient.newHttpClient();
 
         heartBeatTimer = UserThread.runPeriodically(this::sendHeartBeat, HEART_BEAT_DELAY_SEC);


### PR DESCRIPTION
This is the seed node side part of the new monitoring concept.

Currently the monitor requests all data from seed nodes which is up to 10 MB and cause considerable load on the seeds as well as makes the monitoring less reliable.

Now we send from the seed nodes per clearnet the relevant reporting data (not the full data set, just the info we want to know, like number of messages) to a monitoring server.

The monitoring part will come in another PR for the monitor repo.