### PR TITLE
Remove HRK from various currency lists.

### DIFF
--- a/core/src/main/java/bisq/core/payment/PayseraAccount.java
+++ b/core/src/main/java/bisq/core/payment/PayseraAccount.java
@@ -46,7 +46,6 @@ public final class PayseraAccount extends PaymentAccount {
             new FiatCurrency("GBP"),
             new FiatCurrency("GEL"),
             new FiatCurrency("HKD"),
-            new FiatCurrency("HRK"),
             new FiatCurrency("HUF"),
             new FiatCurrency("ILS"),
             new FiatCurrency("INR"),

--- a/core/src/main/java/bisq/core/payment/RevolutAccount.java
+++ b/core/src/main/java/bisq/core/payment/RevolutAccount.java
@@ -43,7 +43,6 @@ public final class RevolutAccount extends PaymentAccount {
             new FiatCurrency("EUR"),
             new FiatCurrency("GBP"),
             new FiatCurrency("HKD"),
-            new FiatCurrency("HRK"),
             new FiatCurrency("HUF"),
             new FiatCurrency("ILS"),
             new FiatCurrency("ISK"),

--- a/core/src/main/java/bisq/core/payment/TransferwiseAccount.java
+++ b/core/src/main/java/bisq/core/payment/TransferwiseAccount.java
@@ -56,7 +56,6 @@ public final class TransferwiseAccount extends PaymentAccount {
             new FiatCurrency("GEL"),
             new FiatCurrency("GHS"),
             new FiatCurrency("HKD"),
-            new FiatCurrency("HRK"),
             new FiatCurrency("HUF"),
             new FiatCurrency("IDR"),
             new FiatCurrency("ILS"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Croatian Kuna (HRK) currency support from multiple payment methods including Paysera, Revolut, and Transferwise. The currency is no longer available as an option for users when selecting their preferred payment method and currency for trading and transaction activities within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->