### PR TITLE
Pass nodes instead of BtcNodes class to FederatedBtcNodeProvider

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
@@ -67,7 +67,9 @@ public class BtcNodesSetupPreferences {
             case PROVIDED:
             default:
                 List<BtcNode> hardcodedBtcNodes = btcNodes.getProvidedBtcNodes();
-                result = FederatedBtcNodeProvider.getNodes(hardcodedBtcNodes, config);
+                List<String> filterProvidedBtcNodes = config.filterProvidedBtcNodes;
+                List<String> bannedBtcNodes = config.bannedBtcNodes;
+                result = FederatedBtcNodeProvider.getNodes(hardcodedBtcNodes, filterProvidedBtcNodes, bannedBtcNodes);
                 break;
         }
 

--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
@@ -66,7 +66,8 @@ public class BtcNodesSetupPreferences {
                 break;
             case PROVIDED:
             default:
-                result = FederatedBtcNodeProvider.getNodes(btcNodes, config);
+                List<BtcNode> hardcodedBtcNodes = btcNodes.getProvidedBtcNodes();
+                result = FederatedBtcNodeProvider.getNodes(hardcodedBtcNodes, config);
                 break;
         }
 

--- a/core/src/main/java/bisq/core/btc/nodes/FederatedBtcNodeProvider.java
+++ b/core/src/main/java/bisq/core/btc/nodes/FederatedBtcNodeProvider.java
@@ -2,8 +2,6 @@ package bisq.core.btc.nodes;
 
 import bisq.network.p2p.NodeAddress;
 
-import bisq.common.config.Config;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -16,8 +14,10 @@ import org.jetbrains.annotations.Nullable;
 @Slf4j
 public class FederatedBtcNodeProvider {
 
-    static List<BtcNodes.BtcNode> getNodes(List<BtcNodes.BtcNode> hardcodedBtcNodes, Config config) {
-        Set<BtcNodes.BtcNode> filterProvidedBtcNodes = config.filterProvidedBtcNodes.stream()
+    static List<BtcNodes.BtcNode> getNodes(List<BtcNodes.BtcNode> hardcodedBtcNodes,
+                                           List<String> filterProvidedBtcNodesConfig,
+                                           List<String> bannedBtcNodesConfig) {
+        Set<BtcNodes.BtcNode> filterProvidedBtcNodes = filterProvidedBtcNodesConfig.stream()
                 .filter(n -> !n.isEmpty())
                 .map(FederatedBtcNodeProvider::getNodeAddress)
                 .filter(Objects::nonNull)
@@ -25,7 +25,7 @@ public class FederatedBtcNodeProvider {
                 .collect(Collectors.toSet());
         hardcodedBtcNodes.addAll(filterProvidedBtcNodes);
 
-        Set<String> bannedBtcNodeHostNames = config.bannedBtcNodes.stream()
+        Set<String> bannedBtcNodeHostNames = bannedBtcNodesConfig.stream()
                 .filter(n -> !n.isEmpty())
                 .map(FederatedBtcNodeProvider::getNodeAddress)
                 .filter(Objects::nonNull)

--- a/core/src/main/java/bisq/core/btc/nodes/FederatedBtcNodeProvider.java
+++ b/core/src/main/java/bisq/core/btc/nodes/FederatedBtcNodeProvider.java
@@ -4,7 +4,6 @@ import bisq.network.p2p.NodeAddress;
 
 import bisq.common.config.Config;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -17,15 +16,14 @@ import org.jetbrains.annotations.Nullable;
 @Slf4j
 public class FederatedBtcNodeProvider {
 
-    static List<BtcNodes.BtcNode> getNodes(BtcNodes btcNodes, Config config) {
-        Set<BtcNodes.BtcNode> providedBtcNodes = new HashSet<>(btcNodes.getProvidedBtcNodes());
+    static List<BtcNodes.BtcNode> getNodes(List<BtcNodes.BtcNode> hardcodedBtcNodes, Config config) {
         Set<BtcNodes.BtcNode> filterProvidedBtcNodes = config.filterProvidedBtcNodes.stream()
                 .filter(n -> !n.isEmpty())
                 .map(FederatedBtcNodeProvider::getNodeAddress)
                 .filter(Objects::nonNull)
                 .map(nodeAddress -> new BtcNodes.BtcNode(null, nodeAddress.getHostName(), null, nodeAddress.getPort(), "Provided by filter"))
                 .collect(Collectors.toSet());
-        providedBtcNodes.addAll(filterProvidedBtcNodes);
+        hardcodedBtcNodes.addAll(filterProvidedBtcNodes);
 
         Set<String> bannedBtcNodeHostNames = config.bannedBtcNodes.stream()
                 .filter(n -> !n.isEmpty())
@@ -33,7 +31,7 @@ public class FederatedBtcNodeProvider {
                 .filter(Objects::nonNull)
                 .map(NodeAddress::getHostName)
                 .collect(Collectors.toSet());
-        return providedBtcNodes.stream()
+        return hardcodedBtcNodes.stream()
                 .filter(e -> !bannedBtcNodeHostNames.contains(e.getHostName()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
- [Pass list of nodes instead of BtcNodes class to FederatedBtcNodeProvider](https://github.com/bisq-network/bisq/commit/bc6954e53a48764dce17ec917122a3aa3438db6c)
- [Pass filterProvidedBtcNodes and bannedBtcNodes to FederatedBtcNodeProvider](https://github.com/bisq-network/bisq/commit/c4e82d59ecd2b29512468bd73a98ac1449a1b9bd)