### PR TITLE
Export accounts and signature key pair to json for import into Bisq 2

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -148,6 +148,7 @@ shared.noAccountsSetupYet=There are no accounts set up yet
 shared.manageAccounts=Manage accounts
 shared.addNewAccount=Add new account
 shared.ExportAccounts=Export Accounts
+shared.exportAccountsForBisq2=Export for Bisq 2
 shared.importAccounts=Import Accounts
 shared.createNewAccount=Create new account
 shared.saveNewAccount=Save new account
@@ -3501,7 +3502,13 @@ systemTray.tooltip=Bisq: A decentralized bitcoin exchange network
 guiUtil.miningFeeInfo=Please be sure that the mining fee used by your external wallet is \
 at least {0} satoshis/vbyte. Otherwise the trade transactions may not be confirmed in time and the trade will end up in a dispute.
 
-guiUtil.accountExport.savedToPath=Trading accounts saved to path:\n{0}
+guiUtil.accountAndPrivateKeyExport.info=Export all your payment accounts, including the private key used for signing, as a JSON file.\n\
+  Importing this file into Bisq 2 restores all account data and allows you to reuse your 'account age' and the 'signed account age witness' in Bisq 2.\n\n\
+  Security note: This file contains your private signing key. Store it only in a secure location and delete it immediately after a successful import.\n\n\
+  Do you want to proceed?
+guiUtil.accountAndPrivateKeyExport.savedToPath=Json file with all trading accounts and the signature key pair is saved to:\n''{0}''
+
+guiUtil.accountExport.savedToPath=Trading accounts saved to:\n{0}
 guiUtil.accountExport.noAccountSetup=You don't have trading accounts set up for exporting.
 guiUtil.accountExport.selectPath=Select path to {0}
 # suppress inspection "TrailingSpacesInProperty"

--- a/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
@@ -44,7 +44,7 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
 
     protected ListView<PaymentAccount> paymentAccountsListView;
     private ChangeListener<PaymentAccount> paymentAccountChangeListener;
-    protected Button addAccountButton, exportButton, importButton;
+    protected Button addAccountButton, exportButton, exportForBisq2Button, importButton;
     protected AccountAgeWitnessService accountAgeWitnessService;
     private EventHandler<KeyEvent> keyEventEventHandler;
 
@@ -83,6 +83,7 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
         paymentAccountsListView.getSelectionModel().selectedItemProperty().addListener(paymentAccountChangeListener);
         addAccountButton.setOnAction(event -> addNewAccount());
         exportButton.setOnAction(event -> exportAccounts());
+        exportForBisq2Button.setOnAction(event -> exportAccountsForBisq2());
         importButton.setOnAction(event -> importAccounts());
         if (root.getScene() != null)
             root.getScene().addEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
@@ -93,6 +94,7 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
         paymentAccountsListView.getSelectionModel().selectedItemProperty().removeListener(paymentAccountChangeListener);
         addAccountButton.setOnAction(null);
         exportButton.setOnAction(null);
+        exportForBisq2Button.setOnAction(null);
         importButton.setOnAction(null);
         if (root.getScene() != null)
             root.getScene().removeEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
@@ -107,7 +109,7 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
                         removeSelectAccountForm();
                     else
                         UserThread.runAfter(() -> new Popup().warning(
-                                Res.get("shared.cannotDeleteAccount"))
+                                        Res.get("shared.cannotDeleteAccount"))
                                 .show(), 100, TimeUnit.MILLISECONDS);
                 })
                 .closeButtonText(Res.get("shared.cancel"))
@@ -168,6 +170,8 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
     protected abstract void importAccounts();
 
     protected abstract void exportAccounts();
+
+    protected abstract void exportAccountsForBisq2();
 
     protected abstract void addNewAccount();
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/PaymentAccountsView.java
@@ -79,6 +79,10 @@ public abstract class PaymentAccountsView<R extends Node, M extends ActivatableW
 
     @Override
     protected void activate() {
+        // Hide the export button until MuSig is rolled out onBisq 2
+        exportForBisq2Button.setVisible(false);
+        exportForBisq2Button.setManaged(false);
+
         paymentAccountsListView.setItems(getPaymentAccounts());
         paymentAccountsListView.getSelectionModel().selectedItemProperty().addListener(paymentAccountChangeListener);
         addAccountButton.setOnAction(event -> addNewAccount());

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsView.java
@@ -51,6 +51,7 @@ import bisq.asset.coins.Monero;
 
 import bisq.common.util.Tuple2;
 import bisq.common.util.Tuple3;
+import bisq.common.util.Tuple4;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -70,10 +71,7 @@ import javafx.util.StringConverter;
 
 import java.util.Optional;
 
-import static bisq.desktop.util.FormBuilder.add2ButtonsAfterGroup;
-import static bisq.desktop.util.FormBuilder.add3ButtonsAfterGroup;
-import static bisq.desktop.util.FormBuilder.addTitledGroupBg;
-import static bisq.desktop.util.FormBuilder.addTopLabelListView;
+import static bisq.desktop.util.FormBuilder.*;
 import static bisq.desktop.util.GUIUtil.getComboBoxButtonCell;
 
 @FxmlView
@@ -129,6 +127,10 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
         model.dataModel.exportAccounts((Stage) root.getScene().getWindow());
     }
 
+    @Override
+    protected void exportAccountsForBisq2() {
+        model.dataModel.exportAccountsForBisq2((Stage) root.getScene().getWindow());
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // UI actions
@@ -140,9 +142,9 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
             if (selectedTradeCurrency instanceof CryptoCurrency && ((CryptoCurrency) selectedTradeCurrency).isAsset()) {
                 String name = selectedTradeCurrency.getName();
                 new Popup().information(Res.get("account.altcoin.popup.wallet.msg",
-                        selectedTradeCurrency.getCodeAndName(),
-                        name,
-                        name))
+                                selectedTradeCurrency.getCodeAndName(),
+                                name,
+                                name))
                         .closeButtonText(Res.get("account.altcoin.popup.wallet.confirm"))
                         .show();
             }
@@ -197,11 +199,12 @@ public class AltCoinAccountsView extends PaymentAccountsView<GridPane, AltCoinAc
         paymentAccountsListView.setMinHeight(prefNumRows * Layout.LIST_ROW_HEIGHT + 28);
         setPaymentAccountsCellFactory();
 
-        Tuple3<Button, Button, Button> tuple3 = add3ButtonsAfterGroup(root, ++gridRow, Res.get("shared.addNewAccount"),
-                Res.get("shared.ExportAccounts"), Res.get("shared.importAccounts"));
-        addAccountButton = tuple3.first;
-        exportButton = tuple3.second;
-        importButton = tuple3.third;
+        Tuple4<Button, Button, Button, Button> tuple4 = add4ButtonsAfterGroup(root, ++gridRow, Res.get("shared.addNewAccount"),
+                Res.get("shared.ExportAccounts"), Res.get("shared.exportAccountsForBisq2"), Res.get("shared.importAccounts"));
+        addAccountButton = tuple4.first;
+        exportButton = tuple4.second;
+        exportForBisq2Button = tuple4.third;
+        importButton = tuple4.fourth;
     }
 
     // Add new account form

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -130,6 +130,7 @@ import bisq.common.crypto.KeyRing;
 import bisq.common.util.Hex;
 import bisq.common.util.Tuple2;
 import bisq.common.util.Tuple3;
+import bisq.common.util.Tuple4;
 import bisq.common.util.Utilities;
 
 import org.bitcoinj.core.Coin;
@@ -157,10 +158,7 @@ import javafx.util.StringConverter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static bisq.desktop.util.FormBuilder.add2ButtonsAfterGroup;
-import static bisq.desktop.util.FormBuilder.add3ButtonsAfterGroup;
-import static bisq.desktop.util.FormBuilder.addTitledGroupBg;
-import static bisq.desktop.util.FormBuilder.addTopLabelListView;
+import static bisq.desktop.util.FormBuilder.*;
 
 @FxmlView
 public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccountsViewModel> {
@@ -269,6 +267,12 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
     protected void exportAccounts() {
         model.dataModel.exportAccounts((Stage) root.getScene().getWindow());
     }
+
+    @Override
+    protected void exportAccountsForBisq2() {
+        model.dataModel.exportAccountsForBisq2((Stage) root.getScene().getWindow());
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // UI actions
@@ -427,11 +431,12 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
         paymentAccountsListView.setMinHeight(prefNumRows * Layout.LIST_ROW_HEIGHT + 28);
         setPaymentAccountsCellFactory();
 
-        Tuple3<Button, Button, Button> tuple3 = add3ButtonsAfterGroup(root, ++gridRow, Res.get("shared.addNewAccount"),
-                Res.get("shared.ExportAccounts"), Res.get("shared.importAccounts"));
-        addAccountButton = tuple3.first;
-        exportButton = tuple3.second;
-        importButton = tuple3.third;
+        Tuple4<Button, Button, Button, Button> tuple4 = add4ButtonsAfterGroup(root, ++gridRow, Res.get("shared.addNewAccount"),
+                Res.get("shared.ExportAccounts"), Res.get("shared.exportAccountsForBisq2"), Res.get("shared.importAccounts"));
+        addAccountButton = tuple4.first;
+        exportButton = tuple4.second;
+        exportForBisq2Button = tuple4.third;
+        importButton = tuple4.fourth;
     }
 
     // Add new account form

--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -2064,6 +2064,51 @@ public class FormBuilder {
         return new Tuple3<>(button1, button2, button3);
     }
 
+    public static Tuple4<Button, Button, Button, Button> add4ButtonsAfterGroup(GridPane gridPane,
+                                                                               int rowIndex,
+                                                                               String title1,
+                                                                               String title2,
+                                                                               String title3,
+                                                                               String title4) {
+        return add4Buttons(gridPane, rowIndex, title1, title2, title3, title4, 15);
+    }
+
+    public static Tuple4<Button, Button, Button, Button> add4Buttons(GridPane gridPane,
+                                                                     int rowIndex,
+                                                                     String title1,
+                                                                     String title2,
+                                                                     String title3,
+                                                                     String title4,
+                                                                     double top) {
+        HBox hBox = new HBox();
+        hBox.setSpacing(10);
+        Button button1 = new AutoTooltipButton(title1);
+
+        button1.getStyleClass().add("action-button");
+        button1.setDefaultButton(true);
+        button1.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(button1, Priority.ALWAYS);
+
+        Button button2 = new AutoTooltipButton(title2);
+        button2.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(button2, Priority.ALWAYS);
+
+        Button button3 = new AutoTooltipButton(title3);
+        button3.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(button3, Priority.ALWAYS);
+
+        Button button4 = new AutoTooltipButton(title4);
+        button4.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(button4, Priority.ALWAYS);
+
+        hBox.getChildren().addAll(button1, button2, button3, button4);
+        GridPane.setRowIndex(hBox, rowIndex);
+        GridPane.setColumnIndex(hBox, 0);
+        GridPane.setMargin(hBox, new Insets(top, 10, 0, 0));
+        gridPane.getChildren().add(hBox);
+        return new Tuple4<>(button1, button2, button3, button4);
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Button + ProgressIndicator + Label


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Export for Bisq 2" button and workflow to export accounts together with a signing key pair as a JSON package.

* **Improvements**
  * Account export now supports a Bisq‑2 style export including signature key data, performed asynchronously and confirming saved path.
  * Export UI extended to expose the new export option for both fiat and altcoin account views.

* **Localization**
  * Added new user-facing messages for the Bisq 2 export flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->