### PR TITLE
Speed up loading and scrolling of trade history

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -440,15 +440,15 @@ public abstract class WalletService {
     public TransactionConfidence getConfidenceForAddress(Address address) {
         List<TransactionConfidence> transactionConfidenceList = new ArrayList<>();
         if (wallet != null) {
-            Set<Transaction> transactions = getAddressToMatchingTxSetMultiset().get(address);
+            Set<Transaction> transactions = getAddressToMatchingTxSetMultimap().get(address);
             transactionConfidenceList.addAll(transactions.stream().map(tx ->
                     getTransactionConfidence(tx, address)).collect(Collectors.toList()));
         }
         return getMostRecentConfidence(transactionConfidenceList);
     }
 
-    private SetMultimap<Address, Transaction> getAddressToMatchingTxSetMultiset() {
-        return addressToMatchingTxSetCache.updateAndGet(set -> set != null ? set : computeAddressToMatchingTxSetMultimap());
+    private SetMultimap<Address, Transaction> getAddressToMatchingTxSetMultimap() {
+        return addressToMatchingTxSetCache.updateAndGet(map -> map != null ? map : computeAddressToMatchingTxSetMultimap());
     }
 
     private SetMultimap<Address, Transaction> computeAddressToMatchingTxSetMultimap() {


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This PR fixes a quadratic time bug while filtering the list of BSQ swap trades for their tx confirmation status, as needed by `ClosedTradesView`. It also fixes a (sort-of) cubic time bug caused by the repeated invocation of `ClosedTradableManager.getNumPastTrades` (once for each list item). It does this by caching the peer node address counts over all the closed trades & confirmed BSQ swaps, as well as caching a mapping of txIds to txs in `WalletService` to avoid repeated copying and scanning of the wallet tx list while checking for confirmation status by txId.

These issues were making the closed trades view load extremely slow on my Bisq instance (taking more than 20s), which has around 1300 past trades, a bit under half of which are BSQ swaps. It was also making scrolling and paging almost unusable. The following is a screenshot of the hotspots from JProfiler, prior to the changes:
![Screenshot from 2023-02-02 10-53-51](https://user-images.githubusercontent.com/54855381/216219827-09905dc3-f8fb-4ead-ab1e-fb5a9dfe6b7f.png)
