### PR TITLE
Ensure AutoConfirmSettings is reset if it contains my retired explorer

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -384,10 +384,15 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             setBsqBlockChainExplorer(bsqExplorers.get((new Random()).nextInt(bsqExplorers.size())));
         }
 
-        // Remove retired XMR AutoConfirm address
+        // Remove retired XMR AutoConfirm addresses
+        List<String> retiredAddresses = List.of(
+                "monero3bec7m26vx6si6qo7q7imlaoz45ot5m2b5z2ppgoooo6jx2rqd",
+                "devinxmrwu4jrfq2zmq5kqjpxb44hx7i7didebkwrtvmvygj4uuop2ad"
+        );
         var doApplyDefaults = prefPayload.getAutoConfirmSettingsList().stream()
                 .map(autoConfirmSettings -> autoConfirmSettings.getServiceAddresses().stream()
-                        .anyMatch(address -> address.contains("monero3bec7m26vx6si6qo7q7imlaoz45ot5m2b5z2ppgoooo6jx2rqd")))
+                        .anyMatch(address -> retiredAddresses.stream()
+                                .anyMatch(address::contains)))
                 .findAny()
                 .orElse(true);
         if (doApplyDefaults) {

--- a/core/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/core/src/test/java/bisq/core/user/PreferencesTest.java
@@ -156,4 +156,34 @@ public class PreferencesTest {
         preferences.readPersisted(() ->
                 assertEquals("US Dollar (USD)", preferences.getFiatCurrenciesAsObservable().get(0).getNameAndCode()));
     }
+
+    @Test
+    void testRemoveRetiredXmrAutoConfirmAddresses() {
+        PreferencesPayload payload = mock(PreferencesPayload.class);
+
+        FiatCurrency usd = new FiatCurrency(Currency.getInstance("USD"), new Locale("de", "AT"));
+        List<AutoConfirmSettings> autoConfirmSettingsList = new ArrayList<>(List.of(
+                new AutoConfirmSettings(
+                        true,
+                        3,
+                        1,
+                        List.of("devinxmrwu4jrfq2zmq5kqjpxb44hx7i7didebkwrtvmvygj4uuop2ad.onion",
+                                "xmrexplrthytnunr4jasr3vnjc6jo5idsyxzv74a7ep7dy7lwcv2eoyd.onion"),
+                        "XMR")
+        ));
+
+        addReadPersistedStub(payload);
+
+        when(payload.getUserLanguage()).thenReturn("en");
+        when(payload.getUserCountry()).thenReturn(CountryUtil.getDefaultCountry());
+        when(payload.getPreferredTradeCurrency()).thenReturn(usd);
+        when(payload.getAutoConfirmSettingsList()).thenReturn(autoConfirmSettingsList);
+
+        preferences.readPersisted(() ->
+                assertEquals(
+                        List.of(
+                                "xmrexplrthytnunr4jasr3vnjc6jo5idsyxzv74a7ep7dy7lwcv2eoyd.onion",
+                                "nklwsomtuok6dhqqecp3a26xzgokfgmeuaplcdkaxehncg57yzarvbad.onion"),
+                        preferences.getAutoConfirmSettingsList().get(0).getServiceAddresses()));
+    }
 }


### PR DESCRIPTION
My XMR explorer was removed in bisq-network/bisq#7137. I just recently shut it down as per https://github.com/bisq-network/roles/issues/109#issuecomment-2581327905. This change ensures AutoConfirmSettings is reset if it contains my explorer address.
