### PR TITLE
Create GetBlocksRequestHandler's reply list once

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
+++ b/core/src/main/java/bisq/core/dao/node/full/network/GetBlocksRequestHandler.java
@@ -92,11 +92,10 @@ class GetBlocksRequestHandler {
     public void onGetBlocksRequest(GetBlocksRequest getBlocksRequest, Connection connection) {
         long ts = System.currentTimeMillis();
         // We limit number of blocks to 3000 which is about 3 weeks and about 5 MB on data
-        List<Block> blocks = daoStateService.getBlocksFromBlockHeight(getBlocksRequest.getFromBlockHeight());
-        List<RawBlock> rawBlocks = new LinkedList<>(blocks).stream()
+        List<RawBlock> rawBlocks = daoStateService.getBlocksFromBlockHeightStream(getBlocksRequest.getFromBlockHeight(), 3000)
                 .map(RawBlock::fromBlock)
-                .limit(3000)
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(LinkedList::new));
+
         GetBlocksResponse getBlocksResponse = new GetBlocksResponse(rawBlocks, getBlocksRequest.getNonce());
         log.info("Received GetBlocksRequest from {} for blocks from height {}. " +
                         "Building GetBlocksResponse with {} blocks took {} ms.",

--- a/core/src/main/java/bisq/core/dao/state/DaoStateService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateService.java
@@ -349,11 +349,21 @@ public class DaoStateService implements DaoSetupService {
     }
 
     public List<Block> getBlocksFromBlockHeight(int fromBlockHeight) {
-        return getBlocks().stream()
-                .filter(block -> block.getHeight() >= fromBlockHeight)
-                .collect(Collectors.toList());
+        return getBlocksFromBlockHeight(fromBlockHeight, Integer.MAX_VALUE);
     }
 
+    public List<Block> getBlocksFromBlockHeight(int fromBlockHeight, int numMaxBlocks) {
+        return getBlocksFromBlockHeightStream(fromBlockHeight, numMaxBlocks)
+                .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    public Stream<Block> getBlocksFromBlockHeightStream(int fromBlockHeight, int numMaxBlocks) {
+        // We limit requests to numMaxBlocks blocks, to avoid performance issues and too
+        // large network data in case a node requests too far back in history.
+        return getBlocks().stream()
+                .filter(block -> block.getHeight() >= fromBlockHeight)
+                .limit(numMaxBlocks);
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Genesis


### PR DESCRIPTION
Previously, the onGetBlocksRequest method created an ArrayList and two LinkedList before creating the GetBlocksResponse. The first two lists were never used. PR #6947 introduced the second LinkedList creation. With this change, the GetBlocksRequestHandler only creates a single LinkedList.