### PR TITLE
Add bridge module

### DIFF
--- a/bridge/build.gradle
+++ b/bridge/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'bisq.application'
+    id 'bisq.gradle.app_start_plugin.AppStartPlugin'
+}
+
+application {
+    mainClass = 'bisq.bridge.BridgeMain'
+    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError']
+}
+
+distTar.enabled = true
+
+dependencies {
+    implementation enforcedPlatform(project(':platform'))
+    implementation project(':common')
+    implementation project(':proto')
+    implementation project(':p2p')
+    implementation project(':core')
+    implementation libs.protobuf.java
+    annotationProcessor libs.lombok
+    compileOnly libs.lombok
+    implementation libs.google.guava
+    implementation libs.slf4j.api
+    implementation(libs.google.guice) {
+        exclude(module: 'guava')
+    }
+
+    implementation(libs.grpc.core) {
+        exclude(module: 'animal-sniffer-annotations')
+        exclude(module: 'guava')
+    }
+    implementation(libs.grpc.stub) {
+        exclude(module: 'animal-sniffer-annotations')
+        exclude(module: 'guava')
+    }
+
+    testAnnotationProcessor libs.lombok
+    testCompileOnly libs.lombok
+}

--- a/bridge/src/main/java/bisq/bridge/Bridge.java
+++ b/bridge/src/main/java/bisq/bridge/Bridge.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge;
+
+import bisq.core.app.BisqHeadlessApp;
+
+import com.google.inject.Injector;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.bridge.grpc.BridgeGrpcServer;
+import bisq.bridge.grpc.services.BsqBlockGrpcService;
+import bisq.bridge.grpc.services.BurningmanGrpcService;
+
+@Slf4j
+public class Bridge extends BisqHeadlessApp {
+    private BridgeGrpcServer bridgeGrpcServer;
+
+    public Bridge(Injector injector) {
+        this.injector = injector;
+    }
+
+    public void startApplication() {
+        super.startApplication();
+
+        bridgeGrpcServer = injector.getInstance(BridgeGrpcServer.class);
+        bridgeGrpcServer.startServer();
+    }
+
+    public void shutDown() {
+        injector.getInstance(BsqBlockGrpcService.class).shutDown();
+        injector.getInstance(BurningmanGrpcService.class).shutDown();
+
+        if (bridgeGrpcServer != null) {
+            bridgeGrpcServer.shutDown();
+            bridgeGrpcServer = null;
+        }
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/BridgeMain.java
+++ b/bridge/src/main/java/bisq/bridge/BridgeMain.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge;
+
+import bisq.core.app.misc.ExecutableForAppWithP2p;
+
+import bisq.common.UserThread;
+import bisq.common.app.Version;
+import bisq.common.handlers.ResultHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class BridgeMain extends ExecutableForAppWithP2p {
+    public static void main(String[] args) {
+        new BridgeMain().execute(args);
+    }
+
+    private Bridge bridge;
+
+    public BridgeMain() {
+        super("Bisq Bridge", "bisq-bridge", "bisq_bridge", Version.VERSION);
+    }
+
+    @Override
+    protected void doExecute() {
+        super.doExecute();
+
+        try {
+            // Prevent from terminating
+            Thread.currentThread().join();
+        } catch (InterruptedException e) {
+            log.error("Failed to run BridgeClient", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void applyInjector() {
+        super.applyInjector();
+        bridge = new Bridge(injector);
+    }
+
+    @Override
+    protected void onHiddenServicePublished() {
+        UserThread.runAfter(this::setupConnectionLossCheck, 60);
+    }
+
+    @Override
+    protected void startApplication() {
+        super.startApplication();
+        bridge.startApplication();
+    }
+
+    @Override
+    public void gracefulShutDown(ResultHandler resultHandler) {
+        bridge.shutDown();
+
+        super.gracefulShutDown(resultHandler);
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/BridgeMain.java
+++ b/bridge/src/main/java/bisq/bridge/BridgeMain.java
@@ -45,7 +45,8 @@ public class BridgeMain extends ExecutableForAppWithP2p {
             // Prevent from terminating
             Thread.currentThread().join();
         } catch (InterruptedException e) {
-            log.error("Failed to run BridgeClient", e);
+            log.error("Thread interrupted while running BridgeMain", e);
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }
@@ -69,8 +70,9 @@ public class BridgeMain extends ExecutableForAppWithP2p {
 
     @Override
     public void gracefulShutDown(ResultHandler resultHandler) {
-        bridge.shutDown();
-
+        if (bridge != null) {
+            bridge.shutDown();
+        }
         super.gracefulShutDown(resultHandler);
     }
 }

--- a/bridge/src/main/java/bisq/bridge/grpc/BridgeGrpcServer.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/BridgeGrpcServer.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc;
+
+import bisq.common.config.Config;
+import bisq.common.util.ExecutorFactory;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+
+import com.google.inject.Inject;
+
+import java.io.IOException;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.bridge.grpc.services.AccountAgeWitnessGrpcService;
+import bisq.bridge.grpc.services.BondedRoleGrpcService;
+import bisq.bridge.grpc.services.BsqBlockGrpcService;
+import bisq.bridge.grpc.services.BurningmanGrpcService;
+import bisq.bridge.grpc.services.SignedWitnessGrpcService;
+
+@Slf4j
+public class BridgeGrpcServer {
+    private final Server server;
+    private final ExecutorService startServerExecutor;
+    private final ExecutorService serverExecutor;
+
+    @Inject
+    public BridgeGrpcServer(Config config,
+                            BsqBlockGrpcService bsqBlockGrpcService,
+                            BurningmanGrpcService burningManGrpcService,
+                            AccountAgeWitnessGrpcService accountAgeWitnessGrpcService,
+                            SignedWitnessGrpcService signedWitnessGrpcService,
+                            BondedRoleGrpcService bondedRoleGrpcService) {
+        int port = config.bridgePort;
+
+        startServerExecutor = ExecutorFactory.newSingleThreadExecutor("BridgeGrpcServer.startServerExecutor");
+        serverExecutor = ExecutorFactory.newSingleThreadExecutor("BridgeGrpcServer.server");
+
+        server = ServerBuilder
+                .forPort(port)
+                .executor(serverExecutor)
+                .addService(bsqBlockGrpcService)
+                .addService(burningManGrpcService)
+                .addService(accountAgeWitnessGrpcService)
+                .addService(signedWitnessGrpcService)
+                .addService(bondedRoleGrpcService)
+                .build();
+        log.info("Create gRPC server listening on port {}", port);
+    }
+
+    public void startServer() {
+        CompletableFuture.runAsync(() -> {
+            Thread.currentThread().setName("BridgeGrpcServer");
+            try {
+                server.start();
+                log.info("Server started.");
+                server.awaitTermination();
+            } catch (IOException e) {
+                log.error("IOException at starting server", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Server interrupted", e);
+            } catch (Exception e) {
+                log.error("Failed to start server", e);
+            }
+        }, startServerExecutor);
+    }
+
+    public void shutDown() {
+        server.shutdown();
+        try {
+            if (!server.awaitTermination(1000, TimeUnit.MILLISECONDS)) {
+                log.warn("Server did not terminate in time, forcing shutdown...");
+                server.shutdownNow();
+            }
+        } catch (InterruptedException ignore) {
+            log.warn("Shutdown interrupted, forcing shutdown now.");
+            server.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+
+        ExecutorFactory.shutdownAndAwaitTermination(serverExecutor, 1000);
+        ExecutorFactory.shutdownAndAwaitTermination(startServerExecutor, 1000);
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/dto/BondedReputationDto.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/dto/BondedReputationDto.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.dto;
+
+import bisq.common.Payload;
+
+import com.google.protobuf.ByteString;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BondedReputationDto implements Payload {
+    private final long amount;
+    private final byte[] bondedReputationHash;
+    private final int lockTime;
+
+    public BondedReputationDto(long amount, byte[] bondedReputationHash, int lockTime) {
+        this.amount = amount;
+        this.bondedReputationHash = bondedReputationHash;
+        this.lockTime = lockTime;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.BondedReputationDto toProtoMessage() {
+        return bisq.bridge.protobuf.BondedReputationDto.newBuilder()
+                .setAmount(amount)
+                .setBondedReputationHash(ByteString.copyFrom(bondedReputationHash))
+                .setLockTime(lockTime)
+                .build();
+    }
+
+    public static BondedReputationDto fromProto(bisq.bridge.protobuf.BondedReputationDto proto) {
+        return new BondedReputationDto(proto.getAmount(),
+                proto.getBondedReputationHash().toByteArray(),
+                proto.getLockTime());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/dto/BsqBlockDto.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/dto/BsqBlockDto.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.dto;
+
+import bisq.common.Payload;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BsqBlockDto implements Payload {
+    private final int height;
+    private final long time;
+    private final List<TxDto> txDtoList;
+
+    public BsqBlockDto(int height,
+                       long time,
+                       List<TxDto> txDtoList) {
+        this.height = height;
+        this.time = time;
+        this.txDtoList = txDtoList;
+    }
+
+    public bisq.bridge.protobuf.BsqBlockDto toProtoMessage() {
+        return bisq.bridge.protobuf.BsqBlockDto.newBuilder()
+                .setHeight(height)
+                .setTime(time)
+                .addAllTxDto(txDtoList.stream().map(TxDto::toProtoMessage).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static BsqBlockDto fromProto(bisq.bridge.protobuf.BsqBlockDto proto) {
+        return new BsqBlockDto(proto.getHeight(),
+                proto.getTime(),
+                proto.getTxDtoList().stream().map(TxDto::fromProto).collect(Collectors.toList()));
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/dto/BurningmanBlockDto.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/dto/BurningmanBlockDto.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.dto;
+
+import bisq.common.Payload;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BurningmanBlockDto implements Payload {
+    private final int height;
+    private final List<BurningmanDto> burningmanDtoList;
+
+    public BurningmanBlockDto(int height,
+                              List<BurningmanDto> burningmanDtoList) {
+        this.height = height;
+        this.burningmanDtoList = burningmanDtoList;
+    }
+
+    public bisq.bridge.protobuf.BurningmanBlockDto toProtoMessage() {
+        return bisq.bridge.protobuf.BurningmanBlockDto.newBuilder()
+                .setHeight(height)
+                .addAllBurningmanItems(burningmanDtoList.stream().map(BurningmanDto::toProtoMessage).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static BurningmanBlockDto fromProto(bisq.bridge.protobuf.BurningmanBlockDto proto) {
+        return new BurningmanBlockDto(proto.getHeight(),
+                proto.getBurningmanItemsList().stream().map(BurningmanDto::fromProto).collect(Collectors.toList()));
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/dto/BurningmanDto.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/dto/BurningmanDto.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.dto;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BurningmanDto implements Payload {
+    private final String receiverAddress;
+    private final double cappedBurnAmountShare;
+
+    public BurningmanDto(String receiverAddress, double cappedBurnAmountShare) {
+        this.receiverAddress = receiverAddress;
+        this.cappedBurnAmountShare = cappedBurnAmountShare;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.BurningmanDto toProtoMessage() {
+        return bisq.bridge.protobuf.BurningmanDto.newBuilder()
+                .setReceiverAddress(receiverAddress)
+                .setCappedBurnAmountShare(cappedBurnAmountShare)
+                .build();
+    }
+
+    public static BurningmanDto fromProto(bisq.bridge.protobuf.BurningmanDto proto) {
+        return new BurningmanDto(proto.getReceiverAddress(), proto.getCappedBurnAmountShare());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/dto/ProofOfBurnDto.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/dto/ProofOfBurnDto.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.dto;
+
+import bisq.common.Payload;
+
+import com.google.protobuf.ByteString;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class ProofOfBurnDto implements Payload {
+    private final long amount;
+    private final byte[] proofOfBurnHash;
+
+    public ProofOfBurnDto(long amount, byte[] proofOfBurnHash) {
+        this.amount = amount;
+        this.proofOfBurnHash = proofOfBurnHash;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.ProofOfBurnDto toProtoMessage() {
+        return bisq.bridge.protobuf.ProofOfBurnDto.newBuilder()
+                .setAmount(amount)
+                .setProofOfBurnHash(ByteString.copyFrom(proofOfBurnHash))
+                .build();
+    }
+
+    public static ProofOfBurnDto fromProto(bisq.bridge.protobuf.ProofOfBurnDto proto) {
+        return new ProofOfBurnDto(proto.getAmount(), proto.getProofOfBurnHash().toByteArray());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/dto/TxDto.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/dto/TxDto.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.dto;
+
+import bisq.common.Payload;
+import bisq.common.util.OptionalUtils;
+
+import java.util.Optional;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class TxDto implements Payload {
+    private final String txId;
+    private final Optional<ProofOfBurnDto> proofOfBurnDto;
+    private final Optional<BondedReputationDto> bondedReputationDto;
+
+    public TxDto(String txId,
+                 Optional<ProofOfBurnDto> proofOfBurnDto,
+                 Optional<BondedReputationDto> bondedReputationDto) {
+        this.txId = txId;
+        this.proofOfBurnDto = proofOfBurnDto;
+        this.bondedReputationDto = bondedReputationDto;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.TxDto toProtoMessage() {
+        var builder = bisq.bridge.protobuf.TxDto.newBuilder()
+                .setTxId(txId);
+        proofOfBurnDto.ifPresent(e -> builder.setProofOfBurnDto(e.toProtoMessage()));
+        bondedReputationDto.ifPresent(e -> builder.setBondedReputationDto(e.toProtoMessage()));
+        return builder.build();
+    }
+
+    public static TxDto fromProto(bisq.bridge.protobuf.TxDto proto) {
+        return new TxDto(proto.getTxId(),
+                OptionalUtils.optionalIf(proto.hasProofOfBurnDto(), () -> ProofOfBurnDto.fromProto(proto.getProofOfBurnDto())),
+                OptionalUtils.optionalIf(proto.hasBondedReputationDto(), () -> BondedReputationDto.fromProto(proto.getBondedReputationDto())));
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/AccountAgeWitnessDateRequest.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/AccountAgeWitnessDateRequest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class AccountAgeWitnessDateRequest implements Payload {
+    private final String hashAsHex;
+
+    public AccountAgeWitnessDateRequest(String hashAsHex) {
+        this.hashAsHex = hashAsHex;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.AccountAgeWitnessDateRequest toProtoMessage() {
+        return bisq.bridge.protobuf.AccountAgeWitnessDateRequest.newBuilder()
+                .setHashAsHex(hashAsHex)
+                .build();
+    }
+
+    public static AccountAgeWitnessDateRequest fromProto(bisq.bridge.protobuf.AccountAgeWitnessDateRequest proto) {
+        return new AccountAgeWitnessDateRequest(proto.getHashAsHex());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/AccountAgeWitnessDateResponse.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/AccountAgeWitnessDateResponse.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class AccountAgeWitnessDateResponse implements Payload {
+    private final long date;
+
+    public AccountAgeWitnessDateResponse(long date) {
+        this.date = date;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.AccountAgeWitnessDateResponse toProtoMessage() {
+        return bisq.bridge.protobuf.AccountAgeWitnessDateResponse.newBuilder()
+                .setDate(date)
+                .build();
+    }
+
+    public static AccountAgeWitnessDateResponse fromProto(bisq.bridge.protobuf.AccountAgeWitnessDateResponse proto) {
+        return new AccountAgeWitnessDateResponse(proto.getDate());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/BondedRoleVerificationRequest.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/BondedRoleVerificationRequest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BondedRoleVerificationRequest implements Payload {
+    private final String bondUserName;
+    private final String roleType;
+    private final String profileId;
+    private final String signatureBase64;
+
+    public BondedRoleVerificationRequest(String bondUserName,
+                                         String roleType,
+                                         String profileId,
+                                         String signatureBase64) {
+        this.bondUserName = bondUserName;
+        this.roleType = roleType;
+        this.profileId = profileId;
+        this.signatureBase64 = signatureBase64;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.BondedRoleVerificationRequest toProtoMessage() {
+        return bisq.bridge.protobuf.BondedRoleVerificationRequest.newBuilder()
+                .setBondUserName(bondUserName)
+                .setRoleType(roleType)
+                .setProfileId(profileId)
+                .setSignatureBase64(signatureBase64)
+                .build();
+    }
+
+    public static BondedRoleVerificationRequest fromProto(bisq.bridge.protobuf.BondedRoleVerificationRequest proto) {
+        return new BondedRoleVerificationRequest(proto.getBondUserName(),
+                proto.getRoleType(),
+                proto.getProfileId(),
+                proto.getSignatureBase64()
+        );
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/BondedRoleVerificationResponse.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/BondedRoleVerificationResponse.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+import bisq.common.util.OptionalUtils;
+
+import java.util.Optional;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BondedRoleVerificationResponse implements Payload {
+    private final Optional<String> errorMessage;
+
+    public BondedRoleVerificationResponse(Optional<String> errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.BondedRoleVerificationResponse toProtoMessage() {
+        var builder = bisq.bridge.protobuf.BondedRoleVerificationResponse.newBuilder();
+        errorMessage.ifPresent(builder::setErrorMessage);
+        return builder.build();
+    }
+
+    public static BondedRoleVerificationResponse fromProto(bisq.bridge.protobuf.BondedRoleVerificationResponse proto) {
+        return new BondedRoleVerificationResponse(OptionalUtils.optionalIf(proto.hasErrorMessage(), proto::getErrorMessage));
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/BsqBlocksRequest.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/BsqBlocksRequest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BsqBlocksRequest implements Payload {
+    private final int startBlockHeight;
+
+    public BsqBlocksRequest(int startBlockHeight) {
+        this.startBlockHeight = startBlockHeight;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.BsqBlocksRequest toProtoMessage() {
+        return bisq.bridge.protobuf.BsqBlocksRequest.newBuilder()
+                .setStartBlockHeight(startBlockHeight)
+                .build();
+    }
+
+    public static BsqBlocksRequest fromProto(bisq.bridge.protobuf.BsqBlocksRequest proto) {
+        return new BsqBlocksRequest(proto.getStartBlockHeight());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/BsqBlocksResponse.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/BsqBlocksResponse.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+
+
+import bisq.bridge.grpc.dto.BsqBlockDto;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BsqBlocksResponse implements Payload {
+    private final List<BsqBlockDto> blocks;
+
+    public BsqBlocksResponse(List<BsqBlockDto> blocks) {
+        this.blocks = blocks;
+    }
+
+    public bisq.bridge.protobuf.BsqBlocksResponse toProtoMessage() {
+        return bisq.bridge.protobuf.BsqBlocksResponse.newBuilder()
+                .addAllBsqBlocks(blocks.stream().map(BsqBlockDto::toProtoMessage).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static BsqBlocksResponse fromProto(bisq.bridge.protobuf.BsqBlocksResponse proto) {
+        return new BsqBlocksResponse(proto.getBsqBlocksList().stream().map(BsqBlockDto::fromProto).collect(Collectors.toList()));
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/BurningmanBlocksRequest.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/BurningmanBlocksRequest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BurningmanBlocksRequest implements Payload {
+    private final int startBlockHeight;
+
+    public BurningmanBlocksRequest(int startBlockHeight) {
+        this.startBlockHeight = startBlockHeight;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.BurningmanBlocksRequest toProtoMessage() {
+        return bisq.bridge.protobuf.BurningmanBlocksRequest.newBuilder()
+                .setStartBlockHeight(startBlockHeight)
+                .build();
+    }
+
+    public static BurningmanBlocksRequest fromProto(bisq.bridge.protobuf.BurningmanBlocksRequest proto) {
+        return new BurningmanBlocksRequest(proto.getStartBlockHeight());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/BurningmanBlocksResponse.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/BurningmanBlocksResponse.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+
+
+import bisq.bridge.grpc.dto.BurningmanBlockDto;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class BurningmanBlocksResponse implements Payload {
+    private final List<BurningmanBlockDto> blocks;
+
+    public BurningmanBlocksResponse(List<BurningmanBlockDto> blocks) {
+        this.blocks = blocks;
+    }
+
+    public bisq.bridge.protobuf.BurningmanBlocksResponse toProtoMessage() {
+        return bisq.bridge.protobuf.BurningmanBlocksResponse.newBuilder()
+                .addAllBurningmanBlocks(blocks.stream().map(BurningmanBlockDto::toProtoMessage).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static BurningmanBlocksResponse fromProto(bisq.bridge.protobuf.BurningmanBlocksResponse proto) {
+        return new BurningmanBlocksResponse(proto.getBurningmanBlocksList().stream().map(BurningmanBlockDto::fromProto).collect(Collectors.toList()));
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/SignedWitnessDateRequest.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/SignedWitnessDateRequest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class SignedWitnessDateRequest implements Payload {
+    private final String hashAsHex;
+
+    public SignedWitnessDateRequest(String hashAsHex) {
+        this.hashAsHex = hashAsHex;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.SignedWitnessDateRequest toProtoMessage() {
+        return bisq.bridge.protobuf.SignedWitnessDateRequest.newBuilder()
+                .setHashAsHex(hashAsHex)
+                .build();
+    }
+
+    public static SignedWitnessDateRequest fromProto(bisq.bridge.protobuf.SignedWitnessDateRequest proto) {
+        return new SignedWitnessDateRequest(proto.getHashAsHex());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/SignedWitnessDateResponse.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/SignedWitnessDateResponse.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class SignedWitnessDateResponse implements Payload {
+    private final long date;
+
+    public SignedWitnessDateResponse(long date) {
+        this.date = date;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.SignedWitnessDateResponse toProtoMessage() {
+        return bisq.bridge.protobuf.SignedWitnessDateResponse.newBuilder()
+                .setDate(date)
+                .build();
+    }
+
+    public static SignedWitnessDateResponse fromProto(bisq.bridge.protobuf.SignedWitnessDateResponse proto) {
+        return new SignedWitnessDateResponse(proto.getDate());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/services/AccountAgeWitnessGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/AccountAgeWitnessGrpcService.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import bisq.core.account.witness.AccountAgeWitness;
+import bisq.core.account.witness.AccountAgeWitnessService;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.Date;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.bridge.protobuf.AccountAgeWitnessDateRequest;
+import bisq.bridge.protobuf.AccountAgeWitnessDateResponse;
+import bisq.bridge.protobuf.AccountAgeWitnessGrpcServiceGrpc;
+
+@Slf4j
+public class AccountAgeWitnessGrpcService extends AccountAgeWitnessGrpcServiceGrpc.AccountAgeWitnessGrpcServiceImplBase {
+    private final AccountAgeWitnessService accountAgeWitnessService;
+
+    @Inject
+    public AccountAgeWitnessGrpcService(AccountAgeWitnessService accountAgeWitnessService) {
+        this.accountAgeWitnessService = accountAgeWitnessService;
+    }
+
+    @Override
+    public void requestAccountAgeWitnessDate(AccountAgeWitnessDateRequest request,
+                                             StreamObserver<AccountAgeWitnessDateResponse> responseObserver) {
+        try {
+            String hashAsHex = request.getHashAsHex();
+            Optional<Long> date = accountAgeWitnessService.getWitnessByHashAsHex(hashAsHex)
+                    .map(AccountAgeWitness::getDate);
+            if (date.isEmpty()) {
+                responseObserver.onError(new RuntimeException("No account age found for hashAsHex: " + hashAsHex));
+                return;
+            }
+            log.info("Account age for hash {}: {} ({})", hashAsHex, date, new Date(date.get()));
+
+            var response = AccountAgeWitnessDateResponse.newBuilder().setDate(date.get()).build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("requestAccountAgeWitnessData failed", e);
+        }
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BondedRoleGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BondedRoleGrpcService.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import bisq.core.dao.SignVerifyService;
+import bisq.core.dao.governance.bond.BondState;
+import bisq.core.dao.governance.bond.role.BondedRolesRepository;
+import bisq.core.dao.state.DaoStateService;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.security.SignatureException;
+
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.bridge.protobuf.BondedRoleGrpcServiceGrpc;
+import bisq.bridge.protobuf.BondedRoleVerificationRequest;
+import bisq.bridge.protobuf.BondedRoleVerificationResponse;
+
+@Slf4j
+public class BondedRoleGrpcService extends BondedRoleGrpcServiceGrpc.BondedRoleGrpcServiceImplBase {
+    private final DaoStateService daoStateService;
+    private final BondedRolesRepository bondedRolesRepository;
+    private final SignVerifyService signVerifyService;
+
+    @Inject
+    public BondedRoleGrpcService(DaoStateService daoStateService,
+                                 BondedRolesRepository bondedRolesRepository,
+                                 SignVerifyService signVerifyService) {
+        this.daoStateService = daoStateService;
+        this.bondedRolesRepository = bondedRolesRepository;
+        this.signVerifyService = signVerifyService;
+    }
+
+    @Override
+    public void requestBondedRoleVerification(BondedRoleVerificationRequest request,
+                                              StreamObserver<BondedRoleVerificationResponse> responseObserver) {
+        try {
+            String bondUserName = request.getBondUserName();
+            String roleType = request.getRoleType();
+            String profileId = request.getProfileId();
+            String signatureBase64 = request.getSignatureBase64();
+
+            log.info("Received request for verifying a bonded role. bondUserName={}, roleType={}, profileId={}, signatureBase64={}",
+                    bondUserName, roleType, profileId, signatureBase64);
+
+            Optional<String> errorMessage = bondedRolesRepository.getAcceptedBonds().stream()
+                    .filter(bondedRole -> bondedRole.getBondedAsset().getBondedRoleType().name().equals(roleType))
+                    .filter(bondedRole -> bondedRole.getBondedAsset().getName().equals(bondUserName))
+                    .filter(bondedRole -> bondedRole.getBondState() == BondState.LOCKUP_TX_CONFIRMED)
+                    .flatMap(bondedRole -> daoStateService.getTx(bondedRole.getLockupTxId()).stream())
+                    .flatMap(tx -> tx.getTxInputs().stream().findFirst().stream())
+                    .map(txInput -> {
+                        try {
+                            signVerifyService.verify(profileId, txInput.getPubKey(), signatureBase64);
+                            log.info("Successfully verified bonded role");
+                            return Optional.<String>empty();
+                        } catch (SignatureException e) {
+                            return Optional.of("Signature verification failed.");
+                        }
+                    })
+                    .findAny()
+                    .orElseGet(() -> {
+                        String message = "Did not find a bonded role matching the parameters";
+                        log.warn(message);
+                        return Optional.of(message);
+                    });
+
+            BondedRoleVerificationResponse.Builder builder = BondedRoleVerificationResponse.newBuilder();
+            errorMessage.ifPresent(builder::setErrorMessage);
+            BondedRoleVerificationResponse response = builder.build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("requestBondedRoleVerification failed", e);
+        }
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BondedRoleGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BondedRoleGrpcService.java
@@ -22,6 +22,7 @@ import bisq.core.dao.governance.bond.BondState;
 import bisq.core.dao.governance.bond.role.BondedRolesRepository;
 import bisq.core.dao.state.DaoStateService;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
 import javax.inject.Inject;
@@ -94,6 +95,10 @@ public class BondedRoleGrpcService extends BondedRoleGrpcServiceGrpc.BondedRoleG
             responseObserver.onCompleted();
         } catch (Exception e) {
             log.error("requestBondedRoleVerification failed", e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Error at bonded role verification")
+                    .withCause(e)
+                    .asRuntimeException());
         }
     }
 }

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
@@ -58,6 +58,8 @@ import bisq.bridge.protobuf.BsqBlockGrpcServiceGrpc;
 
 @Slf4j
 public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcServiceImplBase implements DaoStateListener {
+    private static final int MIN_BONDED_REPUTATION_LOCK_TIME = 50_000;
+
     private final DaoStateService daoStateService;
     private final BondedReputationRepository bondedReputationRepository;
     private final ExecutorService notifyObserversExecutor, requestBlocksExecutor;
@@ -221,7 +223,7 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
         try {
             return bondedReputationRepository.getBondedReputationStream()
                     .filter(BondedReputation::isActive)
-                    .filter(bondedReputation -> bondedReputation.getLockTime() >= 50_000)
+                    .filter(bondedReputation -> bondedReputation.getLockTime() >= MIN_BONDED_REPUTATION_LOCK_TIME)
                     .collect(Collectors.toMap(Bond::getLockupTxId, bondedReputation -> bondedReputation));
         } catch (Exception e) {
             log.error("getBondedReputationByTxId failed", e);

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
@@ -1,0 +1,240 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import bisq.core.dao.governance.bond.Bond;
+import bisq.core.dao.governance.bond.reputation.BondedReputation;
+import bisq.core.dao.governance.bond.reputation.BondedReputationRepository;
+import bisq.core.dao.governance.proofofburn.ProofOfBurnService;
+import bisq.core.dao.state.DaoStateListener;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Block;
+import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.dao.state.model.blockchain.TxType;
+
+import bisq.common.util.ExecutorFactory;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.bridge.grpc.dto.BondedReputationDto;
+import bisq.bridge.grpc.dto.BsqBlockDto;
+import bisq.bridge.grpc.dto.ProofOfBurnDto;
+import bisq.bridge.grpc.dto.TxDto;
+import bisq.bridge.grpc.messages.BsqBlocksRequest;
+import bisq.bridge.grpc.messages.BsqBlocksResponse;
+import bisq.bridge.protobuf.BsqBlockGrpcServiceGrpc;
+
+@Slf4j
+public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcServiceImplBase implements DaoStateListener {
+    private final DaoStateService daoStateService;
+    private final BondedReputationRepository bondedReputationRepository;
+    private final ExecutorService notifyObserversExecutor, requestBlocksExecutor;
+    private final Set<ManagedStreamObserver<bisq.bridge.protobuf.BsqBlockDto>> streamObservers = new CopyOnWriteArraySet<>();
+
+    @Inject
+    public BsqBlockGrpcService(DaoStateService daoStateService,
+                               BondedReputationRepository bondedReputationRepository) {
+        this.daoStateService = daoStateService;
+        this.bondedReputationRepository = bondedReputationRepository;
+
+        daoStateService.addDaoStateListener(this);
+
+        notifyObserversExecutor = ExecutorFactory.newSingleThreadExecutor("BsqBlockGrpcService.notifyObservers");
+        requestBlocksExecutor = ExecutorFactory.newSingleThreadExecutor("BsqBlockGrpcService.requestBsqBlocks");
+    }
+
+    @Override
+    public void onParseBlockCompleteAfterBatchProcessing(Block block) {
+        log.info("onParseBlockCompleteAfterBatchProcessing");
+        if (streamObservers.isEmpty()) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                Map<String, BondedReputation> bondedReputationByTxId = getBondedReputationByTxId();
+                BsqBlockDto bsqBlockDto = toBlockDto(block, bondedReputationByTxId);
+                if (bsqBlockDto.getTxDtoList().isEmpty()) {
+                    log.info("No relevant BSQ transactions in that block, therefor we skip publishing. bsqBlockDto={}", bsqBlockDto);
+                    return;
+                }
+
+                log.info("Notify observers of new bsqBlockDto: {}", bsqBlockDto);
+                var responseProto = bsqBlockDto.toProtoMessage();
+                streamObservers.forEach(observer -> {
+                    try {
+                        observer.onNext(responseProto);
+                    } catch (Exception e) {
+                        log.error("Failed to notify observer", e);
+                        notifyOnError(observer, e);
+                    }
+                });
+            } catch (Exception e) {
+                log.error("Error at processing new bsqBlockDto", e);
+                streamObservers.forEach(observer -> notifyOnError(observer, e));
+            }
+        }, notifyObserversExecutor);
+    }
+
+
+    @Override
+    public void subscribe(bisq.bridge.protobuf.BsqBlockSubscription subscription,
+                          StreamObserver<bisq.bridge.protobuf.BsqBlockDto> streamObserver) {
+        log.info("subscribe streamObserver {}", streamObserver);
+        var managedStreamObserver = new ManagedStreamObserver<>(streamObserver, streamObservers::remove, streamObservers::remove);
+        streamObservers.add(managedStreamObserver);
+    }
+
+    @Override
+    public void requestBsqBlocks(bisq.bridge.protobuf.BsqBlocksRequest bsqBlocksRequest,
+                                 StreamObserver<bisq.bridge.protobuf.BsqBlocksResponse> streamObserver) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                if (!daoStateService.isParseBlockChainComplete()) {
+                    log.warn("Request rejected because blockchain parsing is not completed yet. Chain height={}", daoStateService.getChainHeight());
+                    streamObserver.onError(Status.FAILED_PRECONDITION
+                            .withDescription("Blockchain parsing is not completed yet. Chain height=" + daoStateService.getChainHeight())
+                            .asRuntimeException());
+                    return;
+                }
+
+                long ts = System.currentTimeMillis();
+                int startBlockHeight = BsqBlocksRequest.fromProto(bsqBlocksRequest).getStartBlockHeight();
+                log.info("Request Bsq blocks from block {}", startBlockHeight);
+
+                Map<String, BondedReputation> bondedReputationByTxId = getBondedReputationByTxId();
+                List<BsqBlockDto> blocks = daoStateService.getBlocksFromBlockHeight(startBlockHeight).stream()
+                        .map(block -> toBlockDto(block, bondedReputationByTxId))
+                        .filter(dto -> !dto.getTxDtoList().isEmpty())
+                        .collect(Collectors.toList());
+
+                // About 108 ms for 703 BsqBlocks, responseProto is about 73kb
+                log.info("Creating {} BsqBlocks took {} ms", blocks.size(), System.currentTimeMillis() - ts);
+                var responseProto = new BsqBlocksResponse(blocks).toProtoMessage();
+                streamObserver.onNext(responseProto);
+                streamObserver.onCompleted();
+            } catch (Exception e) {
+                log.error("Error at processing blocks", e);
+                notifyOnError(streamObserver, e);
+            }
+        }, requestBlocksExecutor);
+    }
+
+    public void shutDown() {
+        daoStateService.removeDaoStateListener(this);
+
+        ExecutorFactory.shutdownAndAwaitTermination(notifyObserversExecutor, 1000);
+        ExecutorFactory.shutdownAndAwaitTermination(requestBlocksExecutor, 1000);
+
+        streamObservers.clear();
+    }
+
+    private BsqBlockDto toBlockDto(Block block, Map<String, BondedReputation> bondedReputationByTxId) {
+        try {
+            List<TxDto> txDataList = block.getTxs().stream()
+                    .map(tx -> {
+                        Optional<ProofOfBurnDto> proofOfBurnDto = toProofOfBurnDto(tx);
+                        Optional<BondedReputationDto> bondedReputationDto = toBondedReputationDto(bondedReputationByTxId, tx);
+                        if (proofOfBurnDto.isPresent() || bondedReputationDto.isPresent()) {
+                            return new TxDto(tx.getId(), proofOfBurnDto, bondedReputationDto);
+                        } else {
+                            return null;
+                        }
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            return new BsqBlockDto(block.getHeight(),
+                    block.getTime(),
+                    txDataList);
+        } catch (Exception e) {
+            log.error("toBlockDto failed", e);
+            throw e;
+        }
+    }
+
+    private Optional<ProofOfBurnDto> toProofOfBurnDto(Tx tx) {
+        try {
+            if (tx.getTxType() == TxType.PROOF_OF_BURN) {
+                byte[] proofOfBurnHash = ProofOfBurnService.getHashFromOpReturnData(tx);
+                return Optional.of(new ProofOfBurnDto(tx.getBurntBsq(), proofOfBurnHash));
+            } else {
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            log.error("toProofOfBurnDto failed", e);
+            throw e;
+        }
+    }
+
+    private Optional<BondedReputationDto> toBondedReputationDto(Map<String, BondedReputation> bondedReputationByTxId,
+                                                                Tx tx) {
+        try {
+            if (tx.getTxType() == TxType.LOCKUP) {
+                BondedReputation value = bondedReputationByTxId.get(tx.getId());
+                return Optional.ofNullable(value)
+                        .map(bondedReputation -> new BondedReputationDto(bondedReputation.getAmount(),
+                                bondedReputation.getBondedAsset().getHash(),
+                                bondedReputation.getLockTime()));
+            } else {
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            log.error("toBondedReputationDto failed", e);
+            throw e;
+        }
+    }
+
+    private Map<String, BondedReputation> getBondedReputationByTxId() {
+        // We only consider lock time with at least 50 000 blocks as valid
+        try {
+            return bondedReputationRepository.getBondedReputationStream()
+                    .filter(BondedReputation::isActive)
+                    .filter(bondedReputation -> bondedReputation.getLockTime() >= 50_000)
+                    .collect(Collectors.toMap(Bond::getLockupTxId, bondedReputation -> bondedReputation));
+        } catch (Exception e) {
+            log.error("getBondedReputationByTxId failed", e);
+            throw e;
+        }
+    }
+
+    private void notifyOnError(StreamObserver<?> observer,
+                               Exception exception) {
+        observer.onError(Status.INTERNAL
+                .withDescription("Error processing bsqBlock data")
+                .withCause(exception)
+                .asRuntimeException());
+    }
+
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BurningmanGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BurningmanGrpcService.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import bisq.core.dao.burningman.BurningManService;
+import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
+import bisq.core.dao.state.DaoStateListener;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Block;
+
+import bisq.common.util.ExecutorFactory;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.bridge.grpc.dto.BurningmanBlockDto;
+import bisq.bridge.grpc.dto.BurningmanDto;
+import bisq.bridge.protobuf.BurningmanGrpcServiceGrpc;
+
+@Slf4j
+public class BurningmanGrpcService extends BurningmanGrpcServiceGrpc.BurningmanGrpcServiceImplBase implements DaoStateListener {
+    private final DaoStateService daoStateService;
+    private final BurningManService burningManService;
+    private final DelayedPayoutTxReceiverService delayedPayoutTxReceiverService;
+    private final ExecutorService notifyObserversExecutor, requestBlocksExecutor;
+    private final Set<ManagedStreamObserver<bisq.bridge.protobuf.BurningmanBlockDto>> streamObservers = new CopyOnWriteArraySet<>();
+    private final Object snapshotLock = new Object();
+    private int snapshotHeight;
+
+    @Inject
+    public BurningmanGrpcService(DaoStateService daoStateService,
+                                 BurningManService burningManService,
+                                 DelayedPayoutTxReceiverService delayedPayoutTxReceiverService) {
+        this.daoStateService = daoStateService;
+        this.burningManService = burningManService;
+        this.delayedPayoutTxReceiverService = delayedPayoutTxReceiverService;
+
+        daoStateService.addDaoStateListener(this);
+
+        notifyObserversExecutor = ExecutorFactory.newSingleThreadExecutor("BurningmanGrpcService.notifyObservers");
+        requestBlocksExecutor = ExecutorFactory.newSingleThreadExecutor("BurningmanGrpcService.requestBurningmanBlocks");
+    }
+
+    @Override
+    public void onParseBlockCompleteAfterBatchProcessing(Block block) {
+        log.info("onParseBlockCompleteAfterBatchProcessing");
+        if (streamObservers.isEmpty()) {
+            return;
+        }
+
+        int burningManSelectionHeight = delayedPayoutTxReceiverService.getBurningManSelectionHeight(block.getHeight());
+        synchronized (snapshotLock) {
+            if (snapshotHeight == burningManSelectionHeight) {
+                return;
+            }
+
+            snapshotHeight = burningManSelectionHeight;
+        }
+
+        // We got a new snapshot height and notify our observer.
+        // The block height is the last mod(10) height from the range of the last 10-20 blocks (139 -> 120; 140 -> 130, 141 -> 130).
+        // This ensures that we have not to deal with re-orgs as it is expected that re-orgs never are that
+        // deep (about 3-4 blocks have been historically deepest reorgs).
+        daoStateService.getBlockAtHeight(snapshotHeight).ifPresent(blockAtSnapshotHeight -> {
+            CompletableFuture.runAsync(() -> {
+                try {
+                    BurningmanBlockDto burningManBlockDto = toBurningmanBlockDto(blockAtSnapshotHeight);
+                    log.info("Notify observers of new burningManBlockDto: {}", burningManBlockDto);
+                    var responseProto = burningManBlockDto.toProtoMessage();
+                    streamObservers.forEach(observer -> {
+                        try {
+                            observer.onNext(responseProto);
+                        } catch (Exception e) {
+                            log.error("Failed to notify observer", e);
+                            notifyOnError(observer, e);
+                        }
+                    });
+                } catch (Exception e) {
+                    log.error("Error at processing new burningManBlockDto", e);
+                    streamObservers.forEach(observer -> notifyOnError(observer, e));
+                }
+            }, notifyObserversExecutor);
+        });
+    }
+
+    @Override
+    public void subscribe(bisq.bridge.protobuf.BurningmanBlockSubscription subscription,
+                          StreamObserver<bisq.bridge.protobuf.BurningmanBlockDto> streamObserver) {
+        log.info("subscribe streamObserver {}", streamObserver);
+        var managedStreamObserver = new ManagedStreamObserver<>(streamObserver, streamObservers::remove, streamObservers::remove);
+        streamObservers.add(managedStreamObserver);
+    }
+
+    @Override
+    public void requestBurningmanBlocks(bisq.bridge.protobuf.BurningmanBlocksRequest burningmanBlocksRequest,
+                                        StreamObserver<bisq.bridge.protobuf.BurningmanBlocksResponse> streamObserver) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                if (!daoStateService.isParseBlockChainComplete()) {
+                    log.warn("Request rejected because blockchain parsing is not completed yet. Chain height={}", daoStateService.getChainHeight());
+                    streamObserver.onError(Status.FAILED_PRECONDITION
+                            .withDescription("Blockchain parsing is not completed yet. Chain height=" + daoStateService.getChainHeight())
+                            .asRuntimeException());
+                    return;
+                }
+
+                // Last 100 days will result in 1440 blocks takes about 10 seconds (toBurningmanBlockDto is slow,
+                // we could add caching...)
+                long ts = System.currentTimeMillis();
+                int chainHeight = daoStateService.getChainHeight();
+                int startBlockHeight = chainHeight - 10000;
+                // We only provide blocks with heights which can be a snapshot height (mod 10)
+                List<BurningmanBlockDto> blocks = daoStateService.getBlocksFromBlockHeight(startBlockHeight).stream()
+                        .filter(block -> BurningmanRetention.includeBlock(chainHeight, block.getHeight()))
+                        .map(this::toBurningmanBlockDto)
+                        .collect(Collectors.toList());
+                // Takes about 13 sec for 28 items, size about 43 KB
+                log.info("Creating {} BurningmanBlockDto blocks took {} ms", blocks.size(), System.currentTimeMillis() - ts);
+                var responseProto = new bisq.bridge.grpc.messages.BurningmanBlocksResponse(blocks).toProtoMessage();
+                streamObserver.onNext(responseProto);
+                streamObserver.onCompleted();
+            } catch (Exception e) {
+                log.error("Error at processing burningman blocks", e);
+                notifyOnError(streamObserver, e);
+            }
+        }, requestBlocksExecutor);
+    }
+
+    public void shutDown() {
+        daoStateService.removeDaoStateListener(this);
+
+        ExecutorFactory.shutdownAndAwaitTermination(notifyObserversExecutor, 1000);
+        ExecutorFactory.shutdownAndAwaitTermination(requestBlocksExecutor, 1000);
+
+        streamObservers.clear();
+    }
+
+    private BurningmanBlockDto toBurningmanBlockDto(Block block) {
+        try {
+            List<BurningmanDto> burningmanDtoList = toBurningmanDtoList(block);
+            return new BurningmanBlockDto(block.getHeight(), burningmanDtoList);
+        } catch (Exception e) {
+            log.error("toBurningmanBlockDto failed", e);
+            throw e;
+        }
+    }
+
+    private List<BurningmanDto> toBurningmanDtoList(Block block) {
+        try {
+            return burningManService.getActiveBurningManCandidates(block.getHeight(), true).stream()
+                    .filter(burningManCandidate -> burningManCandidate.getReceiverAddress().isPresent())
+                    .map(burningManCandidate -> {
+                        String receiverAddress = burningManCandidate.getReceiverAddress().orElseThrow();
+                        double cappedBurnAmountShare = burningManCandidate.getCappedBurnAmountShare();
+                        return new BurningmanDto(receiverAddress, cappedBurnAmountShare);
+                    })
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("toBurningmanDtoList failed", e);
+            throw e;
+        }
+    }
+
+    private void notifyOnError(StreamObserver<?> observer,
+                               Exception exception) {
+        observer.onError(Status.INTERNAL
+                .withDescription("Error processing bsqBlock data")
+                .withCause(exception)
+                .asRuntimeException());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BurningmanRetention.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BurningmanRetention.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class BurningmanRetention {
+    public static boolean includeBlock(int chainHeightTip, int blockHeight) {
+        checkArgument(blockHeight <= chainHeightTip, "blockHeight must not be higher than chainHeightTip");
+        int cutOffHeightMod10 = Math.max(0, chainHeightTip - 100);
+        int cutOffHeightMod100 = Math.max(0, chainHeightTip - 1000);
+        int cutOffHeightMod1000 = Math.max(0, chainHeightTip - 10000);
+        if (blockHeight > cutOffHeightMod10) {
+            return blockHeight % 10 == 0; // evey possible snapshot block of the past 100 blocks (about 16 hours);
+        } else if (blockHeight > cutOffHeightMod100) {
+            return blockHeight % 100 == 0;  // evey 10th possible snapshot block of the past 1000 blocks (about 7 days)
+        } else if (blockHeight > cutOffHeightMod1000) {
+            return blockHeight % 1000 == 0;  // evey 100th possible snapshot block of the past 10000 blocks (about 70 days or > 2 months)
+        }
+        return false;
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/services/ManagedStreamObserver.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/ManagedStreamObserver.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import io.grpc.stub.StreamObserver;
+
+import java.util.function.Consumer;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class ManagedStreamObserver<T> implements StreamObserver<T> {
+    @EqualsAndHashCode.Include
+    private final StreamObserver<T> delegate;
+
+    private final Consumer<ManagedStreamObserver<T>> onErrorCallback;
+    private final Consumer<ManagedStreamObserver<T>> onCompletedCallback;
+
+    public ManagedStreamObserver(StreamObserver<T> delegate,
+                                 Consumer<ManagedStreamObserver<T>> onErrorCallback,
+                                 Consumer<ManagedStreamObserver<T>> onCompletedCallback) {
+        this.delegate = delegate;
+        this.onErrorCallback = onErrorCallback;
+        this.onCompletedCallback = onCompletedCallback;
+    }
+
+    @Override
+    public void onNext(T element) {
+        delegate.onNext(element);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        delegate.onError(throwable);
+        onErrorCallback.accept(this);
+    }
+
+    @Override
+    public void onCompleted() {
+        delegate.onCompleted();
+        onCompletedCallback.accept(this);
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/services/SignedWitnessGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/SignedWitnessGrpcService.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import bisq.core.account.witness.AccountAgeWitnessService;
+
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.Date;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.bridge.protobuf.SignedWitnessDateRequest;
+import bisq.bridge.protobuf.SignedWitnessDateResponse;
+import bisq.bridge.protobuf.SignedWitnessGrpcServiceGrpc;
+
+@Slf4j
+public class SignedWitnessGrpcService extends SignedWitnessGrpcServiceGrpc.SignedWitnessGrpcServiceImplBase {
+    private final AccountAgeWitnessService accountAgeWitnessService;
+
+    @Inject
+    public SignedWitnessGrpcService(AccountAgeWitnessService accountAgeWitnessService) {
+        this.accountAgeWitnessService = accountAgeWitnessService;
+    }
+
+    @Override
+    public void requestSignedWitnessDate(SignedWitnessDateRequest request,
+                                         StreamObserver<SignedWitnessDateResponse> responseObserver) {
+        try {
+            String hashAsHex = request.getHashAsHex();
+
+            Optional<Long> date = accountAgeWitnessService.getWitnessByHashAsHex(hashAsHex)
+                    .map(accountAgeWitnessService::getWitnessSignDate);
+            if (date.isEmpty()) {
+                responseObserver.onError(new RuntimeException("No witness found for hashAsHex: " + hashAsHex));
+                return;
+            }
+            log.info("SignedWitness sign date for hash {}: {} ({})", hashAsHex, date, new Date(date.get()));
+            var response = SignedWitnessDateResponse.newBuilder()
+                    .setDate(date.get())
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            log.error("requestSignedWitnessDate failed", e);
+        }
+    }
+}

--- a/bridge/src/main/resources/logback.xml
+++ b/bridge/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{40}: %msg %xEx%n)</pattern>
+        </encoder>
+    </appender>
+
+    <root level="TRACE">
+        <appender-ref ref="CONSOLE_APPENDER"/>
+    </root>
+
+    <!-- <logger name="org.bitcoinj" level="WARN"/>-->
+    <logger name="org.berndpruenster.netlayer.tor.Tor" level="WARN"/>
+</configuration>

--- a/bridge/src/test/java/bisq/bridge/grpc/services/BurningmanRetentionTest.java
+++ b/bridge/src/test/java/bisq/bridge/grpc/services/BurningmanRetentionTest.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+
+import static bisq.bridge.grpc.services.BurningmanRetention.includeBlock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Slf4j
+public class BurningmanRetentionTest {
+    @Test
+    public void testIncludeBlock() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            includeBlock(0, 1);
+        });
+
+        assertEquals(10, resolve(100, 100));
+        // with 100 blocks we have 19 not 20, as one match would be covered by both mod 10 and mod 100
+        assertEquals(19, resolve(1000, 1000));
+        // with 100 blocks we have 28 not 30, as one match would be covered by mod 10 and mod 100 and mod 1000
+        assertEquals(28, resolve(10000, 10000));
+
+        // current block on Jul 25th 2025
+        assertEquals(28, resolve(907074, 10000));
+
+        int fromBlock = 907074; // current block on Jul 25th 2025
+        int toBlock = 892674; // past 100 days = 907074 - 14400 = 892674
+        for (int i = fromBlock; i >= toBlock; i--) {
+            assertEquals(28, resolve(i, 10000));
+        }
+    }
+
+    private static int resolve(int chainHeightTip, int lookBack) {
+        int blockHeight = chainHeightTip - lookBack;
+        int numIncludes = 0;
+        for (int i = chainHeightTip; i > blockHeight; i--) {
+            if (includeBlock(chainHeightTip, i)) {
+                numIncludes++;
+            }
+        }
+        return numIncludes;
+    }
+
+}

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import ch.qos.logback.classic.Level;
 
 import lombok.Getter;
-import lombok.Setter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -125,6 +124,7 @@ public class Config {
     public static final String ALLOW_FAULTY_DELAYED_TXS = "allowFaultyDelayedTxs";
     public static final String API_PASSWORD = "apiPassword";
     public static final String API_PORT = "apiPort";
+    public static final String BRIDGE_PORT = "bridgePort";
     public static final String PREVENT_PERIODIC_SHUTDOWN_AT_SEED_NODE = "preventPeriodicShutdownAtSeedNode";
     public static final String REPUBLISH_MAILBOX_ENTRIES = "republishMailboxEntries";
     public static final String LEGACY_FEE_DATAMAP = "dataMap";
@@ -232,6 +232,7 @@ public class Config {
     public final boolean allowFaultyDelayedTxs;
     public final String apiPassword;
     public final int apiPort;
+    public final int bridgePort;
     public final boolean preventPeriodicShutdownAtSeedNode;
     public final boolean republishMailboxEntries;
     public final boolean bypassMempoolValidation;
@@ -691,6 +692,12 @@ public class Config {
                         .ofType(Integer.class)
                         .defaultsTo(9998);
 
+        ArgumentAcceptingOptionSpec<Integer> bridgePortOpt =
+                parser.accepts(BRIDGE_PORT, "GRPC Bisq 2 bridge port")
+                        .withRequiredArg()
+                        .ofType(Integer.class)
+                        .defaultsTo(50051);
+
         ArgumentAcceptingOptionSpec<Boolean> preventPeriodicShutdownAtSeedNodeOpt =
                 parser.accepts(PREVENT_PERIODIC_SHUTDOWN_AT_SEED_NODE,
                                 "Prevents periodic shutdown at seed nodes")
@@ -876,6 +883,7 @@ public class Config {
             this.allowFaultyDelayedTxs = options.valueOf(allowFaultyDelayedTxsOpt);
             this.apiPassword = options.valueOf(apiPasswordOpt);
             this.apiPort = options.valueOf(apiPortOpt);
+            this.bridgePort = options.valueOf(bridgePortOpt);
             this.preventPeriodicShutdownAtSeedNode = options.valueOf(preventPeriodicShutdownAtSeedNodeOpt);
             this.republishMailboxEntries = options.valueOf(republishMailboxEntriesOpt);
             this.bypassMempoolValidation = options.valueOf(bypassMempoolValidationOpt);

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -696,7 +696,7 @@ public class Config {
                 parser.accepts(BRIDGE_PORT, "GRPC Bisq 2 bridge port")
                         .withRequiredArg()
                         .ofType(Integer.class)
-                        .defaultsTo(50051);
+                        .defaultsTo(50091);
 
         ArgumentAcceptingOptionSpec<Boolean> preventPeriodicShutdownAtSeedNodeOpt =
                 parser.accepts(PREVENT_PERIODIC_SHUTDOWN_AT_SEED_NODE,

--- a/common/src/main/java/bisq/common/util/ExecutorFactory.java
+++ b/common/src/main/java/bisq/common/util/ExecutorFactory.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.util;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+public class ExecutorFactory {
+    public static final int DEFAULT_PRIORITY = 5;
+
+    /* --------------------------------------------------------------------- */
+    // Single Thread Executors
+    /* --------------------------------------------------------------------- */
+
+    public static ExecutorService newSingleThreadExecutor(String name) {
+        return Executors.newSingleThreadExecutor(getThreadFactory(name));
+    }
+    /* --------------------------------------------------------------------- */
+    // ThreadFactory
+    /* --------------------------------------------------------------------- */
+
+    public static ThreadFactory getThreadFactory(String name) {
+        return new ThreadFactoryBuilder()
+                .setNameFormat(name + "-%d")
+                .setDaemon(true)
+                .setPriority(DEFAULT_PRIORITY)
+                .build();
+    }
+
+    /* --------------------------------------------------------------------- */
+    // ShutdownAndAwaitTermination utils
+    /* --------------------------------------------------------------------- */
+
+    public static boolean shutdownAndAwaitTermination(ExecutorService executor, long timeoutMs) {
+        return shutdownAndAwaitTermination(executor, timeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    public static boolean shutdownAndAwaitTermination(ExecutorService executor, long timeout, TimeUnit unit) {
+        //noinspection UnstableApiUsage
+        return MoreExecutors.shutdownAndAwaitTermination(executor, timeout, unit);
+    }
+
+}

--- a/common/src/main/java/bisq/common/util/OptionalUtils.java
+++ b/common/src/main/java/bisq/common/util/OptionalUtils.java
@@ -1,0 +1,10 @@
+package bisq.common.util;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class OptionalUtils {
+    public static <R> Optional<R> optionalIf(boolean condition, Supplier<R> supplier) {
+        return condition ? Optional.of(supplier.get()) : Optional.empty();
+    }
+}

--- a/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
@@ -265,6 +265,7 @@ public abstract class ExecutableForAppWithP2p extends BisqExecutable {
     protected void keepRunning() {
         while (true) {
             try {
+                //noinspection BusyWait
                 Thread.sleep(Long.MAX_VALUE);
             } catch (InterruptedException ignore) {
             }

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -213,7 +213,7 @@ public class BurningManService {
         return getActiveBurningManCandidates(chainHeight, false);
     }
 
-    List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight, boolean limitCappingRounds) {
+    public List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight, boolean limitCappingRounds) {
         return getBurningManCandidatesByName(chainHeight, limitCappingRounds).values().stream()
                 .filter(burningManCandidate -> burningManCandidate.getCappedBurnAmountShare() > 0)
                 .filter(BurningManCandidate::isReceiverAddressValid)

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -118,7 +118,11 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
     // The block height is the last mod(10) height from the range of the last 10-20 blocks (139 -> 120; 140 -> 130, 141 -> 130).
     // We do not have the latest dao state by that but can ensure maker and taker have the same block.
     public int getBurningManSelectionHeight() {
-        return getSnapshotHeight(daoStateService.getGenesisBlockHeight(), currentChainHeight,
+        return getBurningManSelectionHeight(currentChainHeight);
+    }
+
+    public int getBurningManSelectionHeight(int chainHeight) {
+        return getSnapshotHeight(daoStateService.getGenesisBlockHeight(), chainHeight,
                 SNAPSHOT_SELECTION_GRID_SIZE);
     }
 

--- a/proto/src/main/proto/bridge.proto
+++ b/proto/src/main/proto/bridge.proto
@@ -1,0 +1,126 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+syntax = "proto3";
+
+package bisq.bridge.protobuf;
+
+option java_package = "bisq.bridge.protobuf";
+option java_multiple_files = true;
+
+service BsqBlockGrpcService {
+    rpc Subscribe (BsqBlockSubscription) returns (stream BsqBlockDto);
+
+    rpc RequestBsqBlocks (BsqBlocksRequest) returns (BsqBlocksResponse);
+}
+
+message BsqBlockSubscription {
+}
+
+message BsqBlocksRequest {
+    sint32 startBlockHeight = 1;
+}
+
+message BsqBlocksResponse {
+    repeated BsqBlockDto bsqBlocks = 1;
+}
+
+message BsqBlockDto {
+    sint32 height = 1;
+    sint64 time = 2;
+    repeated TxDto txDto = 3;
+}
+
+message TxDto {
+    string txId = 1;
+    optional ProofOfBurnDto proofOfBurnDto = 2;
+    optional BondedReputationDto bondedReputationDto = 3;
+}
+
+message ProofOfBurnDto {
+    sint64 amount = 1;
+    bytes proofOfBurnHash = 2;
+}
+
+message BondedReputationDto {
+    sint64 amount = 1;
+    bytes bondedReputationHash = 2;
+    sint32 lockTime = 3;
+}
+
+service BurningmanGrpcService {
+    rpc Subscribe (BurningmanBlockSubscription) returns (stream BurningmanBlockDto);
+
+    rpc RequestBurningmanBlocks (BurningmanBlocksRequest) returns (BurningmanBlocksResponse);
+}
+
+message BurningmanBlockSubscription {
+}
+
+message BurningmanBlocksRequest {
+    sint32 startBlockHeight = 1;
+}
+
+message BurningmanBlocksResponse {
+    repeated BurningmanBlockDto burningmanBlocks = 1;
+}
+
+message BurningmanBlockDto {
+    sint32 height = 1;
+    repeated BurningmanDto burningmanItems = 2;
+}
+
+message BurningmanDto {
+    string receiverAddress = 1;
+    double cappedBurnAmountShare = 2;
+}
+
+service AccountAgeWitnessGrpcService {
+    rpc RequestAccountAgeWitnessDate (AccountAgeWitnessDateRequest) returns (AccountAgeWitnessDateResponse);
+}
+
+message AccountAgeWitnessDateRequest {
+    string hashAsHex = 1;
+}
+message AccountAgeWitnessDateResponse {
+    sint64 date = 1;
+}
+
+service SignedWitnessGrpcService {
+    rpc RequestSignedWitnessDate (SignedWitnessDateRequest) returns (SignedWitnessDateResponse);
+}
+
+message SignedWitnessDateRequest {
+    string hashAsHex = 1;
+}
+message SignedWitnessDateResponse {
+    sint64 date = 1;
+}
+
+
+service BondedRoleGrpcService {
+    rpc RequestBondedRoleVerification (BondedRoleVerificationRequest) returns (BondedRoleVerificationResponse);
+}
+message BondedRoleVerificationRequest {
+    string bondUserName = 1;
+    string roleType = 2;
+    string profileId = 3;
+    string signatureBase64 = 4;
+}
+message BondedRoleVerificationResponse {
+    optional string errorMessage = 1;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ toolchainManagement {
 
 include 'proto'
 include 'assets'
+include 'bridge'
 include 'btcnodemonitor'
 include 'common'
 include 'p2p'


### PR DESCRIPTION
Requires https://github.com/bisq-network/bisq2/pull/3668 on Bisq 2 side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Bridge module providing gRPC APIs for streaming and on-demand BSQ blocks, burningman blocks, account-age/signed-witness date lookups, and bonded-role verification.

* **Improvements**
  * New configurable bridge gRPC port (default 50091).
  * Improved logging configuration.
  * Thread executor utilities and a small Optional helper.

* **Documentation**
  * Added protobuf service/message definitions for the new APIs.

* **Tests**
  * Added tests for burningman retention logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->