### PR TITLE
Add threadpool for broadcaster

### DIFF
--- a/common/src/main/java/bisq/common/setup/CommonSetup.java
+++ b/common/src/main/java/bisq/common/setup/CommonSetup.java
@@ -35,6 +35,7 @@ import java.net.URISyntaxException;
 
 import java.nio.file.Paths;
 
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import ch.qos.logback.classic.Level;
@@ -72,13 +73,14 @@ public class CommonSetup {
 
     public static void setupUncaughtExceptionHandler(UncaughtExceptionHandler uncaughtExceptionHandler) {
         Thread.UncaughtExceptionHandler handler = (thread, throwable) -> {
-            // Might come from another thread
             if (throwable.getCause() != null && throwable.getCause().getCause() != null &&
                     throwable.getCause().getCause() instanceof BlockStoreException) {
-                log.error(throwable.getMessage());
+                log.error("Uncaught BlockStoreException ", throwable);
             } else if (throwable instanceof ClassCastException &&
                     "sun.awt.image.BufImgSurfaceData cannot be cast to sun.java2d.xr.XRSurfaceData".equals(throwable.getMessage())) {
                 log.warn(throwable.getMessage());
+            } else if (throwable instanceof RejectedExecutionException) {
+                log.error("Uncaught RejectedExecutionException ", throwable);
             } else if (throwable instanceof UnsupportedOperationException &&
                     "The system tray is not supported on the current platform.".equals(throwable.getMessage())) {
                 log.warn(throwable.getMessage());

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -140,7 +141,7 @@ public abstract class NetworkNode implements MessageListener {
 
             SettableFuture<Connection> resultFuture = SettableFuture.create();
             ListenableFuture<Connection> future = connectionExecutor.submit(() -> {
-                Thread.currentThread().setName("NetworkNode:SendMessage-to-" + peersNodeAddress.getFullAddress());
+                Thread.currentThread().setName("NetworkNode.connectionExecutor:SendMessage-to-" + peersNodeAddress.getFullAddress());
 
                 if (peersNodeAddress.equals(getNodeAddress())) {
                     log.warn("We are sending a message to ourselves");
@@ -288,25 +289,36 @@ public abstract class NetworkNode implements MessageListener {
         return null;
     }
 
-
     public SettableFuture<Connection> sendMessage(Connection connection, NetworkEnvelope networkEnvelope) {
-        // connection.sendMessage might take a bit (compression, write to stream), so we use a thread to not block
-        ListenableFuture<Connection> future = sendMessageExecutor.submit(() -> {
-            String id = connection.getPeersNodeAddressOptional().isPresent() ? connection.getPeersNodeAddressOptional().get().getFullAddress() : connection.getUid();
-            Thread.currentThread().setName("NetworkNode:SendMessage-to-" + id);
-            connection.sendMessage(networkEnvelope);
-            return connection;
-        });
-        SettableFuture<Connection> resultFuture = SettableFuture.create();
-        Futures.addCallback(future, new FutureCallback<>() {
-            public void onSuccess(Connection connection) {
-                UserThread.execute(() -> resultFuture.set(connection));
-            }
+        return sendMessage(connection, networkEnvelope, sendMessageExecutor);
+    }
 
-            public void onFailure(@NotNull Throwable throwable) {
-                UserThread.execute(() -> resultFuture.setException(throwable));
-            }
-        }, MoreExecutors.directExecutor());
+    public SettableFuture<Connection> sendMessage(Connection connection,
+                                                  NetworkEnvelope networkEnvelope,
+                                                  ListeningExecutorService executor) {
+        SettableFuture<Connection> resultFuture = SettableFuture.create();
+        try {
+            ListenableFuture<Connection> future = executor.submit(() -> {
+                String id = connection.getPeersNodeAddressOptional().isPresent() ? connection.getPeersNodeAddressOptional().get().getFullAddress() : connection.getUid();
+                Thread.currentThread().setName("NetworkNode:SendMessage-to-" + id);
+                connection.sendMessage(networkEnvelope);
+                return connection;
+            });
+
+            Futures.addCallback(future, new FutureCallback<>() {
+                public void onSuccess(Connection connection) {
+                    UserThread.execute(() -> resultFuture.set(connection));
+                }
+
+                public void onFailure(@NotNull Throwable throwable) {
+                    UserThread.execute(() -> resultFuture.setException(throwable));
+                }
+            }, MoreExecutors.directExecutor());
+
+        } catch (RejectedExecutionException exception) {
+            log.error("RejectedExecutionException at sendMessage: ", exception);
+            resultFuture.setException(exception);
+        }
         return resultFuture;
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkNode.java
@@ -105,12 +105,12 @@ public abstract class NetworkNode implements MessageListener {
                 maxConnections * 2,
                 maxConnections * 3,
                 30,
-                60);
+                30);
         sendMessageExecutor = Utilities.getListeningExecutorService("NetworkNode.sendMessage",
                 maxConnections * 2,
                 maxConnections * 3,
                 30,
-                60);
+                30);
         serverExecutor = Utilities.getSingleThreadExecutor("NetworkNode.server-" + servicePort);
     }
 


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq/issues/6480

At broadcast there can be many messages been sent and if the tor connections are slow the sendMessage threadpool can get exhausted. We did not handle the RejectedExecutionException so it escalated as uncaught exception to the user in from of an error popup (pre 1.9.7 it was swallowed in a debug log, so I assume we had RejectedExecutionException aslo earlier).
We catch now RejectedExecutionException at the sendMessage method as well at the uncaughtExceptionHandler to only log an error but not open an error popup.
We add a dedicated threadpool to the broadcaster so that we can separate that pool from the common sendMessage pool. In case a burst of broadcasts would exhaust the broadcaster pool we get dropped some of the broadcast messages which has little impact and risk. The common sendMessage pool will be not affected in such a scenario, thus important messages like trade messages are not at risk.
We reduced also the keepAliveTime to 30 sec to lower resource comsumption.
 