### PR TITLE
Set -fx-font-smoothing-type to grey.

### DIFF
--- a/common/src/main/java/bisq/common/setup/CommonSetup.java
+++ b/common/src/main/java/bisq/common/setup/CommonSetup.java
@@ -111,8 +111,6 @@ public class CommonSetup {
     }
 
     protected static void setSystemProperties() {
-        if (Utilities.isLinux())
-            System.setProperty("prism.lcdtext", "false");
     }
 
     protected static void setupSigIntHandlers(GracefulShutDownHandler gracefulShutDownHandler) {

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -26,6 +26,11 @@
     -fx-font-family: "IBM Plex Sans";
 }
 
+/* Avoid color artefacts at antialias */
+.text {
+    -fx-font-smoothing-type: gray;
+}
+
 /********************************************************************************************************************
  *                                                                                                                  *
  * General                                                                                                          *


### PR DESCRIPTION
With ` -fx-font-smoothing-type: gray;`:
![lcdtext=false](https://github.com/bisq-network/bisq/assets/116298498/0922447b-8c4e-4b74-8a65-24aafac89f25)

With ` -fx-font-smoothing-type: lcd;`, which is default set by moderna.css:
![def](https://github.com/bisq-network/bisq/assets/116298498/4bd76025-a4b4-4405-bebd-0b60fa9cb8e1)

Images are taken from Bisq2 where the same will be applied.
