### PR TITLE
Bugfix/packaging not including some jars

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -138,9 +138,14 @@ Build output expected:
 
 * Install and run generated package
 
-### Sign release on macOS
+### Sign release & generate/include daemon and cli binaries
 
 * Run [finalize.sh](https://github.com/bisq-network/bisq/blob/master/desktop/package/macosx/finalize.sh)
+
+**PLEASE NOTE**:
+
+ - **Important**: even though finalize.sh script is on a macOS folder, **it should be ran for every platform**
+ - `finalize.sh` was designed to be ran from its own directory, so first make sure you cd into `./desktop/package/macosx` and set the environment variables it describes
 
 Build output expected:
 


### PR DESCRIPTION
## Purpose

 - Users report cli and daemon binaries are not included anymore in bisq release
 - Fixes [#7235](https://github.com/bisq-network/bisq/issues/7235)

## Approach

 - Release scripts seem a bit abandoned, it was not even compiling. Fix that and also the dirs relativity as well as docs to be able for any release manager to execute scripts on terminal and get the release files.

## Dev Logs

     - fix compilation issue on package.gradle to be able to generate
       binaries (packageInstallers task)
     - fix directory management in finalize.sh release script
     - updated docs with important notes for release managers (**finalise.sh should be run always**)
     - fix docs to note that the finalize script needs to be run for every
       platform
     - ensure cli and daemon and built -> cli and daemon binaries get generated and included in the release now

![Screenshot from 2024-09-17 16-54-15](https://github.com/user-attachments/assets/30da9c79-34fc-4abd-934d-9e70c3119ca4)

