### PR TITLE
Handle exception at send

### DIFF
--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -132,7 +132,6 @@ public class Utilities {
         ThreadPoolExecutor executor = new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTimeInSec,
                 TimeUnit.SECONDS, workQueue, threadFactory);
         executor.allowCoreThreadTimeOut(true);
-        executor.setRejectedExecutionHandler((r, e) -> log.debug("RejectedExecutionHandler called"));
         return executor;
     }
 
@@ -167,7 +166,6 @@ public class Utilities {
         executor.allowCoreThreadTimeOut(true);
         executor.setMaximumPoolSize(maximumPoolSize);
         executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-        executor.setRejectedExecutionHandler((r, e) -> log.debug("RejectedExecutionHandler called"));
         return executor;
     }
 

--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -63,7 +63,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -139,14 +138,12 @@ public class Utilities {
 
     public static ExecutorService newCachedThreadPool(int maximumPoolSize,
                                                       long keepAliveTime,
-                                                      TimeUnit timeUnit,
-                                                      RejectedExecutionHandler rejectedExecutionHandler) {
+                                                      TimeUnit timeUnit) {
         return new ThreadPoolExecutor(0,
                 maximumPoolSize,
                 keepAliveTime,
                 timeUnit,
-                new SynchronousQueue<>(),
-                rejectedExecutionHandler);
+                new SynchronousQueue<>());
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -125,8 +125,8 @@ public class Utilities {
                                                             int maximumPoolSize,
                                                             long keepAliveTimeInSec,
                                                             BlockingQueue<Runnable> workQueue) {
-        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat(name)
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat(name + "-%d")
                 .setDaemon(true)
                 .build();
         ThreadPoolExecutor executor = new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTimeInSec,
@@ -136,14 +136,20 @@ public class Utilities {
         return executor;
     }
 
-    public static ExecutorService newCachedThreadPool(int maximumPoolSize,
+    public static ExecutorService newCachedThreadPool(String name,
+                                                      int maximumPoolSize,
                                                       long keepAliveTime,
                                                       TimeUnit timeUnit) {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat(name + "-%d")
+                .setDaemon(true)
+                .build();
         return new ThreadPoolExecutor(0,
                 maximumPoolSize,
                 keepAliveTime,
                 timeUnit,
-                new SynchronousQueue<>());
+                new SynchronousQueue<>(),
+                threadFactory);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/core/src/main/java/bisq/core/dao/monitoring/network/StateNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/network/StateNetworkService.java
@@ -145,7 +145,7 @@ public abstract class StateNetworkService<Msg extends NewStateHashMessage,
         Res getStateHashesResponse = getGetStateHashesResponse(nonce, stateHashes);
         log.info("Send {} with {} stateHashes to peer {}", getStateHashesResponse.getClass().getSimpleName(),
                 stateHashes.size(), connection.getPeersNodeAddressOptional());
-        connection.sendMessage(getStateHashesResponse);
+        networkNode.sendMessage(connection, getStateHashesResponse);
     }
 
     public void requestHashesFromAllConnectedSeedNodes(int fromHeight) {

--- a/core/src/main/java/bisq/core/dao/node/full/rpc/BitcoindDaemon.java
+++ b/core/src/main/java/bisq/core/dao/node/full/rpc/BitcoindDaemon.java
@@ -44,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BitcoindDaemon {
     private final ListeningExecutorService executor = Utilities.getSingleThreadListeningExecutor("block-notification-server");
-    private final ListeningExecutorService workerPool = Utilities.getListeningExecutorService("block-notification-worker-%d",
+    private final ListeningExecutorService workerPool = Utilities.getListeningExecutorService("block-notification-worker",
             1, 10, 60, new ArrayBlockingQueue<>(100));
     private final ServerSocket serverSocket;
     private final Consumer<Throwable> errorHandler;

--- a/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
+++ b/p2p/src/main/java/bisq/network/p2p/NetworkNodeProvider.java
@@ -45,6 +45,7 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
     public NetworkNodeProvider(NetworkProtoResolver networkProtoResolver,
                                BridgeAddressProvider bridgeAddressProvider,
                                @Nullable NetworkFilter networkFilter,
+                               @Named(Config.MAX_CONNECTIONS) int maxConnections,
                                @Named(Config.USE_LOCALHOST_FOR_P2P) boolean useLocalhostForP2P,
                                @Named(Config.NODE_PORT) int port,
                                @Named(Config.TOR_DIR) File torDir,
@@ -56,7 +57,7 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
                                @Named(Config.TOR_STREAM_ISOLATION) boolean streamIsolation,
                                @Named(Config.TOR_CONTROL_USE_SAFE_COOKIE_AUTH) boolean useSafeCookieAuthentication) {
         if (useLocalhostForP2P) {
-            networkNode = new LocalhostNetworkNode(port, networkProtoResolver, networkFilter);
+            networkNode = new LocalhostNetworkNode(port, networkProtoResolver, networkFilter, maxConnections);
         } else {
             TorMode torMode = getTorMode(bridgeAddressProvider,
                     torDir,
@@ -66,7 +67,7 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
                     password,
                     cookieFile,
                     useSafeCookieAuthentication);
-            networkNode = new TorNetworkNode(port, networkProtoResolver, streamIsolation, torMode, networkFilter);
+            networkNode = new TorNetworkNode(port, networkProtoResolver, streamIsolation, torMode, networkFilter, maxConnections);
         }
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -220,8 +220,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         return capabilities;
     }
 
-    // Called from various threads
-    public void sendMessage(NetworkEnvelope networkEnvelope) {
+    void sendMessage(NetworkEnvelope networkEnvelope) {
         long ts = System.currentTimeMillis();
         log.debug(">> Send networkEnvelope of type: {}", networkEnvelope.getClass().getSimpleName());
 
@@ -264,6 +263,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
             }
         } catch (Throwable t) {
             handleException(t);
+            throw new RuntimeException(t);
         }
     }
 
@@ -658,7 +658,6 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                     socket.toString(),
                     this.peersNodeAddressOptional,
                     e.toString());
-            e.printStackTrace();
         }
         shutDown(closeConnectionReason);
     }

--- a/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
@@ -56,8 +56,9 @@ public class LocalhostNetworkNode extends NetworkNode {
 
     public LocalhostNetworkNode(int port,
                                 NetworkProtoResolver networkProtoResolver,
-                                @Nullable NetworkFilter networkFilter) {
-        super(port, networkProtoResolver, networkFilter);
+                                @Nullable NetworkFilter networkFilter,
+                                int maxConnections) {
+        super(port, networkProtoResolver, networkFilter, maxConnections);
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/LocalhostNetworkNode.java
@@ -66,8 +66,6 @@ public class LocalhostNetworkNode extends NetworkNode {
         if (setupListener != null)
             addSetupListener(setupListener);
 
-        createExecutorService();
-
         // simulate tor connection delay
         UserThread.runAfter(() -> {
             nodeAddressProperty.set(new NodeAddress("localhost", servicePort));

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -77,7 +77,7 @@ public abstract class NetworkNode implements MessageListener {
     private final CopyOnWriteArraySet<MessageListener> messageListeners = new CopyOnWriteArraySet<>();
     private final CopyOnWriteArraySet<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<>();
     final CopyOnWriteArraySet<SetupListener> setupListeners = new CopyOnWriteArraySet<>();
-    ListeningExecutorService executorService;
+    protected final ListeningExecutorService executorService;
     private Server server;
 
     private volatile boolean shutDownInProgress;
@@ -98,6 +98,8 @@ public abstract class NetworkNode implements MessageListener {
         this.networkProtoResolver = networkProtoResolver;
         this.networkFilter = networkFilter;
         this.maxConnections = maxConnections;
+
+        executorService = MoreExecutors.listeningDecorator(Utilities.newCachedThreadPool(maxConnections * 4, 3, TimeUnit.MINUTES));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -435,12 +437,6 @@ public abstract class NetworkNode implements MessageListener {
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Protected
     ///////////////////////////////////////////////////////////////////////////////////////////
-
-    void createExecutorService() {
-        if (executorService == null) {
-            executorService = MoreExecutors.listeningDecorator(Utilities.newCachedThreadPool(maxConnections * 4, 3, TimeUnit.MINUTES));
-        }
-    }
 
     void startServer(ServerSocket serverSocket) {
         ConnectionListener connectionListener = new ConnectionListener() {

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -72,6 +72,7 @@ public abstract class NetworkNode implements MessageListener {
     private final NetworkProtoResolver networkProtoResolver;
     @Nullable
     private final NetworkFilter networkFilter;
+    private final int maxConnections;
 
     private final CopyOnWriteArraySet<InboundConnection> inBoundConnections = new CopyOnWriteArraySet<>();
     private final CopyOnWriteArraySet<MessageListener> messageListeners = new CopyOnWriteArraySet<>();
@@ -92,10 +93,12 @@ public abstract class NetworkNode implements MessageListener {
 
     NetworkNode(int servicePort,
                 NetworkProtoResolver networkProtoResolver,
-                @Nullable NetworkFilter networkFilter) {
+                @Nullable NetworkFilter networkFilter,
+                int maxConnections) {
         this.servicePort = servicePort;
         this.networkProtoResolver = networkProtoResolver;
         this.networkFilter = networkFilter;
+        this.maxConnections = maxConnections;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -437,7 +440,10 @@ public abstract class NetworkNode implements MessageListener {
 
     void createExecutorService() {
         if (executorService == null)
-            executorService = Utilities.getListeningExecutorService("NetworkNode-" + servicePort, 15, 30, 60);
+            executorService = Utilities.getListeningExecutorService("NetworkNode-" + servicePort,
+                    maxConnections * 2,
+                    maxConnections * 4,
+                    60);
     }
 
     void startServer(ServerSocket serverSocket) {

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -439,11 +439,9 @@ public abstract class NetworkNode implements MessageListener {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     void createExecutorService() {
-        if (executorService == null)
-            executorService = Utilities.getListeningExecutorService("NetworkNode-" + servicePort,
-                    maxConnections * 2,
-                    maxConnections * 4,
-                    60);
+        if (executorService == null) {
+            executorService = MoreExecutors.listeningDecorator(Utilities.newCachedThreadPool(maxConnections * 4, 3, TimeUnit.MINUTES));
+        }
     }
 
     void startServer(ServerSocket serverSocket) {

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -223,11 +223,8 @@ public abstract class NetworkNode implements MessageListener {
                         outboundConnection.sendMessage(networkEnvelope);
                         return outboundConnection;
                     }
-                } catch (Throwable throwable) {
-                    if (!(throwable instanceof IOException ||
-                            throwable instanceof TimeoutException)) {
-                        log.warn("Executing task failed. " + throwable.getMessage());
-                    }
+                } catch (IOException | TimeoutException throwable) {
+                    log.warn("Executing task failed. " + throwable.getMessage());
                     throw throwable;
                 }
             });

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -77,7 +77,7 @@ public abstract class NetworkNode implements MessageListener {
     private final CopyOnWriteArraySet<MessageListener> messageListeners = new CopyOnWriteArraySet<>();
     private final CopyOnWriteArraySet<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<>();
     final CopyOnWriteArraySet<SetupListener> setupListeners = new CopyOnWriteArraySet<>();
-    protected final ListeningExecutorService executorService;
+    private final ListeningExecutorService executorService;
     private Server server;
 
     private volatile boolean shutDownInProgress;
@@ -372,6 +372,7 @@ public abstract class NetworkNode implements MessageListener {
                         if (shutdownCompleted.get() == numConnections) {
                             log.info("Shutdown completed with all connections closed");
                             timeoutHandler.stop();
+                            executorService.shutdownNow();
                             if (shutDownCompleteHandler != null) {
                                 shutDownCompleteHandler.run();
                             }

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -100,8 +100,8 @@ public abstract class NetworkNode implements MessageListener {
         this.networkProtoResolver = networkProtoResolver;
         this.networkFilter = networkFilter;
 
-        connectionExecutor = MoreExecutors.listeningDecorator(Utilities.newCachedThreadPool(maxConnections * 2, 1, TimeUnit.MINUTES));
-        sendMessageExecutor = MoreExecutors.listeningDecorator(Utilities.newCachedThreadPool(maxConnections * 2, 3, TimeUnit.MINUTES));
+        connectionExecutor = MoreExecutors.listeningDecorator(Utilities.newCachedThreadPool("NetworkNode.connection", maxConnections * 2, 1, TimeUnit.MINUTES));
+        sendMessageExecutor = MoreExecutors.listeningDecorator(Utilities.newCachedThreadPool("NetworkNode.sendMessage", maxConnections * 2, 3, TimeUnit.MINUTES));
         serverExecutor = Utilities.getSingleThreadExecutor("NetworkNode.server-" + servicePort);
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/network/Server.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Server.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import org.jetbrains.annotations.Nullable;
 
-// Runs in UserThread
 class Server implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(Server.class);
 
@@ -42,7 +41,6 @@ class Server implements Runnable {
     @Nullable
     private final NetworkFilter networkFilter;
 
-    // accessed from different threads
     private final ServerSocket serverSocket;
     private final Set<Connection> connections = new CopyOnWriteArraySet<>();
     private volatile boolean stopped;

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -78,8 +78,9 @@ public class TorNetworkNode extends NetworkNode {
                           NetworkProtoResolver networkProtoResolver,
                           boolean useStreamIsolation,
                           TorMode torMode,
-                          @Nullable NetworkFilter networkFilter) {
-        super(servicePort, networkProtoResolver, networkFilter);
+                          @Nullable NetworkFilter networkFilter,
+                          int maxConnections) {
+        super(servicePort, networkProtoResolver, networkFilter, maxConnections);
         this.torMode = torMode;
         this.streamIsolation = useStreamIsolation;
         createExecutorService();

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -195,28 +195,16 @@ public class TorNetworkNode extends NetworkNode {
                 nodeAddressProperty.set(new NodeAddress(hiddenServiceSocket.getServiceName() + ":" + hiddenServiceSocket.getHiddenServicePort()));
                 UserThread.execute(() -> setupListeners.forEach(SetupListener::onTorNodeReady));
                 hiddenServiceSocket.addReadyListener(socket -> {
-                    try {
-                        log.info("\n################################################################\n" +
-                                        "Tor hidden service published after {} ms. Socket={}\n" +
-                                        "################################################################",
-                                System.currentTimeMillis() - ts, socket);
-                        new Thread() {
-                            @Override
-                            public void run() {
-                                try {
-                                    nodeAddressProperty.set(new NodeAddress(hiddenServiceSocket.getServiceName() + ":" + hiddenServiceSocket.getHiddenServicePort()));
-                                    startServer(socket);
-                                    UserThread.execute(() -> setupListeners.forEach(SetupListener::onHiddenServicePublished));
-                                } catch (final Exception e1) {
-                                    log.error(e1.toString());
-                                    e1.printStackTrace();
-                                }
-                            }
-                        }.start();
-                    } catch (final Exception e) {
-                        log.error(e.toString());
-                        e.printStackTrace();
-                    }
+                    log.info("\n################################################################\n" +
+                                    "Tor hidden service published after {} ms. Socket={}\n" +
+                                    "################################################################",
+                            System.currentTimeMillis() - ts, socket);
+
+                    UserThread.execute(() -> {
+                        nodeAddressProperty.set(new NodeAddress(hiddenServiceSocket.getServiceName() + ":" + hiddenServiceSocket.getHiddenServicePort()));
+                        startServer(socket);
+                        setupListeners.forEach(SetupListener::onHiddenServicePublished);
+                    });
                     return null;
                 });
             } catch (TorCtlException e) {

--- a/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/TorNetworkNode.java
@@ -83,7 +83,6 @@ public class TorNetworkNode extends NetworkNode {
         super(servicePort, networkProtoResolver, networkFilter, maxConnections);
         this.torMode = torMode;
         this.streamIsolation = useStreamIsolation;
-        createExecutorService();
     }
 
 

--- a/p2p/src/test/java/bisq/network/p2p/network/LocalhostNetworkNodeTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/network/LocalhostNetworkNodeTest.java
@@ -41,7 +41,7 @@ public class LocalhostNetworkNodeTest {
     @Test
     public void testMessage() throws InterruptedException, IOException {
         CountDownLatch msgLatch = new CountDownLatch(2);
-        LocalhostNetworkNode node1 = new LocalhostNetworkNode(9001, TestUtils.getNetworkProtoResolver(), null);
+        LocalhostNetworkNode node1 = new LocalhostNetworkNode(9001, TestUtils.getNetworkProtoResolver(), null, 12);
         node1.addMessageListener((message, connection) -> {
             log.debug("onMessage node1 " + message);
             msgLatch.countDown();
@@ -69,7 +69,7 @@ public class LocalhostNetworkNodeTest {
             }
         });
 
-        LocalhostNetworkNode node2 = new LocalhostNetworkNode(9002, TestUtils.getNetworkProtoResolver(), null);
+        LocalhostNetworkNode node2 = new LocalhostNetworkNode(9002, TestUtils.getNetworkProtoResolver(), null, 12);
         node2.addMessageListener((message, connection) -> {
             log.debug("onMessage node2 " + message);
             msgLatch.countDown();

--- a/p2p/src/test/java/bisq/network/p2p/network/TorNetworkNodeTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/network/TorNetworkNodeTest.java
@@ -56,7 +56,7 @@ public class TorNetworkNodeTest {
         latch = new CountDownLatch(1);
         int port = 9001;
         TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null);
+                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12);
         node1.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {
@@ -83,7 +83,7 @@ public class TorNetworkNodeTest {
         latch = new CountDownLatch(1);
         int port2 = 9002;
         TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null);
+                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12);
         node2.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {
@@ -141,7 +141,7 @@ public class TorNetworkNodeTest {
         latch = new CountDownLatch(2);
         int port = 9001;
         TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null);
+                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12);
         node1.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {
@@ -167,7 +167,7 @@ public class TorNetworkNodeTest {
 
         int port2 = 9002;
         TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
-                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null);
+                new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12);
         node2.start(new SetupListener() {
             @Override
             public void onTorNodeReady() {

--- a/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
+++ b/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
@@ -249,7 +249,6 @@ public class SeedNodeReportingService {
                     .uri(URI.create(seedNodeReportingServerUrl))
                     .POST(HttpRequest.BodyPublishers.ofByteArray(protoMessageAsBytes))
                     .header("User-Agent", getMyAddress())
-                    .header("Connection", "keep-alive")
                     .build();
             httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, throwable) -> {
                 if (throwable != null) {

--- a/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
+++ b/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
@@ -118,7 +118,7 @@ public class SeedNodeReportingService {
 
         // The pool size must be larger as the expected parallel sends because HttpClient use it
         // internally for asynchronous and dependent tasks.
-        executor = Utilities.newCachedThreadPool(20, 8, TimeUnit.MINUTES);
+        executor = Utilities.newCachedThreadPool("SeedNodeReportingService", 20, 8, TimeUnit.MINUTES);
         httpClient = HttpClient.newBuilder().executor(executor).build();
 
         heartBeatTimer = UserThread.runPeriodically(this::sendHeartBeat, HEART_BEAT_DELAY_SEC);

--- a/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
+++ b/seednode/src/main/java/bisq/seednode/reporting/SeedNodeReportingService.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -115,10 +116,9 @@ public class SeedNodeReportingService {
         this.maxConnections = maxConnections;
         this.seedNodeReportingServerUrl = seedNodeReportingServerUrl;
 
-        executor = Utilities.newCachedThreadPool(5,
-                8,
-                TimeUnit.MINUTES,
-                (runnable, executor) -> log.error("Execution was rejected. We skip the {} task.", runnable.toString()));
+        // The pool size must be larger as the expected parallel sends because HttpClient use it
+        // internally for asynchronous and dependent tasks.
+        executor = Utilities.newCachedThreadPool(20, 8, TimeUnit.MINUTES);
         httpClient = HttpClient.newBuilder().executor(executor).build();
 
         heartBeatTimer = UserThread.runPeriodically(this::sendHeartBeat, HEART_BEAT_DELAY_SEC);
@@ -257,9 +257,10 @@ public class SeedNodeReportingService {
                     log.error("Response error message: {}", response);
                 }
             });
+        } catch (RejectedExecutionException t) {
+            log.warn("Did not send reportingItems {} because of RejectedExecutionException {}", reportingItems, t.toString());
         } catch (Throwable t) {
-            // RejectedExecutionException is thrown if we exceed our pool size.
-            log.error("Did not send reportingItems {} because of exception {}", reportingItems, t.toString());
+            log.warn("Did not send reportingItems {} because of exception {}", reportingItems, t.toString());
         }
     }
 


### PR DESCRIPTION
This PR carries maybe a bit of risk as we did not handle exceptions at send message before. Now the onFailure handler is called. Before the onSuccess was called. There might be some unintended effects from that. If discovered we should fix that as now it uses the correct behaviour.

Based on #6458
