### PR TITLE
Remove my BSQ explorer

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -117,7 +117,6 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     ));
 
     public static final ArrayList<BlockChainExplorer> BSQ_MAIN_NET_EXPLORERS = new ArrayList<>(Arrays.asList(
-            new BlockChainExplorer("mempool.bisq.services (@devinbileck)", "https://mempool.bisq.services/tx/", "https://mempool.bisq.services/address/"),
             new BlockChainExplorer("BSQ Explorer - Tor (@runbtc)", "http://runbtcxzz4v2haszypwbrn2baqdo7tlwt6dw7g27cwwaootd4gktwayd.onion/tx/", "http://runbtcxzz4v2haszypwbrn2baqdo7tlwt6dw7g27cwwaootd4gktwayd.onion/address/")
     ));
 
@@ -129,7 +128,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             "bsq.ninja",
             "bsq.sqrrm.net",
             "bsq.vante.me",
-            "mempool.space"
+            "mempool.space",
+            "mempool.bisq.services"
     );
 
     private static final ArrayList<String> XMR_TX_PROOF_SERVICES_CLEAR_NET = new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
I can retire my node now that @runbtc added his BSQ explorer in #7422.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed "mempool.bisq.services" from the list of available blockchain explorers and marked it as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->