### PR TITLE
Add link to trading rules wiki article in Tac Window

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
@@ -112,17 +112,26 @@ public class TacWindow extends Overlay<TacWindow> {
         String fontStyleClass = smallScreen ? "small-text" : "normal-text";
         messageLabel.getStyleClass().add(fontStyleClass);
 
-        Label label = new AutoTooltipLabel("    - For more details and a general overview please read the full documentation about ");
+        Label rulesLinkLabel = new AutoTooltipLabel("    - Read the complete ");
+        rulesLinkLabel.getStyleClass().add(fontStyleClass);
+
+        Label label = new AutoTooltipLabel(", and find more details and general overview in the full documentation about ");
         label.getStyleClass().add(fontStyleClass);
+
+        //not translated, as noted in String text of show()
+        HyperlinkWithIcon rulesLinkWithIcon = new ExternalHyperlink("trading rules");
+        rulesLinkWithIcon.setOnAction(e -> GUIUtil.openWebPage("https://bisq.wiki/Trading_rules"));
+        rulesLinkWithIcon.getStyleClass().add(fontStyleClass);
+        HBox.setMargin(rulesLinkWithIcon, new Insets(-0.5, 0, 0, 0));
 
         HyperlinkWithIcon hyperlinkWithIcon = new ExternalHyperlink(Res.get("tacWindow.arbitrationSystem").toLowerCase() + ".");
         hyperlinkWithIcon.setOnAction(e -> GUIUtil.openWebPage("https://bisq.wiki/Dispute_resolution"));
         hyperlinkWithIcon.getStyleClass().add(fontStyleClass);
         HBox.setMargin(hyperlinkWithIcon, new Insets(-0.5, 0, 0, 0));
 
-        HBox hBox = new HBox(label, hyperlinkWithIcon);
+        HBox hBox = new HBox(rulesLinkLabel, rulesLinkWithIcon, label, hyperlinkWithIcon);
         GridPane.setRowIndex(hBox, ++rowIndex);
-        GridPane.setMargin(hBox, new Insets(-5, 0, -20, 0));
+        GridPane.setMargin(hBox, new Insets(-12, 0, -20, 0));
         gridPane.getChildren().add(hBox);
     }
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

The trading rules, as explained on https://bisq.wiki/Trading_rules have a tidier layout, and allow for future adjustments in case they are needed, so it is useful to have them linked from the Tac.

I originally intended to make the word "rules" in bullet 6 into a link, but when I understood how the overlay contents are built, I rapidly changed my mind, so I thought about adding another sub-bullet above the dispute resolution link, by creating another HBox and have the two HBox's placed into a VBox, but that in turn proved unfeasible as the relative height of the hyperlinks to the preceding text were inconsistent no matter what I did.
So I finally settled for placing the two in the same HBox, and at the same time fixed the line-spacing with the above bullets, that was larger than the rest in the original version. I found no way of fixing the vertical alignment of the hyperlinks with the text, which was below the base level even in the original version.

Original:
![old](https://github.com/user-attachments/assets/b71a1ddf-7853-4589-b3cf-103f6a6f4b67)

My PR:
![new](https://github.com/user-attachments/assets/f4afc770-cb9a-412e-a3fd-145f01fb0189)

