### PR TITLE
Improve burn tx UI

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2483,6 +2483,11 @@ dao.proofOfBurn.sig=Signature
 dao.proofOfBurn.verify=Verify
 dao.proofOfBurn.verificationResult.ok=Verification succeeded
 dao.proofOfBurn.verificationResult.failed=Verification failed
+dao.proofOfBurn.preImage.notTrimmedWarning=The pre-image contains a leading or trailing space. This is probably not intended.
+dao.proofOfBurn.preImage.notTrimmedWarning.ignore=Ignore warning
+dao.proofOfBurn.preImage.confirmPopup=Are you sure that you want to burn {0} using the pre-image ''{1}''?\n\n\
+  If this action is intended to build your reputation for Bisq Easy, make sure you copied your profile ID directly from the Bisq 2 application to avoid any errors.
+dao.proofOfBurn.preImage.confirmPopup.confirm=Yes, I confirm that the pre-image is correct.
 
 # suppress inspection "UnusedProperty"
 dao.phase.UNDEFINED=Undefined

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/BondingViewUtils.java
@@ -107,7 +107,7 @@ public class BondingViewUtils {
         byte[] hash = myReputation.getHash();
         log.info("Lockup bond for reputation: \n" +
                         "lockupAmount={}\n" +
-                        "lockupTime={}" +
+                        "lockupTime={}\n" +
                         "salt={}\n" +
                         "hash={}",
                 lockupAmount.value,


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq/pull/7457

Add warning if there is a leading or trailing space at the pre-image.
Add confirmation popup displaying the pre-image in quotes.
Display the pre-image in the my-burn-txs table in quotes to spot easier leading or trailing spaces


![Screenshot 2025-05-28 at 15 35 56](https://github.com/user-attachments/assets/b3875fff-16a2-4e95-b821-cbd5c9615ca8)
![Screenshot 2025-05-28 at 15 36 17](https://github.com/user-attachments/assets/ec4f94f4-bd91-4969-8825-6a20aac917c1)
![Screenshot 2025-05-28 at 15 36 30](https://github.com/user-attachments/assets/e9d6e7c1-2c37-43df-9d7e-2588daa254a1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added confirmation popup and warning when attempting to burn with a preimage containing leading or trailing spaces, with options to proceed or cancel.
  - Introduced new localized messages related to proof of burn, including warnings and confirmation dialogs.

- **Improvements**
  - Enhanced logging for proof of burn and bond lockup actions, providing more detailed and structured information for users.
  - Improved readability of confirmation dialogs and preimage display in the user interface.

- **Style**
  - Minor formatting improvements for better code and UI clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->