### PR TITLE
Test All Maker BTC Cases

### DIFF
--- a/core/src/test/java/bisq/core/fee/MakerFeeBtcValidationTests.java
+++ b/core/src/test/java/bisq/core/fee/MakerFeeBtcValidationTests.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.fee;
+
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.filter.Filter;
+import bisq.core.filter.FilterManager;
+import bisq.core.provider.mempool.FeeValidationStatus;
+import bisq.core.provider.mempool.TxValidator;
+
+import org.bitcoinj.core.Coin;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+public class MakerFeeBtcValidationTests {
+    private static final List<String> BTC_FEE_RECEIVERS = List.of("2MzBNTJDjjXgViKBGnatDU3yWkJ8pJkEg9w");
+    private static final String VALID_MAKER_FEE_JSON_RESPONSE = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponseString();
+
+    @Mock
+    private DaoStateService daoStateService;
+    @Mock
+    private FilterManager filterManager;
+    private TxValidator txValidator;
+
+    @BeforeEach
+    void setup() {
+        String txId = "e3607e971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";
+        txValidator = new TxValidator(daoStateService, txId,
+                Coin.valueOf(100000), true, 143, filterManager);
+    }
+
+    @Test
+    void makerCheckFeeAddressBtcTooOldValidFee() {
+        doReturn(Coin.valueOf(5000)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(5000)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, Collections.emptyList());
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.ACK_FEE_OK));
+    }
+
+    @Test
+    void makerExactFeeMatchBtcTest() {
+        doReturn(Coin.valueOf(5000)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(5000)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, BTC_FEE_RECEIVERS);
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.ACK_FEE_OK));
+    }
+
+    @Test
+    void makerHigherBtcFeeThanExpected() {
+        doReturn(Coin.valueOf(4000)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(4000)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, BTC_FEE_RECEIVERS);
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.ACK_FEE_OK));
+    }
+
+    @Test
+    void makerLowerButWithinToleranceBtcFee() {
+        doReturn(Coin.valueOf(5001)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(5001)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, BTC_FEE_RECEIVERS);
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.ACK_FEE_OK));
+    }
+
+    @Test
+    void makerPassFilterFeeCheck() {
+        doReturn(Coin.valueOf(10_000), Coin.valueOf(5_000)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(10_000), Coin.valueOf(5_000)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        Filter filter = mock(Filter.class);
+        doReturn(5_000_000L).when(filter).getMakerFeeBtc();
+        doReturn(filter).when(filterManager).getFilter();
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, BTC_FEE_RECEIVERS);
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.ACK_FEE_OK));
+    }
+
+    @Test
+    void makerFailFilterFeeCheck() {
+        doReturn(Coin.valueOf(10_000)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(10_000)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        Filter filter = mock(Filter.class);
+        doReturn(10_000_000L).when(filter).getMakerFeeBtc();
+        doReturn(filter).when(filterManager).getFilter();
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, BTC_FEE_RECEIVERS);
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_MAKER_FEE_TOO_LOW));
+    }
+
+    @Test
+    void makerNoFilterFeeMatchesDifferentDaoParameter() {
+        doReturn(Coin.valueOf(10_000), Coin.valueOf(5_000)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(10_000), Coin.valueOf(5_000)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        doReturn(null).when(filterManager).getFilter();
+        doReturn(List.of(Coin.valueOf(5_000))).when(daoStateService).getParamChangeList(any());
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, BTC_FEE_RECEIVERS);
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.ACK_FEE_OK));
+    }
+
+    @Test
+    void makerNoFilterFeeTooLow() {
+        doReturn(Coin.valueOf(10_000)).when(daoStateService).getParamValueAsCoin(any(), anyInt());
+        doReturn(Coin.valueOf(10_000)).when(daoStateService).getParamValueAsCoin(any(), anyString());
+
+        doReturn(null).when(filterManager).getFilter();
+        doReturn(List.of(Coin.valueOf(5_000))).when(daoStateService).getParamChangeList(any());
+
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(VALID_MAKER_FEE_JSON_RESPONSE, BTC_FEE_RECEIVERS);
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_MAKER_FEE_TOO_LOW));
+    }
+}

--- a/core/src/test/java/bisq/core/fee/MakerInvalidFeeBtcValidationTests.java
+++ b/core/src/test/java/bisq/core/fee/MakerInvalidFeeBtcValidationTests.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.fee;
+
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.filter.FilterManager;
+import bisq.core.provider.mempool.FeeValidationStatus;
+import bisq.core.provider.mempool.TxValidator;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import java.util.Collections;
+
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class MakerInvalidFeeBtcValidationTests {
+    private TxValidator txValidator;
+
+    @BeforeEach
+    void setup(@Mock DaoStateService daoStateService, @Mock FilterManager filterManager) {
+        String txId = "e3607e971ead7d03619e3a9eeaa771ed5adba14c448839e0299f857f7bb4ec07";
+        txValidator = new TxValidator(daoStateService, txId, filterManager);
+    }
+
+    @Test
+    void makerCheckFeeAddressBtcInvalidFeeAddress() {
+        JsonObject json = MakerTxValidatorSanityCheckTests.getValidBtcMakerFeeMempoolJsonResponse();
+        json.get("status").getAsJsonObject().add("block_height", new JsonPrimitive(600_000));
+
+        var newBlockHeight = json.get("status").getAsJsonObject().get("block_height").getAsInt();
+        assertThat(newBlockHeight, is(600_000));
+
+        String jsonContent = new Gson().toJson(json);
+        TxValidator txValidator1 = txValidator.parseJsonValidateMakerFeeTx(jsonContent, Collections.emptyList());
+        assertThat(txValidator1.getStatus(), is(FeeValidationStatus.NACK_UNKNOWN_FEE_RECEIVER));
+    }
+}

--- a/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
@@ -224,7 +224,7 @@ public class MakerTxValidatorSanityCheckTests {
         assertThat(status, is(equalTo(FeeValidationStatus.NACK_JSON_ERROR)));
     }
 
-    public static JsonObject getValidBtcMakerFeeMempoolJsonResponse() {
+    public static String getValidBtcMakerFeeMempoolJsonResponseString() {
         URL resource = MakerTxValidatorSanityCheckTests.class.getClassLoader()
                 .getResource("mempool_test_data/valid_btc_maker_fee.json");
         String path = Objects.requireNonNull(resource).getPath();
@@ -236,10 +236,14 @@ public class MakerTxValidatorSanityCheckTests {
         }
 
         try {
-            String jsonContent = Files.readString(Path.of(path));
-            return new Gson().fromJson(jsonContent, JsonObject.class);
+            return Files.readString(Path.of(path));
         } catch (IOException e) {
-            throw new IllegalStateException("Couldn't read valid_btc_maker_fee.json", e);
+            throw new IllegalStateException("Couldn't read valid_btc_maker_fee.json.", e);
         }
+    }
+
+    public static JsonObject getValidBtcMakerFeeMempoolJsonResponse() {
+        String jsonContent = getValidBtcMakerFeeMempoolJsonResponseString();
+        return new Gson().fromJson(jsonContent, JsonObject.class);
     }
 }


### PR DESCRIPTION
- [Add getValidBtcMakerFeeMempoolJsonResponseString test asset](https://github.com/bisq-network/bisq/commit/9fd48c0cd09557f4c7b337f367c21b848ce6f6e4)
- [Test all Maker BTC cases](https://github.com/bisq-network/bisq/commit/000b7a78aa7d0c3560b1b0774172d3d5b97143ed)
  - makerCheckFeeAddressBtcInvalidFeeAddress
  - makerCheckFeeAddressBtcTooOldValidFee
  - makerExactFeeMatchBtcTest
  - makerHigherBtcFeeThanExpected
  - makerLowerButWithinToleranceBtcFee
  - makerPassFilterFeeCheck
  - makerFailFilterFeeCheck
  - makerNoFilterFeeMatchesDifferentDaoParameter
  - makerNoFilterFeeTooLow