### PR TITLE
Only show XMR subaddress recommendation if the user has a XMR account setup

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/account/AccountView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/AccountView.java
@@ -41,7 +41,6 @@ import bisq.desktop.main.presentation.AccountPresentation;
 import bisq.core.locale.Res;
 import bisq.core.user.DontShowAgainLookup;
 
-import bisq.common.app.DevEnv;
 import bisq.common.util.Utilities;
 
 import javax.inject.Inject;
@@ -272,14 +271,6 @@ public class AccountView extends ActivatableView<TabPane, Void> {
                     .headLine(Res.get("account.info.headline"))
                     .backgroundInfo(Res.get("account.info.msg"))
                     .dontShowAgainId(key)
-                    .show();
-        } else {
-            // news badge leads to the XMR subaddress info page (added in v1.9.2)
-            new Popup()
-                    .headLine(Res.get("account.altcoin.popup.xmr.dataDirWarningHeadline"))
-                    .backgroundInfo(Res.get("account.altcoin.popup.xmr.dataDirWarning"))
-                    .dontShowAgainId("accountSubAddressInfo")
-                    .width(700)
                     .show();
         }
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
@@ -18,9 +18,11 @@
 package bisq.desktop.main.account.content.altcoinaccounts;
 
 import bisq.desktop.common.model.ActivatableDataModel;
+import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.locale.CryptoCurrency;
+import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.payment.AssetAccount;
@@ -76,6 +78,16 @@ class AltCoinAccountsDataModel extends ActivatableDataModel {
     protected void activate() {
         user.getPaymentAccountsAsObservable().addListener(setChangeListener);
         fillAndSortPaymentAccounts();
+
+        paymentAccounts.stream().filter(e -> e.getSingleTradeCurrency().getCode().equals("XMR"))
+                .findAny().ifPresent(e -> {
+                    new Popup()
+                            .headLine(Res.get("account.altcoin.popup.xmr.dataDirWarningHeadline"))
+                            .backgroundInfo(Res.get("account.altcoin.popup.xmr.dataDirWarning"))
+                            .dontShowAgainId("accountSubAddressInfo")
+                            .width(700)
+                            .show();
+                });
     }
 
     private void fillAndSortPaymentAccounts() {

--- a/desktop/src/main/java/bisq/desktop/main/presentation/AccountPresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/presentation/AccountPresentation.java
@@ -50,7 +50,9 @@ public class AccountPresentation {
 
         preferences.getDontShowAgainMapAsObservable().addListener((MapChangeListener<? super String, ? super Boolean>) change -> {
             if (change.getKey().equals(ACCOUNT_NEWS)) {
-                showNotification.set(!change.wasAdded());
+                // devs enable this when a news badge is required
+                // showNotification.set(!change.wasAdded());
+                showNotification.set(false);
             }
         });
     }
@@ -65,26 +67,26 @@ public class AccountPresentation {
 
     public void setup() {
         // devs enable this when a news badge is required
-        showNotification.set(preferences.showAgain(ACCOUNT_NEWS));
+        //showNotification.set(preferences.showAgain(ACCOUNT_NEWS));
+        showNotification.set(false);
     }
 
-    public void showOneTimeAccountSigningPopup(String key, String s) {
-        showOneTimeAccountSigningPopup(key, s, null);
+    public void showOneTimeAccountSigningPopup(String key, String message) {
+        showOneTimeAccountSigningPopup(key, message, null);
     }
 
-    public void showOneTimeAccountSigningPopup(String key, String s, String optionalParam) {
+    public void showOneTimeAccountSigningPopup(String key, String message, String optionalParam) {
         if (!DevEnv.isDevMode()) {
 
             DontShowAgainLookup.dontShowAgain(ACCOUNT_NEWS, false);
             showNotification.set(true);
 
             DontShowAgainLookup.dontShowAgain(key, true);
-            String message = optionalParam != null ?
-                    Res.get(s, optionalParam, Res.get("popup.accountSigning.generalInformation")) :
-                    Res.get(s, Res.get("popup.accountSigning.generalInformation"));
+            String information = optionalParam != null ?
+                    Res.get(message, optionalParam, Res.get("popup.accountSigning.generalInformation")) :
+                    Res.get(message, Res.get("popup.accountSigning.generalInformation"));
 
-            new Popup().information(message)
-                    .show();
+            new Popup().information(information).show();
         }
     }
 }


### PR DESCRIPTION
We have shown the popup each time the user goes to account.
Now we only show if if the user has an XMR account.