### PR TITLE
BtcNetworkConfig: Shuffle Bitcoin Core peers

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNetworkConfig.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNetworkConfig.java
@@ -29,6 +29,7 @@ import org.bitcoinj.params.MainNetParams;
 
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -56,6 +57,7 @@ public class BtcNetworkConfig {
     public void proposePeers(List<PeerAddress> peers) {
         if (!peers.isEmpty()) {
             log.info("You connect with peerAddresses: {}", peers);
+            Collections.shuffle(peers);
             PeerAddress[] peerAddresses = peers.toArray(new PeerAddress[0]);
             delegate.setPeerNodes(peerAddresses);
         } else if (proxy != null) {

--- a/core/src/main/java/bisq/core/btc/nodes/BtcNetworkConfig.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNetworkConfig.java
@@ -56,7 +56,7 @@ public class BtcNetworkConfig {
     public void proposePeers(List<PeerAddress> peers) {
         if (!peers.isEmpty()) {
             log.info("You connect with peerAddresses: {}", peers);
-            PeerAddress[] peerAddresses = peers.toArray(new PeerAddress[peers.size()]);
+            PeerAddress[] peerAddresses = peers.toArray(new PeerAddress[0]);
             delegate.setPeerNodes(peerAddresses);
         } else if (proxy != null) {
             if (log.isWarnEnabled()) {


### PR DESCRIPTION
We try to connect to the first 7 Bitcoin Core nodes always in the same
order. Only if connections to these nodes fail we look further into the
list. This change shuffles the node addresses before passing them to
BitcoinJ thus removing the bias from the first 7 prioritized nodes.