### PR TITLE
Change bond roles names for Bisq 2 roles

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2301,19 +2301,19 @@ dao.bond.bondedRoleType.UNDEFINED=Undefined
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.GITHUB_ADMIN=GitHub admin
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.FORUM_ADMIN=Forum admin
+dao.bond.bondedRoleType.FORUM_ADMIN=Bisq 2 release manager
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.TWITTER_ADMIN=Twitter admin
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.ROCKET_CHAT_ADMIN=Keybase admin
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.YOUTUBE_ADMIN=YouTube admin
+dao.bond.bondedRoleType.YOUTUBE_ADMIN=Bisq 2 moderator
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.BISQ_MAINTAINER=Bisq maintainer
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.BITCOINJ_MAINTAINER=BitcoinJ-fork maintainer
+dao.bond.bondedRoleType.BITCOINJ_MAINTAINER=Bisq 2 security manager
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.NETLAYER_MAINTAINER=Netlayer maintainer
+dao.bond.bondedRoleType.NETLAYER_MAINTAINER=Bisq 2 oracle node
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.WEBSITE_OPERATOR=Website operator
 # suppress inspection "UnusedProperty"
@@ -2329,7 +2329,7 @@ dao.bond.bondedRoleType.MARKETS_OPERATOR=Markets operator
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.BSQ_EXPLORER_OPERATOR=Explorer operator
 # suppress inspection "UnusedProperty"
-dao.bond.bondedRoleType.MOBILE_NOTIFICATIONS_RELAY_OPERATOR=Mobile notifications relay operator
+dao.bond.bondedRoleType.MOBILE_NOTIFICATIONS_RELAY_OPERATOR=Bisq 2 arbitrator
 # suppress inspection "UnusedProperty"
 dao.bond.bondedRoleType.DOMAIN_NAME_HOLDER=Domain name holder
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
Repurpose not used bonded roles for Bisq 2 roles.

We prefer to not add new roles to avoid risks with DAO consensus issues.


