### PR TITLE
Account for invalid tx BSQ burns in supply & market cap charts and optimise the latter

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/chart/ChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/components/chart/ChartDataModel.java
@@ -23,7 +23,9 @@ import java.time.Instant;
 import java.time.temporal.TemporalAdjuster;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BinaryOperator;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
@@ -89,13 +91,20 @@ public abstract class ChartDataModel extends ActivatableDataModel {
 
     protected abstract void invalidateCache();
 
-    protected Map<Long, Long> getMergedMap(Map<Long, Long> map1,
-                                           Map<Long, Long> map2,
-                                           BinaryOperator<Long> mergeFunction) {
-        return Stream.concat(map1.entrySet().stream(),
-                        map2.entrySet().stream())
-                .collect(Collectors.toMap(Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        mergeFunction));
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Utils
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    protected static <T, R> Function<T, R> memoize(Function<T, R> fn) {
+        Map<T, R> map = new ConcurrentHashMap<>();
+        return x -> map.computeIfAbsent(x, fn);
+    }
+
+    protected static <V> Map<Long, V> getMergedMap(Map<Long, V> map1,
+                                                   Map<Long, V> map2,
+                                                   BinaryOperator<V> mergeFunction) {
+        return Stream.concat(map1.entrySet().stream(), map2.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, mergeFunction));
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/chart/ChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/components/chart/ChartDataModel.java
@@ -26,14 +26,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.function.LongPredicate;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class ChartDataModel extends ActivatableDataModel {
     protected final TemporalAdjusterModel temporalAdjusterModel = new TemporalAdjusterModel();
-    protected Predicate<Long> dateFilter = e -> true;
+    protected LongPredicate dateFilter = e -> true;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -76,7 +76,7 @@ public abstract class ChartDataModel extends ActivatableDataModel {
     // Date filter predicate
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public Predicate<Long> getDateFilter() {
+    public LongPredicate getDateFilter() {
         return dateFilter;
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -238,7 +239,7 @@ public class PriceChartDataModel extends ChartDataModel {
     private Map<Long, Double> getPriceByInterval(Collection<TradeStatistics3> collection,
                                                  Predicate<TradeStatistics3> collectionFilter,
                                                  Function<TradeStatistics3, Long> groupByDateFunction,
-                                                 Predicate<Long> dateFilter,
+                                                 LongPredicate dateFilter,
                                                  Function<List<TradeStatistics3>, Double> getAveragePriceFunction) {
         return collection.stream()
                 .filter(collectionFilter)
@@ -274,7 +275,7 @@ public class PriceChartDataModel extends ChartDataModel {
     private Map<Long, Double> getBsqMarketCapByInterval(Collection<TradeStatistics3> tradeStatistics3s,
                                                         Predicate<TradeStatistics3> collectionFilter,
                                                         Function<TradeStatistics3, Long> groupByDateFunction,
-                                                        Predicate<Long> dateFilter,
+                                                        LongPredicate dateFilter,
                                                         Function<List<TradeStatistics3>, Double> getAveragePriceFunction) {
         Map<Long, List<TradeStatistics3>> pricesGroupedByDate = tradeStatistics3s.stream()
                 .filter(collectionFilter)

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
@@ -307,7 +307,7 @@ public class PriceChartDataModel extends ChartDataModel {
     private NavigableMap<Long, Double> getOutstandingBsqByInterval() {
         Stream<Tx> txStream = daoStateService.getBlocks().stream()
                 .flatMap(b -> b.getTxs().stream())
-                .filter(tx -> tx.getBurntFee() > 0);
+                .filter(tx -> tx.getBurntBsq() > 0);
         Map<Long, Double> simpleBurns = txStream
                 .collect(Collectors.groupingBy(
                         tx -> toTimeInterval(Instant.ofEpochMilli(tx.getTime())),

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/price/PriceChartDataModel.java
@@ -32,22 +32,18 @@ import javax.inject.Inject;
 import java.time.Instant;
 
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
-
-import org.jetbrains.annotations.NotNull;
 
 @Slf4j
 public class PriceChartDataModel extends ChartDataModel {
@@ -266,7 +262,7 @@ public class PriceChartDataModel extends ChartDataModel {
     }
 
     private Map<Long, Double> getBsqMarketCapByInterval(Predicate<TradeStatistics3> collectionFilter,
-                                                 Function<List<TradeStatistics3>, Double> getAveragePriceFunction) {
+                                                        Function<List<TradeStatistics3>, Double> getAveragePriceFunction) {
         var toTimeIntervalFn = toCachedTimeIntervalFn();
         return getBsqMarketCapByInterval(tradeStatisticsManager.getObservableTradeStatisticsSet(),
                 collectionFilter,
@@ -276,92 +272,58 @@ public class PriceChartDataModel extends ChartDataModel {
     }
 
     private Map<Long, Double> getBsqMarketCapByInterval(Collection<TradeStatistics3> tradeStatistics3s,
-                                                     Predicate<TradeStatistics3> collectionFilter,
-                                                     Function<TradeStatistics3, Long> groupByDateFunction,
-                                                     Predicate<Long> dateFilter,
-                                                     Function<List<TradeStatistics3>, Double> getAveragePriceFunction) {
-
+                                                        Predicate<TradeStatistics3> collectionFilter,
+                                                        Function<TradeStatistics3, Long> groupByDateFunction,
+                                                        Predicate<Long> dateFilter,
+                                                        Function<List<TradeStatistics3>, Double> getAveragePriceFunction) {
         Map<Long, List<TradeStatistics3>> pricesGroupedByDate = tradeStatistics3s.stream()
                 .filter(collectionFilter)
                 .collect(Collectors.groupingBy(groupByDateFunction));
 
-        Stream<Map.Entry<Long,List<TradeStatistics3>>> filteredByDate =
-                pricesGroupedByDate.entrySet().stream()
-                        .filter(entry -> dateFilter.test(entry.getKey()));
+        Stream<Map.Entry<Long, List<TradeStatistics3>>> filteredByDate = pricesGroupedByDate.entrySet().stream()
+                .filter(entry -> dateFilter.test(entry.getKey()));
 
         Map<Long, Double> resultsByDateBucket = filteredByDate
                 .map(entry -> new AbstractMap.SimpleEntry<>(
                         entry.getKey(),
                         getAveragePriceFunction.apply(entry.getValue())))
                 .filter(e -> e.getValue() > 0d)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (u, v) -> v, HashMap::new));
 
         // apply the available BSQ to the data set
-        Map<Long, Double> totalSupplyByInterval = getOutstandingBsqByInterval();
-        resultsByDateBucket.keySet().forEach(dateKey -> {
-            Double availableBsq = issuanceAsOfDate(totalSupplyByInterval, dateKey)/100;
-            resultsByDateBucket.put(dateKey, resultsByDateBucket.get(dateKey) * availableBsq); // market cap (price * available BSQ)
+        NavigableMap<Long, Double> totalSupplyByInterval = getOutstandingBsqByInterval();
+        resultsByDateBucket.replaceAll((dateKey, result) -> {
+            double availableBsq = issuanceAsOfDate(totalSupplyByInterval, dateKey) / 100d;
+            return result * availableBsq; // market cap (price * available BSQ)
         });
         return resultsByDateBucket;
     }
 
-    private Double issuanceAsOfDate(@NotNull Map<Long, Double> totalSupplyByInterval, Long dateKey) {
-        ArrayList<Long> list = new ArrayList<>(totalSupplyByInterval.keySet());
-        list.sort(Collections.reverseOrder());
-        Optional<Long> foundKey = list.stream()
-                .filter(d -> dateKey >= d)
-                .findFirst();
-        if (foundKey.isPresent()) {
-            return totalSupplyByInterval.get(foundKey.get());
-        }
-        return 0.0;
+    private double issuanceAsOfDate(NavigableMap<Long, Double> totalSupplyByInterval, long dateKey) {
+        var entry = totalSupplyByInterval.floorEntry(dateKey);
+        return entry != null ? entry.getValue() : 0d;
     }
 
-    private Map<Long, Double> getOutstandingBsqByInterval() {
+    private NavigableMap<Long, Double> getOutstandingBsqByInterval() {
         Stream<Tx> txStream = daoStateService.getBlocks().stream()
                 .flatMap(b -> b.getTxs().stream())
                 .filter(tx -> tx.getBurntFee() > 0);
         Map<Long, Double> simpleBurns = txStream
-                .collect(Collectors.groupingBy(tx ->
-                        toTimeInterval(Instant.ofEpochMilli(tx.getTime()))))
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey,
-                        entry -> entry.getValue().stream()
-                                .mapToDouble(Tx::getBurntBsq)
-                                .sum()));
-        simpleBurns.forEach((k,v) -> simpleBurns.put(k, -v));
+                .collect(Collectors.groupingBy(
+                        tx -> toTimeInterval(Instant.ofEpochMilli(tx.getTime())),
+                        Collectors.summingDouble(Tx::getBurntBsq)));
+        simpleBurns.replaceAll((k, v) -> -v);
 
         Collection<Issuance> issuanceSet = daoStateService.getIssuanceItems();
         Map<Long, Double> simpleIssuance = issuanceSet.stream()
-                .collect(Collectors.groupingBy(issuance ->
-                        toTimeInterval(Instant.ofEpochMilli(blockTimeOfIssuanceFunction.apply(issuance)))))
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey,
-                        entry -> entry.getValue().stream()
-                                .mapToDouble(Issuance::getAmount)
-                                .sum()));
+                .collect(Collectors.groupingBy(
+                        issuance -> toTimeInterval(Instant.ofEpochMilli(blockTimeOfIssuanceFunction.apply(issuance))),
+                        Collectors.summingDouble(Issuance::getAmount)));
 
-        Map<Long, Double> supplyByInterval = Stream.concat(simpleIssuance.entrySet().stream(),
-                simpleBurns.entrySet().stream())
-                .collect(Collectors.toMap(Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        Double::sum));
+        NavigableMap<Long, Double> supplyByInterval = new TreeMap<>(getMergedMap(simpleIssuance, simpleBurns, Double::sum));
 
-        ArrayList<Long> listCombined = new ArrayList<>(supplyByInterval.keySet());
-        Collections.sort(listCombined);
-        AtomicReference<Double> atomicSum = new AtomicReference<>((double) (daoStateService.getGenesisTotalSupply().value));
-        listCombined.forEach(k -> supplyByInterval.put(k, atomicSum.accumulateAndGet(supplyByInterval.get(k), Double::sum)));
+        final double[] partialSum = {daoStateService.getGenesisTotalSupply().value};
+        supplyByInterval.replaceAll((k, v) -> partialSum[0] += v);
         return supplyByInterval;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Utils
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-    private static <T, R> Function<T, R> memoize(Function<T, R> fn) {
-        Map<T, R> map = new ConcurrentHashMap<>();
-        return x -> map.computeIfAbsent(x, fn);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/volume/VolumeChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/dashboard/volume/VolumeChartDataModel.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.function.LongPredicate;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -143,7 +143,7 @@ public class VolumeChartDataModel extends ChartDataModel {
 
     private Map<Long, Long> getVolumeByInterval(Collection<TradeStatistics3> collection,
                                                 Function<TradeStatistics3, Long> groupByDateFunction,
-                                                Predicate<Long> dateFilter,
+                                                LongPredicate dateFilter,
                                                 Function<List<TradeStatistics3>, Long> getVolumeFunction) {
         return collection.stream()
                 .collect(Collectors.groupingBy(groupByDateFunction))

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/dao/DaoChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/dao/DaoChartDataModel.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.function.LongPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -322,7 +322,7 @@ public class DaoChartDataModel extends ChartDataModel {
     // Aggregated collection data by interval
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private Map<Long, Long> getIssuedBsqByInterval(Collection<Issuance> issuanceSet, Predicate<Long> dateFilter) {
+    private Map<Long, Long> getIssuedBsqByInterval(Collection<Issuance> issuanceSet, LongPredicate dateFilter) {
         var allIssuedBsq = issuanceSet.stream()
                 .collect(Collectors.groupingBy(
                         issuance -> toTimeInterval(Instant.ofEpochMilli(blockTimeOfIssuanceFunction.apply(issuance))),
@@ -330,8 +330,7 @@ public class DaoChartDataModel extends ChartDataModel {
         return getDateFilteredMap(allIssuedBsq, dateFilter);
     }
 
-    private Map<Long, Long> getHistoricalIssuedBsqByInterval(Map<Long, Long> historicalData,
-                                                             Predicate<Long> dateFilter) {
+    private Map<Long, Long> getHistoricalIssuedBsqByInterval(Map<Long, Long> historicalData, LongPredicate dateFilter) {
         return historicalData.entrySet().stream()
                 .filter(e -> dateFilter.test(e.getKey()))
                 .collect(Collectors.toMap(e -> toTimeInterval(Instant.ofEpochSecond(e.getKey())),
@@ -339,7 +338,7 @@ public class DaoChartDataModel extends ChartDataModel {
                         Long::sum));
     }
 
-    private Map<Long, Long> getBurntBsqByInterval(Stream<Tx> txStream, Predicate<Long> dateFilter) {
+    private Map<Long, Long> getBurntBsqByInterval(Stream<Tx> txStream, LongPredicate dateFilter) {
         var toTimeIntervalFn = toCachedTimeIntervalFn();
         var allBurntBsq = txStream.collect(Collectors.groupingBy(
                 tx -> toTimeIntervalFn.applyAsLong(Instant.ofEpochMilli(tx.getTime())),
@@ -347,7 +346,7 @@ public class DaoChartDataModel extends ChartDataModel {
         return getDateFilteredMap(allBurntBsq, dateFilter);
     }
 
-    private Predicate<Long> getPostTagDateFilter() {
+    private LongPredicate getPostTagDateFilter() {
         // We filter out old dates as it only makes sense since Nov 2021
         return date -> date >= TAG_DATE.getTimeInMillis() / 1000;  // we use seconds
     }
@@ -371,7 +370,7 @@ public class DaoChartDataModel extends ChartDataModel {
     // Utils
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private static <V> Map<Long, V> getDateFilteredMap(Map<Long, V> map, Predicate<Long> dateFilter) {
+    private static <V> Map<Long, V> getDateFilteredMap(Map<Long, V> map, LongPredicate dateFilter) {
         return map.entrySet().stream()
                 .filter(e -> dateFilter.test(e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (u, v) -> v, HashMap::new));

--- a/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/dao/DaoChartDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/economy/supply/dao/DaoChartDataModel.java
@@ -210,7 +210,7 @@ public class DaoChartDataModel extends ChartDataModel {
             return totalBurnedByInterval;
         }
 
-        totalBurnedByInterval = getBurntBsqByInterval(getBurntFeeTxStream(), getDateFilter());
+        totalBurnedByInterval = getBurntBsqByInterval(getBurntBsqTxStream(), getDateFilter());
         return totalBurnedByInterval;
     }
 
@@ -246,7 +246,7 @@ public class DaoChartDataModel extends ChartDataModel {
             return miscBurnByInterval;
         }
 
-        Map<Long, Long> allMiscBurnByInterval = getBurntFeeTxStream()
+        Map<Long, Long> allMiscBurnByInterval = getBurntBsqTxStream()
                 .filter(e -> e.getTxType() != TxType.PAY_TRADE_FEE)
                 .filter(e -> e.getTxType() != TxType.PROOF_OF_BURN)
                 .collect(Collectors.groupingBy(
@@ -295,7 +295,7 @@ public class DaoChartDataModel extends ChartDataModel {
         Collection<Issuance> issuanceSetForType = daoStateService.getIssuanceItems();
         // get all issued and burnt BSQ, not just the filtered date range
         Map<Long, Long> tmpIssuedByInterval = getIssuedBsqByInterval(issuanceSetForType, e -> true);
-        Map<Long, Long> tmpBurnedByInterval = getBurntBsqByInterval(getBurntFeeTxStream(), e -> true);
+        Map<Long, Long> tmpBurnedByInterval = getBurntBsqByInterval(getBurntBsqTxStream(), e -> true);
         tmpBurnedByInterval.replaceAll((k, v) -> -v);
 
         Map<Long, Long> tmpSupplyByInterval = new TreeMap<>(getMergedMap(tmpIssuedByInterval, tmpBurnedByInterval, Long::sum));
@@ -354,10 +354,10 @@ public class DaoChartDataModel extends ChartDataModel {
 
     // TODO: Consider moving these two methods to DaoStateService:
 
-    private Stream<Tx> getBurntFeeTxStream() {
+    private Stream<Tx> getBurntBsqTxStream() {
         return daoStateService.getBlocks().stream()
                 .flatMap(b -> b.getTxs().stream())
-                .filter(tx -> tx.getBurntFee() > 0);
+                .filter(tx -> tx.getBurntBsq() > 0);
     }
 
     private Stream<Tx> getTradeFeeTxStream() {


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Use `Tx::getBurntBsq` instead of `Tx::getBurntFee`, so as not to exclude BSQ burned by invalid txs from the supply calculations. There are no invalid BSQ txs at present on mainchain, but accidentally burned BSQ should definitely count as a reduction in supply, so this fixes a bug.

Also tidy `DaoChartDataModel` & `PriceChartDataModel` a little and somewhat speed up the market cap calculations in the latter, by fixing a quadratic time bug in `getBsqMarketCapByInterval`.

--

Prior to the above changes, the following hotspots in the market cap chart display are revealed by JProfiler, when changing the date interval size selection 12 times to recompute the chart:
![Screenshot from 2024-02-20 21-25-20](https://github.com/bisq-network/bisq/assets/54855381/8e17450a-f7ea-4dc6-9ef0-5f24440f1224)

After the changes, the following hotspots are seen instead:
![Screenshot from 2024-02-20 21-28-45](https://github.com/bisq-network/bisq/assets/54855381/308281da-6c41-4a64-aa95-ec5633161066)

Thus, a roughly twofold speed improvement is seen.

It isn't clear to me how best to reduce the next biggest hotspot from the stream pipeline in `getAveragePriceFromDateFilter`. Interestingly, changing it to stream directly over the `TreeSet` of `TradeStatistics3` instances, instead of an `ObservableSet` wrapper, actually makes it slower. I think this is due to the native `TreeSet` spliterator being less performant for _serial_ streaming than the default `IteratorSpliterator` that winds up being used from the `ObservableSet` delegation (due to JavaFX not being aware of the stream API).