### PR TITLE
Move seednode JVM arguments to global configuration

### DIFF
--- a/build-logic/app-start-plugin/src/main/kotlin/bisq/gradle/app_start_plugin/AppStartPlugin.kt
+++ b/build-logic/app-start-plugin/src/main/kotlin/bisq/gradle/app_start_plugin/AppStartPlugin.kt
@@ -26,11 +26,6 @@ class AppStartPlugin @Inject constructor(private val javaToolchainService: JavaT
             dependsOn(installDistTask)
             javaLauncher.set(getJavaLauncher(project))
 
-            if (project.name == "seednode") {
-                minHeapSize = "4096M"
-                maxHeapSize = "4096M"
-            }
-
             classpath = installDistTask.map {
                 val appLibsDir = File(it.destinationDir, "lib")
                 val allFiles = appLibsDir.listFiles()

--- a/seednode/bisq.env
+++ b/seednode/bisq.env
@@ -4,9 +4,6 @@
 # java home, set to latest openjdk 11 from os repository
 JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
-# java memory and remote management options
-JAVA_OPTS="-Xms4096M -Xmx4096M -XX:+ExitOnOutOfMemoryError -Djava.net.preferIPv4Stack=true"
-
 # use external tor (change to -1 for internal tor binary)
 BISQ_EXTERNAL_TOR_PORT=9051
 BISQ_EXTERNAL_TOR_CONTROL_USE_COOKIE=true

--- a/seednode/build.gradle
+++ b/seednode/build.gradle
@@ -6,7 +6,8 @@ plugins {
 
 application {
     mainClass = 'bisq.seednode.SeedNodeMain'
-    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError']
+    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-Xms4096M', '-Xmx4096M',
+                                 '-Djava.net.preferIPv4Stack=true']
 }
 
 distTar.enabled = true


### PR DESCRIPTION
The AppStartPlugin currently overrides heap settings for the seednode,
and the bisq seednode service unit overrides both heap settings and other JVM
arguments.

These overrides are not applied in the dev setup, which can lead to
inconsistencies and potentially hide bugs during local testing.

This change moves the seednode JVM arguments to the global configuration
to ensure consistent behavior across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized JVM heap size configuration for seednode. Memory initialization and maximum heap settings (`4096M`), along with out-of-memory error handling and network stack preferences, have been consolidated into the build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->