### PR TITLE
Further speed up transactions view load

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/RelatedTransactionFilterSlices.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/RelatedTransactionFilterSlices.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.funds.transactions;
+
+import org.bitcoinj.core.Transaction;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static bisq.desktop.main.funds.transactions.TransactionAwareTradable.TX_FILTER_SIZE;
+
+public class RelatedTransactionFilterSlices {
+    private final List<TransactionAwareTradable> tradables;
+    private final BitSet[] filterSlices;
+
+    public RelatedTransactionFilterSlices(Collection<? extends TransactionAwareTradable> tradables) {
+        this.tradables = List.copyOf(tradables);
+
+        filterSlices = new BitSet[TX_FILTER_SIZE];
+        Arrays.setAll(filterSlices, i -> new BitSet(this.tradables.size()));
+
+        IntStream.range(0, this.tradables.size())
+                .forEach(j -> this.tradables.get(j).getRelatedTransactionFilter()
+                        .forEach(i -> filterSlices[i].set(j)));
+    }
+
+    public Stream<TransactionAwareTradable> getAllRelatedTradables(Transaction tx) {
+        int i = TransactionAwareTradable.bucketIndex(tx);
+        return filterSlices[i].stream()
+                .mapToObj(tradables::get)
+                .filter(t -> t.isRelatedToTransaction(tx));
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareOpenOffer.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareOpenOffer.java
@@ -34,9 +34,7 @@ class TransactionAwareOpenOffer implements TransactionAwareTradable {
         Offer offer = delegate.getOffer();
         String paymentTxId = offer.getOfferFeePaymentTxId();
 
-        String txId = transaction.getTxId().toString();
-
-        return paymentTxId != null && paymentTxId.equals(txId);
+        return paymentTxId != null && paymentTxId.equals(transaction.getTxId().toString());
     }
 
     public Tradable asTradable() {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareOpenOffer.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareOpenOffer.java
@@ -23,6 +23,8 @@ import bisq.core.trade.model.Tradable;
 
 import org.bitcoinj.core.Transaction;
 
+import java.util.stream.IntStream;
+
 class TransactionAwareOpenOffer implements TransactionAwareTradable {
     private final OpenOffer delegate;
 
@@ -39,5 +41,13 @@ class TransactionAwareOpenOffer implements TransactionAwareTradable {
 
     public Tradable asTradable() {
         return delegate;
+    }
+
+    @Override
+    public IntStream getRelatedTransactionFilter() {
+        Offer offer = delegate.getOffer();
+        String paymentTxId = offer.getOfferFeePaymentTxId();
+        return IntStream.of(TransactionAwareTradable.bucketIndex(paymentTxId))
+                .filter(i -> i >= 0);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -22,7 +22,6 @@ import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
 import bisq.desktop.util.filtering.FilterableListItem;
 
-import bisq.core.btc.listeners.TxConfidenceListener;
 import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletService;
@@ -59,7 +58,6 @@ import javax.annotation.Nullable;
 
 @Slf4j
 class TransactionsListItem implements FilterableListItem {
-    private final BtcWalletService btcWalletService;
     private final CoinFormatter formatter;
     private String dateString;
     private final Date date;
@@ -69,7 +67,6 @@ class TransactionsListItem implements FilterableListItem {
     private String details = "";
     private String addressString = "";
     private String direction = "";
-    private TxConfidenceListener txConfidenceListener;
     private boolean received;
     private Coin amountAsCoin = Coin.ZERO;
     private String memo = "";
@@ -91,7 +88,6 @@ class TransactionsListItem implements FilterableListItem {
     // used at exportCSV
     TransactionsListItem() {
         date = null;
-        btcWalletService = null;
         txId = null;
         formatter = null;
         isDustAttackTx = false;
@@ -105,7 +101,6 @@ class TransactionsListItem implements FilterableListItem {
                          DaoFacade daoFacade,
                          CoinFormatter formatter,
                          long ignoreDustThreshold) {
-        this.btcWalletService = btcWalletService;
         this.formatter = formatter;
         this.memo = transaction.getMemo();
 
@@ -303,19 +298,6 @@ class TransactionsListItem implements FilterableListItem {
             GUIUtil.updateConfidence(confidence, tooltip, txConfidenceIndicator);
             confirmations = confidence.getDepthInBlocks();
         }});
-
-        txConfidenceListener = new TxConfidenceListener(txId) {
-            @Override
-            public void onTransactionConfidenceChanged(TransactionConfidence confidence) {
-                GUIUtil.updateConfidence(confidence, lazy().tooltip, lazy().txConfidenceIndicator);
-                confirmations = confidence.getDepthInBlocks();
-            }
-        };
-        btcWalletService.addTxConfidenceListener(txConfidenceListener);
-    }
-
-    public void cleanup() {
-        btcWalletService.removeTxConfidenceListener(txConfidenceListener);
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -17,10 +17,10 @@
 
 package bisq.desktop.main.funds.transactions;
 
-import bisq.desktop.util.filtering.FilterableListItem;
 import bisq.desktop.components.indicator.TxConfidenceIndicator;
 import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.GUIUtil;
+import bisq.desktop.util.filtering.FilterableListItem;
 
 import bisq.core.btc.listeners.TxConfidenceListener;
 import bisq.core.btc.wallet.BsqWalletService;
@@ -197,7 +197,6 @@ class TransactionsListItem implements FilterableListItem {
 
         if (optionalTradable.isPresent()) {
             tradable = optionalTradable.get();
-            String tradeId = tradable.getShortId();
             if (tradable instanceof OpenOffer) {
                 details = Res.get("funds.tx.createOfferFee");
             } else if (tradable instanceof Trade) {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -288,11 +288,11 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     }
 
     private void updateList() {
+        Set<Tradable> tradables = tradableRepository.getAll();
+
         List<TransactionsListItem> transactionsListItems = btcWalletService.getTransactions(false)
                 .stream()
                 .map(transaction -> {
-                    Set<Tradable> tradables = tradableRepository.getAll();
-
                     TransactionAwareTradable maybeTradable = tradables.stream()
                             .map(tradable -> {
                                 if (tradable instanceof OpenOffer) {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -279,7 +279,6 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     protected void deactivate() {
         filterBox.deactivate();
         sortedList.comparatorProperty().unbind();
-        observableList.forEach(TransactionsListItem::cleanup);
         btcWalletService.removeChangeEventListener(walletChangeEventListener);
 
         if (scene != null)
@@ -328,7 +327,6 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                 })
                 .collect(Collectors.toList());
         // are sorted by getRecentTransactions
-        transactionsListItems.forEach(TransactionsListItem::cleanup);
         observableList.setAll(transactionsListItems);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -201,7 +201,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
 
         dateColumn.setComparator(Comparator.comparing(TransactionsListItem::getDate));
         tradeIdColumn.setComparator(Comparator.comparing(o -> o.getTradable() != null ? o.getTradable().getId() : ""));
-        detailsColumn.setComparator(Comparator.comparing(o -> o.getDetails()));
+        detailsColumn.setComparator(Comparator.comparing(TransactionsListItem::getDetails));
         addressColumn.setComparator(Comparator.comparing(item -> item.getDirection() + item.getAddressString()));
         transactionColumn.setComparator(Comparator.comparing(TransactionsListItem::getTxId));
         amountColumn.setComparator(Comparator.comparing(TransactionsListItem::getAmountAsCoin));
@@ -211,9 +211,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         dateColumn.setSortType(TableColumn.SortType.DESCENDING);
         tableView.getSortOrder().add(dateColumn);
 
-        walletChangeEventListener = wallet -> {
-            updateList();
-        };
+        walletChangeEventListener = wallet -> updateList();
 
         keyEventEventHandler = event -> {
             // Not intended to be public to users as the feature is not well tested
@@ -419,15 +417,13 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                             TransactionsListItem> column) {
                         return new TableCell<>() {
 
-                            private HyperlinkWithIcon hyperlinkWithIcon;
-
                             @Override
                             public void updateItem(final TransactionsListItem item, boolean empty) {
                                 super.updateItem(item, empty);
 
                                 if (item != null && !empty) {
                                     if (item.isDustAttackTx()) {
-                                        hyperlinkWithIcon = new HyperlinkWithIcon(item.getDetails(), AwesomeIcon.WARNING_SIGN);
+                                        var hyperlinkWithIcon = new HyperlinkWithIcon(item.getDetails(), AwesomeIcon.WARNING_SIGN);
                                         hyperlinkWithIcon.setOnAction(event -> new Popup().warning(Res.get("funds.tx.dustAttackTx.popup")).show());
                                         setGraphic(hyperlinkWithIcon);
                                     } else {

--- a/desktop/src/test/java/bisq/desktop/main/funds/transactions/TransactionAwareTradeTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/funds/transactions/TransactionAwareTradeTest.java
@@ -66,13 +66,13 @@ public class TransactionAwareTradeTest {
 
     @Test
     public void testIsRelatedToTransactionWhenPayoutTx() {
-        when(delegate.getPayoutTx().getTxId()).thenReturn(XID);
+        when(delegate.getPayoutTxId()).thenReturn(XID.toString());
         assertTrue(trade.isRelatedToTransaction(transaction));
     }
 
     @Test
     public void testIsRelatedToTransactionWhenDepositTx() {
-        when(delegate.getDepositTx().getTxId()).thenReturn(XID);
+        when(delegate.getDepositTxId()).thenReturn(XID.toString());
         assertTrue(trade.isRelatedToTransaction(transaction));
     }
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This PR is a collection of optimisations to the Funds/Transactions display, via the `TransactionsView.updateList` method. The much earlier PR #5120 also attempted to optimise the transactions view load, but did not completely fix the main quadratic time issue (cost ~ transations count * tradable count, due to this many calls to `TransactionAwareTradable.isRelatedToTransaction`) and since then it has slowed down again a bit.

The main optimisation of this PR is to partition the wallet transactions pseudo-randomly into 64 buckets and use a bit array structure (which could be considered a degenerate Bloom filter with _k_, the number of hash functions, equal to 1), to filter the list of all tradable-transaction pairs prior to calling `isRelatedToTransaction` on each of them. While technically still quadratic time, it cuts down the number of calls (though not the runtime) roughly 40 times (at least when there are similar numbers of BSQ swap trades and escrow trades).

The other main speedup is fixing an issue where the set of all tradables was needlessly rebuild for every transaction listed. In addition to that, some further modest optimisations to `isRelatedToTransaction` and the `TransactionsListItem` constructor were made by introducing some appropriate simple caching, cleaning up the code slightly and removing an unused listener.

The following is a call tree of the transactions view load from JProfiler, prior to the optimisations (in which the load was taking 5-15 seconds on my old Bisq instance with ~1300 trades and ~3000 transactions):
![Screenshot-2023-2-12 Call Tree](https://user-images.githubusercontent.com/54855381/218308793-d3d9e390-fbb2-43b9-8e2d-21052a7c547a.png)

The following is the same call tree after the optimisations, repeatedly tabbing to the view 10 times (instead of just once):
![Screenshot-2023-2-12 Call Tree(1)](https://user-images.githubusercontent.com/54855381/218308931-8a64ade9-dcc6-4ccd-bc6c-580345379819.png)
