### PR TITLE
BisqSetup: Remove redundant BSQ explorer deprecation

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -341,7 +341,6 @@ public class BisqSetup {
         maybeShowLocalhostRunningInfo();
         maybeShowAccountSigningStateInfo();
         maybeShowTorAddressUpgradeInformation();
-        maybeUpgradeBsqExplorerUrl();
         checkInboundConnections();
     }
 
@@ -781,18 +780,6 @@ public class BisqSetup {
         if (signingStateFound && preferences.showAgain(key) &&
                 displayHandler != null) {
             displayHandler.accept(key);
-        }
-    }
-
-    private void maybeUpgradeBsqExplorerUrl() {
-        // if wiz BSQ explorer selected, replace with 1st explorer in the list of available.
-        if (preferences.getBsqBlockChainExplorer().getName().equalsIgnoreCase("mempool.space (@wiz)") &&
-                preferences.getBsqBlockChainExplorers().size() > 0) {
-            preferences.setBsqBlockChainExplorer(preferences.getBsqBlockChainExplorers().get(0));
-        }
-        if (preferences.getBsqBlockChainExplorer().getName().equalsIgnoreCase("bisq.mempool.emzy.de (@emzy)") &&
-                preferences.getBsqBlockChainExplorers().size() > 0) {
-            preferences.setBsqBlockChainExplorer(preferences.getBsqBlockChainExplorers().get(0));
         }
     }
 


### PR DESCRIPTION
PR https://github.com/bisq-network/bisq/pull/7041 and https://github.com/bisq-network/bisq/pull/7213 added this functionality to the BisqSetup class.
However, this functionality existed already in the setupPreferences
(Preferences class) method. The method in the Preferences class has a
longer list of retired nodes.