### PR TITLE
NodeAddress: Fix broken IPV6 parsing

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/NodeAddress.java
+++ b/p2p/src/main/java/bisq/network/p2p/NodeAddress.java
@@ -47,10 +47,19 @@ public final class NodeAddress implements PersistablePayload, NetworkPayload, Us
     }
 
     public NodeAddress(String fullAddress) {
-        final String[] split = fullAddress.split(Pattern.quote(":"));
-        checkArgument(split.length == 2, "fullAddress must contain ':'");
-        this.hostName = split[0];
-        this.port = Integer.parseInt(split[1]);
+        String[] split = fullAddress.split("]");
+        boolean isIpV6Address = split.length == 2 && fullAddress.startsWith("[");
+        if (isIpV6Address) {
+            this.hostName = split[0].replace("[", "");
+            String portString = split[1].replace(":", "");
+            this.port = Integer.parseInt(portString);
+        } else {
+            split = fullAddress.split(Pattern.quote(":"));
+            checkArgument(split.length == 2, "fullAddress must contain ':'");
+            this.hostName = split[0];
+
+            this.port = Integer.parseInt(split[1]);
+        }
     }
 
 


### PR DESCRIPTION
Bisq accepts IPV6 node addresses but the NodeAddress can't parse them.