### PR TITLE
Add AccountTimestampGrpcService

### DIFF
--- a/bridge/src/main/java/bisq/bridge/grpc/BridgeGrpcServer.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/BridgeGrpcServer.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 
 
 import bisq.bridge.grpc.services.AccountAgeWitnessGrpcService;
+import bisq.bridge.grpc.services.AccountTimestampGrpcService;
 import bisq.bridge.grpc.services.BondedRoleGrpcService;
 import bisq.bridge.grpc.services.BsqBlockGrpcService;
 import bisq.bridge.grpc.services.BurningmanGrpcService;
@@ -51,6 +52,7 @@ public class BridgeGrpcServer {
     public BridgeGrpcServer(Config config,
                             BsqBlockGrpcService bsqBlockGrpcService,
                             BurningmanGrpcService burningManGrpcService,
+                            AccountTimestampGrpcService accountTimestampGrpcService,
                             AccountAgeWitnessGrpcService accountAgeWitnessGrpcService,
                             SignedWitnessGrpcService signedWitnessGrpcService,
                             BondedRoleGrpcService bondedRoleGrpcService) {
@@ -64,6 +66,7 @@ public class BridgeGrpcServer {
                 .executor(serverExecutor)
                 .addService(bsqBlockGrpcService)
                 .addService(burningManGrpcService)
+                .addService(accountTimestampGrpcService)
                 .addService(accountAgeWitnessGrpcService)
                 .addService(signedWitnessGrpcService)
                 .addService(bondedRoleGrpcService)

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/AccountTimestampRequest.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/AccountTimestampRequest.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import com.google.protobuf.ByteString;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class AccountTimestampRequest implements Payload {
+    private final byte[] hash;
+
+    public AccountTimestampRequest(byte[] hash) {
+        this.hash = hash;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.AccountTimestampRequest toProtoMessage() {
+        return bisq.bridge.protobuf.AccountTimestampRequest.newBuilder()
+                .setHash(ByteString.copyFrom(hash))
+                .build();
+    }
+
+    public static AccountTimestampRequest fromProto(bisq.bridge.protobuf.AccountTimestampRequest proto) {
+        return new AccountTimestampRequest(proto.getHash().toByteArray());
+    }
+}

--- a/bridge/src/main/java/bisq/bridge/grpc/messages/AccountTimestampResponse.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/messages/AccountTimestampResponse.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.messages;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class AccountTimestampResponse implements Payload {
+    private final long date;
+
+    public AccountTimestampResponse(long date) {
+        this.date = date;
+    }
+
+    @Override
+    public bisq.bridge.protobuf.AccountTimestampResponse toProtoMessage() {
+        return bisq.bridge.protobuf.AccountTimestampResponse.newBuilder()
+                .setDate(date)
+                .build();
+    }
+
+    public static AccountTimestampResponse fromProto(bisq.bridge.protobuf.AccountTimestampResponse proto) {
+        return new AccountTimestampResponse(proto.getDate());
+    }
+}

--- a/core/src/main/java/bisq/core/account/witness/AccountAgeWitness.java
+++ b/core/src/main/java/bisq/core/account/witness/AccountAgeWitness.java
@@ -120,7 +120,7 @@ public class AccountAgeWitness implements ProcessOncePersistableNetworkPayload, 
     public String toString() {
         return "AccountAgeWitness{" +
                 "\n     hash=" + Utilities.bytesAsHexString(hash) +
-                ",\n     date=" + Instant.ofEpochMilli(date) +
+                ",\n     date=" + Instant.ofEpochMilli(date) + " / " + date +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/util/JsonUtil.java
+++ b/core/src/main/java/bisq/core/util/JsonUtil.java
@@ -29,8 +29,12 @@ import com.google.gson.GsonBuilder;
 
 public class JsonUtil {
     public static String objectToJson(Object object) {
+        return objectToJson(object, new AnnotationExclusionStrategy());
+    }
+
+    public static String objectToJson(Object object, ExclusionStrategy exclusionStrategy) {
         GsonBuilder gsonBuilder = new GsonBuilder()
-                .setExclusionStrategies(new AnnotationExclusionStrategy())
+                .setExclusionStrategies(exclusionStrategy)
                 .setPrettyPrinting();
         if (object instanceof Contract || object instanceof OfferPayload) {
             gsonBuilder.registerTypeAdapter(OfferPayload.class,

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
@@ -26,6 +26,7 @@ import bisq.core.locale.FiatCurrency;
 import bisq.core.locale.TradeCurrency;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.payment.AssetAccount;
+import bisq.core.payment.BsqSwapAccount;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.trade.TradeManager;
 import bisq.core.user.Preferences;
@@ -169,6 +170,7 @@ class FiatAccountsDataModel extends ActivatableDataModel {
     private List<PaymentAccount> getFiatAccounts(Set<PaymentAccount> accounts) {
         return accounts.stream()
                 .filter(paymentAccount -> !(paymentAccount instanceof AssetAccount))
+                .filter(paymentAccount -> !(paymentAccount instanceof BsqSwapAccount))
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -87,6 +87,8 @@ import com.googlecode.jcsv.writer.CSVEntryConverter;
 import com.googlecode.jcsv.writer.CSVWriter;
 import com.googlecode.jcsv.writer.internal.CSVWriterBuilder;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -275,7 +277,19 @@ public class GUIUtil {
                                         Base64.encode(signatureKeyPair.getPrivate().getEncoded()),
                                         Base64.encode(signatureKeyPair.getPublic().getEncoded()),
                                         accounts);
-                                jsonFileManager.writeToDisc(JsonUtil.objectToJson(exportToBisq2Model), fileName);
+                                // We want to have the salt included thus we override the ExclusionStrategy
+                                String json = JsonUtil.objectToJson(exportToBisq2Model, new ExclusionStrategy() {
+                                    @Override
+                                    public boolean shouldSkipField(FieldAttributes fieldAttributes) {
+                                        return false;
+                                    }
+
+                                    @Override
+                                    public boolean shouldSkipClass(Class<?> aClass) {
+                                        return false;
+                                    }
+                                });
+                                jsonFileManager.writeToDisc(json, fileName);
                             },
                             executor)
                     .whenComplete((r, t) -> {

--- a/proto/src/main/proto/bridge.proto
+++ b/proto/src/main/proto/bridge.proto
@@ -91,6 +91,17 @@ message BurningmanDto {
     double cappedBurnAmountShare = 2;
 }
 
+service AccountTimestampGrpcService {
+    rpc RequestAccountTimestamp (AccountTimestampRequest) returns (AccountTimestampResponse);
+}
+
+message AccountTimestampRequest {
+    bytes hash = 1;
+}
+message AccountTimestampResponse {
+    sint64 date = 1;
+}
+
 service AccountAgeWitnessGrpcService {
     rpc RequestAccountAgeWitnessDate (AccountAgeWitnessDateRequest) returns (AccountAgeWitnessDateResponse);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Account Timestamp gRPC service with request/response messages to query account timestamps.
* **Integration**
  * Registered the new service with the bridge gRPC server so clients can call it.
* **Bug Fixes**
  * Minor logging tweak for clearer timestamp output.
* **Improvements**
  * Account export now includes additional account types and includes salt data in Bisq2 JSON exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->