### PR TITLE
Migrate deprecated APIs and suppress compiler warnings (7)

### DIFF
--- a/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/TradeTest.java
@@ -78,6 +78,7 @@ public class TradeTest extends AbstractTradeTest {
     @Test
     @Order(3)
     public void testTakeBuyBSQOffer(final TestInfo testInfo) {
+        @SuppressWarnings("deprecation")
         TakeBuyBSQOfferTest test = new TakeBuyBSQOfferTest();
         test.testTakeAlicesSellBTCForBSQOffer(testInfo);
         test.testBobsConfirmPaymentStarted(testInfo);
@@ -100,6 +101,7 @@ public class TradeTest extends AbstractTradeTest {
     @Test
     @Order(5)
     public void testTakeSellBSQOffer(final TestInfo testInfo) {
+        @SuppressWarnings("deprecation")
         TakeSellBSQOfferTest test = new TakeSellBSQOfferTest();
         test.testTakeAlicesBuyBTCForBSQOffer(testInfo);
         test.testAlicesConfirmPaymentStarted(testInfo);

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DownloadTask.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DownloadTask.java
@@ -124,25 +124,19 @@ public class DownloadTask extends Task<List<BisqInstaller.FileDescriptor>> {
         copyInputStreamToFileNew(urlConnection.getInputStream(), outputFile, fileSize);
     }
 
-    public void copyInputStreamToFileNew(final InputStream source, final File destination, int fileSize) throws IOException {
-        try {
-            final FileOutputStream output = FileUtils.openOutputStream(destination);
-            try {
-                final byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
-                long count = 0;
-                int n;
-                while (EOF != (n = source.read(buffer))) {
-                    output.write(buffer, 0, n);
-                    count += n;
-                    log.trace("Progress: {}/{}", count, fileSize);
-                    updateProgress(count, fileSize);
-                }
-                output.close(); // don't swallow close Exception if copy completes normally
-            } finally {
-                IOUtils.closeQuietly(output);
+    public void copyInputStreamToFileNew(final InputStream source,
+                                         final File destination,
+                                         int fileSize) throws IOException {
+        try (final FileOutputStream output = FileUtils.openOutputStream(destination)) {
+            final byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+            long count = 0;
+            int n;
+            while (EOF != (n = source.read(buffer))) {
+                output.write(buffer, 0, n);
+                count += n;
+                log.trace("Progress: {}/{}", count, fileSize);
+                updateProgress(count, fileSize);
             }
-        } finally {
-            IOUtils.closeQuietly(source);
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/MovingAverageUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/MovingAverageUtils.java
@@ -90,6 +90,7 @@ public class MovingAverageUtils {
             this.windowSize = windowSize;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public boolean tryAdvance(Consumer<? super Stream<T>> action) {
             if (windowSize < 1) {

--- a/desktop/src/test/java/bisq/desktop/ComponentsDemo.java
+++ b/desktop/src/test/java/bisq/desktop/ComponentsDemo.java
@@ -49,6 +49,7 @@ public class ComponentsDemo extends Application {
         launch(args);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void start(Stage primaryStage) throws Exception {
         final CryptoCurrency btc = new CryptoCurrency("BTC", "bitcoin");


### PR DESCRIPTION
- [DownloadTask: Migrate deprecated IOUtils.closeQuietly method](https://github.com/bisq-network/bisq/commit/2cd04f4afbcdf73785d4ac6b7b0536e028060a34)
- [MovingAverageUtils: Suppress unchecked warning](https://github.com/bisq-network/bisq/commit/f2d480cd96a9abecdb073aa7e909b7da7eca2ce1)
- [ComponentsDemo: Suppress unchecked warning](https://github.com/bisq-network/bisq/commit/48781ad9d6766bda0670d5e07316fd2ce591ec19)
- [TradeTest: Suppress deprecation warning](https://github.com/bisq-network/bisq/commit/792f09b5921bdc0bdc3e691c9eefc5c68f7f8d83)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code to address compilation warnings and improve resource management practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->