### PR TITLE
cli: Option parser checks if empty twice

### DIFF
--- a/cli/src/main/java/bisq/cli/opts/AbstractMethodOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/AbstractMethodOptionParser.java
@@ -74,8 +74,7 @@ abstract class AbstractMethodOptionParser implements MethodOpts {
         }
     }
 
-    protected final Predicate<OptionSpec<String>> valueNotSpecified = (opt) ->
-            !options.hasArgument(opt) || options.valueOf(opt).isEmpty();
+    protected final Predicate<OptionSpec<String>> valueNotSpecified = (opt) -> !options.hasArgument(opt);
 
     private final Function<OptionException, String> cliExceptionMessageStyle = (ex) -> {
         if (ex.getMessage() == null)


### PR DESCRIPTION
The OptionSet.hasArgument(...) method [1] already check if the argument is empty.

[1] https://github.com/jopt-simple/jopt-simple/blob/jopt-simple-5.0.4/src/main/java/joptsimple/OptionSet.java#L127

Relates to #7386.