### PR TITLE
Optimise/simplify some stream filtering for the REST API

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/accounting/balance/BalanceModel.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/balance/BalanceModel.java
@@ -23,7 +23,6 @@ import bisq.core.dao.burningman.model.BurningManCandidate;
 import bisq.common.util.DateUtil;
 
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -54,8 +53,7 @@ public class BalanceModel {
         receivedBtcBalanceEntries.add(balanceEntry);
 
         Date month = balanceEntry.getMonth();
-        receivedBtcBalanceEntriesByMonth.putIfAbsent(month, new HashSet<>());
-        receivedBtcBalanceEntriesByMonth.get(month).add(balanceEntry);
+        receivedBtcBalanceEntriesByMonth.computeIfAbsent(month, m -> new HashSet<>()).add(balanceEntry);
     }
 
     public Set<ReceivedBtcBalanceEntry> getReceivedBtcBalanceEntries() {
@@ -63,11 +61,7 @@ public class BalanceModel {
     }
 
     public Set<ReceivedBtcBalanceEntry> getReceivedBtcBalanceEntriesByMonth(Date month) {
-        return receivedBtcBalanceEntriesByMonth.entrySet().stream()
-                        .filter(e -> e.getKey().equals(month))
-                        .map(Map.Entry::getValue)
-                        .flatMap(Collection::stream)
-                        .collect(Collectors.toSet());
+        return receivedBtcBalanceEntriesByMonth.getOrDefault(month, Set.of());
     }
 
     public Stream<BurnedBsqBalanceEntry> getBurnedBsqBalanceEntries(Set<BurnOutputModel> burnOutputModels) {

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -33,11 +33,14 @@ import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
 
 import bisq.common.config.Config;
 import bisq.common.file.JsonFileManager;
+import bisq.common.util.RangeUtils;
 
 import com.google.inject.Inject;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import com.google.common.collect.Range;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
@@ -136,10 +139,10 @@ public class TradeStatisticsManager {
     }
 
     public List<TradeStatistics3> getTradeStatisticsList(long dateStart, long dateEnd) {
-        return observableTradeStatisticsSet.stream()
-                .filter(x -> x.getDateAsLong() > dateStart && x.getDateAsLong() <= dateEnd)
-                .sorted((o1, o2) -> (Long.compare(o2.getDateAsLong(), o1.getDateAsLong())))
-                .collect(Collectors.toList());
+        return new ArrayList<>(RangeUtils.subSet(navigableTradeStatisticsSet)
+                .withKey(TradeStatistics3::getDateAsLong)
+                .overRange(Range.openClosed(Math.min(dateStart, dateEnd), dateEnd))
+                .descendingSet());
     }
 
     private void maybeDumpStatistics() {

--- a/daemon/src/main/java/bisq/daemon/grpc/interceptor/CallRateMeteringInterceptor.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/interceptor/CallRateMeteringInterceptor.java
@@ -103,8 +103,8 @@ public final class CallRateMeteringInterceptor implements ServerInterceptor {
 
     private Optional<Map.Entry<String, GrpcCallRateMeter>> getRateMeterKV(ServerCall<?, ?> serverCall) {
         String rateMeterKey = getRateMeterKey(serverCall);
-        return serviceCallRateMeters.entrySet().stream()
-                .filter((e) -> e.getKey().equals(rateMeterKey)).findFirst();
+        return Optional.ofNullable(serviceCallRateMeters.get(rateMeterKey))
+                .map(meter -> Map.entry(rateMeterKey, meter));
     }
 
     private String getRateMeterKey(ServerCall<?, ?> serverCall) {

--- a/restapi/src/main/java/bisq/restapi/endpoints/ExplorerTransactionsApi.java
+++ b/restapi/src/main/java/bisq/restapi/endpoints/ExplorerTransactionsApi.java
@@ -22,11 +22,10 @@ import bisq.core.dao.state.model.blockchain.BaseTx;
 import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.dao.state.model.blockchain.TxType;
 
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -86,10 +85,7 @@ public class ExplorerTransactionsApi {
             address = address.substring(1, address.length());
         }
         String finalAddress = address;
-        List<JsonTx> result = daoStateService.getTxIdSetByAddress().entrySet().stream()
-                .filter(e -> e.getKey().equals(finalAddress))
-                .map(Map.Entry::getValue)
-                .flatMap(Collection::stream)
+        List<JsonTx> result = daoStateService.getTxIdSetByAddress().getOrDefault(finalAddress, Set.of()).stream()
                 .flatMap(txId -> daoStateService.getTx(txId).stream())
                 .map(tx -> BlockDataToJsonConverter.getJsonTx(daoStateService, tx))
                 .collect(Collectors.toList());


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Replace the streaming of `Map` entry sets to pick out a single entry by key equality, and instead do a lookup into the map. Also, optimise the date range filtering in `TradeStatisticsManager::getTradeStatisticsList` by using `RangeUtils::subSet` to avoid scanning the entire collection. (This method is applicable, as the trade statistics set is navigable and naturally sorted by date.)
