### PR TITLE
BsqWalletV2Test: Add invalid and dust send tests

### DIFF
--- a/core/src/integrationTest/java/bisq/core/BitcoinjBsqTests.java
+++ b/core/src/integrationTest/java/bisq/core/BitcoinjBsqTests.java
@@ -2,6 +2,7 @@ package bisq.core;
 
 import bisq.core.btc.exceptions.BsqChangeBelowDustException;
 import bisq.core.btc.wallet.BisqDefaultCoinSelector;
+import bisq.core.btc.wallet.BisqRegtestNetworkParams;
 import bisq.core.btc.wallet.BsqCoinSelector;
 import bisq.core.btc.wallet.BsqWalletV2;
 import bisq.core.btc.wallet.BtcWalletV2;
@@ -15,7 +16,6 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.kits.WalletAppKit;
-import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.wallet.Wallet;
 
 import java.nio.file.Path;
@@ -44,12 +44,6 @@ import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
 @ExtendWith(BitcoindExtension.class)
 @Slf4j
 public class BitcoinjBsqTests {
-
-    private static class BisqRegtestNetworkParams extends RegTestParams {
-        public void setPort(int port) {
-            this.port = port;
-        }
-    }
 
     private final BitcoindRegtestSetup regtestSetup;
     private final BisqRegtestNetworkParams networkParams;

--- a/core/src/main/java/bisq/core/btc/wallet/BisqRegtestNetworkParams.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BisqRegtestNetworkParams.java
@@ -1,0 +1,9 @@
+package bisq.core.btc.wallet;
+
+import org.bitcoinj.params.RegTestParams;
+
+public class BisqRegtestNetworkParams extends RegTestParams {
+    public void setPort(int port) {
+        this.port = port;
+    }
+}

--- a/core/src/test/java/BsqWalletV2Test.java
+++ b/core/src/test/java/BsqWalletV2Test.java
@@ -1,0 +1,47 @@
+import bisq.core.btc.wallet.BisqRegtestNetworkParams;
+import bisq.core.btc.wallet.BsqCoinSelector;
+import bisq.core.btc.wallet.BsqWalletV2;
+import bisq.core.btc.wallet.BtcWalletV2;
+
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.PeerGroup;
+import org.bitcoinj.wallet.Wallet;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class BsqWalletV2Test {
+
+    @ParameterizedTest
+    @MethodSource("invalidCoinsProvider")
+    void sendBsqDustAndInvalidAmount(Coin amountToSend) {
+        var networkParams = new BisqRegtestNetworkParams();
+        var bsqWalletV2 = new BsqWalletV2(networkParams,
+                mock(PeerGroup.class),
+                mock(BtcWalletV2.class),
+                mock(Wallet.class),
+                mock(BsqCoinSelector.class));
+
+        var exception = assertThrows(IllegalArgumentException.class, () -> {
+            Address receiverAddress = mock(Address.class);
+            bsqWalletV2.sendBsq(receiverAddress, amountToSend, Coin.ofSat(10));
+        });
+
+        assertTrue(exception.getMessage().contains("dust limit"),
+                "BSQ wallet send dust amount. This shouldn't happen!");
+    }
+
+    static Stream<Coin> invalidCoinsProvider() {
+        var networkParams = new BisqRegtestNetworkParams();
+        Coin dustAmount = networkParams.getMinNonDustOutput()
+                .minus(Coin.valueOf(1));
+        return Stream.of(dustAmount, Coin.ofSat(0), Coin.ofSat(-1));
+    }
+}


### PR DESCRIPTION
The tests try to send 0 BSQ and the current dust amount in BSQ.