### PR TITLE
Always show ARS blue rate popup (account creation)

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/ArsBlueRatePopup.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/ArsBlueRatePopup.java
@@ -5,7 +5,6 @@ import bisq.desktop.main.overlays.popups.Popup;
 import bisq.core.locale.FiatCurrency;
 import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
-import bisq.core.user.DontShowAgainLookup;
 
 public class ArsBlueRatePopup {
     public static boolean isTradeCurrencyArgentinePesos(TradeCurrency tradeCurrency) {
@@ -13,16 +12,12 @@ public class ArsBlueRatePopup {
         return tradeCurrency.equals(arsCurrency);
     }
 
-    public static void showMaybe() {
-        String key = "arsBlueMarketNotificationPopup";
-        if (DontShowAgainLookup.showAgain(key)) {
-            new Popup()
-                    .headLine(Res.get("popup.arsBlueMarket.title"))
-                    .information(Res.get("popup.arsBlueMarket.info"))
-                    .actionButtonText(Res.get("shared.iUnderstand"))
-                    .hideCloseButton()
-                    .dontShowAgainId(key)
-                    .show();
-        }
+    public static void show() {
+        new Popup()
+                .headLine(Res.get("popup.arsBlueMarket.title"))
+                .information(Res.get("popup.arsBlueMarket.info"))
+                .actionButtonText(Res.get("shared.iUnderstand"))
+                .hideCloseButton()
+                .show();
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/ArsBlueRatePopup.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/ArsBlueRatePopup.java
@@ -1,0 +1,28 @@
+package bisq.desktop.components.paymentmethods;
+
+import bisq.desktop.main.overlays.popups.Popup;
+
+import bisq.core.locale.FiatCurrency;
+import bisq.core.locale.Res;
+import bisq.core.locale.TradeCurrency;
+import bisq.core.user.DontShowAgainLookup;
+
+public class ArsBlueRatePopup {
+    public static boolean isTradeCurrencyArgentinePesos(TradeCurrency tradeCurrency) {
+        FiatCurrency arsCurrency = new FiatCurrency("ARS");
+        return tradeCurrency.equals(arsCurrency);
+    }
+
+    public static void showMaybe() {
+        String key = "arsBlueMarketNotificationPopup";
+        if (DontShowAgainLookup.showAgain(key)) {
+            new Popup()
+                    .headLine(Res.get("popup.arsBlueMarket.title"))
+                    .information(Res.get("popup.arsBlueMarket.info"))
+                    .actionButtonText(Res.get("shared.iUnderstand"))
+                    .hideCloseButton()
+                    .dontShowAgainId(key)
+                    .show();
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -123,7 +123,7 @@ public abstract class PaymentMethodForm {
             updateFromInputs();
 
             if (ArsBlueRatePopup.isTradeCurrencyArgentinePesos(selectedCurrency)) {
-                ArsBlueRatePopup.showMaybe();
+                ArsBlueRatePopup.show();
             }
         });
     }
@@ -316,7 +316,7 @@ public abstract class PaymentMethodForm {
                 paymentAccount.addCurrency(e);
 
                 if (ArsBlueRatePopup.isTradeCurrencyArgentinePesos(e)) {
-                    ArsBlueRatePopup.showMaybe();
+                    ArsBlueRatePopup.show();
                 }
 
             } else {
@@ -328,7 +328,7 @@ public abstract class PaymentMethodForm {
         flowPane.getChildren().add(checkBox);
 
         if (isCurrencySelected && ArsBlueRatePopup.isTradeCurrencyArgentinePesos(e)) {
-            ArsBlueRatePopup.showMaybe();
+            ArsBlueRatePopup.show();
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -37,7 +37,6 @@ import bisq.core.offer.OfferDirection;
 import bisq.core.payment.AssetAccount;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentMethod;
-import bisq.core.user.DontShowAgainLookup;
 import bisq.core.util.coin.CoinFormatter;
 import bisq.core.util.validation.InputValidator;
 
@@ -68,7 +67,6 @@ import javafx.collections.FXCollections;
 import javafx.util.StringConverter;
 
 import java.util.Date;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
@@ -124,8 +122,8 @@ public abstract class PaymentMethodForm {
             paymentAccount.setSingleTradeCurrency(selectedCurrency);
             updateFromInputs();
 
-            if (isArgentinePesos(selectedCurrency)) {
-                maybeShowArgentinePesosBlueRatePopup();
+            if (ArsBlueRatePopup.isTradeCurrencyArgentinePesos(selectedCurrency)) {
+                ArsBlueRatePopup.showMaybe();
             }
         });
     }
@@ -317,8 +315,8 @@ public abstract class PaymentMethodForm {
             if (checkBox.isSelected()) {
                 paymentAccount.addCurrency(e);
 
-                if (isArgentinePesos(e)) {
-                    maybeShowArgentinePesosBlueRatePopup();
+                if (ArsBlueRatePopup.isTradeCurrencyArgentinePesos(e)) {
+                    ArsBlueRatePopup.showMaybe();
                 }
 
             } else {
@@ -329,8 +327,8 @@ public abstract class PaymentMethodForm {
         });
         flowPane.getChildren().add(checkBox);
 
-        if (isCurrencySelected && isArgentinePesos(e)) {
-            maybeShowArgentinePesosBlueRatePopup();
+        if (isCurrencySelected && ArsBlueRatePopup.isTradeCurrencyArgentinePesos(e)) {
+            ArsBlueRatePopup.showMaybe();
         }
     }
 
@@ -371,23 +369,5 @@ public abstract class PaymentMethodForm {
     }
 
     void addAcceptedCountry(String countryCode) {
-    }
-
-    public static boolean isArgentinePesos(TradeCurrency tradeCurrency) {
-        FiatCurrency arsCurrency = new FiatCurrency("ARS");
-        return tradeCurrency.equals(arsCurrency);
-    }
-
-    public static void maybeShowArgentinePesosBlueRatePopup() {
-        String key = "arsBlueMarketNotificationPopup";
-        if (DontShowAgainLookup.showAgain(key)) {
-            new Popup()
-                    .headLine(Res.get("popup.arsBlueMarket.title"))
-                    .information(Res.get("popup.arsBlueMarket.info"))
-                    .actionButtonText(Res.get("shared.iUnderstand"))
-                    .hideCloseButton()
-                    .dontShowAgainId(key)
-                    .show();
-        }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -24,7 +24,7 @@ import bisq.desktop.components.BisqScrollPane;
 import bisq.desktop.components.BisqTextArea;
 import bisq.desktop.components.InfoAutoTooltipLabel;
 import bisq.desktop.components.indicator.TxConfidenceIndicator;
-import bisq.desktop.components.paymentmethods.PaymentMethodForm;
+import bisq.desktop.components.paymentmethods.ArsBlueRatePopup;
 import bisq.desktop.main.MainView;
 import bisq.desktop.main.account.AccountView;
 import bisq.desktop.main.account.content.fiataccounts.FiatAccountsView;
@@ -1108,8 +1108,8 @@ public class GUIUtil {
             TradeCurrency selectedCurrency = currencyComboBox.getSelectionModel().getSelectedItem();
             onTradeCurrencySelectedHandler.accept(selectedCurrency);
 
-            if (PaymentMethodForm.isArgentinePesos(selectedCurrency)) {
-                PaymentMethodForm.maybeShowArgentinePesosBlueRatePopup();
+            if (ArsBlueRatePopup.isTradeCurrencyArgentinePesos(selectedCurrency)) {
+                ArsBlueRatePopup.showMaybe();
             }
         });
 

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -1109,7 +1109,7 @@ public class GUIUtil {
             onTradeCurrencySelectedHandler.accept(selectedCurrency);
 
             if (ArsBlueRatePopup.isTradeCurrencyArgentinePesos(selectedCurrency)) {
-                ArsBlueRatePopup.showMaybe();
+                ArsBlueRatePopup.show();
             }
         });
 


### PR DESCRIPTION
We show the ARS blue rate popup whenever the user creates a payment
method and ARS is selected. Therefore, it makes sense to always show the
ARS blue rate popup.

Changes:
- [Move ARS blue rate popup code to new class](https://github.com/bisq-network/bisq/commit/33eced11178acc0c8584ee4e8e5b8aead6d13fda)
- [Always show ARS blue rate popup](https://github.com/bisq-network/bisq/commit/d0f4b46a5b91c97fe9a729d0391b00dfd15fe49d)