### PR TITLE
Add reset buttons for BM accounting

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/accounting/BurningManAccountingService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/BurningManAccountingService.java
@@ -271,6 +271,15 @@ public class BurningManAccountingService implements DaoSetupService, DaoStateLis
     }
 
 
+    public void resyncAccountingDataFromScratch(Runnable resultHandler) {
+        burningManAccountingStoreService.removeAllBlocks(resultHandler);
+    }
+
+    public void resyncAccountingDataFromResources() {
+        burningManAccountingStoreService.deleteStorageFile();
+    }
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Delegates
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/dao/burningman/accounting/node/AccountingNodeProvider.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/node/AccountingNodeProvider.java
@@ -38,15 +38,16 @@ public class AccountingNodeProvider {
     @Inject
     public AccountingNodeProvider(AccountingLiteNode liteNode,
                                   AccountingFullNode fullNode,
-                                  @Named(Config.IS_BM_FULL_NODE) boolean isBmFullNode,
+                                  @Named(Config.IS_BM_FULL_NODE) boolean isBmFullNodeFromOptions,
                                   Preferences preferences) {
 
-        boolean rpcDataSet = preferences.getRpcUser() != null &&
-                !preferences.getRpcUser().isEmpty()
-                && preferences.getRpcPw() != null &&
-                !preferences.getRpcPw().isEmpty() &&
+        String rpcUser = preferences.getRpcUser();
+        String rpcPw = preferences.getRpcPw();
+        boolean rpcDataSet = rpcUser != null && !rpcUser.isEmpty() &&
+                rpcPw != null && !rpcPw.isEmpty() &&
                 preferences.getBlockNotifyPort() > 0;
-        if (isBmFullNode && rpcDataSet) {
+        boolean fullBMAccountingNode = preferences.isFullBMAccountingNode();
+        if ((fullBMAccountingNode || isBmFullNodeFromOptions) && rpcDataSet) {
             accountingNode = fullNode;
         } else {
             accountingNode = liteNode;

--- a/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStore.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStore.java
@@ -81,6 +81,16 @@ public class BurningManAccountingStore implements PersistableEnvelope {
         }
     }
 
+    public void removeAllBlocks() {
+        Lock writeLock = readWriteLock.writeLock();
+        writeLock.lock();
+        try {
+            blocks.clear();
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
     public Optional<AccountingBlock> getLastBlock() {
         Lock readLock = readWriteLock.readLock();
         readLock.lock();

--- a/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStoreService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStoreService.java
@@ -49,6 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class BurningManAccountingStoreService extends StoreService<BurningManAccountingStore> {
     private static final String FILE_NAME = "BurningManAccountingStore_v2";
+    private volatile boolean removeAllBlocksCalled;
 
     @Inject
     public BurningManAccountingStoreService(ResourceDataStoreService resourceDataStoreService,
@@ -82,6 +83,9 @@ public class BurningManAccountingStoreService extends StoreService<BurningManAcc
     }
 
     public void addIfNewBlock(AccountingBlock block) throws BlockHashNotConnectingException, BlockHeightNotConnectingException {
+        if (removeAllBlocksCalled) {
+            return;
+        }
         store.addIfNewBlock(block);
         requestPersistence();
     }
@@ -91,8 +95,25 @@ public class BurningManAccountingStoreService extends StoreService<BurningManAcc
     }
 
     public void purgeLastTenBlocks() {
+        if (removeAllBlocksCalled) {
+            return;
+        }
         store.purgeLastTenBlocks();
         requestPersistence();
+    }
+
+    public void removeAllBlocks(Runnable resultHandler) {
+        removeAllBlocksCalled = true;
+        store.removeAllBlocks();
+        persistenceManager.persistNow(resultHandler);
+    }
+
+    public void deleteStorageFile() {
+        try {
+            FileUtil.deleteFileIfExists(Path.of(absolutePathOfStorageDir, FILE_NAME).toFile());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public Optional<AccountingBlock> getLastBlock() {

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -772,7 +772,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     public void setDaoFullNode(boolean value) {
         // We only persist if we have not set the program argument
-        if (config.fullDaoNodeOptionSetExplicitly) {
+        if (!config.fullDaoNodeOptionSetExplicitly) {
             prefPayload.setDaoFullNode(value);
             requestPersistence();
         }
@@ -850,6 +850,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     public void setProcessBurningManAccountingData(boolean processBurningManAccountingData) {
         prefPayload.setProcessBurningManAccountingData(processBurningManAccountingData);
+        requestPersistence();
+    }
+
+    public void setFullBMAccountingNode(boolean isFullBMAccountingNode) {
+        prefPayload.setFullBMAccountingNode(isFullBMAccountingNode);
         requestPersistence();
     }
 
@@ -1023,6 +1028,10 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         return fullAccountingNodeFromOptions || prefPayload.isProcessBurningManAccountingData();
     }
 
+    public boolean isFullBMAccountingNode() {
+        return prefPayload.isFullBMAccountingNode();
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
@@ -1145,6 +1154,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
         boolean isProcessBurningManAccountingData();
 
+        boolean isFullBMAccountingNode();
+
         void setDaoFullNode(boolean value);
 
         void setRpcUser(String value);
@@ -1190,5 +1201,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         void setUserHasRaisedTradeLimit(boolean userHasRaisedTradeLimit);
 
         void setProcessBurningManAccountingData(boolean processBurningManAccountingData);
+
+        void setFullBMAccountingNode(boolean isFullBMAccountingNode);
     }
 }

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -148,6 +148,10 @@ public final class PreferencesPayload implements PersistableEnvelope {
     // Added at 1.9.11
     private boolean processBurningManAccountingData = false;
 
+    // Added at 1.9.11
+    private boolean isFullBMAccountingNode = false;
+
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -220,7 +224,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .setUseBitcoinUrisInQrCodes(useBitcoinUrisInQrCodes)
                 .setUserDefinedTradeLimit(userDefinedTradeLimit)
                 .setUserHasRaisedTradeLimit(userHasRaisedTradeLimit)
-                .setProcessBurningManAccountingData(processBurningManAccountingData);
+                .setProcessBurningManAccountingData(processBurningManAccountingData)
+                .setIsFullBMAccountingNode(isFullBMAccountingNode);
 
         Optional.ofNullable(backupDirectory).ifPresent(builder::setBackupDirectory);
         Optional.ofNullable(preferredTradeCurrency).ifPresent(e -> builder.setPreferredTradeCurrency((protobuf.TradeCurrency) e.toProtoMessage()));
@@ -328,7 +333,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.getUseBitcoinUrisInQrCodes(),
                 proto.getUserHasRaisedTradeLimit() ? proto.getUserDefinedTradeLimit() : Preferences.INITIAL_TRADE_LIMIT,
                 proto.getUserHasRaisedTradeLimit(),
-                proto.getProcessBurningManAccountingData()
+                proto.getProcessBurningManAccountingData(),
+                proto.getIsFullBMAccountingNode()
         );
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1427,6 +1427,28 @@ setting.preferences.resetAllFlags=Reset all \"Don't show again\" flags
 settings.preferences.languageChange=To apply the language change to all screens requires a restart.
 settings.preferences.supportLanguageWarning=In case of a dispute, please note that mediation is handled in {0} and arbitration in {1}.
 setting.preferences.daoOptions=DAO options
+
+setting.preferences.dao.resyncBMAccFromScratch=Resync from scratch
+setting.preferences.dao.resyncBMAccFromScratch.popup=To resync the Burningmen accounting data from scratch you need to run a full Bitcoin node.\n\
+  It will take considerable time and CPU resources as it resyncs from 2020 when legacy BM started. Depending on your CPU resources that can take 20-40 hours.\n\n\
+  Are you sure you want to do that?\n\n\
+  Mostly a resync from latest resource files is sufficient and much faster.\n\n\
+  If you proceed, after an application restart the Burningmen accounting data will be rebuild from the transactions requested from your Bitcoin node.
+setting.preferences.dao.resyncBMAccFromScratch.resync=Resync from scratch and shutdown
+setting.preferences.dao.isFullBMAccountingNode=Full BM accounting node
+setting.preferences.dao.resyncBMAccFromResources=Resync from resources
+setting.preferences.dao.resyncBMAccFromResources.popup=To resync the Burningmen accounting data from resources you \
+  will reapply the data from resources of your last downloaded Bisq version and load the missing data from the network.\n\
+  Depending on the age of your last Bisq download that might take a while.\n\n\
+  Are you sure you want to do that?
+setting.preferences.dao.resyncBMAccFromResources.resync=Resync from resources and shutdown
+
+setting.preferences.dao.useFullBMAccountingNode.noDaoMode.popup=To run as full Burningmen accounting node you need to run as full DAO node as well.\n\n\
+  Please enable first the Full-DAO mode option and config RPC.
+setting.preferences.dao.useFullBMAccountingNode.enabledDaoMode.popup=To run as full Burningmen accounting node can take considerable time and CPU resources.\n\n\
+  A restart is required to enable that change.\n\n\
+  Do you want to enable full Burningmen accounting mode?.
+
 setting.preferences.dao.resyncFromGenesis.label=Rebuild DAO state from genesis tx
 setting.preferences.dao.resyncFromResources.label=Rebuild DAO state from resources
 setting.preferences.dao.resyncFromResources.popup=After an application restart the Bisq network governance data will be reloaded from \

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1972,6 +1972,7 @@ message PreferencesPayload {
     int64 user_defined_trade_limit = 67;
     bool user_has_raised_trade_limit = 68;
     bool process_burning_man_accounting_data = 69;
+    bool is_full_b_m_accounting_node = 70;
 }
 
 message AutoConfirmSettings {


### PR DESCRIPTION
Adds button in Settings/DAO to enable full BM accounting mode and reset data to scratch (back to 2020) or resync from latest resource file data.