### PR TITLE
Tidy logback files & add space back to log pattern

### DIFF
--- a/apitest/src/main/resources/logback.xml
+++ b/apitest/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     -->
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{40}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 

--- a/apitest/src/test/resources/logback.xml
+++ b/apitest/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
     -->
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{40}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{40}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 
@@ -11,5 +11,4 @@
     </root>
 
     <logger name="io.grpc.netty" level="WARN"/>
-
 </configuration>

--- a/daemon/src/main/resources/logback.xml
+++ b/daemon/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{40}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 
@@ -11,5 +11,4 @@
     </root>
 
     <logger name="io.grpc.netty" level="WARN"/>
-
 </configuration>

--- a/desktop/src/main/resources/logback.xml
+++ b/desktop/src/main/resources/logback.xml
@@ -2,13 +2,14 @@
 <configuration>
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level%logger{40}: %msg %xEx%n)</pattern>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{40}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 
-    <!-- <logger name="org.bitcoinj" level="WARN"/>-->
-    <logger name="org.berndpruenster.netlayer.tor.Tor" level="WARN"/>
     <root level="TRACE">
         <appender-ref ref="CONSOLE_APPENDER"/>
     </root>
+
+    <!-- <logger name="org.bitcoinj" level="WARN"/>-->
+    <logger name="org.berndpruenster.netlayer.tor.Tor" level="WARN"/>
 </configuration>

--- a/seednode/src/main/resources/logback.xml
+++ b/seednode/src/main/resources/logback.xml
@@ -9,7 +9,4 @@
     <root level="TRACE">
         <appender-ref ref="CONSOLE_APPENDER"/>
     </root>
-
-    <logger name="com.msopentech.thali.toronionproxy.OnionProxyManagerEventHandler" level="INFO"/>
-
 </configuration>

--- a/statsnode/src/main/resources/logback.xml
+++ b/statsnode/src/main/resources/logback.xml
@@ -9,7 +9,4 @@
     <root level="TRACE">
         <appender-ref ref="CONSOLE_APPENDER"/>
     </root>
-
-    <logger name="com.msopentech.thali.toronionproxy.OnionProxyManagerEventHandler" level="INFO"/>
-
 </configuration>


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Uniformise the log patterns somewhat, by making the `Logger` classname field width either 15 for the seednode & statsnode, or 40 for the other applications (lengthened from 30 in a few cases).

Also clean up the _logback.xml_ files somewhat, in particular removing references to the old [Thali](https://github.com/thaliproject/Tor_Onion_Proxy_Library) Tor library, which was replaced years ago with our own fork of [NetLayer](https://github.com/cd2357/netlayer).

Finally, add a missing space back to the log pattern for _bisq-desktop_, to prevent `DEBUG`, `ERROR` or `TRACE` lines appearing as follows:

```
  ... [JavaFX Application Thread] ERRORb.c.s.CommonSetup: ...
```

(It isn't clear whether this recently introduced behaviour was really intentional, though it did prevent two consecutive spaces appearing in the majority `INFO` log lines.)
