### PR TITLE
DaoStateStorageService: Don't call executorService.shutdown() twice

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -128,7 +128,6 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
     }
 
     public void shutDown() {
-        executorService.shutdown();
         // noinspection UnstableApiUsage
         MoreExecutors.shutdownAndAwaitTermination(executorService, 10, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
MoreExecutors.shutdownAndAwaitTermination(executorService, ...) calls executorService.shutdown() before starting its force shutdown timer.