### PR TITLE
Fix blocking call at send Dao hashes response

### DIFF
--- a/core/src/main/java/bisq/core/dao/monitoring/network/StateNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/network/StateNetworkService.java
@@ -145,7 +145,7 @@ public abstract class StateNetworkService<Msg extends NewStateHashMessage,
         Res getStateHashesResponse = getGetStateHashesResponse(nonce, stateHashes);
         log.info("Send {} with {} stateHashes to peer {}", getStateHashesResponse.getClass().getSimpleName(),
                 stateHashes.size(), connection.getPeersNodeAddressOptional());
-        connection.sendMessage(getStateHashesResponse);
+        networkNode.sendMessage(connection, getStateHashesResponse);
     }
 
     public void requestHashesFromAllConnectedSeedNodes(int fromHeight) {


### PR DESCRIPTION
Use networkNode.sendMessage instead of connection.sendMessage as the call on connection is blocking.

This was likely a major bug for seed nodes that at sending hash responses the main thread got blocked.
