### PR TITLE
Fix broken Bisq launch scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ build
 *.java.hsw
 *.~ava
 /bundles
-/bisq-*
 /lib
 /xchange
 desktop.ini

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@
 #  the various Bisq seed and desktop nodes that will make up your
 #  localnet:
 #
-#     $ ls -1 bisq-*
-#     bisq-desktop
-#     bisq-seednode
-#     bisq-statsnode
+#     $ ls -1 scripts
+#     desktop
+#     seednode
+#     statsnode
 #
 #  - You will see a new '.localnet' directory containing the data dirs
 #  for your regtest Bitcoin and Bisq nodes. Once you've deployed them in
@@ -209,7 +209,7 @@ bitcoind2: .localnet
 		-datadir=.localnet/bitcoind2 \
 
 seednode: seednode/build
-	./bisq-seednode \
+	scripts/seednode \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
 		--useDevPrivilegeKeys=true \
@@ -223,7 +223,7 @@ seednode: seednode/build
 		--appName=seednode
 
 seednode2: seednode/build
-	./bisq-seednode \
+	scripts/seednode \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
 		--useDevPrivilegeKeys=true \
@@ -237,7 +237,7 @@ seednode2: seednode/build
 		--appName=seednode2
 
 mediator: desktop/build
-	./bisq-desktop \
+	scripts/desktop \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
 		--useDevPrivilegeKeys=true \
@@ -246,7 +246,7 @@ mediator: desktop/build
 		--appName=Mediator
 
 alice: setup
-	./bisq-desktop \
+	scripts/desktop \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
 		--useDevPrivilegeKeys=true \
@@ -262,7 +262,7 @@ alice: setup
 		--appName=Alice
 
 bob: setup
-	./bisq-desktop \
+	scripts/desktop \
 		--baseCurrencyNetwork=BTC_REGTEST \
 		--useLocalhostForP2P=true \
 		--useDevPrivilegeKeys=true \

--- a/btcnodemonitor/build.gradle
+++ b/btcnodemonitor/build.gradle
@@ -3,7 +3,9 @@ plugins {
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
-mainClassName = 'bisq.btcnodemonitor.BtcNodeMonitorMain'
+application {
+    mainClass = 'bisq.btcnodemonitor.BtcNodeMonitorMain'
+}
 
 distTar.enabled = true
 

--- a/build-logic/app-start-plugin/src/main/kotlin/bisq/gradle/app_start_plugin/AppStartPlugin.kt
+++ b/build-logic/app-start-plugin/src/main/kotlin/bisq/gradle/app_start_plugin/AppStartPlugin.kt
@@ -37,7 +37,7 @@ class AppStartPlugin @Inject constructor(private val javaToolchainService: JavaT
                 project.files(allFiles)
             }.get()
 
-            jvmArgs.addAll(javaApplicationExtension.applicationDefaultJvmArgs)
+            jvmArgs = javaApplicationExtension.applicationDefaultJvmArgs.toList()
 
             workingDir = project.projectDir.parentFile
             mainClass.set(javaApplicationExtension.mainClass)

--- a/build-logic/commons/src/main/groovy/bisq.application.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.application.gradle
@@ -4,44 +4,6 @@ plugins {
 }
 
 build.dependsOn installDist
-installDist.destinationDir = file('build/app')
+
 distZip.enabled = false
 distTar.enabled = false
-
-// the 'installDist' and 'startScripts' blocks below configure bisq executables to put
-// generated shell scripts in the root project directory, such that users can easily
-// discover and invoke e.g. ./bisq-desktop, ./bisq-seednode, etc.
-// See https://stackoverflow.com/q/46327736 for details.
-
-installDist {
-    doLast {
-        // copy generated shell scripts, e.g. `bisq-desktop` directly to the project
-        // root directory for discoverability and ease of use
-
-        copy {
-            from "$destinationDir/bin"
-            into projectDir.parentFile
-        }
-        // copy libs required for generated shell script classpaths to 'lib' dir under
-        // the project root directory
-        copy {
-            from "$destinationDir/lib"
-            into "${projectDir.parentFile}/lib"
-        }
-
-        // edit generated shell scripts such that they expect to be executed in the
-        // project root dir as opposed to a 'bin' subdirectory
-        def windowsScriptFile = file("${rootProject.projectDir}/bisq-${applicationName}.bat")
-        windowsScriptFile.text = windowsScriptFile.text.replace(
-                'set APP_HOME=%DIRNAME%..', 'set APP_HOME=%DIRNAME%')
-
-        def unixScriptFile = file("${rootProject.projectDir}/bisq-$applicationName")
-        unixScriptFile.text = unixScriptFile.text.replace(
-                'APP_HOME=$( cd "${APP_HOME:-./}.." && pwd -P ) || exit', 'APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit')
-    }
-}
-
-startScripts {
-    // rename scripts from, e.g. `desktop` to `bisq-desktop`
-    applicationName = "bisq-$applicationName"
-}

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -5,7 +5,9 @@ plugins {
 
 distTar.enabled = true
 
-mainClassName = 'bisq.cli.CliMain'
+application {
+    mainClass = 'bisq.cli.CliMain'
+}
 
 dependencies {
     implementation project(':proto')

--- a/daemon/build.gradle
+++ b/daemon/build.gradle
@@ -5,7 +5,9 @@ plugins {
 
 distTar.enabled = true
 
-mainClassName = 'bisq.daemon.app.BisqDaemonMain'
+application {
+    mainClass = 'bisq.daemon.app.BisqDaemonMain'
+}
 
 dependencies {
     implementation project(':proto')

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -17,8 +17,6 @@ javafx {
     modules = ['javafx.controls', 'javafx.fxml']
 }
 
-mainClassName = 'bisq.desktop.app.BisqAppMain'
-
 sourceSets.main.resources.srcDirs += ['src/main/java'] // to copy fxml and css files
 
 dependencies {

--- a/inventory/build.gradle
+++ b/inventory/build.gradle
@@ -2,7 +2,10 @@ plugins {
     id 'bisq.application'
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
-mainClassName = 'bisq.inventory.InventoryMonitorMain'
+
+application {
+    mainClass = 'bisq.inventory.InventoryMonitorMain'
+}
 
 distTar.enabled = true
 

--- a/restapi/build.gradle
+++ b/restapi/build.gradle
@@ -3,7 +3,9 @@ plugins {
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
-mainClassName = 'bisq.restapi.RestApiMain'
+application {
+    mainClass = 'bisq.restapi.RestApiMain'
+}
 
 distTar.enabled = false
 

--- a/scripts/apitest
+++ b/scripts/apitest
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew apitest:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/apitest.bat
+++ b/scripts/apitest.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew apitest:startBisqApp --args="""%*"""

--- a/scripts/bridge
+++ b/scripts/bridge
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew bridge:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/bridge.bat
+++ b/scripts/bridge.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew bridge:startBisqApp --args="""%*"""

--- a/scripts/btcnodemonitor
+++ b/scripts/btcnodemonitor
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew btcnodemonitor:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/btcnodemonitor.bat
+++ b/scripts/btcnodemonitor.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew btcnodemonitor:startBisqApp --args="""%*"""

--- a/scripts/cli
+++ b/scripts/cli
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew cli:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/cli.bat
+++ b/scripts/cli.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew cli:startBisqApp --args="""%*"""

--- a/scripts/daemon
+++ b/scripts/daemon
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew daemon:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/daemon.bat
+++ b/scripts/daemon.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew daemon:startBisqApp --args="""%*"""

--- a/scripts/desktop
+++ b/scripts/desktop
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew desktop:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/desktop.bat
+++ b/scripts/desktop.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew desktop:startBisqApp --args="""%*"""

--- a/scripts/inventory
+++ b/scripts/inventory
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew inventory:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/inventory.bat
+++ b/scripts/inventory.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew inventory:startBisqApp --args="""%*"""

--- a/scripts/restapi
+++ b/scripts/restapi
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew restapi:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/restapi.bat
+++ b/scripts/restapi.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew restapi:startBisqApp --args="""%*"""

--- a/scripts/seednode
+++ b/scripts/seednode
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew seednode:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/seednode.bat
+++ b/scripts/seednode.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew seednode:startBisqApp --args="""%*"""

--- a/scripts/statsnode
+++ b/scripts/statsnode
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+absolute_script_path=$(realpath "$0")
+scripts_dir_path=$(dirname "$absolute_script_path")
+
+cd "${scripts_dir_path}/.." || exit 1
+
+gradle_args=()
+for arg in "$@"; do
+    gradle_args+=("$(printf '%q' "$arg")")
+done
+
+./gradlew statsnode:startBisqApp --args=\""${gradle_args[*]}"\"

--- a/scripts/statsnode.bat
+++ b/scripts/statsnode.bat
@@ -1,0 +1,2 @@
+cd "%~dp0.."
+gradlew statsnode:startBisqApp --args="""%*"""

--- a/seednode/bisq.env
+++ b/seednode/bisq.env
@@ -29,7 +29,7 @@ BITCOIN_RPC_BLOCKNOTIFY_PORT=__BITCOIN_RPC_BLOCKNOTIFY_PORT__
 # bisq pathnames
 BISQ_HOME=__BISQ_HOME__
 BISQ_APP_NAME=bisq-seednode
-BISQ_ENTRYPOINT=seednode/build/app/bin/bisq-seednode
+BISQ_ENTRYPOINT=seednode/build/install/seednode/bin/seednode
 BISQ_BASE_CURRENCY=btc_mainnet
 
 # bisq node settings

--- a/statsnode/build.gradle
+++ b/statsnode/build.gradle
@@ -3,7 +3,9 @@ plugins {
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
-mainClassName = 'bisq.statistics.StatisticsMain'
+application {
+    mainClass = 'bisq.statistics.StatisticsMain'
+}
 
 dependencies {
     implementation project(':common')


### PR DESCRIPTION
The previous approach of copying app start scripts from build directories to the root and adjusting them no longer works. This commit introduces wrapper scripts that invoke the custom `<app>:startBisqApp` Gradle task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross‑platform launcher scripts to start apps and services from the project root.

* **Chores**
  * Standardized startup/configuration across modules and updated usage docs to reference script-based entry points.
  * Replaced custom packaging/startup tweaks with default behavior to simplify builds.
  * Restored previously ignored patterns so matching paths are now tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->