### PR TITLE
Increase maxItems at requesting  trade statistic items

### DIFF
--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -400,7 +400,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
 
     @Override
     public int maxItems() {
-        return 3000;
+        return 15000;
     }
 
     public void pruneOptionalData() {


### PR DESCRIPTION
Increase maxItems from 3000 to 15000. 3000 items are about 180.325 kB.

For nodes not being online for longer the repeated requests consumes quite some time. With 15k we can expect a 1 MB payload which is still acceptable.

The past 6 months had about 18 000 trade statistic items.
