### PR TITLE
Refactor and Add Maker Transaction Vouts Tests

### DIFF
--- a/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
@@ -184,6 +184,24 @@ public class TakerTxValidatorSanityCheckTests {
     }
 
     @Test
+    void checkFeeAmountMissingVoutValue() {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+        JsonObject firstOutput = json.getAsJsonArray("vout").get(0).getAsJsonObject();
+        firstOutput.remove("value");
+
+        boolean hasPreVout = json.getAsJsonArray("vout")
+                .get(0).getAsJsonObject()
+                .has("value");
+        assertThat(hasPreVout, is(false));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateTakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
+
+    @Test
     void responseHasDifferentTxId() {
         String differentTxId = "abcde971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";
 

--- a/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
@@ -108,7 +108,7 @@ public class TakerTxValidatorSanityCheckTests {
         assertThrows(IllegalStateException.class, () -> json.get(vinOrVout).getAsJsonArray());
 
         String jsonContent = new Gson().toJson(json);
-        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+        TxValidator txValidator1 = txValidator.parseJsonValidateTakerFeeTx(jsonContent,
                 MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
 
         assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
@@ -121,7 +121,7 @@ public class TakerTxValidatorSanityCheckTests {
         assertThat(json.get("vin").getAsJsonArray().size(), is(0));
 
         String jsonContent = new Gson().toJson(json);
-        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+        TxValidator txValidator1 = txValidator.parseJsonValidateTakerFeeTx(jsonContent,
                 MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
 
         assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
@@ -140,7 +140,7 @@ public class TakerTxValidatorSanityCheckTests {
         assertThat(json.get("vout").getAsJsonArray().size(), is(numberOfVouts));
 
         String jsonContent = new Gson().toJson(json);
-        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+        TxValidator txValidator1 = txValidator.parseJsonValidateTakerFeeTx(jsonContent,
                 MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
 
         assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
@@ -158,7 +158,7 @@ public class TakerTxValidatorSanityCheckTests {
         assertThat(hasPreVout, is(false));
 
         String jsonContent = new Gson().toJson(json);
-        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent,
+        TxValidator txValidator1 = txValidator.parseJsonValidateTakerFeeTx(jsonContent,
                 MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
 
         assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));

--- a/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
@@ -27,15 +27,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
-import java.net.URL;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import java.io.IOException;
-
 import java.util.List;
-import java.util.Objects;
 
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -83,8 +75,8 @@ public class TakerTxValidatorSanityCheckTests {
 
     @ParameterizedTest
     @ValueSource(strings = {"status", "txid", "vin", "vout"})
-    void mempoolResponseWithMissingField(String missingField) throws IOException {
-        JsonObject json = getValidBtcMakerFeeMempoolJsonResponse();
+    void mempoolResponseWithMissingField(String missingField) {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
         json.remove(missingField);
         assertThat(json.has(missingField), is(false));
 
@@ -96,8 +88,8 @@ public class TakerTxValidatorSanityCheckTests {
     }
 
     @Test
-    void mempoolResponseWithoutConfirmedField() throws IOException {
-        JsonObject json = getValidBtcMakerFeeMempoolJsonResponse();
+    void mempoolResponseWithoutConfirmedField() {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
         json.get("status").getAsJsonObject().remove("confirmed");
         assertThat(json.get("status").getAsJsonObject().has("confirmed"), is(false));
 
@@ -110,7 +102,7 @@ public class TakerTxValidatorSanityCheckTests {
 
     @ParameterizedTest
     @ValueSource(strings = {"vin", "vout"})
-    void checkFeeAddressBtcTestVinOrVoutNotJsonArray(String vinOrVout) throws IOException {
+    void checkFeeAddressBtcTestVinOrVoutNotJsonArray(String vinOrVout) {
         JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
         json.add(vinOrVout, new JsonPrimitive(1234));
         assertThrows(IllegalStateException.class, () -> json.get(vinOrVout).getAsJsonArray());
@@ -123,7 +115,7 @@ public class TakerTxValidatorSanityCheckTests {
     }
 
     @Test
-    void checkFeeAddressBtcNoTooFewVin() throws IOException {
+    void checkFeeAddressBtcNoTooFewVin() {
         JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
         json.add("vin", new JsonArray(0));
         assertThat(json.get("vin").getAsJsonArray().size(), is(0));
@@ -137,7 +129,7 @@ public class TakerTxValidatorSanityCheckTests {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1})
-    void checkFeeAddressBtcNoTooFewVout(int numberOfVouts) throws IOException {
+    void checkFeeAddressBtcNoTooFewVout(int numberOfVouts) {
         JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
 
         var jsonArray = new JsonArray(numberOfVouts);
@@ -155,7 +147,7 @@ public class TakerTxValidatorSanityCheckTests {
     }
 
     @Test
-    void checkFeeAmountMissingVinPreVout() throws IOException {
+    void checkFeeAmountMissingVinPreVout() {
         JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
         JsonObject firstInput = json.get("vin").getAsJsonArray().get(0).getAsJsonObject();
         firstInput.remove("prevout");
@@ -173,10 +165,10 @@ public class TakerTxValidatorSanityCheckTests {
     }
 
     @Test
-    void responseHasDifferentTxId() throws IOException {
+    void responseHasDifferentTxId() {
         String differentTxId = "abcde971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";
 
-        JsonObject json = getValidBtcMakerFeeMempoolJsonResponse();
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
         json.add("txid", new JsonPrimitive(differentTxId));
         assertThat(json.get("txid").getAsString(), is(differentTxId));
 
@@ -185,19 +177,5 @@ public class TakerTxValidatorSanityCheckTests {
 
         FeeValidationStatus status = txValidator1.getStatus();
         assertThat(status, is(equalTo(FeeValidationStatus.NACK_JSON_ERROR)));
-    }
-
-    private JsonObject getValidBtcMakerFeeMempoolJsonResponse() throws IOException {
-        URL resource = getClass().getClassLoader().getResource("mempool_test_data/valid_btc_maker_fee.json");
-        String path = Objects.requireNonNull(resource).getPath();
-
-        if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
-            // We need to remove the first character on Windows because the path starts with a
-            // leading slash "/C:/Users/..."
-            path = path.substring(1);
-        }
-
-        String jsonContent = Files.readString(Path.of(path));
-        return new Gson().fromJson(jsonContent, JsonObject.class);
     }
 }

--- a/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/TakerTxValidatorSanityCheckTests.java
@@ -165,6 +165,25 @@ public class TakerTxValidatorSanityCheckTests {
     }
 
     @Test
+    void checkFeeAmountMissingVinPreVoutValue() {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+        JsonObject firstInput = json.get("vin").getAsJsonArray().get(0).getAsJsonObject();
+        firstInput.getAsJsonObject("prevout").remove("value");
+
+        boolean hasPreVout = json.get("vin").getAsJsonArray()
+                .get(0).getAsJsonObject()
+                .getAsJsonObject("prevout")
+                .has("value");
+        assertThat(hasPreVout, is(false));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateTakerFeeTx(jsonContent,
+                MakerTxValidatorSanityCheckTests.FEE_RECEIVER_ADDRESSES);
+
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_JSON_ERROR));
+    }
+
+    @Test
     void responseHasDifferentTxId() {
         String differentTxId = "abcde971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";
 


### PR DESCRIPTION
- [Reuse makerTx in TakerTxValidatorSanityCheckTests](https://github.com/bisq-network/bisq/commit/8d331a6de158d639c1f991f76c2cf1d6a0506019)
- [Fix: Call parseJsonValidateTakerFeeTx in taker tests](https://github.com/bisq-network/bisq/commit/b0d57120708919629c21e15f66e053b209179fb1)
- [TakerTxSanityCheckTests: Add checkFeeAmountMissingVinPreVoutValue test](https://github.com/bisq-network/bisq/commit/c81ba0d686fb55cb4e505583505b7c881e952fc4)
- [TakerTxSanityCheckTests: Add checkFeeAmountMissingVoutValue test](https://github.com/bisq-network/bisq/commit/077c5f5e713d5840242f582d0b0c2f16191c0b28)