### PR TITLE
Change burning man capping algorithm

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -73,10 +73,10 @@ public class BurningManService {
     private static final double GENESIS_OUTPUT_AMOUNT_FACTOR = 0.1;
 
     // The number of cycles we go back for the decay function used for compensation request amounts.
-    private static final int NUM_CYCLES_COMP_REQUEST_DECAY = 24;
+    static final int NUM_CYCLES_COMP_REQUEST_DECAY = 24;
 
     // The number of cycles we go back for the decay function used for burned amounts.
-    private static final int NUM_CYCLES_BURN_AMOUNT_DECAY = 12;
+    static final int NUM_CYCLES_BURN_AMOUNT_DECAY = 12;
 
     // Factor for boosting the issuance share (issuance is compensation requests + genesis output).
     // This will be used for increasing the allowed burn amount. The factor gives more flexibility

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -48,6 +48,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -111,7 +112,7 @@ public class BurningManService {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     Map<String, BurningManCandidate> getBurningManCandidatesByName(int chainHeight) {
-        Map<String, BurningManCandidate> burningManCandidatesByName = new HashMap<>();
+        Map<String, BurningManCandidate> burningManCandidatesByName = new TreeMap<>();
         Map<P2PDataStorage.ByteArray, Set<TxOutput>> proofOfBurnOpReturnTxOutputByHash = getProofOfBurnOpReturnTxOutputByHash(chainHeight);
 
         // Add contributors who made a compensation request
@@ -120,8 +121,7 @@ public class BurningManService {
                 .forEach(issuance -> {
                             getCompensationProposalsForIssuance(issuance).forEach(compensationProposal -> {
                                 String name = compensationProposal.getName();
-                                burningManCandidatesByName.putIfAbsent(name, new BurningManCandidate());
-                                BurningManCandidate candidate = burningManCandidatesByName.get(name);
+                                BurningManCandidate candidate = burningManCandidatesByName.computeIfAbsent(name, n -> new BurningManCandidate());
 
                                 // Issuance
                                 Optional<String> customAddress = compensationProposal.getBurningManReceiverAddress();

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -56,9 +56,16 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
     // requests change address.
     // See: https://github.com/bisq-network/bisq/issues/6699
     public static final Date BUGFIX_6699_ACTIVATION_DATE = Utilities.getUTCDate(2023, GregorianCalendar.JULY, 24);
+    // See: https://github.com/bisq-network/proposals/issues/412
+    public static final Date PROPOSAL_412_ACTIVATION_DATE = Utilities.getUTCDate(2024, GregorianCalendar.JANUARY, 1);
 
     public static boolean isBugfix6699Activated() {
         return new Date().after(BUGFIX_6699_ACTIVATION_DATE);
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean isProposal412Activated() {
+        return new Date().after(PROPOSAL_412_ACTIVATION_DATE);
     }
 
     // We don't allow to get further back than 767950 (the block height from Dec. 18th 2022).

--- a/core/src/main/java/bisq/core/dao/burningman/model/LegacyBurningMan.java
+++ b/core/src/main/java/bisq/core/dao/burningman/model/LegacyBurningMan.java
@@ -49,8 +49,14 @@ public final class LegacyBurningMan extends BurningManCandidate {
     }
 
     @Override
+    public void imposeCap(int cappingRound, double adjustedBurnAmountShare) {
+        // do nothing
+    }
+
+    @Override
     public void calculateCappedAndAdjustedShares(double sumAllCappedBurnAmountShares,
-                                                 double sumAllNonCappedBurnAmountShares) {
+                                                 double sumAllNonCappedBurnAmountShares,
+                                                 int numAppliedCappingRounds) {
         // do nothing
     }
 

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -52,9 +52,10 @@ import java.util.stream.IntStream;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.MockitoSession;
 import org.mockito.stubbing.Answer;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -91,6 +92,7 @@ public class BurningManServiceTest {
 
     @Nested
     public class BurnShareTest {
+        private MockitoSession mockitoSession;
         @Mock
         private DaoStateService daoStateService;
         @Mock
@@ -102,11 +104,16 @@ public class BurningManServiceTest {
 
         @BeforeEach
         public void setUp() {
-            MockitoAnnotations.initMocks(this);
+            mockitoSession = Mockito.mockitoSession().initMocks(this).startMocking();
             when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_BURN_AMOUNT_DECAY))
                     .thenReturn(750000);
             when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_COMP_REQUEST_DECAY))
                     .thenReturn(700000);
+        }
+
+        @AfterEach
+        public void tearDown() {
+            mockitoSession.finishMocking();
         }
 
         private void addProofOfBurnTxs(Tx... txs) {

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -17,10 +17,52 @@
 
 package bisq.core.dao.burningman;
 
+import bisq.core.dao.CyclesInDaoStateService;
+import bisq.core.dao.burningman.model.BurningManCandidate;
+import bisq.core.dao.governance.proofofburn.ProofOfBurnConsensus;
+import bisq.core.dao.governance.proposal.ProposalService;
+import bisq.core.dao.governance.proposal.storage.appendonly.ProposalPayload;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.dao.state.model.governance.CompensationProposal;
+import bisq.core.dao.state.model.governance.Issuance;
+import bisq.core.dao.state.model.governance.IssuanceType;
 
+import bisq.common.util.Tuple2;
+
+import protobuf.BaseTx;
+import protobuf.BaseTxOutput;
+import protobuf.TxOutput;
+import protobuf.TxOutputType;
+import protobuf.TxType;
+
+import com.google.protobuf.ByteString;
+
+import org.bitcoinj.core.Coin;
+
+import javafx.collections.FXCollections;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 public class BurningManServiceTest {
     @Test
@@ -43,6 +85,204 @@ public class BurningManServiceTest {
         assertEquals(7, BurningManService.getDecayedAmount(amount, 120, 400, 100));
         assertEquals(3, BurningManService.getDecayedAmount(amount, 120, 410, 110));
         assertEquals(40, BurningManService.getDecayedAmount(amount, 220, 400, 100));
+    }
 
+    @Nested
+    public class BurnShareTest {
+        @Mock
+        private DaoStateService daoStateService;
+        @Mock
+        private CyclesInDaoStateService cyclesInDaoStateService;
+        @Mock
+        private ProposalService proposalService;
+        @InjectMocks
+        private BurningManService burningManService;
+
+        @BeforeEach
+        public void setUp() {
+            MockitoAnnotations.initMocks(this);
+            when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_BURN_AMOUNT_DECAY))
+                    .thenReturn(750000);
+            when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_COMP_REQUEST_DECAY))
+                    .thenReturn(700000);
+        }
+
+        private void addProofOfBurnTxs(Tx... txs) {
+            var txsById = Arrays.stream(txs)
+                    .collect(Collectors.toMap(Tx::getId, tx -> tx));
+            when(daoStateService.getProofOfBurnOpReturnTxOutputs())
+                    .thenReturn(Arrays.stream(txs).map(tx -> tx.getTxOutputs().get(0)).collect(Collectors.toSet()));
+            when(daoStateService.getTx(Mockito.anyString()))
+                    .thenAnswer((Answer<Optional<Tx>>) inv -> Optional.ofNullable(txsById.get(inv.getArgument(0, String.class))));
+        }
+
+        private void addCompensationIssuanceAndPayloads(Collection<Tuple2<Issuance, ProposalPayload>> tuples) {
+            when(daoStateService.getIssuanceSetForType(IssuanceType.COMPENSATION))
+                    .thenReturn(tuples.stream().map(t -> t.first).collect(Collectors.toSet()));
+            when(proposalService.getProposalPayloads())
+                    .thenReturn(tuples.stream().map(t -> t.second).collect(Collectors.toCollection(FXCollections::observableArrayList)));
+        }
+
+        @SafeVarargs
+        private void addCompensationIssuanceAndPayloads(Tuple2<Issuance, ProposalPayload>... tuples) {
+            addCompensationIssuanceAndPayloads(Arrays.asList(tuples));
+        }
+
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToLessThanUnity_allCapped_oneCappingRoundNeeded() {
+            addCompensationIssuanceAndPayloads(
+                    compensationIssuanceAndPayload("alice", "0000", 760000, 10000),
+                    compensationIssuanceAndPayload("bob", "0001", 770000, 20000)
+            );
+            addProofOfBurnTxs(
+                    proofOfBurnTx("alice", "1000", 780000, 400000),
+                    proofOfBurnTx("bob", "1001", 790000, 300000)
+            );
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
+
+            assertEquals(0.5, candidateMap.get("alice").getBurnAmountShare());
+            assertEquals(0.5, candidateMap.get("bob").getBurnAmountShare());
+
+            assertEquals(0.11, candidateMap.get("alice").getCappedBurnAmountShare());
+            assertEquals(0.11, candidateMap.get("bob").getCappedBurnAmountShare());
+        }
+
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_noneCapped_oneCappingRoundNeeded() {
+            addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
+                    compensationIssuanceAndPayload("alice" + i, "000" + i, 710000, 100000)
+            ).collect(Collectors.toList()));
+
+            addProofOfBurnTxs(IntStream.range(0, 10).mapToObj(i ->
+                    proofOfBurnTx("alice" + i, "100" + i, 760000, 400000)
+            ).toArray(Tx[]::new));
+
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
+
+            assertAll(IntStream.range(0, 10).mapToObj(i -> () -> {
+                var candidate = candidateMap.get("alice" + i);
+                assertEquals(0.11, candidate.getMaxBoostedCompensationShare());
+                assertEquals(0.1, candidate.getBurnAmountShare());
+                assertEquals(0.1, candidate.getCappedBurnAmountShare());
+            }));
+        }
+
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_someCapped_twoCappingRoundsNeeded() {
+            addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
+                    compensationIssuanceAndPayload("alice" + i, "000" + i, 710000, 100000)
+            ).collect(Collectors.toList()));
+
+            addProofOfBurnTxs(IntStream.range(0, 10).mapToObj(i ->
+                    proofOfBurnTx("alice" + i, "100" + i, 760000, i < 6 ? 400000 : 200000)
+            ).toArray(Tx[]::new));
+
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
+
+            // Note the expected rounding error below. To prevent DPT verification failures, the
+            // capping algorithm output must be well defined to the nearest floating point ULP.
+            assertAll(IntStream.range(0, 10).mapToObj(i -> () -> {
+                var candidate = candidateMap.get("alice" + i);
+                assertEquals(0.11, candidate.getMaxBoostedCompensationShare());
+                assertEquals(i < 6 ? 0.125 : 0.0625, candidate.getBurnAmountShare());
+                assertEquals(i < 6 ? 0.11 : 0.08499999999999999, candidate.getCappedBurnAmountShare());
+            }));
+            // Only two capping rounds were required to achieve a burn share total of 100%, so
+            // nothing goes to the LBM in this case.
+            double burnShareTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getCappedBurnAmountShare).sum();
+            assertEquals(1.0, burnShareTotal);
+        }
+
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_someCapped_threeCappingRoundsNeeded() {
+            addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
+                    compensationIssuanceAndPayload("alice" + i, "000" + i, 710000, i < 8 ? 123250 : 7000)
+            ).collect(Collectors.toList()));
+
+            addProofOfBurnTxs(IntStream.range(0, 10).mapToObj(i ->
+                    proofOfBurnTx("alice" + i, "100" + i, 760000, i < 6 ? 400000 : 200000)
+            ).toArray(Tx[]::new));
+
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
+
+            // Note the expected rounding error below. To prevent DPT verification failures, the
+            // capping algorithm output must be well defined to the nearest floating point ULP.
+            assertAll(IntStream.range(0, 10).mapToObj(i -> () -> {
+                var candidate = candidateMap.get("alice" + i);
+                assertEquals(i < 8 ? 0.11 : 0.07, candidate.getMaxBoostedCompensationShare());
+                assertEquals(i < 6 ? 0.125 : 0.0625, candidate.getBurnAmountShare());
+                assertEquals(i < 6 ? 0.11 : i < 8 ? 0.08499999999999999 : 0.07, candidate.getCappedBurnAmountShare());
+            }));
+            // Three capping rounds would have been required to achieve a burn share total of
+            // 100%, but our capping algorithm only applies two, so 3% ends up going to the LBM
+            // in this case, instead of being distributed between `alice6` & `alice7`. The caps
+            // sum to more than 100%, however, so we could have avoided giving him any.
+            double capTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getMaxBoostedCompensationShare).sum();
+            double burnShareTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getCappedBurnAmountShare).sum();
+            assertEquals(1.02, capTotal);
+            assertEquals(0.97, burnShareTotal);
+        }
+
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToLessThanUnity_allShouldBeCapped_fourCappingRoundsNeeded() {
+            addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
+                    compensationIssuanceAndPayload("alice" + i, "000" + i, 710000,
+                            i < 6 ? 483200 : i == 6 ? 31800 : i == 7 ? 27000 : 21000)
+            ).collect(Collectors.toList()));
+
+            addProofOfBurnTxs(IntStream.range(0, 10).mapToObj(i ->
+                    proofOfBurnTx("alice" + i, "100" + i, 760000, i < 6 ? 400000 : 200000)
+            ).toArray(Tx[]::new));
+
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
+
+            // Note the expected rounding error below. To prevent DPT verification failures, the
+            // capping algorithm output must be well defined to the nearest floating point ULP.
+            assertAll(IntStream.range(0, 10).mapToObj(i -> () -> {
+                var candidate = candidateMap.get("alice" + i);
+                assertEquals(i < 6 ? 0.11 : i == 6 ? 0.106 : i == 7 ? 0.09 : 0.07, candidate.getMaxBoostedCompensationShare());
+                assertEquals(i < 6 ? 0.125 : 0.0625, candidate.getBurnAmountShare());
+                assertEquals(i < 6 ? 0.11 : i < 8 ? 0.08499999999999999 : 0.07, candidate.getCappedBurnAmountShare());
+            }));
+            // Four capping rounds would have been required to achieve a maximum possible burn
+            // share total of 99.6%, with all the contributors being capped. But our capping
+            // algorithm only applies two rounds, so 3% ends up going to the LBM instead of the
+            // minimum possible amount of 0.4% (100% less the cap sum). Contributors `alice6` &
+            // `alice7` therefore receive less than they could have done.
+            double capTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getMaxBoostedCompensationShare).sum();
+            double burnShareTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getCappedBurnAmountShare).sum();
+            assertEquals(0.996, capTotal);
+            assertEquals(0.97, burnShareTotal);
+        }
+    }
+
+    // Returns a cut-down issuance and compensation proposal payload tuple for mocking.
+    private static Tuple2<Issuance, ProposalPayload> compensationIssuanceAndPayload(String name,
+                                                                                    String txId,
+                                                                                    int chainHeight,
+                                                                                    long amount) {
+        var issuance = new Issuance(txId, chainHeight, amount, null, IssuanceType.COMPENSATION);
+        var extraDataMap = Map.of(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, "receiverAddress");
+        var proposal = new CompensationProposal(name, "link", Coin.valueOf(amount), "bsqAddress", extraDataMap);
+        return new Tuple2<>(issuance, new ProposalPayload(proposal.cloneProposalAndAddTxId(txId)));
+    }
+
+    // Returns a cut-down proof-of-burn tx for mocking. FIXME: Going via a protobuf object is a bit of a hack.
+    private static Tx proofOfBurnTx(String candidateName, String txId, int blockHeight, long burntBsq) {
+        byte[] opReturnData = ProofOfBurnConsensus.getOpReturnData(ProofOfBurnConsensus.getHash(candidateName.getBytes(UTF_8)));
+        var txOutput = BaseTxOutput.newBuilder()
+                .setTxOutput(TxOutput.newBuilder()
+                        .setTxOutputType(TxOutputType.PROOF_OF_BURN_OP_RETURN_OUTPUT))
+                .setOpReturnData(ByteString.copyFrom(opReturnData))
+                .setTxId(txId)
+                .setBlockHeight(blockHeight)
+                .build();
+        return Tx.fromProto(BaseTx.newBuilder()
+                .setId(txId)
+                .setTx(protobuf.Tx.newBuilder()
+                        .addTxOutputs(txOutput)
+                        .setTxType(TxType.PROOF_OF_BURN)
+                        .setBurntBsq(burntBsq))
+                .build());
     }
 }

--- a/core/src/test/java/bisq/core/dao/governance/proposal/ProposalServiceP2PDataStorageListenerTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/proposal/ProposalServiceP2PDataStorageListenerTest.java
@@ -36,8 +36,11 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
+import org.mockito.MockitoSession;
+import org.mockito.quality.Strictness;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,20 +51,22 @@ import static org.mockito.Mockito.*;
  * Tests of the P2PDataStorage::onRemoved callback behavior to ensure that the proper number of signal events occur.
  */
 public class ProposalServiceP2PDataStorageListenerTest {
-    private ProposalService proposalService;
+    private MockitoSession mockitoSession;
 
+    private ProposalService proposalService;
     @Mock
     private PeriodService periodService;
-
     @Mock
     private DaoStateService daoStateService;
-
     @Mock
     private ListChangeListener<Proposal> tempProposalListener;
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        mockitoSession = Mockito.mockitoSession()
+                .initMocks(this)
+                .strictness(Strictness.LENIENT) // the two stubs below are not used in every test
+                .startMocking();
 
         this.proposalService = new ProposalService(
                 mock(P2PService.class),
@@ -76,6 +81,11 @@ public class ProposalServiceP2PDataStorageListenerTest {
         // Create a state so that all added/removed Proposals will actually update the tempProposals list.
         when(this.periodService.isInPhase(anyInt(), any(DaoPhase.Phase.class))).thenReturn(true);
         when(this.daoStateService.isParseBlockChainComplete()).thenReturn(false);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockitoSession.finishMocking();
     }
 
     private static ProtectedStorageEntry buildProtectedStorageEntry() {

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
@@ -45,8 +45,11 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
+import org.mockito.MockitoSession;
+import org.mockito.quality.Strictness;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +63,7 @@ import static org.mockito.Mockito.withSettings;
 
 public class P2PDataStorageBuildGetDataResponseTest {
     abstract static class P2PDataStorageBuildGetDataResponseTestBase {
+        private MockitoSession mockitoSession;
         // GIVEN null & non-null supportedCapabilities
         private TestState testState;
 
@@ -72,7 +76,10 @@ public class P2PDataStorageBuildGetDataResponseTest {
 
         @BeforeEach
         public void setUp() {
-            MockitoAnnotations.initMocks(this);
+            mockitoSession = Mockito.mockitoSession()
+                    .initMocks(this)
+                    .strictness(Strictness.LENIENT) // there are unused stubs in TestState & elsewhere
+                    .startMocking();
             this.testState = new TestState();
 
             this.localNodeAddress = new NodeAddress("localhost", 8080);
@@ -80,6 +87,11 @@ public class P2PDataStorageBuildGetDataResponseTest {
 
             // Set up basic capabilities to ensure message contains it
             Capabilities.app.addAll(Capability.MEDIATION);
+        }
+
+        @AfterEach
+        public void tearDown() {
+            mockitoSession.finishMocking();
         }
 
         static class RequiredCapabilitiesPNPStub extends PersistableNetworkPayloadStub

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProcessGetDataResponse.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageProcessGetDataResponse.java
@@ -34,8 +34,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
-import org.mockito.MockitoAnnotations;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +48,6 @@ public class P2PDataStorageProcessGetDataResponse {
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         this.testState = new TestState();
 
         this.peerNodeAddress = new NodeAddress("peer", 8080);
@@ -111,7 +108,7 @@ public class P2PDataStorageProcessGetDataResponse {
     // XXXBUGXXX: We signal listeners w/ non ProcessOncePersistableNetworkPayloads
     @Test
     public void processGetDataResponse_newPNPUpdatesState() {
-        PersistableNetworkPayload persistableNetworkPayload = new PersistableNetworkPayloadStub(new byte[] { 1 });
+        PersistableNetworkPayload persistableNetworkPayload = new PersistableNetworkPayloadStub(new byte[]{1});
 
         GetDataResponse getDataResponse = buildGetDataResponse(persistableNetworkPayload);
 
@@ -137,7 +134,7 @@ public class P2PDataStorageProcessGetDataResponse {
     // TESTCASE: GetDataResponse w/ existing PNP changes no state
     @Test
     public void processGetDataResponse_duplicatePNPDoesNothing() {
-        PersistableNetworkPayload persistableNetworkPayload = new PersistableNetworkPayloadStub(new byte[] { 1 });
+        PersistableNetworkPayload persistableNetworkPayload = new PersistableNetworkPayloadStub(new byte[]{1});
         this.testState.mockedStorage.addPersistableNetworkPayload(persistableNetworkPayload,
                 this.peerNodeAddress, false);
 
@@ -152,7 +149,7 @@ public class P2PDataStorageProcessGetDataResponse {
     // TESTCASE: GetDataResponse w/ missing PNP is added with no broadcast or listener signal (ProcessOncePersistableNetworkPayload)
     @Test
     public void processGetDataResponse_newPNPUpdatesState_LazyProcessed() {
-        PersistableNetworkPayload persistableNetworkPayload = new LazyPersistableNetworkPayloadStub(new byte[] { 1 });
+        PersistableNetworkPayload persistableNetworkPayload = new LazyPersistableNetworkPayloadStub(new byte[]{1});
 
         GetDataResponse getDataResponse = buildGetDataResponse(persistableNetworkPayload);
 
@@ -165,7 +162,7 @@ public class P2PDataStorageProcessGetDataResponse {
     // TESTCASE: GetDataResponse w/ existing PNP changes no state (ProcessOncePersistableNetworkPayload)
     @Test
     public void processGetDataResponse_duplicatePNPDoesNothing_LazyProcessed() {
-        PersistableNetworkPayload persistableNetworkPayload = new LazyPersistableNetworkPayloadStub(new byte[] { 1 });
+        PersistableNetworkPayload persistableNetworkPayload = new LazyPersistableNetworkPayloadStub(new byte[]{1});
         this.testState.mockedStorage.addPersistableNetworkPayload(persistableNetworkPayload,
                 this.peerNodeAddress, false);
 
@@ -180,7 +177,7 @@ public class P2PDataStorageProcessGetDataResponse {
     // TESTCASE: Second call to processGetDataResponse adds PNP for non-ProcessOncePersistableNetworkPayloads
     @Test
     public void processGetDataResponse_secondProcessNewPNPUpdatesState() {
-        PersistableNetworkPayload addFromFirstProcess = new PersistableNetworkPayloadStub(new byte[] { 1 });
+        PersistableNetworkPayload addFromFirstProcess = new PersistableNetworkPayloadStub(new byte[]{1});
         GetDataResponse getDataResponse = buildGetDataResponse(addFromFirstProcess);
 
         TestState.SavedTestState beforeState = this.testState.saveTestState(addFromFirstProcess);
@@ -188,7 +185,7 @@ public class P2PDataStorageProcessGetDataResponse {
         this.testState.verifyPersistableAdd(
                 beforeState, addFromFirstProcess, true, true, false);
 
-        PersistableNetworkPayload addFromSecondProcess = new PersistableNetworkPayloadStub(new byte[] { 2 });
+        PersistableNetworkPayload addFromSecondProcess = new PersistableNetworkPayloadStub(new byte[]{2});
         getDataResponse = buildGetDataResponse(addFromSecondProcess);
         beforeState = this.testState.saveTestState(addFromSecondProcess);
         this.testState.mockedStorage.processGetDataResponse(getDataResponse, this.peerNodeAddress);
@@ -199,7 +196,7 @@ public class P2PDataStorageProcessGetDataResponse {
     // TESTCASE: Second call to processGetDataResponse does not add any PNP (LazyProcessed)
     @Test
     public void processGetDataResponse_secondProcessNoPNPUpdates_LazyProcessed() {
-        PersistableNetworkPayload addFromFirstProcess = new LazyPersistableNetworkPayloadStub(new byte[] { 1 });
+        PersistableNetworkPayload addFromFirstProcess = new LazyPersistableNetworkPayloadStub(new byte[]{1});
         GetDataResponse getDataResponse = buildGetDataResponse(addFromFirstProcess);
 
         TestState.SavedTestState beforeState = this.testState.saveTestState(addFromFirstProcess);
@@ -207,7 +204,7 @@ public class P2PDataStorageProcessGetDataResponse {
         this.testState.verifyPersistableAdd(
                 beforeState, addFromFirstProcess, true, false, false);
 
-        PersistableNetworkPayload addFromSecondProcess = new LazyPersistableNetworkPayloadStub(new byte[] { 2 });
+        PersistableNetworkPayload addFromSecondProcess = new LazyPersistableNetworkPayloadStub(new byte[]{2});
         getDataResponse = buildGetDataResponse(addFromSecondProcess);
         beforeState = this.testState.saveTestState(addFromSecondProcess);
         this.testState.mockedStorage.processGetDataResponse(getDataResponse, this.peerNodeAddress);

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRequestDataTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRequestDataTest.java
@@ -35,8 +35,6 @@ import java.security.NoSuchAlgorithmException;
 
 import java.util.Set;
 
-import org.mockito.MockitoAnnotations;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +51,6 @@ public class P2PDataStorageRequestDataTest {
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         this.testState = new TestState();
 
         this.localNodeAddress = new NodeAddress("localhost", 8080);
@@ -119,8 +116,8 @@ public class P2PDataStorageRequestDataTest {
     // correct GetDataRequestMessage with both sets of keys.
     @Test
     public void buildPreliminaryGetDataRequest_FilledP2PDataStore() throws NoSuchAlgorithmException {
-        PersistableNetworkPayload toAdd1 = new PersistableNetworkPayloadStub(new byte[] { 1 });
-        PersistableNetworkPayload toAdd2 = new PersistableNetworkPayloadStub(new byte[] { 2 });
+        PersistableNetworkPayload toAdd1 = new PersistableNetworkPayloadStub(new byte[]{1});
+        PersistableNetworkPayload toAdd2 = new PersistableNetworkPayloadStub(new byte[]{2});
         ProtectedStorageEntry toAdd3 = getProtectedStorageEntryForAdd();
         ProtectedStorageEntry toAdd4 = getProtectedStorageEntryForAdd();
 
@@ -147,8 +144,8 @@ public class P2PDataStorageRequestDataTest {
     // correct GetDataRequestMessage with both sets of keys.
     @Test
     public void requestData_FilledP2PDataStore_GetUpdatedDataRequest() throws NoSuchAlgorithmException {
-        PersistableNetworkPayload toAdd1 = new PersistableNetworkPayloadStub(new byte[] { 1 });
-        PersistableNetworkPayload toAdd2 = new PersistableNetworkPayloadStub(new byte[] { 2 });
+        PersistableNetworkPayload toAdd1 = new PersistableNetworkPayloadStub(new byte[]{1});
+        PersistableNetworkPayload toAdd2 = new PersistableNetworkPayloadStub(new byte[]{2});
         ProtectedStorageEntry toAdd3 = getProtectedStorageEntryForAdd();
         ProtectedStorageEntry toAdd4 = getProtectedStorageEntryForAdd();
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Change the algorithm used to adjust & cap the burn share of each BM candidate to use an unlimited number of 'rounds', as described in https://github.com/bisq-network/proposals/issues/412. That is, instead of capping the shares once, then distributing the excess to the remaining BM, then capping again and giving any excess to the Legacy Burning Man, we cap-redistribute-cap-redistribute-... an unlimited number of times until no more candidates are capped. This has the effect of reducing the LBM's share and increasing everyone else's, alleviating the security risk of giving too much to the LBM (who is necessarily uncapped).

#### Implementation details

Instead of implementing the new algorithm directly, we simply enlarge the set of candidates who should be capped to include those who would eventually be capped by the new algorithm, in order to determine how much excess burn share should go to the remaining BM. Then we apply the original method, `candidate.calculateCappedAndAdjustedShares(..)`, to set each share to be equal to its respective cap or uniformly scaled upwards from the starting amount accordingly.
    
To this end, the static method `BurningManService.imposeCaps` is added, which determines which candidates will eventually be capped, by sorting them in descending order of burn-share/cap-share ratio, then marking all the candidates in some suitable prefix of the list as capped, iterating through them one-by-one & gradually increasing the virtual capping round (starting at zero) until the end of the prefix is reached. (The method also determines what the uncapped adjusted burn share of each BM should be, but that only affects the BM view & burn targets.) In this way, the new algorithm runs in guaranteed _O(n * log n)_ time.

#### Activation date

To prevent failed trades, the new algorithm is set to activate at time `DelayedPayoutTxReceiverService.PROPOSAL_412_ACTIVATION_DATE`, with a placeholder value of _12am, 1st January 2024 (UTC)_. This simply toggles whether the for-loop in `imposeCaps` should stop after capping round 0, since doing so will lead to identical behaviour to the original code (even accounting for FP rounding errors).
