### PR TITLE
Add instruction to select JDK version at build time

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,8 @@
    ```sh
    git clone https://github.com/bisq-network/bisq
    # if you intend to do testing on the latest release, you can clone the respective branch selectively, without downloading the whole repository
-   # for the 1.9.3 release, you would do it like this:
-   git clone --recurse-submodules --branch release/v1.9.3 https://github.com/bisq-network/bisq
+   # for the 1.9.18 release, you would do it like this:
+   git clone --recurse-submodules --branch release/v1.9.18 https://github.com/bisq-network/bisq
    cd bisq
    ```
 
@@ -33,6 +33,18 @@
 
    ```sh
    javac -version
+   ```
+
+   If you have multiple JDK versions installed, check which one Gradle will use, with:
+
+   ```sh
+   ./gradlew --version
+   ```
+
+   and if the version number on the JVM line is not a supported one, you can pick the correct JDK at runtime with this syntax (verify your system path):
+
+   ```sh
+   ./gradlew build -Dorg.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64/
    ```
 
 If you do not have JDK 11 installed, check out scripts in the [scripts](../scripts) directory or download it manually from https://jdk.java.net/archive/.


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

When multiple JDK versions are installed in Linux, Gradle will usually select the last one. When this is JDK22, for example used to build Bisq2. this will not yield a correct build for Bisq1.
Hence, I provided steps to fix this.
