### PR TITLE
Reduce Response size

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
+++ b/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
@@ -91,8 +91,8 @@ class GetBlocksRequestHandler {
 
     public void onGetBlocksRequest(GetBlocksRequest getBlocksRequest, Connection connection) {
         long ts = System.currentTimeMillis();
-        // We limit number of blocks to 4000 which is about 1 month.
-        List<Block> blocks = new LinkedList<>(daoStateService.getBlocksFromBlockHeight(getBlocksRequest.getFromBlockHeight(), 4000));
+        // We limit number of blocks to 3000 which is about 3 weeks.
+        List<Block> blocks = new LinkedList<>(daoStateService.getBlocksFromBlockHeight(getBlocksRequest.getFromBlockHeight(), 3000));
         List<RawBlock> rawBlocks = blocks.stream().map(RawBlock::fromBlock).collect(Collectors.toList());
         GetBlocksResponse getBlocksResponse = new GetBlocksResponse(rawBlocks, getBlocksRequest.getNonce());
         log.info("Received GetBlocksRequest from {} for blocks from height {}. " +

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -312,7 +312,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         Map<ByteArray, PersistableNetworkPayload> mapForDataResponse = getMapForDataResponse(getDataRequest.getVersion());
 
         // Give a bit of tolerance for message overhead
-        double maxSize = Connection.getMaxPermittedMessageSize() * 0.9;
+        double maxSize = Connection.getMaxPermittedMessageSize() * 0.6;
 
         // 25% of space is allocated for PersistableNetworkPayloads
         long limit = Math.round(maxSize * 0.25);


### PR DESCRIPTION
Reduce getDataResponse size from 9 MB to 6 MB
Reduce number of blocks at GetBlocksResponse from 4000 to 3000

No need to get that into the release branch as it affects seed nodes only. 