### PR TITLE
Add account owner names to TransferWise, MoneyBeam (N26) and Pix

### DIFF
--- a/core/src/main/java/bisq/core/payment/MoneyBeamAccount.java
+++ b/core/src/main/java/bisq/core/payment/MoneyBeamAccount.java
@@ -56,4 +56,12 @@ public final class MoneyBeamAccount extends PaymentAccount {
     public String getAccountId() {
         return ((MoneyBeamAccountPayload) paymentAccountPayload).getAccountId();
     }
+
+    public void setHolderName(String holderName) {
+        ((MoneyBeamAccountPayload) paymentAccountPayload).setHolderName(holderName);
+    }
+
+    public String getHolderName() {
+        return ((MoneyBeamAccountPayload) paymentAccountPayload).getHolderName();
+    }
 }

--- a/core/src/main/java/bisq/core/payment/PixAccount.java
+++ b/core/src/main/java/bisq/core/payment/PixAccount.java
@@ -50,6 +50,14 @@ public final class PixAccount extends CountryBasedPaymentAccount {
         return ((PixAccountPayload) paymentAccountPayload).getPixKey();
     }
 
+    public void setHolderName(String holderName) {
+        ((PixAccountPayload) paymentAccountPayload).setHolderName(holderName);
+    }
+
+    public String getHolderName() {
+        return ((PixAccountPayload) paymentAccountPayload).getHolderName();
+    }
+
     public String getMessageForBuyer() {
         return "payment.pix.info.buyer";
     }

--- a/core/src/main/java/bisq/core/payment/TransferwiseAccount.java
+++ b/core/src/main/java/bisq/core/payment/TransferwiseAccount.java
@@ -112,4 +112,12 @@ public final class TransferwiseAccount extends PaymentAccount {
     public String getEmail() {
         return ((TransferwiseAccountPayload) paymentAccountPayload).getEmail();
     }
+
+    public void setHolderName(String holderName) {
+        ((TransferwiseAccountPayload) paymentAccountPayload).setHolderName(holderName);
+    }
+
+    public String getHolderName() {
+        return ((TransferwiseAccountPayload) paymentAccountPayload).getHolderName();
+    }
 }

--- a/core/src/main/java/bisq/core/payment/payload/MoneyBeamAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/MoneyBeamAccountPayload.java
@@ -37,8 +37,9 @@ import lombok.extern.slf4j.Slf4j;
 @Setter
 @Getter
 @Slf4j
-public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
+public final class MoneyBeamAccountPayload extends PaymentAccountPayload implements PayloadWithHolderName {
     private String accountId = "";
+    private String holderName = "";
 
     public MoneyBeamAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
@@ -52,6 +53,7 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
     private MoneyBeamAccountPayload(String paymentMethod,
                                     String id,
                                     String accountId,
+                                    String holderName,
                                     long maxTradePeriod,
                                     Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
@@ -60,13 +62,15 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
                 excludeFromJsonDataMap);
 
         this.accountId = accountId;
+        this.holderName = holderName;
     }
 
     @Override
     public Message toProtoMessage() {
         return getPaymentAccountPayloadBuilder()
                 .setMoneyBeamAccountPayload(protobuf.MoneyBeamAccountPayload.newBuilder()
-                        .setAccountId(accountId))
+                        .setAccountId(accountId)
+                        .setHolderName(holderName))
                 .build();
     }
 
@@ -74,6 +78,7 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
         return new MoneyBeamAccountPayload(proto.getPaymentMethodId(),
                 proto.getId(),
                 proto.getMoneyBeamAccountPayload().getAccountId(),
+                proto.getMoneyBeamAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
                 new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
@@ -85,7 +90,7 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account") + " " + accountId;
+        return Res.get(paymentMethodId) + " - "  + Res.getWithCol("payment.account.owner") + " " + holderName + ", " + Res.getWithCol("payment.account") + " " + accountId;
     }
 
     @Override
@@ -96,5 +101,10 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
     @Override
     public byte[] getAgeWitnessInputData() {
         return super.getAgeWitnessInputData(accountId.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String getOwnerId() {
+        return holderName;
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/TransferwiseAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/TransferwiseAccountPayload.java
@@ -39,8 +39,9 @@ import lombok.extern.slf4j.Slf4j;
 @Setter
 @Getter
 @Slf4j
-public final class TransferwiseAccountPayload extends PaymentAccountPayload {
+public final class TransferwiseAccountPayload extends PaymentAccountPayload implements PayloadWithHolderName {
     private String email = "";
+    private String holderName = "";
 
     public TransferwiseAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
@@ -54,6 +55,7 @@ public final class TransferwiseAccountPayload extends PaymentAccountPayload {
     private TransferwiseAccountPayload(String paymentMethod,
                                        String id,
                                        String email,
+                                       String holderName,
                                        long maxTradePeriod,
                                        Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
@@ -62,12 +64,15 @@ public final class TransferwiseAccountPayload extends PaymentAccountPayload {
                 excludeFromJsonDataMap);
 
         this.email = email;
+        this.holderName = holderName;
     }
 
     @Override
     public Message toProtoMessage() {
         return getPaymentAccountPayloadBuilder()
-                .setTransferwiseAccountPayload(protobuf.TransferwiseAccountPayload.newBuilder().setEmail(email))
+                .setTransferwiseAccountPayload(protobuf.TransferwiseAccountPayload.newBuilder()
+                        .setEmail(email)
+                        .setHolderName(holderName))
                 .build();
     }
 
@@ -75,6 +80,7 @@ public final class TransferwiseAccountPayload extends PaymentAccountPayload {
         return new TransferwiseAccountPayload(proto.getPaymentMethodId(),
                 proto.getId(),
                 proto.getTransferwiseAccountPayload().getEmail(),
+                proto.getTransferwiseAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
                 new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
@@ -86,7 +92,7 @@ public final class TransferwiseAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.email") + " " + email;
+        return Res.get(paymentMethodId) + " - "+ Res.getWithCol("payment.account.owner") + " " + holderName + ", " + Res.getWithCol("payment.email") + " " + email;
     }
 
     @Override
@@ -101,5 +107,10 @@ public final class TransferwiseAccountPayload extends PaymentAccountPayload {
         return super.getAgeWitnessInputData(ArrayUtils.addAll(
                 email.getBytes(StandardCharsets.UTF_8),
                 getHolderName().getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Override
+    public String getOwnerId() {
+        return holderName;
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/MoneyBeamForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/MoneyBeamForm.java
@@ -43,7 +43,10 @@ public class MoneyBeamForm extends PaymentMethodForm {
     private final MoneyBeamValidator validator;
 
     public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
-        addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.moneyBeam.accountId"), ((MoneyBeamAccountPayload) paymentAccountPayload).getAccountId());
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                ((MoneyBeamAccountPayload) paymentAccountPayload).getHolderName());
+        addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.moneyBeam.accountId"),
+                ((MoneyBeamAccountPayload) paymentAccountPayload).getAccountId());
         return gridRow;
     }
 
@@ -56,6 +59,14 @@ public class MoneyBeamForm extends PaymentMethodForm {
     @Override
     public void addFormForAddAccount() {
         gridRowFrom = gridRow + 1;
+
+        InputTextField holderNameInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow,
+                Res.get("payment.account.owner"));
+        holderNameInputTextField.setValidator(inputValidator);
+        holderNameInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            account.setHolderName(newValue.trim());
+            updateFromInputs();
+        });
 
         InputTextField accountIdInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, Res.get("payment.moneyBeam.accountId"));
         accountIdInputTextField.setValidator(validator);
@@ -81,6 +92,8 @@ public class MoneyBeamForm extends PaymentMethodForm {
         gridRowFrom = gridRow;
         addAccountNameTextFieldWithAutoFillToggleButton();
         addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"), Res.get(account.getPaymentMethod().getId()));
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                account.getHolderName());
         TextField field = addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.moneyBeam.accountId"), account.getAccountId()).second;
         field.setMouseTransparent(false);
         final TradeCurrency singleTradeCurrency = account.getSingleTradeCurrency();
@@ -92,6 +105,7 @@ public class MoneyBeamForm extends PaymentMethodForm {
     @Override
     public void updateAllInputsValid() {
         allInputsValid.set(isAccountNameValid()
+                && inputValidator.validate(account.getHolderName()).isValid
                 && validator.validate(account.getAccountId()).isValid
                 && account.getTradeCurrencies().size() > 0);
     }

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PixForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PixForm.java
@@ -43,6 +43,8 @@ public class PixForm extends PaymentMethodForm {
 
     public static int addFormForBuyer(GridPane gridPane, int gridRow,
                                       PaymentAccountPayload paymentAccountPayload) {
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                ((PixAccountPayload) paymentAccountPayload).getHolderName());
         addTopLabelTextFieldWithCopyIcon(gridPane, gridRow, 1, Res.get("payment.pix.key"),
                 ((PixAccountPayload) paymentAccountPayload).getPixKey(), Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE);
         addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
@@ -64,6 +66,14 @@ public class PixForm extends PaymentMethodForm {
         CountryUtil.findCountryByCode("BR").ifPresent(c -> account.setCountry(c));
 
         gridRowFrom = gridRow + 1;
+
+        InputTextField holderNameInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow,
+        Res.get("payment.account.owner"));
+        holderNameInputTextField.setValidator(inputValidator);
+        holderNameInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            account.setHolderName(newValue.trim());
+            updateFromInputs();
+        });
 
         InputTextField pixKeyInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, Res.get("payment.pix.key"));
         pixKeyInputTextField.setValidator(inputValidator);
@@ -97,6 +107,8 @@ public class PixForm extends PaymentMethodForm {
         addAccountNameTextFieldWithAutoFillToggleButton();
         addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"),
                 Res.get(account.getPaymentMethod().getId()));
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                account.getHolderName());
         TextField field = addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.pix.key"),
                 account.getPixKey()).second;
         field.setMouseTransparent(false);

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/TransferwiseForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/TransferwiseForm.java
@@ -43,6 +43,8 @@ public class TransferwiseForm extends PaymentMethodForm {
 
     public static int addFormForBuyer(GridPane gridPane, int gridRow,
                                       PaymentAccountPayload paymentAccountPayload) {
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                ((TransferwiseAccountPayload) paymentAccountPayload).getHolderName());
         addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.email"),
                 ((TransferwiseAccountPayload) paymentAccountPayload).getEmail());
         addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
@@ -61,6 +63,14 @@ public class TransferwiseForm extends PaymentMethodForm {
     @Override
     public void addFormForAddAccount() {
         gridRowFrom = gridRow + 1;
+
+        InputTextField holderNameInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow,
+        Res.get("payment.account.owner"));
+        holderNameInputTextField.setValidator(inputValidator);
+        holderNameInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            account.setHolderName(newValue.trim());
+            updateFromInputs();
+        });
 
         InputTextField emailInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow, Res.get("payment.email"));
         emailInputTextField.setValidator(validator);
@@ -107,6 +117,8 @@ public class TransferwiseForm extends PaymentMethodForm {
         addAccountNameTextFieldWithAutoFillToggleButton();
         addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"),
                 Res.get(account.getPaymentMethod().getId()));
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.account.owner"),
+                account.getHolderName());
         TextField field = addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.email"),
                 account.getEmail()).second;
         field.setMouseTransparent(false);
@@ -119,6 +131,7 @@ public class TransferwiseForm extends PaymentMethodForm {
     @Override
     public void updateAllInputsValid() {
         allInputsValid.set(isAccountNameValid()
+                && inputValidator.validate(account.getHolderName()).isValid
                 && validator.validate(account.getEmail()).isValid
                 && inputValidator.validate(account.getHolderName()).isValid
                 && account.getTradeCurrencies().size() > 0);


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #6817

Adds "Account owner name" to TransferWise, MoneyBeam (N26) and PIX in order to better identify payments