### PR TITLE
Fix crash due to broken filter provided nodes merge

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodesSetupPreferences.java
@@ -26,6 +26,7 @@ import bisq.common.util.Utilities;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,9 +67,9 @@ public class BtcNodesSetupPreferences {
                 break;
             case PROVIDED:
             default:
-                List<BtcNode> hardcodedBtcNodes = btcNodes.getProvidedBtcNodes();
-                List<String> filterProvidedBtcNodes = config.filterProvidedBtcNodes;
-                List<String> bannedBtcNodes = config.bannedBtcNodes;
+                Stream<BtcNode> hardcodedBtcNodes = btcNodes.getProvidedBtcNodes().stream();
+                Stream<String> filterProvidedBtcNodes = config.filterProvidedBtcNodes.stream();
+                Stream<String> bannedBtcNodes = config.bannedBtcNodes.stream();
                 result = FederatedBtcNodeProvider.getNodes(hardcodedBtcNodes, filterProvidedBtcNodes, bannedBtcNodes);
                 break;
         }

--- a/core/src/main/java/bisq/core/btc/nodes/FederatedBtcNodeProvider.java
+++ b/core/src/main/java/bisq/core/btc/nodes/FederatedBtcNodeProvider.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,24 +15,23 @@ import org.jetbrains.annotations.Nullable;
 @Slf4j
 public class FederatedBtcNodeProvider {
 
-    static List<BtcNodes.BtcNode> getNodes(List<BtcNodes.BtcNode> hardcodedBtcNodes,
-                                           List<String> filterProvidedBtcNodesConfig,
-                                           List<String> bannedBtcNodesConfig) {
-        Set<BtcNodes.BtcNode> filterProvidedBtcNodes = filterProvidedBtcNodesConfig.stream()
+    static List<BtcNodes.BtcNode> getNodes(Stream<BtcNodes.BtcNode> hardcodedBtcNodes,
+                                           Stream<String> filterProvidedBtcNodesConfig,
+                                           Stream<String> bannedBtcNodesConfig) {
+        Stream<BtcNodes.BtcNode> filterProvidedBtcNodes = filterProvidedBtcNodesConfig
                 .filter(n -> !n.isEmpty())
                 .map(FederatedBtcNodeProvider::getNodeAddress)
                 .filter(Objects::nonNull)
-                .map(nodeAddress -> new BtcNodes.BtcNode(null, nodeAddress.getHostName(), null, nodeAddress.getPort(), "Provided by filter"))
-                .collect(Collectors.toSet());
-        hardcodedBtcNodes.addAll(filterProvidedBtcNodes);
+                .map(nodeAddress -> new BtcNodes.BtcNode(null, nodeAddress.getHostName(), null,
+                        nodeAddress.getPort(), "Provided by filter"));
 
-        Set<NodeAddress> bannedBtcNodeHostNames = bannedBtcNodesConfig.stream()
+        Set<NodeAddress> bannedBtcNodeHostNames = bannedBtcNodesConfig
                 .filter(n -> !n.isEmpty())
                 .map(FederatedBtcNodeProvider::getNodeAddress)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        return hardcodedBtcNodes.stream()
+        return Stream.concat(hardcodedBtcNodes, filterProvidedBtcNodes)
                 .filter(btcNode -> {
                     String nodeAddress = btcNode.hasOnionAddress() ? btcNode.getOnionAddress() :
                             btcNode.getHostNameOrAddress();

--- a/core/src/test/java/bisq/core/btc/nodes/FederatedBtcNodeProviderTest.java
+++ b/core/src/test/java/bisq/core/btc/nodes/FederatedBtcNodeProviderTest.java
@@ -1,8 +1,7 @@
 package bisq.core.btc.nodes;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,12 +19,11 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
-        List<String> bannedBtcNodes = Collections.emptyList();
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
+        Stream<String> bannedBtcNodes = Stream.empty();
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         assertIterableEquals(hardcodedNodes, selectedNodes);
     }
@@ -43,13 +41,12 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
         String bannedFullAddress = bannedAddress + ":" + port;
-        List<String> bannedBtcNodes = List.of(bannedFullAddress);
+        Stream<String> bannedBtcNodes = Stream.of(bannedFullAddress);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         var expected = List.of(
                 new BtcNodes.BtcNode(null, "alice.onion", null,
@@ -72,13 +69,12 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
         String bannedFullAddress = bannedAddress + ":" + 1234;
-        List<String> bannedBtcNodes = List.of(bannedFullAddress);
+        Stream<String> bannedBtcNodes = Stream.of(bannedFullAddress);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         assertIterableEquals(hardcodedNodes, selectedNodes);
     }
@@ -96,13 +92,12 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
         String bannedFullAddress = "[" + bannedAddress + "]" + ":" + port;
-        List<String> bannedBtcNodes = List.of(bannedFullAddress);
+        Stream<String> bannedBtcNodes = Stream.of(bannedFullAddress);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         var expected = List.of(
                 new BtcNodes.BtcNode(null, "alice.onion", null,
@@ -125,13 +120,12 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
         String bannedFullAddress = "[" + bannedAddress + "]" + ":" + 1234;
-        List<String> bannedBtcNodes = List.of(bannedFullAddress);
+        Stream<String> bannedBtcNodes = Stream.of(bannedFullAddress);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         assertIterableEquals(hardcodedNodes, selectedNodes);
     }
@@ -149,12 +143,11 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
-        List<String> bannedBtcNodes = List.of(bannedHostName + ":" + port);
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
+        Stream<String> bannedBtcNodes = Stream.of(bannedHostName + ":" + port);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         var expected = List.of(
                 new BtcNodes.BtcNode(null, "alice.onion", null,
@@ -177,12 +170,11 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
-        List<String> bannedBtcNodes = List.of(bannedHostName + ":" + 1234);
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
+        Stream<String> bannedBtcNodes = Stream.of(bannedHostName + ":" + 1234);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         assertIterableEquals(hardcodedNodes, selectedNodes);
     }
@@ -200,12 +192,11 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
-        List<String> bannedBtcNodes = List.of(bannedOnionAddress + ":" + BtcNodes.BtcNode.DEFAULT_PORT);
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
+        Stream<String> bannedBtcNodes = Stream.of(bannedOnionAddress + ":" + BtcNodes.BtcNode.DEFAULT_PORT);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         var expected = List.of(
                 new BtcNodes.BtcNode(null, "alice.onion", null,
@@ -229,12 +220,11 @@ public class FederatedBtcNodeProviderTest {
                         BtcNodes.BtcNode.DEFAULT_PORT, "@charlie")
         );
 
-        List<BtcNodes.BtcNode> mutableHardcodedList = new ArrayList<>(hardcodedNodes);
-        List<String> filterProvidedBtcNodes = Collections.emptyList();
-        List<String> bannedBtcNodes = List.of(bannedOnionAddress + ":" + 1234);
+        Stream<String> filterProvidedBtcNodes = Stream.empty();
+        Stream<String> bannedBtcNodes = Stream.of(bannedOnionAddress + ":" + 1234);
 
         List<BtcNodes.BtcNode> selectedNodes = FederatedBtcNodeProvider
-                .getNodes(mutableHardcodedList, filterProvidedBtcNodes, bannedBtcNodes);
+                .getNodes(hardcodedNodes.stream(), filterProvidedBtcNodes, bannedBtcNodes);
 
         assertIterableEquals(hardcodedNodes, selectedNodes);
     }


### PR DESCRIPTION
The filter provided nodes were added to a read-only List and this lead
to crashes at start-up. We didn't catch the bug before because the lists
in the tests are mutable. Now the FederatedBtcNodeProvider.getNodes
method operates on Streams.