### PR TITLE
Speed up Vote Result display, cycle list item selection & JSON export

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ProposalListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ProposalListItem.java
@@ -40,7 +40,6 @@ import org.bitcoinj.core.Coin;
 import de.jensd.fx.fontawesome.AwesomeIcon;
 
 import javafx.scene.control.Label;
-import javafx.scene.control.TableRow;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 
@@ -51,17 +50,13 @@ import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 public class ProposalListItem {
-
     @Getter
-    private EvaluatedProposal evaluatedProposal;
+    private final EvaluatedProposal evaluatedProposal;
     @Getter
     private final Proposal proposal;
     private final Vote vote;
     private final boolean isMyBallotIncluded;
     private final BsqFormatter bsqFormatter;
-
-    private TableRow tableRow;
-
 
     ProposalListItem(EvaluatedProposal evaluatedProposal, Ballot ballot, boolean isMyBallotIncluded,
                      BsqFormatter bsqFormatter) {
@@ -102,17 +97,6 @@ public class ProposalListItem {
         myVoteIcon = FormBuilder.getIcon(awesomeIcon);
         myVoteIcon.getStyleClass().add(s);
         return myVoteIcon;
-    }
-
-    public void setTableRow(TableRow tableRow) {
-        this.tableRow = tableRow;
-    }
-
-    public void resetTableRow() {
-        if (tableRow != null) {
-            tableRow.setStyle(null);
-            tableRow.requestLayout();
-        }
     }
 
     public String getProposalOwnerName() {

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -495,7 +495,6 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
         proposalsTableView.setItems(sortedProposalList);
         sortedProposalList.comparatorProperty().bind(proposalsTableView.comparatorProperty());
 
-        proposalList.forEach(ProposalListItem::resetTableRow);
         proposalList.clear();
 
         Map<String, Ballot> ballotByProposalTxIdMap = daoFacade.getAllValidBallots().stream()

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -412,7 +412,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
                             .collect(Collectors.toList());
 
                     AtomicLong stakeAndMerit = new AtomicLong();
-                    List<DecryptedBallotsWithMerits> decryptedVotesForCycle = daoStateService.getDecryptedBallotsWithMeritsList().stream()
+                    List<DecryptedBallotsWithMerits> decryptedVotesForCycle = daoStateService.getDecryptedBallotsWithMeritsList().parallelStream()
                             .filter(decryptedBallotsWithMerits -> cycleService.isTxInCycle(cycle, decryptedBallotsWithMerits.getBlindVoteTxId()))
                             .filter(decryptedBallotsWithMerits -> cycleService.isTxInCycle(cycle, decryptedBallotsWithMerits.getVoteRevealTxId()))
                             .peek(decryptedBallotsWithMerits -> stakeAndMerit.getAndAdd(decryptedBallotsWithMerits.getStake() + decryptedBallotsWithMerits.getMerit(daoStateService)))

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -985,9 +985,9 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
                                 voteJson.addProperty("hashOfBlindVoteList", Utilities.bytesAsHexString(decryptedBallotsWithMerits.getHashOfBlindVoteList()));
                                 voteJson.addProperty("blindVoteTxId", decryptedBallotsWithMerits.getBlindVoteTxId());
                                 voteJson.addProperty("voteRevealTxId", decryptedBallotsWithMerits.getVoteRevealTxId());
-                                voteJson.addProperty("stake", decryptedBallotsWithMerits.getStake());
-
-                                voteJson.addProperty("voteWeight", meritStakeMap.get(decryptedBallotsWithMerits.getBlindVoteTxId()));
+                                long stake = decryptedBallotsWithMerits.getStake();
+                                voteJson.addProperty("stake", stake);
+                                voteJson.addProperty("voteWeight", stake + meritStakeMap.get(decryptedBallotsWithMerits.getBlindVoteTxId()));
                                 String voteResult = decryptedBallotsWithMerits.getVote(evaluatedProp.getProposalTxId())
                                         .map(vote -> vote.isAccepted() ? "Accepted" : "Rejected")
                                         .orElse("Ignored");


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Alleviate some hotspots displaying the Vote Result table (under DAO / Governance) for the first time after application startup, selecting a cycle list item to display the evaluated proposals for that cycle, and exporting the vote result history JSON. Also fix a bug in the JSON export, where the BSQ stake of each submitted ballot list was not added to the respective `voteWeight` fields in the JSON, with them incorrectly showing the merit alone (thus, many of the individual vote weights show as zero).

--

The two main hotspots revealed by profiling were the signature verification of each `Merit` object in the DAO state, when computing the merit totals, and searching the BSQ wallet for blind vote txs to determine if the user voted in the given cycle. The former hotspot affects JSON generation and the initial display of the cycle table the first time the Vote Result view is activated. The latter hotspot is revealed upon selection of a cycle in the table.

To alleviate the former hotspot, the merit calculations were parallelised when calling `VoteResultView.doFillCycleList()` upon view activation, and ensuring each `Merit` object is considered only once during JSON export, by moving merit calculations to the outer loop of `VoteResultView.getVotingHistoryJson()`.

The latter hotspot was eliminated by replacing linear searches of the BSQ wallet for a given txId with a lookup into an added cached map, `BsqWalletService.walletTransactionsById`, as well as removing some needless looping over all the evaluated proposals of the cycle.

A third hotspot computing a map of ballots by proposal txId was eliminated from the cycle selection and evaluated proposal table display, by instead computing the map only once upon view activation, renaming the method `VoteResultView.doFillCycleList()` to `doFillCycleListAndBallotMap()`.

--

Before the changes in this PR, JProfiler shows the following call tree when activating the view for the first time:
![Screenshot from 2024-05-07 16-02-45](https://github.com/bisq-network/bisq/assets/54855381/0d5b47ac-d2fc-4e3d-8398-9647e605468f)

The best that I was able to do to speed this up was parallelise the merit calculations (and hence signature checking) somewhat. As the validity of the signatures affects the final merit sums, the expensive signature checks cannot easily be avoided.

--

Before the changes in this PR, JProfiler shows the following call tree when toggling between cycle list item selections ten times:
![Screenshot from 2024-05-07 16-11-48](https://github.com/bisq-network/bisq/assets/54855381/1fcfaf68-959c-4d87-a430-911ecaf2c051)

After the changes, the following call tree is seen instead:
![Screenshot from 2024-05-07 16-14-27](https://github.com/bisq-network/bisq/assets/54855381/735a66bb-b224-4e42-b364-6dc6eb4e19b5)

As can be seen, most of the remaining hotspots are coming from JavaFX. (I tried to optimise the method `GUIUtil.removeChildrenFromGridPaneRows` to remove the next biggest hotspot, but was not really able to.)

--

Before the changes in this PR, JProfiler shows the following call tree when exporting the JSON:
![Screenshot from 2024-05-07 16-21-19](https://github.com/bisq-network/bisq/assets/54855381/493e4ead-6483-46a7-af74-022d8859d312)

It took more than six minutes, so I stopped profiling part way through. After the changes, the following call tree is seen instead:
![Screenshot from 2024-05-07 16-24-10](https://github.com/bisq-network/bisq/assets/54855381/3b4b0bb6-a931-45b6-b8bc-e8fc161223c2)

Verifying `Merit` signatures is still the biggest hotspot, but now they are verified without repetition.
