### PR TITLE
Fix: Allow multiple btcNodes in command-line argument

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -209,7 +209,7 @@ public class Config {
     public final int msgThrottlePer10Sec;
     public final int sendMsgThrottleTrigger;
     public final int sendMsgThrottleSleep;
-    public final String btcNodes;
+    public final List<String> btcNodes;
     public final boolean useTorForBtc;
     public final boolean useTorForBtcOptionSetExplicitly;
     public final String socks5DiscoverMode;
@@ -853,7 +853,7 @@ public class Config {
             this.msgThrottlePer10Sec = options.valueOf(msgThrottlePer10SecOpt);
             this.sendMsgThrottleTrigger = options.valueOf(sendMsgThrottleTriggerOpt);
             this.sendMsgThrottleSleep = options.valueOf(sendMsgThrottleSleepOpt);
-            this.btcNodes = options.valueOf(btcNodesOpt);
+            this.btcNodes = options.valuesOf(btcNodesOpt);
             this.useTorForBtc = options.valueOf(useTorForBtcOpt);
             this.useTorForBtcOptionSetExplicitly = options.has(useTorForBtcOpt);
             this.socks5DiscoverMode = options.valueOf(socks5DiscoverModeOpt);

--- a/core/src/main/java/bisq/core/btc/BitcoinModule.java
+++ b/core/src/main/java/bisq/core/btc/BitcoinModule.java
@@ -75,7 +75,9 @@ public class BitcoinModule extends AppModule {
 
         bind(File.class).annotatedWith(named(WALLET_DIR)).toInstance(config.walletDir);
 
-        bindConstant().annotatedWith(named(Config.BTC_NODES)).to(config.btcNodes);
+        bind(new com.google.inject.TypeLiteral<java.util.List<String>>() {})
+            .annotatedWith(named(Config.BTC_NODES))
+            .toInstance(config.btcNodes);
         bindConstant().annotatedWith(named(Config.USER_AGENT)).to(config.userAgent);
         bindConstant().annotatedWith(named(Config.NUM_CONNECTIONS_FOR_BTC)).to(config.numConnectionsForBtc);
         bindConstant().annotatedWith(named(Config.USE_ALL_PROVIDED_NODES)).to(config.useAllProvidedNodes);

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -195,7 +195,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
                        Config config,
                        FeeService feeService,
                        LocalBitcoinNode localBitcoinNode,
-                       @Named(Config.BTC_NODES) String btcNodesFromOptions,
+                       @Named(Config.BTC_NODES) List<String> btcNodesFromOptions,
                        @Named(Config.REFERRAL_ID) String referralId,
                        @Named(Config.FULL_DAO_NODE) boolean fullDaoNode,
                        @Named(Config.IS_BM_FULL_NODE) boolean fullAccountingNode,
@@ -208,7 +208,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         this.config = config;
         this.feeService = feeService;
         this.localBitcoinNode = localBitcoinNode;
-        this.btcNodesFromOptions = btcNodesFromOptions;
+        this.btcNodesFromOptions = String.join(",", btcNodesFromOptions);
         this.referralIdFromOptions = referralId;
         this.fullDaoNodeFromOptions = fullDaoNode;
         this.fullAccountingNodeFromOptions = fullAccountingNode;


### PR DESCRIPTION
Fixes issue #7448

Bisq would not load if multiple nodes were provided via the `--btcNodes` command-line argument because the value was being parsed as a single `String`

To solve that: 
- Updated `Config.java` to correctly parse the `--btcNodes` argument as a `List<String>`

- Updated `BitcoinModule.java` to handle the new list type during dependency injection

- Updated `Preferences.java` to correctly process the list of nodes from the configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced BTC nodes configuration to support specifying multiple nodes instead of a single entry.

* **Bug Fixes**
  * Improved handling of BTC node options to allow for multiple entries, ensuring more flexible and robust configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->