### PR TITLE
Centralize Gradle Test Setup

### DIFF
--- a/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
@@ -24,4 +24,10 @@ dependencies {
     testImplementation libs.junit.jupiter.api
     testImplementation libs.junit.jupiter.params
     testImplementation libs.mockito
+
+    testRuntimeOnly libs.junit.jupiter.engine
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -504,7 +504,6 @@ configure(project(':apitest')) {
         testAnnotationProcessor libs.lombok
         testCompileOnly libs.lombok
         testRuntimeOnly libs.javax.annotation
-        testRuntimeOnly(libs.junit.jupiter.engine)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -436,7 +436,6 @@ configure(project(':apitest')) {
     }
 
     test {
-        useJUnitPlatform()
         outputs.upToDateWhen { false }          // Don't use previously cached test outputs.
         testLogging {
             showStackTraces = true              // Show full stack traces in the console.

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     testImplementation libs.cowwoc.diff.match.patch
 
     testRuntimeOnly libs.javax.annotation
-    testRuntimeOnly libs.junit.jupiter.engine
 }
 
 test {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -34,7 +34,3 @@ dependencies {
 
     testRuntimeOnly libs.javax.annotation
 }
-
-test {
-    useJUnitPlatform()
-}

--- a/daemon/build.gradle
+++ b/daemon/build.gradle
@@ -48,5 +48,4 @@ dependencies {
     }
     testAnnotationProcessor libs.lombok
     testCompileOnly libs.lombok
-    testRuntimeOnly(libs.junit.jupiter.engine)
 }


### PR DESCRIPTION
- [Remove redundant 'testRuntimeOnly libs.junit.jupiter.engine'](https://github.com/bisq-network/bisq/commit/509781acf28c0a0eef2754f91b001271b92381a7)
- [Remove redundant 'useJUnitPlatform()' declarations](https://github.com/bisq-network/bisq/commit/db6c1d1176946084cc082c2f5386076deb644221)