### PR TITLE
Fix initial data request handling

### DIFF
--- a/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
+++ b/core/src/main/java/bisq/core/account/sign/SignedWitnessService.java
@@ -140,7 +140,7 @@ public class SignedWitnessService {
         } else {
             p2PService.addP2PServiceListener(new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     onBootstrapComplete();
                 }
             });

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitnessService.java
@@ -214,7 +214,7 @@ public class AccountAgeWitnessService {
         } else {
             p2PService.addP2PServiceListener(new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     onBootStrapped();
                 }
             });

--- a/core/src/main/java/bisq/core/app/AppStartupState.java
+++ b/core/src/main/java/bisq/core/app/AppStartupState.java
@@ -48,7 +48,7 @@ public class AppStartupState {
     private final BooleanProperty walletAndNetworkReady = new SimpleBooleanProperty();
     private final BooleanProperty allDomainServicesInitialized = new SimpleBooleanProperty();
     private final BooleanProperty applicationFullyInitialized = new SimpleBooleanProperty();
-    private final BooleanProperty updatedDataReceived = new SimpleBooleanProperty();
+    private final BooleanProperty dataReceived = new SimpleBooleanProperty();
     private final BooleanProperty isBlockDownloadComplete = new SimpleBooleanProperty();
     private final BooleanProperty hasSufficientPeersForBroadcast = new SimpleBooleanProperty();
 
@@ -57,8 +57,8 @@ public class AppStartupState {
 
         p2PService.addP2PServiceListener(new BootstrapListener() {
             @Override
-            public void onUpdatedDataReceived() {
-                updatedDataReceived.set(true);
+            public void onDataReceived() {
+                dataReceived.set(true);
             }
         });
 
@@ -72,7 +72,7 @@ public class AppStartupState {
                 hasSufficientPeersForBroadcast.set(true);
         });
 
-        p2pNetworkAndWalletInitialized = EasyBind.combine(updatedDataReceived,
+        p2pNetworkAndWalletInitialized = EasyBind.combine(dataReceived,
                 isBlockDownloadComplete,
                 hasSufficientPeersForBroadcast,
                 allDomainServicesInitialized,
@@ -120,14 +120,6 @@ public class AppStartupState {
 
     public ReadOnlyBooleanProperty applicationFullyInitializedProperty() {
         return applicationFullyInitialized;
-    }
-
-    public boolean isUpdatedDataReceived() {
-        return updatedDataReceived.get();
-    }
-
-    public ReadOnlyBooleanProperty updatedDataReceivedProperty() {
-        return updatedDataReceived;
     }
 
     public boolean isBlockDownloadComplete() {

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -849,8 +849,8 @@ public class BisqSetup {
         return p2PNetworkSetup.getP2PNetworkStatusIconId();
     }
 
-    public BooleanProperty getUpdatedDataReceived() {
-        return p2PNetworkSetup.getUpdatedDataReceived();
+    public BooleanProperty getDataReceived() {
+        return p2PNetworkSetup.getDataReceived();
     }
 
     public StringProperty getP2pNetworkLabelId() {

--- a/core/src/main/java/bisq/core/app/P2PNetworkSetup.java
+++ b/core/src/main/java/bisq/core/app/P2PNetworkSetup.java
@@ -73,7 +73,7 @@ public class P2PNetworkSetup {
     @Getter
     final StringProperty p2pNetworkWarnMsg = new SimpleStringProperty();
     @Getter
-    final BooleanProperty updatedDataReceived = new SimpleBooleanProperty();
+    final BooleanProperty dataReceived = new SimpleBooleanProperty();
     @Getter
     final BooleanProperty p2pNetworkFailed = new SimpleBooleanProperty();
     final FilterManager filterManager;
@@ -97,12 +97,11 @@ public class P2PNetworkSetup {
         StringProperty bootstrapState = new SimpleStringProperty();
         StringProperty bootstrapWarning = new SimpleStringProperty();
         BooleanProperty hiddenServicePublished = new SimpleBooleanProperty();
-        BooleanProperty initialP2PNetworkDataReceived = new SimpleBooleanProperty();
 
         addP2PMessageFilter();
 
         p2PNetworkInfoBinding = EasyBind.combine(bootstrapState, bootstrapWarning, p2PService.getNumConnectedPeers(),
-                walletsSetup.numPeersProperty(), hiddenServicePublished, initialP2PNetworkDataReceived,
+                walletsSetup.numPeersProperty(), hiddenServicePublished, dataReceived,
                 (state, warning, numP2pPeers, numBtcPeers, hiddenService, dataReceived) -> {
                     String result;
                     String daoFullNode = preferences.isDaoFullNode() ? Res.get("mainView.footer.daoFullNode") + " / " : "";
@@ -171,8 +170,8 @@ public class P2PNetworkSetup {
             @Override
             public void onDataReceived() {
                 log.debug("onRequestingDataCompleted");
-                initialP2PNetworkDataReceived.set(true);
                 bootstrapState.set(Res.get("mainView.bootstrapState.initialDataReceived"));
+                dataReceived.set(true);
                 splashP2PNetworkAnimationVisible.set(false);
                 p2pNetworkInitialized.set(true);
             }
@@ -208,7 +207,6 @@ public class P2PNetworkSetup {
             public void onUpdatedDataReceived() {
                 log.debug("onUpdatedDataReceived");
                 splashP2PNetworkAnimationVisible.set(false);
-                updatedDataReceived.set(true);
             }
 
             @Override

--- a/core/src/main/java/bisq/core/dao/burningman/accounting/node/AccountingNode.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/node/AccountingNode.java
@@ -183,7 +183,7 @@ public abstract class AccountingNode implements DaoSetupService, DaoStateListene
             }
 
             @Override
-            public void onUpdatedDataReceived() {
+            public void onDataReceived() {
                 onP2PNetworkReady();
             }
         };

--- a/core/src/main/java/bisq/core/dao/node/BsqNode.java
+++ b/core/src/main/java/bisq/core/dao/node/BsqNode.java
@@ -113,6 +113,7 @@ public abstract class BsqNode implements DaoSetupService {
 
             @Override
             public void onDataReceived() {
+                onP2PNetworkReady();
             }
 
             @Override
@@ -126,7 +127,6 @@ public abstract class BsqNode implements DaoSetupService {
 
             @Override
             public void onUpdatedDataReceived() {
-                onP2PNetworkReady();
             }
         };
     }

--- a/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
+++ b/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
@@ -91,9 +91,12 @@ class GetBlocksRequestHandler {
 
     public void onGetBlocksRequest(GetBlocksRequest getBlocksRequest, Connection connection) {
         long ts = System.currentTimeMillis();
-        // We limit number of blocks to 3000 which is about 3 weeks.
-        List<Block> blocks = new LinkedList<>(daoStateService.getBlocksFromBlockHeight(getBlocksRequest.getFromBlockHeight(), 3000));
-        List<RawBlock> rawBlocks = blocks.stream().map(RawBlock::fromBlock).collect(Collectors.toList());
+        // We limit number of blocks to 3000 which is about 3 weeks and about 5 MB on data
+        List<Block> blocks = daoStateService.getBlocksFromBlockHeight(getBlocksRequest.getFromBlockHeight());
+        List<RawBlock> rawBlocks = new LinkedList<>(blocks).stream()
+                .map(RawBlock::fromBlock)
+                .limit(3000)
+                .collect(Collectors.toList());
         GetBlocksResponse getBlocksResponse = new GetBlocksResponse(rawBlocks, getBlocksRequest.getNonce());
         log.info("Received GetBlocksRequest from {} for blocks from height {}. " +
                         "Building GetBlocksResponse with {} blocks took {} ms.",

--- a/core/src/main/java/bisq/core/dao/node/lite/network/RequestBlocksHandler.java
+++ b/core/src/main/java/bisq/core/dao/node/lite/network/RequestBlocksHandler.java
@@ -128,7 +128,7 @@ public class RequestBlocksHandler implements MessageListener {
                 },
                 TIMEOUT_MIN, TimeUnit.MINUTES);
 
-        log.info("We request blocks from peer {} from block height {}.", nodeAddress, getBlocksRequest.getFromBlockHeight());
+        log.info("\n\n>> We request blocks from peer {} from block height {}.\n", nodeAddress, getBlocksRequest.getFromBlockHeight());
 
         networkNode.addMessageListener(this);
 
@@ -136,7 +136,7 @@ public class RequestBlocksHandler implements MessageListener {
         Futures.addCallback(future, new FutureCallback<>() {
             @Override
             public void onSuccess(Connection connection) {
-                log.info("Sending of GetBlocksRequest message to peer {} succeeded.", nodeAddress.getFullAddress());
+                log.debug("Sending of GetBlocksRequest message to peer {} succeeded.", nodeAddress.getFullAddress());
             }
 
             @Override
@@ -190,7 +190,9 @@ public class RequestBlocksHandler implements MessageListener {
             }
 
             terminate();
-            log.info("We received from peer {} a BlocksResponse with {} blocks",
+            log.info("\n#################################################################\n" +
+                            "We received from peer {} a BlocksResponse with {} blocks" +
+                            "\n#################################################################\n",
                     nodeAddress.getFullAddress(), getBlocksResponse.getBlocks().size());
             listener.onComplete(getBlocksResponse);
         }

--- a/core/src/main/java/bisq/core/dao/node/messages/GetBlocksResponse.java
+++ b/core/src/main/java/bisq/core/dao/node/messages/GetBlocksResponse.java
@@ -75,7 +75,7 @@ public final class GetBlocksResponse extends NetworkEnvelope implements DirectMe
         List<RawBlock> list = proto.getRawBlocksList().stream()
                 .map(RawBlock::fromProto)
                 .collect(Collectors.toList());
-        log.info("Received a GetBlocksResponse with {} blocks and {} kB size", list.size(), proto.getSerializedSize() / 1000d);
+        log.info("\n\n<< Received a GetBlocksResponse with {} blocks and {} kB size\n", list.size(), proto.getSerializedSize() / 1000d);
         return new GetBlocksResponse(proto.getRawBlocksList().isEmpty() ?
                 new ArrayList<>() :
                 list,

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -349,15 +349,8 @@ public class DaoStateService implements DaoSetupService {
     }
 
     public List<Block> getBlocksFromBlockHeight(int fromBlockHeight) {
-        return getBlocksFromBlockHeight(fromBlockHeight, Integer.MAX_VALUE);
-    }
-
-    public List<Block> getBlocksFromBlockHeight(int fromBlockHeight, int numMaxBlocks) {
-        // We limit requests to numMaxBlocks blocks, to avoid performance issues and too
-        // large network data in case a node requests too far back in history.
         return getBlocks().stream()
                 .filter(block -> block.getHeight() >= fromBlockHeight)
-                .limit(numMaxBlocks)
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -188,6 +188,12 @@ public class FilterManager {
         p2PService.addP2PServiceListener(new P2PServiceListener() {
             @Override
             public void onDataReceived() {
+                // We should have received all data at that point and if the filters were not set we
+                // clean up the persisted banned nodes in the options file as it might be that we missed the filter
+                // remove message if we have not been online.
+                if (filterProperty.get() == null) {
+                    clearBannedNodes();
+                }
             }
 
             @Override
@@ -200,12 +206,6 @@ public class FilterManager {
 
             @Override
             public void onUpdatedDataReceived() {
-                // We should have received all data at that point and if the filters were not set we
-                // clean up the persisted banned nodes in the options file as it might be that we missed the filter
-                // remove message if we have not been online.
-                if (filterProperty.get() == null) {
-                    clearBannedNodes();
-                }
             }
 
             @Override

--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -112,7 +112,7 @@ public class OfferBookService {
         if (dumpStatistics) {
             p2PService.addP2PServiceListener(new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     addOfferBookChangedListener(new OfferBookChangedListener() {
                         @Override
                         public void onAdded(Offer offer) {

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -211,7 +211,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         } else {
             p2PService.addP2PServiceListener(new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     onBootstrapComplete();
                 }
             });

--- a/core/src/main/java/bisq/core/offer/bisq_v1/TriggerPriceService.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/TriggerPriceService.java
@@ -78,7 +78,7 @@ public class TriggerPriceService {
         } else {
             p2PService.addP2PServiceListener(new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     onBootstrapComplete();
                 }
             });

--- a/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
@@ -122,7 +122,7 @@ public class OpenBsqSwapOfferService {
         };
         bootstrapListener = new BootstrapListener() {
             @Override
-            public void onUpdatedDataReceived() {
+            public void onDataReceived() {
                 onP2PServiceReady();
                 p2PService.removeP2PServiceListener(bootstrapListener);
             }

--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -253,7 +253,7 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
 
         p2PService.addP2PServiceListener(new BootstrapListener() {
             @Override
-            public void onUpdatedDataReceived() {
+            public void onDataReceived() {
                 tryApplyMessages();
                 checkDisputesForUpdates();
             }

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentManager.java
@@ -161,7 +161,7 @@ public abstract class DisputeAgentManager<T extends DisputeAgent> {
             else
                 p2PService.addP2PServiceListener(new BootstrapListener() {
                     @Override
-                    public void onUpdatedDataReceived() {
+                    public void onDataReceived() {
                         startRepublishDisputeAgent();
                     }
                 });

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -400,7 +400,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         } else {
             p2PService.addP2PServiceListener(new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     initPersistedTrades();
                 }
             });

--- a/core/src/main/java/bisq/core/trade/bisq_v1/CleanupMailboxMessagesService.java
+++ b/core/src/main/java/bisq/core/trade/bisq_v1/CleanupMailboxMessagesService.java
@@ -69,7 +69,7 @@ public class CleanupMailboxMessagesService {
             } else {
                 p2PService.addP2PServiceListener(new BootstrapListener() {
                     @Override
-                    public void onUpdatedDataReceived() {
+                    public void onDataReceived() {
                         cleanupMailboxMessages(trades);
                     }
                 });

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsConverter.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsConverter.java
@@ -95,7 +95,7 @@ public class TradeStatisticsConverter {
             }
 
             @Override
-            public void onUpdatedDataReceived() {
+            public void onDataReceived() {
             }
         });
 

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
@@ -337,7 +337,7 @@ public class XmrTxProofService implements AssetTxProofService {
         } else {
             bootstrapListener = new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     p2PService.removeP2PServiceListener(bootstrapListener);
                     result.set(true);
                 }

--- a/desktop/src/main/java/bisq/desktop/main/MainView.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainView.java
@@ -820,7 +820,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>
             }
         });
 
-        model.getUpdatedDataReceived().addListener((observable, oldValue, newValue) -> {
+        model.getDataReceived().addListener((observable, oldValue, newValue) -> {
             p2PNetworkIcon.setOpacity(1);
             p2pNetworkProgressBar.setProgress(0);
         });

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -536,7 +536,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         } else {
             p2PService.addP2PServiceListener(new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     setupInvalidOpenOffersHandler();
                 }
             });
@@ -699,7 +699,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
             } else {
                 p2PService.addP2PServiceListener(new BootstrapListener() {
                     @Override
-                    public void onUpdatedDataReceived() {
+                    public void onDataReceived() {
                         accountAgeWitnessService.publishMyAccountAgeWitness(aliPayAccount.getPaymentAccountPayload());
                     }
                 });
@@ -842,8 +842,8 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         return bisqSetup.getP2PNetworkStatusIconId();
     }
 
-    BooleanProperty getUpdatedDataReceived() {
-        return bisqSetup.getUpdatedDataReceived();
+    BooleanProperty getDataReceived() {
+        return bisqSetup.getDataReceived();
     }
 
     StringProperty getP2pNetworkLabelId() {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -208,7 +208,7 @@ public abstract class TradeStepView extends AnchorPane {
         } else {
             bootstrapListener = new BootstrapListener() {
                 @Override
-                public void onUpdatedDataReceived() {
+                public void onDataReceived() {
                     registerSubscriptions();
                 }
             };

--- a/desktop/src/main/resources/logback.xml
+++ b/desktop/src/main/resources/logback.xml
@@ -2,10 +2,12 @@
 <configuration>
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level%logger{30}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 
+    <!-- <logger name="org.bitcoinj" level="WARN"/>-->
+    <logger name="org.berndpruenster.netlayer.tor.Tor" level="WARN"/>
     <root level="TRACE">
         <appender-ref ref="CONSOLE_APPENDER"/>
     </root>

--- a/desktop/src/main/resources/logback.xml
+++ b/desktop/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level%logger{30}: %msg %xEx%n)</pattern>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level%logger{40}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 

--- a/p2p/src/main/java/bisq/network/p2p/BootstrapListener.java
+++ b/p2p/src/main/java/bisq/network/p2p/BootstrapListener.java
@@ -40,11 +40,11 @@ public abstract class BootstrapListener implements P2PServiceListener {
     }
 
     @Override
-    public void onDataReceived() {
+    public void onUpdatedDataReceived() {
     }
 
     @Override
-    public abstract void onUpdatedDataReceived();
+    public abstract void onDataReceived();
 
     @Override
     public void onRequestCustomBridges() {

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -310,7 +310,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
     @Override
     public void onUpdatedDataReceived() {
-        applyIsBootstrapped(P2PServiceListener::onUpdatedDataReceived);
+        p2pServiceListeners.forEach(P2PServiceListener::onUpdatedDataReceived);
     }
 
     @Override
@@ -325,7 +325,8 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
     @Override
     public void onDataReceived() {
-        p2pServiceListeners.forEach(P2PServiceListener::onDataReceived);
+        applyIsBootstrapped(P2PServiceListener::onDataReceived);
+
     }
 
     private void applyIsBootstrapped(Consumer<P2PServiceListener> listenerHandler) {

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -142,7 +142,7 @@ class RequestDataHandler implements MessageListener {
             }
 
             getDataRequestType = getDataRequest.getClass().getSimpleName();
-            log.info("We send a {} to peer {}. ", getDataRequestType, nodeAddress);
+            log.info("\n\n>> We send a {} to peer {}\n", getDataRequestType, nodeAddress);
             networkNode.addMessageListener(this);
             SettableFuture<Connection> future = networkNode.sendMessage(nodeAddress, getDataRequest);
             //noinspection UnstableApiUsage
@@ -242,7 +242,7 @@ class RequestDataHandler implements MessageListener {
         StringBuilder sb = new StringBuilder();
         String sep = System.lineSeparator();
         sb.append(sep).append("#################################################################").append(sep);
-        sb.append("Connected to node: ").append(peersNodeAddress.getFullAddress()).append(sep);
+        sb.append("Data provided by node: ").append(peersNodeAddress.getFullAddress()).append(sep);
         int items = dataSet.size() + persistableNetworkPayloadSet.size();
         sb.append("Received ").append(items).append(" instances from a ")
                 .append(getDataRequestType).append(sep);
@@ -252,7 +252,7 @@ class RequestDataHandler implements MessageListener {
                 .append(" / ")
                 .append(Utilities.readableFileSize(value.second.get()))
                 .append(sep));
-        sb.append("#################################################################");
+        sb.append("#################################################################\n");
         log.info(sb.toString());
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -360,15 +360,19 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                 }
 
                                 if (wasTruncated) {
-                                    if (numRepeatedRequests < 10) {
+                                    if (numRepeatedRequests < 20) {
                                         log.info("DataResponse did not contain all data, so we repeat request until we got all data");
                                         UserThread.runAfter(() -> requestData(nodeAddress, remainingNodeAddresses), 2);
                                     } else {
-                                        log.info("DataResponse still did not contained all data but we requested already 10 times and stop now.");
+                                        log.warn("#################################################################\n" +
+                                                "Loading initial data did not complete after 20 repeated requests. \n" +
+                                                "#################################################################");
                                         checkNotNull(listener).onDataReceived();
                                     }
                                 } else {
-                                    log.info("DataResponse contained all data");
+                                    log.info("#################################################################\n" +
+                                            "Loading initial data completed\n" +
+                                            "#################################################################");
                                     checkNotNull(listener).onDataReceived();
                                 }
                             }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -359,17 +359,17 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                     checkNotNull(listener).onUpdatedDataReceived();
                                 }
 
-                                checkNotNull(listener).onDataReceived();
-
                                 if (wasTruncated) {
                                     if (numRepeatedRequests < 10) {
                                         log.info("DataResponse did not contain all data, so we repeat request until we got all data");
                                         UserThread.runAfter(() -> requestData(nodeAddress, remainingNodeAddresses), 2);
                                     } else {
                                         log.info("DataResponse still did not contained all data but we requested already 10 times and stop now.");
+                                        checkNotNull(listener).onDataReceived();
                                     }
                                 } else {
                                     log.info("DataResponse contained all data");
+                                    checkNotNull(listener).onDataReceived();
                                 }
                             }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -364,15 +364,15 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                         log.info("DataResponse did not contain all data, so we repeat request until we got all data");
                                         UserThread.runAfter(() -> requestData(nodeAddress, remainingNodeAddresses), 2);
                                     } else {
-                                        log.warn("#################################################################\n" +
+                                        log.warn("\n#################################################################\n" +
                                                 "Loading initial data did not complete after 20 repeated requests. \n" +
-                                                "#################################################################");
+                                                "#################################################################\n");
                                         checkNotNull(listener).onDataReceived();
                                     }
                                 } else {
-                                    log.info("#################################################################\n" +
+                                    log.info("\n#################################################################\n" +
                                             "Loading initial data completed\n" +
-                                            "#################################################################");
+                                            "#################################################################\n");
                                     checkNotNull(listener).onDataReceived();
                                 }
                             }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -126,7 +126,7 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
                                             NetworkProtoResolver resolver,
                                             int messageVersion) {
         boolean wasTruncated = proto.getWasTruncated();
-        log.info("Received a GetDataResponse with {} {}",
+        log.info("\n\n<< Received a GetDataResponse with {} {}\n",
                 Utilities.readableFileSize(proto.getSerializedSize()),
                 wasTruncated ? " (was truncated)" : "");
         Set<ProtectedStorageEntry> dataSet = proto.getDataSetList().stream()

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -128,7 +128,7 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
         boolean wasTruncated = proto.getWasTruncated();
         log.info("\n\n<< Received a GetDataResponse with {} {}\n",
                 Utilities.readableFileSize(proto.getSerializedSize()),
-                wasTruncated ? " (was truncated)" : "");
+                wasTruncated ? " (still data missing)" : " (all data received)");
         Set<ProtectedStorageEntry> dataSet = proto.getDataSetList().stream()
                 .map(entry -> (ProtectedStorageEntry) resolver.fromProto(entry)).collect(Collectors.toSet());
         Set<PersistableNetworkPayload> persistableNetworkPayloadSet = proto.getPersistableNetworkPayloadItemsList().stream()

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
@@ -145,7 +145,7 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
     @Override
     protected void readFromResources(String postFix, Runnable completeHandler) {
         readStore(persisted -> {
-            log.info("We have created the {} store for the live data and filled it with {} entries from the persisted data.",
+            log.debug("We have created the {} store for the live data and filled it with {} entries from the persisted data.",
                     getFileName(), getMapOfLiveData().size());
 
             // Now we add our historical data stores.
@@ -185,7 +185,7 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
         persistenceManager.readPersisted(fileName, persisted -> {
                     storesByVersion.put(version, persisted);
                     allHistoricalPayloads.putAll(persisted.getMap());
-                    log.info("We have read from {} {} historical items.", fileName, persisted.getMap().size());
+                    log.debug("We have read from {} {} historical items.", fileName, persisted.getMap().size());
                     pruneStore(persisted, version);
                     completeHandler.run();
                 },
@@ -199,11 +199,11 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
         mapOfLiveData.keySet().removeAll(historicalStore.getMap().keySet());
         int postLive = mapOfLiveData.size();
         if (preLive > postLive) {
-            log.info("We pruned data from our live data store which are already contained in the historical data store with version {}. " +
+            log.debug("We pruned data from our live data store which are already contained in the historical data store with version {}. " +
                             "The live map had {} entries before pruning and has {} entries afterwards.",
                     version, preLive, postLive);
         } else {
-            log.info("No pruning from historical data store with version {} was applied", version);
+            log.debug("No pruning from historical data store with version {} was applied", version);
         }
         requestPersistence();
     }

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/StoreService.java
@@ -113,18 +113,18 @@ public abstract class StoreService<T extends PersistableEnvelope> {
         File destinationFile = new File(Paths.get(absolutePathOfStorageDir, fileName).toString());
         if (!destinationFile.exists()) {
             try {
-                log.info("We copy resource to file: resourceFileName={}, destinationFile={}", resourceFileName, destinationFile);
+                log.debug("We copy resource to file: resourceFileName={}, destinationFile={}", resourceFileName, destinationFile);
                 FileUtil.resourceToFile(resourceFileName, destinationFile);
                 return true;
             } catch (ResourceNotFoundException e) {
-                log.info("Could not find resourceFile " + resourceFileName + ". That is expected if none is provided yet.");
+                log.debug("Could not find resourceFile " + resourceFileName + ". That is expected if none is provided yet.");
             } catch (Throwable e) {
                 log.error("Could not copy resourceFile " + resourceFileName + " to " +
                         destinationFile.getAbsolutePath() + ".\n" + e.getMessage());
                 e.printStackTrace();
             }
         } else {
-            log.info("No resource file was copied. {} exists already.", fileName);
+            log.debug("No resource file was copied. {} exists already.", fileName);
         }
         return false;
     }

--- a/p2p/src/test/java/bisq/network/p2p/PeerServiceTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/PeerServiceTest.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 // TorNode created. Took 6 sec.
 // Hidden service created. Took 40-50 sec.
@@ -94,7 +93,7 @@ public class PeerServiceTest {
     }
 
 
-    @Test
+    //@Test
     public void testSingleSeedNode() throws InterruptedException {
         LocalhostNetworkNode.setSimulateTorDelayTorNode(0);
         LocalhostNetworkNode.setSimulateTorDelayHiddenService(0);

--- a/statsnode/src/main/java/bisq/statistics/Statistics.java
+++ b/statsnode/src/main/java/bisq/statistics/Statistics.java
@@ -55,7 +55,7 @@ public class Statistics {
         priceFeedService.setCurrencyCode("USD");
         p2pService.addP2PServiceListener(new BootstrapListener() {
             @Override
-            public void onUpdatedDataReceived() {
+            public void onDataReceived() {
                 // we need to have tor ready
                 log.info("onBootstrapComplete: we start requestPriceFeed");
                 priceFeedService.requestPriceFeed(price -> log.info("requestPriceFeed. price=" + price),


### PR DESCRIPTION
This should fix the issues with dao hash conflicts when starting a node which was missing many blocks.

Now we wait until the updated data requests do not report that data is still missing (truncated flag). Only after that (when at least one seed responded with a non-truncated response) we consider the network initialized and trigger client code.

In the dao block requests there are some fixes as well which should make the block deliver more stable.

This work is based on @jmacxx draft PR https://github.com/bisq-network/bisq/pull/6946.