### PR TITLE
[v1.9.7] Wallet password broken: Not use additional `-%d` in name format because of refactoring

### DIFF
--- a/core/src/main/java/bisq/core/crypto/ScryptUtil.java
+++ b/core/src/main/java/bisq/core/crypto/ScryptUtil.java
@@ -49,7 +49,7 @@ public class ScryptUtil {
     }
 
     public static void deriveKeyWithScrypt(KeyCrypterScrypt keyCrypterScrypt, String password, DeriveKeyResultHandler resultHandler) {
-        Utilities.getThreadPoolExecutor("ScryptUtil:deriveKeyWithScrypt-%d", 1, 2, 5L).submit(() -> {
+        Utilities.getThreadPoolExecutor("ScryptUtil:deriveKeyWithScrypt", 1, 2, 5L).submit(() -> {
             try {
                 log.debug("Doing key derivation");
                 long start = System.currentTimeMillis();


### PR DESCRIPTION
Because of the changes in https://github.com/bisq-network/bisq/blob/f66e6936051b587ac6271576f895c1991a8ac2ff/common/src/main/java/bisq/common/util/Utilities.java#L145
we don't need the duplicate Guava placeholder for the unique identifier anymore.