### PR TITLE
Fix randomly blank currency box upon opening the Offer screen

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -258,7 +258,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
             currencyComboBox.getSelectionModel().select(model.getTradeCurrency());
             paymentAccountsComboBox.setItems(getPaymentAccounts());
-            UserThread.execute(() -> paymentAccountsComboBox.getSelectionModel().select(model.getPaymentAccount()));
+            paymentAccountsComboBox.getSelectionModel().select(model.getPaymentAccount());
             onPaymentAccountsComboBoxSelected();
 
             balanceTextField.setTargetAmount(model.getDataModel().totalToPayAsCoinProperty().get());


### PR DESCRIPTION
When clicking Create Buy/Sell Offer, or Edit/Duplicate/Clone an existing offer, randomly the initial display of "Currency" associated with the initially selected payment method was displayed as blank. This seems to have been caused by scheduling the selection of the initial payment method combobox selection to happen on a different thread rather than immediately selecting it (apparently, sometimes the secondary event to select the currency gets lost).