### PR TITLE
Speedup Makefile Deployment and Restore Targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,12 +152,6 @@ deploy: setup
 	sleep 5
 	# generate a block to ensure Bisq nodes get dao-synced
 	make block
-	tail -f .localnet/bitcoind_shell.log \
-			.localnet/seednode_1_shell.log \
-			.localnet/seednode_2_shell.log \
-			.localnet/alice_shell.log \
-			.localnet/bob_shell.log \
-			.localnet/mediator_shell.log
 
 # Undeploy a running localnet by killing all Bitcoin and Bisq
 # node processes, then killing the localnet screen session altogether

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,77 @@ deploy: setup
 undeploy:
 	./gradlew :stopRegtest
 
+bitcoind: .localnet
+	bitcoind \
+		-regtest \
+		-prune=0 \
+		-txindex=1 \
+		-peerbloomfilters=1 \
+		-server \
+		-rpcuser=bisqdao \
+		-rpcpassword=bsq \
+		-datadir=.localnet/bitcoind \
+		-blocknotify='.localnet/bitcoind/blocknotify %s'
+
+seednode: seednode/build
+	./bisq-seednode \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--fullDaoNode=true \
+		--rpcUser=bisqdao \
+		--rpcPassword=bsq \
+		--rpcBlockNotificationPort=5120 \
+		--nodePort=2002 \
+		--userDataDir=.localnet \
+		--appName=seednode
+
+seednode2: seednode/build
+	./bisq-seednode \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--fullDaoNode=true \
+		--rpcUser=bisqdao \
+		--rpcPassword=bsq \
+		--rpcBlockNotificationPort=5121 \
+		--nodePort=3002 \
+		--userDataDir=.localnet \
+		--appName=seednode2
+
+mediator: desktop/build
+	./bisq-desktop \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--nodePort=4444 \
+		--appDataDir=.localnet/mediator \
+		--appName=Mediator
+
+alice: setup
+	./bisq-desktop \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--nodePort=5555 \
+		--fullDaoNode=true \
+		--rpcUser=bisqdao \
+		--rpcPassword=bsq \
+		--rpcBlockNotificationPort=5122 \
+		--genesisBlockHeight=111 \
+		--genesisTxId=30af0050040befd8af25068cc697e418e09c2d8ebd8d411d2240591b9ec203cf \
+		--appDataDir=.localnet/alice \
+		--appName=Alice
+
+bob: setup
+	./bisq-desktop \
+		--baseCurrencyNetwork=BTC_REGTEST \
+		--useLocalhostForP2P=true \
+		--useDevPrivilegeKeys=true \
+		--nodePort=6666 \
+		--appDataDir=.localnet/bob \
+		--appName=Bob
+
 # Generate a new block on your Bitcoin regtest network. Requires that
 # bitcoind is already running. See the `bitcoind` target above.
 block:

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@
 
 # Set up everything necessary for deploying your localnet. This is the
 # default target.
-setup: .localnet
+setup: build .localnet
 
 clean: clean-build clean-localnet
 
@@ -109,6 +109,15 @@ clean-build:
 
 clean-localnet:
 	rm -rf .localnet ./dao-setup
+
+# Build Bisq binaries and shell scripts used in the targets below
+build: seednode/build desktop/build
+
+seednode/build:
+	./gradlew :seednode:build
+
+desktop/build:
+	./gradlew :desktop:build
 
 # Unpack and customize a Bitcoin regtest node and Alice and Bob Bisq
 # nodes that have been preconfigured with a blockchain containing the

--- a/Makefile
+++ b/Makefile
@@ -165,16 +165,7 @@ undeploy:
 	./gradlew :stopRegtest
 
 bitcoind: .localnet
-	bitcoind \
-		-regtest \
-		-prune=0 \
-		-txindex=1 \
-		-peerbloomfilters=1 \
-		-server \
-		-rpcuser=bisqdao \
-		-rpcpassword=bsq \
-		-datadir=.localnet/bitcoind \
-		-blocknotify='.localnet/bitcoind/blocknotify %s'
+	./gradlew :stopRegtestBitcoind :startRegtestBitcoind
 
 seednode: seednode/build
 	./bisq-seednode \

--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/StartBisqTask.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/StartBisqTask.kt
@@ -32,12 +32,6 @@ abstract class StartBisqTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        ProcessKiller(pidFile.asFile.get())
-            .kill()
-
-        // Wait until process stopped
-        Thread.sleep(5000)
-
         val processBuilder = ProcessBuilder(
             javaExecutable.asFile.get().absolutePath,
 

--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/StartBitcoindTask.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/StartBitcoindTask.kt
@@ -28,12 +28,6 @@ abstract class StartBitcoindTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        ProcessKiller(pidFile.asFile.get())
-                .kill()
-
-        // Wait until process stopped
-        Thread.sleep(5000)
-
         val processBuilder = ProcessBuilder(
                 "bitcoind",
                 "-datadir=${dataDirectory.asFile.get().absolutePath}",


### PR DESCRIPTION
- [Regtest: Bypass recursive Gradle invocations](https://github.com/bisq-network/bisq/commit/f872d41d30435ec316ebd8766b39e95ec6576184)
- [Regtest: Don't kill old instances](https://github.com/bisq-network/bisq/commit/3930966f3e993dce1827e05ae9a0f555efc373de)
- [Revert "Makefile: Don't build twice"](https://github.com/bisq-network/bisq/commit/e2c13d027715d1f0d2274b55ba9f2fcdd20272b9)
- [Revert "Makefile: Remove old targets"](https://github.com/bisq-network/bisq/commit/72d1f0ae89e1c8f6ac370be626cca0b0725cd7eb)
- [Makefile: Stop running instance before starting new](https://github.com/bisq-network/bisq/commit/803abc3d0b4a9f3a732feca1da137f05848587ad)
- [Makefile: Don't spam console with all nodes' logs](https://github.com/bisq-network/bisq/commit/593d17c32f2c354bb5532a3b0847f0cdbb608c9f)