### PR TITLE
Suspend instances in Apitest by CSV list in apitest.properties

### DIFF
--- a/apitest/src/main/java/bisq/apitest/config/ApiTestConfig.java
+++ b/apitest/src/main/java/bisq/apitest/config/ApiTestConfig.java
@@ -85,6 +85,8 @@ public class ApiTestConfig {
     static final String ENABLE_BISQ_DEBUGGING = "enableBisqDebugging";
     static final String REGISTER_DISPUTE_AGENTS = "registerDisputeAgents";
 
+    static final String SUSPEND_INSTANCE = "suspendInstance";
+
     // Default values for certain options
     static final String DEFAULT_CONFIG_FILE_NAME = "apitest.properties";
 
@@ -125,6 +127,8 @@ public class ApiTestConfig {
     public final String rootProjectDir;
     public final String baseBuildResourcesDir;
     public final String baseSrcResourcesDir;
+
+    public final String suspendedInstances;
 
     // The parser that will be used to parse both cmd line and config file options
     private final OptionParser parser = new OptionParser();
@@ -261,6 +265,12 @@ public class ApiTestConfig {
                         .withRequiredArg()
                         .ofType(Boolean.class)
                         .defaultsTo(true);
+
+        ArgumentAcceptingOptionSpec<String> suspendInstancesOpt =
+                parser.accepts(SUSPEND_INSTANCE, "Suspended the given instances when debugging")
+                        .withRequiredArg()
+                        .ofType(String.class)
+                        .defaultsTo(EMPTY);
         try {
             CompositeOptionSet options = new CompositeOptionSet();
 
@@ -319,6 +329,7 @@ public class ApiTestConfig {
             this.callRateMeteringConfigPath = options.valueOf(callRateMeteringConfigPathOpt);
             this.enableBisqDebugging = options.valueOf(enableBisqDebuggingOpt);
             this.registerDisputeAgents = options.valueOf(registerDisputeAgentsOpt);
+            this.suspendedInstances = options.valueOf(suspendInstancesOpt);
 
             // Assign values to special-case static fields.
             BASH_PATH_VALUE = bashPath;

--- a/apitest/src/main/java/bisq/apitest/linux/BisqProcess.java
+++ b/apitest/src/main/java/bisq/apitest/linux/BisqProcess.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
@@ -66,8 +67,9 @@ public class BisqProcess extends AbstractLinuxProcess implements LinuxProcess {
         this.useDevPrivilegeKeys = true;
         this.findBisqPidScript = (config.isRunningTest ? "." : "./apitest")
                 + "/scripts/get-bisq-pid.sh";
-        this.debugOpts = config.enableBisqDebugging
-                ? " -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:" + bisqAppConfig.remoteDebugPort
+        this.debugOpts = config.enableBisqDebugging ? " -agentlib:jdwp=transport=dt_socket,server=y,"
+                + "suspend=" + (Arrays.asList(config.suspendedInstances.split(",")).contains(bisqAppConfig.name()) ? "y" : "n")
+                + ",address=*:" + bisqAppConfig.remoteDebugPort
                 : "";
     }
 


### PR DESCRIPTION
There's currently no way to suspend any subset of instances in debugging mode in Apitest.

This change enables any or all instances to be suspended in debugging mode by the inclusion of the instance name(s) in a CSV list in the apitest.properties file.