### PR TITLE
Speed up BSQ tx view load

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/TxConfidenceListItem.java
+++ b/desktop/src/main/java/bisq/desktop/components/TxConfidenceListItem.java
@@ -26,50 +26,78 @@ import bisq.core.btc.wallet.BsqWalletService;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 
+import com.google.common.base.Suppliers;
+
 import javafx.scene.control.Tooltip;
 
-import lombok.Data;
+import java.util.function.Supplier;
 
+import lombok.Getter;
 
-@Data
 public class TxConfidenceListItem {
+    @Getter
     protected final BsqWalletService bsqWalletService;
+    @Getter
     protected final String txId;
-    protected int confirmations = 0;
-    protected TxConfidenceIndicator txConfidenceIndicator;
-    protected TxConfidenceListener txConfidenceListener;
+    private final TxConfidenceListener txConfidenceListener;
+    private final Supplier<LazyFields> lazyFieldsSupplier;
+    private volatile LazyFields lazyFields;
+
+    private static class LazyFields {
+        int confirmations;
+        TxConfidenceIndicator txConfidenceIndicator;
+        Tooltip tooltip;
+    }
+
+    private LazyFields lazy() {
+        return lazyFieldsSupplier.get();
+    }
 
     protected TxConfidenceListItem(Transaction transaction,
                                    BsqWalletService bsqWalletService) {
         this.bsqWalletService = bsqWalletService;
 
         txId = transaction.getTxId().toString();
-        txConfidenceIndicator = new TxConfidenceIndicator();
-        txConfidenceIndicator.setId("funds-confidence");
-        Tooltip tooltip = new Tooltip();
-        txConfidenceIndicator.setProgress(0);
-        txConfidenceIndicator.setPrefSize(24, 24);
-        txConfidenceIndicator.setTooltip(tooltip);
+        lazyFieldsSupplier = Suppliers.memoize(() -> new LazyFields() {{
+            txConfidenceIndicator = new TxConfidenceIndicator();
+            txConfidenceIndicator.setId("funds-confidence");
+            tooltip = new Tooltip();
+            txConfidenceIndicator.setProgress(0);
+            txConfidenceIndicator.setPrefSize(24, 24);
+            txConfidenceIndicator.setTooltip(tooltip);
+
+            lazyFields = this;
+            updateConfidence(bsqWalletService.getConfidenceForTxId(txId));
+        }});
 
         txConfidenceListener = new TxConfidenceListener(txId) {
             @Override
             public void onTransactionConfidenceChanged(TransactionConfidence confidence) {
-                updateConfidence(confidence, tooltip);
+                updateConfidence(confidence);
             }
         };
         bsqWalletService.addTxConfidenceListener(txConfidenceListener);
-        updateConfidence(bsqWalletService.getConfidenceForTxId(txId), tooltip);
     }
 
     protected TxConfidenceListItem() {
-        this.bsqWalletService = null;
-        this.txId = null;
+        bsqWalletService = null;
+        txId = null;
+        txConfidenceListener = null;
+        lazyFieldsSupplier = null;
     }
 
-    private void updateConfidence(TransactionConfidence confidence, Tooltip tooltip) {
-        if (confidence != null) {
-            GUIUtil.updateConfidence(confidence, tooltip, txConfidenceIndicator);
-            confirmations = confidence.getDepthInBlocks();
+    public int getNumConfirmations() {
+        return lazy().confirmations;
+    }
+
+    public TxConfidenceIndicator getTxConfidenceIndicator() {
+        return lazy().txConfidenceIndicator;
+    }
+
+    private void updateConfidence(TransactionConfidence confidence) {
+        if (confidence != null && lazyFields != null) {
+            GUIUtil.updateConfidence(confidence, lazyFields.tooltip, lazyFields.txConfidenceIndicator);
+            lazyFields.confirmations = confidence.getDepthInBlocks();
         }
     }
 
@@ -77,4 +105,3 @@ public class TxConfidenceListItem {
         bsqWalletService.removeTxConfidenceListener(txConfidenceListener);
     }
 }
-

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
@@ -151,7 +151,7 @@ class BsqTxListItem extends TxConfidenceListItem {
     TxType getTxType() {
         return daoFacade.getTx(txId)
                 .flatMap(tx -> daoFacade.getOptionalTxType(tx.getId()))
-                .orElse(confirmations == 0 ? TxType.UNVERIFIED : TxType.UNDEFINED_TX_TYPE);
+                .orElse(getNumConfirmations() == 0 ? TxType.UNVERIFIED : TxType.UNDEFINED_TX_TYPE);
     }
 
     boolean isWithdrawalToBTCWallet() {

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
@@ -18,7 +18,6 @@
 package bisq.desktop.main.dao.wallet.tx;
 
 import bisq.desktop.components.TxConfidenceListItem;
-import bisq.desktop.main.funds.transactions.TradableRepository;
 import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.btc.wallet.BsqWalletService;
@@ -36,6 +35,7 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionOutput;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
@@ -66,7 +66,7 @@ class BsqTxListItem extends TxConfidenceListItem {
                   DaoFacade daoFacade,
                   Date date,
                   BsqFormatter bsqFormatter,
-                  TradableRepository tradableRepository) {
+                  Map<String, BsqSwapTrade> swapTradeByTxIdMap) {
         super(transaction, bsqWalletService);
 
         this.daoFacade = daoFacade;
@@ -133,12 +133,7 @@ class BsqTxListItem extends TxConfidenceListItem {
         else
             address = "";
 
-
-        optionalBsqTrade = tradableRepository.getAll().stream()
-                .filter(tradable -> tradable instanceof BsqSwapTrade)
-                .map(tradable -> (BsqSwapTrade) tradable)
-                .filter(tradable -> txId.equals(tradable.getTxId()))
-                .findFirst();
+        optionalBsqTrade = Optional.ofNullable(swapTradeByTxIdMap.get(txId));
     }
 
     BsqTxListItem() {

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -202,14 +202,13 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
 
         daoFacade.addBsqStateListener(this);
 
-        updateList();
-
         walletChainHeight = bsqWalletService.getBestChainHeight();
         blockHeightBeforeProcessing = daoFacade.getChainHeight();
         missingBlocks = walletChainHeight - blockHeightBeforeProcessing;
         if (!daoStateService.isParseBlockChainComplete()) {
             updateAnyChainHeightTimer = UserThread.runPeriodically(this::onUpdateAnyChainHeight, 100, TimeUnit.MILLISECONDS);
         }
+        // This indirectly calls updateList(), as required:
         onUpdateAnyChainHeight();
 
         exportButton.setOnAction(event -> {

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -235,7 +235,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                 columns[3] = item.getAddress();
                 columns[4] = String.valueOf(item.isReceived());
                 columns[5] = item.getAmountAsString();
-                columns[6] = String.valueOf(item.getConfirmations());
+                columns[6] = String.valueOf(item.getNumConfirmations());
                 columns[7] = item.getTxType().name();
                 return columns;
             };
@@ -490,7 +490,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                                     TxType txType = item.getTxType();
                                     String labelString = Res.get("dao.tx.type.enum." + txType.name());
                                     Label label;
-                                    if (item.getConfirmations() > 0 && isValidType(txType)) {
+                                    if (item.getNumConfirmations() > 0 && isValidType(txType)) {
                                         if (item.getOptionalBsqTrade().isPresent()) {
                                             if (field != null)
                                                 field.setOnAction(null);
@@ -578,7 +578,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
 
                             String bsqAmount = Res.get("shared.na");
 
-                            if (item.getConfirmations() > 0) {
+                            if (item.getNumConfirmations() > 0) {
                                 if (isValidType(txType))
                                     bsqAmount = item.getAmountAsString();
                                 else if (item.isWithdrawalToBTCWallet())

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -70,13 +70,13 @@ class TransactionsListItem implements FilterableListItem {
     private boolean received;
     private Coin amountAsCoin = Coin.ZERO;
     private String memo = "";
-    private int confirmations = 0;
     @Getter
     private final boolean isDustAttackTx;
     private boolean initialTxConfidenceVisibility = true;
     private final Supplier<LazyFields> lazyFieldsSupplier;
 
     private static class LazyFields {
+        int confirmations;
         TxConfidenceIndicator txConfidenceIndicator;
         Tooltip tooltip;
     }
@@ -349,7 +349,7 @@ class TransactionsListItem implements FilterableListItem {
     }
 
     public String getNumConfirmations() {
-        return String.valueOf(confirmations);
+        return String.valueOf(lazy().confirmations);
     }
 
     public String getMemo() {


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Apply some fairly simple optimisations to speed up the BSQ tx list display under _DAO_ / _BSQ Wallet_ / _Transactions_:

1. Avoid needlessly calling `updateList()` twice in `BsqTxView`;
2. Build a `Map<String, BsqSwapTrade>` from txIds to swap trades, to fix a quadratic-time performance regression whereby all the tradables were repeatedly scanned to identify the possible matching swap trade for each BSQ tx;
3. Lazily load tooltips and confidence indicators, as some of the other list views do.

Additionally fix a related bug in the BTC transactions CSV export discovered while working on 3 above, and optimise the BTC funds deposit view slightly with some short circuit logic in `DepositListItem`, to make it more consistent with change 3 above.

--

With a large number (~1600) of BSQ txs in my Bisq wallet, the following call tree was produced by JProfiler by tabbing to the BSQ tx view 10 times:
![Screenshot-2023-3-9 Call Tree](https://user-images.githubusercontent.com/54855381/223781979-ea87ed56-d02e-4f8f-ad9d-30e2cdadf805.png)

After the optimisations in this PR, the new call tree (from tabbing to the view 10 times) was produced:
![Screenshot-2023-3-9 Call Tree(1)](https://user-images.githubusercontent.com/54855381/223784061-c1347d43-1234-4928-b39d-1dc959c5325c.png)

Thus the average load time has gone from around 8.2 seconds to around 170 ms.
