### PR TITLE
BisqExecutable: Fix startApplication() threading issue

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -150,7 +150,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
             // If user tried to downgrade we do not read the persisted data to avoid data corruption
             // We call startApplication to enable UI to show popup. We prevent in BisqSetup to go further
             // in the process and require a shut down.
-            startApplication();
+            UserThread.execute(this::startApplication);
         } else {
             readAllPersisted(this::startApplication);
         }


### PR DESCRIPTION
The startApplication method is only called on the user thread if the
user didn't downgrade his app. The readAllPersisted method calls
startApplication on the user thread. However, the code path handling
downgrades doesn't call startApplication on the user thread.