### PR TITLE
Socks5MultiDiscovery: Don't create useless array

### DIFF
--- a/p2p/src/main/java/bisq/network/Socks5MultiDiscovery.java
+++ b/p2p/src/main/java/bisq/network/Socks5MultiDiscovery.java
@@ -75,7 +75,7 @@ public class Socks5MultiDiscovery implements PeerDiscovery {
             list.addAll(Arrays.asList(discovery.getPeers(services, timeoutValue, timeoutUnit)));
         }
 
-        return list.toArray(new InetSocketAddress[list.size()]);
+        return list.toArray(new InetSocketAddress[0]);
     }
 
     @Override


### PR DESCRIPTION
We create an array in the getPeers method and throw it away without
using it.