### PR TITLE
Add link to trading rules wiki article in Tac Window

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
@@ -112,17 +112,26 @@ public class TacWindow extends Overlay<TacWindow> {
         String fontStyleClass = smallScreen ? "small-text" : "normal-text";
         messageLabel.getStyleClass().add(fontStyleClass);
 
-        Label label = new AutoTooltipLabel("    - For more details and a general overview please read the full documentation about ");
+        Label rulesLinkLabel = new AutoTooltipLabel("    - Read the complete ");
+        rulesLinkLabel.getStyleClass().add(fontStyleClass);
+
+        Label label = new AutoTooltipLabel(", and find more details and general overview in the full documentation about ");
         label.getStyleClass().add(fontStyleClass);
+
+        //not translated, as noted in String text of show()
+        HyperlinkWithIcon rulesLinkWithIcon = new ExternalHyperlink("trading rules");
+        rulesLinkWithIcon.setOnAction(e -> GUIUtil.openWebPage("https://bisq.wiki/Trading_rules"));
+        rulesLinkWithIcon.getStyleClass().add(fontStyleClass);
+        HBox.setMargin(rulesLinkWithIcon, new Insets(-0.5, 0, 0, 0));
 
         HyperlinkWithIcon hyperlinkWithIcon = new ExternalHyperlink(Res.get("tacWindow.arbitrationSystem").toLowerCase() + ".");
         hyperlinkWithIcon.setOnAction(e -> GUIUtil.openWebPage("https://bisq.wiki/Dispute_resolution"));
         hyperlinkWithIcon.getStyleClass().add(fontStyleClass);
         HBox.setMargin(hyperlinkWithIcon, new Insets(-0.5, 0, 0, 0));
 
-        HBox hBox = new HBox(label, hyperlinkWithIcon);
+        HBox hBox = new HBox(rulesLinkLabel, rulesLinkWithIcon, label, hyperlinkWithIcon);
         GridPane.setRowIndex(hBox, ++rowIndex);
-        GridPane.setMargin(hBox, new Insets(-5, 0, -20, 0));
+        GridPane.setMargin(hBox, new Insets(-12, 0, -20, 0));
         gridPane.getChildren().add(hBox);
     }
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,8 @@
    ```sh
    git clone https://github.com/bisq-network/bisq
    # if you intend to do testing on the latest release, you can clone the respective branch selectively, without downloading the whole repository
-   # for the 1.9.18 release, you would do it like this:
-   git clone --recurse-submodules --branch release/v1.9.18 https://github.com/bisq-network/bisq
+   # for the 1.9.3 release, you would do it like this:
+   git clone --recurse-submodules --branch release/v1.9.3 https://github.com/bisq-network/bisq
    cd bisq
    ```
 
@@ -33,18 +33,6 @@
 
    ```sh
    javac -version
-   ```
-
-   If you have multiple JDK versions installed, check which one Gradle will use, with:
-
-   ```sh
-   ./gradlew --version
-   ```
-
-   and if the version number on the JVM line is not a supported one, you can pick the correct JDK at runtime with this syntax (verify your system path):
-
-   ```sh
-   ./gradlew build -Dorg.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64/
    ```
 
 If you do not have JDK 11 installed, check out scripts in the [scripts](../scripts) directory or download it manually from https://jdk.java.net/archive/.

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,8 @@
    ```sh
    git clone https://github.com/bisq-network/bisq
    # if you intend to do testing on the latest release, you can clone the respective branch selectively, without downloading the whole repository
-   # for the 1.9.3 release, you would do it like this:
-   git clone --recurse-submodules --branch release/v1.9.3 https://github.com/bisq-network/bisq
+   # for the 1.9.18 release, you would do it like this:
+   git clone --recurse-submodules --branch release/v1.9.18 https://github.com/bisq-network/bisq
    cd bisq
    ```
 
@@ -33,6 +33,18 @@
 
    ```sh
    javac -version
+   ```
+
+   If you have multiple JDK versions installed, check which one Gradle will use, with:
+
+   ```sh
+   ./gradlew --version
+   ```
+
+   and if the version number on the JVM line is not a supported one, you can pick the correct JDK at runtime with this syntax (verify your system path):
+
+   ```sh
+   ./gradlew build -Dorg.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64/
    ```
 
 If you do not have JDK 11 installed, check out scripts in the [scripts](../scripts) directory or download it manually from https://jdk.java.net/archive/.


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

The trading rules, as explained on https://bisq.wiki/Trading_rules have a tidier layout, and allow for future adjustments in case they are needed, so it is useful to have them linked from the Tac.

I originally intended to make the word "rules" in bullet 6 into a link, but when I understood how the overlay contents are built, I rapidly changed my mind, so I thought about adding another sub-bullet above the dispute resolution link, by creating another HBox and have the two HBox's placed into a VBox, but that in turn proved unfeasible as the relative height of the hyperlinks to the preceding text were inconsistent no matter what I did.
So I finally settled for placing the two in the same HBox, and at the same time fixed the line-spacing with the above bullets, that was larger than the rest in the original version. I found no way of fixing the vertical alignment of the hyperlinks with the text, which was below the base level even in the original version.

Original:
![old](https://github.com/user-attachments/assets/b71a1ddf-7853-4589-b3cf-103f6a6f4b67)

My PR:
![new](https://github.com/user-attachments/assets/f4afc770-cb9a-412e-a3fd-145f01fb0189)

