### PR TITLE
API: allow filtering BTC addresses with positive balance

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -67,6 +67,7 @@ import bisq.cli.opts.GetAddressBalanceOptionParser;
 import bisq.cli.opts.GetAvgBsqPriceOptionParser;
 import bisq.cli.opts.GetBTCMarketPriceOptionParser;
 import bisq.cli.opts.GetBalanceOptionParser;
+import bisq.cli.opts.GetFundingAddressesOptionParser;
 import bisq.cli.opts.GetOffersOptionParser;
 import bisq.cli.opts.GetPaymentAcctFormOptionParser;
 import bisq.cli.opts.GetTradeOptionParser;
@@ -249,11 +250,14 @@ public class CliMain {
                     return;
                 }
                 case getfundingaddresses: {
-                    if (new SimpleMethodOptionParser(args).parse().isForHelp()) {
+                    var opts = new GetFundingAddressesOptionParser(args).parse();
+                    if (opts.isForHelp()) {
                         out.println(client.getMethodHelp(method));
                         return;
                     }
-                    var fundingAddresses = client.getFundingAddresses();
+                    var onlyFunded = opts.getIsOnlyFunded();
+
+                    var fundingAddresses = client.getFundingAddresses(onlyFunded);
                     new TableBuilder(ADDRESS_BALANCE_TBL, fundingAddresses).build().print(out);
                     return;
                 }
@@ -897,6 +901,7 @@ public class CliMain {
             stream.format(rowFormat, getbtcprice.name(), "--currency-code=<currency-code>", "Get current market btc price");
             stream.println();
             stream.format(rowFormat, getfundingaddresses.name(), "", "Get BTC funding addresses");
+            stream.format(rowFormat, "", "[--only-funded=<true|false>]", "");
             stream.println();
             stream.format(rowFormat, getunusedbsqaddress.name(), "", "Get unused BSQ address");
             stream.println();

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -115,8 +115,8 @@ public final class GrpcClient {
         return walletsServiceRequest.getBtcPrice(currencyCode);
     }
 
-    public List<AddressBalanceInfo> getFundingAddresses() {
-        return walletsServiceRequest.getFundingAddresses();
+    public List<AddressBalanceInfo> getFundingAddresses(boolean onlyFunded) {
+        return walletsServiceRequest.getFundingAddresses(onlyFunded);
     }
 
     public String getUnusedBsqAddress() {

--- a/cli/src/main/java/bisq/cli/opts/GetFundingAddressesOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/GetFundingAddressesOptionParser.java
@@ -1,0 +1,26 @@
+package bisq.cli.opts;
+
+import joptsimple.OptionSpec;
+
+import static bisq.cli.opts.OptLabel.OPT_ONLY_FUNDED;
+
+public class GetFundingAddressesOptionParser extends AbstractMethodOptionParser implements MethodOpts {
+    final OptionSpec<Boolean> onlyFundedOpt = parser.accepts(OPT_ONLY_FUNDED, "only funded addresses")
+            .withOptionalArg()
+            .ofType(boolean.class)
+            .defaultsTo(Boolean.FALSE);
+
+    public GetFundingAddressesOptionParser(String[] args) {
+        super(args);
+    }
+
+    public GetFundingAddressesOptionParser parse() {
+        super.parse();
+
+        return this;
+    }
+
+    public boolean getIsOnlyFunded() {
+        return options.valueOf(onlyFundedOpt);
+    }
+}

--- a/cli/src/main/java/bisq/cli/opts/OptLabel.java
+++ b/cli/src/main/java/bisq/cli/opts/OptLabel.java
@@ -38,6 +38,7 @@ public class OptLabel {
     public final static String OPT_MKT_PRICE_MARGIN = "market-price-margin";
     public final static String OPT_MIN_AMOUNT = "min-amount";
     public final static String OPT_OFFER_ID = "offer-id";
+    public final static String OPT_ONLY_FUNDED = "only-funded";
     public final static String OPT_PASSWORD = "password";
     public final static String OPT_PAYMENT_ACCOUNT_ID = "payment-account-id";
     public final static String OPT_PAYMENT_ACCOUNT_FORM = "payment-account-form";

--- a/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
+++ b/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
@@ -44,6 +44,7 @@ import bisq.proto.grpc.UnsetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.VerifyBsqSentToAddressRequest;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 
@@ -99,9 +100,18 @@ public class WalletsServiceRequest {
         return grpcStubs.priceService.getMarketPrice(request).getPrice();
     }
 
-    public List<AddressBalanceInfo> getFundingAddresses() {
+    public List<AddressBalanceInfo> getFundingAddresses(boolean onlyFunded) {
         var request = GetFundingAddressesRequest.newBuilder().build();
-        return grpcStubs.walletsService.getFundingAddresses(request).getAddressBalanceInfoList();
+        var addressBalances = grpcStubs.walletsService.getFundingAddresses(request)
+                .getAddressBalanceInfoList();
+        if (onlyFunded) {
+            return addressBalances.stream()
+                    .filter(address -> address.getBalance() > 0L)
+                    .collect(Collectors.toList());
+
+        } else {
+            return addressBalances;
+        }
     }
 
     public String getUnusedBsqAddress() {

--- a/cli/src/test/java/bisq/cli/table/AddressCliOutputDiffTest.java
+++ b/cli/src/test/java/bisq/cli/table/AddressCliOutputDiffTest.java
@@ -27,7 +27,7 @@ public class AddressCliOutputDiffTest extends AbstractCliTest {
     }
 
     private void getFundingAddresses() {
-        var fundingAddresses = aliceClient.getFundingAddresses();
+        var fundingAddresses = aliceClient.getFundingAddresses(false);
         if (fundingAddresses.size() > 0) {
             // TableFormat class had been deprecated, then deleted on 17-Feb-2022, but
             // these diff tests can be useful for testing changes to the current tbl formatting api.
@@ -42,7 +42,7 @@ public class AddressCliOutputDiffTest extends AbstractCliTest {
     }
 
     private void getAddressBalance() {
-        List<AddressBalanceInfo> addresses = aliceClient.getFundingAddresses();
+        List<AddressBalanceInfo> addresses = aliceClient.getFundingAddresses(false);
         int numAddresses = addresses.size();
         // Check output for last 2 addresses.
         for (int i = numAddresses - 2; i < addresses.size(); i++) {

--- a/core/src/main/resources/help/getfundingaddresses-help.txt
+++ b/core/src/main/resources/help/getfundingaddresses-help.txt
@@ -7,10 +7,17 @@ getfundingaddresses - list BTC receiving address
 SYNOPSIS
 --------
 getfundingaddresses
+		[--only-funded=<true|false>]
 
 DESCRIPTION
 -----------
 Returns a list of receiving BTC addresses.
+
+OPTIONS
+-------
+--only-funded
+        If true, only addresses with a positive balance will be included.
+        Useful for filtering out empty addresses.
 
 EXAMPLES
 --------


### PR DESCRIPTION
This PR introduces a new `--only-funded` flag to the `getfundingaddresses` method, allowing users to filter the output to include only addresses with a positive balance. It improves usability by helping users focus on relevant, active addresses and reduces unnecessary output in large wallets. The default behavior remains unchanged when the flag is not used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional command-line parameter to the `getfundingaddresses` command, allowing users to filter and display only funded addresses.
* **Documentation**
  * Updated help text to describe the new `--only-funded` option for the `getfundingaddresses` command.
* **Tests**
  * Adjusted tests to accommodate the new parameter for filtering funded addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->