### PR TITLE
Fix DaoSnapshotService threading issues

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -81,7 +81,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
     private Runnable resyncDaoStateFromResourcesHandler;
     private int daoRequiresRestartHandlerAttempts = 0;
     private final AtomicBoolean persistingBlockInProgress = new AtomicBoolean();
-    private boolean isParseBlockChainComplete;
+    private final AtomicBoolean isParseBlockChainComplete = new AtomicBoolean();
     private final List<Integer> heightsOfLastAppliedSnapshots = new ArrayList<>();
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -156,7 +156,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
         // Otherwise, we do it only after the initial blockchain parsing is completed to not delay the parsing.
         // In that case we get the missing hashes from the seed nodes. At any new block we do the hash calculation
         // ourselves and therefore get back confidence that our DAO state is in sync with the network.
-        if (preferences.isUseFullModeDaoMonitor() || isParseBlockChainComplete) {
+        if (preferences.isUseFullModeDaoMonitor() || isParseBlockChainComplete.get()) {
             // We need to execute first the daoStateMonitoringService.createHashFromBlock to get the hash created
             daoStateMonitoringService.createHashFromBlock(block);
             maybeCreateSnapshot(block);
@@ -168,7 +168,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
 
     @Override
     public void onParseBlockChainComplete() {
-        isParseBlockChainComplete = true;
+        isParseBlockChainComplete.set(true);
 
         // In case we have dao monitoring deactivated we create the snapshot after we are completed with parsing,
         // and we got called back from daoStateMonitoringService once the hashes are created from peers data.

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -79,7 +80,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
     @Nullable
     private Runnable resyncDaoStateFromResourcesHandler;
     private int daoRequiresRestartHandlerAttempts = 0;
-    private boolean persistingBlockInProgress;
+    private final AtomicBoolean persistingBlockInProgress = new AtomicBoolean();
     private boolean isParseBlockChainComplete;
     private final List<Integer> heightsOfLastAppliedSnapshots = new ArrayList<>();
 
@@ -233,7 +234,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
         // We protect to get called while we are not completed with persisting the daoState. This can take about
         // 20 seconds, and it is not expected that we get triggered another snapshot event in that period, but this
         // check guards that we would skip such calls.
-        if (persistingBlockInProgress) {
+        if (persistingBlockInProgress.get()) {
             if (preferences.isUseFullModeDaoMonitor()) {
                 // In case we don't use isUseFullModeDaoMonitor we might get called here too often as the parsing is much
                 // faster than the persistence, and we likely create only 1 snapshot during initial parsing, so
@@ -256,7 +257,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
 
     private void persist() {
         long ts = System.currentTimeMillis();
-        persistingBlockInProgress = true;
+        persistingBlockInProgress.set(true);
         daoStateStorageService.requestPersistence(daoStateCandidate,
                 blocksCandidate,
                 hashChainCandidate,
@@ -265,7 +266,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
                             snapshotHeight, System.currentTimeMillis() - ts);
 
                     createSnapshot();
-                    persistingBlockInProgress = false;
+                    persistingBlockInProgress.set(false);
                 });
     }
 

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -294,7 +294,7 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
         applySnapshot(false);
     }
 
-    private void applySnapshot(boolean fromInitialize) {
+    private synchronized void applySnapshot(boolean fromInitialize) {
         DaoState persistedDaoState = daoStateStorageService.getPersistedBsqState();
         if (persistedDaoState == null) {
             log.info("Try to apply snapshot but no stored snapshot available. That is expected at first blocks.");


### PR DESCRIPTION
- [DaoSnapshot: Fix persistingBlockInProgress data race](https://github.com/bisq-network/bisq/commit/3b5ccd267b1af484b6eb9ac0f42c3987271b054b)
  - The persistingBlockInProgress field is read by the block parsing thread. However, the block parsing thread and user thread write to the persistingBlockInProgress field. The block parsing thread might see the update too late and trigger another snapshot before the previous was done.
- [DaoSnapshot: Skip snapshot creation early if another in progress](https://github.com/bisq-network/bisq/commit/f5a0b6982e0c62d958f5851b36515bc9f3ff768d)
  - Check if another snapshot creation is in progress before doing any computation.
- [DaoSnapshot: Fix isParseBlockChainComplete field data race](https://github.com/bisq-network/bisq/commit/3de36509f0eca52af10b8a4fba4a480cacddd546)
- [DaoSnapshot: Fix race condition in applySnapshot](https://github.com/bisq-network/bisq/commit/15f6b8ece5e1fda33867e512c6eaa376be66d0d2)
- [DaoSnapshot: Fix resyncDaoStateFromResources race condition](https://github.com/bisq-network/bisq/commit/4ec4477ddfd035cd2571c7b06ce520b607f576f0)