### PR TITLE
Fix getdata response for preleases

### DIFF
--- a/core/src/main/java/bisq/core/network/p2p/inventory/GetInventoryRequestHandler.java
+++ b/core/src/main/java/bisq/core/network/p2p/inventory/GetInventoryRequestHandler.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import java.lang.management.ManagementFactory;
 
@@ -101,7 +102,7 @@ public class GetInventoryRequestHandler implements MessageListener {
             // Data
             GetInventoryRequest getInventoryRequest = (GetInventoryRequest) networkEnvelope;
             Map<InventoryItem, Integer> dataObjects = new HashMap<>();
-            p2PDataStorage.getMapForDataResponse(getInventoryRequest.getVersion(), Collections.emptySet())
+            p2PDataStorage.getMapForDataResponse(getInventoryRequest.getVersion(), Collections.emptySet(), new AtomicBoolean(false))
                     .values().stream()
                     .map(e -> e.getClass().getSimpleName())
                     .forEach(className -> addClassNameToMap(dataObjects, className));

--- a/core/src/main/java/bisq/core/network/p2p/inventory/GetInventoryRequestHandler.java
+++ b/core/src/main/java/bisq/core/network/p2p/inventory/GetInventoryRequestHandler.java
@@ -51,6 +51,7 @@ import com.google.common.base.Enums;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -100,7 +101,8 @@ public class GetInventoryRequestHandler implements MessageListener {
             // Data
             GetInventoryRequest getInventoryRequest = (GetInventoryRequest) networkEnvelope;
             Map<InventoryItem, Integer> dataObjects = new HashMap<>();
-            p2PDataStorage.getMapForDataResponse(getInventoryRequest.getVersion()).values().stream()
+            p2PDataStorage.getMapForDataResponse(getInventoryRequest.getVersion(), Collections.emptySet())
+                    .values().stream()
                     .map(e -> e.getClass().getSimpleName())
                     .forEach(className -> addClassNameToMap(dataObjects, className));
             p2PDataStorage.getMap().values().stream()

--- a/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessStorageServiceTest.java
+++ b/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessStorageServiceTest.java
@@ -10,8 +10,11 @@ import java.nio.file.Path;
 
 import java.io.File;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +37,7 @@ public class AccountAgeWitnessStorageServiceTest {
     @Test
     void emptyStore() {
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion(Version.VERSION);
+                storageService.getMapSinceVersion(Version.VERSION, Collections.emptySet());
         assertThat(mapSinceVersion, is(anEmptyMap()));
     }
 
@@ -44,7 +47,7 @@ public class AccountAgeWitnessStorageServiceTest {
         DummyAccountAgeWitnessFactory.addNewAccountAgeWitnessesToMap(liveDataMap, 2);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion(Version.VERSION);
+                storageService.getMapSinceVersion(Version.VERSION, Collections.emptySet());
 
         P2PDataStorage.ByteArray firstByteArray = new P2PDataStorage.ByteArray(new byte[]{0});
         P2PDataStorage.ByteArray secondByteArray = new P2PDataStorage.ByteArray(new byte[]{1});
@@ -67,7 +70,7 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.7.0");
+                storageService.getMapSinceVersion("1.7.0", Collections.emptySet());
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>(versionStore.getMap());
         assertThat(mapSinceVersion, is(expected));
@@ -90,7 +93,7 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion(null);
+                storageService.getMapSinceVersion(null, Collections.emptySet());
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>();
         expected.putAll(liveDataMap);
@@ -117,7 +120,7 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.8.5");
+                storageService.getMapSinceVersion("1.8.5", Collections.emptySet());
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>();
         expected.putAll(liveDataMap);
@@ -143,9 +146,76 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.9.5");
+                storageService.getMapSinceVersion("1.9.5", Collections.emptySet());
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>(liveDataMap);
+        assertThat(mapSinceVersion, is(expected));
+    }
+
+    @Test
+    void testKnownHashes() {
+        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> liveDataMap = storageService.getStore().getMap();
+        DummyAccountAgeWitnessFactory.addNewAccountAgeWitnessesToMap(liveDataMap, 3);
+
+        AccountAgeWitnessStore firstVersionStore = DummyAccountAgeWitnessFactory.
+                createAccountAgeWitnessStore(4, 100);
+        AccountAgeWitnessStore secondVersionStore = DummyAccountAgeWitnessFactory.
+                createAccountAgeWitnessStore(5, 200);
+
+        Map<String, PersistableNetworkPayloadStore<? extends PersistableNetworkPayload>> storeByVersion = Map.of(
+                "1.8.0", firstVersionStore,
+                "1.9.0", secondVersionStore);
+
+        storageService.setStoresByVersion(storeByVersion);
+
+        P2PDataStorage.ByteArray excludeFromLiveMap = liveDataMap.keySet().stream()
+                .findAny()
+                .orElseThrow();
+
+        P2PDataStorage.ByteArray excludeFromSecondStore = secondVersionStore.getMap()
+                .keySet().stream()
+                .findAny()
+                .orElseThrow();
+
+        Set<P2PDataStorage.ByteArray> knownHashes = Set.of(excludeFromLiveMap, excludeFromSecondStore);
+
+        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
+                storageService.getMapSinceVersion("1.7.0", knownHashes);
+
+        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>(liveDataMap);
+        expected.putAll(firstVersionStore.getMap());
+        expected.putAll(secondVersionStore.getMap());
+
+        expected.remove(excludeFromLiveMap);
+        expected.remove(excludeFromSecondStore);
+
+        assertThat(mapSinceVersion, is(expected));
+    }
+
+    @Test
+    void testExcludeAllHashes() {
+        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> liveDataMap = storageService.getStore().getMap();
+        DummyAccountAgeWitnessFactory.addNewAccountAgeWitnessesToMap(liveDataMap, 3);
+
+        AccountAgeWitnessStore firstVersionStore = DummyAccountAgeWitnessFactory.
+                createAccountAgeWitnessStore(4, 100);
+        AccountAgeWitnessStore secondVersionStore = DummyAccountAgeWitnessFactory.
+                createAccountAgeWitnessStore(5, 200);
+
+        Map<String, PersistableNetworkPayloadStore<? extends PersistableNetworkPayload>> storeByVersion = Map.of(
+                "1.8.0", firstVersionStore,
+                "1.9.0", secondVersionStore);
+
+        storageService.setStoresByVersion(storeByVersion);
+
+        Set<P2PDataStorage.ByteArray> knownHashes = new HashSet<>(liveDataMap.keySet());
+        Set<P2PDataStorage.ByteArray> secondStoreKeys = secondVersionStore.getMap().keySet();
+        knownHashes.addAll(secondStoreKeys);
+
+        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
+                storageService.getMapSinceVersion("1.8.5", knownHashes);
+
+        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = Collections.emptyMap();
         assertThat(mapSinceVersion, is(expected));
     }
 }

--- a/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessStorageServiceTest.java
+++ b/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessStorageServiceTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 
 
 public class AccountAgeWitnessStorageServiceTest {
+    private final AtomicBoolean payloadsTruncated = new AtomicBoolean(false);
     private DummyHistoricalDataStoreService storageService;
 
     @BeforeEach
@@ -37,8 +39,9 @@ public class AccountAgeWitnessStorageServiceTest {
     @Test
     void emptyStore() {
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion(Version.VERSION, Collections.emptySet());
+                storageService.getMapSinceVersion(Version.VERSION, Collections.emptySet(), payloadsTruncated);
         assertThat(mapSinceVersion, is(anEmptyMap()));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -47,7 +50,7 @@ public class AccountAgeWitnessStorageServiceTest {
         DummyAccountAgeWitnessFactory.addNewAccountAgeWitnessesToMap(liveDataMap, 2);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion(Version.VERSION, Collections.emptySet());
+                storageService.getMapSinceVersion(Version.VERSION, Collections.emptySet(), payloadsTruncated);
 
         P2PDataStorage.ByteArray firstByteArray = new P2PDataStorage.ByteArray(new byte[]{0});
         P2PDataStorage.ByteArray secondByteArray = new P2PDataStorage.ByteArray(new byte[]{1});
@@ -57,6 +60,7 @@ public class AccountAgeWitnessStorageServiceTest {
                 secondByteArray, liveDataMap.get(secondByteArray));
 
         assertThat(mapSinceVersion, is(expected));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -70,10 +74,11 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.7.0", Collections.emptySet());
+                storageService.getMapSinceVersion("1.7.0", Collections.emptySet(), payloadsTruncated);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>(versionStore.getMap());
         assertThat(mapSinceVersion, is(expected));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -93,7 +98,7 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion(null, Collections.emptySet());
+                storageService.getMapSinceVersion(null, Collections.emptySet(), payloadsTruncated);
 
         int mapSize = mapSinceVersion.size();
         assertThat(mapSize, is(100));
@@ -102,6 +107,8 @@ public class AccountAgeWitnessStorageServiceTest {
             var expected = liveDataMap.get(entry.getKey());
             assertThat(entry.getValue(), is(expected));
         }
+
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -121,7 +128,7 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.2.3", Collections.emptySet());
+                storageService.getMapSinceVersion("1.2.3", Collections.emptySet(), payloadsTruncated);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>();
         expected.putAll(liveDataMap);
@@ -129,6 +136,7 @@ public class AccountAgeWitnessStorageServiceTest {
         expected.putAll(secondVersionStore.getMap());
 
         assertThat(mapSinceVersion, is(expected));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -148,13 +156,14 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.8.5", Collections.emptySet());
+                storageService.getMapSinceVersion("1.8.5", Collections.emptySet(), payloadsTruncated);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>();
         expected.putAll(liveDataMap);
         expected.putAll(secondVersionStore.getMap());
 
         assertThat(mapSinceVersion, is(expected));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -174,10 +183,11 @@ public class AccountAgeWitnessStorageServiceTest {
         storageService.setStoresByVersion(storeByVersion);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.9.5", Collections.emptySet());
+                storageService.getMapSinceVersion("1.9.5", Collections.emptySet(), payloadsTruncated);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>(liveDataMap);
         assertThat(mapSinceVersion, is(expected));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -201,7 +211,7 @@ public class AccountAgeWitnessStorageServiceTest {
                 Version.getMinorVersion(version) + "." + (Version.getPatchVersion(version) + 1);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion(higherVersion, Collections.emptySet());
+                storageService.getMapSinceVersion(higherVersion, Collections.emptySet(), payloadsTruncated);
 
         int mapSize = mapSinceVersion.size();
         assertThat(mapSize, is(100));
@@ -210,6 +220,8 @@ public class AccountAgeWitnessStorageServiceTest {
             var expected = liveDataMap.get(entry.getKey());
             assertThat(entry.getValue(), is(expected));
         }
+
+        assertThat(payloadsTruncated.get(), is(true));
     }
 
     @Test
@@ -240,7 +252,7 @@ public class AccountAgeWitnessStorageServiceTest {
         Set<P2PDataStorage.ByteArray> knownHashes = Set.of(excludeFromLiveMap, excludeFromSecondStore);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.7.0", knownHashes);
+                storageService.getMapSinceVersion("1.7.0", knownHashes, payloadsTruncated);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = new HashMap<>(liveDataMap);
         expected.putAll(firstVersionStore.getMap());
@@ -250,6 +262,7 @@ public class AccountAgeWitnessStorageServiceTest {
         expected.remove(excludeFromSecondStore);
 
         assertThat(mapSinceVersion, is(expected));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 
     @Test
@@ -273,9 +286,10 @@ public class AccountAgeWitnessStorageServiceTest {
         knownHashes.addAll(secondStoreKeys);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapSinceVersion =
-                storageService.getMapSinceVersion("1.8.5", knownHashes);
+                storageService.getMapSinceVersion("1.8.5", knownHashes, payloadsTruncated);
 
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> expected = Collections.emptyMap();
         assertThat(mapSinceVersion, is(expected));
+        assertThat(payloadsTruncated.get(), is(false));
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -59,6 +59,9 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
     // Added at v1.9.6
     private final boolean wasTruncated;
 
+    // Added at v1.9.19
+    private final String version;
+
     public GetDataResponse(@NotNull Set<ProtectedStorageEntry> dataSet,
                            @NotNull Set<PersistableNetworkPayload> persistableNetworkPayloadSet,
                            int requestNonce,
@@ -70,7 +73,8 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
                 isGetUpdatedDataResponse,
                 wasTruncated,
                 Capabilities.app,
-                Version.getP2PMessageVersion());
+                Version.getP2PMessageVersion(),
+                Version.VERSION);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -83,7 +87,8 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
                             boolean isGetUpdatedDataResponse,
                             boolean wasTruncated,
                             @NotNull Capabilities supportedCapabilities,
-                            int messageVersion) {
+                            int messageVersion,
+                            String version) {
         super(messageVersion);
 
         this.dataSet = dataSet;
@@ -92,6 +97,7 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
         this.isGetUpdatedDataResponse = isGetUpdatedDataResponse;
         this.wasTruncated = wasTruncated;
         this.supportedCapabilities = supportedCapabilities;
+        this.version = version;
     }
 
     @Override
@@ -113,6 +119,7 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
                 .setRequestNonce(requestNonce)
                 .setIsGetUpdatedDataResponse(isGetUpdatedDataResponse)
                 .setWasTruncated(wasTruncated)
+                .setVersion(version)
                 .addAllSupportedCapabilities(Capabilities.toIntList(supportedCapabilities));
 
         protobuf.NetworkEnvelope proto = getNetworkEnvelopeBuilder()
@@ -139,7 +146,8 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
                 proto.getIsGetUpdatedDataResponse(),
                 wasTruncated,
                 Capabilities.fromIntList(proto.getSupportedCapabilitiesList()),
-                messageVersion);
+                messageVersion,
+                proto.getVersion());
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -314,7 +314,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         // mapForDataResponse contains the filtered by version data from HistoricalDataStoreService as well as all other
         // maps of the remaining appendOnlyDataStoreServices.
         Map<ByteArray, PersistableNetworkPayload> mapForDataResponse =
-                getMapForDataResponse(getDataRequest.getVersion(), excludedKeysAsByteArray);
+                getMapForDataResponse(getDataRequest.getVersion(),
+                        excludedKeysAsByteArray, wasPersistableNetworkPayloadsTruncated);
 
         // Give a bit of tolerance for message overhead
         double maxSize = Connection.getMaxPermittedMessageSize() * 0.6;
@@ -393,14 +394,16 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         return map;
     }
 
-    public Map<ByteArray, PersistableNetworkPayload> getMapForDataResponse(String requestersVersion, Set<P2PDataStorage.ByteArray> keysToExclude) {
+    public Map<ByteArray, PersistableNetworkPayload> getMapForDataResponse(String requestersVersion,
+                                                                           Set<P2PDataStorage.ByteArray> keysToExclude,
+                                                                           AtomicBoolean arePayloadsTruncated) {
         Map<ByteArray, PersistableNetworkPayload> map = new HashMap<>();
         appendOnlyDataStoreService.getServices()
                 .forEach(service -> {
                     Map<ByteArray, PersistableNetworkPayload> serviceMap;
                     if (service instanceof HistoricalDataStoreService) {
                         var historicalDataStoreService = (HistoricalDataStoreService<? extends PersistableNetworkPayloadStore>) service;
-                        serviceMap = historicalDataStoreService.getMapSinceVersion(requestersVersion, keysToExclude);
+                        serviceMap = historicalDataStoreService.getMapSinceVersion(requestersVersion, keysToExclude, arePayloadsTruncated);
                     } else {
                         serviceMap = service.getMap();
                     }

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -313,7 +313,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         // The methods in HistoricalDataStoreService will return all historical data in that case.
         // mapForDataResponse contains the filtered by version data from HistoricalDataStoreService as well as all other
         // maps of the remaining appendOnlyDataStoreServices.
-        Map<ByteArray, PersistableNetworkPayload> mapForDataResponse = getMapForDataResponse(getDataRequest.getVersion());
+        Map<ByteArray, PersistableNetworkPayload> mapForDataResponse =
+                getMapForDataResponse(getDataRequest.getVersion(), excludedKeysAsByteArray);
 
         // Give a bit of tolerance for message overhead
         double maxSize = Connection.getMaxPermittedMessageSize() * 0.6;
@@ -392,14 +393,14 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         return map;
     }
 
-    public Map<ByteArray, PersistableNetworkPayload> getMapForDataResponse(String requestersVersion) {
+    public Map<ByteArray, PersistableNetworkPayload> getMapForDataResponse(String requestersVersion, Set<P2PDataStorage.ByteArray> keysToExclude) {
         Map<ByteArray, PersistableNetworkPayload> map = new HashMap<>();
         appendOnlyDataStoreService.getServices()
                 .forEach(service -> {
                     Map<ByteArray, PersistableNetworkPayload> serviceMap;
                     if (service instanceof HistoricalDataStoreService) {
                         var historicalDataStoreService = (HistoricalDataStoreService<? extends PersistableNetworkPayloadStore>) service;
-                        serviceMap = historicalDataStoreService.getMapSinceVersion(requestersVersion);
+                        serviceMap = historicalDataStoreService.getMapSinceVersion(requestersVersion, keysToExclude);
                     } else {
                         serviceMap = service.getMap();
                     }

--- a/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/persistence/HistoricalDataStoreService.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -72,9 +71,19 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
         Stream<Map.Entry<P2PDataStorage.ByteArray, PersistableNetworkPayload>> liveDataStream =
                 store.getMap().entrySet().stream();
 
+
         if (requestersVersion == null) {
             log.warn("The requester did not send a version but the field was added in v1.4.0. " +
                     "Returning capped live data (100 items).");
+
+            return liveDataStream
+                    .limit(100)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        boolean isRequesterVersionNewer = Version.isNewVersion(requestersVersion, Version.VERSION);
+        if (isRequesterVersionNewer) {
+            log.warn("The requester's version is newer than ours. Returning capped live data (100 items).");
 
             return liveDataStream
                     .limit(100)

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRequestDataTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageRequestDataTest.java
@@ -33,6 +33,7 @@ import bisq.common.app.Capability;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -105,7 +106,7 @@ public class P2PDataStorageRequestDataTest {
     @Test
     public void buildGetUpdatedDataRequest_EmptyP2PDataStore() {
         GetUpdatedDataRequest getDataRequest =
-                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1);
+                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1, Optional.empty());
 
         assertEquals(getDataRequest.getNonce(), 1);
         assertEquals(getDataRequest.getSenderNodeAddress(), this.localNodeAddress);
@@ -156,7 +157,7 @@ public class P2PDataStorageRequestDataTest {
         this.testState.mockedStorage.addProtectedStorageEntry(toAdd4, this.localNodeAddress, null);
 
         GetUpdatedDataRequest getDataRequest =
-                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1);
+                this.testState.mockedStorage.buildGetUpdatedDataRequest(this.localNodeAddress, 1, Optional.empty());
 
         assertEquals(getDataRequest.getNonce(), 1);
         assertEquals(getDataRequest.getSenderNodeAddress(), this.localNodeAddress);

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -123,6 +123,7 @@ message GetDataResponse {
     repeated int32 supported_capabilities = 4;
     repeated PersistableNetworkPayload persistable_network_payload_items = 5;
     bool was_truncated = 6;
+    string version = 7;
 }
 
 message GetUpdatedDataRequest {


### PR DESCRIPTION
- [Send back seednode version in get data response back to client](https://github.com/bisq-network/bisq/commit/5a3d1326c4c5c5fba18f7c342f9cbb5d20b3df80)
- [Filter for known items in HistoricalDataStoreService.getMapSinceVersion(...)](https://github.com/bisq-network/bisq/commit/4698fa2c1f5d8991b485049c2b2ad58f1b7b3404)
- [Remove redundant Map creation in HistoricalDataStoreService.getMapSinceVersion(...)](https://github.com/bisq-network/bisq/commit/0a42bf685131f6ccf90a7f7d0f9a1a1501a51b8f)
- [Cap items if requesterVersion is null in HistoricalDataStoreService.getMapSinceVersion(...)](https://github.com/bisq-network/bisq/commit/e15a34f1b6a18b8894fef1240b00164ed1d21740)
- [Cap items if requesterVersion is newer in HistoricalDataStoreService.getMapSinceVersion(...)](https://github.com/bisq-network/bisq/commit/97330ba8aa2ed3932e6dae95e4e73a4aec638993)
- [Set wasPersistableNetworkPayloadsTruncated if requester Version newer and capped](https://github.com/bisq-network/bisq/commit/ddfa14aa0796c7fb0a8819779d108564d2b70601)
  - Cap items if requesterVersion is newer in HistoricalDataStoreService.getMapSinceVersion(...)
- [Include responders missing hashes from our historical data store](https://github.com/bisq-network/bisq/commit/da7cd47d51c6d3ac3d61803f570c4ad89dc0e941)