### PR TITLE
UX: Show disk space warning only once

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -557,16 +557,21 @@ public class BisqSetup {
             }
         });
     }
-
+    
+    boolean hasShownStorageWarning = false;
     private void checkFreeDiskSpace() {
         long TWO_GIGABYTES = 2147483648L;
         long usableSpace = new File(Config.appDataDir(), VERSION_FILE_NAME).getUsableSpace();
+        if (hasShownStorageWarning) {
+            return;
+        }
         if (usableSpace < TWO_GIGABYTES) {
             String message = Res.get("popup.warning.diskSpace", formatBytes(usableSpace), formatBytes(TWO_GIGABYTES));
             log.warn(message);
             if (diskSpaceWarningHandler != null) {
                 diskSpaceWarningHandler.accept(message);
             }
+            hasShownStorageWarning = true;
         }
     }
 


### PR DESCRIPTION
<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

This PR fixes an issue that causes Bisq to constantly nag the user about low disk space, instead of just warning the user once.

Changes:
 - Added a bool to store if the storage warning has been shown yet
 - When checkFreeDiskSpace() is ran, it will check for low disk space, and, if disk space is low, will warn user and set bool to true.
 - When re-ran, if disk space is low and the user has already been warned, then it will do nothing.

I wrote this PR as anyone who has experienced this knows how annoying it is to get the error pop up randomly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated disk space warnings. The low disk space alert now displays only once per application session.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->