### PR TITLE
BtcNodes: Fix hostname parsing

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
@@ -125,6 +126,10 @@ public class BtcNodes {
                 host = parts[0];
                 if (parts.length == 2)
                     port = Integer.parseInt(parts[1]);
+
+                if (isHostName(host)) {
+                    return new BtcNode(host, null, null, port, null);
+                }
             }
 
             checkArgument(host.length() > 0, "BtcNode address format not recognised");
@@ -171,6 +176,12 @@ public class BtcNodes {
             String address = this.address == null ? "" : this.address + ", ";
             String onionAddress = this.onionAddress == null ? "" : this.onionAddress;
             return operator + ": [" + address + onionAddress + "]";
+        }
+
+        private static boolean isHostName(String hostName) {
+            String ipV4RegEx = "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}";
+            boolean isIpV4Address = Pattern.matches(ipV4RegEx, hostName);
+            return !isIpV4Address && !hostName.endsWith(".onion");
         }
     }
 }

--- a/core/src/test/java/bisq/core/btc/nodes/BtcNodeTest.java
+++ b/core/src/test/java/bisq/core/btc/nodes/BtcNodeTest.java
@@ -1,6 +1,8 @@
 package bisq.core.btc.nodes;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,5 +19,70 @@ public class BtcNodeTest {
                 BtcNodes.BtcNode.DEFAULT_PORT, "Provided by filter");
 
         assertThat(aliceHardcodedBtcNode, equalTo(aliceNodeFromFilter));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"123.456.890.123", "2001:db8:85a3:8d3:1319:8a2e:370"})
+    void fromFullAddressIpNoPort(String address) {
+        BtcNodes.BtcNode btcNode = BtcNodes.BtcNode.fromFullAddress(address);
+        assertThat(btcNode.getAddress(), equalTo(address));
+        assertThat(btcNode.getPort(), equalTo(BtcNodes.BtcNode.DEFAULT_PORT));
+    }
+
+    @Test
+    void fromFullAddressIpV4() {
+        String address = "123.456.890.123";
+        int port = 4567;
+        BtcNodes.BtcNode btcNode = BtcNodes.BtcNode.fromFullAddress(address + ":" + port);
+
+        assertThat(btcNode.getAddress(), equalTo(address));
+        assertThat(btcNode.getPort(), equalTo(port));
+    }
+
+    @Test
+    void fromFullAddressIpV6() {
+        String address = "2001:db8:85a3:8d3:1319:8a2e:370";
+        int port = 7348;
+        String fullAddress = "[" + address + "]:" + port;
+        BtcNodes.BtcNode btcNode = BtcNodes.BtcNode.fromFullAddress(fullAddress);
+
+        assertThat(btcNode.getAddress(), equalTo(address));
+        assertThat(btcNode.getPort(), equalTo(port));
+    }
+
+    @Test
+    void fromFullAddressHostNameNoPort() {
+        String hostname = "btc-node.bisq.network";
+        BtcNodes.BtcNode btcNode = BtcNodes.BtcNode.fromFullAddress(hostname);
+        assertThat(btcNode.getHostName(), equalTo(hostname));
+        assertThat(btcNode.getPort(), equalTo(BtcNodes.BtcNode.DEFAULT_PORT));
+    }
+
+    @Test
+    void fromFullAddressHostName() {
+        String hostname = "btc-node.bisq.network";
+        int port = 4567;
+        BtcNodes.BtcNode btcNode = BtcNodes.BtcNode.fromFullAddress(hostname + ":" + port);
+
+        assertThat(btcNode.getHostName(), equalTo(hostname));
+        assertThat(btcNode.getPort(), equalTo(port));
+    }
+
+    @Test
+    void fromFullAddressOnionNoPort() {
+        String onionAddress = "alice.onion";
+        BtcNodes.BtcNode btcNode = BtcNodes.BtcNode.fromFullAddress(onionAddress);
+        assertThat(btcNode.getOnionAddress(), equalTo(onionAddress));
+        assertThat(btcNode.getPort(), equalTo(BtcNodes.BtcNode.DEFAULT_PORT));
+    }
+
+    @Test
+    void fromFullAddressOnion() {
+        String onionAddress = "alice.onion";
+        int port = 4567;
+        BtcNodes.BtcNode btcNode = BtcNodes.BtcNode.fromFullAddress(onionAddress + ":" + port);
+
+        assertThat(btcNode.getOnionAddress(), equalTo(onionAddress));
+        assertThat(btcNode.getPort(), equalTo(port));
     }
 }


### PR DESCRIPTION
The fromFullAddress method parsed hostnames as IPV4 addresses instead as
hostnames.