### PR TITLE
Increase MAX_REPEATED_REQUESTS

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -62,6 +62,7 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     private static int NUM_SEEDS_FOR_PRELIMINARY_REQUEST = 2;
     // how many seeds additional to the first responding PreliminaryGetDataRequest seed we request the GetUpdatedDataRequest from
     private static int NUM_ADDITIONAL_SEEDS_FOR_UPDATE_REQUEST = 1;
+    private static int MAX_REPEATED_REQUESTS = 30;
     private boolean isPreliminaryDataRequest = true;
 
 
@@ -140,6 +141,7 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                 if (seedNodeRepository.isSeedNode(myAddress)) {
                     NUM_SEEDS_FOR_PRELIMINARY_REQUEST = 3;
                     NUM_ADDITIONAL_SEEDS_FOR_UPDATE_REQUEST = 2;
+                    MAX_REPEATED_REQUESTS = 100;
                 }
             }
         });
@@ -361,7 +363,7 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                 }
 
                                 if (wasTruncated) {
-                                    if (numRepeatedRequests < 20) {
+                                    if (numRepeatedRequests < MAX_REPEATED_REQUESTS) {
                                         // If we had allDataReceived already set to true but get a response with truncated flag,
                                         // we still repeat the request to that node for higher redundancy. Otherwise, one seed node
                                         // providing incomplete data would stop others to fill the gaps.


### PR DESCRIPTION
Increase MAX_REPEATED_REQUESTS from 20 to 30 and in case we are a seed node to 100.

This should mitigate issues when we the last release was long ago and the seed nodes have not updated yet to a new release. The historical data would not be considered in that case and the new node would request all the missing data, which can hit the limit of 20 repeated GetDataRequests. Then if the get data process was never completed we do not load the DaoHashes, thus DAO sync never starts.

The reason to increase for seed nodes more is to ensure that seed nodes would enter a deadlock when one has updated but the others not.  

@jmacxx @alvasw : Here is a branch on my repo for seed nodes to temporary update.
https://github.com/HenrikJannsen/bisq/tree/update-to-version-1.9.15-and-add-accountAge-and-tradeStat-resources

This set the version to 1.9.15 and adds the resources but no the DAO data we still don't know if the DAO data are correct. 
This branch can be used by seed nodes to update (best to update only 50% initially and test then) so that we can further test the DAO state with the release candidate. 
If all OK the release candidate might update the resource files from that branch as it contains more recent data. But not a hard requirement...