### PR TITLE
api: Move BTC positive balance filtering to API-level

### DIFF
--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -67,6 +67,7 @@ import bisq.cli.opts.GetAddressBalanceOptionParser;
 import bisq.cli.opts.GetAvgBsqPriceOptionParser;
 import bisq.cli.opts.GetBTCMarketPriceOptionParser;
 import bisq.cli.opts.GetBalanceOptionParser;
+import bisq.cli.opts.GetFundingAddressesOptionParser;
 import bisq.cli.opts.GetOffersOptionParser;
 import bisq.cli.opts.GetPaymentAcctFormOptionParser;
 import bisq.cli.opts.GetTradeOptionParser;
@@ -249,11 +250,14 @@ public class CliMain {
                     return;
                 }
                 case getfundingaddresses: {
-                    if (new SimpleMethodOptionParser(args).parse().isForHelp()) {
+                    var opts = new GetFundingAddressesOptionParser(args).parse();
+                    if (opts.isForHelp()) {
                         out.println(client.getMethodHelp(method));
                         return;
                     }
-                    var fundingAddresses = client.getFundingAddresses();
+                    var onlyFunded = opts.getIsOnlyFunded();
+
+                    var fundingAddresses = client.getFundingAddresses(onlyFunded);
                     new TableBuilder(ADDRESS_BALANCE_TBL, fundingAddresses).build().print(out);
                     return;
                 }
@@ -897,6 +901,7 @@ public class CliMain {
             stream.format(rowFormat, getbtcprice.name(), "--currency-code=<currency-code>", "Get current market btc price");
             stream.println();
             stream.format(rowFormat, getfundingaddresses.name(), "", "Get BTC funding addresses");
+            stream.format(rowFormat, "", "[--only-funded=<true|false>]", "");
             stream.println();
             stream.format(rowFormat, getunusedbsqaddress.name(), "", "Get unused BSQ address");
             stream.println();

--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -115,8 +115,8 @@ public final class GrpcClient {
         return walletsServiceRequest.getBtcPrice(currencyCode);
     }
 
-    public List<AddressBalanceInfo> getFundingAddresses() {
-        return walletsServiceRequest.getFundingAddresses();
+    public List<AddressBalanceInfo> getFundingAddresses(boolean onlyFunded) {
+        return walletsServiceRequest.getFundingAddresses(onlyFunded);
     }
 
     public String getUnusedBsqAddress() {

--- a/cli/src/main/java/bisq/cli/opts/GetFundingAddressesOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/GetFundingAddressesOptionParser.java
@@ -1,0 +1,26 @@
+package bisq.cli.opts;
+
+import joptsimple.OptionSpec;
+
+import static bisq.cli.opts.OptLabel.OPT_ONLY_FUNDED;
+
+public class GetFundingAddressesOptionParser extends AbstractMethodOptionParser implements MethodOpts {
+    final OptionSpec<Boolean> onlyFundedOpt = parser.accepts(OPT_ONLY_FUNDED, "only funded addresses")
+            .withOptionalArg()
+            .ofType(boolean.class)
+            .defaultsTo(Boolean.FALSE);
+
+    public GetFundingAddressesOptionParser(String[] args) {
+        super(args);
+    }
+
+    public GetFundingAddressesOptionParser parse() {
+        super.parse();
+
+        return this;
+    }
+
+    public boolean getIsOnlyFunded() {
+        return options.valueOf(onlyFundedOpt);
+    }
+}

--- a/cli/src/main/java/bisq/cli/opts/OptLabel.java
+++ b/cli/src/main/java/bisq/cli/opts/OptLabel.java
@@ -38,6 +38,7 @@ public class OptLabel {
     public final static String OPT_MKT_PRICE_MARGIN = "market-price-margin";
     public final static String OPT_MIN_AMOUNT = "min-amount";
     public final static String OPT_OFFER_ID = "offer-id";
+    public final static String OPT_ONLY_FUNDED = "only-funded";
     public final static String OPT_PASSWORD = "password";
     public final static String OPT_PAYMENT_ACCOUNT_ID = "payment-account-id";
     public final static String OPT_PAYMENT_ACCOUNT_FORM = "payment-account-form";

--- a/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
+++ b/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
@@ -44,6 +44,7 @@ import bisq.proto.grpc.UnsetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.VerifyBsqSentToAddressRequest;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 
@@ -99,9 +100,18 @@ public class WalletsServiceRequest {
         return grpcStubs.priceService.getMarketPrice(request).getPrice();
     }
 
-    public List<AddressBalanceInfo> getFundingAddresses() {
+    public List<AddressBalanceInfo> getFundingAddresses(boolean onlyFunded) {
         var request = GetFundingAddressesRequest.newBuilder().build();
-        return grpcStubs.walletsService.getFundingAddresses(request).getAddressBalanceInfoList();
+        var addressBalances = grpcStubs.walletsService.getFundingAddresses(request)
+                .getAddressBalanceInfoList();
+        if (onlyFunded) {
+            return addressBalances.stream()
+                    .filter(address -> address.getBalance() > 0L)
+                    .collect(Collectors.toList());
+
+        } else {
+            return addressBalances;
+        }
     }
 
     public String getUnusedBsqAddress() {

--- a/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
+++ b/cli/src/main/java/bisq/cli/request/WalletsServiceRequest.java
@@ -44,7 +44,6 @@ import bisq.proto.grpc.UnsetTxFeeRatePreferenceRequest;
 import bisq.proto.grpc.VerifyBsqSentToAddressRequest;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 
 
@@ -101,17 +100,11 @@ public class WalletsServiceRequest {
     }
 
     public List<AddressBalanceInfo> getFundingAddresses(boolean onlyFunded) {
-        var request = GetFundingAddressesRequest.newBuilder().build();
-        var addressBalances = grpcStubs.walletsService.getFundingAddresses(request)
+        var request = GetFundingAddressesRequest.newBuilder()
+                .setOnlyFunded(onlyFunded)
+                .build();
+        return grpcStubs.walletsService.getFundingAddresses(request)
                 .getAddressBalanceInfoList();
-        if (onlyFunded) {
-            return addressBalances.stream()
-                    .filter(address -> address.getBalance() > 0L)
-                    .collect(Collectors.toList());
-
-        } else {
-            return addressBalances;
-        }
     }
 
     public String getUnusedBsqAddress() {

--- a/cli/src/test/java/bisq/cli/table/AddressCliOutputDiffTest.java
+++ b/cli/src/test/java/bisq/cli/table/AddressCliOutputDiffTest.java
@@ -27,7 +27,7 @@ public class AddressCliOutputDiffTest extends AbstractCliTest {
     }
 
     private void getFundingAddresses() {
-        var fundingAddresses = aliceClient.getFundingAddresses();
+        var fundingAddresses = aliceClient.getFundingAddresses(false);
         if (fundingAddresses.size() > 0) {
             // TableFormat class had been deprecated, then deleted on 17-Feb-2022, but
             // these diff tests can be useful for testing changes to the current tbl formatting api.
@@ -42,7 +42,7 @@ public class AddressCliOutputDiffTest extends AbstractCliTest {
     }
 
     private void getAddressBalance() {
-        List<AddressBalanceInfo> addresses = aliceClient.getFundingAddresses();
+        List<AddressBalanceInfo> addresses = aliceClient.getFundingAddresses(false);
         int numAddresses = addresses.size();
         // Check output for last 2 addresses.
         for (int i = numAddresses - 2; i < addresses.size(); i++) {

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -392,8 +392,8 @@ public class CoreApi {
         return walletsService.getAddressBalanceInfo(addressString);
     }
 
-    public List<AddressBalanceInfo> getFundingAddresses() {
-        return walletsService.getFundingAddresses();
+    public List<AddressBalanceInfo> getFundingAddresses(boolean onlyFunded) {
+        return walletsService.getFundingAddresses(onlyFunded);
     }
 
     public String getUnusedBsqAddress() {

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -78,6 +78,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -201,7 +202,7 @@ class CoreWalletsService {
                 btcWalletService.isAddressUnused(address));
     }
 
-    List<AddressBalanceInfo> getFundingAddresses() {
+    List<AddressBalanceInfo> getFundingAddresses(boolean onlyFunded) {
         verifyWalletsAreAvailable();
         verifyEncryptedWalletIsUnlocked();
 
@@ -231,7 +232,12 @@ class CoreWalletsService {
             addressStrings.add(newZeroBalanceAddress.getAddressString());
         }
 
-        return addressStrings.stream().map(address ->
+        Stream<String> resultStream = addressStrings.stream();
+        if (onlyFunded) {
+            resultStream = resultStream.filter(address -> balances.getUnchecked(address) > 0);
+        }
+
+        return resultStream.map(address ->
                         new AddressBalanceInfo(address,
                                 balances.getUnchecked(address),
                                 getNumConfirmationsForMostRecentTransaction(address),

--- a/core/src/main/resources/help/getfundingaddresses-help.txt
+++ b/core/src/main/resources/help/getfundingaddresses-help.txt
@@ -7,10 +7,17 @@ getfundingaddresses - list BTC receiving address
 SYNOPSIS
 --------
 getfundingaddresses
+		[--only-funded=<true|false>]
 
 DESCRIPTION
 -----------
 Returns a list of receiving BTC addresses.
+
+OPTIONS
+-------
+--only-funded
+        If true, only addresses with a positive balance will be included.
+        Useful for filtering out empty addresses.
 
 EXAMPLES
 --------

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -161,7 +161,8 @@ class GrpcWalletsService extends WalletsImplBase {
     public void getFundingAddresses(GetFundingAddressesRequest req,
                                     StreamObserver<GetFundingAddressesReply> responseObserver) {
         try {
-            List<AddressBalanceInfo> balanceInfo = coreApi.getFundingAddresses();
+            boolean onlyFunded = req.getOnlyFunded();
+            List<AddressBalanceInfo> balanceInfo = coreApi.getFundingAddresses(onlyFunded);
             var reply = GetFundingAddressesReply.newBuilder()
                     .addAllAddressBalanceInfo(
                             balanceInfo.stream()

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -927,6 +927,7 @@ message GetTransactionReply {
 }
 
 message GetFundingAddressesRequest {
+    optional bool only_funded = 1; // Return only addresses with positive balance.
 }
 
 message GetFundingAddressesReply {


### PR DESCRIPTION
PR https://github.com/bisq-network/bisq/pull/7483 added the --only-funded flag to the getfundingaddresses method.
This flag was added to bisq-cli and the filtering happened client-side.
This change moves the filtering to the server-side, so that all API
users can use the 'only-funded' option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added --only-funded option to getfundingaddresses, allowing display of only addresses with a positive balance.
* API
  * gRPC now accepts an only_funded flag in the funding addresses request to filter results to funded addresses.
* Documentation
  * Updated help text for getfundingaddresses to describe the new filtering option.
* Tests
  * Updated tests to cover the new only-funded behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->