### PR TITLE
Remove null check for unLockupTxId

### DIFF
--- a/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
@@ -217,8 +217,6 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
                         .map(bondedReputation -> {
                             String lockupTxId = checkNotNull(bondedReputation.getLockupTxId(),
                                     "lockupTxId must not be null if txType is LOCKUP. bondedReputation=" + bondedReputation);
-                            checkArgument(bondedReputation.getUnlockTxId() == null,
-                                    "unLockupTxId must be null if txType is LOCKUP. bondedReputation=" + bondedReputation);
                             checkArgument(lockupTxId.equals(txId),
                                     "lockupTxId must match txId if txType is LOCKUP. bondedReputation=" + bondedReputation);
                             return new BondedReputationDto(bondedReputation.getAmount(),


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bonded reputation records to properly process LOCKUP transactions that may have associated unlock transactions, removing an overly restrictive validation constraint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->