### PR TITLE
Increase tmpfs size for dumping Bisq blockchain data

### DIFF
--- a/seednode/bisq.service
+++ b/seednode/bisq.service
@@ -35,7 +35,7 @@ ExecStart=/bin/bash __BISQ_HOME__/__BISQ_REPO_NAME__/${BISQ_ENTRYPOINT} \
 ExecStop=/bin/kill ${MAINPID} ; sleep 5
 Restart=on-failure
 
-ExecStartPre=+/bin/bash -c "if [ $BISQ_DUMP_BLOCKCHAIN = true ];then mkdir -p $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json && mount -t tmpfs none -o size=5000M,uid=bisq,gid=bisq $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json;else true;fi"
+ExecStartPre=+/bin/bash -c "if [ $BISQ_DUMP_BLOCKCHAIN = true ];then mkdir -p $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json && mount -t tmpfs none -o size=8000M,uid=bisq,gid=bisq $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json;else true;fi"
 ExecStopPost=+/bin/bash -c "if [ $BISQ_DUMP_BLOCKCHAIN = true ];then umount $BISQ_HOME/$BISQ_APP_NAME/$BISQ_BASE_CURRENCY/db/json;else true;fi"
 
 User=bisq


### PR DESCRIPTION
Currently, it requires about 5.2G of space.
Therefore, increase it to allow for future growth. However, hopefully this becomes irrelevant soon
with the changes in bisq-network/mempool#13.