### PR TITLE
Remove connection:keep-alive header

### DIFF
--- a/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
+++ b/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
@@ -249,7 +249,6 @@ public class SeedNodeReportingService {
                     .uri(URI.create(seedNodeReportingServerUrl))
                     .POST(HttpRequest.BodyPublishers.ofByteArray(protoMessageAsBytes))
                     .header("User-Agent", getMyAddress())
-                    .header("Connection", "keep-alive")
                     .build();
             httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, throwable) -> {
                 if (throwable != null) {


### PR DESCRIPTION
The connection:keep-alive header is restricted in java and would require a jvm option to allow it.