### PR TITLE
Return correct matrix address for refundagent2

### DIFF
--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentLookupMap.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgentLookupMap.java
@@ -56,6 +56,10 @@ public class DisputeAgentLookupMap {
         // the table above is updated in the software.
         // as a stopgap measure, replace unknown ones with a link to the Bisq team
         String agentName = getMatrixUserName(onion).replaceAll(Res.get("shared.na"), "bisq");
-        return "https://matrix.to/#/@" + agentName + ":matrix.org";
+        if ("refundagent2".equals(agentName)) {
+            return "https://matrix.to/#/@" + agentName + ":bitcoinist.org";
+        } else {
+            return "https://matrix.to/#/@" + agentName + ":matrix.org";
+        }
     }
 }


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

refundagent2 pointed out the arbitration message reported a wrong matrix address for his account.
The method returning the address has `:matrix.org` hardcoded, so I had to add a condition check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Matrix chat links so that the "refundagent2" agent now directs users to a new domain. All other agents continue to use the original domain for their Matrix links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->