### PR TITLE
Add missing snapshot creation in full DAO mode

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -719,7 +719,7 @@ public class Config {
                 parser.accepts(DAO_NODE_API_PORT, "Dao node API port")
                         .withRequiredArg()
                         .ofType(Integer.class)
-                        .defaultsTo(8082);
+                        .defaultsTo(8081);
 
         ArgumentAcceptingOptionSpec<Boolean> isBmFullNode =
                 parser.accepts(IS_BM_FULL_NODE, "Run as Burningman full node")

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -139,6 +139,7 @@ public class Config {
     public static final String BM_ORACLE_NODE_PRIV_KEY = "bmOracleNodePrivKey";
     public static final String SEED_NODE_REPORTING_SERVER_URL = "seedNodeReportingServerUrl";
     public static final String USE_TOR_FOR_BTC_MONITOR = "useTorForBtcMonitor";
+    public static final String USE_FULL_MODE_DAO_MONITOR = "useFullModeDaoMonitor";
 
     // Default values for certain options
     public static final int UNSPECIFIED_PORT = -1;
@@ -239,6 +240,8 @@ public class Config {
     public final String bmOracleNodePrivKey;
     public final String seedNodeReportingServerUrl;
     public final boolean useTorForBtcMonitor;
+    public final boolean useFullModeDaoMonitor;
+    public final boolean useFullModeDaoMonitorSetExplicitly;
 
     // Properties derived from options but not exposed as options themselves
     public final File torDir;
@@ -746,6 +749,14 @@ public class Config {
                         .ofType(Boolean.class)
                         .defaultsTo(true);
 
+        ArgumentAcceptingOptionSpec<Boolean> useFullModeDaoMonitorOpt =
+                parser.accepts(USE_FULL_MODE_DAO_MONITOR, "If set to true full mode DAO monitor is activated. " +
+                                "By that at each block during parsing the dao state hash is created, " +
+                                "otherwise only after block parsing is complete and on new blocks.")
+                        .withRequiredArg()
+                        .ofType(Boolean.class)
+                        .defaultsTo(false);
+
         try {
             CompositeOptionSet options = new CompositeOptionSet();
 
@@ -873,6 +884,8 @@ public class Config {
             this.bmOracleNodePrivKey = options.valueOf(bmOracleNodePrivKey);
             this.seedNodeReportingServerUrl = options.valueOf(seedNodeReportingServerUrlOpt);
             this.useTorForBtcMonitor = options.valueOf(useTorForBtcMonitorOpt);
+            this.useFullModeDaoMonitor = options.valueOf(useFullModeDaoMonitorOpt);
+            this.useFullModeDaoMonitorSetExplicitly = options.has(useFullModeDaoMonitorOpt);
         } catch (OptionException ex) {
             throw new ConfigException("problem parsing option '%s': %s",
                     ex.options().get(0),

--- a/core/src/main/java/bisq/core/dao/DaoModule.java
+++ b/core/src/main/java/bisq/core/dao/DaoModule.java
@@ -225,6 +225,7 @@ public class DaoModule extends AppModule {
         bindConstant().annotatedWith(named(Config.IS_BM_FULL_NODE)).to(config.isBmFullNode);
         bindConstant().annotatedWith(named(Config.BM_ORACLE_NODE_PUB_KEY)).to(config.bmOracleNodePubKey);
         bindConstant().annotatedWith(named(Config.BM_ORACLE_NODE_PRIV_KEY)).to(config.bmOracleNodePrivKey);
+        bindConstant().annotatedWith(named(Config.USE_FULL_MODE_DAO_MONITOR)).to(config.useFullModeDaoMonitor);
     }
 }
 

--- a/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/DaoStateMonitoringService.java
@@ -203,7 +203,7 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
             verifyCheckpoints();
         }
 
-        log.info("ParseBlockChainComplete: Accumulated updateHashChain() calls for {} block took {} ms " +
+        log.info("ParseBlockChainComplete: Accumulated updateHashChain() calls for {} blocks took {} ms " +
                         "({} ms in average / block)",
                 numCalls,
                 accumulatedDuration,
@@ -370,12 +370,19 @@ public class DaoStateMonitoringService implements DaoSetupService, DaoStateListe
             UserThread.runAfter(() -> daoStateNetworkService.broadcastMyStateHash(myDaoStateHash), delayInSec);
         }
         long duration = System.currentTimeMillis() - ts;
-        // We don't want to spam the output. We log accumulated time after parsing is completed.
         log.trace("updateHashChain for block {} took {} ms",
                 block.getHeight(),
                 duration);
         accumulatedDuration += duration;
         numCalls++;
+
+        if (numCalls % 10 == 0) {
+            log.info("Accumulated updateHashChain() calls for {} blocks took {} ms " +
+                            "({} ms in average / block)",
+                    numCalls,
+                    accumulatedDuration,
+                    (int) ((double) accumulatedDuration / (double) numCalls));
+        }
         listeners.forEach(Listener::onDaoStateBlockCreated);
         return Optional.of(daoStateBlock);
     }

--- a/core/src/main/java/bisq/core/dao/monitoring/model/DaoStateHash.java
+++ b/core/src/main/java/bisq/core/dao/monitoring/model/DaoStateHash.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class DaoStateHash extends StateHash {
-    // If we have built the hash by ourself opposed to that we got delivered the hash from seed nodes or resources
+    // If we have built the hash by ourselves opposed to that we got delivered the hash from seed nodes or resources
     private final boolean isSelfCreated;
 
     public DaoStateHash(int height, byte[] hash, boolean isSelfCreated) {

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -218,10 +218,8 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
             return;
         }
 
-        // Either we don't have a snapshot candidate yet, or if we have one the height at that snapshot candidate must be
-        // different to our current height.
-        boolean noSnapshotCandidateOrDifferentHeight = daoStateCandidate == null || snapshotHeight != chainHeight;
-        if (!noSnapshotCandidateOrDifferentHeight) {
+        if (daoStateCandidate != null && snapshotHeight == chainHeight) {
+            log.error("snapshotHeight is same as chainHeight. This should never happen. chainHeight={}", chainHeight);
             return;
         }
 

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -204,7 +204,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
 
     // We need to process during batch processing as well to write snapshots during that process.
     public void maybeCreateSnapshot(Block block) {
-        if (!isHeightAtLeastGenesisHeight(daoStateService.getBlockHeightOfLastBlock())) {
+        if (isHeightBelowGenesisHeight(daoStateService.getBlockHeightOfLastBlock())) {
             return;
         }
         int chainHeight = block.getHeight();
@@ -317,7 +317,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
             return;
         }
 
-        if (!isHeightAtLeastGenesisHeight(chainHeightOfPersistedDaoState)) {
+        if (isHeightBelowGenesisHeight(chainHeightOfPersistedDaoState)) {
             return;
         }
 
@@ -344,12 +344,12 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private boolean isHeightAtLeastGenesisHeight(int heightOfLastBlock) {
-        boolean isHeightAtLeastGenesisHeight = heightOfLastBlock >= genesisTxInfo.getGenesisBlockHeight();
-        if (!isHeightAtLeastGenesisHeight) {
-            log.error("heightOfPersistedLastBlock is below genesis height. This should never happen. heightOfLastBlock={}", heightOfLastBlock);
+    private boolean isHeightBelowGenesisHeight(int height) {
+        boolean isHeightBelowGenesisHeight = height < genesisTxInfo.getGenesisBlockHeight();
+        if (isHeightBelowGenesisHeight) {
+            log.error("height is below genesis height. This should never happen. height={}", height);
         }
-        return isHeightAtLeastGenesisHeight;
+        return isHeightBelowGenesisHeight;
     }
 
     private void resyncDaoStateFromResources() {

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -171,7 +171,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     private final String btcNodesFromOptions, referralIdFromOptions,
             rpcUserFromOptions, rpcPwFromOptions;
     private final int blockNotifyPortFromOptions;
-    private final boolean fullDaoNodeFromOptions, fullAccountingNodeFromOptions;
+    private final boolean fullDaoNodeFromOptions, fullAccountingNodeFromOptions, useFullModeDaoMonitorFromOptions;
     @Getter
     private final BooleanProperty useStandbyModeProperty = new SimpleBooleanProperty(prefPayload.isUseStandbyMode());
 
@@ -191,7 +191,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
                        @Named(Config.IS_BM_FULL_NODE) boolean fullAccountingNode,
                        @Named(Config.RPC_USER) String rpcUser,
                        @Named(Config.RPC_PASSWORD) String rpcPassword,
-                       @Named(Config.RPC_BLOCK_NOTIFICATION_PORT) int rpcBlockNotificationPort) {
+                       @Named(Config.RPC_BLOCK_NOTIFICATION_PORT) int rpcBlockNotificationPort,
+                       @Named(Config.USE_FULL_MODE_DAO_MONITOR) boolean useFullModeDaoMonitor) {
 
         this.persistenceManager = persistenceManager;
         this.config = config;
@@ -204,6 +205,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         this.rpcUserFromOptions = rpcUser;
         this.rpcPwFromOptions = rpcPassword;
         this.blockNotifyPortFromOptions = rpcBlockNotificationPort;
+        this.useFullModeDaoMonitorFromOptions = useFullModeDaoMonitor;
 
         useAnimationsProperty.addListener((ov) -> {
             prefPayload.setUseAnimations(useAnimationsProperty.get());
@@ -828,8 +830,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     }
 
     public void setUseFullModeDaoMonitor(boolean value) {
-        prefPayload.setUseFullModeDaoMonitor(value);
-        requestPersistence();
+        // We only persist if we have not set the program argument
+        if (!config.useFullModeDaoMonitorSetExplicitly) {
+            prefPayload.setUseFullModeDaoMonitor(value);
+            requestPersistence();
+        }
     }
 
     public void setUseBitcoinUrisInQrCodes(boolean value) {
@@ -1031,6 +1036,14 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         return prefPayload.isFullBMAccountingNode();
     }
 
+    public boolean isUseFullModeDaoMonitor() {
+        if (config.useFullModeDaoMonitorSetExplicitly) {
+            return useFullModeDaoMonitorFromOptions;
+        } else {
+            return prefPayload.isUseFullModeDaoMonitor();
+        }
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
@@ -1202,5 +1215,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         void setProcessBurningManAccountingData(boolean processBurningManAccountingData);
 
         void setFullBMAccountingNode(boolean isFullBMAccountingNode);
+
+        boolean isUseFullModeDaoMonitor();
     }
 }

--- a/core/src/test/java/bisq/core/dao/state/DaoStateSnapshotServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/state/DaoStateSnapshotServiceTest.java
@@ -41,7 +41,8 @@ public class DaoStateSnapshotServiceTest {
                 null,
                 null,
                 null,
-                null);
+                null,
+                true);
     }
 
     @Test

--- a/core/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/core/src/test/java/bisq/core/user/PreferencesTest.java
@@ -69,7 +69,7 @@ public class PreferencesTest {
         LocalBitcoinNode localBitcoinNode = new LocalBitcoinNode(config);
         preferences = new Preferences(
                 persistenceManager, config, null, localBitcoinNode, null, null, Config.DEFAULT_FULL_DAO_NODE,
-                false, null, null, Config.UNSPECIFIED_PORT);
+                false, null, null, Config.UNSPECIFIED_PORT, true);
     }
 
     @SuppressWarnings("unchecked")

--- a/desktop/src/test/java/bisq/desktop/maker/PreferenceMakers.java
+++ b/desktop/src/test/java/bisq/desktop/maker/PreferenceMakers.java
@@ -47,7 +47,7 @@ public class PreferenceMakers {
             lookup.valueOf(localBitcoinNode, new SameValueDonor<>(null)),
             lookup.valueOf(useTorFlagFromOptions, new SameValueDonor<>(null)),
             lookup.valueOf(referralID, new SameValueDonor<>(null)),
-            Config.DEFAULT_FULL_DAO_NODE, false, null, null, Config.UNSPECIFIED_PORT);
+            Config.DEFAULT_FULL_DAO_NODE, false, null, null, Config.UNSPECIFIED_PORT, false);
 
     public static final Preferences empty = make(a(Preferences));
 }


### PR DESCRIPTION
If running a full DAO node but not having Full mode for DAO Monitor activated we did not create snapshots while parsing blocks. 
This was bad when doing a resync as only after parsing complete which can take very long in case of a resync from genesis there have been no blocks and state persisted. Activating Full mode for DAO Monitor would slow down parsing as at each block the dao state hash would get created.

With this PR we create snapshots if full DAO mode is activated.

However when running a full DAO node it is recommended to set `--useFullModeDaoMonitor` to true to ensure the linked list of dao state hashes is correct and we do not depend on data provided by seed nodes. 