### PR TITLE
Refactor blockchain explorer selection

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -786,11 +786,11 @@ public class BisqSetup {
 
     private void maybeUpgradeBsqExplorerUrl() {
         // if wiz BSQ explorer selected, replace with 1st explorer in the list of available.
-        if (preferences.getBsqBlockChainExplorer().name.equalsIgnoreCase("mempool.space (@wiz)") &&
+        if (preferences.getBsqBlockChainExplorer().getName().equalsIgnoreCase("mempool.space (@wiz)") &&
                 preferences.getBsqBlockChainExplorers().size() > 0) {
             preferences.setBsqBlockChainExplorer(preferences.getBsqBlockChainExplorers().get(0));
         }
-        if (preferences.getBsqBlockChainExplorer().name.equalsIgnoreCase("bisq.mempool.emzy.de (@emzy)") &&
+        if (preferences.getBsqBlockChainExplorer().getName().equalsIgnoreCase("bisq.mempool.emzy.de (@emzy)") &&
                 preferences.getBsqBlockChainExplorers().size() > 0) {
             preferences.setBsqBlockChainExplorer(preferences.getBsqBlockChainExplorers().get(0));
         }

--- a/core/src/main/java/bisq/core/user/BlockChainExplorer.java
+++ b/core/src/main/java/bisq/core/user/BlockChainExplorer.java
@@ -22,11 +22,14 @@ import bisq.common.proto.persistable.PersistablePayload;
 import com.google.protobuf.Message;
 
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public final class BlockChainExplorer implements PersistablePayload {
     private final String name;
     private final String txUrl;
+    @ToString.Exclude
     private final String addressUrl;
 
     public BlockChainExplorer(String name, String txUrl, String addressUrl) {

--- a/core/src/main/java/bisq/core/user/BlockChainExplorer.java
+++ b/core/src/main/java/bisq/core/user/BlockChainExplorer.java
@@ -21,10 +21,13 @@ import bisq.common.proto.persistable.PersistablePayload;
 
 import com.google.protobuf.Message;
 
+import lombok.Getter;
+
+@Getter
 public final class BlockChainExplorer implements PersistablePayload {
-    public final String name;
-    public final String txUrl;
-    public final String addressUrl;
+    private final String name;
+    private final String txUrl;
+    private final String addressUrl;
 
     public BlockChainExplorer(String name, String txUrl, String addressUrl) {
         this.name = name;

--- a/core/src/main/java/bisq/core/user/BlockchainExplorerSelection.java
+++ b/core/src/main/java/bisq/core/user/BlockchainExplorerSelection.java
@@ -26,16 +26,16 @@ public class BlockchainExplorerSelection {
         // if no valid Bitcoin block explorer is set, select the 1st valid Bitcoin block explorer
         ArrayList<BlockChainExplorer> btcExplorers = preferences.getBlockChainExplorers();
         if (preferences.getBlockChainExplorer() == null ||
-                preferences.getBlockChainExplorer().name.length() == 0 ||
-                preferences.getBlockChainExplorer().name.matches(deprecatedExplorers)) {
+                preferences.getBlockChainExplorer().getName().length() == 0 ||
+                preferences.getBlockChainExplorer().getName().matches(deprecatedExplorers)) {
             preferences.setBlockChainExplorer(btcExplorers.get(0));
         }
 
         // if no valid BSQ block explorer is set, randomly select a valid BSQ block explorer
         ArrayList<BlockChainExplorer> bsqExplorers = preferences.getBsqBlockChainExplorers();
         if (preferences.getBsqBlockChainExplorer() == null ||
-                preferences.getBsqBlockChainExplorer().name.length() == 0 ||
-                preferences.getBsqBlockChainExplorer().name.matches(deprecatedExplorers)) {
+                preferences.getBsqBlockChainExplorer().getName().length() == 0 ||
+                preferences.getBsqBlockChainExplorer().getName().matches(deprecatedExplorers)) {
             preferences.setBsqBlockChainExplorer(bsqExplorers.get((new Random()).nextInt(bsqExplorers.size())));
         }
 

--- a/core/src/main/java/bisq/core/user/BlockchainExplorerSelection.java
+++ b/core/src/main/java/bisq/core/user/BlockchainExplorerSelection.java
@@ -1,0 +1,63 @@
+package bisq.core.user;
+
+import bisq.common.persistence.PersistenceManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class BlockchainExplorerSelection {
+    private final Preferences preferences;
+    private final PreferencesPayload prefPayload;
+    private final PersistenceManager<PreferencesPayload> persistenceManager;
+
+    public BlockchainExplorerSelection(Preferences preferences, PreferencesPayload prefPayload,
+                                       PersistenceManager<PreferencesPayload> persistenceManager) {
+        this.preferences = preferences;
+        this.prefPayload = prefPayload;
+        this.persistenceManager = persistenceManager;
+    }
+
+    public void selectNodes() {
+        // a list of previously-used federated explorers
+        // if user preference references any deprecated explorers we need to select a new valid explorer
+        String deprecatedExplorers = "(bsq.bisq.cc|bsq.vante.me|bsq.emzy.de|bsq.sqrrm.net|bsq.bisq.services|bsq.ninja|bisq.mempool.emzy.de).*";
+
+        // if no valid Bitcoin block explorer is set, select the 1st valid Bitcoin block explorer
+        ArrayList<BlockChainExplorer> btcExplorers = preferences.getBlockChainExplorers();
+        if (preferences.getBlockChainExplorer() == null ||
+                preferences.getBlockChainExplorer().name.length() == 0 ||
+                preferences.getBlockChainExplorer().name.matches(deprecatedExplorers)) {
+            preferences.setBlockChainExplorer(btcExplorers.get(0));
+        }
+
+        // if no valid BSQ block explorer is set, randomly select a valid BSQ block explorer
+        ArrayList<BlockChainExplorer> bsqExplorers = preferences.getBsqBlockChainExplorers();
+        if (preferences.getBsqBlockChainExplorer() == null ||
+                preferences.getBsqBlockChainExplorer().name.length() == 0 ||
+                preferences.getBsqBlockChainExplorer().name.matches(deprecatedExplorers)) {
+            preferences.setBsqBlockChainExplorer(bsqExplorers.get((new Random()).nextInt(bsqExplorers.size())));
+        }
+
+        // Remove retired XMR AutoConfirm addresses
+        List<String> retiredAddresses = List.of(
+                "monero3bec7m26vx6si6qo7q7imlaoz45ot5m2b5z2ppgoooo6jx2rqd",
+                "devinxmrwu4jrfq2zmq5kqjpxb44hx7i7didebkwrtvmvygj4uuop2ad"
+        );
+        var doApplyDefaults = prefPayload.getAutoConfirmSettingsList().stream()
+                .map(autoConfirmSettings -> autoConfirmSettings.getServiceAddresses().stream()
+                        .anyMatch(address -> retiredAddresses.stream()
+                                .anyMatch(address::contains)))
+                .findAny()
+                .orElse(true);
+        if (doApplyDefaults) {
+            prefPayload.getAutoConfirmSettingsList().clear();
+            List<String> defaultXmrTxProofServices = preferences.getDefaultXmrTxProofServices();
+            AutoConfirmSettings.getDefault(defaultXmrTxProofServices, "XMR")
+                    .ifPresent(xmrAutoConfirmSettings -> {
+                        preferences.getAutoConfirmSettingsList().add(xmrAutoConfirmSettings);
+                    });
+            persistenceManager.forcePersistNow();
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/core/src/test/java/bisq/core/user/PreferencesTest.java
@@ -156,34 +156,4 @@ public class PreferencesTest {
         preferences.readPersisted(() ->
                 assertEquals("US Dollar (USD)", preferences.getFiatCurrenciesAsObservable().get(0).getNameAndCode()));
     }
-
-    @Test
-    void testRemoveRetiredXmrAutoConfirmAddresses() {
-        PreferencesPayload payload = mock(PreferencesPayload.class);
-
-        FiatCurrency usd = new FiatCurrency(Currency.getInstance("USD"), new Locale("de", "AT"));
-        List<AutoConfirmSettings> autoConfirmSettingsList = new ArrayList<>(List.of(
-                new AutoConfirmSettings(
-                        true,
-                        3,
-                        1,
-                        List.of("devinxmrwu4jrfq2zmq5kqjpxb44hx7i7didebkwrtvmvygj4uuop2ad.onion",
-                                "xmrexplrthytnunr4jasr3vnjc6jo5idsyxzv74a7ep7dy7lwcv2eoyd.onion"),
-                        "XMR")
-        ));
-
-        addReadPersistedStub(payload);
-
-        when(payload.getUserLanguage()).thenReturn("en");
-        when(payload.getUserCountry()).thenReturn(CountryUtil.getDefaultCountry());
-        when(payload.getPreferredTradeCurrency()).thenReturn(usd);
-        when(payload.getAutoConfirmSettingsList()).thenReturn(autoConfirmSettingsList);
-
-        preferences.readPersisted(() ->
-                assertEquals(
-                        List.of(
-                                "xmrexplrthytnunr4jasr3vnjc6jo5idsyxzv74a7ep7dy7lwcv2eoyd.onion",
-                                "nklwsomtuok6dhqqecp3a26xzgokfgmeuaplcdkaxehncg57yzarvbad.onion"),
-                        preferences.getAutoConfirmSettingsList().get(0).getServiceAddresses()));
-    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/EditCustomExplorerWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/EditCustomExplorerWindow.java
@@ -130,9 +130,9 @@ public class EditCustomExplorerWindow extends Overlay<EditCustomExplorerWindow> 
         button.setOnAction(e -> {
             BlockChainExplorer blockChainExplorer = listView.getSelectionModel().getSelectedItem();
             if (blockChainExplorer != null) {
-                nameInputTextField.setText(blockChainExplorer.name);
-                txUrlInputTextField.setText(blockChainExplorer.txUrl);
-                addressUrlInputTextField.setText(blockChainExplorer.addressUrl);
+                nameInputTextField.setText(blockChainExplorer.getName());
+                txUrlInputTextField.setText(blockChainExplorer.getTxUrl());
+                addressUrlInputTextField.setText(blockChainExplorer.getAddressUrl());
             }
         });
         button.setStyle("-fx-pref-width: 50px; -fx-pref-height: 30; -fx-padding: 3 3 3 3;");
@@ -159,7 +159,7 @@ public class EditCustomExplorerWindow extends Overlay<EditCustomExplorerWindow> 
                     public void updateItem(final BlockChainExplorer item, boolean empty) {
                         super.updateItem(item, empty);
                         if (item != null && !empty) {
-                            label.setText(item.name);
+                            label.setText(item.getName());
                             setGraphic(pane);
                         } else {
                             setGraphic(null);
@@ -172,9 +172,9 @@ public class EditCustomExplorerWindow extends Overlay<EditCustomExplorerWindow> 
                     public void handle(MouseEvent event) {
                         if (event.getClickCount() == 2) {
                             BlockChainExplorer blockChainExplorer = listView.getSelectionModel().getSelectedItem();
-                            nameInputTextField.setText(blockChainExplorer.name);
-                            txUrlInputTextField.setText(blockChainExplorer.txUrl);
-                            addressUrlInputTextField.setText(blockChainExplorer.addressUrl);
+                            nameInputTextField.setText(blockChainExplorer.getName());
+                            txUrlInputTextField.setText(blockChainExplorer.getTxUrl());
+                            addressUrlInputTextField.setText(blockChainExplorer.getAddressUrl());
                         }
                     }
                 });
@@ -192,8 +192,8 @@ public class EditCustomExplorerWindow extends Overlay<EditCustomExplorerWindow> 
         nameInputTextField.setPrefWidth(Layout.INITIAL_WINDOW_WIDTH);
         txUrlInputTextField = addInputTextField(autoConfirmGridPane, ++localRowIndex, Res.get("settings.preferences.editCustomExplorer.txUrl"));
         addressUrlInputTextField = addInputTextField(autoConfirmGridPane, ++localRowIndex, Res.get("settings.preferences.editCustomExplorer.addressUrl"));
-        nameInputTextField.setText(currentExplorer.name);
-        txUrlInputTextField.setText(currentExplorer.txUrl);
-        addressUrlInputTextField.setText(currentExplorer.addressUrl);
+        nameInputTextField.setText(currentExplorer.getName());
+        txUrlInputTextField.setText(currentExplorer.getTxUrl());
+        addressUrlInputTextField.setText(currentExplorer.getAddressUrl());
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -1001,8 +1001,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         useBisqWalletForFundingToggle.setOnAction(e ->
                 preferences.setUseBisqWalletFunding(useBisqWalletForFundingToggle.isSelected()));
 
-        btcExplorerTextField.setText(preferences.getBlockChainExplorer().name);
-        bsqExplorerTextField.setText(preferences.getBsqBlockChainExplorer().name);
+        btcExplorerTextField.setText(preferences.getBlockChainExplorer().getName());
+        bsqExplorerTextField.setText(preferences.getBsqBlockChainExplorer().getName());
 
         deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent()));
         deviationInputTextField.textProperty().addListener(deviationListener);
@@ -1110,7 +1110,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                     .actionButtonText(Res.get("shared.save"))
                     .onAction(() -> {
                         preferences.setBlockChainExplorer(urlWindow.getEditedBlockChainExplorer());
-                        btcExplorerTextField.setText(preferences.getBlockChainExplorer().name);
+                        btcExplorerTextField.setText(preferences.getBlockChainExplorer().getName());
                     })
                     .closeButtonText(Res.get("shared.cancel"))
                     .onClose(urlWindow::hide)
@@ -1124,7 +1124,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                     .actionButtonText(Res.get("shared.save"))
                     .onAction(() -> {
                         preferences.setBsqBlockChainExplorer(urlWindow.getEditedBlockChainExplorer());
-                        bsqExplorerTextField.setText(preferences.getBsqBlockChainExplorer().name);
+                        bsqExplorerTextField.setText(preferences.getBsqBlockChainExplorer().getName());
                     })
                     .closeButtonText(Res.get("shared.cancel"))
                     .onClose(urlWindow::hide)

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -1221,19 +1221,19 @@ public class GUIUtil {
     }
 
     public static String getAddressUrl(String address) {
-        return preferences.getBlockChainExplorer().addressUrl + address;
+        return preferences.getBlockChainExplorer().getAddressUrl() + address;
     }
 
     public static String getBsqAddressUrl(String address) {
-        return preferences.getBsqBlockChainExplorer().addressUrl + address;
+        return preferences.getBsqBlockChainExplorer().getAddressUrl() + address;
     }
 
     public static String getTxUrl(String txId) {
-        return preferences.getBlockChainExplorer().txUrl + txId;
+        return preferences.getBlockChainExplorer().getTxUrl() + txId;
     }
 
     public static String getBsqTxUrl(String txId) {
-        return preferences.getBsqBlockChainExplorer().txUrl + txId;
+        return preferences.getBsqBlockChainExplorer().getTxUrl() + txId;
     }
 
     public static String getBsqInUsd(Price bsqPrice,


### PR DESCRIPTION
It's impossible to test the current blockchain explorer selection code. This change makes the required changes to the code.

Changes:
- [Move blockchain explorer selection to separate class](https://github.com/bisq-network/bisq/commit/eac2ed69d98e466695facff67852bc3fb39f1086)
- [BlockChainExplorer: Make fields private and add getters](https://github.com/bisq-network/bisq/commit/0e87610ca3e07ef4f7197f45c8062681ded42a5f)
- [Add toString() to BlockChainExplorer](https://github.com/bisq-network/bisq/commit/186ae2f29cb881a5737a0b424a37219c09aaea73)