### PR TITLE
Fix duplicates in BtcNode list

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -80,19 +80,23 @@ public class BtcNodes {
                 .collect(Collectors.toList());
     }
 
-    @EqualsAndHashCode
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
     @Getter
     public static class BtcNode {
-        private static final int DEFAULT_PORT = Config.baseCurrencyNetworkParameters().getPort(); //8333
+        static final int DEFAULT_PORT = Config.baseCurrencyNetworkParameters().getPort(); //8333
 
+        @EqualsAndHashCode.Include
         @Nullable
         private final String onionAddress;
+        @EqualsAndHashCode.Include
         @Nullable
         private final String hostName;
         @Nullable
         private final String operator; // null in case the user provides a list of custom btc nodes
+        @EqualsAndHashCode.Include
         @Nullable
         private final String address; // IPv4 address
+        @EqualsAndHashCode.Include
         private int port = DEFAULT_PORT;
 
         /**

--- a/core/src/test/java/bisq/core/btc/nodes/BtcNodeTest.java
+++ b/core/src/test/java/bisq/core/btc/nodes/BtcNodeTest.java
@@ -1,0 +1,21 @@
+package bisq.core.btc.nodes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BtcNodeTest {
+    @Test
+    void hardcodedAndFilterProvidedNodeShouldBeEqual() {
+        var aliceHardcodedBtcNode = new BtcNodes.BtcNode(null,
+                "alice_btc_node.onion", null,
+                BtcNodes.BtcNode.DEFAULT_PORT, "@Alice");
+
+        var aliceNodeFromFilter = new BtcNodes.BtcNode(null,
+                "alice_btc_node.onion", null,
+                BtcNodes.BtcNode.DEFAULT_PORT, "Provided by filter");
+
+        assertThat(aliceHardcodedBtcNode, equalTo(aliceNodeFromFilter));
+    }
+}


### PR DESCRIPTION
When the user uses our federated BTC nodes, we merge the hard-coded
nodes with the ones provided by the filter. The hard-coded node's
operator field is set to the node's operator and operator field of the
nodes from the filter is set to "Provided by filter". When the same BTC
node is in the hard-coded list and the filter, Bisq adds both to the
merged list because the operator field is different.

This change explicitly marks the onionAddress, hostName, address, and
port field to be used in the hashCode and equals implementation.