### PR TITLE
JLinkTask: Make Java Modules Optional

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JLinkTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JLinkTask.kt
@@ -15,7 +15,7 @@ abstract class JLinkTask : DefaultTask() {
     abstract val jdkDirectory: DirectoryProperty
 
     @get:InputDirectory
-    abstract val javaFxJmodsDirectory: DirectoryProperty
+    abstract val javaModulesDirectory: DirectoryProperty
 
     @get:InputFile
     abstract val jDepsOutputFile: RegularFileProperty
@@ -33,7 +33,7 @@ abstract class JLinkTask : DefaultTask() {
         val processBuilder = ProcessBuilder(
                 jLinkPath.toAbsolutePath().toString(),
 
-                "--module-path", javaFxJmodsDirectory.asFile.get().absolutePath,
+                "--module-path", javaModulesDirectory.asFile.get().absolutePath,
                 "--add-modules", parseUsedJavaModulesFromJDepsOutput(),
 
                 "--strip-native-commands",


### PR DESCRIPTION
- [JLinkTask: Rename javaFxJmodsDirectory to javaModulesDirectory](https://github.com/bisq-network/bisq/commit/456925303455d30cde87cfed2a09571c00629bfb)
- [JLinkTask: Make javaModulesDirectory optional](https://github.com/bisq-network/bisq/commit/793e7a28e2037f0b526cd5a25443c33887cf71a9)