### PR TITLE
Set seednode JVM arguments

### DIFF
--- a/build-logic/app-start-plugin/src/main/kotlin/bisq/gradle/app_start_plugin/AppStartPlugin.kt
+++ b/build-logic/app-start-plugin/src/main/kotlin/bisq/gradle/app_start_plugin/AppStartPlugin.kt
@@ -26,6 +26,11 @@ class AppStartPlugin @Inject constructor(private val javaToolchainService: JavaT
             dependsOn(installDistTask)
             javaLauncher.set(getJavaLauncher(project))
 
+            if (project.name == "seednode") {
+                minHeapSize = "4096M"
+                maxHeapSize = "4096M"
+            }
+
             classpath = installDistTask.map {
                 val appLibsDir = File(it.destinationDir, "lib")
                 val allFiles = appLibsDir.listFiles()

--- a/seednode/build.gradle
+++ b/seednode/build.gradle
@@ -3,7 +3,10 @@ plugins {
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
-mainClassName = 'bisq.seednode.SeedNodeMain'
+application {
+    mainClass = 'bisq.seednode.SeedNodeMain'
+    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError']
+}
 
 dependencies {
     implementation enforcedPlatform(project(':platform'))


### PR DESCRIPTION
- [seednode: Set ExitOnOutOfMemoryError JVM arg](https://github.com/bisq-network/bisq/commit/79992ed991f7b1b7883e29a99a7ecfaa75128102)
- [seednode: Set JVM heap size to 4096M](https://github.com/bisq-network/bisq/commit/34fc85f9c6e077ece06da3a9aa9f1b713b6688c3)

Logs:
```
[main] INFO  b.c.u.Profiler: Total memory: 4 GB; Used memory: 44 MB; Free memory: 3.957 GB; Max memory: 4 GB; No. of threads: 1 
[main] INFO  b.c.s.CoreNetworkCapabilities: TRADE_STATISTICS [0], TRADE_STATISTICS_2 [1], ACCOUNT_AGE_WITNESS [2], PROPOSAL [5], BLIND_VOTE [6], ACK_MSG [7], RECEIVE_BSQ_BLOCK [8], DAO_STATE [9], BUNDLE_OF_ENVELOPES [10], SIGNED_ACCOUNT_AGE_WITNESS [11], MEDIATION [12], REFUND_AGENT [13], TRADE_STATISTICS_HASH_UPDATE [14], NO_ADDRESS_PRE_FIX [15], TRADE_STATISTICS_3 [16], BSQ_SWAP_OFFER [17] 
[main] INFO  b.c.l.GlobalSettings: Locale info: en 
```