### PR TITLE
Fix SwishValidator

### DIFF
--- a/desktop/src/main/java/bisq/desktop/util/validation/SwishValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/SwishValidator.java
@@ -26,7 +26,7 @@ public final class SwishValidator extends PhoneNumberValidator {
     // Public no-arg constructor required by Guice injector.
     // Superclass' isoCountryCode must be set before validation.
     public SwishValidator() {
-        this.setIsoCountryCode("SE");
+        super("SE");
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
SwishValidator did not call super, thus not initializing fields, which led to a NP at Swish account creation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code initialization for payment method processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->