### PR TITLE
Add logs for proof or burn and lockup BSQ transaction input data

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/bond/lockup/LockupTxService.java
+++ b/core/src/main/java/bisq/core/dao/governance/bond/lockup/LockupTxService.java
@@ -73,6 +73,7 @@ public class LockupTxService {
                 lockTime >= BondConsensus.getMinLockTime(), "lockTime not in range");
         try {
             Transaction lockupTx = getLockupTx(lockupAmount, lockTime, lockupReason, hash);
+            log.info("lockupTx {}", lockupTx);
             walletsManager.publishAndCommitBsqTx(lockupTx, TxType.LOCKUP, new TxBroadcaster.Callback() {
                 @Override
                 public void onSuccess(Transaction transaction) {
@@ -86,12 +87,15 @@ public class LockupTxService {
             });
 
         } catch (TransactionVerificationException | InsufficientMoneyException | WalletException |
-                IOException exception) {
+                 IOException exception) {
             exceptionHandler.handleException(exception);
         }
     }
 
-    public Tuple2<Coin, Integer> getMiningFeeAndTxVsize(Coin lockupAmount, int lockTime, LockupReason lockupReason, byte[] hash)
+    public Tuple2<Coin, Integer> getMiningFeeAndTxVsize(Coin lockupAmount,
+                                                        int lockTime,
+                                                        LockupReason lockupReason,
+                                                        byte[] hash)
             throws InsufficientMoneyException, WalletException, TransactionVerificationException, IOException {
         Transaction tx = getLockupTx(lockupAmount, lockTime, lockupReason, hash);
         Coin miningFee = tx.getFee();

--- a/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
+++ b/core/src/main/java/bisq/core/dao/governance/proofofburn/ProofOfBurnService.java
@@ -36,6 +36,7 @@ import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
+import bisq.common.util.Hex;
 import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Coin;
@@ -142,7 +143,15 @@ public class ProofOfBurnService implements DaoSetupService, DaoStateListener {
             Transaction txWithBtcFee = btcWalletService.completePreparedBurnBsqTx(preparedBurnFeeTx, opReturnData);
             // We sign the BSQ inputs of the final tx.
             Transaction transaction = bsqWalletService.signTxAndVerifyNoDustOutputs(txWithBtcFee);
-            log.info("Proof of burn tx: " + transaction);
+            log.info("Proof of burn transaction details:\n" +
+                            "preImage={}" +
+                            "hash={}" +
+                            "opReturnData={}" +
+                            "transaction={}",
+                    preImageAsString,
+                    Hex.encode(hash),
+                    Hex.encode(opReturnData),
+                    transaction);
             return transaction;
         } catch (WalletException | TransactionVerificationException e) {
             throw new TxException(e);

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
@@ -34,13 +34,14 @@ import bisq.core.dao.state.model.blockchain.TxOutput;
 import bisq.core.dao.state.model.governance.Role;
 import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.locale.Res;
+import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinUtil;
-import bisq.core.util.FormattingUtils;
 
 import bisq.network.p2p.P2PService;
 
 import bisq.common.app.DevEnv;
+import bisq.common.util.Hex;
 import bisq.common.util.Tuple2;
 
 import org.bitcoinj.core.Coin;
@@ -98,9 +99,23 @@ public class BondingViewUtils {
         }
     }
 
-    public void lockupBondForReputation(Coin lockupAmount, int lockupTime, byte[] salt, Consumer<String> resultHandler) {
+    public void lockupBondForReputation(Coin lockupAmount,
+                                        int lockupTime,
+                                        byte[] salt,
+                                        Consumer<String> resultHandler) {
         MyReputation myReputation = new MyReputation(salt);
-        lockupBond(myReputation.getHash(), lockupAmount, lockupTime, LockupReason.REPUTATION, resultHandler);
+        byte[] hash = myReputation.getHash();
+        log.info("Lockup bond for reputation: \n" +
+                        "lockupAmount={}\n" +
+                        "lockupTime={}" +
+                        "salt={}\n" +
+                        "hash={}",
+                lockupAmount.value,
+                lockupTime,
+                Hex.encode(salt),
+                Hex.encode(hash)
+        );
+        lockupBond(hash, lockupAmount, lockupTime, LockupReason.REPUTATION, resultHandler);
         myReputationListService.addReputation(myReputation);
     }
 
@@ -137,7 +152,11 @@ public class BondingViewUtils {
         }
     }
 
-    private void publishLockupTx(Coin lockupAmount, int lockupTime, LockupReason lockupReason, byte[] hash, Consumer<String> resultHandler) {
+    private void publishLockupTx(Coin lockupAmount,
+                                 int lockupTime,
+                                 LockupReason lockupReason,
+                                 byte[] hash,
+                                 Consumer<String> resultHandler) {
         daoFacade.publishLockupTx(lockupAmount,
                 lockupTime,
                 lockupReason,

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
@@ -169,7 +169,9 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
         lockupButton.setOnAction((event) -> {
             Coin lockupAmount = ParsingUtils.parseToCoin(amountInputTextField.getText(), bsqFormatter);
             int lockupTime = Integer.parseInt(timeInputTextField.getText());
-            byte[] salt = Utilities.decodeFromHex(saltInputTextField.getText());
+            String saltAsString = saltInputTextField.getText();
+            log.info("Lockup BSQ: salt as hex string={}", saltAsString);
+            byte[] salt = Utilities.decodeFromHex(saltAsString);
             bondingViewUtils.lockupBondForReputation(lockupAmount,
                     lockupTime,
                     salt,


### PR DESCRIPTION
Add logs for proof or burn and lockup BSQ transaction input data (pre-image, salt and resulting hashes).

This should make debugging easier in case users make mistakes with pasting Bisq 2 profile IDs for building Bisq 2 reputation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting and readability of method signatures and code structure in several areas.
- **New Features**
  - Enhanced logging throughout the application to provide more detailed information about transactions and input data during bond lockup and proof-of-burn operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->