### PR TITLE
Speed up burningman and statistics view loads

### DIFF
--- a/common/src/main/java/bisq/common/util/ComparableExt.java
+++ b/common/src/main/java/bisq/common/util/ComparableExt.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.util;
+
+import java.util.NavigableSet;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import static bisq.common.util.Preconditions.checkComparatorNullOrNatural;
+
+/**
+ * A {@link Comparable} which may be compared with adhoc mark/delimiter objects, in
+ * addition to objects of the same type, to support searches for adjacent elements in
+ * a sorted collection without having to use dummy objects for this purpose. For example,
+ * one may wish to find the smallest object after a given date, in a collection sorted by
+ * date. This is to work round the limitation that {@link java.util.SortedSet} and
+ * {@link java.util.SortedMap} only support comparison with other keys when searching for
+ * elements rather than allowing general binary searches with a predicate.
+ *
+ * <p>Implementations should define {@link Comparable#compareTo(Object)} like follows:
+ * <pre>{@code
+ * public int compareTo(@NotNull ComparableExt<Foo> o) {
+ *     return o instanceof Foo ? this.normalCompareTo((Foo) o) : -o.compareTo(this);
+ * }
+ * }</pre>
+ * @param <T>
+ */
+public interface ComparableExt<T> extends Comparable<ComparableExt<T>> {
+    @SuppressWarnings("unchecked")
+    @Nullable
+    static <E extends ComparableExt<E>> E lower(NavigableSet<E> set, Predicate<? super E> filter) {
+        checkComparatorNullOrNatural(set.comparator(), "Set must be naturally ordered");
+        return (E) ((NavigableSet<ComparableExt<E>>) set).lower(Mark.of(filter));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    static <E extends ComparableExt<E>> E higher(NavigableSet<E> set, Predicate<? super E> filter) {
+        checkComparatorNullOrNatural(set.comparator(), "Set must be naturally ordered");
+        return (E) ((NavigableSet<ComparableExt<E>>) set).higher(Mark.of(filter));
+    }
+
+    interface Mark<T> extends ComparableExt<T> {
+        @SuppressWarnings("unchecked")
+        static <T> Mark<T> of(Predicate<? super T> filter) {
+            return x -> x instanceof Mark ? 0 : filter.test((T) x) ? -1 : 1;
+        }
+    }
+}

--- a/common/src/main/java/bisq/common/util/MathUtils.java
+++ b/common/src/main/java/bisq/common/util/MathUtils.java
@@ -101,7 +101,7 @@ public class MathUtils {
         return BigDecimal.valueOf(value1).multiply(BigDecimal.valueOf(value2)).doubleValue();
     }
 
-    public static long getMedian(Long[] list) {
+    public static long getMedian(long[] list) {
         if (list.length == 0) {
             return 0L;
         }

--- a/common/src/main/java/bisq/common/util/Preconditions.java
+++ b/common/src/main/java/bisq/common/util/Preconditions.java
@@ -1,7 +1,12 @@
 package bisq.common.util;
 
+import com.google.common.collect.Ordering;
+
 import java.io.File;
 
+import java.util.Comparator;
+
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 
 /**
@@ -28,5 +33,11 @@ public class Preconditions {
             throw new IllegalArgumentException(format("Directory '%s' is not writeable", dir));
 
         return dir;
+    }
+
+    // needed since Guava makes it impossible to create an ImmutableSorted[Set|Map] with a null comparator:
+    public static void checkComparatorNullOrNatural(Comparator<?> comparator, Object errorMessage) {
+        checkArgument(comparator == null || comparator.equals(Ordering.natural()) ||
+                comparator.equals(Comparator.naturalOrder()), errorMessage);
     }
 }

--- a/common/src/main/java/bisq/common/util/RangeUtils.java
+++ b/common/src/main/java/bisq/common/util/RangeUtils.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.util;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+
+import java.util.Collections;
+import java.util.NavigableSet;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public final class RangeUtils {
+    private RangeUtils() {
+    }
+
+    public static <E extends ComparableExt<E>> NavigableSet<E> subSet(NavigableSet<E> set,
+                                                                      Predicate<? super E> fromFilter,
+                                                                      Predicate<? super E> toFilter) {
+        E fromElement = ComparableExt.higher(set, fromFilter);
+        E toElement = ComparableExt.lower(set, toFilter);
+        return fromElement != null && toElement != null && fromElement.compareTo(toElement) <= 0 ?
+                set.subSet(fromElement, true, toElement, true) : Collections.emptyNavigableSet();
+    }
+
+    public static <E extends ComparableExt<E>> SubCollection<NavigableSet<E>, E> subSet(NavigableSet<E> set) {
+        return new SubCollection<>() {
+            @Override
+            public <K extends Comparable<? super K>> WithKeyFunction<NavigableSet<E>, K> withKey(Function<E, K> increasingKeyFn) {
+                return (Range<K> range) -> {
+                    var fromToFilter = boundFilters(increasingKeyFn, range);
+                    return subSet(set, fromToFilter.first, fromToFilter.second);
+                };
+            }
+        };
+    }
+
+    private static <E, K extends Comparable<? super K>> Tuple2<Predicate<E>, Predicate<E>> boundFilters(Function<E, K> keyFn,
+                                                                                                        Range<K> keyRange) {
+        Predicate<E> fromFilter, toFilter;
+        if (keyRange.hasLowerBound()) {
+            K fromKey = keyRange.lowerEndpoint();
+            fromFilter = keyRange.lowerBoundType() == BoundType.CLOSED
+                    ? (E e) -> fromKey.compareTo(keyFn.apply(e)) <= 0
+                    : (E e) -> fromKey.compareTo(keyFn.apply(e)) < 0;
+        } else {
+            fromFilter = e -> true;
+        }
+        if (keyRange.hasUpperBound()) {
+            K toKey = keyRange.upperEndpoint();
+            toFilter = keyRange.upperBoundType() == BoundType.CLOSED
+                    ? (E e) -> toKey.compareTo(keyFn.apply(e)) < 0
+                    : (E e) -> toKey.compareTo(keyFn.apply(e)) <= 0;
+        } else {
+            toFilter = e -> false;
+        }
+        return new Tuple2<>(fromFilter, toFilter);
+    }
+
+    public interface SubCollection<C, E> {
+        <K extends Comparable<? super K>> WithKeyFunction<C, K> withKey(Function<E, K> increasingKeyFn);
+    }
+
+    public interface WithKeyFunction<C, K extends Comparable<? super K>> {
+        C overRange(Range<K> range);
+    }
+}

--- a/common/src/test/java/bisq/common/util/RangeUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/RangeUtilsTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.util;
+
+import com.google.common.collect.ImmutableSortedSet;
+
+import java.util.Comparator;
+import java.util.NavigableSet;
+import java.util.stream.IntStream;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.junit.jupiter.api.Test;
+
+import static bisq.common.util.RangeUtils.subSet;
+import static com.google.common.collect.Range.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RangeUtilsTest {
+    @Test
+    public void subSetWithStrictlyIncreasingKey() {
+        var subSetWithValue = subSet(range(0, 10)).withKey(n -> n.value);
+
+        assertEquals(range(0, 10), subSetWithValue.overRange(all()));
+        assertEquals(range(0, 6), subSetWithValue.overRange(atMost(5)));
+        assertEquals(range(5, 10), subSetWithValue.overRange(atLeast(5)));
+        assertEquals(range(0, 5), subSetWithValue.overRange(lessThan(5)));
+        assertEquals(range(6, 10), subSetWithValue.overRange(greaterThan(5)));
+        assertEquals(range(3, 8), subSetWithValue.overRange(closed(3, 7)));
+        assertEquals(range(3, 7), subSetWithValue.overRange(closedOpen(3, 7)));
+        assertEquals(range(4, 8), subSetWithValue.overRange(openClosed(3, 7)));
+        assertEquals(range(4, 7), subSetWithValue.overRange(open(3, 7)));
+        assertEquals(range(5, 6), subSetWithValue.overRange(singleton(5)));
+        assertEquals(range(0, 1), subSetWithValue.overRange(singleton(0)));
+        assertEquals(range(0, 0), subSetWithValue.overRange(singleton(-1)));
+        assertEquals(range(9, 10), subSetWithValue.overRange(singleton(9)));
+        assertEquals(range(0, 0), subSetWithValue.overRange(singleton(10)));
+        assertEquals(range(0, 0), subSetWithValue.overRange(closedOpen(5, 5)));
+        assertEquals(range(0, 10), subSetWithValue.overRange(closed(-1, 10)));
+    }
+
+    @Test
+    public void subSetWithNonStrictlyIncreasingKey() {
+        var subSetWithValueDiv3 = subSet(range(0, 10)).withKey(n -> n.value / 3);
+
+        assertEquals(range(0, 10), subSetWithValueDiv3.overRange(closed(0, 3)));
+        assertEquals(range(0, 9), subSetWithValueDiv3.overRange(closedOpen(0, 3)));
+        assertEquals(range(3, 10), subSetWithValueDiv3.overRange(openClosed(0, 3)));
+        assertEquals(range(3, 9), subSetWithValueDiv3.overRange(open(0, 3)));
+        assertEquals(range(0, 3), subSetWithValueDiv3.overRange(singleton(0)));
+        assertEquals(range(3, 6), subSetWithValueDiv3.overRange(singleton(1)));
+        assertEquals(range(9, 10), subSetWithValueDiv3.overRange(singleton(3)));
+    }
+
+    private static NavigableSet<TestInteger> range(int startInclusive, int endExclusive) {
+        return IntStream.range(startInclusive, endExclusive)
+                .mapToObj(TestInteger::new)
+                .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+    }
+
+    private static final class TestInteger implements ComparableExt<TestInteger> {
+        int value;
+
+        TestInteger(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(@NotNull ComparableExt<TestInteger> o) {
+            return o instanceof TestInteger ? Integer.compare(value, ((TestInteger) o).value) : -o.compareTo(this);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return this == o || o instanceof TestInteger && value == ((TestInteger) o).value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(value);
+        }
+
+        @Override
+        public String toString() {
+            return Integer.toString(value);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManPresentationService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManPresentationService.java
@@ -90,6 +90,7 @@ public class BurningManPresentationService implements DaoStateListener {
     private int currentChainHeight;
     private Optional<Long> burnTarget = Optional.empty();
     private final Map<String, BurningManCandidate> burningManCandidatesByName = new HashMap<>();
+    private Long accumulatedDecayedBurnedAmount;
     private final Set<ReimbursementModel> reimbursements = new HashSet<>();
     private Optional<Long> averageDistributionPerCycle = Optional.empty();
     private Set<String> myCompensationRequestNames = null;
@@ -132,6 +133,7 @@ public class BurningManPresentationService implements DaoStateListener {
         burningManCandidatesByName.clear();
         reimbursements.clear();
         burnTarget = Optional.empty();
+        accumulatedDecayedBurnedAmount = null;
         myCompensationRequestNames = null;
         averageDistributionPerCycle = Optional.empty();
         legacyBurningManDPT = Optional.empty();
@@ -188,8 +190,7 @@ public class BurningManPresentationService implements DaoStateListener {
         long lowerBaseTarget = Math.round(burnTarget * maxCompensationShare);
         double maxBoostedCompensationShare = burningManCandidate.getMaxBoostedCompensationShare();
         long upperBaseTarget = Math.round(boostedBurnTarget * maxBoostedCompensationShare);
-        Collection<BurningManCandidate> burningManCandidates = getBurningManCandidatesByName().values();
-        long totalBurnedAmount = burnTargetService.getAccumulatedDecayedBurnedAmount(burningManCandidates, currentChainHeight);
+        long totalBurnedAmount = getAccumulatedDecayedBurnedAmount();
 
         if (totalBurnedAmount == 0) {
             // The first BM would reach their max burn share by 5.46 BSQ already. But we suggest the lowerBaseTarget
@@ -344,7 +345,6 @@ public class BurningManPresentationService implements DaoStateListener {
             receiverAddressesByBurningManName.get(name).addAll(burningManCandidate.getAllAddresses());
         });
 
-
         Map<String, String> map = new HashMap<>();
         receiverAddressesByBurningManName
                 .forEach((name, addresses) -> addresses
@@ -370,5 +370,13 @@ public class BurningManPresentationService implements DaoStateListener {
 
         proofOfBurnOpReturnTxOutputByHash.putAll(burningManService.getProofOfBurnOpReturnTxOutputByHash(currentChainHeight));
         return proofOfBurnOpReturnTxOutputByHash;
+    }
+
+    private long getAccumulatedDecayedBurnedAmount() {
+        if (accumulatedDecayedBurnedAmount == null) {
+            Collection<BurningManCandidate> burningManCandidates = getBurningManCandidatesByName().values();
+            accumulatedDecayedBurnedAmount = burnTargetService.getAccumulatedDecayedBurnedAmount(burningManCandidates, currentChainHeight);
+        }
+        return accumulatedDecayedBurnedAmount;
     }
 }

--- a/core/src/main/java/bisq/core/offer/availability/DisputeAgentSelection.java
+++ b/core/src/main/java/bisq/core/offer/availability/DisputeAgentSelection.java
@@ -26,8 +26,6 @@ import bisq.common.util.Tuple2;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -35,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,16 +61,11 @@ public class DisputeAgentSelection {
                                                                        DisputeAgentManager<T> disputeAgentManager,
                                                                        boolean isMediator) {
         // We take last 100 entries from trade statistics
-        List<TradeStatistics3> list = new ArrayList<>(tradeStatisticsManager.getObservableTradeStatisticsSet());
-        list.sort(Comparator.comparing(TradeStatistics3::getDateAsLong));
-        Collections.reverse(list);
-        if (!list.isEmpty()) {
-            int max = Math.min(list.size(), LOOK_BACK_RANGE);
-            list = list.subList(0, max);
-        }
+        Stream<TradeStatistics3> stream = tradeStatisticsManager.getNavigableTradeStatisticsSet().descendingSet().stream()
+                .limit(LOOK_BACK_RANGE);
 
         // We stored only first 4 chars of disputeAgents onion address
-        List<String> lastAddressesUsedInTrades = list.stream()
+        List<String> lastAddressesUsedInTrades = stream
                 .map(tradeStatistics3 -> isMediator ? tradeStatistics3.getMediator() : tradeStatistics3.getRefundAgent())
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -18,7 +18,6 @@
 package bisq.core.trade.statistics;
 
 import bisq.core.monetary.Altcoin;
-import bisq.core.monetary.AltcoinExchangeRate;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
@@ -45,8 +44,6 @@ import bisq.common.util.Utilities;
 import com.google.protobuf.ByteString;
 
 import org.bitcoinj.core.Coin;
-import org.bitcoinj.utils.ExchangeRate;
-import org.bitcoinj.utils.Fiat;
 
 import com.google.common.base.Charsets;
 
@@ -311,12 +308,10 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
     }
 
     public Volume getTradeVolume() {
-        if (getTradePrice().getMonetary() instanceof Altcoin) {
-            return new Volume(new AltcoinExchangeRate((Altcoin) getTradePrice().getMonetary()).coinToAltcoin(getTradeAmount()));
-        } else {
-            Volume volume = new Volume(new ExchangeRate((Fiat) getTradePrice().getMonetary()).coinToFiat(getTradeAmount()));
-            return VolumeUtil.getRoundedFiatVolume(volume);
-        }
+        Price price = getTradePrice();
+        return price.getMonetary() instanceof Altcoin
+                ? price.getVolumeByAmount(getTradeAmount())
+                : VolumeUtil.getRoundedFiatVolume(price.getVolumeByAmount(getTradeAmount()));
     }
 
     public boolean isValid() {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -138,7 +138,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     // The payment method string can be quite long and would consume 15% more space.
     // When we get a new payment method we can add it to the enum at the end. Old users would add it as string if not
     // recognized.
-    private enum PaymentMethodMapper {
+    @VisibleForTesting
+    enum PaymentMethodMapper {
         OK_PAY,
         CASH_APP,
         VENMO,
@@ -298,7 +299,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         String tempPaymentMethod;
         try {
             tempPaymentMethod = String.valueOf(PaymentMethodMapper.valueOf(paymentMethod).ordinal());
-        } catch (Throwable t) {
+        } catch (IllegalArgumentException e) {
             tempPaymentMethod = paymentMethod;
         }
         this.paymentMethod = tempPaymentMethod;
@@ -403,9 +404,12 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     }
 
     public String getPaymentMethodId() {
+        if (paymentMethod.isEmpty() || paymentMethod.charAt(0) > '9') {
+            return paymentMethod;
+        }
         try {
             return PaymentMethodMapper.values()[Integer.parseInt(paymentMethod)].name();
-        } catch (Throwable ignore) {
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
             return paymentMethod;
         }
     }

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -200,7 +200,9 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         TIKKIE,
         TRANSFERWISE_USD,
         ACH_TRANSFER,
-        DOMESTIC_WIRE_TRANSFER
+        DOMESTIC_WIRE_TRANSFER;
+
+        private static final PaymentMethodMapper[] values = values(); // cache for perf gain
     }
 
     @Getter
@@ -413,7 +415,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
             return paymentMethod;
         }
         try {
-            return PaymentMethodMapper.values()[Integer.parseInt(paymentMethod)].name();
+            return PaymentMethodMapper.values[Integer.parseInt(paymentMethod)].name();
         } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
             return paymentMethod;
         }

--- a/core/src/main/java/bisq/core/util/AveragePriceUtil.java
+++ b/core/src/main/java/bisq/core/util/AveragePriceUtil.java
@@ -91,8 +91,8 @@ public class AveragePriceUtil {
         double lowerBound = tuple.first;
         double upperBound = tuple.second;
         return list.stream()
-                .filter(e -> e.getPrice() > lowerBound)
-                .filter(e -> e.getPrice() < upperBound)
+                .filter(e -> (double) e.getPrice() >= lowerBound)
+                .filter(e -> (double) e.getPrice() <= upperBound)
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bisq/core/util/AveragePriceUtil.java
+++ b/core/src/main/java/bisq/core/util/AveragePriceUtil.java
@@ -28,6 +28,8 @@ import bisq.common.util.Tuple2;
 
 import org.bitcoinj.utils.Fiat;
 
+import com.google.common.primitives.Doubles;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Comparator;
@@ -82,10 +84,10 @@ public class AveragePriceUtil {
     }
 
     private static List<TradeStatistics3> removeOutliers(List<TradeStatistics3> list, double percentToTrim) {
-        List<Double> yValues = list.stream()
+        List<Double> yValues = Doubles.asList(list.stream()
                 .filter(TradeStatistics3::isValid)
-                .map(e -> (double) e.getPrice())
-                .collect(Collectors.toList());
+                .mapToDouble(TradeStatistics3::getPrice)
+                .toArray());
 
         Tuple2<Double, Double> tuple = InlierUtil.findInlierRange(yValues, percentToTrim, HOW_MANY_STD_DEVS_CONSTITUTE_OUTLIER);
         double lowerBound = tuple.first;

--- a/core/src/main/java/bisq/core/util/VolumeUtil.java
+++ b/core/src/main/java/bisq/core/util/VolumeUtil.java
@@ -19,14 +19,10 @@ package bisq.core.util;
 
 import bisq.core.locale.Res;
 import bisq.core.monetary.Altcoin;
-import bisq.core.monetary.AltcoinExchangeRate;
-import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
 
-import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
-import org.bitcoinj.utils.ExchangeRate;
 import org.bitcoinj.utils.Fiat;
 import org.bitcoinj.utils.MonetaryFormat;
 
@@ -64,14 +60,6 @@ public class VolumeUtil {
         // Smallest allowed volume is factor (e.g. 10 EUR or 1 EUR,...)
         roundedVolume = Math.max(factor, roundedVolume);
         return Volume.parse(String.valueOf(roundedVolume), volumeByAmount.getCurrencyCode());
-    }
-
-    public static Volume getVolume(Coin amount, Price price) {
-        if (price.getMonetary() instanceof Altcoin) {
-            return new Volume(new AltcoinExchangeRate((Altcoin) price.getMonetary()).coinToAltcoin(amount));
-        } else {
-            return new Volume(new ExchangeRate((Fiat) price.getMonetary()).coinToFiat(amount));
-        }
     }
 
 

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.core.payment.payload.PaymentMethod;
+
+import com.google.common.collect.Sets;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TradeStatistics3Test {
+    @Disabled("Not fixed yet")
+    @Test
+    public void allPaymentMethodsCoveredByWrapper() {
+        Set<String> paymentMethodCodes = PaymentMethod.getPaymentMethods().stream()
+                .map(PaymentMethod::getId)
+                .collect(Collectors.toSet());
+
+        Set<String> wrapperCodes = Arrays.stream(TradeStatistics3.PaymentMethodMapper.values())
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+
+        assertEquals(Set.of(), Sets.difference(paymentMethodCodes, wrapperCodes));
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/components/chart/ChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/components/chart/ChartDataModel.java
@@ -22,10 +22,10 @@ import bisq.desktop.common.model.ActivatableDataModel;
 import java.time.Instant;
 import java.time.temporal.TemporalAdjuster;
 
-import java.util.Comparator;
 import java.util.Map;
 import java.util.function.BinaryOperator;
 import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,6 +64,11 @@ public abstract class ChartDataModel extends ActivatableDataModel {
         return temporalAdjusterModel.toTimeInterval(instant);
     }
 
+    // optimized for use when the input times are sequential and not too spread out
+    public ToLongFunction<Instant> toCachedTimeIntervalFn() {
+        return temporalAdjusterModel.withCache()::toTimeInterval;
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Date filter predicate
@@ -88,7 +93,7 @@ public abstract class ChartDataModel extends ActivatableDataModel {
                                            Map<Long, Long> map2,
                                            BinaryOperator<Long> mergeFunction) {
         return Stream.concat(map1.entrySet().stream(),
-                map2.entrySet().stream())
+                        map2.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey,
                         Map.Entry::getValue,
                         mergeFunction));

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
@@ -188,9 +188,10 @@ public class PriceChartDataModel extends ChartDataModel {
 
     private Map<Long, Double> getPriceByInterval(Predicate<TradeStatistics3> collectionFilter,
                                                  Function<List<TradeStatistics3>, Double> getAveragePriceFunction) {
+        var toTimeIntervalFn = toCachedTimeIntervalFn();
         return getPriceByInterval(tradeStatisticsManager.getObservableTradeStatisticsSet(),
                 collectionFilter,
-                tradeStatistics -> toTimeInterval(Instant.ofEpochMilli(tradeStatistics.getDateAsLong())),
+                tradeStatistics -> toTimeIntervalFn.applyAsLong(Instant.ofEpochMilli(tradeStatistics.getDateAsLong())),
                 dateFilter,
                 getAveragePriceFunction);
     }

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/volume/VolumeChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/volume/VolumeChartDataModel.java
@@ -134,8 +134,9 @@ public class VolumeChartDataModel extends ChartDataModel {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private Map<Long, Long> getVolumeByInterval(Function<List<TradeStatistics3>, Long> getVolumeFunction) {
+        var toTimeIntervalFn = toCachedTimeIntervalFn();
         return getVolumeByInterval(tradeStatisticsManager.getObservableTradeStatisticsSet(),
-                tradeStatistics -> toTimeInterval(Instant.ofEpochMilli(tradeStatistics.getDateAsLong())),
+                tradeStatistics -> toTimeIntervalFn.applyAsLong(Instant.ofEpochMilli(tradeStatistics.getDateAsLong())),
                 dateFilter,
                 getVolumeFunction);
     }

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
@@ -57,6 +57,7 @@ import lombok.Getter;
 import static bisq.desktop.main.market.trades.TradesChartsViewModel.MAX_TICKS;
 
 public class ChartCalculations {
+    @VisibleForTesting
     static final ZoneId ZONE_ID = ZoneId.systemDefault();
 
 

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
@@ -73,20 +73,21 @@ public class ChartCalculations {
                 dateMapsPerTickUnit.put(tick, new HashMap<>());
             }
 
+            TradesChartsViewModel.TickUnit[] tickUnits = TradesChartsViewModel.TickUnit.values();
             tradeStatisticsSet.stream()
                     .filter(e -> e.getCurrency().equals("USD"))
                     .forEach(tradeStatistics -> {
-                        for (TradesChartsViewModel.TickUnit tick : TradesChartsViewModel.TickUnit.values()) {
-                            long time = roundToTick(tradeStatistics.getLocalDateTime(), tick).getTime();
-                            Map<Long, List<TradeStatistics3>> map = dateMapsPerTickUnit.get(tick);
+                        for (TradesChartsViewModel.TickUnit tickUnit : tickUnits) {
+                            long time = roundToTick(tradeStatistics.getLocalDateTime(), tickUnit).getTime();
+                            Map<Long, List<TradeStatistics3>> map = dateMapsPerTickUnit.get(tickUnit);
                             map.computeIfAbsent(time, t -> new ArrayList<>()).add(tradeStatistics);
                         }
                     });
 
-            dateMapsPerTickUnit.forEach((tick, map) -> {
+            dateMapsPerTickUnit.forEach((tickUnit, map) -> {
                 HashMap<Long, Long> priceMap = new HashMap<>();
                 map.forEach((date, tradeStatisticsList) -> priceMap.put(date, getAveragePrice(tradeStatisticsList)));
-                usdAveragePriceMapsPerTickUnit.put(tick, priceMap);
+                usdAveragePriceMapsPerTickUnit.put(tickUnit, priceMap);
             });
             return usdAveragePriceMapsPerTickUnit;
         });

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
@@ -77,8 +77,7 @@ public class ChartCalculations {
                         for (TradesChartsViewModel.TickUnit tick : TradesChartsViewModel.TickUnit.values()) {
                             long time = roundToTick(tradeStatistics.getLocalDateTime(), tick).getTime();
                             Map<Long, List<TradeStatistics3>> map = dateMapsPerTickUnit.get(tick);
-                            map.putIfAbsent(time, new ArrayList<>());
-                            map.get(time).add(tradeStatistics);
+                            map.computeIfAbsent(time, t -> new ArrayList<>()).add(tradeStatistics);
                         }
                     });
 
@@ -94,11 +93,9 @@ public class ChartCalculations {
     static CompletableFuture<List<TradeStatistics3>> getTradeStatisticsForCurrency(Set<TradeStatistics3> tradeStatisticsSet,
                                                                                    String currencyCode,
                                                                                    boolean showAllTradeCurrencies) {
-        return CompletableFuture.supplyAsync(() -> {
-            return tradeStatisticsSet.stream()
-                    .filter(e -> showAllTradeCurrencies || e.getCurrency().equals(currencyCode))
-                    .collect(Collectors.toList());
-        });
+        return CompletableFuture.supplyAsync(() -> tradeStatisticsSet.stream()
+                .filter(e -> showAllTradeCurrencies || e.getCurrency().equals(currencyCode))
+                .collect(Collectors.toList()));
     }
 
     static CompletableFuture<UpdateChartResult> getUpdateChartResult(List<TradeStatistics3> tradeStatisticsByCurrency,
@@ -193,7 +190,7 @@ public class ChartCalculations {
     }
 
 
-    static Date roundToTick(LocalDateTime localDate, TradesChartsViewModel.TickUnit tickUnit) {
+    private static Date roundToTick(LocalDateTime localDate, TradesChartsViewModel.TickUnit tickUnit) {
         switch (tickUnit) {
             case YEAR:
                 return Date.from(localDate.withMonth(1).withDayOfYear(1).withHour(0).withMinute(0).withSecond(0).withNano(0).atZone(ZONE_ID).toInstant());
@@ -214,6 +211,7 @@ public class ChartCalculations {
         }
     }
 
+    @VisibleForTesting
     static Date roundToTick(Date time, TradesChartsViewModel.TickUnit tickUnit) {
         return roundToTick(time.toInstant().atZone(ChartCalculations.ZONE_ID).toLocalDateTime(), tickUnit);
     }

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradeStatistics3ListItem.java
@@ -26,6 +26,9 @@ import bisq.core.util.FormattingUtils;
 import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.value.ObservableValue;
+
 import lombok.experimental.Delegate;
 
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +38,7 @@ public class TradeStatistics3ListItem {
     private final TradeStatistics3 tradeStatistics3;
     private final CoinFormatter coinFormatter;
     private final boolean showAllTradeCurrencies;
+    private final ObservableValue<TradeStatistics3ListItem> observableWrapper;
     private String dateString;
     private String market;
     private String priceString;
@@ -48,6 +52,11 @@ public class TradeStatistics3ListItem {
         this.tradeStatistics3 = tradeStatistics3;
         this.coinFormatter = coinFormatter;
         this.showAllTradeCurrencies = showAllTradeCurrencies;
+        observableWrapper = new ReadOnlyObjectWrapper<>(this).getReadOnlyProperty();
+    }
+
+    public ObservableValue<TradeStatistics3ListItem> asObservableValue() {
+        return observableWrapper;
     }
 
     public String getDateString() {

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -640,7 +640,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         return new StringConverter<>() {
             @Override
             public String toString(Number object) {
-                long index = MathUtils.doubleToLong((double) object);
+                int index = object.intValue();
                 // The last tick is on the chart edge, it is not well spaced with
                 // the previous tick and interferes with its label.
                 if (MAX_TICKS + 1 == index) return "";

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -53,6 +53,8 @@ import com.googlecode.jcsv.writer.CSVEntryConverter;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.google.common.collect.Lists;
+
 import com.jfoenix.controls.JFXTabPane;
 
 import javafx.stage.Stage;
@@ -85,7 +87,6 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 import org.fxmisc.easybind.monadic.MonadicBinding;
 
-import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
@@ -390,7 +391,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private void fillList() {
         long ts = System.currentTimeMillis();
         boolean showAllTradeCurrencies = model.showAllTradeCurrenciesProperty.get();
-        CompletableFuture.supplyAsync(() -> model.tradeStatisticsByCurrency.stream()
+        // Collect the list items in reverse chronological order, as this is the likely
+        // order 'sortedList' will place them in - this skips most of its (slow) sorting.
+        CompletableFuture.supplyAsync(() -> Lists.reverse(model.tradeStatisticsByCurrency).stream()
                 .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
                         coinFormatter,
                         showAllTradeCurrencies))
@@ -755,7 +758,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             }
         };
         dateColumn.getStyleClass().addAll("number-column", "first-column");
-        dateColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
+        dateColumn.setCellValueFactory(tradeStatistics -> tradeStatistics.getValue().asObservableValue());
         dateColumn.setCellFactory(
                 new Callback<>() {
                     @Override
@@ -784,7 +787,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             }
         };
         marketColumn.getStyleClass().add("number-column");
-        marketColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
+        marketColumn.setCellValueFactory(tradeStatistics -> tradeStatistics.getValue().asObservableValue());
         marketColumn.setCellFactory(
                 new Callback<>() {
                     @Override
@@ -808,7 +811,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         // price
         priceColumn = new TableColumn<>();
         priceColumn.getStyleClass().add("number-column");
-        priceColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
+        priceColumn.setCellValueFactory(tradeStatistics -> tradeStatistics.getValue().asObservableValue());
         priceColumn.setCellFactory(
                 new Callback<>() {
                     @Override
@@ -832,7 +835,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         // amount
         TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem> amountColumn = new AutoTooltipTableColumn<>(Res.get("shared.amountWithCur", Res.getBaseCurrencyCode()));
         amountColumn.getStyleClass().add("number-column");
-        amountColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
+        amountColumn.setCellValueFactory(tradeStatistics -> tradeStatistics.getValue().asObservableValue());
         amountColumn.setCellFactory(
                 new Callback<>() {
                     @Override
@@ -857,7 +860,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         // volume
         volumeColumn = new TableColumn<>();
         volumeColumn.getStyleClass().add("number-column");
-        volumeColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
+        volumeColumn.setCellValueFactory(tradeStatistics -> tradeStatistics.getValue().asObservableValue());
         volumeColumn.setCellFactory(
                 new Callback<>() {
                     @Override
@@ -881,7 +884,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         // paymentMethod
         TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem> paymentMethodColumn = new AutoTooltipTableColumn<>(Res.get("shared.paymentMethod"));
         paymentMethodColumn.getStyleClass().add("number-column");
-        paymentMethodColumn.setCellValueFactory((tradeStatistics) -> new ReadOnlyObjectWrapper<>(tradeStatistics.getValue()));
+        paymentMethodColumn.setCellValueFactory(tradeStatistics -> tradeStatistics.getValue().asObservableValue());
         paymentMethodColumn.setCellFactory(
                 new Callback<>() {
                     @Override

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -389,13 +389,13 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     private void fillList() {
         long ts = System.currentTimeMillis();
-        CompletableFuture.supplyAsync(() -> {
-            return model.tradeStatisticsByCurrency.stream()
-                    .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
-                            coinFormatter,
-                            model.showAllTradeCurrenciesProperty.get()))
-                    .collect(Collectors.toCollection(FXCollections::observableArrayList));
-        }).whenComplete((listItems, throwable) -> {
+        boolean showAllTradeCurrencies = model.showAllTradeCurrenciesProperty.get();
+        CompletableFuture.supplyAsync(() -> model.tradeStatisticsByCurrency.stream()
+                .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
+                        coinFormatter,
+                        showAllTradeCurrencies))
+                .collect(Collectors.toCollection(FXCollections::observableArrayList))
+        ).whenComplete((listItems, throwable) -> {
             log.debug("Creating listItems took {} ms", System.currentTimeMillis() - ts);
 
             long ts2 = System.currentTimeMillis();

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -73,6 +73,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
     // Enum
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    // NOTE: For the code to work correctly, order must be from biggest to smallest duration:
     public enum TickUnit {
         YEAR,
         MONTH,
@@ -208,7 +209,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
 
     private void applyAsyncUsdAveragePriceMapsPerTickUnit(CompletableFuture<Boolean> completeFuture) {
         long ts = System.currentTimeMillis();
-        ChartCalculations.getUsdAveragePriceMapsPerTickUnit(tradeStatisticsManager.getObservableTradeStatisticsSet())
+        ChartCalculations.getUsdAveragePriceMapsPerTickUnit(tradeStatisticsManager.getNavigableTradeStatisticsSet())
                 .whenComplete((usdAveragePriceMapsPerTickUnit, throwable) -> {
                     if (deactivateCalled) {
                         return;
@@ -236,8 +237,8 @@ class TradesChartsViewModel extends ActivatableViewModel {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         long ts = System.currentTimeMillis();
         ChartCalculations.getTradeStatisticsForCurrency(tradeStatisticsManager.getObservableTradeStatisticsSet(),
-                currencyCode,
-                showAllTradeCurrenciesProperty.get())
+                        currencyCode,
+                        showAllTradeCurrenciesProperty.get())
                 .whenComplete((list, throwable) -> {
                     if (deactivateCalled) {
                         return;
@@ -265,9 +266,9 @@ class TradesChartsViewModel extends ActivatableViewModel {
     private void applyAsyncChartData() {
         long ts = System.currentTimeMillis();
         ChartCalculations.getUpdateChartResult(new ArrayList<>(tradeStatisticsByCurrency),
-                tickUnit,
-                usdAveragePriceMapsPerTickUnit,
-                getCurrencyCode())
+                        tickUnit,
+                        usdAveragePriceMapsPerTickUnit,
+                        getCurrencyCode())
                 .whenComplete((updateChartResult, throwable) -> {
                     if (deactivateCalled) {
                         return;

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -96,7 +96,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
     final ObservableList<XYChart.Data<Number, Number>> priceItems = FXCollections.observableArrayList();
     final ObservableList<XYChart.Data<Number, Number>> volumeItems = FXCollections.observableArrayList();
     final ObservableList<XYChart.Data<Number, Number>> volumeInUsdItems = FXCollections.observableArrayList();
-    private final Map<Long, Pair<Date, Set<TradeStatistics3>>> itemsPerInterval = new HashMap<>();
+    private final List<Pair<Date, Set<TradeStatistics3>>> itemsPerInterval = new ArrayList<>();
 
     TickUnit tickUnit;
     private int selectedTabIndex;
@@ -278,7 +278,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
                     }
                     UserThread.execute(() -> {
                         itemsPerInterval.clear();
-                        itemsPerInterval.putAll(updateChartResult.getItemsPerInterval());
+                        itemsPerInterval.addAll(updateChartResult.getItemsPerInterval());
 
                         priceItems.setAll(updateChartResult.getPriceItems());
                         volumeItems.setAll(updateChartResult.getVolumeItems());
@@ -356,8 +356,8 @@ class TradesChartsViewModel extends ActivatableViewModel {
         return currencyListItems.getObservableList().stream().filter(e -> e.tradeCurrency.equals(selectedTradeCurrencyProperty.get())).findAny();
     }
 
-    long getTimeFromTickIndex(long tick) {
-        return ChartCalculations.getTimeFromTickIndex(tick, itemsPerInterval);
+    long getTimeFromTickIndex(int tickIndex) {
+        return ChartCalculations.getTimeFromTickIndex(tickIndex, itemsPerInterval);
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -368,7 +368,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
 
     private void fillTradeCurrencies() {
         // Don't use a set as we need all entries
-        List<TradeCurrency> tradeCurrencyList = tradeStatisticsManager.getObservableTradeStatisticsSet().stream()
+        List<TradeCurrency> tradeCurrencyList = tradeStatisticsManager.getNavigableTradeStatisticsSet().parallelStream()
                 .flatMap(e -> CurrencyUtil.getTradeCurrency(e.getCurrency()).stream())
                 .collect(Collectors.toList());
         currencyListItems.updateWithCurrencies(tradeCurrencyList, showAllCurrencyListItem);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesDataModel.java
@@ -33,7 +33,6 @@ import bisq.core.trade.bsq_swap.BsqSwapTradeManager;
 import bisq.core.trade.model.Tradable;
 import bisq.core.user.Preferences;
 import bisq.core.util.PriceUtil;
-import bisq.core.util.VolumeUtil;
 
 import org.bitcoinj.core.Coin;
 
@@ -120,7 +119,7 @@ class ClosedTradesDataModel extends ActivatableDataModel {
         }
 
         Price price = PriceUtil.marketPriceToPrice(marketPrice);
-        return Optional.of(VolumeUtil.getVolume(amount, price));
+        return Optional.of(price.getVolumeByAmount(amount));
     }
 
     Volume getBsqVolumeInUsdWithAveragePrice(Coin amount) {

--- a/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
@@ -47,7 +47,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -171,9 +171,10 @@ public class TradesChartsViewModelTest {
                 null,
                 null));
 
-        Map<Long, Pair<Date, Set<TradeStatistics3>>> itemsPerInterval = null;
+        List<Pair<Date, Set<TradeStatistics3>>> itemsPerInterval = List.of();
         long tick = ChartCalculations.roundToTick(now, TradesChartsViewModel.TickUnit.DAY).getTime();
-        CandleData candleData = ChartCalculations.getCandleData(tick,
+        // FIXME: Type error - trying to pass a time (long) as a tick index (int from 0 to 91 inclusive)!!
+        CandleData candleData = ChartCalculations.getCandleData((int) tick,
                 set,
                 0,
                 TradesChartsViewModel.TickUnit.DAY, currencyCode,

--- a/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -60,9 +60,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Collections;
 
 import com.natpryce.makeiteasy.Maker;
 
@@ -86,7 +84,6 @@ import static org.mockito.Mockito.when;
 
 public class OfferBookViewModelTest {
     private final CoinFormatter coinFormatter = new ImmutableCoinFormatter(Config.baseCurrencyNetworkParameters().getMonetaryFormat());
-    private static final Logger log = LoggerFactory.getLogger(OfferBookViewModelTest.class);
     private User user;
 
     @BeforeEach
@@ -101,7 +98,7 @@ public class OfferBookViewModelTest {
     private PriceUtil getPriceUtil() {
         PriceFeedService priceFeedService = mock(PriceFeedService.class);
         TradeStatisticsManager tradeStatisticsManager = mock(TradeStatisticsManager.class);
-        when(tradeStatisticsManager.getObservableTradeStatisticsSet()).thenReturn(FXCollections.observableSet());
+        when(tradeStatisticsManager.getNavigableTradeStatisticsSet()).thenReturn(Collections.emptyNavigableSet());
         return new PriceUtil(priceFeedService, tradeStatisticsManager, empty);
     }
 
@@ -639,4 +636,3 @@ public class OfferBookViewModelTest {
                 1));
     }
 }
-


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This PR makes the trade statistics set held by `TradeStatisticsManager` into a sorted collection (a `TreeSet`), in order to make certain optimisations possible which speed up the Burning Man view, the Trades Charts view and the BSQ Dashboard view (plus a few other minor areas of the application). The PR also applies quite a lot of miscellaneous optimisations to those three views, plus a simple related optimisation to the BSQ Supply view.

The two main benefits of holding the trade statistics in a sorted set (with chronological ordering) are:

1) Lightweight caches can be used in timezone, time interval and similar calculations much more easily, since consecutive trade statistics objects tend to be close to each other in time;
2) It is possible to obtain a date range view of the trade statistics set very cheaply (in _O(log n)_ time), avoiding the need to stream over the entire collection in `AveragePriceUtil` and elsewhere. For this purpose, a `RangeUtils` class is provided, which works round the limitation that `java.util.NavigableSet` only allows searching with keys of the collection type, not mapped keys such as dates.

Note that even though a tree has somewhat slower lookups than a hash table, it doesn't matter here since there are no lookups into the trade statistics set, only streaming & filtering of the elements, plus occasional insertions. (Also I believe `TreeSet`s are a little more memory efficient than `HashSet`s.)

--

The biggest speedup is probably to the burning man view (Under _DAO_ / _Proof of Burn_ / _Burningmen_). Tabbing to it five times gives the following hotspots from JProfiler before the changes:
![Screenshot-2023-5-10 Hot Spots](https://github.com/bisq-network/bisq/assets/54855381/187254f6-d1b8-4077-9583-e074a7c74942)
As can be seen, by far the biggest hotspot comes from `AveragePriceUtil.getAveragePriceTuple`, which filters the entire trade statistics set for BSQ & USD trades in a given one-month (as specified) period.

After the changes, tabbing to the view five times gives the following hotspots from JProfiler:
![Screenshot-2023-5-10 Hot Spots(1)](https://github.com/bisq-network/bisq/assets/54855381/0e236e7b-cc5d-48e7-8967-c804fdb6164d)
