### PR TITLE
Add anchor to ScriptType.

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/ScriptType.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/ScriptType.java
@@ -48,7 +48,8 @@ public enum ScriptType implements ImmutableDaoStateModel {
     WITNESS_V0_KEYHASH("witness_v0_keyhash"),
     WITNESS_V0_SCRIPTHASH("witness_v0_scripthash"),
     WITNESS_V1_TAPROOT("witness_v1_taproot"),
-    WITNESS_UNKNOWN("witness_unknown");
+    WITNESS_UNKNOWN("witness_unknown"),
+    ANCHOR("anchor");
 
     private final String name;
 

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -2217,6 +2217,7 @@ enum ScriptType {
     NONSTANDARD = 8;
     WITNESS_UNKNOWN = 9;
     WITNESS_V1_TAPROOT = 10;
+    ANCHOR = 11;
 }
 
 message PubKeyScript {


### PR DESCRIPTION
This new script type appeared first in block 927618.

Error without it at block 927618:
```
[RpcService] ERROR bisq.core.dao.node.full.RpcService: Error at requestDtoBlock: blockHeight=927618, error={} com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `bisq.core.dao.state.model.blockchain.ScriptType`, problem: Expected the argument to be a valid 'bitcoind' script type, but was invalid/unsupported instead. Received scriptType=anchor
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: bisq.core.dao.node.full.rpc.dto.RawDtoBlock["tx"]->java.util.ArrayList[2691]->bisq.core.dao.node.full.rpc.dto.RawDtoTransaction["vout"]->java.util.ArrayList[0]->bisq.core.dao.node.full.rpc.dto.RawDtoOutput["scriptPubKey"]->bisq.core.dao.node.full.rpc.dto.DtoPubKeyScript["type"])
	at com.fasterxml.jackson.databind.exc.ValueInstantiationException.from(ValueInstantiationException.java:47)
	at com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:2014)
	at com.fasterxml.jackson.databind.DeserializationContext.handleInstantiationProblem(DeserializationContext.java:1426)
	at com.fasterxml.jackson.databind.deser.std.FactoryBasedEnumDeserializer.deserialize(FactoryBasedEnumDeserializer.java:205)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:545)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:570)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:440)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1493)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:348)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:310)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:361)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:246)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:30)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:310)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:361)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:246)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:30)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:310)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4881)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3104)
	at com.googlecode.jsonrpc4j.JsonRpcClient.constructResponseObject(JsonRpcClient.java:292)
	at com.googlecode.jsonrpc4j.JsonRpcClient.readResponse(JsonRpcClient.java:202)
	at com.googlecode.jsonrpc4j.JsonRpcClient.readResponse(JsonRpcClient.java:539)
	at com.googlecode.jsonrpc4j.JsonRpcHttpClient.invoke(JsonRpcHttpClient.java:143)
	at com.googlecode.jsonrpc4j.ProxyUtil$3.invoke(ProxyUtil.java:213)
	at com.sun.proxy.$Proxy27.getBlock(Unknown Source)
	at bisq.core.dao.node.full.RpcService.lambda$requestDtoBlock$8(RpcService.java:337)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.lang.IllegalArgumentException: Expected the argument to be a valid 'bitcoind' script type, but was invalid/unsupported instead. Received scriptType=anchor
	at bisq.core.dao.state.model.blockchain.ScriptType.forName(ScriptType.java:69)
	at jdk.internal.reflect.GeneratedMethodAccessor10.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at com.fasterxml.jackson.databind.introspect.AnnotatedMethod.callOnWith(AnnotatedMethod.java:118)
	at com.fasterxml.jackson.databind.deser.std.FactoryBasedEnumDeserializer.deserialize(FactoryBasedEnumDeserializer.java:194)
	... 37 common frames omitted
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for a new blockchain script type ("anchor"), expanding accepted script kinds for transaction/script handling within the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->