### PR TITLE
TxValidator: Fix crash on missing vin[0].prevout

### DIFF
--- a/core/src/main/java/bisq/core/provider/mempool/TxValidator.java
+++ b/core/src/main/java/bisq/core/provider/mempool/TxValidator.java
@@ -190,7 +190,13 @@ public class TxValidator {
         JsonArray jsonVout = getVinAndVout(jsonTxt).second;
         JsonObject jsonVin0 = jsonVin.get(0).getAsJsonObject();
         JsonObject jsonVout0 = jsonVout.get(0).getAsJsonObject();
-        JsonElement jsonVIn0Value = jsonVin0.getAsJsonObject("prevout").get("value");
+
+        JsonObject jsonVin0PreVout = jsonVin0.getAsJsonObject("prevout");
+        if (jsonVin0PreVout == null) {
+            throw new JsonSyntaxException("vin[0].prevout missing");
+        }
+
+        JsonElement jsonVIn0Value = jsonVin0PreVout.get("value");
         JsonElement jsonFeeValue = jsonVout0.get("value");
         if (jsonVIn0Value == null || jsonFeeValue == null) {
             throw new JsonSyntaxException("vin/vout missing data");

--- a/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
@@ -155,6 +155,24 @@ public class MakerTxValidatorSanityCheckTests {
     }
 
     @Test
+    void checkFeeAmountMissingVinPreVout() throws IOException {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+        JsonObject firstInput = json.get("vin").getAsJsonArray().get(0).getAsJsonObject();
+        firstInput.remove("prevout");
+
+        boolean hasPreVout = json.get("vin").getAsJsonArray()
+                .get(0).getAsJsonObject()
+                .has("prevout");
+        assertThat(hasPreVout, is(false));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
+
+    @Test
     void responseHasDifferentTxId() throws IOException {
         String differentTxId = "abcde971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";
 

--- a/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
@@ -135,6 +135,24 @@ public class MakerTxValidatorSanityCheckTests {
         assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void checkFeeAddressBtcNoTooFewVout(int numberOfVouts) throws IOException {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+
+        var jsonArray = new JsonArray(numberOfVouts);
+        for (int i = 0; i < numberOfVouts; i++) {
+            jsonArray.add(i);
+        }
+        json.add("vout", jsonArray);
+        assertThat(json.get("vout").getAsJsonArray().size(), is(numberOfVouts));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
 
     @Test
     void responseHasDifferentTxId() throws IOException {

--- a/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
@@ -23,6 +23,7 @@ import bisq.core.provider.mempool.FeeValidationStatus;
 import bisq.core.provider.mempool.TxValidator;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
@@ -120,6 +121,20 @@ public class MakerTxValidatorSanityCheckTests {
 
         assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
     }
+
+    @Test
+    void checkFeeAddressBtcNoTooFewVin() throws IOException {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+        json.add("vin", new JsonArray(0));
+        assertThat(json.get("vin").getAsJsonArray().size(), is(0));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
+
 
     @Test
     void responseHasDifferentTxId() throws IOException {

--- a/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
@@ -155,6 +155,24 @@ public class TakerTxValidatorSanityCheckTests {
     }
 
     @Test
+    void checkFeeAmountMissingVinPreVout() throws IOException {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+        JsonObject firstInput = json.get("vin").getAsJsonArray().get(0).getAsJsonObject();
+        firstInput.remove("prevout");
+
+        boolean hasPreVout = json.get("vin").getAsJsonArray()
+                .get(0).getAsJsonObject()
+                .has("prevout");
+        assertThat(hasPreVout, is(false));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
+
+    @Test
     void responseHasDifferentTxId() throws IOException {
         String differentTxId = "abcde971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";
 

--- a/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
@@ -135,6 +135,25 @@ public class TakerTxValidatorSanityCheckTests {
         assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void checkFeeAddressBtcNoTooFewVout(int numberOfVouts) throws IOException {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+
+        var jsonArray = new JsonArray(numberOfVouts);
+        for (int i = 0; i < numberOfVouts; i++) {
+            jsonArray.add(i);
+        }
+        json.add("vout", jsonArray);
+        assertThat(json.get("vout").getAsJsonArray().size(), is(numberOfVouts));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
+
     @Test
     void responseHasDifferentTxId() throws IOException {
         String differentTxId = "abcde971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";

--- a/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
@@ -23,6 +23,7 @@ import bisq.core.provider.mempool.FeeValidationStatus;
 import bisq.core.provider.mempool.TxValidator;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
@@ -113,6 +114,19 @@ public class TakerTxValidatorSanityCheckTests {
         JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
         json.add(vinOrVout, new JsonPrimitive(1234));
         assertThrows(IllegalStateException.class, () -> json.get(vinOrVout).getAsJsonArray());
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
+
+    @Test
+    void checkFeeAddressBtcNoTooFewVin() throws IOException {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+        json.add("vin", new JsonArray(0));
+        assertThat(json.get("vin").getAsJsonArray().size(), is(0));
 
         String jsonContent = new Gson().toJson(json);
         TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,


### PR DESCRIPTION
The `checkFeeAmountBTC` method looks up the `value` field of the `vin[0].prevout` field without checking whether `vin[0].prevout` exists. When the field is missing `JsonElement jsonVIn0Value = jsonVin0.getAsJsonObject("prevout").get("value");` (line 193) throws a NullPointerException.

Changes:
- [Test too few inputs in fee payment](https://github.com/bisq-network/bisq/commit/05dfbca07d0a31cc78c455995d6ee1475eab55bc)
- [Test too few outputs in fee payment](https://github.com/bisq-network/bisq/commit/ba09db4356650f99edfc74e4a30cc7f830fde6a5)
- [TxValidator: Fix crash on missing vin[0].prevout](https://github.com/bisq-network/bisq/commit/516d3c8d7dfc524048d35addf90ec7952bf27f8c)