### PR TITLE
Update binary build instructions, remove windows support

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,8 @@
    ```sh
    git clone https://github.com/bisq-network/bisq
    # if you intend to do testing on the latest release, you can clone the respective branch selectively, without downloading the whole repository
-   # for the 1.9.18 release, you would do it like this:
-   git clone --recurse-submodules --branch release/v1.9.19 https://github.com/bisq-network/bisq
+   # for the 1.9.21 release, you would do it like this:
+   git clone --recurse-submodules --branch release/v1.9.21 https://github.com/bisq-network/bisq
    cd bisq
    ```
 
@@ -15,13 +15,8 @@
    On macOS and Linux, execute:
    ```sh
    ./gradlew build
+   ./gradlew installDist
    ```
-
-   On Windows:
-   ```cmd
-   gradlew.bat build
-   ```
-
    If you prefer to skip tests to speed up the building process, just append _-x test_ to the previous commands.
 
 ### Important notes
@@ -44,7 +39,8 @@
    and if the version number on the JVM line is not a supported one, you can pick the correct JDK at runtime with this syntax (verify your system path):
 
    ```sh
-   ./gradlew build -Dorg.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64/
+   JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH ./gradlew clean build
+   JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH ./gradlew installDist
    ```
 
 If you do not have JDK 11 installed, check out scripts in the [scripts](../scripts) directory or download it manually from https://jdk.java.net/archive/.
@@ -55,16 +51,11 @@ Once Bisq is installed, its executables will be available in the root project di
 
 On macOS and Linux:
 ```sh
-./bisq-desktop
+./desktop/build/app/bin/bisq-desktop
 ```
 or, to select a specific version of Java:
 ```sh
-env JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 ./bisq-desktop
-```
-
-On Windows:
-```cmd
-bisq-desktop.bat
+env JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 ./desktop/build/app/bin/bisq-desktop
 ```
 
 ## See also

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,8 @@
    ```sh
    git clone https://github.com/bisq-network/bisq
    # if you intend to do testing on the latest release, you can clone the respective branch selectively, without downloading the whole repository
-   # for the 1.9.21 release, you would do it like this:
-   git clone --recurse-submodules --branch release/v1.9.21 https://github.com/bisq-network/bisq
+   # for the 1.9.22 release, you would do it like this:
+   git clone --recurse-submodules --branch release/v1.9.22 https://github.com/bisq-network/bisq
    cd bisq
    ```
 
@@ -15,7 +15,11 @@
    On macOS and Linux, execute:
    ```sh
    ./gradlew build
-   ./gradlew installDist
+   ```
+
+   On Windows:
+   ```cmd
+   gradlew.bat build
    ```
    If you prefer to skip tests to speed up the building process, just append _-x test_ to the previous commands.
 
@@ -40,22 +44,26 @@
 
    ```sh
    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH ./gradlew clean build
-   JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH ./gradlew installDist
    ```
 
 If you do not have JDK 11 installed, check out scripts in the [scripts](../scripts) directory or download it manually from https://jdk.java.net/archive/.
 
 ## Running Bisq
 
-Once Bisq is installed, its executables will be available in the root project directory. Run **Bisq Desktop** as follows:
+Once Bisq is installed, its executables will be available in the `scripts` folder under the root project directory. Run **Bisq Desktop** as follows:
 
 On macOS and Linux:
 ```sh
-./desktop/build/app/bin/bisq-desktop
+./scripts/desktop
 ```
 or, to select a specific version of Java:
 ```sh
-env JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 ./desktop/build/app/bin/bisq-desktop
+env JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 ./scripts/desktop
+```
+
+On Windows:
+```cmd
+scripts\desktop.bat
 ```
 
 ## See also


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->
Instructions to build Bisq from source were fixed to reflect currently working method (running bisq-desktop from repo root, and running ./gradlew :desktop:run were not functional anymore).
Also removed references to Windows, since it is unlikely the existing directions would still work, and also that any contributor would be able to support building from source on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions and release reference to the latest release.
  * Streamlined build and runtime invocation guidance (explicit Java environment setup and clean build step).
  * Corrected executable/run paths for all platforms and cleaned up formatting in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->