### PR TITLE
Check burning man receiver address validity

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/BtcFeeReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BtcFeeReceiverService.java
@@ -27,7 +27,6 @@ import javax.inject.Singleton;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -69,7 +68,7 @@ public class BtcFeeReceiverService implements DaoStateListener {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public String getAddress() {
-        List<BurningManCandidate> activeBurningManCandidates = new ArrayList<>(burningManService.getActiveBurningManCandidates(currentChainHeight));
+        List<BurningManCandidate> activeBurningManCandidates = burningManService.getActiveBurningManCandidates(currentChainHeight);
         if (activeBurningManCandidates.isEmpty()) {
             // If there are no compensation requests (e.g. at dev testing) we fall back to the default address
             return burningManService.getLegacyBurningManAddress(currentChainHeight);

--- a/core/src/main/java/bisq/core/dao/burningman/BtcFeeReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BtcFeeReceiverService.java
@@ -96,9 +96,7 @@ public class BtcFeeReceiverService implements DaoStateListener {
             // the burningManCandidates as we added for the legacy BM an entry at the end.
             return burningManService.getLegacyBurningManAddress(currentChainHeight);
         }
-        // For the fee selection we do not need to wait for activation date of the bugfix for
-        // the receiver address (https://github.com/bisq-network/bisq/issues/6699) as it has no impact on the trade protocol.
-        return activeBurningManCandidates.get(winnerIndex).getReceiverAddress(true)
+        return activeBurningManCandidates.get(winnerIndex).getReceiverAddress()
                 .orElse(burningManService.getLegacyBurningManAddress(currentChainHeight));
     }
 

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -216,7 +216,7 @@ public class BurningManService {
     List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight, boolean limitCappingRounds) {
         return getBurningManCandidatesByName(chainHeight, limitCappingRounds).values().stream()
                 .filter(burningManCandidate -> burningManCandidate.getCappedBurnAmountShare() > 0)
-                .filter(candidate -> candidate.getReceiverAddress().isPresent())
+                .filter(BurningManCandidate::isReceiverAddressValid)
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -116,7 +116,7 @@ public class BurningManService {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     Map<String, BurningManCandidate> getBurningManCandidatesByName(int chainHeight) {
-        return getBurningManCandidatesByName(chainHeight, !DelayedPayoutTxReceiverService.isProposal412Activated());
+        return getBurningManCandidatesByName(chainHeight, false);
     }
 
     Map<String, BurningManCandidate> getBurningManCandidatesByName(int chainHeight, boolean limitCappingRounds) {
@@ -210,7 +210,7 @@ public class BurningManService {
     }
 
     List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight) {
-        return getActiveBurningManCandidates(chainHeight, !DelayedPayoutTxReceiverService.isProposal412Activated());
+        return getActiveBurningManCandidates(chainHeight, false);
     }
 
     List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight, boolean limitCappingRounds) {

--- a/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
+++ b/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
@@ -18,7 +18,6 @@
 package bisq.core.dao.burningman.model;
 
 import bisq.core.dao.burningman.BurningManService;
-import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 
 import bisq.common.util.DateUtil;
 
@@ -77,7 +76,7 @@ public class BurningManCandidate {
     }
 
     public Optional<String> getReceiverAddress() {
-        return getReceiverAddress(DelayedPayoutTxReceiverService.isBugfix6699Activated());
+        return getReceiverAddress(true);
     }
 
     public Optional<String> getReceiverAddress(boolean isBugfix6699Activated) {

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -56,7 +56,6 @@ import bisq.common.util.Tuple2;
 
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
@@ -195,7 +194,7 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
         checkNotNull(chatMessage, "chatMessage must not be null");
         Optional<Dispute> disputeOptional = findDispute(disputeResult);
         String uid = disputeResultMessage.getUid();
-        if (!disputeOptional.isPresent()) {
+        if (disputeOptional.isEmpty()) {
             log.warn("We got a dispute result msg but we don't have a matching dispute. " +
                     "That might happen when we get the disputeResultMessage before the dispute was created. " +
                     "We try again after 2 sec. to apply the disputeResultMessage. TradeId = " + tradeId);
@@ -333,11 +332,13 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
         int selectionHeight = dispute.getBurningManSelectionHeight();
 
         boolean wasBugfix6699ActivatedAtTradeDate = dispute.getTradeDate().after(DelayedPayoutTxReceiverService.BUGFIX_6699_ACTIVATION_DATE);
+        boolean wasProposal412ActivatedAtTradeDate = dispute.getTradeDate().after(DelayedPayoutTxReceiverService.PROPOSAL_412_ACTIVATION_DATE);
         List<Tuple2<Long, String>> delayedPayoutTxReceivers = delayedPayoutTxReceiverService.getReceivers(
                 selectionHeight,
                 inputAmount,
                 dispute.getTradeTxFee(),
-                wasBugfix6699ActivatedAtTradeDate);
+                wasBugfix6699ActivatedAtTradeDate,
+                wasProposal412ActivatedAtTradeDate);
         log.info("Verify delayedPayoutTx using selectionHeight {} and receivers {}", selectionHeight, delayedPayoutTxReceivers);
         checkArgument(delayedPayoutTx.getOutputs().size() == delayedPayoutTxReceivers.size(),
                 "Size of outputs and delayedPayoutTxReceivers must be the same");

--- a/core/src/main/java/bisq/core/util/validation/BtcAddressValidator.java
+++ b/core/src/main/java/bisq/core/util/validation/BtcAddressValidator.java
@@ -47,9 +47,9 @@ public final class BtcAddressValidator extends InputValidator {
             return new ValidationResult(true);
         }
         try {
-            Address.fromString(Config.baseCurrencyNetworkParameters(), input);
+            Address.fromString(Config.baseCurrencyNetworkParameters(), input).getOutputScriptType();
             return new ValidationResult(true);
-        } catch (AddressFormatException e) {
+        } catch (AddressFormatException | IllegalStateException e) {
             return new ValidationResult(false, Res.get("validation.btc.invalidFormat"));
         }
     }

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -27,6 +27,7 @@ import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.dao.state.model.governance.CompensationProposal;
 import bisq.core.dao.state.model.governance.Issuance;
 import bisq.core.dao.state.model.governance.IssuanceType;
+import bisq.core.locale.Res;
 
 import bisq.common.util.Tuple2;
 
@@ -68,6 +69,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 public class BurningManServiceTest {
+    private static final String VALID_P2SH_ADDRESS = "3AdD7ZaJQw9m1maN39CeJ1zVyXQLn2MEHR";
+    private static final String VALID_P2WPKH_ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    private static final String VALID_P2TR_ADDRESS = "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0"; // unsupported
+    private static final String INVALID_ADDRESS = "invalid_address";
+
     @Test
     public void testGetDecayedAmount() {
         long amount = 100;
@@ -104,6 +110,7 @@ public class BurningManServiceTest {
 
         @BeforeEach
         public void setUp() {
+            Res.setup();
             when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_BURN_AMOUNT_DECAY))
                     .thenReturn(750000);
             when(cyclesInDaoStateService.getChainHeightOfPastCycle(800000, BurningManService.NUM_CYCLES_COMP_REQUEST_DECAY))
@@ -131,6 +138,34 @@ public class BurningManServiceTest {
         @SafeVarargs
         private void addCompensationIssuanceAndPayloads(Tuple2<Issuance, ProposalPayload>... tuples) {
             addCompensationIssuanceAndPayloads(Arrays.asList(tuples));
+        }
+
+        @ValueSource(booleans = {true, false})
+        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
+        public void testGetBurningManCandidatesByName_invalidReceiverAddresses(boolean limitCappingRounds) {
+            addCompensationIssuanceAndPayloads(
+                    compensationIssuanceAndPayload("alice", "0000", 790000, 10000, VALID_P2SH_ADDRESS),
+                    compensationIssuanceAndPayload("bob", "0001", 790000, 10000, VALID_P2WPKH_ADDRESS),
+                    compensationIssuanceAndPayload("carol", "0002", 790000, 10000, VALID_P2TR_ADDRESS),
+                    compensationIssuanceAndPayload("dave", "0003", 790000, 10000, INVALID_ADDRESS)
+            );
+            addProofOfBurnTxs(
+                    proofOfBurnTx("alice", "1000", 790000, 10000),
+                    proofOfBurnTx("bob", "1001", 790000, 10000),
+                    proofOfBurnTx("carol", "1002", 790000, 10000),
+                    proofOfBurnTx("dave", "1003", 790000, 10000)
+            );
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+
+            assertEquals(0.11, candidateMap.get("alice").getMaxBoostedCompensationShare());
+            assertEquals(0.11, candidateMap.get("bob").getMaxBoostedCompensationShare());
+            assertEquals(0.0, candidateMap.get("carol").getMaxBoostedCompensationShare());
+            assertEquals(0.0, candidateMap.get("dave").getMaxBoostedCompensationShare());
+
+            assertAll(candidateMap.values().stream().map(candidate -> () -> {
+                assertEquals(0.25, candidate.getBurnAmountShare());
+                assertEquals(candidate.getMaxBoostedCompensationShare(), candidate.getCappedBurnAmountShare());
+            }));
         }
 
         @ValueSource(booleans = {true, false})
@@ -341,8 +376,16 @@ public class BurningManServiceTest {
                                                                                     String txId,
                                                                                     int chainHeight,
                                                                                     long amount) {
+        return compensationIssuanceAndPayload(name, txId, chainHeight, amount, VALID_P2WPKH_ADDRESS);
+    }
+
+    private static Tuple2<Issuance, ProposalPayload> compensationIssuanceAndPayload(String name,
+                                                                                    String txId,
+                                                                                    int chainHeight,
+                                                                                    long amount,
+                                                                                    String receiverAddress) {
         var issuance = new Issuance(txId, chainHeight, amount, null, IssuanceType.COMPENSATION);
-        var extraDataMap = Map.of(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, "receiverAddress");
+        var extraDataMap = Map.of(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, receiverAddress);
         var proposal = new CompensationProposal(name, "link", Coin.valueOf(amount), "bsqAddress", extraDataMap);
         return new Tuple2<>(issuance, new ProposalPayload(proposal.cloneProposalAndAddTxId(txId)));
     }

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -73,6 +73,9 @@ public class BurningManServiceTest {
     private static final String VALID_P2WPKH_ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
     private static final String VALID_P2TR_ADDRESS = "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0"; // unsupported
     private static final String INVALID_ADDRESS = "invalid_address";
+    // Valid Bech32 encoding of a witness v2 program, which is standard in outputs, but anyone-can-spend (as of 2024).
+    // Bitcoinj should be upgraded to reject such addresses, as only Bech32m should be used for witness v1 and above.
+    private static final String BADLY_ENCODED_ADDRESS = "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj";
 
     @Test
     public void testGetDecayedAmount() {
@@ -147,13 +150,15 @@ public class BurningManServiceTest {
                     compensationIssuanceAndPayload("alice", "0000", 790000, 10000, VALID_P2SH_ADDRESS),
                     compensationIssuanceAndPayload("bob", "0001", 790000, 10000, VALID_P2WPKH_ADDRESS),
                     compensationIssuanceAndPayload("carol", "0002", 790000, 10000, VALID_P2TR_ADDRESS),
-                    compensationIssuanceAndPayload("dave", "0003", 790000, 10000, INVALID_ADDRESS)
+                    compensationIssuanceAndPayload("dave", "0003", 790000, 10000, INVALID_ADDRESS),
+                    compensationIssuanceAndPayload("earl", "0004", 790000, 10000, BADLY_ENCODED_ADDRESS)
             );
             addProofOfBurnTxs(
                     proofOfBurnTx("alice", "1000", 790000, 10000),
                     proofOfBurnTx("bob", "1001", 790000, 10000),
                     proofOfBurnTx("carol", "1002", 790000, 10000),
-                    proofOfBurnTx("dave", "1003", 790000, 10000)
+                    proofOfBurnTx("dave", "1003", 790000, 10000),
+                    proofOfBurnTx("earl", "1004", 790000, 10000)
             );
             var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
 
@@ -161,9 +166,10 @@ public class BurningManServiceTest {
             assertEquals(0.11, candidateMap.get("bob").getMaxBoostedCompensationShare());
             assertEquals(0.0, candidateMap.get("carol").getMaxBoostedCompensationShare());
             assertEquals(0.0, candidateMap.get("dave").getMaxBoostedCompensationShare());
+            assertEquals(0.0, candidateMap.get("earl").getMaxBoostedCompensationShare());
 
             assertAll(candidateMap.values().stream().map(candidate -> () -> {
-                assertEquals(0.25, candidate.getBurnAmountShare());
+                assertEquals(0.2, candidate.getBurnAmountShare());
                 assertEquals(candidate.getMaxBoostedCompensationShare(), candidate.getCappedBurnAmountShare());
             }));
         }

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -120,10 +120,12 @@ public class BurningManServiceTest {
         }
 
         private void addCompensationIssuanceAndPayloads(Collection<Tuple2<Issuance, ProposalPayload>> tuples) {
-            when(daoStateService.getIssuanceSetForType(IssuanceType.COMPENSATION))
-                    .thenReturn(tuples.stream().map(t -> t.first).collect(Collectors.toSet()));
+            var issuanceMap = tuples.stream()
+                    .collect(Collectors.toMap(t -> t.first.getTxId(), t -> t.first));
             when(proposalService.getProposalPayloads())
                     .thenReturn(tuples.stream().map(t -> t.second).collect(Collectors.toCollection(FXCollections::observableArrayList)));
+            when(daoStateService.getIssuance(Mockito.anyString()))
+                    .thenAnswer((Answer<Optional<Issuance>>) inv -> Optional.ofNullable(issuanceMap.get(inv.getArgument(0, String.class))));
         }
 
         @SafeVarargs


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Set the burn cap of a candidate to zero if he has an invalid receiver address, that is, one that bitcoinj cannot parse. This prevents trade protocol failure when creating the DPT, by making such BM inactive and distributing their shares to the other BM. (Setting the burn cap to zero is a little more robust than simply filtering out such candidates, as `BurningManService` handles subsequent share redistribution better than `DelayedPayoutTxReceiverService` or `BtcFeeReceiverService`.

While this case should normally never occur, due to UI validation of the custom receiver address, there are at least two ways a BM could invalidate his own receiver address if so inclined:

 1. He could simply bypass the UI validation;
 2. He could manually create a compensation issuance tx with a change address type unrecognised by bitcoinj, such as P2TR, as the address field is pulled straight from the RPC JSON by each full DAO node.

Thus, it is necessary to check both change and custom addresses.

--

This PR additionally does a couple of minor optimisations to `BurningManService`, fixes nondeterministic receiver address selection in the edge case of multiple accepted compensation proposals by the same candidate in the same cycle, and cleans up redundant date checks for the activation of fixes for https://github.com/bisq-network/bisq/issues/6699 and https://github.com/bisq-network/proposals/issues/412.

None of the changes should alter the candidate burn shares or receiver addresses, except in possible future edge cases where the addresses would be nondeterministic or invalid, resulting in DPT creation/validation errors anyway (and thus failure to open the trade). So an activation date for these changes shouldn't be necessary.
