### PR TITLE
BitcoinjRegtestSetup: Implement wallet funding

### DIFF
--- a/core/src/integrationTest/java/bisq/core/BitcoinjRegtestSetup.java
+++ b/core/src/integrationTest/java/bisq/core/BitcoinjRegtestSetup.java
@@ -1,0 +1,53 @@
+package bisq.core;
+
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+
+
+import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
+
+public class BitcoinjRegtestSetup {
+    private final BitcoindRegtestSetup bitcoindRegtestSetup;
+
+    public BitcoinjRegtestSetup(BitcoindRegtestSetup bitcoindRegtestSetup) {
+        this.bitcoindRegtestSetup = bitcoindRegtestSetup;
+    }
+
+    public void fundWallet(Wallet wallet, double amount) throws InterruptedException {
+        var walletReceivedLatch = new CountDownLatch(1);
+        WalletCoinsReceivedEventListener coinsReceivedEventListener =
+                (affectedWallet, tx, prevBalance, newBalance) -> {
+                    walletReceivedLatch.countDown();
+                };
+
+        wallet.addCoinsReceivedEventListener(coinsReceivedEventListener);
+        Coin previousBalance = wallet.getBalance();
+
+        Address currentReceiveAddress = wallet.currentReceiveAddress();
+        String address = currentReceiveAddress.toString();
+        bitcoindRegtestSetup.fundAddress(address, amount);
+        bitcoindRegtestSetup.mineOneBlock();
+
+        boolean isSuccess = walletReceivedLatch.await(30, TimeUnit.SECONDS);
+        wallet.removeCoinsReceivedEventListener(coinsReceivedEventListener);
+        if (!isSuccess) {
+            throw new IllegalStateException("Wallet not funded after 30 seconds.");
+        }
+
+        Coin balance = wallet.getBalance();
+        Coin receivedAmount = balance.minus(previousBalance);
+
+        long receivedAmountAsLong = receivedAmount.value;
+        long fundedAmount = (long) amount * 100_000_000;
+        if (receivedAmount.value != fundedAmount) {
+            throw new IllegalStateException("Wallet balance is " + receivedAmountAsLong +
+                    " but should be " + fundedAmount + ".");
+        }
+    }
+}


### PR DESCRIPTION
The fundWallet method sends the given amount to the BitcoinJ wallet from
the Bitcoin Core miner wallet, mines one block, and waits until the
BitcoinJ wallet updates its wallet balance.