### PR TITLE
add 4th btc node from jester4042 to balance load

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -52,6 +52,7 @@ public class BtcNodes {
                         new BtcNode(null, "uxu2kwzqakspsgojbzwazzmrmewwtgdle5uahb6oaonecamezc35vqyd.onion", null, BtcNode.DEFAULT_PORT, "@jester4042"),
                         new BtcNode(null, "l65ab4jecc62mjihifr7m3mx7ljehwoy2iutz2lue4ra5goor3f4xeqd.onion", null, BtcNode.DEFAULT_PORT, "@jester4042"),
                         new BtcNode(null, "oe6lfkjeuqkcvjw62dadzqfsiyd7xpeiznqvy4ugvboks6tcf3bgmjyd.onion", null, BtcNode.DEFAULT_PORT, "@jester4042"),
+                        new BtcNode(null, "ft7xwom4xfqj2tagj3rsu57rktqd7revklr6eb5dh7mta7uyertjboad.onion", null, BtcNode.DEFAULT_PORT, "@jester4042"),
 
                         // node_op_324
                         new BtcNode(null, "a2vr3buoei2dfnocjl4ilwjwruxqofv6kzagmn7dfdtoilsxlx45flad.onion", null, BtcNode.DEFAULT_PORT, "@node_op_324"),


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Add 4th btc node from jester4042 to balance the load so that ops are each running 4 nodes.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Bitcoin node to the list of available nodes for improved connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->