### PR TITLE
Use taker's burning man selection height

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -90,7 +90,7 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
             checkArgument(areBurningManSelectionHeightsValid,
                     "takersBurningManSelectionHeight does no match makersBurningManSelectionHeight");
 
-            processModel.setBurningManSelectionHeight(makersBurningManSelectionHeight);
+            processModel.setBurningManSelectionHeight(takersBurningManSelectionHeight);
 
             // We set the taker fee only in the processModel yet not in the trade as the tx was only created but not
             // published yet. Once it was published we move it to trade. The takerFeeTx should be sent in a later


### PR DESCRIPTION
When a taker takes a trade he sends his burning man selection height to
the maker. After validating the taker's burning man selection height, he
has to use the taker's burning man selection height to verify the
taker's delayed payout transaction because the maker's and taker's
burning man selection height could be different. The current
implementation uses the maker's burning man selection height. This can
cause failed trades.

Relates to https://github.com/bisq-network/bisq/pull/7393.