### PR TITLE
Disable ImageCaptureReaderTest

### DIFF
--- a/desktop/src/test/java/bisq/desktop/main/account/content/notifications/qr/ImageCaptureReaderTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/account/content/notifications/qr/ImageCaptureReaderTest.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -39,6 +40,13 @@ import static org.mockito.Mockito.*;
 import org.bytedeco.javacv.Frame;
 import org.bytedeco.javacv.FrameGrabber;
 
+// TODO fix dependency problems
+// If tests are run via gradle I get an error:
+// `Loading library prism_es2 from resource failed: java.lang.UnsatisfiedLinkError: Can't load library: /Users/dev/.openjfx/cache/16/libprism_es2.dylib`
+// If run from the IDE it works.
+// CI on windows also fails, other OS work.
+// Seems that there are some platfomr specific dependency issues...
+@Disabled
 @ExtendWith(MockitoExtension.class)
 class ImageCaptureReaderTest {
     @Mock


### PR DESCRIPTION
If tests are run via gradle I get an error:
`Loading library prism_es2 from resource failed: java.lang.UnsatisfiedLinkError: Can't load library: /Users/dev/.openjfx/cache/16/libprism_es2.dylib` If run from the IDE it works.
CI on windows also fails, other OS work.
Seems that there are some platform specific dependency issues...

@devinbileck @alvasw Any ideas how to fix that?