### PR TITLE
Remove VERSE from list of payment methods for creating new account

### DIFF
--- a/core/src/main/java/bisq/core/payment/VerseAccount.java
+++ b/core/src/main/java/bisq/core/payment/VerseAccount.java
@@ -28,6 +28,8 @@ import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 
+// Verse was shut down
+@Deprecated
 @EqualsAndHashCode(callSuper = true)
 public final class VerseAccount extends PaymentAccount {
 

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -121,6 +121,8 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static final String MONESE_ID = "MONESE";
     public static final String SATISPAY_ID = "SATISPAY";
     public static final String TIKKIE_ID = "TIKKIE";
+    // Verse was shut down
+    @Deprecated
     public static final String VERSE_ID = "VERSE";
     public static final String STRIKE_ID = "STRIKE";
     public static final String SWIFT_ID = "SWIFT";
@@ -186,6 +188,8 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static PaymentMethod MONESE;
     public static PaymentMethod SATISPAY;
     public static PaymentMethod TIKKIE;
+    // Verse was shut down
+    @Deprecated
     public static PaymentMethod VERSE;
     public static PaymentMethod STRIKE;
     public static PaymentMethod SWIFT;
@@ -260,6 +264,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
             MONESE = new PaymentMethod(MONESE_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
             SATISPAY = new PaymentMethod(SATISPAY_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
             TIKKIE = new PaymentMethod(TIKKIE_ID, DAY, Coin.parseCoin("0.05")),
+            // Verse was shut down
             VERSE = new PaymentMethod(VERSE_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
             STRIKE = new PaymentMethod(STRIKE_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
             SWIFT = new PaymentMethod(SWIFT_ID, 7 * DAY, DEFAULT_TRADE_LIMIT_MID_RISK),

--- a/core/src/main/java/bisq/core/payment/payload/VerseAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/VerseAccountPayload.java
@@ -32,6 +32,8 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+// Verse was shut down
+@Deprecated
 @EqualsAndHashCode(callSuper = true)
 @ToString
 @Setter

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -451,6 +451,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
         paymentMethodComboBox.setPrefWidth(250);
         List<PaymentMethod> list = PaymentMethod.getPaymentMethods().stream()
                 .filter(PaymentMethod::isFiat)
+                .filter(paymentMethod -> !paymentMethod.getId().equals(PaymentMethod.VERSE_ID)) // Verse not existing anymore
                 .sorted()
                 .collect(Collectors.toList());
         paymentMethodComboBox.setItems(FXCollections.observableArrayList(list));


### PR DESCRIPTION
Verse is not operating anymore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Verse payment method has been removed from the application and is no longer available when managing fiat payment accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->