### PR TITLE
fix: use payment-account-id param name consistently

### DIFF
--- a/apitest/scripts/limit-order-simulation.sh
+++ b/apitest/scripts/limit-order-simulation.sh
@@ -115,7 +115,7 @@ done
 
 printdate "ALICE: Creating $DIRECTION $CURRENCY_CODE offer with payment acct $ALICE_ACCT_ID."
 CMD="$CLI_BASE --port=$ALICE_PORT createoffer"
-CMD+=" --payment-account=$ALICE_ACCT_ID"
+CMD+=" --payment-account-id=$ALICE_ACCT_ID"
 CMD+=" --direction=$DIRECTION"
 CMD+=" --currency-code=$CURRENCY_CODE"
 CMD+=" --amount=$AMOUNT"

--- a/apitest/scripts/trade-simulation-utils.sh
+++ b/apitest/scripts/trade-simulation-utils.sh
@@ -183,7 +183,7 @@ gencreateoffercommand() {
     PORT="$1"
     ACCT_ID="$2"
     CMD="$CLI_BASE --port=$PORT createoffer"
-    CMD+=" --payment-account=$ACCT_ID"
+    CMD+=" --payment-account-id=$ACCT_ID"
     CMD+=" --direction=$DIRECTION"
     CMD+=" --currency-code=$CURRENCY_CODE"
     CMD+=" --amount=$AMOUNT"
@@ -476,7 +476,7 @@ executetrade() {
     printdate "First offer found: $OFFER_ID"
 
     # Take Alice's offer.
-    CMD="$CLI_BASE --port=$BOB_PORT takeoffer --offer-id=$OFFER_ID --payment-account=$BOB_ACCT_ID --fee-currency=BSQ"
+    CMD="$CLI_BASE --port=$BOB_PORT takeoffer --offer-id=$OFFER_ID --payment-account-id=$BOB_ACCT_ID --fee-currency=BSQ"
     printdate "BOB CLI: $CMD"
     TRADE=$($CMD)
     commandalert $? "Could not take offer."

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -920,7 +920,7 @@ public class CliMain {
             stream.println();
             stream.format(rowFormat, gettransaction.name(), "--transaction-id=<transaction-id>", "Get transaction with id");
             stream.println();
-            stream.format(rowFormat, createoffer.name(), "--payment-account=<payment-account-id> \\", "Create and place an offer");
+            stream.format(rowFormat, createoffer.name(), "--payment-account-id=<payment-account-id> \\", "Create and place an offer");
             stream.format(rowFormat, "", "--direction=<buy|sell> \\", "");
             stream.format(rowFormat, "", "--currency-code=<currency-code> \\", "");
             stream.format(rowFormat, "", "--amount=<btc-amount> \\", "");
@@ -950,7 +950,7 @@ public class CliMain {
             stream.format(rowFormat, "", "--currency-code=<currency-code>", "");
             stream.println();
             stream.format(rowFormat, takeoffer.name(), "--offer-id=<offer-id> \\", "Take offer with id");
-            stream.format(rowFormat, "", "[--payment-account=<payment-account-id>]", "");
+            stream.format(rowFormat, "", "[--payment-account-id=<payment-account-id>]", "");
             stream.format(rowFormat, "", "[--fee-currency=<btc|bsq>]", "");
             stream.format(rowFormat, "", "[--amount=<min-btc-amount >= amount <= btc-amount>]", "");
             stream.println();

--- a/core/src/main/resources/help/createoffer-help.txt
+++ b/core/src/main/resources/help/createoffer-help.txt
@@ -12,7 +12,7 @@ createoffer
 		--currency-code=<bsq|eur|usd|...>
 		--direction=<buy|sell>
 		--fixed-price=<btc-price> | --market-price-margin=<percent>
-		--payment-account=<payment-acct-id>
+		--payment-account-id=<payment-acct-id>
 		--security-deposit=<percent>
 		--swap=<true|false>
 		[--fee-currency=<bsq|btc>]
@@ -59,7 +59,7 @@ OPTIONS
 		The % above or below market BTC price, e.g., 1.00 (1%).
 		If --market-price-margin is not present, --fixed-price must be.
 
---payment-account
+--payment-account-id
 		The ID of the fiat payment account used to send or receive funds during the trade.
 
 --security-deposit
@@ -82,7 +82,7 @@ To create a BUY 0.125 BTC with EUR offer
 	using a payment account with ID 7413d263-225a-4f1b-837a-1e3094dc0d77,
 	putting up a 30 percent security deposit,
 	and paying the Bisq maker trading fee in BSQ:
-$ ./bisq-cli --password=xyz --port=9998 createoffer --payment-account=7413d263-225a-4f1b-837a-1e3094dc0d77 \
+$ ./bisq-cli --password=xyz --port=9998 createoffer --payment-account-id=7413d263-225a-4f1b-837a-1e3094dc0d77 \
     --direction=buy \
     --currency-code=eur \
     --amount=0.125 \
@@ -95,7 +95,7 @@ To create a SELL 0.006 BTC for USD offer
 	using a payment account with ID 7413d263-225a-4f1b-837a-1e3094dc0d77,
 	putting up a 25 percent security deposit,
 	and paying the Bisq maker trading fee in BTC:
-$ ./bisq-cli --password=xyz --port=9998 createoffer --payment-account=7413d263-225a-4f1b-837a-1e3094dc0d77 \
+$ ./bisq-cli --password=xyz --port=9998 createoffer --payment-account-id=7413d263-225a-4f1b-837a-1e3094dc0d77 \
     --direction=sell \
     --currency-code=usd \
     --amount=0.006 \

--- a/core/src/main/resources/help/takeoffer-help.txt
+++ b/core/src/main/resources/help/takeoffer-help.txt
@@ -8,7 +8,7 @@ SYNOPSIS
 --------
 takeoffer  (Bisq v1 Protocol)
 		--offer-id=<offer-id>
-		--payment-account=<payment-acct-id>
+		--payment-account-id=<payment-acct-id>
 		[--fee-currency=<btc|bsq>]
 		[--amount=<offer.min-btc-amount >= amount <= offer.btc-amount>]
 
@@ -25,7 +25,7 @@ Take an existing offer. There are currently two types offers and trade protocols
         The takeoffer command only requires an offer-id parameter, and sufficient BSQ and/or BTC
         to cover the trade amount and the taker fee.
         The amount parameter is optional.
-        The payment-account parameter is invalid;  BSQ Swap transactions use the default BsqSwapAccount.
+        The payment-account-id parameter is invalid;  BSQ Swap transactions use the default BsqSwapAccount.
         The fee-currency parameter is invalid;  BSQ is always used to pay BSQ swap trade fees.
         The swap will be executed immediately after being successfully taken.
 
@@ -39,7 +39,7 @@ OPTIONS
 --offer-id
 		The ID of the buy or sell offer to take.
 
---payment-account
+--payment-account-id
 		The ID of the fiat payment account used to send or receive funds during the Bisq v1 protocol trade.
 		The payment account's payment method must match that of the offer.
 		This parameter is not valid for taking BSQ Swaps, due to swaps' different transaction structure,
@@ -66,6 +66,6 @@ To take an offer with ID 83e8b2e2-51b6-4f39-a748-3ebd29c22aea
 	paying the Bisq trading fee in BSQ,
 	and setting the trade amount = the offer's min-amount (0.025 BTC):
 $ ./bisq-cli --password=xyz --port=9998 takeoffer --offer-id=83e8b2e2-51b6-4f39-a748-3ebd29c22aea \
-    --payment-account=fe20cdbd-22be-4b8a-a4b6-d2608ff09d6e \
+    --payment-account-id=fe20cdbd-22be-4b8a-a4b6-d2608ff09d6e \
     --fee-currency=bsq \
     --amount=0.025


### PR DESCRIPTION
makes usage of `payment-account-id` parameter name more consistent
the correct name is `payment-account-id`, but it was sometimes referred to as `payment-account`

https://github.com/bisq-network/bisq/blob/ce2ffceccf5fc1c896f25276a7b71f7aa64ddef5/cli/src/main/java/bisq/cli/opts/OptLabel.java#L42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated help texts and documentation to consistently use `--payment-account-id` instead of `--payment-account` for relevant CLI commands.

- **Chores**
  - Updated scripts to use the new `--payment-account-id` parameter name in CLI commands for offer creation and trading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->