### PR TITLE
chore: print RemoveAssetProposal instead of generic

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
@@ -133,7 +133,7 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
 
     @Override
     public String toString() {
-        return "GenericProposal{" +
+        return "RemoveAssetProposal{" +
                 "\n     tickerSymbol=" + tickerSymbol +
                 "\n} " + super.toString();
     }


### PR DESCRIPTION
small fix to `toString` to reflect name of class correctly
