### PR TITLE
Fix failing TakeBuyBTCOfferTest

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyBTCOfferTest.java
@@ -59,8 +59,8 @@ public class TakeBuyBTCOfferTest extends AbstractTradeTest {
             PaymentAccount alicesUsdAccount = createDummyF2FAccount(aliceClient, "US");
             var alicesOffer = aliceClient.createMarketBasedPricedOffer(BUY.name(),
                     USD,
-                    12_500_000L,
-                    12_500_000L, // min-amount = amount
+                    10_000_000L,
+                    10_000_000L, // min-amount = amount
                     0.00,
                     defaultBuyerSecurityDepositPct.get(),
                     alicesUsdAccount.getId(),


### PR DESCRIPTION
The TakeBuyBTCOfferTest was failing as amount and minAmount were set above the maximum trade limit for a new user which is 0.1 BTC. 

This change sets amount and minAmount of the offer to 10_000_000, the max trade limit.


