### PR TITLE
Fix codacy coverage reporter Java version

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Set up JDK
               uses: actions/setup-java@v3.12.0
               with:
-                  java-version: '15'
+                  java-version: '11'
                   distribution: 'zulu'
 
             - name: Build with Gradle


### PR DESCRIPTION
@alvasw's PRs enforce Java 11 but the codacy coverage reporter yml file uses Java 15.