### PR TITLE
[1] Refactor Proto interface

### DIFF
--- a/common/src/main/java/bisq/common/Proto.java
+++ b/common/src/main/java/bisq/common/Proto.java
@@ -24,4 +24,12 @@ import com.google.protobuf.Message;
  */
 public interface Proto {
     Message toProtoMessage();
+
+    default byte[] serialize() {
+        return toProtoMessage().toByteArray();
+    }
+
+    default byte[] serializeForHash() {
+        return serialize();
+    }
 }

--- a/core/src/main/java/bisq/core/dao/burningman/accounting/node/AccountingNode.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/node/AccountingNode.java
@@ -60,7 +60,7 @@ public abstract class AccountingNode implements DaoSetupService, DaoStateListene
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static Sha256Hash getSha256Hash(AccountingBlock block) {
-        return Sha256Hash.of(block.toProtoMessage().toByteArray());
+        return Sha256Hash.of(block.serializeForHash());
     }
 
     @Nullable
@@ -68,7 +68,7 @@ public abstract class AccountingNode implements DaoSetupService, DaoStateListene
         long ts = System.currentTimeMillis();
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             for (AccountingBlock accountingBlock : blocks) {
-                outputStream.write(accountingBlock.toProtoMessage().toByteArray());
+                outputStream.write(accountingBlock.serializeForHash());
             }
             Sha256Hash hash = Sha256Hash.of(outputStream.toByteArray());
             // 2833 blocks takes about 23 ms

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteConsensus.java
@@ -84,14 +84,14 @@ public class BlindVoteConsensus {
     }
 
     public static byte[] getEncryptedVotes(VoteWithProposalTxIdList voteWithProposalTxIdList, SecretKey secretKey) throws CryptoException {
-        byte[] bytes = voteWithProposalTxIdList.toProtoMessage().toByteArray();
+        byte[] bytes = voteWithProposalTxIdList.serialize();
         byte[] encrypted = Encryption.encrypt(bytes, secretKey);
         log.info("EncryptedVotes: " + Utilities.bytesAsHexString(encrypted));
         return encrypted;
     }
 
     public static byte[] getEncryptedMeritList(MeritList meritList, SecretKey secretKey) throws CryptoException {
-        byte[] bytes = meritList.toProtoMessage().toByteArray();
+        byte[] bytes = meritList.serialize();
         return Encryption.encrypt(bytes, secretKey);
     }
 

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/storage/BlindVotePayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/storage/BlindVotePayload.java
@@ -48,7 +48,7 @@ public final class BlindVotePayload implements PersistableNetworkPayload, Consen
     protected final byte[] hash;        // 20 byte
 
     public BlindVotePayload(BlindVote blindVote) {
-        this(blindVote, Hash.getRipemd160hash(blindVote.toProtoMessage().toByteArray()));
+        this(blindVote, Hash.getRipemd160hash(blindVote.serializeForHash()));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/dao/governance/proposal/ProposalConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/ProposalConsensus.java
@@ -40,7 +40,7 @@ public class ProposalConsensus {
     }
 
     public static byte[] getHashOfPayload(Proposal payload) {
-        final byte[] bytes = payload.toProtoMessage().toByteArray();
+        final byte[] bytes = payload.serializeForHash();
         return Hash.getSha256Ripemd160hash(bytes);
     }
 

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/appendonly/ProposalPayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/appendonly/ProposalPayload.java
@@ -44,7 +44,7 @@ public class ProposalPayload implements PersistableNetworkPayload, ConsensusCrit
     protected final byte[] hash;        // 20 byte
 
     public ProposalPayload(Proposal proposal) {
-        this(proposal, Hash.getRipemd160hash(proposal.toProtoMessage().toByteArray()));
+        this(proposal, Hash.getRipemd160hash(proposal.serializeForHash()));
     }
 
 

--- a/core/src/main/java/bisq/core/dao/governance/votereveal/VoteRevealConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/votereveal/VoteRevealConsensus.java
@@ -41,7 +41,7 @@ public class VoteRevealConsensus {
     public static byte[] getHashOfBlindVoteList(List<BlindVote> blindVotes) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         blindVotes.forEach(blindVote -> {
-            byte[] data = blindVote.toProtoMessage().toByteArray();
+            byte[] data = blindVote.serializeForHash();
             try {
                 outputStream.write(data);
             } catch (IOException e) {

--- a/core/src/main/java/bisq/core/dao/monitoring/BlindVoteStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/BlindVoteStateMonitoringService.java
@@ -268,7 +268,7 @@ public class BlindVoteStateMonitoringService implements DaoSetupService, DaoStat
                     .collect(Collectors.toList());
 
             // We use MyBlindVoteList to get the serialized bytes from the blindVotes list
-            byte[] serializedBlindVotes = new MyBlindVoteList(blindVotes).toProtoMessage().toByteArray();
+            byte[] serializedBlindVotes = new MyBlindVoteList(blindVotes).serializeForHash();
 
             byte[] prevHash;
             if (blindVoteStateBlockChain.isEmpty()) {

--- a/core/src/main/java/bisq/core/dao/monitoring/ProposalStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/ProposalStateMonitoringService.java
@@ -270,7 +270,7 @@ public class ProposalStateMonitoringService implements DaoSetupService, DaoState
                     .collect(Collectors.toList());
 
             // We use MyProposalList to get the serialized bytes from the proposals list
-            byte[] serializedProposals = new MyProposalList(proposals).toProtoMessage().toByteArray();
+            byte[] serializedProposals = new MyProposalList(proposals).serializeForHash();
 
             byte[] prevHash;
             if (proposalStateBlockChain.isEmpty()) {

--- a/core/src/main/java/bisq/core/dao/state/model/governance/Role.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/Role.java
@@ -78,7 +78,7 @@ public final class Role implements PersistablePayload, NetworkPayload, BondedAss
         this.link = link;
         this.bondedRoleType = bondedRoleType;
 
-        hash = Hash.getSha256Ripemd160hash(toProtoMessage().toByteArray());
+        hash = Hash.getSha256Ripemd160hash(serializeForHash());
     }
 
     @Override

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -701,7 +701,7 @@ public class FilterManager {
     }
 
     private Sha256Hash getSha256Hash(Filter filter) {
-        byte[] filterData = filter.toProtoMessage().toByteArray();
+        byte[] filterData = filter.serializeForHash();
         return Sha256Hash.of(filterData);
     }
 

--- a/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
@@ -99,7 +99,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
 
     public byte[] getHash() {
         if (this.hash == null) {
-            this.hash = Hash.getSha256Hash(this.toProtoMessage().toByteArray());
+            this.hash = Hash.getSha256Hash(serializeForHash());
         }
         return this.hash;
     }

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
@@ -218,7 +218,7 @@ public final class OfferPayload extends OfferPayloadBase {
         if (this.hash == null && this.offerFeePaymentTxId != null) {
             // A proto message can be created only after the offerFeePaymentTxId is
             // set to a non-null value;  now is the time to cache the payload hash.
-            this.hash = Hash.getSha256Hash(this.toProtoMessage().toByteArray());
+            this.hash = Hash.getSha256Hash(serializeForHash());
         }
         return this.hash;
     }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
@@ -87,7 +87,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class ProcessModel implements ProtocolModel<TradingPeer> {
 
     public static byte[] hashOfPaymentAccountPayload(PaymentAccountPayload paymentAccountPayload) {
-        return Hash.getRipemd160hash(checkNotNull(paymentAccountPayload).toProtoMessage().toByteArray());
+        return Hash.getRipemd160hash(checkNotNull(paymentAccountPayload).serializeForHash());
     }
 
     // Transient/Immutable (net set in constructor so they are not final, but at init)

--- a/core/src/test/java/bisq/core/filter/TestFilter.java
+++ b/core/src/test/java/bisq/core/filter/TestFilter.java
@@ -109,7 +109,7 @@ public class TestFilter {
     }
 
     public static Filter signFilter(Filter unsignedFilter, ECKey signerKey) {
-        byte[] filterData = unsignedFilter.toProtoMessage().toByteArray();
+        byte[] filterData = unsignedFilter.serializeForHash();
         Sha256Hash hash = Sha256Hash.of(filterData);
 
         ECKey.ECDSASignature ecdsaSignature = signerKey.sign(hash);

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -1240,7 +1240,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
      * @return Hash of data
      */
     public static byte[] get32ByteHash(NetworkPayload data) {
-        return Hash.getSha256Hash(data.toProtoMessage().toByteArray());
+        return Hash.getSha256Hash(data.serializeForHash());
     }
 
 

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageBuildGetDataResponseTest.java
@@ -129,6 +129,8 @@ public class P2PDataStorageBuildGetDataResponseTest {
             Message messageMock = mock(Message.class);
             when(messageMock.toByteArray()).thenReturn(Sig.getPublicKeyBytes(ownerKeys.getPublic()));
             when(protectedStoragePayload.toProtoMessage()).thenReturn(messageMock);
+            when(protectedStoragePayload.serialize()).thenReturn(new byte[]{});
+            when(protectedStoragePayload.serializeForHash()).thenReturn(new byte[]{});
 
             // Entry stub
             ProtectedStorageEntry stub = mock(ProtectedStorageEntry.class);

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -359,6 +359,8 @@ public class TestState {
         when(payloadMock.getOwnerPubKey()).thenReturn(receiverKey);
         when(payloadMock.getSenderPubKeyForAddOperation()).thenReturn(senderKey);
         when(payloadMock.toProtoMessage()).thenReturn(messageMock);
+        when(payloadMock.serialize()).thenReturn(new byte[]{});
+        when(payloadMock.serializeForHash()).thenReturn(new byte[]{});
 
         return payloadMock;
     }


### PR DESCRIPTION
Refactor: Replace toProtoMessage().toByteArray() calls to serialize() or serializeForHash() methods.

Currenty serializeForHash just calls serialize. This will be change in later commits
