### PR TITLE
Remove hardcoding of enableBisqDebugging in ApiTest

### DIFF
--- a/apitest/src/test/java/bisq/apitest/ApiTestCase.java
+++ b/apitest/src/test/java/bisq/apitest/ApiTestCase.java
@@ -87,8 +87,7 @@ public class ApiTestCase {
             throws InterruptedException, ExecutionException, IOException {
         String[] params = new String[]{
                 "--supportingApps", stream(supportingApps).map(Enum::name).collect(Collectors.joining(",")),
-                "--callRateMeteringConfigPath", getTestRateMeterInterceptorConfig().getAbsolutePath(),
-                "--enableBisqDebugging", "false"
+                "--callRateMeteringConfigPath", getTestRateMeterInterceptorConfig().getAbsolutePath()
         };
         setUpScaffold(params);
     }

--- a/apitest/src/test/java/bisq/apitest/method/CallRateMeteringInterceptorTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/CallRateMeteringInterceptorTest.java
@@ -45,7 +45,6 @@ public class CallRateMeteringInterceptorTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         startSupportingApps(false,
-                false,
                 bitcoind, alicedaemon);
     }
 

--- a/apitest/src/test/java/bisq/apitest/method/MethodTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/MethodTest.java
@@ -70,13 +70,11 @@ public class MethodTest extends ApiTestCase {
 
     public static void startSupportingApps(File callRateMeteringConfigFile,
                                            boolean generateBtcBlock,
-                                           boolean startSupportingAppsInDebugMode,
                                            Enum<?>... supportingApps) {
         try {
             setUpScaffold(new String[]{
                     "--supportingApps", toNameList.apply(supportingApps),
                     "--callRateMeteringConfigPath", callRateMeteringConfigFile.getAbsolutePath(),
-                    "--enableBisqDebugging", startSupportingAppsInDebugMode ? "true" : "false"
             });
             doPostStartup(generateBtcBlock);
         } catch (Exception ex) {
@@ -84,16 +82,13 @@ public class MethodTest extends ApiTestCase {
         }
     }
 
-    public static void startSupportingApps(boolean generateBtcBlock,
-                                           boolean startSupportingAppsInDebugMode,
-                                           Enum<?>... supportingApps) {
+    public static void startSupportingApps(boolean generateBtcBlock, Enum<?>... supportingApps) {
         try {
             // Disable call rate metering where there is no callRateMeteringConfigFile.
             File callRateMeteringConfigFile = getTestRateMeterInterceptorConfig();
             setUpScaffold(new String[]{
                     "--supportingApps", toNameList.apply(supportingApps),
-                    "--callRateMeteringConfigPath", callRateMeteringConfigFile.getAbsolutePath(),
-                    "--enableBisqDebugging", startSupportingAppsInDebugMode ? "true" : "false"
+                    "--callRateMeteringConfigPath", callRateMeteringConfigFile.getAbsolutePath()
             });
             doPostStartup(generateBtcBlock);
         } catch (Exception ex) {

--- a/apitest/src/test/java/bisq/apitest/method/offer/AbstractOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/AbstractOfferTest.java
@@ -77,12 +77,7 @@ public abstract class AbstractOfferTest extends MethodTest {
 
     @BeforeAll
     public static void setUp() {
-        setUp(false);
-    }
-
-    public static void setUp(boolean startSupportingAppsInDebugMode) {
         startSupportingApps(true,
-                startSupportingAppsInDebugMode,
                 bitcoind,
                 seednode,
                 arbdaemon,

--- a/apitest/src/test/java/bisq/apitest/method/offer/BsqSwapOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/BsqSwapOfferTest.java
@@ -44,10 +44,6 @@ import static protobuf.OfferDirection.BUY;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class BsqSwapOfferTest extends AbstractOfferTest {
 
-    @BeforeAll
-    public static void setUp() {
-        AbstractOfferTest.setUp(false);
-    }
 
     @BeforeEach
     public void generateBtcBlock() {

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferWithNationalBankAcctTest.java
@@ -78,10 +78,6 @@ public class TakeBuyBTCOfferWithNationalBankAcctTest extends AbstractTradeTest {
     private static PaymentAccount alicesPaymentAccount;
     private static PaymentAccount bobsPaymentAccount;
 
-    @BeforeAll
-    public static void setUp() {
-        setUp(false);
-    }
 
     @Test
     @Order(1)

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
@@ -60,7 +60,7 @@ public class TakeSellXMROfferTest extends AbstractTradeTest {
 
     @BeforeAll
     public static void setUp() {
-        AbstractOfferTest.setUp(false);
+        AbstractOfferTest.setUp();
         createXmrPaymentAccounts();
         EXPECTED_PROTOCOL_STATUS.init();
     }

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BsqWalletTest.java
@@ -48,7 +48,6 @@ public class BsqWalletTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         startSupportingApps(true,
-                false,
                 bitcoind,
                 seednode,
                 arbdaemon,

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BtcTxFeeRateTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BtcTxFeeRateTest.java
@@ -36,7 +36,6 @@ public class BtcTxFeeRateTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         startSupportingApps(false,
-                true,
                 bitcoind,
                 seednode,
                 alicedaemon);

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BtcWalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BtcWalletTest.java
@@ -41,7 +41,6 @@ public class BtcWalletTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         startSupportingApps(false,
-                false,
                 bitcoind,
                 seednode,
                 alicedaemon,

--- a/apitest/src/test/java/bisq/apitest/scenario/OfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/OfferTest.java
@@ -43,11 +43,6 @@ import bisq.apitest.method.offer.ValidateCreateOfferTest;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class OfferTest extends AbstractOfferTest {
 
-    @BeforeAll
-    public static void setUp() {
-        setUp(false); // Use setUp(true) for running API daemons in remote debug mode.
-    }
-
     @Test
     @Order(1)
     public void testCreateOfferValidation() {

--- a/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/StartupTest.java
@@ -58,7 +58,6 @@ public class StartupTest extends MethodTest {
             callRateMeteringConfigFile = getTestRateMeterInterceptorConfig();
             startSupportingApps(callRateMeteringConfigFile,
                     false,
-                    false,
                     bitcoind, seednode, arbdaemon, alicedaemon);
         } catch (Exception ex) {
             fail(ex);

--- a/apitest/src/test/java/bisq/apitest/scenario/WalletTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/WalletTest.java
@@ -53,7 +53,6 @@ public class WalletTest extends MethodTest {
     @BeforeAll
     public static void setUp() {
         startSupportingApps(true,
-                false,
                 bitcoind,
                 seednode,
                 arbdaemon,


### PR DESCRIPTION
Hardcode enableBisqDebugging in the Api tests prevents the option to set it from the apitest.properties file as any hardcoded value will be set as a command line option which will always take precedence over any value placed in the apitest.properties file. This makes it impossible to turn on debugging without altering the code in various places. It is also redundant as hardcoded value is false, which is the default anyway. 

This change removes the hardcoding of the value, allowing the test hardness to fallback on the default of debugging being turned off, with the option to turn it on from the apitest.properties file. 

