### PR TITLE
Remove ClearXchange references from payment methods UI

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -4376,7 +4376,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_it.properties
+++ b/core/src/main/resources/i18n/displayStrings_it.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pl.properties
+++ b/core/src/main/resources/i18n/displayStrings_pl.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle (ClearXchange)
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hans.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hans.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle（ClearXchange）
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hant.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hant.properties
@@ -3272,7 +3272,7 @@ FASTER_PAYMENTS=Faster Payment System (UK)
 # suppress inspection "UnusedProperty"
 SWISH=Swish
 # suppress inspection "UnusedProperty"
-CLEAR_X_CHANGE=Zelle（ClearXchange）
+CLEAR_X_CHANGE=Zelle
 # suppress inspection "UnusedProperty"
 CHASE_QUICK_PAY=Chase QuickPay
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

As per https://bisq.community/t/zelle-clear-xchange-2022-shutdown/13014/1 I have removed the reference to ClearXchange, which was shutdown in 2022, from the Zelle line in the fiat account type dropdown, without refactoring the variable names as to avoid unnecessary complication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the display name for the payment method previously shown as "Zelle (ClearXchange)" to "Zelle" across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->