### PR TITLE
Fix resource path URL decoding in tx validator tests and clean similar tests

### DIFF
--- a/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
+++ b/core/src/test/java/bisq/core/app/BisqHelpFormatterTest.java
@@ -31,6 +31,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import java.util.Objects;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -125,11 +127,11 @@ public class BisqHelpFormatterTest {
                 .defaultsTo(AnEnum.foo);
 
         ByteArrayOutputStream actual = new ByteArrayOutputStream();
-        String expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output.txt").toURI())));
+        String expected = Files.readString(Paths.get(Objects.requireNonNull(getClass().getResource("cli-output.txt")).toURI()));
         if (System.getProperty("os.name").startsWith("Windows")) {
             // Load the expected content from a different file for Windows due to different path separator
             // And normalize line endings to LF in case the file has CRLF line endings
-            expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("cli-output_windows.txt").toURI())))
+            expected = Files.readString(Paths.get(Objects.requireNonNull(getClass().getResource("cli-output_windows.txt")).toURI()))
                     .replaceAll("\\r\\n?", "\n");
         }
 

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -52,13 +52,13 @@ import java.util.stream.IntStream;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoSession;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -91,8 +91,8 @@ public class BurningManServiceTest {
     }
 
     @Nested
+    @ExtendWith(MockitoExtension.class)
     public class BurnShareTest {
-        private MockitoSession mockitoSession;
         @Mock
         private DaoStateService daoStateService;
         @Mock
@@ -104,16 +104,10 @@ public class BurningManServiceTest {
 
         @BeforeEach
         public void setUp() {
-            mockitoSession = Mockito.mockitoSession().initMocks(this).startMocking();
             when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_BURN_AMOUNT_DECAY))
                     .thenReturn(750000);
             when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_COMP_REQUEST_DECAY))
                     .thenReturn(700000);
-        }
-
-        @AfterEach
-        public void tearDown() {
-            mockitoSession.finishMocking();
         }
 
         private void addProofOfBurnTxs(Tx... txs) {

--- a/core/src/test/java/bisq/core/dao/governance/proposal/ProposalServiceP2PDataStorageListenerTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/proposal/ProposalServiceP2PDataStorageListenerTest.java
@@ -36,23 +36,22 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoSession;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.Mockito.*;
-
 
 /**
  * Tests of the P2PDataStorage::onRemoved callback behavior to ensure that the proper number of signal events occur.
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT) // the two stubs in setUp() are not used in every test
 public class ProposalServiceP2PDataStorageListenerTest {
-    private MockitoSession mockitoSession;
-
     private ProposalService proposalService;
     @Mock
     private PeriodService periodService;
@@ -63,11 +62,6 @@ public class ProposalServiceP2PDataStorageListenerTest {
 
     @BeforeEach
     public void setUp() {
-        mockitoSession = Mockito.mockitoSession()
-                .initMocks(this)
-                .strictness(Strictness.LENIENT) // the two stubs below are not used in every test
-                .startMocking();
-
         this.proposalService = new ProposalService(
                 mock(P2PService.class),
                 this.periodService,
@@ -81,11 +75,6 @@ public class ProposalServiceP2PDataStorageListenerTest {
         // Create a state so that all added/removed Proposals will actually update the tempProposals list.
         when(this.periodService.isInPhase(anyInt(), any(DaoPhase.Phase.class))).thenReturn(true);
         when(this.daoStateService.isParseBlockChainComplete()).thenReturn(false);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        mockitoSession.finishMocking();
     }
 
     private static ProtectedStorageEntry buildProtectedStorageEntry() {

--- a/core/src/test/java/bisq/core/dao/node/full/rpc/BitcoindClientTest.java
+++ b/core/src/test/java/bisq/core/dao/node/full/rpc/BitcoindClientTest.java
@@ -36,6 +36,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import java.util.Objects;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +54,6 @@ import static org.mockito.Mockito.when;
 import com.googlecode.jsonrpc4j.HttpException;
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
 import com.googlecode.jsonrpc4j.RequestIDGenerator;
-import kotlin.text.Charsets;
 
 public class BitcoindClientTest {
     private static final String TEST_BLOCK_HASH = "015f37a20d517645a11a6cdd316049f41bc77b4a4057b2dd092114b78147f42c";
@@ -66,7 +67,7 @@ public class BitcoindClientTest {
     private boolean canConnect = true;
     private ByteArrayInputStream mockResponse;
     private ByteArrayInputStream mockErrorResponse;
-    private ByteArrayOutputStream mockOutputStream = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream mockOutputStream = new ByteArrayOutputStream();
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -116,7 +117,7 @@ public class BitcoindClientTest {
     }
 
     @Test
-    public void testGetBlockCount_wrongCredentials() throws Exception {
+    public void testGetBlockCount_wrongCredentials() {
         mockResponseCode = 401;
 //        mockResponseCustomHeaders.put("WWW-Authenticate", "[Basic realm=\"jsonrpc\"]");
         assertThrows(HttpException.class, () -> client.getBlockCount());
@@ -218,8 +219,8 @@ public class BitcoindClientTest {
 
     private static String readFromResourcesUnPrettified(String resourceName) {
         try {
-            var path = Paths.get(BitcoindClientTest.class.getResource(resourceName).toURI());
-            return new String(Files.readAllBytes(path), Charsets.UTF_8).replaceAll("(\\s+\\B|\\B\\s+|\\v)", "");
+            var path = Paths.get(Objects.requireNonNull(BitcoindClientTest.class.getResource(resourceName)).toURI());
+            return Files.readString(path).replaceAll("(\\s+\\B|\\B\\s+|\\v)", "");
         } catch (Exception e) {
             return "";
         }

--- a/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
+++ b/core/src/test/java/bisq/core/fee/MakerTxValidatorSanityCheckTests.java
@@ -30,9 +30,7 @@ import com.google.gson.JsonPrimitive;
 import java.net.URL;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
-
-import java.io.IOException;
+import java.nio.file.Paths;
 
 import java.util.List;
 import java.util.Objects;
@@ -225,19 +223,12 @@ public class MakerTxValidatorSanityCheckTests {
     }
 
     public static String getValidBtcMakerFeeMempoolJsonResponseString() {
-        URL resource = MakerTxValidatorSanityCheckTests.class.getClassLoader()
-                .getResource("mempool_test_data/valid_btc_maker_fee.json");
-        String path = Objects.requireNonNull(resource).getPath();
-
-        if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
-            // We need to remove the first character on Windows because the path starts with a
-            // leading slash "/C:/Users/..."
-            path = path.substring(1);
-        }
-
         try {
-            return Files.readString(Path.of(path));
-        } catch (IOException e) {
+            URL resource = MakerTxValidatorSanityCheckTests.class.getClassLoader()
+                    .getResource("mempool_test_data/valid_btc_maker_fee.json");
+            var path = Paths.get(Objects.requireNonNull(resource).toURI());
+            return Files.readString(path);
+        } catch (Exception e) {
             throw new IllegalStateException("Couldn't read valid_btc_maker_fee.json.", e);
         }
     }

--- a/core/src/test/java/bisq/core/provider/mempool/TxValidatorTest.java
+++ b/core/src/test/java/bisq/core/provider/mempool/TxValidatorTest.java
@@ -29,16 +29,18 @@ import bisq.core.util.coin.BsqFormatter;
 import org.bitcoinj.core.Coin;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.IOUtils;
 
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -50,6 +52,7 @@ import org.mockito.stubbing.Answer;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -58,7 +61,7 @@ import static org.mockito.Mockito.when;
 public class TxValidatorTest {
     private static final Logger log = LoggerFactory.getLogger(TxValidatorTest.class);
 
-    private List<String> btcFeeReceivers = new ArrayList<>();
+    private final List<String> btcFeeReceivers = new ArrayList<>();
 
     public TxValidatorTest() {
         btcFeeReceivers.add("1EKXx73oUhHaUh8JBimtiPGgHfwNmxYKAj");
@@ -72,12 +75,12 @@ public class TxValidatorTest {
         btcFeeReceivers.add("1BVxNn3T12veSK6DgqwU4Hdn7QHcDDRag7");
         btcFeeReceivers.add("3A8Zc1XioE2HRzYfbb5P8iemCS72M6vRJV");
         btcFeeReceivers.add(DelayedPayoutAddressProvider.BM3_ADDRESS);
-        log.warn("Known BTC fee receivers: {}", btcFeeReceivers.toString());
+        log.warn("Known BTC fee receivers: {}", btcFeeReceivers);
     }
 
     @Test
     public void testMakerTx() {
-        String mempoolData, offerData;
+        String /*mempoolData, */offerData;
 
         log.info("checking issue from user 2022-10-07");
         offerData = "1322804,5bec4007de1cb8cf18a5fa859d80d66031b8c78cfd99674e09ffd65cf23b50fc,9630000,137,0,757500";
@@ -121,17 +124,17 @@ public class TxValidatorTest {
 
         log.info("========== test case: The fee matched what we expected (BSQ)");
         offerData = "00072328,12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166,6250000,188,0,615955";
-        mempoolData = "{\"txid\":\"12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":19980}},{\"vout\":2,\"prevout\":{\"value\":2086015}},{\"vout\":0,\"prevout\":{\"value\":1100000}},{\"vout\":2,\"prevout\":{\"value\":938200}}],\"vout\":[{\"scriptpubkey_address\":\"17qiF1TYgT1YvsCPJyXQoKMtBZ7YJBW9GH\",\"value\":19792},{\"scriptpubkey_address\":\"16aFKD5hvEjJgPme5yRNJT2rAPdTXzdQc2\",\"value\":3768432},{\"scriptpubkey_address\":\"1D5V3QW8f5n4PhwfPgNkW9eWZwNJFyVU8n\",\"value\":346755}],\"size\":701,\"weight\":2804,\"fee\":9216,\"status\":{\"confirmed\":true,\"block_height\":615955}}";
+        //mempoolData = "{\"txid\":\"12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":19980}},{\"vout\":2,\"prevout\":{\"value\":2086015}},{\"vout\":0,\"prevout\":{\"value\":1100000}},{\"vout\":2,\"prevout\":{\"value\":938200}}],\"vout\":[{\"scriptpubkey_address\":\"17qiF1TYgT1YvsCPJyXQoKMtBZ7YJBW9GH\",\"value\":19792},{\"scriptpubkey_address\":\"16aFKD5hvEjJgPme5yRNJT2rAPdTXzdQc2\",\"value\":3768432},{\"scriptpubkey_address\":\"1D5V3QW8f5n4PhwfPgNkW9eWZwNJFyVU8n\",\"value\":346755}],\"size\":701,\"weight\":2804,\"fee\":9216,\"status\":{\"confirmed\":true,\"block_height\":615955}}";
         assertTrue(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case: No BSQ was burnt (error)");
         offerData = "NOBURN,12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166,6250000,0,0,615955";
-        mempoolData = "{\"txid\":\"12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":19980}},{\"vout\":2,\"prevout\":{\"value\":2086015}},{\"vout\":0,\"prevout\":{\"value\":1100000}},{\"vout\":2,\"prevout\":{\"value\":938200}}],\"vout\":[{\"scriptpubkey_address\":\"17qiF1TYgT1YvsCPJyXQoKMtBZ7YJBW9GH\",\"value\":19980},{\"scriptpubkey_address\":\"16aFKD5hvEjJgPme5yRNJT2rAPdTXzdQc2\",\"value\":3768432},{\"scriptpubkey_address\":\"1D5V3QW8f5n4PhwfPgNkW9eWZwNJFyVU8n\",\"value\":346755}],\"size\":701,\"weight\":2804,\"fee\":9216,\"status\":{\"confirmed\":true,\"block_height\":615955}}";
+        //mempoolData = "{\"txid\":\"12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":19980}},{\"vout\":2,\"prevout\":{\"value\":2086015}},{\"vout\":0,\"prevout\":{\"value\":1100000}},{\"vout\":2,\"prevout\":{\"value\":938200}}],\"vout\":[{\"scriptpubkey_address\":\"17qiF1TYgT1YvsCPJyXQoKMtBZ7YJBW9GH\",\"value\":19980},{\"scriptpubkey_address\":\"16aFKD5hvEjJgPme5yRNJT2rAPdTXzdQc2\",\"value\":3768432},{\"scriptpubkey_address\":\"1D5V3QW8f5n4PhwfPgNkW9eWZwNJFyVU8n\",\"value\":346755}],\"size\":701,\"weight\":2804,\"fee\":9216,\"status\":{\"confirmed\":true,\"block_height\":615955}}";
         assertFalse(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case: No BSQ input (error)");
         offerData = "NOBSQ,12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166,6250000,0,0,615955";
-        mempoolData = "{\"txid\":\"12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":2,\"prevout\":{\"value\":2086015}},{\"vout\":0,\"prevout\":{\"value\":1100000}},{\"vout\":2,\"prevout\":{\"value\":938200}}],\"vout\":[{\"scriptpubkey_address\":\"16aFKD5hvEjJgPme5yRNJT2rAPdTXzdQc2\",\"value\":3768432},{\"scriptpubkey_address\":\"1D5V3QW8f5n4PhwfPgNkW9eWZwNJFyVU8n\",\"value\":346755}],\"size\":701,\"weight\":2804,\"fee\":9216,\"status\":{\"confirmed\":true,\"block_height\":615955}}";
+        //mempoolData = "{\"txid\":\"12f658954890d38ce698355be0b27fdd68d092c7b1b7475381918db060f46166\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":2,\"prevout\":{\"value\":2086015}},{\"vout\":0,\"prevout\":{\"value\":1100000}},{\"vout\":2,\"prevout\":{\"value\":938200}}],\"vout\":[{\"scriptpubkey_address\":\"16aFKD5hvEjJgPme5yRNJT2rAPdTXzdQc2\",\"value\":3768432},{\"scriptpubkey_address\":\"1D5V3QW8f5n4PhwfPgNkW9eWZwNJFyVU8n\",\"value\":346755}],\"size\":701,\"weight\":2804,\"fee\":9216,\"status\":{\"confirmed\":true,\"block_height\":615955}}";
         assertFalse(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case: The fee was what we expected: (7000 sats)");
@@ -141,12 +144,12 @@ public class TxValidatorTest {
 
         log.info("========== test case: The fee matched what we expected");
         offerData = "89284,e1269aad63b3d894f5133ad658960971ef5c0fce6a13ad10544dc50fa3360588,900000,47,0,666473";
-        mempoolData = "{\"txid\":\"e1269aad63b3d894f5133ad658960971ef5c0fce6a13ad10544dc50fa3360588\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":72738}},{\"vout\":0,\"prevout\":{\"value\":1600000}}],\"vout\":[{\"scriptpubkey_address\":\"17Kh5Ype9yNomqRrqu2k1mdV5c6FcKfGwQ\",\"value\":72691},{\"scriptpubkey_address\":\"bc1qdr9zcw7gf2sehxkux4fmqujm5uguhaqz7l9lca\",\"value\":629016},{\"scriptpubkey_address\":\"bc1qgqrrqv8q6l5d3t52fe28ghuhz4xqrsyxlwn03z\",\"value\":956523}],\"size\":404,\"weight\":1286,\"fee\":14508,\"status\":{\"confirmed\":true,\"block_height\":672388}}";
+        //mempoolData = "{\"txid\":\"e1269aad63b3d894f5133ad658960971ef5c0fce6a13ad10544dc50fa3360588\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":72738}},{\"vout\":0,\"prevout\":{\"value\":1600000}}],\"vout\":[{\"scriptpubkey_address\":\"17Kh5Ype9yNomqRrqu2k1mdV5c6FcKfGwQ\",\"value\":72691},{\"scriptpubkey_address\":\"bc1qdr9zcw7gf2sehxkux4fmqujm5uguhaqz7l9lca\",\"value\":629016},{\"scriptpubkey_address\":\"bc1qgqrrqv8q6l5d3t52fe28ghuhz4xqrsyxlwn03z\",\"value\":956523}],\"size\":404,\"weight\":1286,\"fee\":14508,\"status\":{\"confirmed\":true,\"block_height\":672388}}";
         assertTrue(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case for UNDERPAID: Expected fee: 7.04 BSQ, actual fee paid: 1.01 BSQ");
         offerData = "VOxRS,e99ea06aefc824fd45031447f7a0b56efb8117a09f9b8982e2c4da480a3a0e91,10000000,101,0,669129";
-        mempoolData = "{\"txid\":\"e99ea06aefc824fd45031447f7a0b56efb8117a09f9b8982e2c4da480a3a0e91\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":16739}},{\"vout\":2,\"prevout\":{\"value\":113293809}}],\"vout\":[{\"scriptpubkey_address\":\"1F14nF6zoUfJkqZrFgdmK5VX5QVwEpAnKW\",\"value\":16638},{\"scriptpubkey_address\":\"bc1q80y688ev7u43vqy964yf7feqddvt2mkm8977cm\",\"value\":11500000},{\"scriptpubkey_address\":\"bc1q9whgyc2du9mrgnxz0nl0shwpw8ugrcae0j0w8p\",\"value\":101784485}],\"size\":406,\"weight\":1291,\"fee\":9425,\"status\":{\"confirmed\":true,\"block_height\":669134}}";
+        //mempoolData = "{\"txid\":\"e99ea06aefc824fd45031447f7a0b56efb8117a09f9b8982e2c4da480a3a0e91\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":16739}},{\"vout\":2,\"prevout\":{\"value\":113293809}}],\"vout\":[{\"scriptpubkey_address\":\"1F14nF6zoUfJkqZrFgdmK5VX5QVwEpAnKW\",\"value\":16638},{\"scriptpubkey_address\":\"bc1q80y688ev7u43vqy964yf7feqddvt2mkm8977cm\",\"value\":11500000},{\"scriptpubkey_address\":\"bc1q9whgyc2du9mrgnxz0nl0shwpw8ugrcae0j0w8p\",\"value\":101784485}],\"size\":406,\"weight\":1291,\"fee\":9425,\"status\":{\"confirmed\":true,\"block_height\":669134}}";
         assertFalse(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case for UNDERPAID: Expected fee: 1029000 sats BTC, actual fee paid: 441000 sats BTC because they used the default rate of 0.003 should have been 0.007 per BTC");
@@ -158,27 +161,27 @@ public class TxValidatorTest {
 
         log.info("========== test case for UNDERPAID: Expected fee: 2.12 BSQ, actual fee paid: 0.03 BSQ -- this is the example from the BSQ fee scammer Oct 2021");
         offerData = "957500,26e1a5e1f842cb7baa18bd197bd084e7f043d07720b9853e947158eb0a32677d,2000000,101,3,709426";
-        mempoolData = "{\"txid\":\"26e1a5e1f842cb7baa18bd197bd084e7f043d07720b9853e947158eb0a32677d\",\"version\":1,\"locktime\":0,\"vin\":[{\"txid\":\"\",\"vout\":0,\"prevout\":{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"\",\"value\":3688},\"scriptsig\":\"\",\"scriptsig_asm\":\"\",\"witness\":[\"\",\"\"],\"is_coinbase\":false,\"sequence\":4294967295},{\"txid\":\"\",\"vout\":2,\"prevout\":{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"\",\"value\":796203},\"scriptsig\":\"\",\"scriptsig_asm\":\"\",\"witness\":[\"\",\"\"],\"is_coinbase\":false,\"sequence\":4294967295}],\"vout\":[{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"bc1qydcyfe7kp6968hywcp0uek2xvgem3nlx0x0hfy\",\"value\":3685},{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"bc1qc4amk6sd3c4gzxjgd5sdlaegt0r5juq54vnrll\",\"value\":503346},{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"bc1q66e7m8y5lzfk5smg2a80xeaqzhslgeavg9y70t\",\"value\":291187}],\"size\":403,\"weight\":958,\"fee\":1673,\"status\":{\"confirmed\":true,\"block_height\":709426,\"block_hash\":\"\",\"block_time\":1636751288}}";
+        //mempoolData = "{\"txid\":\"26e1a5e1f842cb7baa18bd197bd084e7f043d07720b9853e947158eb0a32677d\",\"version\":1,\"locktime\":0,\"vin\":[{\"txid\":\"\",\"vout\":0,\"prevout\":{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"\",\"value\":3688},\"scriptsig\":\"\",\"scriptsig_asm\":\"\",\"witness\":[\"\",\"\"],\"is_coinbase\":false,\"sequence\":4294967295},{\"txid\":\"\",\"vout\":2,\"prevout\":{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"\",\"value\":796203},\"scriptsig\":\"\",\"scriptsig_asm\":\"\",\"witness\":[\"\",\"\"],\"is_coinbase\":false,\"sequence\":4294967295}],\"vout\":[{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"bc1qydcyfe7kp6968hywcp0uek2xvgem3nlx0x0hfy\",\"value\":3685},{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"bc1qc4amk6sd3c4gzxjgd5sdlaegt0r5juq54vnrll\",\"value\":503346},{\"scriptpubkey\":\"\",\"scriptpubkey_asm\":\"\",\"scriptpubkey_type\":\"v0_p2wpkh\",\"scriptpubkey_address\":\"bc1q66e7m8y5lzfk5smg2a80xeaqzhslgeavg9y70t\",\"value\":291187}],\"size\":403,\"weight\":958,\"fee\":1673,\"status\":{\"confirmed\":true,\"block_height\":709426,\"block_hash\":\"\",\"block_time\":1636751288}}";
         assertFalse(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case: expected fee paid using two BSQ UTXOs");
         offerData = "ZHNYCAE,a91c6f1cb62721a7943678547aa814d6f29125ed63ad076073eb5ae7f16a76e9,83000000,8796,0,717000";
-        mempoolData = "{\"txid\":\"a91c6f1cb62721a7943678547aa814d6f29125ed63ad076073eb5ae7f16a76e9\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":3510}},{\"vout\":0,\"prevout\":{\"value\":6190}},{\"vout\":0,\"prevout\":{\"value\":46000000}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qmqphx028eu4tzdvgccf5re52qtv6pmjanrpq29\",\"value\":904},{\"scriptpubkey_address\":\"bc1qtkvu4zeh0g0pce452335tgnswxd8ayxlktfj2s\",\"value\":30007648},{\"scriptpubkey_address\":\"bc1qdatwgzrrntp2m53tpzmax4dxu6md2c0c9vj8ut\",\"value\":15997324}],\"size\":549,\"weight\":1227,\"fee\":3824,\"status\":{\"confirmed\":true,\"block_height\":716444}}";
+        //mempoolData = "{\"txid\":\"a91c6f1cb62721a7943678547aa814d6f29125ed63ad076073eb5ae7f16a76e9\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":3510}},{\"vout\":0,\"prevout\":{\"value\":6190}},{\"vout\":0,\"prevout\":{\"value\":46000000}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qmqphx028eu4tzdvgccf5re52qtv6pmjanrpq29\",\"value\":904},{\"scriptpubkey_address\":\"bc1qtkvu4zeh0g0pce452335tgnswxd8ayxlktfj2s\",\"value\":30007648},{\"scriptpubkey_address\":\"bc1qdatwgzrrntp2m53tpzmax4dxu6md2c0c9vj8ut\",\"value\":15997324}],\"size\":549,\"weight\":1227,\"fee\":3824,\"status\":{\"confirmed\":true,\"block_height\":716444}}";
         assertTrue(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case: expected fee paid using three BSQ UTXOs");
         offerData = "3UTXOGOOD,c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262,200000000,17888,0,733715";
-        mempoolData = "{\"txid\":\"c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":9833}},{\"vout\":0,\"prevout\":{\"value\":1362}},{vout\":0,\"prevout\":{\"value\":17488}},{\"vout\":2,\"prevout\":{\"value\":573360131}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qvwpm87kmrlgave9srxk6nfwleehll0kxetu5j0\",\"value\":10795},{\"scriptpubkey_address\":\"bc1qz5n83ppfpdznnzff4e7tjep5c6f6jce9mqnrzh\",\"value\":230004780},{\"scriptpubkey_address\":\"bc1qcfyjajhuv55fyu6g5ug664r57u9a7qg55cgt5p\",\"value\":343370849}],\"size\":699,\"weight\":1500,\"fee\":2390,\"status\":{\"confirmed\":true,\"block_height\":733715}}";
+        //mempoolData = "{\"txid\":\"c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":9833}},{\"vout\":0,\"prevout\":{\"value\":1362}},{vout\":0,\"prevout\":{\"value\":17488}},{\"vout\":2,\"prevout\":{\"value\":573360131}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qvwpm87kmrlgave9srxk6nfwleehll0kxetu5j0\",\"value\":10795},{\"scriptpubkey_address\":\"bc1qz5n83ppfpdznnzff4e7tjep5c6f6jce9mqnrzh\",\"value\":230004780},{\"scriptpubkey_address\":\"bc1qcfyjajhuv55fyu6g5ug664r57u9a7qg55cgt5p\",\"value\":343370849}],\"size\":699,\"weight\":1500,\"fee\":2390,\"status\":{\"confirmed\":true,\"block_height\":733715}}";
         assertTrue(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case: expected fee paid using four BSQ UTXOs");
         offerData = "4UTXOGOOD,c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262,200000000,17888,0,733715";
-        mempoolData = "{\"txid\":\"c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":4833}},{\"vout\":0,\"prevout\":{\"value\":5000}},{\"vout\":0,\"prevout\":{\"value\":1362}},{vout\":0,\"prevout\":{\"value\":17488}},{\"vout\":2,\"prevout\":{\"value\":573360131}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qvwpm87kmrlgave9srxk6nfwleehll0kxetu5j0\",\"value\":10795},{\"scriptpubkey_address\":\"bc1qz5n83ppfpdznnzff4e7tjep5c6f6jce9mqnrzh\",\"value\":230004780},{\"scriptpubkey_address\":\"bc1qcfyjajhuv55fyu6g5ug664r57u9a7qg55cgt5p\",\"value\":343370849}],\"size\":699,\"weight\":1500,\"fee\":2390,\"status\":{\"confirmed\":true,\"block_height\":733715}}";
+        //mempoolData = "{\"txid\":\"c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":4833}},{\"vout\":0,\"prevout\":{\"value\":5000}},{\"vout\":0,\"prevout\":{\"value\":1362}},{vout\":0,\"prevout\":{\"value\":17488}},{\"vout\":2,\"prevout\":{\"value\":573360131}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qvwpm87kmrlgave9srxk6nfwleehll0kxetu5j0\",\"value\":10795},{\"scriptpubkey_address\":\"bc1qz5n83ppfpdznnzff4e7tjep5c6f6jce9mqnrzh\",\"value\":230004780},{\"scriptpubkey_address\":\"bc1qcfyjajhuv55fyu6g5ug664r57u9a7qg55cgt5p\",\"value\":343370849}],\"size\":699,\"weight\":1500,\"fee\":2390,\"status\":{\"confirmed\":true,\"block_height\":733715}}";
         assertTrue(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
 
         log.info("========== test case: three BSQ UTXOs, but fee paid is too low");
         offerData = "3UTXOLOWFEE,c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262,200000000,101,0,733715";
-        mempoolData = "{\"txid\":\"c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":9833}},{\"vout\":0,\"prevout\":{\"value\":1362}},{vout\":0,\"prevout\":{\"value\":1362}},{\"vout\":2,\"prevout\":{\"value\":573360131}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qvwpm87kmrlgave9srxk6nfwleehll0kxetu5j0\",\"value\":10795},{\"scriptpubkey_address\":\"bc1qz5n83ppfpdznnzff4e7tjep5c6f6jce9mqnrzh\",\"value\":230004780},{\"scriptpubkey_address\":\"bc1qcfyjajhuv55fyu6g5ug664r57u9a7qg55cgt5p\",\"value\":343370849}],\"size\":699,\"weight\":1500,\"fee\":2390,\"status\":{\"confirmed\":true,\"block_height\":733715}}";
+        //mempoolData = "{\"txid\":\"c7dddc267a366fa1d87840eeb0dcd89918a886ccb9aabee80f667635a5d4e262\",\"version\":1,\"locktime\":0,\"vin\":[{\"vout\":0,\"prevout\":{\"value\":9833}},{\"vout\":0,\"prevout\":{\"value\":1362}},{vout\":0,\"prevout\":{\"value\":1362}},{\"vout\":2,\"prevout\":{\"value\":573360131}}],\"vout\":[{\"scriptpubkey_address\":\"bc1qvwpm87kmrlgave9srxk6nfwleehll0kxetu5j0\",\"value\":10795},{\"scriptpubkey_address\":\"bc1qz5n83ppfpdznnzff4e7tjep5c6f6jce9mqnrzh\",\"value\":230004780},{\"scriptpubkey_address\":\"bc1qcfyjajhuv55fyu6g5ug664r57u9a7qg55cgt5p\",\"value\":343370849}],\"size\":699,\"weight\":1500,\"fee\":2390,\"status\":{\"confirmed\":true,\"block_height\":733715}}";
         assertFalse(createTxValidator(offerData).validateBsqFeeTx(false).getResult());
     }
 
@@ -214,11 +217,11 @@ public class TxValidatorTest {
                     assertFalse(expectedResult);  // tx was not found in explorer
                 } else {
                     txValidator.parseJsonValidateMakerFeeTx(jsonTxt, btcFeeReceivers);
-                    assertTrue(expectedResult == txValidator.getResult());
+                    assertEquals(expectedResult, txValidator.getResult());
                 }
             } else {
                 txValidator.validateBsqFeeTx(true);
-                assertTrue(expectedResult == txValidator.getResult());
+                assertEquals(expectedResult, txValidator.getResult());
             }
         });
     }
@@ -226,79 +229,64 @@ public class TxValidatorTest {
     private Map<String, String> loadJsonTestData(String fileName) {
         String json = "";
         try {
-            json = IOUtils.toString(this.getClass().getResourceAsStream(fileName), "UTF-8");
-        } catch (IOException e) {
+            json = IOUtils.toString(Objects.requireNonNull(this.getClass().getResourceAsStream(fileName)), StandardCharsets.UTF_8);
+        } catch (Exception e) {
             log.error(e.toString());
         }
-        Map<String, String> map = new Gson().fromJson(json, Map.class);
-        return map;
+        return new Gson().fromJson(json, new TypeToken<Map<String, String>>() {
+        }.getType());
     }
 
     // initialize the TxValidator with offerData to be validated
     // and mock the used DaoStateService
     private TxValidator createTxValidator(String offerData) {
-        try {
-            String[] y = offerData.split(",");
-            String txId = y[1];
-            long amount = Long.parseLong(y[2]);
-            long feePaid = Long.parseLong(y[3]);
-            boolean isCurrencyForMakerFeeBtc = Long.parseLong(y[4]) > 0;
-            long feePaymentBlockHeight = Long.parseLong(y[5]);
-            DaoStateService mockedDaoStateService = mock(DaoStateService.class);
-            Tx mockedTx = mock(Tx.class);
+        String[] y = offerData.split(",");
+        String txId = y[1];
+        long amount = Long.parseLong(y[2]);
+        long feePaid = Long.parseLong(y[3]);
+        boolean isCurrencyForMakerFeeBtc = Long.parseLong(y[4]) > 0;
+        long feePaymentBlockHeight = Long.parseLong(y[5]);
+        DaoStateService mockedDaoStateService = mock(DaoStateService.class);
+        Tx mockedTx = mock(Tx.class);
 
-            Answer<Coin> mockGetFeeRate = invocation -> {
-                return mockedLookupFeeRate(invocation.getArgument(0), invocation.getArgument(1));
-            };
-            Answer<Coin> mockGetParamValueAsCoin = invocation -> {
-                return mockedGetParamValueAsCoin(invocation.getArgument(0), invocation.getArgument(1));
-            };
-            Answer<List<Coin>> mockGetParamChangeList = invocation -> {
-                return mockedGetParamChangeList(invocation.getArgument(0));
-            };
-            Answer<Optional<Tx>> mockGetBsqTx = invocation -> {
-                return Optional.of(mockedTx);
-            };
-            Answer<Long> mockGetBurntBsq = invocation -> {
-                return feePaid;
-            };
-            when(mockedDaoStateService.getParamValueAsCoin(Mockito.any(Param.class), Mockito.anyInt())).thenAnswer(mockGetFeeRate);
-            when(mockedDaoStateService.getParamValueAsCoin(Mockito.any(Param.class), Mockito.anyString())).thenAnswer(mockGetParamValueAsCoin);
-            when(mockedDaoStateService.getParamChangeList(Mockito.any())).thenAnswer(mockGetParamChangeList);
-            when(mockedDaoStateService.getTx(Mockito.any())).thenAnswer(mockGetBsqTx);
-            when(mockedTx.getBurntBsq()).thenAnswer(mockGetBurntBsq);
+        Answer<Coin> mockGetFeeRate = invocation ->
+                mockedLookupFeeRate(invocation.getArgument(0), invocation.getArgument(1));
+        Answer<Coin> mockGetParamValueAsCoin = invocation ->
+                mockedGetParamValueAsCoin(invocation.getArgument(0), invocation.getArgument(1));
+        Answer<List<Coin>> mockGetParamChangeList = invocation ->
+                mockedGetParamChangeList(invocation.getArgument(0));
+        Answer<Optional<Tx>> mockGetBsqTx = invocation ->
+                Optional.of(mockedTx);
+        Answer<Long> mockGetBurntBsq = invocation ->
+                feePaid;
+        when(mockedDaoStateService.getParamValueAsCoin(Mockito.any(Param.class), Mockito.anyInt())).thenAnswer(mockGetFeeRate);
+        when(mockedDaoStateService.getParamValueAsCoin(Mockito.any(Param.class), Mockito.anyString())).thenAnswer(mockGetParamValueAsCoin);
+        when(mockedDaoStateService.getParamChangeList(Mockito.any())).thenAnswer(mockGetParamChangeList);
+        when(mockedDaoStateService.getTx(Mockito.any())).thenAnswer(mockGetBsqTx);
+        when(mockedTx.getBurntBsq()).thenAnswer(mockGetBurntBsq);
 
-            Answer<Long> getMakerFeeBsq = invocation -> 1514L;
-            Answer<Long> getTakerFeeBsq = invocation -> 10597L;
-            Answer<Long> getMakerFeeBtc = invocation -> 100000L;
-            Answer<Long> getTakerFeeBtc = invocation -> 700000L;
-            Filter mockedFilter = mock(Filter.class);
-            when(mockedFilter.getMakerFeeBsq()).thenAnswer(getMakerFeeBsq);
-            when(mockedFilter.getTakerFeeBsq()).thenAnswer(getTakerFeeBsq);
-            when(mockedFilter.getMakerFeeBtc()).thenAnswer(getMakerFeeBtc);
-            when(mockedFilter.getTakerFeeBtc()).thenAnswer(getTakerFeeBtc);
-            FilterManager filterManager = mock(FilterManager.class);
-            when(filterManager.getFilter()).thenReturn(mockedFilter);
-            TxValidator txValidator = new TxValidator(mockedDaoStateService, txId, Coin.valueOf(amount), isCurrencyForMakerFeeBtc, feePaymentBlockHeight, filterManager);
-            return txValidator;
-        } catch (RuntimeException ignore) {
-            // If input format is not as expected we ignore entry
-        }
-        return null;
+        Filter mockedFilter = mock(Filter.class);
+        when(mockedFilter.getMakerFeeBsq()).thenReturn(1514L);
+        when(mockedFilter.getTakerFeeBsq()).thenReturn(10597L);
+        when(mockedFilter.getMakerFeeBtc()).thenReturn(100000L);
+        when(mockedFilter.getTakerFeeBtc()).thenReturn(700000L);
+        FilterManager filterManager = mock(FilterManager.class);
+        when(filterManager.getFilter()).thenReturn(mockedFilter);
+        return new TxValidator(mockedDaoStateService, txId, Coin.valueOf(amount), isCurrencyForMakerFeeBtc, feePaymentBlockHeight, filterManager);
     }
 
-    Coin mockedLookupFeeRate(Param param, int blockHeight) {
+    private Coin mockedLookupFeeRate(Param param, int blockHeight) {
         BsqFormatter bsqFormatter = new BsqFormatter();
         LinkedHashMap<Long, String> feeMap = mockedGetFeeRateMap(param);
         for (Map.Entry<Long, String> entry : feeMap.entrySet()) {
             if (blockHeight >= entry.getKey()) {
-                if (param.equals(Param.DEFAULT_MAKER_FEE_BTC) || param.equals(Param.DEFAULT_TAKER_FEE_BTC))
+                if (param == Param.DEFAULT_MAKER_FEE_BTC || param == Param.DEFAULT_TAKER_FEE_BTC)
                     return bsqFormatter.parseToBTC(entry.getValue());
                 else
                     return ParsingUtils.parseToCoin(entry.getValue(), bsqFormatter);
             }
         }
-        if (param.equals(Param.DEFAULT_MAKER_FEE_BTC) || param.equals(Param.DEFAULT_TAKER_FEE_BTC))
+        if (param == Param.DEFAULT_MAKER_FEE_BTC || param == Param.DEFAULT_TAKER_FEE_BTC)
             return bsqFormatter.parseToBTC(param.getDefaultValue());
         else
             return ParsingUtils.parseToCoin(param.getDefaultValue(), bsqFormatter);
@@ -354,14 +342,14 @@ public class TxValidatorTest {
         return feeMap;
     }
 
-    public Coin mockedGetParamValueAsCoin(Param param, String paramValue) {
+    private Coin mockedGetParamValueAsCoin(Param param, String paramValue) {
         BsqFormatter bsqFormatter = new BsqFormatter();
         return bsqFormatter.parseParamValueToCoin(param, paramValue);
     }
 
-    public List<Coin> mockedGetParamChangeList(Param param) {
+    private List<Coin> mockedGetParamChangeList(Param param) {
         BsqFormatter bsqFormatter = new BsqFormatter();
-        List<Coin> retVal = new ArrayList<Coin>();
+        List<Coin> retVal = new ArrayList<>();
         Map<Long, String> feeMap = mockedGetFeeRateMap(param);
         for (Map.Entry<Long, String> entry : feeMap.entrySet()) {
             retVal.add(ParsingUtils.parseToCoin(entry.getValue(), bsqFormatter));

--- a/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
@@ -31,30 +31,31 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Slf4j
 public class BisqInstallerTest {
     @Test
-    public void call() throws Exception {
+    public void call() {
     }
 
     @Test
     public void verifySignature() throws Exception {
-        URL url = this.getClass().getResource("/downloadUpdate/test.txt");
+        URL url = requireNonNull(getClass().getResource("/downloadUpdate/test.txt"));
         File dataFile = new File(url.toURI().getPath());
-        url = this.getClass().getResource("/downloadUpdate/test.txt.asc");
+        url = requireNonNull(getClass().getResource("/downloadUpdate/test.txt.asc"));
         File sigFile = new File(url.toURI().getPath());
-        url = this.getClass().getResource("/downloadUpdate/F379A1C6.asc");
+        url = requireNonNull(getClass().getResource("/downloadUpdate/F379A1C6.asc"));
         File pubKeyFile = new File(url.toURI().getPath());
 
         assertEquals(BisqInstaller.VerifyStatusEnum.OK, BisqInstaller.verifySignature(pubKeyFile, sigFile, dataFile));
 
-        url = this.getClass().getResource("/downloadUpdate/test_bad.txt");
+        url = requireNonNull(getClass().getResource("/downloadUpdate/test_bad.txt"));
         dataFile = new File(url.toURI().getPath());
-        url = this.getClass().getResource("/downloadUpdate/test_bad.txt.asc");
+        url = requireNonNull(getClass().getResource("/downloadUpdate/test_bad.txt.asc"));
         sigFile = new File(url.toURI().getPath());
-        url = this.getClass().getResource("/downloadUpdate/F379A1C6.asc");
+        url = requireNonNull(getClass().getResource("/downloadUpdate/F379A1C6.asc"));
         pubKeyFile = new File(url.toURI().getPath());
 
         BisqInstaller.verifySignature(pubKeyFile, sigFile, dataFile);
@@ -62,19 +63,19 @@ public class BisqInstallerTest {
     }
 
     @Test
-    public void getFileName() throws Exception {
+    public void getFileName() {
     }
 
     @Test
-    public void getDownloadType() throws Exception {
+    public void getDownloadType() {
     }
 
     @Test
-    public void getIndex() throws Exception {
+    public void getIndex() {
     }
 
     @Test
-    public void getSigFileDescriptors() throws Exception {
+    public void getSigFileDescriptors() {
         BisqInstaller bisqInstaller = new BisqInstaller();
         FileDescriptor installerFileDescriptor = FileDescriptor.builder().fileName("filename.txt").id("filename").loadUrl("url://filename.txt").build();
         FileDescriptor key1 = FileDescriptor.builder().fileName("key1").id("key1").loadUrl("").build();
@@ -84,6 +85,5 @@ public class BisqInstallerTest {
         sigFileDescriptors = bisqInstaller.getSigFileDescriptors(installerFileDescriptor, Lists.newArrayList(key1, key2));
         assertEquals(2, sigFileDescriptors.size());
         log.info("test");
-
     }
 }

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
@@ -45,13 +45,13 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoSession;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -62,8 +62,9 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 public class P2PDataStorageBuildGetDataResponseTest {
+    @ExtendWith(MockitoExtension.class)
+    @MockitoSettings(strictness = Strictness.LENIENT) // there are unused stubs in TestState & elsewhere
     abstract static class P2PDataStorageBuildGetDataResponseTestBase {
-        private MockitoSession mockitoSession;
         // GIVEN null & non-null supportedCapabilities
         private TestState testState;
 
@@ -76,10 +77,6 @@ public class P2PDataStorageBuildGetDataResponseTest {
 
         @BeforeEach
         public void setUp() {
-            mockitoSession = Mockito.mockitoSession()
-                    .initMocks(this)
-                    .strictness(Strictness.LENIENT) // there are unused stubs in TestState & elsewhere
-                    .startMocking();
             this.testState = new TestState();
 
             this.localNodeAddress = new NodeAddress("localhost", 8080);
@@ -87,11 +84,6 @@ public class P2PDataStorageBuildGetDataResponseTest {
 
             // Set up basic capabilities to ensure message contains it
             Capabilities.app.addAll(Capability.MEDIATION);
-        }
-
-        @AfterEach
-        public void tearDown() {
-            mockitoSession.finishMocking();
         }
 
         static class RequiredCapabilitiesPNPStub extends PersistableNetworkPayloadStub


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Prevent tests calling `MakerTxValidatorSanityCheckTests::getValidBtcMakerFeeMempoolJsonResponseString` from failing when running the build from a working directory with spaces in its absolute path, due to the fact that the test resource paths returned by `Class::getResource` are URL encoded.

Also do some minor tidying of other tests which load resources, and replace manual `MockitoSession` setup & tear down in tests which still do that, now that `mockito-junit-jupiter` has been added to the build dependencies.
