### PR TITLE
Use new burningman accounting file from full accounting node

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStoreService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStoreService.java
@@ -48,7 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Singleton
 public class BurningManAccountingStoreService extends StoreService<BurningManAccountingStore> {
-    private static final String FILE_NAME = "BurningManAccountingStore_v2";
+    private static final String FILE_NAME = "BurningManAccountingStore_v3";
 
     @Inject
     public BurningManAccountingStoreService(ResourceDataStoreService resourceDataStoreService,
@@ -66,6 +66,7 @@ public class BurningManAccountingStoreService extends StoreService<BurningManAcc
             try {
                 // Delete old BurningManAccountingStore file which was missing some data.
                 FileUtil.deleteFileIfExists(Path.of(absolutePathOfStorageDir, "BurningManAccountingStore").toFile());
+                FileUtil.deleteFileIfExists(Path.of(absolutePathOfStorageDir, "BurningManAccountingStore_v2").toFile());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
PR https://github.com/bisq-network/bisq/pull/6740 was a diff against master (instead against the release/v1.9.11 branch). The previous merge into the release branch corrupted the accounting file.