### PR TITLE
Fix trade protocol filter version enforcement

### DIFF
--- a/core/src/main/java/bisq/core/trade/bisq_v1/TradeUtil.java
+++ b/core/src/main/java/bisq/core/trade/bisq_v1/TradeUtil.java
@@ -266,9 +266,6 @@ public class TradeUtil {
         } else if (paymentAccountPayload != null && filterManager.arePeersPaymentAccountDataBanned(paymentAccountPayload)) {
             failed.handleErrorMessage("Other trader is banned by their trading account data.\n" +
                     "paymentAccountPayload=" + paymentAccountPayload.getPaymentDetails());
-        } else if (filterManager.requireUpdateToNewVersionForTrading()) {
-            failed.handleErrorMessage("Your version of Bisq is not compatible for trading anymore. " +
-                    "Please update to the latest Bisq version at https://bisq.network/downloads.");
         } else {
             complete.handleResult();
         }

--- a/core/src/main/java/bisq/core/trade/bisq_v1/TradeUtil.java
+++ b/core/src/main/java/bisq/core/trade/bisq_v1/TradeUtil.java
@@ -273,4 +273,15 @@ public class TradeUtil {
             complete.handleResult();
         }
     }
+
+    public static void enforceFilterVersion(FilterManager filterManager,
+                                            ResultHandler complete,
+                                            ErrorMessageHandler failed) {
+        if (filterManager.requireUpdateToNewVersionForTrading()) {
+            failed.handleErrorMessage("Your version of Bisq is not compatible for trading anymore. " +
+                    "Please update to the latest Bisq version at https://bisq.network/downloads.");
+        } else {
+            complete.handleResult();
+        }
+    }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsMakerProtocol.java
@@ -27,6 +27,7 @@ import bisq.core.trade.protocol.bisq_v1.messages.PayoutTxPublishedMessage;
 import bisq.core.trade.protocol.bisq_v1.tasks.ApplyFilter;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckIfDaoStateIsInSync;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckRestrictions;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.core.trade.protocol.bisq_v1.tasks.buyer.BuyerFinalizesDelayedPayoutTx;
 import bisq.core.trade.protocol.bisq_v1.tasks.buyer.BuyerProcessDelayedPayoutTxSignatureRequest;
@@ -73,6 +74,7 @@ public class BuyerAsMakerProtocol extends BuyerProtocol implements MakerProtocol
                 .with(message)
                 .from(peer))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         CheckIfDaoStateIsInSync.class,
                         MakerProcessesInputsForDepositTxRequest.class,
                         ApplyFilter.class,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerAsTakerProtocol.java
@@ -29,6 +29,7 @@ import bisq.core.trade.protocol.bisq_v1.messages.PayoutTxPublishedMessage;
 import bisq.core.trade.protocol.bisq_v1.tasks.ApplyFilter;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckIfDaoStateIsInSync;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckRestrictions;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.core.trade.protocol.bisq_v1.tasks.buyer.BuyerFinalizesDelayedPayoutTx;
 import bisq.core.trade.protocol.bisq_v1.tasks.buyer.BuyerProcessDelayedPayoutTxSignatureRequest;
@@ -79,6 +80,7 @@ public class BuyerAsTakerProtocol extends BuyerProtocol implements TakerProtocol
         expect(phase(Trade.Phase.INIT)
                 .with(TakerEvent.TAKE_OFFER))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         CheckIfDaoStateIsInSync.class,
                         ApplyFilter.class,
                         CheckRestrictions.class,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsMakerProtocol.java
@@ -29,6 +29,7 @@ import bisq.core.trade.protocol.bisq_v1.messages.InputsForDepositTxRequest;
 import bisq.core.trade.protocol.bisq_v1.tasks.ApplyFilter;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckIfDaoStateIsInSync;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckRestrictions;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.core.trade.protocol.bisq_v1.tasks.maker.MakerCreateAndSignContract;
 import bisq.core.trade.protocol.bisq_v1.tasks.maker.MakerProcessesInputsForDepositTxRequest;
@@ -75,6 +76,7 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
                 .with(message)
                 .from(peer))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         CheckIfDaoStateIsInSync.class,
                         MaybeCreateSubAccount.class,
                         MakerProcessesInputsForDepositTxRequest.class,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerAsTakerProtocol.java
@@ -28,6 +28,7 @@ import bisq.core.trade.protocol.bisq_v1.messages.InputsForDepositTxResponse;
 import bisq.core.trade.protocol.bisq_v1.tasks.ApplyFilter;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckIfDaoStateIsInSync;
 import bisq.core.trade.protocol.bisq_v1.tasks.CheckRestrictions;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.core.trade.protocol.bisq_v1.tasks.seller.MaybeCreateSubAccount;
 import bisq.core.trade.protocol.bisq_v1.tasks.seller.SellerCreatesDelayedPayoutTx;
@@ -75,6 +76,7 @@ public class SellerAsTakerProtocol extends SellerProtocol implements TakerProtoc
                 .with(TakerEvent.TAKE_OFFER)
                 .from(trade.getTradingPeerNodeAddress()))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         CheckIfDaoStateIsInSync.class,
                         MaybeCreateSubAccount.class,
                         ApplyFilter.class,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/EnforceFilterVersion.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/EnforceFilterVersion.java
@@ -1,0 +1,24 @@
+package bisq.core.trade.protocol.bisq_v1.tasks;
+
+import bisq.core.filter.FilterManager;
+import bisq.core.trade.bisq_v1.TradeUtil;
+import bisq.core.trade.model.bisq_v1.Trade;
+
+import bisq.common.taskrunner.TaskRunner;
+
+public class EnforceFilterVersion extends TradeTask {
+    public EnforceFilterVersion(TaskRunner<Trade> taskHandler, Trade trade) {
+        super(taskHandler, trade);
+    }
+
+    @Override
+    protected void run() {
+        try {
+            runInterceptHook();
+            FilterManager filterManager = processModel.getFilterManager();
+            TradeUtil.enforceFilterVersion(filterManager, this::complete, this::failed);
+        } catch (Throwable t) {
+            failed(t);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapBuyerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapBuyerAsMakerProtocol.java
@@ -21,6 +21,7 @@ package bisq.core.trade.protocol.bsq_swap;
 import bisq.core.trade.model.bsq_swap.BsqSwapBuyerAsMakerTrade;
 import bisq.core.trade.protocol.TradeMessage;
 import bisq.core.trade.protocol.TradeTaskRunner;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapFinalizeTxRequest;
 import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapRequest;
 import bisq.core.trade.protocol.bsq_swap.messages.SellersBsqSwapRequest;
@@ -59,6 +60,7 @@ public class BsqSwapBuyerAsMakerProtocol extends BsqSwapBuyerProtocol implements
                 .with(request)
                 .from(sender))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         ApplyFilter.class,
                         ProcessSellersBsqSwapRequest.class,
                         BuyerAsMakerCreatesBsqInputsAndChange.class,

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapBuyerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapBuyerAsTakerProtocol.java
@@ -22,6 +22,7 @@ import bisq.core.offer.Offer;
 import bisq.core.trade.model.bsq_swap.BsqSwapBuyerAsTakerTrade;
 import bisq.core.trade.protocol.TradeMessage;
 import bisq.core.trade.protocol.TradeTaskRunner;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapFinalizeTxRequest;
 import bisq.core.trade.protocol.bsq_swap.tasks.ApplyFilter;
 import bisq.core.trade.protocol.bsq_swap.tasks.buyer.BuyerPublishesTx;
@@ -56,6 +57,7 @@ public class BsqSwapBuyerAsTakerProtocol extends BsqSwapBuyerProtocol implements
                 .with(TAKE_OFFER)
                 .from(trade.getTradingPeerNodeAddress()))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         ApplyFilter.class,
                         BuyerAsTakerCreatesBsqInputsAndChange.class,
                         SendBuyersBsqSwapRequest.class)

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapSellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapSellerAsMakerProtocol.java
@@ -21,6 +21,7 @@ package bisq.core.trade.protocol.bsq_swap;
 import bisq.core.trade.model.bsq_swap.BsqSwapSellerAsMakerTrade;
 import bisq.core.trade.protocol.TradeMessage;
 import bisq.core.trade.protocol.TradeTaskRunner;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapFinalizedTxMessage;
 import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapRequest;
 import bisq.core.trade.protocol.bsq_swap.messages.BuyersBsqSwapRequest;
@@ -57,6 +58,7 @@ public class BsqSwapSellerAsMakerProtocol extends BsqSwapSellerProtocol implemen
                 .with(request)
                 .from(sender))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         ApplyFilter.class,
                         ProcessBuyersBsqSwapRequest.class,
                         SellerAsMakerCreatesAndSignsTx.class,

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapSellerAsTakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/BsqSwapSellerAsTakerProtocol.java
@@ -22,6 +22,7 @@ import bisq.core.offer.Offer;
 import bisq.core.trade.model.bsq_swap.BsqSwapSellerAsTakerTrade;
 import bisq.core.trade.protocol.TradeMessage;
 import bisq.core.trade.protocol.TradeTaskRunner;
+import bisq.core.trade.protocol.bisq_v1.tasks.EnforceFilterVersion;
 import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapFinalizedTxMessage;
 import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapTxInputsMessage;
 import bisq.core.trade.protocol.bsq_swap.tasks.ApplyFilter;
@@ -57,6 +58,7 @@ public class BsqSwapSellerAsTakerProtocol extends BsqSwapSellerProtocol implemen
                 .with(TAKE_OFFER)
                 .from(trade.getTradingPeerNodeAddress()))
                 .setup(tasks(
+                        EnforceFilterVersion.class,
                         ApplyFilter.class,
                         SendSellersBsqSwapRequest.class)
                         .withTimeout(40))


### PR DESCRIPTION
- [Implement EnforceFilterVersion TradeTask](https://github.com/bisq-network/bisq/commit/54a9fed0209768174efa3ebd92aad14a521a22c0)
  - The EnforceFilterVersion (TradeTask) enforces that both traders run the required minimum version.
- [Run EnforceFilterVersion in protocol](https://github.com/bisq-network/bisq/commit/1a083ab246fa9abafa72c1532a5f69a81b4faa78)
  - We run the EnforceFilterVersion (TradeTask) when a taker "takes" an offer and when a maker receives a "take offer" request.
- [ApplyFilter task: Remove version enforcement](https://github.com/bisq-network/bisq/commit/96b4b915f17257f584568b7f2235febfa7ea4f14)
  - The EnforceFilterVersion task always runs before the ApplyFilter and ensures both traders run the minimum required version.