### PR TITLE
Remove Azul JDK Enforcement

### DIFF
--- a/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
@@ -12,8 +12,6 @@ repositories {
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.AZUL
-        implementation = JvmImplementation.VENDOR_SPECIFIC
     }
 }
 

--- a/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
     id 'java'
     id 'jacoco'
@@ -11,7 +13,11 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        if (Os.isFamily(Os.FAMILY_MAC)) {
+            languageVersion = JavaLanguageVersion.of(15)
+        } else {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
     }
 }
 


### PR DESCRIPTION
- [Remove Azul JDK Enforcement](https://github.com/bisq-network/bisq/commit/7ae04bfc396ce5a3d38ba63b98c9a243aedad709)
  - This is not needed anymore.
- [Fallback to Java 15 on macOS](https://github.com/bisq-network/bisq/commit/294fcb34592d79384e9cc953c510481ec724f24c)