### PR TITLE
Migrate deprecated utilities and suppress compiler warnings (1)

### DIFF
--- a/assets/src/main/java/bisq/asset/AbstractAsset.java
+++ b/assets/src/main/java/bisq/asset/AbstractAsset.java
@@ -17,8 +17,9 @@
 
 package bisq.asset;
 
+import java.util.Objects;
+
 import static org.apache.commons.lang3.Validate.notBlank;
-import static org.apache.commons.lang3.Validate.notNull;
 
 /**
  * Abstract base class for {@link Asset} implementations. Most implementations should not
@@ -37,7 +38,7 @@ public abstract class AbstractAsset implements Asset {
     public AbstractAsset(String name, String tickerSymbol, AddressValidator addressValidator) {
         this.name = notBlank(name);
         this.tickerSymbol = notBlank(tickerSymbol);
-        this.addressValidator = notNull(addressValidator);
+        this.addressValidator = Objects.requireNonNull(addressValidator);
     }
 
     @Override

--- a/common/src/main/java/bisq/common/ExcludeForHashAwareProto.java
+++ b/common/src/main/java/bisq/common/ExcludeForHashAwareProto.java
@@ -69,8 +69,8 @@ public interface ExcludeForHashAwareProto extends Proto {
         return toProto(false);
     }
 
+    @SuppressWarnings("unchecked")
     default <T extends Message> T resolveProto(boolean serializeForHash) {
-        //noinspection unchecked
         return (T) resolveBuilder(getBuilder(serializeForHash), serializeForHash).build();
     }
 

--- a/common/src/main/java/bisq/common/config/EnumValueConverter.java
+++ b/common/src/main/java/bisq/common/config/EnumValueConverter.java
@@ -31,6 +31,7 @@ import java.util.Set;
  * {@link joptsimple.ArgumentAcceptingOptionSpec#ofType(Class)} when the type in question
  * is an enum.
  */
+@SuppressWarnings("rawtypes")
 class EnumValueConverter implements ValueConverter<Enum> {
 
     private final Class<? extends Enum> enumType;
@@ -50,6 +51,7 @@ class EnumValueConverter implements ValueConverter<Enum> {
     public Enum convert(String value) {
         Set<String> candidates = Sets.newHashSet(value, value.toUpperCase(), value.toLowerCase());
         for (String candidate : candidates) {
+            @SuppressWarnings("unchecked")
             Optional<? extends Enum> result = Enums.getIfPresent(enumType, candidate);
             if (result.isPresent())
                 return result.get();

--- a/common/src/main/java/bisq/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/bisq/common/persistence/PersistenceManager.java
@@ -355,7 +355,7 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         long ts = System.currentTimeMillis();
         try (FileInputStream fileInputStream = new FileInputStream(storageFile)) {
             protobuf.PersistableEnvelope proto = protobuf.PersistableEnvelope.parseDelimitedFrom(fileInputStream);
-            //noinspection unchecked
+            @SuppressWarnings("unchecked")
             T persistableEnvelope = (T) persistenceProtoResolver.fromProto(proto);
             log.info("Reading {} completed in {} ms", fileName, System.currentTimeMillis() - ts);
             return persistableEnvelope;

--- a/common/src/main/java/bisq/common/taskrunner/TaskRunner.java
+++ b/common/src/main/java/bisq/common/taskrunner/TaskRunner.java
@@ -39,8 +39,8 @@ public class TaskRunner<T extends Model> {
     private Class<? extends Task<T>> currentTask;
 
 
+    @SuppressWarnings("unchecked")
     public TaskRunner(T sharedModel, ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
-        //noinspection unchecked
         this(sharedModel, (Class<T>) sharedModel.getClass(), resultHandler, errorMessageHandler);
     }
 

--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
@@ -569,18 +570,18 @@ public class Utilities {
 
         String duration = durationMillis > 0 ? DurationFormatUtils.formatDuration(durationMillis, format) : "";
 
-        duration = StringUtils.replacePattern(duration, "^1 " + seconds + "|\\b1 " + seconds, "1 " + second);
-        duration = StringUtils.replacePattern(duration, "^1 " + minutes + "|\\b1 " + minutes, "1 " + minute);
-        duration = StringUtils.replacePattern(duration, "^1 " + hours + "|\\b1 " + hours, "1 " + hour);
-        duration = StringUtils.replacePattern(duration, "^1 " + days + "|\\b1 " + days, "1 " + day);
+        duration = RegExUtils.replacePattern(duration, "^1 " + seconds + "|\\b1 " + seconds, "1 " + second);
+        duration = RegExUtils.replacePattern(duration, "^1 " + minutes + "|\\b1 " + minutes, "1 " + minute);
+        duration = RegExUtils.replacePattern(duration, "^1 " + hours + "|\\b1 " + hours, "1 " + hour);
+        duration = RegExUtils.replacePattern(duration, "^1 " + days + "|\\b1 " + days, "1 " + day);
 
         duration = duration.replace(", 0 seconds", "");
         duration = duration.replace(", 0 minutes", "");
         duration = duration.replace(", 0 hours", "");
-        duration = StringUtils.replacePattern(duration, "^0 days, ", "");
-        duration = StringUtils.replacePattern(duration, "^0 hours, ", "");
-        duration = StringUtils.replacePattern(duration, "^0 minutes, ", "");
-        duration = StringUtils.replacePattern(duration, "^0 seconds, ", "");
+        duration = RegExUtils.replacePattern(duration, "^0 days, ", "");
+        duration = RegExUtils.replacePattern(duration, "^0 hours, ", "");
+        duration = RegExUtils.replacePattern(duration, "^0 minutes, ", "");
+        duration = RegExUtils.replacePattern(duration, "^0 seconds, ", "");
 
         String result = duration.trim();
         if (result.isEmpty()) {

--- a/common/src/test/java/bisq/common/app/CapabilitiesTest.java
+++ b/common/src/test/java/bisq/common/app/CapabilitiesTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class CapabilitiesTest {
 
     @Test

--- a/common/src/test/java/bisq/common/config/ConfigTests.java
+++ b/common/src/test/java/bisq/common/config/ConfigTests.java
@@ -20,7 +20,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -214,8 +215,8 @@ public class ConfigTests {
             System.setOut(outTest);
             System.setErr(errTest);
             new Config();
-            assertThat(outBytes.toString(), isEmptyString());
-            assertThat(errBytes.toString(), isEmptyString());
+            assertThat(outBytes.toString(), is(emptyString()));
+            assertThat(errBytes.toString(), is(emptyString()));
         } finally {
             System.setOut(outOrig);
             System.setErr(errOrig);

--- a/p2p/src/main/java/bisq/network/http/SocksSSLConnectionSocketFactory.java
+++ b/p2p/src/main/java/bisq/network/http/SocksSSLConnectionSocketFactory.java
@@ -18,6 +18,7 @@
 package bisq.network.http;
 
 import org.apache.http.HttpHost;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.protocol.HttpContext;
 
@@ -36,10 +37,8 @@ import java.io.IOException;
 class SocksSSLConnectionSocketFactory extends SSLConnectionSocketFactory {
 
     public SocksSSLConnectionSocketFactory(final SSLContext sslContext) {
-
-        // TODO check alternative to deprecated call
         // Only allow connection's to site's with valid certs.
-        super(sslContext, STRICT_HOSTNAME_VERIFIER);
+        super(sslContext, new DefaultHostnameVerifier());
 
         // Or to allow "insecure" (eg self-signed certs)
         // super(sslContext, ALLOW_ALL_HOSTNAME_VERIFIER);

--- a/p2p/src/main/java/bisq/network/p2p/BundleOfEnvelopes.java
+++ b/p2p/src/main/java/bisq/network/p2p/BundleOfEnvelopes.java
@@ -94,6 +94,7 @@ public final class BundleOfEnvelopes extends BroadcastMessage implements Extende
     // CapabilityRequiringPayload
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    @SuppressWarnings("deprecation")
     @Override
     public Capabilities getRequiredCapabilities() {
         return new Capabilities(Capability.BUNDLE_OF_ENVELOPES);

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -77,6 +77,7 @@ public class TestState {
     final ClockFake clockFake;
     private RemovedPayloadsService removedPayloadsService;
 
+    @SuppressWarnings("unchecked")
     TestState() {
         this.mockBroadcaster = mock(Broadcaster.class);
         this.mockSeqNrPersistenceManager = mock(PersistenceManager.class);
@@ -270,6 +271,7 @@ public class TestState {
         // The default matcher expects orders to stay the same. So, create a custom matcher function since
         // we don't care about the order.
         if (expectedListenersSignaled) {
+            @SuppressWarnings("unchecked")
             final ArgumentCaptor<Collection<ProtectedStorageEntry>> argument = ArgumentCaptor.forClass(Collection.class);
             verify(this.hashMapChangedListener).onRemoved(argument.capture());
 


### PR DESCRIPTION
- [CapabilitiesTest: Allow use of deprecated Capabilities](https://github.com/bisq-network/bisq/commit/e6740b89cab88d8f82950995e9abbce43cdd39a4)
- [ConfigTests: Migrate deprecated string empty assertions](https://github.com/bisq-network/bisq/commit/6c961a41914e1192154ba6fd00de615f0d653421)
- [Utilities: Migrate deprecated regex pattern replacement](https://github.com/bisq-network/bisq/commit/15302fe987e9259cc0dabb925b56324238b69572)
- [common: Suppress unchecked method invocation and conversion warnings](https://github.com/bisq-network/bisq/commit/9a12fd12f6898aa84fcc1d12cc6f067eff6b761a)
- [AbstractAsset: Migrate deprecated notNull method](https://github.com/bisq-network/bisq/commit/102a6cda64b0af936ac51bb9f7a0c675519e2159)
- [BundleOfEnvelopes: Allow deprecated Capability BUNDLE_OF_ENVELOPES](https://github.com/bisq-network/bisq/commit/6bcde9191261ebe7bf67d97f10777645f6e7551f)
- [SocksSSLConnectionSocketFactory: Migrate deprecated HostnameVerifier](https://github.com/bisq-network/bisq/commit/2fa6f7ff36556fe13b9385acc735bb0a11c30912)
- [p2p: Suppress unchecked warnings in TestState mocking](https://github.com/bisq-network/bisq/commit/b2c8e218c02d60022c7e8fcb13cb5b0ebccd2113)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized null-check usage and replaced deprecated behaviors with modern equivalents across core modules.
  * Consolidated compiler warning suppressions for clearer code.
  * Harmonized regex handling for consistent string processing.
  * Updated hostname verification to use a current verifier implementation.

* **Tests**
  * Refined test annotations and assertions for clearer, warning-free test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->