### PR TITLE
Update suddenwhipvapor node onion

### DIFF
--- a/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
+++ b/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java
@@ -58,7 +58,7 @@ public class BtcNodes {
                         new BtcNode(null, "2oalsctcn76axnrnaqjddiiu5qhrc7hv3raik2lyfxb7eoktk4vw6sad.onion", null, BtcNode.DEFAULT_PORT, "@suddenwhipvapor"),
                         new BtcNode(null, "ybryiy2k4p4pery4qseap4iu2rxput2akuvpvczwvg4eyfafcdsvyqid.onion", null, BtcNode.DEFAULT_PORT, "@suddenwhipvapor"),
                         new BtcNode(null, "o7clg6znpl7a5kk6s6l75lskm63orxubygasuh73iscnffhvij2k5qqd.onion", null, BtcNode.DEFAULT_PORT, "@suddenwhipvapor"),
-                        new BtcNode(null, "izdwkfkzlzzporvnmaykbskibeswr3wfrk52p2lkhobacqqsim74b4qd.onion", null, BtcNode.DEFAULT_PORT, "@suddenwhipvapor"),
+                        new BtcNode(null, "gl5mai53ucr7wgws6jrniiko3shxovxbnefvx5h4euhucprii52wl7ad.onion", null, BtcNode.DEFAULT_PORT, "@suddenwhipvapor"),
 
                         // runbtc
                         new BtcNode(null, "runbtcnd22qxdwlmhzsrw6zyfmkivuy5nuqbhasaztekildcxc7lseyd.onion", null, BtcNode.DEFAULT_PORT, "@runbtc"),


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

A human error led to backing up the onion private key for node o7cl into the file for izdw, so the real private key for izdw was lost.
When restoring the node, I had to generate a new onon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bitcoin node address configuration to maintain network connectivity and service reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->