### PR TITLE
Speed up BM accounting store sync

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStore.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStore.java
@@ -27,9 +27,7 @@ import com.google.protobuf.Message;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
@@ -44,10 +42,20 @@ import static bisq.core.dao.burningman.accounting.BurningManAccountingService.EA
 @Slf4j
 public class BurningManAccountingStore implements PersistableEnvelope {
     private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-    private final LinkedList<AccountingBlock> blocks = new LinkedList<>();
+
+    // We preserve the invariant that block heights are contiguous, starting from EARLIEST_BLOCK_HEIGHT:
+    private final List<AccountingBlock> blocks = new ArrayList<>();
 
     public BurningManAccountingStore(List<AccountingBlock> blocks) {
-        this.blocks.addAll(blocks);
+        AccountingBlock previousBlock = null;
+        for (var block : blocks) {
+            if (block.getHeight() != (previousBlock != null ? previousBlock.getHeight() + 1 : EARLIEST_BLOCK_HEIGHT)) {
+                log.error("Initializing with non-connecting block at height {}. Ignoring it and all subsequent blocks.", block.getHeight());
+                break;
+            }
+            this.blocks.add(block);
+            previousBlock = block;
+        }
     }
 
     public void addIfNewBlock(AccountingBlock newBlock) throws BlockHeightNotConnectingException, BlockHashNotConnectingException {
@@ -74,9 +82,7 @@ public class BurningManAccountingStore implements PersistableEnvelope {
         Lock writeLock = readWriteLock.writeLock();
         writeLock.lock();
         try {
-            for (int i = 0; i < 10 && !blocks.isEmpty(); i++) {
-                blocks.removeLast();
-            }
+            blocks.subList(Math.max(blocks.size() - 10, 0), blocks.size()).clear();
         } finally {
             writeLock.unlock();
         }
@@ -96,8 +102,7 @@ public class BurningManAccountingStore implements PersistableEnvelope {
         Lock readLock = readWriteLock.readLock();
         readLock.lock();
         try {
-            return blocks.stream()
-                    .max(Comparator.comparing(AccountingBlock::getHeight));
+            return !blocks.isEmpty() ? Optional.of(blocks.get(blocks.size() - 1)) : Optional.empty();
         } finally {
             readLock.unlock();
         }
@@ -107,9 +112,8 @@ public class BurningManAccountingStore implements PersistableEnvelope {
         Lock readLock = readWriteLock.readLock();
         readLock.lock();
         try {
-            return blocks.stream()
-                    .filter(block -> block.getHeight() == height)
-                    .findAny();
+            return height >= EARLIEST_BLOCK_HEIGHT && height < EARLIEST_BLOCK_HEIGHT + blocks.size() ?
+                    Optional.of(blocks.get(height - EARLIEST_BLOCK_HEIGHT)) : Optional.empty();
         } finally {
             readLock.unlock();
         }
@@ -119,16 +123,20 @@ public class BurningManAccountingStore implements PersistableEnvelope {
         Lock readLock = readWriteLock.readLock();
         readLock.lock();
         try {
-            return blocks.stream()
-                    .filter(block -> block.getHeight() >= minHeight)
-                    .collect(Collectors.toList());
+            return minHeight >= EARLIEST_BLOCK_HEIGHT && minHeight < EARLIEST_BLOCK_HEIGHT + blocks.size() ?
+                    List.copyOf(blocks.subList(minHeight - EARLIEST_BLOCK_HEIGHT, blocks.size())) : List.of();
         } finally {
             readLock.unlock();
         }
     }
 
+    private boolean contains(AccountingBlock block) {
+        var blockAtSameHeight = getBlockAtHeight(block.getHeight());
+        return blockAtSameHeight.isPresent() && blockAtSameHeight.get().equals(block);
+    }
+
     private void tryToAddNewBlock(AccountingBlock newBlock) throws BlockHeightNotConnectingException, BlockHashNotConnectingException {
-        if (!blocks.contains(newBlock)) {
+        if (!contains(newBlock)) {
             Optional<AccountingBlock> optionalLastBlock = getLastBlock();
             if (optionalLastBlock.isPresent()) {
                 AccountingBlock lastBlock = optionalLastBlock.get();

--- a/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStore.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/storage/BurningManAccountingStore.java
@@ -131,8 +131,8 @@ public class BurningManAccountingStore implements PersistableEnvelope {
     }
 
     private boolean contains(AccountingBlock block) {
-        var blockAtSameHeight = getBlockAtHeight(block.getHeight());
-        return blockAtSameHeight.isPresent() && blockAtSameHeight.get().equals(block);
+        int idx = block.getHeight() - EARLIEST_BLOCK_HEIGHT;
+        return idx >= 0 && idx < blocks.size() && blocks.get(idx).equals(block);
     }
 
     private void tryToAddNewBlock(AccountingBlock newBlock) throws BlockHeightNotConnectingException, BlockHashNotConnectingException {

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -240,7 +240,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     protected void activate() {
         String key = "sensitiveDataRemovalInfo";
         if (DontShowAgainLookup.showAgain(key) &&
-                preferences.getClearDataAfterDays() == preferences.CLEAR_DATA_AFTER_DAYS_INITIAL) {
+                preferences.getClearDataAfterDays() == Preferences.CLEAR_DATA_AFTER_DAYS_INITIAL) {
             new Popup()
                     .headLine(Res.get("setting.info.headline"))
                     .backgroundInfo(Res.get("settings.preferences.sensitiveDataRemoval.msg"))
@@ -248,7 +248,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                     .onAction(() -> {
                         DontShowAgainLookup.dontShowAgain(key, true);
                         // user has acknowledged, enable the feature with a reasonable default value
-                        preferences.setClearDataAfterDays(preferences.CLEAR_DATA_AFTER_DAYS_DEFAULT);
+                        preferences.setClearDataAfterDays(Preferences.CLEAR_DATA_AFTER_DAYS_DEFAULT);
                         clearDataAfterDaysInputTextField.setText(String.valueOf(preferences.getClearDataAfterDays()));
                     })
                     .closeButtonText(Res.get("shared.cancel"))
@@ -365,7 +365,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                     UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
                 }
             } catch (NumberFormatException t) {
-                log.error("Exception at parseDouble deviation: " + t.toString());
+                log.error("Exception at parseDouble deviation: {}", t.toString());
                 UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
             }
         };
@@ -466,7 +466,6 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     }
 
     private void initializeDisplayCurrencies() {
-
         TitledGroupBg titledGroupBg = addTitledGroupBg(root, displayCurrenciesGridRowIndex, 8,
                 Res.get("setting.preferences.currenciesInList"));
         GridPane.setColumnIndex(titledGroupBg, 2);
@@ -742,7 +741,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                             preferences.getBsqAverageTrimThreshold())), 100, TimeUnit.MILLISECONDS);
                 }
             } catch (NumberFormatException t) {
-                log.error("Exception: " + t.toString());
+                log.error("Exception: {}", t.toString());
                 UserThread.runAfter(() -> bsqAverageTrimThresholdTextField.setText(FormattingUtils.formatToPercentWithSymbol(
                         preferences.getBsqAverageTrimThreshold())), 100, TimeUnit.MILLISECONDS);
             }
@@ -818,7 +817,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                 // if *.onion hostname, we use Tor normally
                 // if localhost, LAN address, or *.local FQDN we use HTTP without Tor
                 // otherwise we enforce https:// for any clearnet FQDN hostname
-                List<String> serviceAddressesParsed = new ArrayList<String>();
+                List<String> serviceAddressesParsed = new ArrayList<>();
                 serviceAddressesRaw.forEach((addr) -> {
                     addr = addr.replaceAll("http://", "").replaceAll("https://", "");
                     if (onionRegex.validate(addr).isValid) {
@@ -881,9 +880,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             }
         };
 
-        filterChangeListener = (observable, oldValue, newValue) -> {
-            autoConfirmGridPane.setDisable(newValue != null && newValue.isDisableAutoConf());
-        };
+        filterChangeListener = (observable, oldValue, newValue) ->
+                autoConfirmGridPane.setDisable(newValue != null && newValue.isDisableAutoConf());
         autoConfirmGridPane.setDisable(filterManager.getFilter() != null && filterManager.getFilter().isDisableAutoConf());
     }
 
@@ -1020,7 +1018,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         Coin fee = (preferences.isUseCustomWithdrawalTxFee()) ?
                 Coin.valueOf(preferences.getWithdrawalTxFeeInVbytes()) :
                 feeService.getTxFeePerVbyte();
-        log.info("tx fee = " + fee.toFriendlyString());
+        log.info("tx fee = {}", fee.toFriendlyString());
         return fee;
     }
 
@@ -1241,14 +1239,14 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         resyncDaoFromGenesisButton.setOnAction(e ->
                 new Popup().attention(Res.get("setting.preferences.dao.resyncFromGenesis.popup"))
                         .actionButtonText(Res.get("setting.preferences.dao.resyncFromGenesis.resync"))
-                        .onAction(() -> daoFacade.resyncDaoStateFromGenesis(() -> BisqApp.getShutDownHandler().run()))
+                        .onAction(() -> daoFacade.resyncDaoStateFromGenesis(BisqApp.getShutDownHandler()))
                         .closeButtonText(Res.get("shared.cancel"))
                         .show());
 
         resyncBMAccFromScratchButton.setOnAction(e ->
                 new Popup().attention(Res.get("setting.preferences.dao.resyncBMAccFromScratch.popup"))
                         .actionButtonText(Res.get("setting.preferences.dao.resyncBMAccFromScratch.resync"))
-                        .onAction(() -> burningManAccountingService.resyncAccountingDataFromScratch(BisqApp::getShutDownHandler))
+                        .onAction(() -> burningManAccountingService.resyncAccountingDataFromScratch(BisqApp.getShutDownHandler()))
                         .closeButtonText(Res.get("shared.cancel"))
                         .show());
 
@@ -1307,9 +1305,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             autoConfTradeLimitTf.textProperty().addListener(autoConfTradeLimitListener);
             autoConfServiceAddressTf.textProperty().addListener(autoConfServiceAddressListener);
             autoConfServiceAddressTf.focusedProperty().addListener(autoConfServiceAddressFocusOutListener);
-            autoConfirmXmrToggle.setOnAction(e -> {
-                preferences.setAutoConfEnabled(autoConfirmSettings.getCurrencyCode(), autoConfirmXmrToggle.isSelected());
-            });
+            autoConfirmXmrToggle.setOnAction(e ->
+                    preferences.setAutoConfEnabled(autoConfirmSettings.getCurrencyCode(), autoConfirmXmrToggle.isSelected()));
             filterManager.filterProperty().addListener(filterChangeListener);
         });
     }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Avoid doing linear scans of the entire list of accounting blocks every time a new block is added (once to check for duplicates and once to get the block with max height in `BurningManAccountingStore::getLastBlock`, which JProfiler reveals to be the main bottleneck during syncs). Do this by enforcing the invariant that the block heights are contiguous and start from `BurningManAccountingService.EARLIEST_BLOCK_HEIGHT`, so that there is a 1-to-1 mapping between heights and list indices, permitting direct lookup by index. Also use a backing ArrayList instead of a linked list, since the only disadvantage of the former is the failure to free surplus capacity when the list is cleared (but that amounts to a few MB at most, and it is otherwise more memory efficient).

(The above invariant needs to be additionally enforced in the store constructor, so discard the first and all subsequent non-connecting blocks and log an error. That was the only place in the code where it could have been broken, as a result of corrupted store persistence.)

--

Also fix an errant `BisqApp::getShutDownHandler` method reference in `PreferencesView` where a direct method call was almost certainly intended, preventing the shutdown handler from being invoked when the BM accounting data is resynced from scratch. Do some additional minor tidying of the class as well. (Not fully tested, as I don't currently have a full node available.)

--

The following hotspots were revealed by JProfiler prior to the optimisation, when attempting to sync about six months of accounting data on my local (light-client) Bisq instance (which was estimated to take several hours without the speedup):

![Screenshot from 2025-05-01 21-37-00](https://github.com/user-attachments/assets/77167936-90cd-48b7-85ff-84e3928fcafe)

(After the changes, there was no longer any significant hotspot in `BurningManAccountingStore`, so the sync proceeded rather too quickly to attach the profiler.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal performance and reliability of block storage and retrieval, resulting in faster access to accounting data.
  - Enhanced code readability and maintainability through stylistic and formatting improvements in preferences settings.

- **Style**
  - Updated logging statements and streamlined code structure for better clarity in the preferences settings interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->