### PR TITLE
Delay shutdown when payout transaction broadcasts are pending

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -136,6 +136,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
     // Desktop gets called from JavaFx thread
     protected void onApplicationLaunched() {
         configUserThread();
+        ShutdownDelayer.setClock(new ShutdownDelayer.BlockingClock());
 
         // Now we can use the user thread start periodic tasks
         CommonSetup.startPeriodicTasks();

--- a/core/src/main/java/bisq/core/app/ShutdownDelayer.java
+++ b/core/src/main/java/bisq/core/app/ShutdownDelayer.java
@@ -1,0 +1,70 @@
+package bisq.core.app;
+
+import java.time.Duration;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ShutdownDelayer {
+
+    interface Clock {
+        long getTimeInMillis();
+
+        void waitForMillis(int millis) throws InterruptedException;
+    }
+
+    @Slf4j
+    public static class BlockingClock implements Clock {
+        @Override
+        public long getTimeInMillis() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public void waitForMillis(int millis) throws InterruptedException {
+            Thread.sleep(millis);
+        }
+    }
+
+    public static final long SHUTDOWN_TIMEOUT = Duration.ofSeconds(2).toMillis();
+    private static final AtomicInteger pendingPaymentReceivedMessages = new AtomicInteger(0);
+
+    @Setter
+    private static Clock clock;
+
+    public static void reportPendingPaymentReceivedMessage() {
+        pendingPaymentReceivedMessages.incrementAndGet();
+    }
+
+    public static void reportPaymentReceivedMessageSent() {
+        pendingPaymentReceivedMessages.decrementAndGet();
+    }
+
+    public static void maybeWaitForPendingMessagesToBePublished() {
+        int numberOfPendingMessages = pendingPaymentReceivedMessages.get();
+        if (numberOfPendingMessages > 0) {
+            log.info("Payment received messages are pending. Waiting for 2 more seconds");
+            waitForMessagesToBeSent(numberOfPendingMessages);
+        }
+    }
+
+    private static void waitForMessagesToBeSent(int numberOfPendingMessages) {
+        long deadline = clock.getTimeInMillis() + SHUTDOWN_TIMEOUT;
+        while (numberOfPendingMessages > 0 && clock.getTimeInMillis() <= deadline) {
+            try {
+                clock.waitForMillis(200);
+            } catch (InterruptedException e) {
+                // Nothing to do.
+            } finally {
+                numberOfPendingMessages = pendingPaymentReceivedMessages.get();
+            }
+        }
+
+        if (numberOfPendingMessages > 0 && clock.getTimeInMillis() >= deadline) {
+            log.info("2 second timer expired.");
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/app/ShutdownDelayerTests.java
+++ b/core/src/test/java/bisq/core/app/ShutdownDelayerTests.java
@@ -1,0 +1,62 @@
+package bisq.core.app;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ShutdownDelayerTests {
+
+    @Slf4j
+    static class FakeClock implements ShutdownDelayer.Clock {
+        private long timeInMillis = System.currentTimeMillis();
+
+        @Override
+        public long getTimeInMillis() {
+            return timeInMillis;
+        }
+
+        @Override
+        public void waitForMillis(int millis) {
+            timeInMillis += millis;
+        }
+    }
+
+    @Test
+    void noDelayTest() {
+        ShutdownDelayer.Clock clock = new FakeClock();
+        ShutdownDelayer.setClock(clock);
+
+        long startTime = clock.getTimeInMillis();
+        ShutdownDelayer.maybeWaitForPendingMessagesToBePublished();
+        long endTime = clock.getTimeInMillis();
+
+        long diff = endTime - startTime;
+        assertEquals(0, diff, "There should be no shutdown delay because we have no pending messages.");
+    }
+
+    @Test
+    void delayTest() {
+        ShutdownDelayer.Clock clock = new FakeClock();
+        ShutdownDelayer.setClock(clock);
+
+        ShutdownDelayer.reportPendingPaymentReceivedMessage();
+        ShutdownDelayer.reportPendingPaymentReceivedMessage();
+
+        long startTime = clock.getTimeInMillis();
+        ShutdownDelayer.maybeWaitForPendingMessagesToBePublished();
+        long endTime = clock.getTimeInMillis();
+
+        // If we don't clean up the pending messages the other test will start in a
+        // pending state.
+        ShutdownDelayer.reportPaymentReceivedMessageSent();
+        ShutdownDelayer.reportPaymentReceivedMessageSent();
+
+        long diff = endTime - startTime;
+        if (diff < ShutdownDelayer.SHUTDOWN_TIMEOUT) {
+            fail("Timeout is shorter than " + ShutdownDelayer.SHUTDOWN_TIMEOUT);
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/app/BisqApp.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqApp.java
@@ -34,6 +34,7 @@ import bisq.desktop.util.CssTheme;
 import bisq.desktop.util.DisplayUtils;
 import bisq.desktop.util.ImageUtil;
 
+import bisq.core.app.ShutdownDelayer;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletsManager;
 import bisq.core.dao.governance.voteresult.MissingDataRequestService;
@@ -371,6 +372,7 @@ public class BisqApp extends Application implements UncaughtExceptionHandler {
         String potentialIssues = checkTradesAtShutdown() + checkDisputesAtShutdown() + checkOffersAtShutdown();
         promptUserAtShutdown(potentialIssues).thenAccept(asyncOkToShutDown -> {
             if (asyncOkToShutDown) {
+                ShutdownDelayer.maybeWaitForPendingMessagesToBePublished();
                 stop();
             }
         });

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.portfolio.pendingtrades.steps.seller;
 
+import bisq.core.app.ShutdownDelayer;
 import bisq.desktop.components.AutoTooltipButton;
 import bisq.desktop.components.BusyAnimation;
 import bisq.desktop.components.InfoTextField;
@@ -535,11 +536,13 @@ public class SellerStep3View extends TradeStepView {
 
     private void onReleaseBitcoin() {
         if (!model.dataModel.requiresPayoutDelay() || model.dataModel.requiredPayoutDelayHasPassed()) {
+            ShutdownDelayer.reportPendingPaymentReceivedMessage();
+
             busyAnimation.play();
             statusLabel.setText(Res.get("shared.sendingConfirmation"));
 
-            model.dataModel.onFiatPaymentReceived(() -> {
-            }, errorMessage -> {
+            model.dataModel.onFiatPaymentReceived(ShutdownDelayer::reportPaymentReceivedMessageSent, errorMessage -> {
+                ShutdownDelayer.reportPaymentReceivedMessageSent();
                 busyAnimation.stop();
                 new Popup().warning(Res.get("popup.warning.sendMsgFailed")).show();
             });


### PR DESCRIPTION
A support team member reported an issue where sellers confirm receipt of payment, but the payout transaction is not broadcasted because they close Bisq before the transaction is broadcasted.

To address this, we now check for pending payout transaction broadcasts during shutdown and delay the shutdown if necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shutdown now waits briefly (up to 2s) to ensure pending payment-received messages are published before the app stops, reducing risk of lost notifications during shutdown.
  * Release flow now tracks payment-received messages to ensure they are sent even on failures.

* **Tests**
  * Added tests covering shutdown wait behavior and payment-message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->