### PR TITLE
AsyncFileWriter: Truncate before write

### DIFF
--- a/persistence/src/main/java/bisq/persistence/AsyncFileChannelWriter.java
+++ b/persistence/src/main/java/bisq/persistence/AsyncFileChannelWriter.java
@@ -22,6 +22,8 @@ import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.CompletionHandler;
 import java.nio.file.Path;
 
+import java.io.IOException;
+
 import java.util.concurrent.CompletableFuture;
 
 import lombok.Getter;
@@ -34,6 +36,18 @@ public class AsyncFileChannelWriter implements AsyncFileWriter {
     public AsyncFileChannelWriter(Path filePath, AsynchronousFileChannel fileChannel) {
         this.filePath = filePath;
         this.fileChannel = fileChannel;
+    }
+
+    @Override
+    public CompletableFuture<Void> truncate() {
+        var completableFuture = new CompletableFuture<Void>();
+        try {
+            fileChannel.truncate(0);
+            completableFuture.complete(null);
+        } catch (IOException e) {
+            completableFuture.completeExceptionally(e);
+        }
+        return completableFuture;
     }
 
     @Override

--- a/persistence/src/main/java/bisq/persistence/AsyncFileWriter.java
+++ b/persistence/src/main/java/bisq/persistence/AsyncFileWriter.java
@@ -22,6 +22,8 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
 public interface AsyncFileWriter {
+    CompletableFuture<Void> truncate();
+
     CompletableFuture<Integer> write(byte[] data, int offset);
 
     Path getFilePath();

--- a/persistence/src/main/java/bisq/persistence/PersistenceFileWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistenceFileWriter.java
@@ -19,7 +19,7 @@ package bisq.persistence;
 
 import java.nio.file.Path;
 
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
@@ -32,35 +32,39 @@ public class PersistenceFileWriter {
         this.writeRequestScheduler = writeRequestScheduler;
     }
 
-    public CountDownLatch write(byte[] data) {
-        CountDownLatch writeFinished = new CountDownLatch(1);
-        scheduleAsyncWrite(data, 0, data.length, writeFinished);
-        return writeFinished;
+    public CompletableFuture<Void> write(byte[] data) {
+        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        scheduleAsyncWrite(data, 0, data.length, completableFuture);
+        return completableFuture;
     }
 
     public Path getFilePath() {
         return asyncWriter.getFilePath();
     }
 
-    private void scheduleAsyncWrite(byte[] data, int offset, int size, CountDownLatch writeFinished) {
+    private void scheduleAsyncWrite(byte[] data, int offset, int size, CompletableFuture<Void> completableFuture) {
         asyncWriter.write(data, offset)
-                .thenAcceptAsync(writeUntilEndAsync(data, offset, size, writeFinished), writeRequestScheduler);
+                .thenAcceptAsync(writeUntilEndAsync(data, offset, size, completableFuture), writeRequestScheduler)
+                .exceptionally(throwable -> {
+                    completableFuture.completeExceptionally(throwable);
+                    return null;
+                });
     }
 
     private Consumer<Integer> writeUntilEndAsync(byte[] data,
                                                  int offset,
                                                  int totalBytes,
-                                                 CountDownLatch writeFinished) {
+                                                 CompletableFuture<Void> completableFuture) {
         return writtenBytes -> {
             if (writtenBytes == totalBytes) {
-                writeFinished.countDown();
+                completableFuture.complete(null);
                 return;
             }
 
             int remainingBytes = totalBytes - writtenBytes;
             if (remainingBytes > 0) {
                 int newOffset = offset + writtenBytes;
-                scheduleAsyncWrite(data, newOffset, remainingBytes, writeFinished);
+                scheduleAsyncWrite(data, newOffset, remainingBytes, completableFuture);
             }
         };
     }

--- a/persistence/src/main/java/bisq/persistence/PersistenceFileWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistenceFileWriter.java
@@ -34,7 +34,12 @@ public class PersistenceFileWriter {
 
     public CompletableFuture<Void> write(byte[] data) {
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-        scheduleAsyncWrite(data, 0, data.length, completableFuture);
+        asyncWriter.truncate()
+                .thenRun(() -> scheduleAsyncWrite(data, 0, data.length, completableFuture))
+                .exceptionally(throwable -> {
+                    completableFuture.completeExceptionally(throwable);
+                    return null;
+                });
         return completableFuture;
     }
 

--- a/persistence/src/test/java/bisq/persistence/AtomicFileWriterIntegrationTests.java
+++ b/persistence/src/test/java/bisq/persistence/AtomicFileWriterIntegrationTests.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.persistence;
+
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import java.io.IOException;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+@ExtendWith(MockitoExtension.class)
+public class AtomicFileWriterIntegrationTests {
+    private static ExecutorService executorService;
+    private Path filePath;
+    private AtomicFileWriter atomicFileWriter;
+
+    @BeforeAll
+    static void beforeAll() {
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        executorService.shutdownNow();
+    }
+
+    @BeforeEach
+    void setup(@TempDir Path tempDir) throws IOException {
+        filePath = tempDir.resolve("file");
+        var fileChannel = AsynchronousFileChannel.open(filePath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+        AsyncFileChannelWriter asyncFileChannelWriter = new AsyncFileChannelWriter(filePath, fileChannel);
+        PersistenceFileWriter persistenceFileWriter = new PersistenceFileWriter(asyncFileChannelWriter, executorService);
+        atomicFileWriter = new AtomicFileWriter(filePath, persistenceFileWriter);
+    }
+
+    @Test
+    void singleWrite() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        byte[] expectedData = "Hello World!".getBytes(StandardCharsets.UTF_8);
+        atomicFileWriter.write(expectedData).get(30, TimeUnit.SECONDS);
+
+        byte[] actualData = Files.readAllBytes(filePath);
+        assertThat(actualData, is(expectedData));
+    }
+
+    @Test
+    void twoWritesSecondSmaller() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        byte[] expectedData = "Hello World!".getBytes(StandardCharsets.UTF_8);
+        atomicFileWriter.write(expectedData).get(30, TimeUnit.SECONDS);
+
+        expectedData = "Bye!".getBytes(StandardCharsets.UTF_8);
+        atomicFileWriter.write(expectedData).get(30, TimeUnit.SECONDS);
+
+        byte[] actualData = Files.readAllBytes(filePath);
+        assertThat(actualData, is(expectedData));
+    }
+
+    @Test
+    void twoWriteSecondLarger() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        byte[] expectedData = "Hello World!".getBytes(StandardCharsets.UTF_8);
+        atomicFileWriter.write(expectedData).get(30, TimeUnit.SECONDS);
+
+        expectedData = "Bye! Hello World!".getBytes(StandardCharsets.UTF_8);
+        atomicFileWriter.write(expectedData).get(30, TimeUnit.SECONDS);
+
+        byte[] actualData = Files.readAllBytes(filePath);
+        assertThat(actualData, is(expectedData));
+    }
+}

--- a/persistence/src/test/java/bisq/persistence/PersistenceFileWriterTests.java
+++ b/persistence/src/test/java/bisq/persistence/PersistenceFileWriterTests.java
@@ -17,9 +17,11 @@
 
 package bisq.persistence;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,8 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -57,40 +57,37 @@ public class PersistenceFileWriterTests {
     }
 
     @Test
-    void writeInOneGo() throws InterruptedException {
+    void writeInOneGo() throws InterruptedException, ExecutionException, TimeoutException {
         doReturn(completedFuture(DATA.length))
                 .when(asyncWriter).write(any(), anyInt());
 
-        boolean isSuccess = fileWriter.write(DATA)
-                .await(30, TimeUnit.SECONDS);
+        fileWriter.write(DATA)
+                .get(30, TimeUnit.SECONDS);
 
-        assertThat(isSuccess, is(true));
         verify(asyncWriter, times(1)).write(any(), anyInt());
     }
 
     @Test
-    void writeInTwoPhases() throws InterruptedException {
+    void writeInTwoPhases() throws InterruptedException, ExecutionException, TimeoutException {
         doReturn(completedFuture(25), completedFuture(75))
                 .when(asyncWriter).write(any(), anyInt());
 
-        boolean isSuccess = fileWriter.write(DATA)
-                .await(30, TimeUnit.SECONDS);
+        fileWriter.write(DATA)
+                .get(30, TimeUnit.SECONDS);
 
-        assertThat(isSuccess, is(true));
         verify(asyncWriter, times(2)).write(any(), anyInt());
     }
 
     @Test
-    void writeInFivePhases() throws InterruptedException {
+    void writeInFivePhases() throws InterruptedException, ExecutionException, TimeoutException {
         doReturn(completedFuture(10), completedFuture(20),
                 completedFuture(30), completedFuture(15),
                 completedFuture(25))
                 .when(asyncWriter).write(any(), anyInt());
 
-        boolean isSuccess = fileWriter.write(DATA)
-                .await(30, TimeUnit.SECONDS);
+        fileWriter.write(DATA)
+                .get(30, TimeUnit.SECONDS);
 
-        assertThat(isSuccess, is(true));
         verify(asyncWriter, times(5)).write(any(), anyInt());
     }
 }


### PR DESCRIPTION
- [Implement AsyncFileWriter.truncate()](https://github.com/bisq-network/bisq/commit/a30d4d55d6e0097b8d78a786a0435387c5c7b2fc)
- [Return CompletableFuture in PersistenceFileWriter.write](https://github.com/bisq-network/bisq/commit/bf575246715cdce20db1ffbae792b820e88ad479)
- [PersistenceFileWrite: Truncate file before writing](https://github.com/bisq-network/bisq/commit/f7443b76765eb9f09ad45c466cf9c4e185ed4320)
- [Implement AtomicFileWriterIntegrationTests](https://github.com/bisq-network/bisq/commit/fd6b446544919e92e7d3892b3fab0fd8bb1228a7)
  - singleWrite
  - twoWritesSecondSmaller
  - twoWriteSecondLarger