### PR TITLE
Fix broken codacy coverage reporter

### DIFF
--- a/.github/codacy-coverage-reporter.yml
+++ b/.github/codacy-coverage-reporter.yml
@@ -1,0 +1,30 @@
+name: Codacy Coverage Reporter
+
+on: ["push"]
+
+permissions:
+    contents: read
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        name: codacy-coverage-reporter
+        steps:
+            - uses: actions/checkout@v3.5.3
+
+            - name: Set up JDK
+              uses: actions/setup-java@v3.11.0
+              with:
+                  java-version: '15'
+                  distribution: 'zulu'
+
+            - name: Build with Gradle
+              uses: gradle/gradle-build-action@v2.5.1
+              with:
+                  arguments: build jacocoTestReport testCodeCoverageReport --scan
+
+            - name: Run codacy-coverage-reporter
+              uses: codacy/codacy-coverage-reporter-action@v1.3.0
+              with:
+                  project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+                  coverage-reports: ${{ github.workspace }}/code-coverage-report/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,26 +28,4 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2.5.1
       with:
-        arguments: build jacocoTestReport testCodeCoverageReport --scan
-
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v3
-      with:
-          name: coverage-report
-          path: code-coverage-report/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
-
-  publish_coverage:
-    name: Publish coverage
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-        - name: Download coverage report
-          uses: actions/download-artifact@v3
-          with:
-              name: coverage-report
-              path: code-coverage-report/build/reports/jacoco/testCodeCoverageReport
-        - name: Run codacy-coverage-reporter
-          uses: codacy/codacy-coverage-reporter-action@v1.3.0
-          with:
-              project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-              coverage-reports: ${{ github.workspace }}/code-coverage-report/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+        arguments: build --scan


### PR DESCRIPTION
All PR CI runs fail due to the misconfigured codacy coverage reporter.
