### PR TITLE
Exclude mostRecentAddress from EqualsAndHashCode

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
+++ b/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
@@ -54,6 +54,7 @@ public class BurningManCandidate {
     // trade protocol. We use the legacyMostRecentAddress until the activation date where we
     // enforce the version by the filter to ensure users have updated.
     // See: https://github.com/bisq-network/bisq/issues/6699
+    @EqualsAndHashCode.Exclude
     protected Optional<String> mostRecentAddress = Optional.empty();
 
     private final Set<BurnOutputModel> burnOutputModels = new HashSet<>();


### PR DESCRIPTION
The getter was called by EqualsAndHashCode which throws an exception as it is is not intended to get used anymore.
