### PR TITLE
Include useFullModeDaoMonitor option in seednode bisq.service

### DIFF
--- a/seednode/bisq.service
+++ b/seednode/bisq.service
@@ -12,6 +12,7 @@ EnvironmentFile=/etc/default/bisq.env
 
 ExecStart=/bin/bash __BISQ_HOME__/__BISQ_REPO_NAME__/${BISQ_ENTRYPOINT} \
           --fullDaoNode=${BISQ_DAO_FULLNODE} \
+          --useFullModeDaoMonitor=${BISQ_DAO_FULLNODE} \
           --userDataDir=${BISQ_HOME} \
           --appName=${BISQ_APP_NAME} \
           --baseCurrencyNetwork=${BISQ_BASE_CURRENCY} \


### PR DESCRIPTION
Reference: https://github.com/bisq-network/bisq/pull/7185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Bisq node service configuration to include an additional command-line argument for enhanced monitoring options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->