### PR TITLE
Fix bug with applying snapshot

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
@@ -92,7 +92,7 @@ public class TxBroadcaster {
     public static void broadcastTx(Wallet wallet, PeerGroup peerGroup, Transaction tx, Callback callback, int timeOut) {
         Timer timeoutTimer;
         final String txId = tx.getTxId().toString();
-        log.info("Txid: {} hex: {}", txId, Utils.HEX.encode(tx.bitcoinSerialize()));
+        log.info("Broadcast transaction with ID: {}. Serialized tx: {}", txId, Utils.HEX.encode(tx.bitcoinSerialize()));
         if (!broadcastTimerMap.containsKey(txId)) {
             timeoutTimer = UserThread.runAfter(() -> {
                 log.warn("Broadcast of tx {} not completed after {} sec.", txId, timeOut);

--- a/core/src/main/java/bisq/core/dao/burningman/accounting/node/full/AccountingFullNode.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/node/full/AccountingFullNode.java
@@ -34,6 +34,7 @@ import bisq.network.p2p.P2PService;
 
 import bisq.common.UserThread;
 import bisq.common.handlers.ResultHandler;
+import bisq.common.util.Hex;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -277,7 +278,7 @@ public class AccountingFullNode extends AccountingNode {
                     rawDtoBlock.getHash(),
                     rawDtoBlock.getPreviousBlockHash(),
                     lastBlock.isPresent() ? lastBlock.get().getHeight() : "lastBlock not present",
-                    lastBlock.isPresent() ? lastBlock.get().getTruncatedHash() : "lastBlock not present");
+                    lastBlock.isPresent() ? Hex.encode(lastBlock.get().getTruncatedHash()) : "lastBlock not present");
 
             pendingRawDtoBlocks.clear();
             applyReOrg();
@@ -291,8 +292,7 @@ public class AccountingFullNode extends AccountingNode {
             log.warn(throwable.toString());
         } else {
             String errorMessage = "An error occurred: Error=" + throwable.toString();
-            log.error(errorMessage);
-            throwable.printStackTrace();
+            log.error(errorMessage, throwable);
 
             if (throwable instanceof RpcException) {
                 Throwable cause = throwable.getCause();

--- a/core/src/main/java/bisq/core/dao/node/BsqNode.java
+++ b/core/src/main/java/bisq/core/dao/node/BsqNode.java
@@ -203,8 +203,15 @@ public abstract class BsqNode implements DaoSetupService {
         // We check if we have a block with that height. If so we return. We do not use the chainHeight as with genesis
         // height we have no block but chainHeight is initially set to genesis height (bad design ;-( but a bit tricky
         // to change now as it used in many areas.)
-        if (daoStateService.getBlockAtHeight(rawBlock.getHeight()).isPresent()) {
-            log.info("We have already a block with the height of the new block. Height of new block={}", rawBlock.getHeight());
+        Optional<Block> optionalBlockAtHeight = daoStateService.getBlockAtHeight(rawBlock.getHeight());
+        if (optionalBlockAtHeight.isPresent()) {
+            if (optionalBlockAtHeight.get().getHash().equals(rawBlock.getHash())) {
+                log.info("We have already a block with the height of the new block and the same hash. Height of new block={}", rawBlock.getHeight());
+            } else {
+                log.info("We have already a block with the height of the new block but the new block has a different hash. This can happen in case of a chain fork. We will only switch the chain if the fork becomes the longer chain. " +
+                                "Height of new block={}; Hash of new block={}; Hash of existing block={}",
+                        rawBlock.getHeight(), rawBlock.getHash(), optionalBlockAtHeight.get().getHash());
+            }
             return Optional.empty();
         }
 

--- a/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
+++ b/core/src/main/java/bisq/core/dao/state/DaoStateSnapshotService.java
@@ -341,13 +341,13 @@ public class DaoStateSnapshotService implements DaoSetupService, DaoStateListene
         }
 
         if (!daoStateStorageService.isChainHeightMatchingLastBlockHeight(persistedDaoState)) {
-            log.warn("ChainHeight not matching last blockHeight. We call resyncDaoStateFromResources");
+            log.warn("Chain height not matching last blockHeight. We call resyncDaoStateFromResources");
             resyncDaoStateFromResources();
             return false;
         }
 
         if (isHeightBelowGenesisHeight(chainHeightOfPersistedDaoState)) {
-            log.warn("isHeightBelowGenesisHeight. We call resyncDaoStateFromResources");
+            log.warn("chainHeight of persistedDaoState is below genesis height. This must never happen.");
             return false;
         }
 

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -221,6 +221,10 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
     }
 
     public boolean isChainHeightMatchingLastBlockHeight(DaoState persistedDaoState) {
+        if (persistedDaoState.getBlocks().isEmpty()) {
+            log.warn("Cannot check chain height: DaoState has no blocks.");
+            return true;
+        }
         int heightOfPersistedLastBlock = persistedDaoState.getLastBlock().getHeight();
         int chainHeightOfPersistedDaoState = persistedDaoState.getChainHeight();
         boolean isMatching = heightOfPersistedLastBlock == chainHeightOfPersistedDaoState;

--- a/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
+++ b/core/src/main/java/bisq/core/dao/state/storage/DaoStateStorageService.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -168,7 +169,46 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
         }).start();
     }
 
-    public DaoState getPersistedBsqState() {
+    public void loadPersistedDaoData(BiConsumer<DaoState, LinkedList<DaoStateHash>> consumer) {
+        String fileName = getFileName();
+        readStore(fileName, daoStateStore -> {
+            DaoState daoState;
+            protobuf.DaoState daoStateAsProto = daoStateStore.getDaoStateAsProto();
+            if (daoStateAsProto != null) {
+                long ts = System.currentTimeMillis();
+                LinkedList<Block> blocks;
+                if (daoStateAsProto.getBlocksList().isEmpty()) {
+                    int chainHeight = daoStateAsProto.getChainHeight();
+                    blocks = bsqBlocksStorageService.readBlocks(chainHeight);
+                    if (!blocks.isEmpty()) {
+                        int heightOfLastBlock = blocks.getLast().getHeight();
+                        if (heightOfLastBlock != chainHeight) {
+                            log.error("Error at readFromResources. " +
+                                            "heightOfLastBlock not same as chainHeight.\n" +
+                                            "heightOfLastBlock={}; chainHeight={}.\n" +
+                                            "This error scenario is handled by DaoStateSnapshotService, " +
+                                            "it will resync from resources & reboot",
+                                    heightOfLastBlock, chainHeight);
+                        }
+                    }
+                } else {
+                    blocks = bsqBlocksStorageService.migrateBlocks(daoStateAsProto.getBlocksList());
+                }
+                daoState = DaoState.fromProto(daoStateAsProto, blocks);
+                log.info("Deserializing DaoState with {} blocks took {} ms",
+                        daoState.getBlocks().size(), System.currentTimeMillis() - ts);
+            } else {
+                daoState = new DaoState();
+            }
+
+            LinkedList<DaoStateHash> daoStateHashChain = daoStateStore.getDaoStateHashChain();
+            consumer.accept(daoState, daoStateHashChain);
+        });
+    }
+
+    // Only used at startup, as later we delete the data inside the store after persisting to reduce memory footprint.
+    // For snapshot recovery we use loadPersistedDaoData
+    public DaoState getPersistedBsqStateAtStartup() {
         protobuf.DaoState daoStateAsProto = store.getDaoStateAsProto();
         if (daoStateAsProto != null) {
             long ts = System.currentTimeMillis();
@@ -180,8 +220,7 @@ public class DaoStateStorageService extends StoreService<DaoStateStore> {
         return new DaoState();
     }
 
-    public boolean isChainHeighMatchingLastBlockHeight() {
-        DaoState persistedDaoState = getPersistedBsqState();
+    public boolean isChainHeightMatchingLastBlockHeight(DaoState persistedDaoState) {
         int heightOfPersistedLastBlock = persistedDaoState.getLastBlock().getHeight();
         int chainHeightOfPersistedDaoState = persistedDaoState.getChainHeight();
         boolean isMatching = heightOfPersistedLastBlock == chainHeightOfPersistedDaoState;


### PR DESCRIPTION
This fixes a critical problem when chain forks happen. It caused an inconsistent dao state from a resync of the seed nodes and incorrect dao state hashes.

Cause of the problem:
We accessed the dao data from the store which gets cleared after initial application of the persisted data.

Now we load the data from disk and use that. This adds asynchronous handling for the parsing after the application of the snapshot.

It also fixes the comparison of previous applied snapshots, which is now only set when called from a resync, not from the initial application of the persisted data.
