### PR TITLE
Support "all" attribute in getoffers API method

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/offer/CreateBSQOffersTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/CreateBSQOffersTest.java
@@ -277,7 +277,7 @@ public class CreateBSQOffersTest extends AbstractOfferTest {
     @Test
     @Order(6)
     public void testGetAvailableBsqOffers() {
-        List<OfferInfo> offers = bobClient.getOffersSortedByDate(BSQ);
+        List<OfferInfo> offers = bobClient.getOffersSortedByDate(BSQ, false);
         log.debug("All Bob's Available BSQ Offers:\n{}", toOffersTable.apply(offers));
         assertEquals(4, offers.size());
         log.debug("BOB'S BALANCES\n{}", formatBalancesTbls(bobClient.getBalances()));

--- a/apitest/src/test/java/bisq/apitest/method/offer/CreateXMROffersTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/CreateXMROffersTest.java
@@ -274,7 +274,7 @@ public class CreateXMROffersTest extends AbstractOfferTest {
     @Test
     @Order(6)
     public void testGetAvailableXMROffers() {
-        List<OfferInfo> offers = bobClient.getOffersSortedByDate(XMR);
+        List<OfferInfo> offers = bobClient.getOffersSortedByDate(XMR, false);
         log.debug("All of Bob's available XMR offers:\n{}", toOffersTable.apply(offers));
         assertEquals(4, offers.size());
         log.debug("Bob's balances\n{}", formatBalancesTbls(bobClient.getBalances()));

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellBTCOfferTest.java
@@ -86,7 +86,7 @@ public class TakeSellBTCOfferTest extends AbstractTradeTest {
                     0L,
                     false);
             sleep(2_500);  // Allow available offer to be removed from offer book.
-            var takeableUsdOffers = bobClient.getOffersSortedByDate(SELL.name(), USD);
+            var takeableUsdOffers = bobClient.getOffersSortedByDate(SELL.name(), USD, false);
             assertEquals(0, takeableUsdOffers.size());
 
             trade = bobClient.getTrade(tradeId);

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -468,7 +468,8 @@ public class CliMain {
                     }
                     var direction = opts.getDirection();
                     var currencyCode = opts.getCurrencyCode();
-                    List<OfferInfo> offers = client.getOffers(direction, currencyCode);
+                    var all = opts.getAll();
+                    List<OfferInfo> offers = client.getOffers(direction, currencyCode, all);
                     if (offers.isEmpty())
                         out.printf("no %s %s offers found%n", direction, currencyCode);
                     else

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -293,16 +293,16 @@ public final class GrpcClient {
         return offersServiceRequest.getBsqSwapOffers(direction);
     }
 
-    public List<OfferInfo> getOffers(String direction, String currencyCode) {
-        return offersServiceRequest.getOffers(direction, currencyCode);
+    public List<OfferInfo> getOffers(String direction, String currencyCode, boolean all) {
+        return offersServiceRequest.getOffers(direction, currencyCode, all);
     }
 
-    public List<OfferInfo> getOffersSortedByDate(String currencyCode) {
-        return offersServiceRequest.getOffersSortedByDate(currencyCode);
+    public List<OfferInfo> getOffersSortedByDate(String currencyCode, boolean all) {
+        return offersServiceRequest.getOffersSortedByDate(currencyCode, all);
     }
 
-    public List<OfferInfo> getOffersSortedByDate(String direction, String currencyCode) {
-        return offersServiceRequest.getOffersSortedByDate(direction, currencyCode);
+    public List<OfferInfo> getOffersSortedByDate(String direction, String currencyCode, boolean all) {
+        return offersServiceRequest.getOffersSortedByDate(direction, currencyCode, all);
     }
 
     public List<OfferInfo> getBsqSwapOffersSortedByDate() {

--- a/cli/src/main/java/bisq/cli/opts/GetOffersOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/GetOffersOptionParser.java
@@ -20,6 +20,7 @@ package bisq.cli.opts;
 
 import joptsimple.OptionSpec;
 
+import static bisq.cli.opts.OptLabel.OPT_ALL;
 import static bisq.cli.opts.OptLabel.OPT_CURRENCY_CODE;
 import static bisq.cli.opts.OptLabel.OPT_DIRECTION;
 
@@ -30,6 +31,11 @@ public class GetOffersOptionParser extends AbstractMethodOptionParser implements
 
     final OptionSpec<String> currencyCodeOpt = parser.accepts(OPT_CURRENCY_CODE, "currency code (bsq|xmr|eur|usd|...)")
             .withRequiredArg();
+
+    final OptionSpec<Boolean> allOpt = parser.accepts(OPT_ALL, "get all offers")
+            .withOptionalArg()
+            .ofType(boolean.class)
+            .defaultsTo(Boolean.FALSE);
 
     public GetOffersOptionParser(String[] args) {
         super(args);
@@ -57,5 +63,9 @@ public class GetOffersOptionParser extends AbstractMethodOptionParser implements
 
     public String getCurrencyCode() {
         return options.valueOf(currencyCodeOpt);
+    }
+
+    public boolean getAll() {
+        return options.valueOf(allOpt);
     }
 }

--- a/cli/src/main/java/bisq/cli/opts/OptLabel.java
+++ b/cli/src/main/java/bisq/cli/opts/OptLabel.java
@@ -26,6 +26,7 @@ public class OptLabel {
     public final static String OPT_AMOUNT = "amount";
     public final static String OPT_CATEGORY = "category";
     public final static String OPT_CURRENCY_CODE = "currency-code";
+    public final static String OPT_ALL = "all";
     public final static String OPT_DAYS = "days";
     public final static String OPT_DIRECTION = "direction";
     public final static String OPT_DISPUTE_AGENT_TYPE = "dispute-agent-type";

--- a/cli/src/main/java/bisq/cli/request/OffersServiceRequest.java
+++ b/cli/src/main/java/bisq/cli/request/OffersServiceRequest.java
@@ -231,23 +231,24 @@ public class OffersServiceRequest {
         return grpcStubs.offersService.getBsqSwapOffers(request).getBsqSwapOffersList();
     }
 
-    public List<OfferInfo> getOffers(String direction, String currencyCode) {
+    public List<OfferInfo> getOffers(String direction, String currencyCode, boolean all) {
         var request = GetOffersRequest.newBuilder()
                 .setDirection(direction)
                 .setCurrencyCode(currencyCode)
+                .setAll(all)
                 .build();
         return grpcStubs.offersService.getOffers(request).getOffersList();
     }
 
-    public List<OfferInfo> getOffersSortedByDate(String currencyCode) {
+    public List<OfferInfo> getOffersSortedByDate(String currencyCode, boolean all) {
         ArrayList<OfferInfo> offers = new ArrayList<>();
-        offers.addAll(getOffers(BUY.name(), currencyCode));
-        offers.addAll(getOffers(SELL.name(), currencyCode));
+        offers.addAll(getOffers(BUY.name(), currencyCode, all));
+        offers.addAll(getOffers(SELL.name(), currencyCode, all));
         return offers.isEmpty() ? offers : sortOffersByDate(offers);
     }
 
-    public List<OfferInfo> getOffersSortedByDate(String direction, String currencyCode) {
-        var offers = getOffers(direction, currencyCode);
+    public List<OfferInfo> getOffersSortedByDate(String direction, String currencyCode, boolean all) {
+        var offers = getOffers(direction, currencyCode, all);
         return offers.isEmpty() ? offers : sortOffersByDate(offers);
     }
 
@@ -292,8 +293,8 @@ public class OffersServiceRequest {
         return sortOffersByDate(offers);
     }
 
-    public OfferInfo getMostRecentOffer(String direction, String currencyCode) {
-        List<OfferInfo> offers = getOffersSortedByDate(direction, currencyCode);
+    public OfferInfo getMostRecentOffer(String direction, String currencyCode, boolean all) {
+        List<OfferInfo> offers = getOffersSortedByDate(direction, currencyCode, all);
         return offers.isEmpty() ? null : offers.get(offers.size() - 1);
     }
 

--- a/cli/src/test/java/bisq/cli/table/GetOffersCliOutputDiffTest.java
+++ b/cli/src/test/java/bisq/cli/table/GetOffersCliOutputDiffTest.java
@@ -59,12 +59,12 @@ public class GetOffersCliOutputDiffTest extends AbstractCliTest {
     }
 
     private void getAvailableBuyUsdOffers() {
-        var offers = bobClient.getOffers(BUY.name(), "USD");
+        var offers = bobClient.getOffers(BUY.name(), "USD", false);
         printAndCheckDiffs(offers, BUY.name(), "USD");
     }
 
     private void getAvailableSellUsdOffers() {
-        var offers = bobClient.getOffers(SELL.name(), "USD");
+        var offers = bobClient.getOffers(SELL.name(), "USD", false);
         printAndCheckDiffs(offers, SELL.name(), "USD");
     }
 
@@ -79,12 +79,12 @@ public class GetOffersCliOutputDiffTest extends AbstractCliTest {
     }
 
     private void getAvailableBuyXmrOffers() {
-        var offers = bobClient.getOffers(BUY.name(), "XMR");
+        var offers = bobClient.getOffers(BUY.name(), "XMR", false);
         printAndCheckDiffs(offers, BUY.name(), "XMR");
     }
 
     private void getAvailableSellXmrOffers() {
-        var offers = bobClient.getOffers(SELL.name(), "XMR");
+        var offers = bobClient.getOffers(SELL.name(), "XMR", false);
         printAndCheckDiffs(offers, SELL.name(), "XMR");
     }
 
@@ -99,12 +99,12 @@ public class GetOffersCliOutputDiffTest extends AbstractCliTest {
     }
 
     private void getAvailableBuyBsqOffers() {
-        var offers = bobClient.getOffers(BUY.name(), "BSQ");
+        var offers = bobClient.getOffers(BUY.name(), "BSQ", false);
         printAndCheckDiffs(offers, BUY.name(), "BSQ");
     }
 
     private void getAvailableSellBsqOffers() {
-        var offers = bobClient.getOffers(SELL.name(), "BSQ");
+        var offers = bobClient.getOffers(SELL.name(), "BSQ", false);
         printAndCheckDiffs(offers, SELL.name(), "BSQ");
     }
 

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -164,8 +164,8 @@ public class CoreApi {
         return coreOffersService.getBsqSwapOffers(direction);
     }
 
-    public List<Offer> getOffers(String direction, String currencyCode) {
-        return coreOffersService.getOffers(direction, currencyCode);
+    public List<Offer> getOffers(String direction, String currencyCode, boolean all) {
+        return coreOffersService.getOffers(direction, currencyCode, all);
     }
 
     public List<OpenOffer> getMyOffers(String direction, String currencyCode) {

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -206,14 +206,14 @@ class CoreOffersService {
                 .collect(Collectors.toList());
     }
 
-    List<Offer> getOffers(String direction, String currencyCode) {
+    List<Offer> getOffers(String direction, String currencyCode, boolean all) {
         var upperCaseCurrencyCode = currencyCode.toUpperCase();
         var isFiat = isFiatCurrency(upperCaseCurrencyCode);
         if (isFiat) {
             return offerBookService.getOffers().stream()
                     .filter(o -> !o.isMyOffer(keyRing))
                     .filter(o -> offerMatchesDirectionAndCurrency(o, direction, upperCaseCurrencyCode))
-                    .filter(o -> offerFilterService.canTakeOffer(o, coreContext.isApiUser()).isValid())
+                    .filter(o -> all || offerFilterService.canTakeOffer(o, coreContext.isApiUser()).isValid())
                     .sorted(priceComparator(direction, true))
                     .collect(Collectors.toList());
         } else {
@@ -226,7 +226,7 @@ class CoreOffersService {
                         .filter(o -> !o.isMyOffer(keyRing))
                         .filter(o -> offerMatchesDirectionAndCurrency(o, direction, "BTC"))
                         .filter(o -> o.getBaseCurrencyCode().equalsIgnoreCase(upperCaseCurrencyCode))
-                        .filter(o -> offerFilterService.canTakeOffer(o, coreContext.isApiUser()).isValid())
+                        .filter(o -> all || offerFilterService.canTakeOffer(o, coreContext.isApiUser()).isValid())
                         .sorted(priceComparator(direction, false))
                         .collect(Collectors.toList());
             else

--- a/core/src/main/resources/help/getoffers-help.txt
+++ b/core/src/main/resources/help/getoffers-help.txt
@@ -9,6 +9,7 @@ SYNOPSIS
 getoffers
 		--direction=<buy|sell>
 		--currency-code=<eur|usd>
+		--all=<true|false>
 
 DESCRIPTION
 -----------
@@ -23,6 +24,9 @@ OPTIONS
 
 --currency-code
 		The three letter code for the fiat used to buy or sell BTC, e.g., EUR, USD, BRL, ...
+
+--all
+		Whether return all offers or only these matching my accounts
 
 EXAMPLES
 --------

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -195,7 +195,7 @@ class GrpcOffersService extends OffersImplBase {
     public void getOffers(GetOffersRequest req,
                           StreamObserver<GetOffersReply> responseObserver) {
         try {
-            List<OfferInfo> result = coreApi.getOffers(req.getDirection(), req.getCurrencyCode())
+            List<OfferInfo> result = coreApi.getOffers(req.getDirection(), req.getCurrencyCode(), req.getAll())
                     .stream()
                     .map(OfferInfo::toOfferInfo)
                     .collect(Collectors.toList());

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -148,6 +148,7 @@ message GetMyOfferReply {
 message GetOffersRequest {
     string direction = 1;       // The offer's BUY (BTC) or SELL (BTC) direction.
     string currency_code = 2;   // The offer's fiat or altcoin currency code.
+    bool all = 3;               // Return all or only these matching my account
 }
 
 message GetOffersReply {


### PR DESCRIPTION
Fixes #6645

Possibility to return all offers, not only these matching my accounts:
```
./bisq-cli --password=xyz getoffers --direction=sell --currency-code=EUR --all=true
```