### PR TITLE
fix: return after calling failed

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -116,8 +116,10 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
                 trade.setPriceAsLong(takersTradePrice);
             } catch (TradePriceOutOfToleranceException e) {
                 failed(e.getMessage());
+                return;
             } catch (Throwable e2) {
                 failed(e2);
+                return;
             }
 
             checkArgument(request.getTradeAmount() > 0);

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerVerifyAndSignContract.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerVerifyAndSignContract.java
@@ -115,6 +115,7 @@ public class TakerVerifyAndSignContract extends TradeTask {
             if (!contractAsJson.equals(processModel.getTradePeer().getContractAsJson())) {
                 contract.printDiff(processModel.getTradePeer().getContractAsJson());
                 failed("Contracts are not matching");
+                return;
             }
 
             String signature = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), contractAsJson);


### PR DESCRIPTION
adds return after a few `failed()` calls, like the rest of tasks