### PR TITLE
Speed up bond repository update and remove some raw types

### DIFF
--- a/core/src/main/java/bisq/core/dao/DaoFacade.java
+++ b/core/src/main/java/bisq/core/dao/DaoFacade.java
@@ -598,14 +598,14 @@ public class DaoFacade implements DaoSetupService {
     }
 
 
-    public List<Bond> getAllBonds() {
-        List<Bond> bonds = new ArrayList<>(bondedReputationRepository.getBonds());
+    public List<Bond<?>> getAllBonds() {
+        List<Bond<?>> bonds = new ArrayList<>(bondedReputationRepository.getBonds());
         bonds.addAll(bondedRolesRepository.getBonds());
         return bonds;
     }
 
-    public List<Bond> getAllActiveBonds() {
-        List<Bond> bonds = new ArrayList<>(bondedReputationRepository.getActiveBonds());
+    public List<Bond<?>> getAllActiveBonds() {
+        List<Bond<?>> bonds = new ArrayList<>(bondedReputationRepository.getActiveBonds());
         bonds.addAll(bondedRolesRepository.getActiveBonds());
         return bonds;
     }
@@ -739,7 +739,7 @@ public class DaoFacade implements DaoSetupService {
         return bondedRolesRepository.isMyRole(role);
     }
 
-    public Optional<Bond> getBondByLockupTxId(String lockupTxId) {
+    public Optional<Bond<?>> getBondByLockupTxId(String lockupTxId) {
         return getAllBonds().stream().filter(e -> lockupTxId.equals(e.getLockupTxId())).findAny();
     }
 

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -167,8 +167,7 @@ public class BurningManService {
         daoStateService.getGenesisTx()
                 .ifPresent(tx -> tx.getTxOutputs().forEach(txOutput -> {
                     String name = GENESIS_OUTPUT_PREFIX + txOutput.getIndex();
-                    burningManCandidatesByName.putIfAbsent(name, new BurningManCandidate());
-                    BurningManCandidate candidate = burningManCandidatesByName.get(name);
+                    BurningManCandidate candidate = burningManCandidatesByName.computeIfAbsent(name, n -> new BurningManCandidate());
 
                     // Issuance
                     int issuanceHeight = txOutput.getBlockHeight();
@@ -262,8 +261,7 @@ public class BurningManService {
                 .filter(txOutput -> txOutput.getBlockHeight() <= chainHeight)
                 .forEach(txOutput -> {
                     P2PDataStorage.ByteArray key = new P2PDataStorage.ByteArray(ProofOfBurnConsensus.getHashFromOpReturnData(txOutput.getOpReturnData()));
-                    map.putIfAbsent(key, new HashSet<>());
-                    map.get(key).add(txOutput);
+                    map.computeIfAbsent(key, k -> new HashSet<>()).add(txOutput);
                 });
         return map;
     }

--- a/core/src/main/java/bisq/core/dao/governance/bond/BondRepository.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/BondRepository.java
@@ -213,6 +213,7 @@ public abstract class BondRepository<B extends Bond<T>, T extends BondedAsset> i
     protected abstract Stream<T> getBondedAssetStream();
 
     protected void update() {
+        long ts = System.currentTimeMillis();
         log.debug("update");
         getBondedAssetStream().forEach(bondedAsset -> {
             String uid = bondedAsset.getUid();
@@ -226,6 +227,7 @@ public abstract class BondRepository<B extends Bond<T>, T extends BondedAsset> i
         updateBondStateFromUnconfirmedUnlockTxs();
 
         bonds.setAll(bondByUidMap.values());
+        log.debug("update took {} ms", System.currentTimeMillis() - ts);
     }
 
 

--- a/core/src/main/java/bisq/core/dao/governance/bond/role/BondedRolesRepository.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/role/BondedRolesRepository.java
@@ -27,12 +27,13 @@ import bisq.core.dao.state.model.governance.Proposal;
 import bisq.core.dao.state.model.governance.Role;
 import bisq.core.dao.state.model.governance.RoleProposal;
 
+import com.google.protobuf.ByteString;
+
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -107,16 +108,10 @@ public class BondedRolesRepository extends BondRepository<BondedRole, Role> {
             // We used the hash of the bonded bondedAsset object as our hash in OpReturn of the lock up tx to have a
             // unique binding of the tx to the data object.
             byte[] hash = BondConsensus.getHashFromOpReturnData(opReturnData);
-            Optional<Role> candidate = findBondedAssetByHash(hash);
-            if (candidate.isPresent() && bondedAsset.equals(candidate.get()))
+            Role candidateOrNull = getBondedAssetByHashMap().get(ByteString.copyFrom(hash));
+            if (bondedAsset.equals(candidateOrNull))
                 applyBondState(daoStateService, bond, lockupTx, lockupTxOutput);
         });
-    }
-
-    private Optional<Role> findBondedAssetByHash(byte[] hash) {
-        return getBondedAssetStream()
-                .filter(bondedAsset -> Arrays.equals(bondedAsset.getHash(), hash))
-                .findAny();
     }
 
     private Stream<RoleProposal> getBondedRoleProposalStream() {

--- a/core/src/main/java/bisq/core/dao/monitoring/network/RequestStateHashesHandler.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/network/RequestStateHashesHandler.java
@@ -45,7 +45,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Slf4j
-abstract class RequestStateHashesHandler<Req extends GetStateHashesRequest, Res extends GetStateHashesResponse> implements MessageListener {
+abstract class RequestStateHashesHandler<Req extends GetStateHashesRequest, Res extends GetStateHashesResponse<?>> implements MessageListener {
     private static final long TIMEOUT = 180;
 
 
@@ -53,7 +53,7 @@ abstract class RequestStateHashesHandler<Req extends GetStateHashesRequest, Res 
     // Listener
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public interface Listener<Res extends GetStateHashesResponse> {
+    public interface Listener<Res extends GetStateHashesResponse<?>> {
         void onComplete(Res getStateHashesResponse, Optional<NodeAddress> peersNodeAddress);
 
         @SuppressWarnings("UnusedParameters")

--- a/core/src/main/java/bisq/core/dao/monitoring/network/StateNetworkService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/network/StateNetworkService.java
@@ -53,13 +53,13 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.Nullable;
 
 @Slf4j
-public abstract class StateNetworkService<Msg extends NewStateHashMessage,
+public abstract class StateNetworkService<Msg extends NewStateHashMessage<StH>,
         Req extends GetStateHashesRequest,
         Res extends GetStateHashesResponse<StH>,
-        Han extends RequestStateHashesHandler,
+        Han extends RequestStateHashesHandler<Req, Res>,
         StH extends StateHash> implements MessageListener {
 
-    public interface Listener<Msg extends NewStateHashMessage, Req extends GetStateHashesRequest, StH extends StateHash> {
+    public interface Listener<Msg extends NewStateHashMessage<StH>, Req extends GetStateHashesRequest, StH extends StateHash> {
         void onNewStateHashMessage(Msg newStateHashMessage, Connection connection);
 
         void onGetStateHashRequest(Connection connection, Req getStateHashRequest);

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/TxOutputKey.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/TxOutputKey.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @Value
-public final class TxOutputKey implements ImmutableDaoStateModel, Comparable {
+public final class TxOutputKey implements ImmutableDaoStateModel, Comparable<Object> {
     private final String txId;
     private final int index;
 
@@ -47,7 +47,7 @@ public final class TxOutputKey implements ImmutableDaoStateModel, Comparable {
 
     public static TxOutputKey getKeyFromString(String keyAsString) {
         final String[] tokens = keyAsString.split(":");
-        return new TxOutputKey(tokens[0], Integer.valueOf(tokens[1]));
+        return new TxOutputKey(tokens[0], Integer.parseInt(tokens[1]));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -88,8 +88,8 @@ public class CurrencyUtil {
         return new ArrayList<>(fiatCurrencyMapSupplier.get().values());
     }
 
-    public static Collection<FiatCurrency> getAllSortedFiatCurrencies(Comparator comparator) {
-        return (List<FiatCurrency>) getAllSortedFiatCurrencies().stream()
+    public static Collection<FiatCurrency> getAllSortedFiatCurrencies(Comparator<? super FiatCurrency> comparator) {
+        return getAllSortedFiatCurrencies().stream()
                 .sorted(comparator)                     // sorted by comparator param
                 .collect(Collectors.toList());
     }

--- a/core/src/test/java/bisq/core/dao/governance/proposal/MyProposalListServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/proposal/MyProposalListServiceTest.java
@@ -11,20 +11,24 @@ import bisq.common.persistence.PersistenceManager;
 
 import javafx.beans.property.SimpleIntegerProperty;
 
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class MyProposalListServiceTest {
     @Test
-    public void canInstantiate() {
+    public void canInstantiate(@Mock PersistenceManager<MyProposalList> persistenceManager) {
         P2PService p2PService = mock(P2PService.class);
         when(p2PService.getNumConnectedPeers()).thenReturn(new SimpleIntegerProperty(0));
-        PersistenceManager persistenceManager = mock(PersistenceManager.class);
-        MyProposalListService service = new MyProposalListService(p2PService,
-                mock(DaoStateService.class),
-                mock(PeriodService.class), mock(WalletsManager.class), persistenceManager, mock(PubKeyRing.class)
+
+        new MyProposalListService(p2PService, mock(DaoStateService.class), mock(PeriodService.class),
+                mock(WalletsManager.class), persistenceManager, mock(PubKeyRing.class)
         );
     }
 }

--- a/core/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/core/src/test/java/bisq/core/user/PreferencesTest.java
@@ -35,8 +35,14 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,10 +50,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT) // FIXME: Broken tests: stale persistenceManager stubbing
 public class PreferencesTest {
-
     private Preferences preferences;
-    private PersistenceManager persistenceManager;
+    @Mock
+    private PersistenceManager<PreferencesPayload> persistenceManager;
 
     @BeforeEach
     public void setUp() {
@@ -57,7 +65,6 @@ public class PreferencesTest {
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
 
-        persistenceManager = mock(PersistenceManager.class);
         Config config = new Config();
         LocalBitcoinNode localBitcoinNode = new LocalBitcoinNode(config);
         preferences = new Preferences(
@@ -114,9 +121,7 @@ public class PreferencesTest {
         when(payload.getPreferredTradeCurrency()).thenReturn(new FiatCurrency("USD"));
         when(payload.getCryptoCurrencies()).thenReturn(cryptoCurrencies);
 
-        preferences.readPersisted(() -> {
-            assertTrue(preferences.getCryptoCurrenciesAsObservable().contains(dash));
-        });
+        preferences.readPersisted(() -> assertTrue(preferences.getCryptoCurrenciesAsObservable().contains(dash)));
     }
 
     @Test
@@ -135,8 +140,7 @@ public class PreferencesTest {
         when(payload.getPreferredTradeCurrency()).thenReturn(usd);
         when(payload.getFiatCurrencies()).thenReturn(fiatCurrencies);
 
-        preferences.readPersisted(() -> {
-            assertEquals("US Dollar (USD)", preferences.getFiatCurrenciesAsObservable().get(0).getNameAndCode());
-        });
+        preferences.readPersisted(() ->
+                assertEquals("US Dollar (USD)", preferences.getFiatCurrenciesAsObservable().get(0).getNameAndCode()));
     }
 }

--- a/core/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/core/src/test/java/bisq/core/user/PreferencesTest.java
@@ -34,11 +34,10 @@ import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Consumer;
 
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,12 +45,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT) // FIXME: Broken tests: stale persistenceManager stubbing
 public class PreferencesTest {
     private Preferences preferences;
     @Mock
@@ -59,7 +59,7 @@ public class PreferencesTest {
 
     @BeforeEach
     public void setUp() {
-        final Locale en_US = new Locale("en", "US");
+        Locale en_US = new Locale("en", "US");
         Locale.setDefault(en_US);
         GlobalSettings.setLocale(en_US);
         Res.setBaseCurrencyCode("BTC");
@@ -72,11 +72,19 @@ public class PreferencesTest {
                 false, null, null, Config.UNSPECIFIED_PORT);
     }
 
+    @SuppressWarnings("unchecked")
+    private void addReadPersistedStub(PreferencesPayload payload) {
+        doAnswer(invocation -> {
+            ((Consumer<PreferencesPayload>) invocation.getArgument(1)).accept(payload);
+            return null;
+        }).when(persistenceManager).readPersisted(anyString(), any(), any());
+    }
+
     @Test
     public void testAddFiatCurrency() {
-        final FiatCurrency usd = new FiatCurrency("USD");
-        final FiatCurrency usd2 = new FiatCurrency("USD");
-        final ObservableList<FiatCurrency> fiatCurrencies = preferences.getFiatCurrenciesAsObservable();
+        FiatCurrency usd = new FiatCurrency("USD");
+        FiatCurrency usd2 = new FiatCurrency("USD");
+        ObservableList<FiatCurrency> fiatCurrencies = preferences.getFiatCurrenciesAsObservable();
 
         preferences.addFiatCurrency(usd);
 
@@ -92,17 +100,18 @@ public class PreferencesTest {
         PreferencesPayload payload = mock(PreferencesPayload.class);
 
         List<FiatCurrency> fiatCurrencies = CurrencyUtil.getMainFiatCurrencies();
-        final FiatCurrency usd = new FiatCurrency("USD");
+        int numMainFiatCurrencies = fiatCurrencies.size();
+        FiatCurrency usd = new FiatCurrency("USD");
         fiatCurrencies.add(usd);
 
-        when(persistenceManager.getPersisted(anyString())).thenReturn(payload);
+        addReadPersistedStub(payload);
         when(payload.getUserLanguage()).thenReturn("en");
         when(payload.getUserCountry()).thenReturn(CountryUtil.getDefaultCountry());
         when(payload.getPreferredTradeCurrency()).thenReturn(usd);
         when(payload.getFiatCurrencies()).thenReturn(fiatCurrencies);
 
         preferences.readPersisted(() -> {
-            assertEquals(7, preferences.getFiatCurrenciesAsObservable().size());
+            assertEquals(numMainFiatCurrencies, preferences.getFiatCurrenciesAsObservable().size());
             assertTrue(preferences.getFiatCurrenciesAsObservable().contains(usd));
         });
     }
@@ -112,16 +121,20 @@ public class PreferencesTest {
         PreferencesPayload payload = mock(PreferencesPayload.class);
 
         List<CryptoCurrency> cryptoCurrencies = CurrencyUtil.getMainCryptoCurrencies();
-        final CryptoCurrency dash = new CryptoCurrency("DASH", "Dash");
+        int numMainCryptoCurrencies = cryptoCurrencies.size();
+        CryptoCurrency dash = new CryptoCurrency("DASH", "Dash");
         cryptoCurrencies.add(dash);
 
-        when(persistenceManager.getPersisted(anyString())).thenReturn(payload);
+        addReadPersistedStub(payload);
         when(payload.getUserLanguage()).thenReturn("en");
         when(payload.getUserCountry()).thenReturn(CountryUtil.getDefaultCountry());
         when(payload.getPreferredTradeCurrency()).thenReturn(new FiatCurrency("USD"));
         when(payload.getCryptoCurrencies()).thenReturn(cryptoCurrencies);
 
-        preferences.readPersisted(() -> assertTrue(preferences.getCryptoCurrenciesAsObservable().contains(dash)));
+        preferences.readPersisted(() -> {
+            assertEquals(numMainCryptoCurrencies, preferences.getCryptoCurrenciesAsObservable().size());
+            assertTrue(preferences.getCryptoCurrenciesAsObservable().contains(dash));
+        });
     }
 
     @Test
@@ -129,12 +142,12 @@ public class PreferencesTest {
         PreferencesPayload payload = mock(PreferencesPayload.class);
 
         List<FiatCurrency> fiatCurrencies = new ArrayList<>();
-        final FiatCurrency usd = new FiatCurrency(Currency.getInstance("USD"), new Locale("de", "AT"));
+        FiatCurrency usd = new FiatCurrency(Currency.getInstance("USD"), new Locale("de", "AT"));
         fiatCurrencies.add(usd);
 
         assertEquals("US-Dollar (USD)", usd.getNameAndCode());
 
-        when(persistenceManager.getPersisted(anyString())).thenReturn(payload);
+        addReadPersistedStub(payload);
         when(payload.getUserLanguage()).thenReturn("en");
         when(payload.getUserCountry()).thenReturn(CountryUtil.getDefaultCountry());
         when(payload.getPreferredTradeCurrency()).thenReturn(usd);

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingView.java
@@ -50,7 +50,6 @@ import javax.annotation.Nullable;
 
 @FxmlView
 public class BondingView extends ActivatableView<AnchorPane, Void> {
-
     private final ViewLoader viewLoader;
     private final Navigation navigation;
 
@@ -138,8 +137,7 @@ public class BondingView extends ActivatableView<AnchorPane, Void> {
         else if (view instanceof BondsView) {
             toggleGroup.selectToggle(bonds);
             if (data instanceof Bond)
-                ((BondsView) view).setSelectedBond((Bond) data);
+                ((BondsView) view).setSelectedBond((Bond<?>) data);
         }
-
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondListItem.java
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Value
 @Slf4j
 class BondListItem {
-    private final Bond bond;
+    private final Bond<?> bond;
     private final String bondType;
     private final String lockupTxId;
     private final String amount;
@@ -47,7 +47,7 @@ class BondListItem {
     private final BondState bondState;
     private final String bondStateString;
 
-    BondListItem(Bond bond, BsqFormatter bsqFormatter) {
+    BondListItem(Bond<?> bond, BsqFormatter bsqFormatter) {
         this.bond = bond;
 
         amount = bsqFormatter.formatCoin(Coin.valueOf(bond.getAmount()));

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/bonds/BondsView.java
@@ -76,7 +76,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
     private ListChangeListener<BondedRole> bondedRolesListener;
     private ListChangeListener<BondedReputation> bondedReputationListener;
 
-    private Bond selectedBond;
+    private Bond<?> selectedBond;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor, lifecycle
@@ -124,7 +124,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public void setSelectedBond(Bond bond) {
+    public void setSelectedBond(Bond<?> bond) {
         // Set the selected bond if it's found in the tableView, which listens to sortedList.
         // If this is called before the sortedList has been populated the selected bond is stored and
         // we try to apply again after the next update.
@@ -141,7 +141,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void updateList() {
-        List<Bond> combined = new ArrayList<>(bondedReputationRepository.getBonds());
+        List<Bond<?>> combined = new ArrayList<>(bondedReputationRepository.getBonds());
         combined.addAll(bondedRolesRepository.getBonds());
         observableList.setAll(combined.stream()
                 .map(bond -> new BondListItem(bond, bsqFormatter))
@@ -149,7 +149,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
                 .collect(Collectors.toList()));
         GUIUtil.setFitToRowsForTableView(tableView, 37, 28, 2, 30);
         if (selectedBond != null) {
-            Bond bond = selectedBond;
+            Bond<?> bond = selectedBond;
             selectedBond = null;
             setSelectedBond(bond);
         }
@@ -259,8 +259,6 @@ public class BondsView extends ActivatableView<GridPane, Void> {
             @Override
             public TableCell<BondListItem, BondListItem> call(TableColumn<BondListItem, BondListItem> column) {
                 return new TableCell<>() {
-                    private InfoAutoTooltipLabel infoTextField;
-
                     @Override
                     public void updateItem(final BondListItem item, boolean empty) {
                         super.updateItem(item, empty);
@@ -271,7 +269,7 @@ public class BondsView extends ActivatableView<GridPane, Void> {
                                 info = item.getBondDetails() + "\n" + info;
                             }
 
-                            infoTextField = new InfoAutoTooltipLabel(item.getBondDetails(),
+                            InfoAutoTooltipLabel infoTextField = new InfoAutoTooltipLabel(item.getBondDetails(),
                                     AwesomeIcon.INFO_SIGN,
                                     ContentDisplay.LEFT,
                                     info,

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/ProposalDisplay.java
@@ -120,7 +120,7 @@ public class ProposalDisplay {
     @Nullable
     public ComboBox<Param> paramComboBox;
     @Nullable
-    public ComboBox<Bond> confiscateBondComboBox;
+    public ComboBox<Bond<?>> confiscateBondComboBox;
     @Nullable
     public ComboBox<BondedRoleType> bondedRoleTypeComboBox;
     @Nullable
@@ -371,7 +371,7 @@ public class ProposalDisplay {
                 confiscateBondComboBox.setItems(FXCollections.observableArrayList(daoFacade.getAllActiveBonds()));
                 confiscateBondComboBox.setConverter(new StringConverter<>() {
                     @Override
-                    public String toString(Bond bond) {
+                    public String toString(Bond<?> bond) {
                         String details = " (" + Res.get("dao.bond.table.column.lockupTxId") + ": " + bond.getLockupTxId() + ")";
                         if (bond instanceof BondedRole) {
                             return bond.getBondedAsset().getDisplayString() + details;
@@ -381,7 +381,7 @@ public class ProposalDisplay {
                     }
 
                     @Override
-                    public Bond fromString(String string) {
+                    public Bond<?> fromString(String string) {
                         return null;
                     }
                 });

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/make/MakeProposalView.java
@@ -453,7 +453,7 @@ public class MakeProposalView extends ActivatableView<GridPane, Void> implements
             case CONFISCATE_BOND:
                 checkNotNull(proposalDisplay.confiscateBondComboBox,
                         "proposalDisplay.confiscateBondComboBox must not be null");
-                Bond bond = proposalDisplay.confiscateBondComboBox.getSelectionModel().getSelectedItem();
+                Bond<?> bond = proposalDisplay.confiscateBondComboBox.getSelectionModel().getSelectedItem();
 
                 if (!bond.isActive())
                     throw new VoteResultException.ValidationException("Bond is not locked and can't be confiscated");

--- a/desktop/src/test/java/bisq/desktop/maker/PreferenceMakers.java
+++ b/desktop/src/test/java/bisq/desktop/maker/PreferenceMakers.java
@@ -20,6 +20,7 @@ package bisq.desktop.maker;
 import bisq.core.btc.nodes.LocalBitcoinNode;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Preferences;
+import bisq.core.user.PreferencesPayload;
 
 import bisq.common.config.Config;
 import bisq.common.persistence.PersistenceManager;
@@ -32,8 +33,7 @@ import static com.natpryce.makeiteasy.MakeItEasy.a;
 import static com.natpryce.makeiteasy.MakeItEasy.make;
 
 public class PreferenceMakers {
-
-    public static final Property<Preferences, PersistenceManager> storage = new Property<>();
+    public static final Property<Preferences, PersistenceManager<PreferencesPayload>> storage = new Property<>();
     public static final Property<Preferences, Config> config = new Property<>();
     public static final Property<Preferences, FeeService> feeService = new Property<>();
     public static final Property<Preferences, LocalBitcoinNode> localBitcoinNode = new Property<>();
@@ -41,14 +41,13 @@ public class PreferenceMakers {
     public static final Property<Preferences, String> referralID = new Property<>();
 
     public static final Instantiator<Preferences> Preferences = lookup -> new Preferences(
-            lookup.valueOf(storage, new SameValueDonor<PersistenceManager>(null)),
-            lookup.valueOf(config, new SameValueDonor<Config>(null)),
-            lookup.valueOf(feeService, new SameValueDonor<FeeService>(null)),
-            lookup.valueOf(localBitcoinNode, new SameValueDonor<LocalBitcoinNode>(null)),
-            lookup.valueOf(useTorFlagFromOptions, new SameValueDonor<String>(null)),
-            lookup.valueOf(referralID, new SameValueDonor<String>(null)),
+            lookup.valueOf(storage, new SameValueDonor<>(null)),
+            lookup.valueOf(config, new SameValueDonor<>(null)),
+            lookup.valueOf(feeService, new SameValueDonor<>(null)),
+            lookup.valueOf(localBitcoinNode, new SameValueDonor<>(null)),
+            lookup.valueOf(useTorFlagFromOptions, new SameValueDonor<>(null)),
+            lookup.valueOf(referralID, new SameValueDonor<>(null)),
             Config.DEFAULT_FULL_DAO_NODE, false, null, null, Config.UNSPECIFIED_PORT);
 
     public static final Preferences empty = make(a(Preferences));
-
 }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Alleviate a cubic time bug during the update of the bonded roles repository, reducing it to quadratic running time. On Mainnet, this gives a roughly ten-fold speedup and should allow better scaling in the event that many new bonded roles are added.

Replace calls to `BondedRolesRepository.findBondedAssetByHash` with a lookup into a lazily initialised map of bonded assets (`Role`s) by hash (reset at the start of each call to `BondRepository.update()` to prevent stale caching). This avoids rescanning the roles list for every pair of roles and lockup tx outputs, thus reducing the number of steps (to highest order) from:

> #roles * #roles * #lockup-tx-outputs

to:

> #roles * #lockup-tx-outputs

(The logs show 2 or 3 calls to `BondedRepository.update()` every time a new block arrives, and while this was only taking around a second or so on Mainnet, it could, I think, potentially grow to something problematic with cubic scaling in the number of bonded roles.)

--

In addition to the above optimisation, this PR also generifies the raw types which involve the DAO classes (mainly `Bond` occurrences) and fixes a broken test encountered during that cleanup.

The code changes touch the DAO packages, though not in a way that should cause any functional change.

--

Before the optimisation (last commit in the PR), the following update times are seen in the logs on my laptop:

```
steven@debian:~/Documents/Java Projects/bisq$ grep "Apr-19.*update took" ~/.local/share/Bisq/bisq_1.log | head -n 40
Apr-19 16:41:39.982 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 5 ms 
Apr-19 16:45:11.840 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 896 ms 
Apr-19 16:45:13.109 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 917 ms 
Apr-19 17:00:47.838 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 612 ms 
Apr-19 17:00:50.993 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 823 ms 
Apr-19 17:00:55.297 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 722 ms 
Apr-19 17:13:02.580 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 608 ms 
Apr-19 17:13:03.728 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 617 ms 
Apr-19 17:13:07.579 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 793 ms 
Apr-19 17:24:23.431 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 614 ms 
Apr-19 17:24:25.180 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 706 ms 
Apr-19 17:24:28.818 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 617 ms 
Apr-19 17:41:35.146 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 610 ms 
Apr-19 17:41:38.878 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 737 ms 
Apr-19 17:43:21.343 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 678 ms 
Apr-19 17:43:23.798 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 624 ms 
Apr-19 17:47:53.033 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 605 ms 
Apr-19 17:47:55.819 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 720 ms 
Apr-19 17:59:54.365 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 735 ms 
Apr-19 17:59:56.519 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 622 ms 
Apr-19 18:03:49.322 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 603 ms 
Apr-19 18:03:51.959 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 623 ms 
Apr-19 18:24:27.585 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 597 ms 
Apr-19 18:24:30.208 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 608 ms 
Apr-19 18:32:32.426 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 825 ms 
Apr-19 18:43:15.572 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 688 ms 
Apr-19 18:43:17.389 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 665 ms 
Apr-19 18:43:20.846 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 832 ms 
Apr-19 18:54:44.159 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 671 ms 
Apr-19 18:54:50.715 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 638 ms 
Apr-19 18:54:53.389 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 700 ms 
Apr-19 18:57:36.168 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 645 ms 
Apr-19 18:57:39.637 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 838 ms 
Apr-19 18:57:42.323 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 981 ms 
Apr-19 19:03:17.933 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 631 ms 
Apr-19 19:03:23.409 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 671 ms 
Apr-19 19:03:27.281 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 650 ms 
Apr-19 19:10:10.297 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 622 ms 
Apr-19 19:10:14.412 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 663 ms 
Apr-19 19:10:18.469 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 644 ms 
```

(The first very short update time of 5ms occurs when the Bisq instance is starting up and the DAO state has not yet been loaded.)

After the optimisation, the following update times are seen in the logs:

```
steven@debian:~/Documents/Java Projects/bisq$ grep "Apr-19.*update took" ~/.local/share/Bisq/bisq.log | head -n 40
Apr-19 22:20:59.456 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 91 ms 
Apr-19 22:21:06.250 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 87 ms 
Apr-19 22:21:08.282 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 75 ms 
Apr-19 22:21:27.895 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 58 ms 
Apr-19 22:21:30.207 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 61 ms 
Apr-19 22:21:54.428 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 67 ms 
Apr-19 22:21:56.546 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 72 ms 
Apr-19 22:21:57.590 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 60 ms 
Apr-19 22:36:55.658 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 58 ms 
Apr-19 22:36:58.761 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 62 ms 
Apr-19 22:37:02.351 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 57 ms 
Apr-19 22:40:36.976 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 59 ms 
Apr-19 22:40:39.478 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 84 ms 
Apr-19 22:40:42.849 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 62 ms 
Apr-19 22:47:37.600 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 60 ms 
Apr-19 22:47:38.518 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 99 ms 
Apr-19 22:47:40.648 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 74 ms 
Apr-19 22:53:42.378 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 61 ms 
Apr-19 22:53:46.480 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 64 ms 
Apr-19 22:53:49.793 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 62 ms 
Apr-19 22:57:50.609 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 64 ms 
Apr-19 22:57:56.863 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 66 ms 
Apr-19 22:57:59.834 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 148 ms 
Apr-19 23:01:20.784 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 72 ms 
Apr-19 23:01:24.188 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 87 ms 
Apr-19 23:15:13.056 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 57 ms 
Apr-19 23:15:13.982 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 52 ms 
Apr-19 23:15:18.548 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 62 ms 
Apr-19 23:24:37.167 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 60 ms 
Apr-19 23:24:38.181 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 62 ms 
Apr-19 23:24:41.172 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 62 ms 
Apr-19 23:33:01.655 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 66 ms 
Apr-19 23:33:02.848 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 67 ms 
Apr-19 23:33:06.434 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 72 ms 
Apr-19 23:33:44.921 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 61 ms 
Apr-19 23:33:48.624 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 60 ms 
Apr-19 23:33:50.790 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 73 ms 
Apr-19 23:39:43.736 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 58 ms 
Apr-19 23:39:45.941 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 85 ms 
Apr-19 23:39:49.207 [JavaFX Application Thread] DEBUG b.c.d.g.b.BondRepository: update took 59 ms 
```

Thus, there is something around a ten-fold speedup. As can be seen from the logs, `update()` usually gets called 3 times per incoming block (though this may depend on whether accounting is enabled, which it was on my instance).
