### PR TITLE
Show ARS Blue Rate popup during payment account creation

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
@@ -126,19 +126,6 @@ class FiatAccountsDataModel extends ActivatableDataModel {
 
         accountAgeWitnessService.publishMyAccountAgeWitness(paymentAccount.getPaymentAccountPayload());
         accountAgeWitnessService.signAndPublishSameNameAccounts();
-
-        if (paymentAccount.getSingleTradeCurrency().getCode().equals("ARS")) {
-            String key = "arsBlueMarketNotificationPopup";
-            if (DontShowAgainLookup.showAgain(key)) {
-                new Popup()
-                        .headLine(Res.get("popup.arsBlueMarket.title"))
-                        .information(Res.get("popup.arsBlueMarket.info"))
-                        .actionButtonText(Res.get("shared.iUnderstand"))
-                        .hideCloseButton()
-                        .dontShowAgainId(key)
-                        .show();
-            }
-        }
     }
 
     public void onUpdateAccount(PaymentAccount paymentAccount) {

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -24,6 +24,7 @@ import bisq.desktop.components.BisqScrollPane;
 import bisq.desktop.components.BisqTextArea;
 import bisq.desktop.components.InfoAutoTooltipLabel;
 import bisq.desktop.components.indicator.TxConfidenceIndicator;
+import bisq.desktop.components.paymentmethods.PaymentMethodForm;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.account.AccountView;
 import bisq.desktop.main.account.content.fiataccounts.FiatAccountsView;
@@ -1103,8 +1104,14 @@ public class GUIUtil {
         });
         currencyComboBox.setDisable(true);
 
-        currencyComboBox.setOnAction(e ->
-                onTradeCurrencySelectedHandler.accept(currencyComboBox.getSelectionModel().getSelectedItem()));
+        currencyComboBox.setOnAction(e -> {
+            TradeCurrency selectedCurrency = currencyComboBox.getSelectionModel().getSelectedItem();
+            onTradeCurrencySelectedHandler.accept(selectedCurrency);
+
+            if (PaymentMethodForm.isArgentinePesos(selectedCurrency)) {
+                PaymentMethodForm.maybeShowArgentinePesosBlueRatePopup();
+            }
+        });
 
         return new Tuple2<>(currencyComboBox, gridRow);
     }


### PR DESCRIPTION
At the moment, we show the ARS Blue Rate popup when the user saves a single currency payment account (PR #7122). This misses many payment accounts that support ARS. The new behaviour is to show the ARS Blue Rate popup when ARS is selected during account generation (either pre-selected or later selected by the user).

Payment accounts supporting ARS:
- CashByMail
- CashDeposit
- F2F
- MoneyGram
- National bank
- OKPayAccount (deprecated)
- Same bank
- Specific bank
- Transferwise
- Uphold
- Western Union