### PR TITLE
Handle burning man selection height edge cases

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -59,6 +59,8 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
     // See: https://github.com/bisq-network/proposals/issues/412
     public static final Date PROPOSAL_412_ACTIVATION_DATE = Utilities.getUTCDate(2024, GregorianCalendar.MAY, 1);
 
+    public static final int SNAPSHOT_SELECTION_GRID_SIZE = 10;
+
     // We don't allow to get further back than 767950 (the block height from Dec. 18th 2022).
     static final int MIN_SNAPSHOT_HEIGHT = Config.baseCurrencyNetwork().isRegtest() ? 0 : 767950;
 
@@ -116,7 +118,8 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
     // The block height is the last mod(10) height from the range of the last 10-20 blocks (139 -> 120; 140 -> 130, 141 -> 130).
     // We do not have the latest dao state by that but can ensure maker and taker have the same block.
     public int getBurningManSelectionHeight() {
-        return getSnapshotHeight(daoStateService.getGenesisBlockHeight(), currentChainHeight, 10);
+        return getSnapshotHeight(daoStateService.getGenesisBlockHeight(), currentChainHeight,
+                SNAPSHOT_SELECTION_GRID_SIZE);
     }
 
     public List<Tuple2<Long, String>> getReceivers(int burningManSelectionHeight,

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -217,7 +217,7 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
 
     // Borrowed from DaoStateSnapshotService. We prefer to not reuse to avoid dependency to an unrelated domain.
     @VisibleForTesting
-    static int getSnapshotHeight(int genesisHeight, int height, int grid, int minSnapshotHeight) {
+    public static int getSnapshotHeight(int genesisHeight, int height, int grid, int minSnapshotHeight) {
         if (height > (genesisHeight + 3 * grid)) {
             int ratio = (int) Math.round(height / (double) grid);
             return Math.max(minSnapshotHeight, ratio * grid - grid);

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -47,6 +47,7 @@ import bisq.core.support.dispute.refund.refundagent.RefundAgentManager;
 import bisq.core.trade.ClosedTradableManager;
 import bisq.core.trade.bisq_v1.TransactionResultHandler;
 import bisq.core.trade.model.TradableList;
+import bisq.core.trade.protocol.bisq_v1.tasks.maker.MakerProcessesInputsForDepositTxRequest;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
@@ -857,7 +858,10 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 checkArgument(takersBurningManSelectionHeight > 0, "takersBurningManSelectionHeight must not be 0");
 
                 int makersBurningManSelectionHeight = delayedPayoutTxReceiverService.getBurningManSelectionHeight();
-                checkArgument(takersBurningManSelectionHeight == makersBurningManSelectionHeight,
+
+                boolean areBurningManSelectionHeightsValid = MakerProcessesInputsForDepositTxRequest
+                        .verifyBurningManSelectionHeight(takersBurningManSelectionHeight, makersBurningManSelectionHeight);
+                checkArgument(areBurningManSelectionHeightsValid,
                         "takersBurningManSelectionHeight does no match makersBurningManSelectionHeight. " +
                                 "takersBurningManSelectionHeight=" + takersBurningManSelectionHeight + "; makersBurningManSelectionHeight=" + makersBurningManSelectionHeight);
             } catch (Throwable t) {

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequestTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequestTest.java
@@ -1,0 +1,44 @@
+package bisq.core.trade.protocol.bisq_v1.tasks.maker;
+
+import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MakerProcessesInputsForDepositTxRequestTest {
+    private static final int GENESIS_HEIGHT = 102;
+    private static final int GRID_SIZE = DelayedPayoutTxReceiverService.SNAPSHOT_SELECTION_GRID_SIZE;
+
+    @Test
+    void burningManSelectionHeightSameBlock() {
+        assertEquals(130,
+                DelayedPayoutTxReceiverService.getSnapshotHeight(GENESIS_HEIGHT, 139, GRID_SIZE, 0));
+        boolean isValid = MakerProcessesInputsForDepositTxRequest
+                .verifyBurningManSelectionHeight(130, 130);
+        assertTrue(isValid);
+    }
+
+    @Test
+    void burningManSelectionHeightMakerOneBlockInFuture() {
+        assertEquals(120,
+                DelayedPayoutTxReceiverService.getSnapshotHeight(GENESIS_HEIGHT, 134, GRID_SIZE, 0));
+        assertEquals(130,
+                DelayedPayoutTxReceiverService.getSnapshotHeight(GENESIS_HEIGHT, 135, GRID_SIZE, 0));
+        boolean isValid = MakerProcessesInputsForDepositTxRequest
+                .verifyBurningManSelectionHeight(120, 130);
+        assertTrue(isValid);
+    }
+
+    @Test
+    void burningManSelectionHeightTakerOneBlockInFuture() {
+        assertEquals(120,
+                DelayedPayoutTxReceiverService.getSnapshotHeight(GENESIS_HEIGHT, 134, GRID_SIZE, 0));
+        assertEquals(130,
+                DelayedPayoutTxReceiverService.getSnapshotHeight(GENESIS_HEIGHT, 135, GRID_SIZE, 0));
+        boolean isValid = MakerProcessesInputsForDepositTxRequest
+                .verifyBurningManSelectionHeight(130, 120);
+        assertTrue(isValid);
+    }
+}


### PR DESCRIPTION
If trader A's block height is 134 his burning man selection height is
120, and if trader B's block height is 135 his burning man selection
height is 130.

The current burning man selection height verification code doesn't
handle these edge-cases.

Changes:
- [DelayedPayoutTxReceiverService: Make bm snapshot grid size a constant](https://github.com/bisq-network/bisq/commit/353ff6d06f11d7f6eed7a4f1be52cfd0ad7e0c68)
- [Handle burning man selection height edge-cases](https://github.com/bisq-network/bisq/commit/96355d7a3cd0ad3cf5d6dfbe62c6cfd28e9a4e45)