### PR TITLE
Sort foreign alphabet payment methods above the untranslated ones.

### DIFF
--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,6 +51,9 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Static
     ///////////////////////////////////////////////////////////////////////////////////////////
+
+    // For sorting payment methods, we want names that contain only ASCII and Extended-ASCII to go *below* other languages
+    private static final Pattern ASCII_PATTERN = Pattern.compile("[\\x00-\\xFF]*");
 
     // time in blocks (average 10 min for one block confirmation
     private static final long DAY = TimeUnit.HOURS.toMillis(24);
@@ -424,7 +428,14 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
 
     @Override
     public int compareTo(@NotNull PaymentMethod other) {
-        return Res.get(id).compareTo(Res.get(other.id));
+        // Not all accounts have translations into other languages, and when mixed with Latin they sort to the bottom.
+        // So we need some extra logic to get the Latin to sort separately underneath the non-Latin.
+        boolean isLatin = ASCII_PATTERN.matcher(Res.get(id)).matches();
+        boolean otherIsLatin = ASCII_PATTERN.matcher(Res.get(other.id)).matches();
+        if(isLatin == otherIsLatin)
+            return Res.get(id).compareTo(Res.get(other.id));
+        else
+            return isLatin ? 1 : -1;
     }
 
     public String getDisplayString() {


### PR DESCRIPTION
By default, JAVA sorts foreign characters below English characters. However, the payment methods that are translated are also more likely to be used by someone native to that language, so it makes better sense to sort as two separate lists and put the foreign language ones on top. This commit does just that for the payment methods list on the Accounts page.