### PR TITLE
Fix broken gson version enforcement

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ fontawesomefx-materialdesign-font = { strictly = '2.0.26-9.1.2' }
 fxmisc-easybind = { strictly = '1.0.3' }
 
 google-findbugs = { strictly = '3.0.2' }
-google-gson = { strictly = '2.8.5' }
+google-gson = { strictly = '2.8.6' }
 google-guava = { strictly = '30.1.1-jre' }
 google-guice = { strictly = '5.0.1' }
 


### PR DESCRIPTION
We strictly enforce version 2.8.5 for all modules, but the cli module transitively depends on version 2.8.6.