### PR TITLE
api: Refactor CoreOffersService findAvailableOffer

### DIFF
--- a/core/src/main/java/bisq/core/api/exception/CannotTakeOfferException.java
+++ b/core/src/main/java/bisq/core/api/exception/CannotTakeOfferException.java
@@ -1,0 +1,10 @@
+package bisq.core.api.exception;
+
+import bisq.common.BisqException;
+
+public class CannotTakeOfferException extends BisqException {
+
+    public CannotTakeOfferException(String format, Object... args) {
+        super(format, args);
+    }
+}


### PR DESCRIPTION
- Throw CannotTakeOfferException instead of IllegalStateException when
offer can't be taken
- Make error messages user-friendly
- Extract and reuse checkIsNotMyOffer, checkCanTakeOffer,
  checkIsBsqOffer

Relates to https://github.com/bisq-network/bisq/pull/7433.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocks attempts to take your own offer with a clear, immediate error message.
  * Performs upfront validation of offer eligibility and shows specific reasons when an offer can’t be taken (including non-BSQ swap offers).
  * Surfaces errors earlier to avoid confusing late failures during offer selection.
  * Improves reliability and consistency of offer availability checks, reducing edge-case misbehavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->