### PR TITLE
DaoStateStorageService: Fix shutdown data corruption bug

### DIFF
--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -89,12 +89,25 @@ public class Utilities {
         return getSingleThreadExecutor(name);
     }
 
+    public static ExecutorService getNonDaemonSingleThreadExecutor(Class<?> aClass) {
+        String name = aClass.getSimpleName();
+        return getSingleThreadExecutor(name, false);
+    }
+
     public static ExecutorService getSingleThreadExecutor(String name) {
-        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat(name)
-                .setDaemon(true)
-                .build();
+        return getSingleThreadExecutor(name, true);
+    }
+
+    private static ExecutorService getSingleThreadExecutor(String name, boolean isDaemonThread) {
+        final ThreadFactory threadFactory = getThreadFactory(name, isDaemonThread);
         return Executors.newSingleThreadExecutor(threadFactory);
+    }
+
+    private static ThreadFactory getThreadFactory(String name, boolean isDaemonThread) {
+        return new ThreadFactoryBuilder()
+                .setNameFormat(name)
+                .setDaemon(isDaemonThread)
+                .build();
     }
 
     public static ExecutorService getSingleThreadExecutor(ThreadFactory threadFactory) {

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -34,8 +34,6 @@ import bisq.common.util.Utilities;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.google.common.util.concurrent.MoreExecutors;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -44,7 +42,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -58,7 +55,7 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
     private final BsqBlocksStorageService bsqBlocksStorageService;
     private final File storageDir;
     private final LinkedList<Block> blocks = new LinkedList<>();
-    private final ExecutorService executorService = Utilities.getSingleThreadExecutor(this.getClass());
+    private final ExecutorService executorService = Utilities.getNonDaemonSingleThreadExecutor(this.getClass());
     private Optional<Future<?>> future = Optional.empty();
 
 
@@ -128,8 +125,7 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
     }
 
     public void shutDown() {
-        // noinspection UnstableApiUsage
-        MoreExecutors.shutdownAndAwaitTermination(executorService, 10, TimeUnit.SECONDS);
+        executorService.shutdown();
     }
 
     @Override


### PR DESCRIPTION
The DaoStateStorageService submits tasks to a daemon thread executor service. The JVM continues to execute threads until all non-daemon threads have terminated. So the JVM will kill the DaoStateStorageService during write requests leading to data corruption.

This change uses a non-daemon thread executor service at waits during shutdown until all data is written to disk.