### PR TITLE
Improve XMR subaddress popup behaviour

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/XmrForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/XmrForm.java
@@ -203,6 +203,13 @@ public class XmrForm extends AssetsForm {
         setFieldManagement(xmrAccountDelegate.isUsingSubAddresses());
         addLimitations(false);
         addAccountNameTextFieldWithAutoFillToggleButton();
+
+        new Popup()
+                .headLine(Res.get("account.altcoin.popup.xmr.dataDirWarningHeadline"))
+                .backgroundInfo(Res.get("account.altcoin.popup.xmr.dataDirWarning"))
+                .dontShowAgainId("accountSubAddressInfo")
+                .width(700)
+                .show();
     }
 
     void setFieldManagement(boolean useSubAddresses) {

--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/XmrForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/XmrForm.java
@@ -204,12 +204,7 @@ public class XmrForm extends AssetsForm {
         addLimitations(false);
         addAccountNameTextFieldWithAutoFillToggleButton();
 
-        new Popup()
-                .headLine(Res.get("account.altcoin.popup.xmr.dataDirWarningHeadline"))
-                .backgroundInfo(Res.get("account.altcoin.popup.xmr.dataDirWarning"))
-                .dontShowAgainId("accountSubAddressInfo")
-                .width(700)
-                .show();
+        showXmrSubAddressPopup();
     }
 
     void setFieldManagement(boolean useSubAddresses) {
@@ -367,6 +362,15 @@ public class XmrForm extends AssetsForm {
                         && xmrAccountDelegate.getAccount().getSingleTradeCurrency() != null);
             }
         }
+    }
+
+    public static void showXmrSubAddressPopup() {
+        new Popup()
+                .headLine(Res.get("account.altcoin.popup.xmr.dataDirWarningHeadline"))
+                .backgroundInfo(Res.get("account.altcoin.popup.xmr.dataDirWarning"))
+                .dontShowAgainId("accountSubAddressInfo")
+                .width(700)
+                .show();
     }
 
     private void maybeShowXmrSubAddressInfo() {

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
@@ -18,11 +18,10 @@
 package bisq.desktop.main.account.content.altcoinaccounts;
 
 import bisq.desktop.common.model.ActivatableDataModel;
-import bisq.desktop.main.overlays.popups.Popup;
+import bisq.desktop.components.paymentmethods.XmrForm;
 import bisq.desktop.util.GUIUtil;
 
 import bisq.core.locale.CryptoCurrency;
-import bisq.core.locale.Res;
 import bisq.core.locale.TradeCurrency;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.payment.AssetAccount;
@@ -85,12 +84,7 @@ class AltCoinAccountsDataModel extends ActivatableDataModel {
                 .filter(e -> e.getSingleTradeCurrency().getCode().equals("XMR"))
                 .forEach(e -> {
                     if (!xmrAccountUsesSubAddresses(e)) {
-                        new Popup()
-                                .headLine(Res.get("account.altcoin.popup.xmr.dataDirWarningHeadline"))
-                                .backgroundInfo(Res.get("account.altcoin.popup.xmr.dataDirWarning"))
-                                .dontShowAgainId("accountSubAddressInfo")
-                                .width(700)
-                                .show();
+                        XmrForm.showXmrSubAddressPopup();
                     }
                 });
     }


### PR DESCRIPTION
- [Show XMR subaddress popup if user has non-subaddress account](https://github.com/bisq-network/bisq/commit/958661f25bf31624e82af0778fd6974052837682)
  - Before PR https://github.com/bisq-network/bisq/pull/7123, we showed the XMR subaddress popup whenever the user navigated to the account tab. After PR https://github.com/bisq-network/bisq/pull/7123, we show the XMR subaddress popup if the user has an XMR account. However, it's better show the popup if the user has a non-subaddress XMR account.
- [Show XMR subaddress popup during account creation](https://github.com/bisq-network/bisq/commit/5e04336c4d0daa17c3dff1b401eaace0a8433222)
  - Additionally show the XMR subaddress popup during account creation, so that user can look up how subaddresses work and set it up.
- [Refactor duplicate XMR subaddress popup code](https://github.com/bisq-network/bisq/commit/861f655ae7de9d42196aa6deb696c78b57fa5266)