### PR TITLE
Fix bisq.properties pickup in ApiTest

### DIFF
--- a/apitest/dao-setup.gradle
+++ b/apitest/dao-setup.gradle
@@ -11,14 +11,14 @@
 //
 // The :apitest subproject will not run on Windows, and these tasks have not been
 // tested on Windows.
-def buildResourcesDir = project(":apitest").buildDir.path + '/resources/main'
+def buildResourcesDir = project(":apitest").sourceSets.main.resources.srcDirs.first().path
 
 // This task requires ant in the system $PATH.
 task installDaoSetup(dependsOn: 'cleanDaoSetup') {
     doLast {
         println "Installing dao-setup directories in build dir $buildResourcesDir ..."
         def src = 'https://github.com/bisq-network/bisq/raw/master/docs/dao-setup.zip'
-        def destfile = project.rootDir.path + '/apitest/src/main/resources/dao-setup.zip'
+        def destfile = buildResourcesDir + '/dao-setup.zip'
         def url = new URL(src)
         def f = new File(destfile)
         if (f.exists()) {
@@ -48,21 +48,14 @@ task installDaoSetup(dependsOn: 'cleanDaoSetup') {
         }
 
         // Copy files from unzip target dir 'dao-setup' to build/resources/main.
-        def daoSetupSrc = project.rootDir.path + '/apitest/src/main/resources/dao-setup'
-        def daoSetupDest = buildResourcesDir + '/dao-setup'
+        def daoSetupSrc = buildResourcesDir + '/dao-setup'
+        def daoSetupDest = buildResourcesDir
         println "Copying $daoSetupSrc to $daoSetupDest ..."
         copy {
             from daoSetupSrc
             into daoSetupDest
         }
 
-        // Move dao-setup files from build/resources/main/dao-setup to build/resources/main
-        file(buildResourcesDir + '/dao-setup/Bitcoin-regtest')
-                .renameTo(file(buildResourcesDir + '/Bitcoin-regtest'))
-        file(buildResourcesDir + '/dao-setup/bisq-BTC_REGTEST_Alice_dao')
-                .renameTo(file(buildResourcesDir + '/bisq-BTC_REGTEST_Alice_dao'))
-        file(buildResourcesDir + '/dao-setup/bisq-BTC_REGTEST_Bob_dao')
-                .renameTo(file(buildResourcesDir + '/bisq-BTC_REGTEST_Bob_dao'))
         delete file(buildResourcesDir + '/dao-setup')
     }
 }

--- a/apitest/src/main/java/bisq/apitest/Scaffold.java
+++ b/apitest/src/main/java/bisq/apitest/Scaffold.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -242,26 +243,50 @@ public class Scaffold {
 
             log.info("Copied all dao-setup files to {}", buildDataDir);
 
+            // Copy 'bisq.properties' file from 'src/main/resources' to each
+            // Bisq instance's DataDir
+            copyBisqPropertiesFileToAppDataDir();
+
             // Try to avoid confusion about which 'bisq.properties' file is or was loaded
             // by a Bisq instance:  delete the 'bisq.properties' file automatically copied
             // to the 'apitest/build/resources/main' directory during IDE or Gradle build.
             // Note:  there is no way to prevent this deleted file from being re-copied
             // from 'src/main/resources' to the buildDataDir each time you hit the build
             // button in the IDE.
-            BashCommand rmRedundantBisqPropertiesFile =
-                    new BashCommand("rm -rf " + buildDataDir + "/bisq.properties");
-            if (rmRedundantBisqPropertiesFile.run().getExitStatus() != 0)
-                throw new IllegalStateException("Could not delete redundant bisq.properties file");
+            deleteRedundantBisqPropertiesFile();
 
             // Copy the blocknotify script from the src resources dir to the build
             // resources dir.  Users may want to edit comment out some lines when all
             // the default block notifcation ports being will not be used (to avoid
             // seeing rpc notifcation warnings in log files).
             installBitcoinBlocknotify();
-
         } catch (IOException | InterruptedException ex) {
             throw new IllegalStateException("Could not install dao-setup files from " + daoSetupDir, ex);
         }
+    }
+
+    private void copyBisqPropertiesFileToAppDataDir() throws IOException, InterruptedException {
+        copyBisqPropertiesFileToAppDataDir(alicedaemon);
+        copyBisqPropertiesFileToAppDataDir(bobdaemon);
+    }
+    private void copyBisqPropertiesFileToAppDataDir(BisqAppConfig bisqAppConfig) throws IOException, InterruptedException {
+        String instanceDataDir = config.rootAppDataDir + "/" + bisqAppConfig.appName;
+
+        BashCommand moveToDataDir =
+                new BashCommand("cp " + config.baseSrcResourcesDir + "/bisq.properties " + instanceDataDir);
+
+        if(moveToDataDir.run().getExitStatus() !=0)
+            throw new IllegalStateException("Could not copy bisq.properties to " + instanceDataDir);
+
+        log.debug("bisq.properties copied to " + instanceDataDir);
+    }
+
+    private void deleteRedundantBisqPropertiesFile() throws IOException, InterruptedException {
+        BashCommand rmRedundantBisqPropertiesFile =
+                new BashCommand("rm -rf " + config.rootAppDataDir.getAbsolutePath() + "/bisq.properties");
+
+        if (rmRedundantBisqPropertiesFile.run().getExitStatus() != 0)
+            throw new IllegalStateException("Could not delete redundant bisq.properties file");
     }
 
     private void cleanDaoSetupDirectories() {

--- a/apitest/src/main/java/bisq/apitest/Scaffold.java
+++ b/apitest/src/main/java/bisq/apitest/Scaffold.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -247,14 +246,6 @@ public class Scaffold {
             // Bisq instance's DataDir
             copyBisqPropertiesFileToAppDataDir();
 
-            // Try to avoid confusion about which 'bisq.properties' file is or was loaded
-            // by a Bisq instance:  delete the 'bisq.properties' file automatically copied
-            // to the 'apitest/build/resources/main' directory during IDE or Gradle build.
-            // Note:  there is no way to prevent this deleted file from being re-copied
-            // from 'src/main/resources' to the buildDataDir each time you hit the build
-            // button in the IDE.
-            deleteRedundantBisqPropertiesFile();
-
             // Copy the blocknotify script from the src resources dir to the build
             // resources dir.  Users may want to edit comment out some lines when all
             // the default block notifcation ports being will not be used (to avoid
@@ -269,25 +260,18 @@ public class Scaffold {
         copyBisqPropertiesFileToAppDataDir(alicedaemon);
         copyBisqPropertiesFileToAppDataDir(bobdaemon);
     }
-    private void copyBisqPropertiesFileToAppDataDir(BisqAppConfig bisqAppConfig) throws IOException, InterruptedException {
-        String instanceDataDir = config.rootAppDataDir + "/" + bisqAppConfig.appName;
 
+    private void copyBisqPropertiesFileToAppDataDir(BisqAppConfig bisqAppConfig) throws IOException, InterruptedException {
+        if (!new File(config.baseSrcResourcesDir + "/bisq.properties").exists()) return;
+
+        String instanceDataDir = config.rootAppDataDir + "/" + bisqAppConfig.appName;
         BashCommand moveToDataDir =
                 new BashCommand("cp " + config.baseSrcResourcesDir + "/bisq.properties " + instanceDataDir);
-
-        if(moveToDataDir.run().getExitStatus() !=0)
+        if (moveToDataDir.run().getExitStatus() != 0)
             throw new IllegalStateException("Could not copy bisq.properties to " + instanceDataDir);
-
         log.debug("bisq.properties copied to " + instanceDataDir);
     }
 
-    private void deleteRedundantBisqPropertiesFile() throws IOException, InterruptedException {
-        BashCommand rmRedundantBisqPropertiesFile =
-                new BashCommand("rm -rf " + config.rootAppDataDir.getAbsolutePath() + "/bisq.properties");
-
-        if (rmRedundantBisqPropertiesFile.run().getExitStatus() != 0)
-            throw new IllegalStateException("Could not delete redundant bisq.properties file");
-    }
 
     private void cleanDaoSetupDirectories() {
         String buildDataDir = config.rootAppDataDir.getAbsolutePath();


### PR DESCRIPTION
This change copies the 'bisq.properties' file in apitest/src/main/resources to each instance's DataDir on test harness startup.

This was necessary as #5718 was not copying the file into the instance's data dir but leaving it in 'build/resources/main' where it wasn't picked up by the instance.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
