### PR TITLE
Updater: Remove JAR_HASH download

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
@@ -74,16 +74,12 @@ public class BisqInstaller {
         // tells us which key was used for signing
         FileDescriptor signingKeyDescriptor = getSigningKeyDescriptor(partialUrl);
 
-        // Hash of jar file inside of the binary
-        FileDescriptor jarHashDescriptor = getJarHashDescriptor(version, partialUrl);
-
         List<FileDescriptor> keyFileDescriptors = getKeyFileDescriptors();
         List<FileDescriptor> sigFileDescriptors = getSigFileDescriptors(installerFileDescriptor, keyFileDescriptors);
 
         List<FileDescriptor> allFiles = Lists.newArrayList();
         allFiles.add(installerFileDescriptor);
         allFiles.add(signingKeyDescriptor);
-        allFiles.add(jarHashDescriptor);
         allFiles.addAll(keyFileDescriptors);
         allFiles.addAll(sigFileDescriptors);
 
@@ -234,17 +230,6 @@ public class BisqInstaller {
                 .build();
     }
 
-    @NotNull
-    private FileDescriptor getJarHashDescriptor(String version, String partialUrl) {
-        String fileName = "Bisq-" + version + ".jar.txt";
-        return FileDescriptor.builder()
-                .type(DownloadType.JAR_HASH)
-                .fileName(fileName)
-                .id(fileName)
-                .loadUrl(partialUrl.concat(fileName))
-                .build();
-    }
-
     /**
      * The files containing the gpg keys of the bisq signers.
      * Currently these are 2 hard-coded keys, one included with bisq and the same key online for maximum security.
@@ -342,8 +327,7 @@ public class BisqInstaller {
         KEY,
         SIG,
         SIGNING_KEY,
-        MISC,
-        JAR_HASH
+        MISC
     }
 }
 

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DisplayUpdateDownloadWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DisplayUpdateDownloadWindow.java
@@ -51,18 +51,12 @@ import javafx.geometry.Pos;
 
 import javafx.beans.value.ChangeListener;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintWriter;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Scanner;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -232,11 +226,6 @@ public class DisplayUpdateDownloadWindow extends Overlay<DisplayUpdateDownloadWi
                             log.debug("Download completed successfully.");
                             downloadedFilesLabel.getStyleClass().add("success-text");
 
-                            downloadTask.getFileDescriptors().stream()
-                                    .filter(fileDescriptor -> fileDescriptor.getType() == BisqInstaller.DownloadType.JAR_HASH)
-                                    .findFirst()
-                                    .ifPresent(this::copyJarHashToDataDir);
-
                             verifyTask = installer.verify(downloadResults);
                             verifiedSigLabel.setOpacity(1);
 
@@ -284,32 +273,6 @@ public class DisplayUpdateDownloadWindow extends Overlay<DisplayUpdateDownloadWi
                 showErrorMessage(downloadButton, statusLabel, (Res.get("displayUpdateDownloadWindow.installer.failed")));
             }
         });
-    }
-
-    private void copyJarHashToDataDir(BisqInstaller.FileDescriptor fileDescriptor) {
-        StringBuilder sb = new StringBuilder();
-        final File sourceFile = fileDescriptor.getSaveFile();
-        try (Scanner scanner = new Scanner(new FileReader(sourceFile))) {
-            while (scanner.hasNext()) {
-                sb.append(scanner.next());
-            }
-            scanner.close();
-            final String hashOfJar = sb.toString();
-
-            Path path = Paths.get(config.appDataDir.getPath(), fileDescriptor.getFileName());
-            final String target = path.toString();
-            try (PrintWriter writer = new PrintWriter(target, "UTF-8")) {
-                writer.println(hashOfJar);
-                writer.close();
-                log.info("Copied hash of jar from {} to {}", sourceFile.getAbsolutePath(), target);
-            } catch (Exception e) {
-                log.error(e.toString());
-                e.printStackTrace();
-            }
-        } catch (Exception e) {
-            log.error(e.toString());
-            e.printStackTrace();
-        }
     }
 
     @Override


### PR DESCRIPTION
Recent changes broke reproducibility and the last release's JAR_HASH
file contains "Dummy file (needed for updater)". We need to keep
creating a dummy file because the updater fails without a dummy file.
This change fixes the bug.