### PR TITLE
Fix broken low-R signing with a password encrypted wallet

### DIFF
--- a/core/src/main/java/bisq/core/crypto/LowRSigningKey.java
+++ b/core/src/main/java/bisq/core/crypto/LowRSigningKey.java
@@ -34,8 +34,10 @@ public class LowRSigningKey extends ECKey {
 
     protected LowRSigningKey(ECKey key) {
         super(key.hasPrivKey() ? key.getPrivKey() : null, new LazyECPoint(CURVE.getCurve(), key.getPubKey()));
-        this.keyCrypter = key.getKeyCrypter();
-        this.encryptedPrivateKey = key.getEncryptedPrivateKey();
+        if (this.priv == null) {
+            this.keyCrypter = key.getKeyCrypter();
+            this.encryptedPrivateKey = key.getEncryptedPrivateKey();
+        }
         originalKey = key;
     }
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #7241

Prevent `KeyIsEncryptedException` from being thrown when signing with a `LowRSigningKey`-wrapped, encrypted HD key, due to breakage of the apparent invariant that the `keyCrypter` field of `ECKey` should be null whenever the key isn't encrypted.

When signing with a wrapped, encrypted HD key, the original key is decrypted and then re-wrapped as a `LowRSigningKey` instance. This was blindly copying the `keyCrypter` property of the decrypted key. But `DeterministicKey::getKeyCrypter` returns non-null if its parent does, even if the actual field is null, and the decrypted HD key has the same parent as the encrypted original. Thus, blindly copying the property (rather than the field) breaks the above invariant.

--

I've tested the fix on regtest, and proposals, blind votes and vote reveals now appear to publish OK with both encrypted and unencrypted wallets. The unfixed code produced the following exception stack trace on regtest, when making a reimbursement request with a password encrypted wallet:

```
org.bitcoinj.core.ECKey$KeyIsEncryptedException
	at org.bitcoinj.core.ECKey.sign(ECKey.java:661)
	at org.bitcoinj.core.ECKey.sign(ECKey.java:636)
	at org.bitcoinj.core.ECKey.sign(ECKey.java:662)
	at org.bitcoinj.core.Transaction.calculateWitnessSignature(Transaction.java:1333)
	at org.bitcoinj.core.Transaction.calculateWitnessSignature(Transaction.java:1344)
	at bisq.core.btc.wallet.WalletService.signTransactionInput(WalletService.java:390)
	at bisq.core.btc.wallet.BtcWalletService.signAllBtcInputs(BtcWalletService.java:411)
	at bisq.core.btc.wallet.BtcWalletService.completePreparedProposalTx(BtcWalletService.java:287)
	at bisq.core.btc.wallet.BtcWalletService.completePreparedReimbursementRequestTx(BtcWalletService.java:176)
	at bisq.core.dao.governance.proposal.reimbursement.ReimbursementProposalFactory.completeTx(ReimbursementProposalFactory.java:97)
	at bisq.core.dao.governance.proposal.BaseProposalFactory.createTransaction(BaseProposalFactory.java:99)
	at bisq.core.dao.governance.proposal.BaseProposalFactory.createProposalWithTransaction(BaseProposalFactory.java:76)
	at bisq.core.dao.governance.proposal.reimbursement.ReimbursementProposalFactory.createProposalWithTransaction(ReimbursementProposalFactory.java:73)
	at bisq.core.dao.DaoFacade.getReimbursementProposalWithTransaction(DaoFacade.java:268)
	at bisq.desktop.main.dao.governance.make.MakeProposalView.getProposalWithTransaction(MakeProposalView.java:417)
	at bisq.desktop.main.dao.governance.make.MakeProposalView.publishMyProposal(MakeProposalView.java:279)
	at bisq.desktop.main.dao.governance.make.MakeProposalView.lambda$setMakeProposalButtonHandler$6(MakeProposalView.java:511)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:234)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:49)
	at javafx.event.Event.fireEvent(Event.java:198)
	at javafx.scene.Node.fireEvent(Node.java:8889)
	at javafx.scene.control.Button.fire(Button.java:203)
	at com.sun.javafx.scene.control.behavior.ButtonBehavior.mouseReleased(ButtonBehavior.java:208)
	at com.sun.javafx.scene.control.inputmap.InputMap.handle(InputMap.java:274)
	at com.sun.javafx.event.CompositeEventHandler$NormalEventHandlerRecord.handleBubblingEvent(CompositeEventHandler.java:247)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:80)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:234)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.event.Event.fireEvent(Event.java:198)
	at javafx.scene.Scene$MouseHandler.process(Scene.java:3856)
	at javafx.scene.Scene.processMouseEvent(Scene.java:1851)
	at javafx.scene.Scene$ScenePeerListener.mouseEvent(Scene.java:2584)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:409)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:299)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler.lambda$handleMouseEvent$2(GlassViewEventHandler.java:447)
	at com.sun.javafx.tk.quantum.QuantumToolkit.runWithoutRenderLock(QuantumToolkit.java:412)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler.handleMouseEvent(GlassViewEventHandler.java:446)
	at com.sun.glass.ui.View.handleMouseEvent(View.java:556)
	at com.sun.glass.ui.View.notifyMouse(View.java:942)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$11(GtkApplication.java:277)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
