### PR TITLE
Create payment method "Faster Payments System (SBP)" for Russian Ruble

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -4297,7 +4297,7 @@ payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send
   - Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -4364,7 +4364,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Instant Payments
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -4464,7 +4464,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=PayID jako telefonní číslo, e-mailová adresa nebo austral
 payment.amazonGiftCard.info=Chcete-li platit dárkovou kartou Amazon eGift, budete muset prodejci BTC poslat kartu Amazon eGift přes svůj účet Amazon.\n\nPro další detaily a rady viz wiki: [HYPERLINK:https://bisq.wiki/Amazon_eGift_card].\n\nZde jsou tři důležité poznámky:\n- Preferujte dárkové karty v hodnotě do 100 USD, protože Amazon může považovat nákupy karet s vyššími částkami jako podezřelé a zablokovat je.\n- Na kartě do zprávy pro příjemce můžete přidat i vlastní originální text (např. "Happy birthday Susan!"). V takovém případě o tom informujte protistranu pomocí obchodního chatu, aby mohli s jistotou ověřit, že obdržená dárková karta pochází od vás.\n- Karty Amazon eGift lze uplatnit pouze na té stránce Amazon, na které byly také koupeny (např. karta koupená na amazon.it může být uplatněna zase jen na amazon.it).
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Okamžité platby
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA okamžité
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=Eine PayID wie eine Telefonnummer, E-Mail Adresse oder Austra
 payment.amazonGiftCard.info=Um mit einer Amazon eGift Card zu bezahlen, müssen Sie eine Amazon eGift Card über Ihr Amazon-Konto an den BTC-Verkäufer senden. \n\nDetails und bewährte Methoden finden Sie im Wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card]. \n\nDrei wichtige Hinweise:\n- Versuchen Sie, Geschenkkarten mit Beträgen von 100 USD oder weniger zu versenden, da Amazon dafür bekannt ist, größere Geschenkkarten als betrügerisch einzustufen\n- Versuchen Sie, einen kreativen, glaubwürdigen Text für die Nachricht der Geschenkkarte zu verwenden (z. B. "Alles Gute zum Geburtstag, Susi!") und nutzen Sie den Händler-Chat, um Ihrem Handelspartner den von Ihnen gewählten Referenztext mitzuteilen, damit er Ihre Zahlung überprüfen kann.\n- Amazon eGift Cards können nur auf der Amazon-Website eingelöst werden, auf der sie gekauft wurden (z. B. kann eine auf amazon.it gekaufte Geschenkkarte nur auf amazon.it eingelöst werden)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Echtzeitzahlungen
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Echtzeit
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=Un PayID como un número de teléfono, dirección email o Aus
 payment.amazonGiftCard.info=Para pagar con Tarjeta eGift Amazon. necesitará enviar una Tarjeta eGift Amazon al vendedor BTC a través de su cuenta Amazon.\n\nPor favor vea la wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] para más detalles y mejores prácticas.\n\nTres puntos a considerar:\n- Pruebe a enviar las tarjetas regalo en cantidades de 100USD o menores, ya que Amazon está señalando tarjetas regalo mayores como fraudulentas.\n- Pruebe a usar  textos creativos y creíbles para el mensaje de la tarjeta regalo (p.ej. Feliz cumpleaños!) y usar el chat de intercambio para comentar a su par de intercambio el texto de referencia elegido de tal modo que pueda verificar su pago.\n- Las tarjetas Amazon eGift pueden ser redimidas únicamente en la web de Amazon en la que se compraron (por ejemplo, una tarjeta comprada en amazon.it solo puede ser redimida en amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=Pagos instantáneos SEPA
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=پرداخت های فوری SEPA
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=پرداخت سریع تر
+FASTER_PAYMENTS=سیستم پرداخت سریعتر (بریتانیا)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=پرداخت سریع تر
+FASTER_PAYMENTS_SHORT=سریعتر (بریتانیا)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=Un PayID, tel qu'un numéro de téléphone, une adresse élec
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Instant Payments
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Système de paiement plus rapide (GB)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Paiements plus rapides
+FASTER_PAYMENTS_SHORT=Plus rapide (GB)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_it.properties
+++ b/core/src/main/resources/i18n/displayStrings_it.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=Pagamenti istantanei SEPA
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Istantaneo
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ja.properties
+++ b/core/src/main/resources/i18n/displayStrings_ja.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=銀行、信用金庫、あるいは住宅金融組合アカ�
 payment.amazonGiftCard.info=Amazonギフト券で支払うには、Amazonアカウントを使ってギフト券をBTC売り手に送る必要があります。 \n\n最良の慣行について詳しくはWikiを参照して下さい：[HYPERLINK:https://bisq.wiki/Amazon_eGift_card] \n\n3つの注意点：\n- 可能であれば、100米ドル価格以下のeGiftカードを送って下さい。それ以上の価格はアマゾンに不正な取引というフラグが立てられることがあります\n- ギフト券のメッセージフィールドに、信ぴょう性のあるメッセージを入力して下さい。（例えば「隆さん、お誕生日おめでとう！」）。そして確認のため、取引者チャットでトレードピアにメッセージの内容を伝えて下さい\n- Amazonギフト券は買われたサイトのみに交換できます（例えば、amazon.co.jpから買われたカードはamazon.co.jpのみに交換できます）
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPAインスタント支払い 
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA インスタント
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pl.properties
+++ b/core/src/main/resources/i18n/displayStrings_pl.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=PayID jak numer telefonu, adres email czy Australijski numer 
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=Natychmiastowe płatności SEPA
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=Natychmiastowa SEPA
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Instant Payments
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Instant Payments
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ru.properties
+++ b/core/src/main/resources/i18n/displayStrings_ru.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=Система быстрых платежей (СБП) — это межбанковский сервис денежных переводов в РОССИИ, позволяющий физическим лицам \
+payment.sbp.info.account=Система быстрых платежей (СБП) — это межбанковский сервис денежных переводов в России, позволяющий физическим лицам \
  совершать личные платежи, используя только номер мобильного телефона.\n\n\
  1. Сервис предназначен для платежей и переводов между российскими банковскими счетами только в российских рублях.\n\n\
  2. Для использования сервиса можно зарегистрировать только номера мобильных операторов России (+7 код страны).\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Instant Payments
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=การชำระเงินทันใจของ SEPA
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=A PayID like a phone number, email address or an Australian B
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA Instant Payments
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=Faster Payments
+FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=Faster Payments
+FASTER_PAYMENTS_SHORT=Faster (UK)
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hans.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hans.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=PayID，如电话号码、电子邮件地址或澳大利亚�
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA 即时支付
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=更快的支付方式
+FASTER_PAYMENTS=快速支付系统（英国）
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=更快的支付方式
+FASTER_PAYMENTS_SHORT=快速支付系统（英国）
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hant.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hant.properties
@@ -3208,7 +3208,7 @@ payment.payid.info=PayID，如電話號碼、電子郵件地址或澳大利亞�
 payment.amazonGiftCard.info=To pay with Amazon eGift Card, you will need to send an Amazon eGift Card to the BTC seller via your Amazon account. \n\nPlease see the wiki [HYPERLINK:https://bisq.wiki/Amazon_eGift_card] for further details and best practices. \n\nThree important notes:\n- try to send gift cards with amounts of 100 USD or smaller, as Amazon is known to flag larger gift cards as fraudulent\n- try to use creative, believable text for the gift card''s message (e.g., "Happy birthday Susan!") and use trader chat to tell your trading peer the reference text you picked so they can verify your payment\n- Amazon eGift Cards can only be redeemed on the Amazon website they were purchased on (e.g., a gift card purchased on amazon.it can only be redeemed on amazon.it)
 payment.mercadoPago.holderId=UserID linked to financial institution. Like phone number or email or CVU.
 
-payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in RUSSIA that allows individuals \
+payment.sbp.info.account=The Faster Payments System (SBP) is an inter-bank funds transfer service in Russia that allows individuals \
  to make personal payments using just a mobile phone number.\n\n\
   1. The service is for payments and transfers between Russian bank accounts in Russian Rubles only.\n\n\
   2. Only Russian carrier mobile numbers (+7 country code) can be registered for use with the service.\n\n\
@@ -3275,7 +3275,7 @@ SEPA=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT=SEPA 即時支付
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS=更快的支付方式
+FASTER_PAYMENTS=快速支付系統（英國）
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
@@ -3375,7 +3375,7 @@ SEPA_SHORT=SEPA
 # suppress inspection "UnusedProperty"
 SEPA_INSTANT_SHORT=SEPA Instant
 # suppress inspection "UnusedProperty"
-FASTER_PAYMENTS_SHORT=更快的支付方式
+FASTER_PAYMENTS_SHORT=快速支付系統（英國）
 # suppress inspection "UnusedProperty"
 SWISH_SHORT=Swish
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
Removed all caps of "RUSSIA" in new account pop-up and renamed existing payment method "Faster Payments" which is a similarly named payment method to "Faster Payment System (UK)", as required follow-up to to pull request https://github.com/bisq-network/bisq/pull/7255 and discussed in issue https://github.com/bisq-network/growth/issues/288