### PR TITLE
Update offer book UI

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -304,8 +304,8 @@ market.tabs.spreadPayment=Offers by Payment Method
 market.tabs.trades=Trades
 
 # OfferBookChartView
-market.offerBook.sellOffersHeaderLabel=Sell {0} to
-market.offerBook.buyOffersHeaderLabel=Buy {0} from
+market.offerBook.sellOffersHeaderLabel=Sell offers
+market.offerBook.buyOffersHeaderLabel=Buy offers
 market.offerBook.buy=I want to buy bitcoin
 market.offerBook.sell=I want to sell bitcoin
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -306,8 +306,6 @@ market.tabs.trades=Trades
 # OfferBookChartView
 market.offerBook.sellOffersHeaderLabel=Sell offers
 market.offerBook.buyOffersHeaderLabel=Buy offers
-market.offerBook.buy=I want to buy bitcoin
-market.offerBook.sell=I want to sell bitcoin
 
 # SpreadView
 market.spread.numberOfOffersColumn=All offers ({0})

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -1756,19 +1756,19 @@ textfield */
 }
 
 #charts .default-color0.chart-area-symbol {
-    -fx-background-color: -bs-sell, -bs-background-color;
-}
-
-#charts .default-color1.chart-area-symbol, #charts-dao .default-color0.chart-area-symbol {
     -fx-background-color: -bs-buy, -bs-background-color;
 }
 
+#charts .default-color1.chart-area-symbol, #charts-dao .default-color0.chart-area-symbol {
+    -fx-background-color: -bs-sell, -bs-background-color;
+}
+
 #charts .default-color0.chart-series-area-line {
-    -fx-stroke: -bs-sell;
+    -fx-stroke: -bs-buy;
 }
 
 #charts .default-color1.chart-series-area-line, #charts-dao .default-color0.chart-series-area-line {
-    -fx-stroke: -bs-buy;
+    -fx-stroke: -bs-sell;
 }
 
 /* The .chart-line-symbol rules change the color of the legend symbol */
@@ -1960,11 +1960,11 @@ textfield */
 }
 
 #charts .default-color0.chart-series-area-fill {
-    -fx-fill: -bs-sell-transparent;
+    -fx-fill: -bs-buy-transparent;
 }
 
 #charts .default-color1.chart-series-area-fill, #charts-dao .default-color0.chart-series-area-fill {
-    -fx-fill: -bs-buy-transparent;
+    -fx-fill: -bs-sell-transparent;
 }
 
 .chart-vertical-grid-lines {

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -1734,12 +1734,12 @@ textfield */
     -fx-background-color: -bs-background-color;
 }
 
-#charts .chart-legend, #charts-dao .chart-legend {
+#charts-offer-book .chart-legend, #charts-dao .chart-legend {
     -fx-font-size: 1.077em;
     -fx-alignment: center;
 }
 
-#charts .axis, #price-chart .axis, #volume-chart .axis, #charts-dao .axis {
+#charts-offer-book .axis, #price-chart .axis, #volume-chart .axis, #charts-dao .axis {
     -fx-tick-label-fill: -bs-rd-font-lighter;
     -fx-tick-label-font-size: 0.769em;
     -fx-font-size: 0.880em;
@@ -1751,23 +1751,23 @@ textfield */
     -fx-text-alignment: center;
 }
 
-#charts .chart-plot-background, #charts-dao .chart-plot-background {
+#charts-offer-book .chart-plot-background, #charts-dao .chart-plot-background {
     -fx-background-color: -bs-background-color;
 }
 
-#charts .default-color0.chart-area-symbol {
+#charts-offer-book .default-color0.chart-area-symbol {
     -fx-background-color: -bs-buy, -bs-background-color;
 }
 
-#charts .default-color1.chart-area-symbol, #charts-dao .default-color0.chart-area-symbol {
+#charts-offer-book .default-color1.chart-area-symbol, #charts-dao .default-color0.chart-area-symbol {
     -fx-background-color: -bs-sell, -bs-background-color;
 }
 
-#charts .default-color0.chart-series-area-line {
+#charts-offer-book .default-color0.chart-series-area-line {
     -fx-stroke: -bs-buy;
 }
 
-#charts .default-color1.chart-series-area-line, #charts-dao .default-color0.chart-series-area-line {
+#charts-offer-book .default-color1.chart-series-area-line, #charts-dao .default-color0.chart-series-area-line {
     -fx-stroke: -bs-sell;
 }
 
@@ -1959,11 +1959,11 @@ textfield */
     -fx-stroke-width: 2px;
 }
 
-#charts .default-color0.chart-series-area-fill {
+#charts-offer-book .default-color0.chart-series-area-fill {
     -fx-fill: -bs-buy-transparent;
 }
 
-#charts .default-color1.chart-series-area-fill, #charts-dao .default-color0.chart-series-area-fill {
+#charts-offer-book .default-color1.chart-series-area-fill, #charts-dao .default-color0.chart-series-area-fill {
     -fx-fill: -bs-sell-transparent;
 }
 
@@ -1971,12 +1971,12 @@ textfield */
     -fx-stroke: transparent;
 }
 
-#charts .axis-label {
+#charts-offer-book .axis-label {
     -fx-font-size: 0.769em;
     -fx-alignment: center-left;
 }
 
-#charts .axisy .axis-label {
+#charts-offer-book .axisy .axis-label {
     -fx-alignment: center;
 }
 

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -163,8 +163,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         buyButton = (AutoTooltipButton) tupleBuy.third;
         sellButton = (AutoTooltipButton) tupleSell.third;
 
-        sellHeaderLabel = tupleBuy.fourth;
-        buyHeaderLabel = tupleSell.fourth;
+        buyHeaderLabel = tupleBuy.fourth;
+        sellHeaderLabel = tupleSell.fourth;
 
         HBox bottomHBox = new HBox();
         bottomHBox.setSpacing(20); //30
@@ -243,10 +243,10 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                     String viewBaseCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? code : Res.getBaseCurrencyCode();
                     String viewPriceCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? Res.getBaseCurrencyCode() : code;
 
-                    sellHeaderLabel.setText(Res.get("market.offerBook.sellOffersHeaderLabel", viewBaseCurrencyCode));
+                    sellHeaderLabel.setText(Res.get("market.offerBook.sellOffersHeaderLabel"));
                     sellButton.updateText(Res.get("shared.sellCurrency", viewBaseCurrencyCode, viewPriceCurrencyCode));
 
-                    buyHeaderLabel.setText(Res.get("market.offerBook.buyOffersHeaderLabel", viewBaseCurrencyCode));
+                    buyHeaderLabel.setText(Res.get("market.offerBook.buyOffersHeaderLabel"));
                     buyButton.updateText(Res.get("shared.buyCurrency", viewBaseCurrencyCode, viewPriceCurrencyCode));
 
                     priceColumnLabel.set(Res.get("shared.priceWithCur", viewPriceCurrencyCode));

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -43,7 +43,6 @@ import bisq.network.p2p.NodeAddress;
 import bisq.common.UserThread;
 import bisq.common.config.Config;
 import bisq.common.util.Tuple3;
-import bisq.common.util.Tuple4;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -115,7 +114,6 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     private AutoTooltipButton buyButton;
     private ChangeListener<Number> selectedTabIndexListener;
     private SingleSelectionModel<Tab> tabPaneSelectionModel;
-    private Label sellHeaderLabel, buyHeaderLabel;
     private ChangeListener<OfferListItem> sellTableRowSelectionListener, buyTableRowSelectionListener;
     private ListChangeListener<OfferBookListItem> changeListener;
     private ListChangeListener<CurrencyListItem> currencyListItemsListener;
@@ -155,16 +153,13 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
 
         VBox.setMargin(chartPane, new Insets(0, 0, 5, 0));
 
-        Tuple4<TableView<OfferListItem>, VBox, Button, Label> tupleBuy = getOfferTable(OfferDirection.BUY);
-        Tuple4<TableView<OfferListItem>, VBox, Button, Label> tupleSell = getOfferTable(OfferDirection.SELL);
+        Tuple3<TableView<OfferListItem>, VBox, Button> tupleBuy = getOfferTable(OfferDirection.BUY);
+        Tuple3<TableView<OfferListItem>, VBox, Button> tupleSell = getOfferTable(OfferDirection.SELL);
         buyOfferTableView = tupleBuy.first;
         sellOfferTableView = tupleSell.first;
 
         buyButton = (AutoTooltipButton) tupleBuy.third;
         sellButton = (AutoTooltipButton) tupleSell.third;
-
-        buyHeaderLabel = tupleBuy.fourth;
-        sellHeaderLabel = tupleSell.fourth;
 
         HBox bottomHBox = new HBox();
         bottomHBox.setSpacing(20); //30
@@ -243,18 +238,15 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                     String viewBaseCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? code : Res.getBaseCurrencyCode();
                     String viewPriceCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? Res.getBaseCurrencyCode() : code;
 
-                    sellHeaderLabel.setText(Res.get("market.offerBook.sellOffersHeaderLabel"));
                     sellButton.updateText(Res.get("shared.sellCurrency", viewBaseCurrencyCode, viewPriceCurrencyCode));
-
-                    buyHeaderLabel.setText(Res.get("market.offerBook.buyOffersHeaderLabel"));
                     buyButton.updateText(Res.get("shared.buyCurrency", viewBaseCurrencyCode, viewPriceCurrencyCode));
 
                     priceColumnLabel.set(Res.get("shared.priceWithCur", viewPriceCurrencyCode));
 
                     xAxis.setLabel(CurrencyUtil.getPriceWithCurrencyCode(code));
 
-                    seriesBuy.setName(sellHeaderLabel.getText() + "   ");
-                    seriesSell.setName(buyHeaderLabel.getText());
+                    seriesBuy.setName(Res.get("market.offerBook.sellOffersHeaderLabel") + "   ");
+                    seriesSell.setName(Res.get("market.offerBook.buyOffersHeaderLabel"));
                 });
 
         buyOfferTableView.setItems(model.getTopBuyOfferList());
@@ -425,7 +417,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                 .collect(Collectors.toList());
     }
 
-    private Tuple4<TableView<OfferListItem>, VBox, Button, Label> getOfferTable(OfferDirection direction) {
+    private Tuple3<TableView<OfferListItem>, VBox, Button> getOfferTable(OfferDirection direction) {
         TableView<OfferListItem> tableView = new TableView<>();
         tableView.setMinHeight(initialOfferTableViewHeight);
         tableView.setPrefHeight(initialOfferTableViewHeight);
@@ -634,6 +626,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
 
         Label titleLabel = new AutoTooltipLabel();
         titleLabel.getStyleClass().add("table-title");
+        titleLabel.setText(isSellOffer ? Res.get("market.offerBook.sellOffersHeaderLabel") : Res.get("market.offerBook.buyOffersHeaderLabel"));
 
         AutoTooltipButton button = new AutoTooltipButton();
         ImageView iconView = new ImageView();
@@ -659,7 +652,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         vBox.setMinHeight(190);
         vBox.getChildren().addAll(titleButtonBox, tableView);
 
-        return new Tuple4<>(tableView, vBox, button, titleLabel);
+        return new Tuple3<>(tableView, vBox, button);
     }
 
     private void layout() {

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -42,6 +42,7 @@ import bisq.network.p2p.NodeAddress;
 
 import bisq.common.UserThread;
 import bisq.common.config.Config;
+import bisq.common.util.Tuple2;
 import bisq.common.util.Tuple3;
 
 import javax.inject.Inject;
@@ -52,7 +53,6 @@ import com.jfoenix.controls.JFXTabPane;
 import javafx.scene.chart.AreaChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
-import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.SingleSelectionModel;
@@ -110,8 +110,6 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
     private Subscription tradeCurrencySubscriber;
     private final StringProperty volumeColumnLabel = new SimpleStringProperty();
     private final StringProperty priceColumnLabel = new SimpleStringProperty();
-    private AutoTooltipButton sellButton;
-    private AutoTooltipButton buyButton;
     private ChangeListener<Number> selectedTabIndexListener;
     private SingleSelectionModel<Tab> tabPaneSelectionModel;
     private ChangeListener<OfferListItem> sellTableRowSelectionListener, buyTableRowSelectionListener;
@@ -153,13 +151,10 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
 
         VBox.setMargin(chartPane, new Insets(0, 0, 5, 0));
 
-        Tuple3<TableView<OfferListItem>, VBox, Button> tupleBuy = getOfferTable(OfferDirection.BUY);
-        Tuple3<TableView<OfferListItem>, VBox, Button> tupleSell = getOfferTable(OfferDirection.SELL);
+        Tuple2<TableView<OfferListItem>, VBox> tupleBuy = getOfferTable(OfferDirection.BUY);
+        Tuple2<TableView<OfferListItem>, VBox> tupleSell = getOfferTable(OfferDirection.SELL);
         buyOfferTableView = tupleBuy.first;
         sellOfferTableView = tupleSell.first;
-
-        buyButton = (AutoTooltipButton) tupleBuy.third;
-        sellButton = (AutoTooltipButton) tupleSell.third;
 
         HBox bottomHBox = new HBox();
         bottomHBox.setSpacing(20); //30
@@ -235,11 +230,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                         }
                     });
 
-                    String viewBaseCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? code : Res.getBaseCurrencyCode();
                     String viewPriceCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? Res.getBaseCurrencyCode() : code;
-
-                    sellButton.updateText(Res.get("shared.sellCurrency", viewBaseCurrencyCode, viewPriceCurrencyCode));
-                    buyButton.updateText(Res.get("shared.buyCurrency", viewBaseCurrencyCode, viewPriceCurrencyCode));
 
                     priceColumnLabel.set(Res.get("shared.priceWithCur", viewPriceCurrencyCode));
 
@@ -417,7 +408,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                 .collect(Collectors.toList());
     }
 
-    private Tuple3<TableView<OfferListItem>, VBox, Button> getOfferTable(OfferDirection direction) {
+    private Tuple2<TableView<OfferListItem>, VBox> getOfferTable(OfferDirection direction) {
         TableView<OfferListItem> tableView = new TableView<>();
         tableView.setMinHeight(initialOfferTableViewHeight);
         tableView.setPrefHeight(initialOfferTableViewHeight);
@@ -633,7 +624,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         iconView.setId(isSellOffer ? "image-sell-white" : "image-buy-white");
         button.setGraphic(iconView);
         button.setGraphicTextGap(10);
-        button.updateText(isSellOffer ? Res.get("market.offerBook.sell") : Res.get("market.offerBook.buy"));
+        button.updateText(isSellOffer ? Res.get("shared.sellCurrency", "BTC") : Res.get("shared.buyCurrency", "BTC"));
+
         button.setMinHeight(32);
         button.setId(isSellOffer ? "sell-button-big" : "buy-button-big");
         button.setOnAction(e -> model.goToOfferView(direction));
@@ -652,7 +644,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         vBox.setMinHeight(190);
         vBox.getChildren().addAll(titleButtonBox, tableView);
 
-        return new Tuple3<>(tableView, vBox, button);
+        return new Tuple2<>(tableView, vBox);
     }
 
     private void layout() {

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -160,8 +160,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         buyOfferTableView = tupleBuy.first;
         sellOfferTableView = tupleSell.first;
 
-        sellButton = (AutoTooltipButton) tupleBuy.third;
-        buyButton = (AutoTooltipButton) tupleSell.third;
+        buyButton = (AutoTooltipButton) tupleBuy.third;
+        sellButton = (AutoTooltipButton) tupleSell.third;
 
         sellHeaderLabel = tupleBuy.fourth;
         buyHeaderLabel = tupleSell.fourth;
@@ -637,12 +637,12 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
 
         AutoTooltipButton button = new AutoTooltipButton();
         ImageView iconView = new ImageView();
-        iconView.setId(isSellOffer ? "image-buy-white" : "image-sell-white");
+        iconView.setId(isSellOffer ? "image-sell-white" : "image-buy-white");
         button.setGraphic(iconView);
         button.setGraphicTextGap(10);
-        button.updateText(isSellOffer ? Res.get("market.offerBook.buy") : Res.get("market.offerBook.sell"));
+        button.updateText(isSellOffer ? Res.get("market.offerBook.sell") : Res.get("market.offerBook.buy"));
         button.setMinHeight(32);
-        button.setId(isSellOffer ? "buy-button-big" : "sell-button-big");
+        button.setId(isSellOffer ? "sell-button-big" : "buy-button-big");
         button.setOnAction(e -> model.goToOfferView(direction));
 
         Region spacer = new Region();

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -280,8 +280,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                 currencyComboBox.getSelectionModel().select(model.getSelectedCurrencyListItem().get());
         };
 
-        buyTableRowSelectionListener = (observable, oldValue, newValue) -> model.goToOfferView(OfferDirection.BUY);
-        sellTableRowSelectionListener = (observable, oldValue, newValue) -> model.goToOfferView(OfferDirection.SELL);
+        buyTableRowSelectionListener = (observable, oldValue, newValue) -> model.goToOfferView(OfferDirection.SELL);
+        sellTableRowSelectionListener = (observable, oldValue, newValue) -> model.goToOfferView(OfferDirection.BUY);
 
         bisqWindowVerticalSizeListener = (observable, oldValue, newValue) -> layout();
     }

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -335,7 +335,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         areaChart = new AreaChart<>(xAxis, yAxis);
         areaChart.setLegendVisible(false);
         areaChart.setAnimated(false);
-        areaChart.setId("charts");
+        areaChart.setId("charts-offer-book");
         areaChart.setMinHeight(270);
         areaChart.setPrefHeight(270);
         areaChart.setCreateSymbols(true);

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -220,7 +220,7 @@ class OfferBookChartViewModel extends ActivatableViewModel {
 
     public void goToOfferView(OfferDirection direction) {
         updateScreenCurrencyInPreferences(direction);
-        Class<? extends OfferView> offerView = isSellOffer(direction) ? BuyOfferView.class : SellOfferView.class;
+        Class<? extends OfferView> offerView = isSellOffer(direction) ? SellOfferView.class : BuyOfferView.class;
         navigation.navigateTo(MainView.class, offerView, OfferViewUtil.getOfferBookViewClass(getCurrencyCode()));
     }
 

--- a/desktop/src/main/java/bisq/desktop/theme-dark.css
+++ b/desktop/src/main/java/bisq/desktop/theme-dark.css
@@ -255,14 +255,14 @@
 }
 
 .chart-pane, .chart-plot-background,
-#charts .chart-plot-background,
+#charts-offer-book .chart-plot-background,
 #charts-dao .chart-plot-background {
     -fx-background-color: transparent;
 }
 .axis:top, .axis:right, .axis:bottom, .axis:left {
     -fx-border-color: transparent transparent transparent transparent;
 }
-#charts .axis, #price-chart .axis, #volume-chart .axis, #charts-dao .axis {
+#charts-offer-book .axis, #price-chart .axis, #volume-chart .axis, #charts-dao .axis {
     -fx-tick-label-fill: -bs-chart-tick;
 }
 .chart-horizontal-grid-lines,


### PR DESCRIPTION
Fixes #6639

PR inverts colors on market depth chart, as suggested in reported issue:
![chart-colors](https://user-images.githubusercontent.com/128257662/230729477-4dbbea61-e9df-4a4c-ba6f-c77949ed5adc.png)


[Second commit](https://github.com/bisq-network/bisq/commit/50e3b44f7fb686288b0ccca5d5ec655233d9fcb3) contains rename of class from `#charts` into `#charts-offer-book` - `#charts` seemed to be too generic.