### PR TITLE
Fix BSQ wallet CSV tx type mapping for swaps and issuance

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
@@ -24,6 +24,7 @@ import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletService;
 import bisq.core.dao.DaoFacade;
+import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.locale.Res;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
@@ -48,6 +49,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @EqualsAndHashCode(callSuper = true)
 @Getter
 class BsqTxListItem extends TxConfidenceListItem {
+    private static final String BSQ_SWAP_TX_TYPE_FOR_EXPORT = "BSQ_SWAP";
+    private static final String COMPENSATION_ISSUANCE_TX_TYPE_FOR_EXPORT = "ISSUANCE_FROM_COMPENSATION_REQUEST";
+    private static final String REIMBURSEMENT_ISSUANCE_TX_TYPE_FOR_EXPORT = "ISSUANCE_FROM_REIMBURSEMENT_REQUEST";
     private final DaoFacade daoFacade;
     private final BsqFormatter bsqFormatter;
     private final Date date;
@@ -169,5 +173,27 @@ class BsqTxListItem extends TxConfidenceListItem {
     boolean isBsqSwapTx() {
         return getOptionalBsqTrade().isPresent();
     }
-}
 
+    boolean isCompensationIssuanceTx() {
+        return getTxType() == TxType.COMPENSATION_REQUEST &&
+                daoFacade.isIssuanceTx(txId, IssuanceType.COMPENSATION);
+    }
+
+    boolean isReimbursementIssuanceTx() {
+        return getTxType() == TxType.REIMBURSEMENT_REQUEST &&
+                daoFacade.isIssuanceTx(txId, IssuanceType.REIMBURSEMENT);
+    }
+
+    String getTxTypeForExport() {
+        if (isBsqSwapTx())
+            return BSQ_SWAP_TX_TYPE_FOR_EXPORT;
+
+        if (isCompensationIssuanceTx())
+            return COMPENSATION_ISSUANCE_TX_TYPE_FOR_EXPORT;
+
+        if (isReimbursementIssuanceTx())
+            return REIMBURSEMENT_ISSUANCE_TX_TYPE_FOR_EXPORT;
+
+        return getTxType().name();
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
@@ -175,12 +175,20 @@ class BsqTxListItem extends TxConfidenceListItem {
     }
 
     boolean isCompensationIssuanceTx() {
-        return getTxType() == TxType.COMPENSATION_REQUEST &&
+        return isCompensationIssuanceTx(getTxType());
+    }
+
+    boolean isCompensationIssuanceTx(TxType txType) {
+        return txType == TxType.COMPENSATION_REQUEST &&
                 daoFacade.isIssuanceTx(txId, IssuanceType.COMPENSATION);
     }
 
     boolean isReimbursementIssuanceTx() {
-        return getTxType() == TxType.REIMBURSEMENT_REQUEST &&
+        return isReimbursementIssuanceTx(getTxType());
+    }
+
+    boolean isReimbursementIssuanceTx(TxType txType) {
+        return txType == TxType.REIMBURSEMENT_REQUEST &&
                 daoFacade.isIssuanceTx(txId, IssuanceType.REIMBURSEMENT);
     }
 
@@ -189,10 +197,10 @@ class BsqTxListItem extends TxConfidenceListItem {
             return PaymentMethod.BSQ_SWAP_ID;
 
         TxType txType = getTxType();
-        if (isCompensationIssuanceTx())
+        if (isCompensationIssuanceTx(txType))
             return getIssuanceTxTypeForExport(IssuanceType.COMPENSATION);
 
-        if (isReimbursementIssuanceTx())
+        if (isReimbursementIssuanceTx(txType))
             return getIssuanceTxTypeForExport(IssuanceType.REIMBURSEMENT);
 
         return txType.name();

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java
@@ -27,6 +27,7 @@ import bisq.core.dao.DaoFacade;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.dao.state.model.blockchain.TxType;
 import bisq.core.locale.Res;
+import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
 import bisq.core.util.coin.BsqFormatter;
 
@@ -49,9 +50,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @EqualsAndHashCode(callSuper = true)
 @Getter
 class BsqTxListItem extends TxConfidenceListItem {
-    private static final String BSQ_SWAP_TX_TYPE_FOR_EXPORT = "BSQ_SWAP";
-    private static final String COMPENSATION_ISSUANCE_TX_TYPE_FOR_EXPORT = "ISSUANCE_FROM_COMPENSATION_REQUEST";
-    private static final String REIMBURSEMENT_ISSUANCE_TX_TYPE_FOR_EXPORT = "ISSUANCE_FROM_REIMBURSEMENT_REQUEST";
+    private static final String ISSUANCE_TX_TYPE_FOR_EXPORT_PREFIX = "ISSUANCE_FROM_";
+    private static final String ISSUANCE_TX_TYPE_FOR_EXPORT_SUFFIX = "_REQUEST";
     private final DaoFacade daoFacade;
     private final BsqFormatter bsqFormatter;
     private final Date date;
@@ -186,14 +186,19 @@ class BsqTxListItem extends TxConfidenceListItem {
 
     String getTxTypeForExport() {
         if (isBsqSwapTx())
-            return BSQ_SWAP_TX_TYPE_FOR_EXPORT;
+            return PaymentMethod.BSQ_SWAP_ID;
 
+        TxType txType = getTxType();
         if (isCompensationIssuanceTx())
-            return COMPENSATION_ISSUANCE_TX_TYPE_FOR_EXPORT;
+            return getIssuanceTxTypeForExport(IssuanceType.COMPENSATION);
 
         if (isReimbursementIssuanceTx())
-            return REIMBURSEMENT_ISSUANCE_TX_TYPE_FOR_EXPORT;
+            return getIssuanceTxTypeForExport(IssuanceType.REIMBURSEMENT);
 
-        return getTxType().name();
+        return txType.name();
+    }
+
+    private String getIssuanceTxTypeForExport(IssuanceType issuanceType) {
+        return ISSUANCE_TX_TYPE_FOR_EXPORT_PREFIX + issuanceType.name() + ISSUANCE_TX_TYPE_FOR_EXPORT_SUFFIX;
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -236,7 +236,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
                 columns[4] = String.valueOf(item.isReceived());
                 columns[5] = item.getAmountAsString();
                 columns[6] = String.valueOf(item.getNumConfirmations());
-                columns[7] = item.getTxType().name();
+                columns[7] = item.getTxTypeForExport();
                 return columns;
             };
 
@@ -771,4 +771,3 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
         tableView.getColumns().add(column);
     }
 }
-

--- a/desktop/src/test/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItemTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItemTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.dao.wallet.tx;
+
+import bisq.core.dao.state.model.blockchain.TxType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class BsqTxListItemTest {
+
+    @Test
+    public void getTxTypeForExport_returnsBsqSwap_forBsqSwapTx() {
+        BsqTxListItem item = spy(new BsqTxListItem());
+        doReturn(true).when(item).isBsqSwapTx();
+
+        assertEquals("BSQ_SWAP", item.getTxTypeForExport());
+    }
+
+    @Test
+    public void getTxTypeForExport_returnsRegularTxType_forNonBsqSwapTx() {
+        BsqTxListItem item = spy(new BsqTxListItem());
+        doReturn(false).when(item).isBsqSwapTx();
+        doReturn(TxType.PAY_TRADE_FEE).when(item).getTxType();
+
+        assertEquals("PAY_TRADE_FEE", item.getTxTypeForExport());
+    }
+
+    @Test
+    public void getTxTypeForExport_returnsCompensationIssuance_forCompensationIssuanceTx() {
+        BsqTxListItem item = spy(new BsqTxListItem());
+        doReturn(false).when(item).isBsqSwapTx();
+        doReturn(true).when(item).isCompensationIssuanceTx();
+        doReturn(false).when(item).isReimbursementIssuanceTx();
+
+        assertEquals("ISSUANCE_FROM_COMPENSATION_REQUEST", item.getTxTypeForExport());
+    }
+
+    @Test
+    public void getTxTypeForExport_returnsReimbursementIssuance_forReimbursementIssuanceTx() {
+        BsqTxListItem item = spy(new BsqTxListItem());
+        doReturn(false).when(item).isBsqSwapTx();
+        doReturn(false).when(item).isCompensationIssuanceTx();
+        doReturn(true).when(item).isReimbursementIssuanceTx();
+
+        assertEquals("ISSUANCE_FROM_REIMBURSEMENT_REQUEST", item.getTxTypeForExport());
+    }
+}

--- a/desktop/src/test/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItemTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItemTest.java
@@ -41,9 +41,9 @@ public class BsqTxListItemTest {
     public void getTxTypeForExport_returnsRegularTxType_forNonBsqSwapTx() {
         BsqTxListItem item = spy(new BsqTxListItem());
         doReturn(false).when(item).isBsqSwapTx();
-        doReturn(false).when(item).isCompensationIssuanceTx();
-        doReturn(false).when(item).isReimbursementIssuanceTx();
         doReturn(TxType.PAY_TRADE_FEE).when(item).getTxType();
+        doReturn(false).when(item).isCompensationIssuanceTx(TxType.PAY_TRADE_FEE);
+        doReturn(false).when(item).isReimbursementIssuanceTx(TxType.PAY_TRADE_FEE);
 
         assertEquals("PAY_TRADE_FEE", item.getTxTypeForExport());
     }
@@ -52,9 +52,8 @@ public class BsqTxListItemTest {
     public void getTxTypeForExport_returnsCompensationIssuance_forCompensationIssuanceTx() {
         BsqTxListItem item = spy(new BsqTxListItem());
         doReturn(false).when(item).isBsqSwapTx();
-        doReturn(true).when(item).isCompensationIssuanceTx();
-        doReturn(false).when(item).isReimbursementIssuanceTx();
         doReturn(TxType.COMPENSATION_REQUEST).when(item).getTxType();
+        doReturn(true).when(item).isCompensationIssuanceTx(TxType.COMPENSATION_REQUEST);
 
         assertEquals(getIssuanceTypeForExport(IssuanceType.COMPENSATION), item.getTxTypeForExport());
     }
@@ -63,9 +62,9 @@ public class BsqTxListItemTest {
     public void getTxTypeForExport_returnsReimbursementIssuance_forReimbursementIssuanceTx() {
         BsqTxListItem item = spy(new BsqTxListItem());
         doReturn(false).when(item).isBsqSwapTx();
-        doReturn(false).when(item).isCompensationIssuanceTx();
-        doReturn(true).when(item).isReimbursementIssuanceTx();
         doReturn(TxType.REIMBURSEMENT_REQUEST).when(item).getTxType();
+        doReturn(false).when(item).isCompensationIssuanceTx(TxType.REIMBURSEMENT_REQUEST);
+        doReturn(true).when(item).isReimbursementIssuanceTx(TxType.REIMBURSEMENT_REQUEST);
 
         assertEquals(getIssuanceTypeForExport(IssuanceType.REIMBURSEMENT), item.getTxTypeForExport());
     }

--- a/desktop/src/test/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItemTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItemTest.java
@@ -18,6 +18,8 @@
 package bisq.desktop.main.dao.wallet.tx;
 
 import bisq.core.dao.state.model.blockchain.TxType;
+import bisq.core.dao.state.model.governance.IssuanceType;
+import bisq.core.payment.payload.PaymentMethod;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,13 +34,15 @@ public class BsqTxListItemTest {
         BsqTxListItem item = spy(new BsqTxListItem());
         doReturn(true).when(item).isBsqSwapTx();
 
-        assertEquals("BSQ_SWAP", item.getTxTypeForExport());
+        assertEquals(PaymentMethod.BSQ_SWAP_ID, item.getTxTypeForExport());
     }
 
     @Test
     public void getTxTypeForExport_returnsRegularTxType_forNonBsqSwapTx() {
         BsqTxListItem item = spy(new BsqTxListItem());
         doReturn(false).when(item).isBsqSwapTx();
+        doReturn(false).when(item).isCompensationIssuanceTx();
+        doReturn(false).when(item).isReimbursementIssuanceTx();
         doReturn(TxType.PAY_TRADE_FEE).when(item).getTxType();
 
         assertEquals("PAY_TRADE_FEE", item.getTxTypeForExport());
@@ -50,8 +54,9 @@ public class BsqTxListItemTest {
         doReturn(false).when(item).isBsqSwapTx();
         doReturn(true).when(item).isCompensationIssuanceTx();
         doReturn(false).when(item).isReimbursementIssuanceTx();
+        doReturn(TxType.COMPENSATION_REQUEST).when(item).getTxType();
 
-        assertEquals("ISSUANCE_FROM_COMPENSATION_REQUEST", item.getTxTypeForExport());
+        assertEquals(getIssuanceTypeForExport(IssuanceType.COMPENSATION), item.getTxTypeForExport());
     }
 
     @Test
@@ -60,7 +65,12 @@ public class BsqTxListItemTest {
         doReturn(false).when(item).isBsqSwapTx();
         doReturn(false).when(item).isCompensationIssuanceTx();
         doReturn(true).when(item).isReimbursementIssuanceTx();
+        doReturn(TxType.REIMBURSEMENT_REQUEST).when(item).getTxType();
 
-        assertEquals("ISSUANCE_FROM_REIMBURSEMENT_REQUEST", item.getTxTypeForExport());
+        assertEquals(getIssuanceTypeForExport(IssuanceType.REIMBURSEMENT), item.getTxTypeForExport());
+    }
+
+    private static String getIssuanceTypeForExport(IssuanceType issuanceType) {
+        return "ISSUANCE_FROM_" + issuanceType.name() + "_REQUEST";
     }
 }


### PR DESCRIPTION
## Summary
  This PR fixes BSQ wallet CSV export type mapping so it matches the desktop UI differentiation.

  Previously, BSQ swap transactions and trade-fee transactions were both exported as `PAY_TRADE_FEE`, and issuance cases were not differentiated in CSV type output.

  ## What Changed
  - Updated BSQ wallet CSV export type mapping to use export-specific logic:
    - BSQ swap txs export as `BSQ_SWAP`
    - Compensation issuance txs export as `ISSUANCE_FROM_COMPENSATION_REQUEST`
    - Reimbursement issuance txs export as `ISSUANCE_FROM_REIMBURSEMENT_REQUEST`
    - Other txs continue to export as `TxType.name()`
  - CSV type column in `BsqTxView` now uses `item.getTxTypeForExport()`
  - Added focused unit tests for export type mapping in `BsqTxListItemTest`

  ## Files
  - `desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java`
  - `desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItem.java`
  - `desktop/src/test/java/bisq/desktop/main/dao/wallet/tx/BsqTxListItemTest.java`

  ## Validation
  - `./gradlew :desktop:compileJava -x test`
  - `./gradlew :desktop:test --tests bisq.desktop.main.dao.wallet.tx.BsqTxListItemTest`

  ## Notes
  This is a CSV export behavior fix only; UI display logic is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV transaction export now uses clearer, specific labels for BSQ swaps and issuance-related transactions (compensation and reimbursement) to improve export clarity.

* **Tests**
  * Added unit tests validating the export-type classification for BSQ swaps, compensation issuance, reimbursement issuance, and regular transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->