### PR TITLE
Fix bridge address initialization order in TorNetworkSettingsWindow

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TorNetworkSettingsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TorNetworkSettingsWindow.java
@@ -295,6 +295,8 @@ public class TorNetworkSettingsWindow extends Overlay<TorNetworkSettingsWindow> 
 
         // init persisted values
         selectedBridgeOption = BridgeOption.values()[preferences.getBridgeOptionOrdinal()];
+        selectedTorTransportOrdinal = Transport.values()[preferences.getTorTransportOrdinal()];
+        customBridges = preferences.getCustomBridges();
         switch (selectedBridgeOption) {
             case PROVIDED:
                 toggleGroup.selectToggle(providedBridgesRadioButton);
@@ -309,10 +311,7 @@ public class TorNetworkSettingsWindow extends Overlay<TorNetworkSettingsWindow> 
         }
         applyToggleSelection();
 
-        selectedTorTransportOrdinal = Transport.values()[preferences.getTorTransportOrdinal()];
         transportTypeComboBox.getSelectionModel().select(selectedTorTransportOrdinal);
-
-        customBridges = preferences.getCustomBridges();
         bridgeEntriesTextArea.setText(customBridges);
 
         toggleGroup.selectedToggleProperty().addListener((observable, oldValue, newValue) -> {


### PR DESCRIPTION
### Problem

Opening the Tor Network Settings window corrupts the stored bridge address list,
causing Tor to start without bridges on the next restart — even if the window is
closed without making any changes. The text field still displays the correct bridge
address, making the bug invisible to users.

The root cause is an initialization ordering issue in
`TorNetworkSettingsWindow.addContent()`. Two fields are loaded from preferences
*after* `applyToggleSelection()` is called:

```java
applyToggleSelection();   // calls setBridgeAddressesByCustomBridges() here
                          // but customBridges is still "" (class field default)
selectedTorTransportOrdinal = ...  // too late
customBridges = preferences.getCustomBridges();  // too late
```

When the bridge option is `CUSTOM`, `applyToggleSelection()` calls
`setBridgeAddressesByCustomBridges()`, which splits the empty string `""` and
immediately force-persists `[""]` to disk via `Preferences.setBridgeAddresses()` →
`forcePersistNow()`. The `customBridges` display string is loaded correctly on the
next line, so the UI looks fine, but `bridgeAddresses` — the field actually read by
`BridgeAddressProvider.getBridgeAddresses()` at startup and passed to the Tor process
— is now `[""]`.

At the next startup, `NewTor.getTor()` receives `[""]` and Tor starts
without `UseBridges 1` in its torrc. The startup log prints `[StartTor] INFO
bisq.network.p2p.network.NewTor: Using bridges:` (blank).

The same issue affects `PROVIDED` bridges: if the stored transport type is not OBFS4
(the class field default for `selectedTorTransportOrdinal`), `applyToggleSelection()`
overwrites `bridgeAddresses` with OBFS4 bridges before the real transport ordinal is
loaded.

### How to reproduce (failure)

1. Set a custom bridge in Tor Network Settings, click Shut Down, confirm bridges work
   on restart (`Using bridges: <address>` in log)
2. Open Tor Network Settings again
3. Make no changes, click Shut down
4. Restart Bisq
5. Log shows `Using bridges:` (empty) — Tor connects without bridges

### How to work around it (before this fix)

After opening the window, trigger any listener before closing:
- Click **No bridges**, then click **Custom bridges** again, or
- Click in the bridge text field and make any edit (e.g. add and delete a space)

Either action fires a listener that was registered *after* `applyToggleSelection()`,
at which point `customBridges` is already correctly loaded, so
`setBridgeAddressesByCustomBridges()` re-persists the correct value.

### Fix

Load `selectedTorTransportOrdinal` and `customBridges` from preferences *before*
calling `applyToggleSelection()`, so the method always operates on the persisted
values rather than class field defaults.


### Disclaimer

I have no time to compile and test this patch. Can somebody test it please?

Regarding this topic, I also second this: [Allow the user to configure Tor before connecting to it #3010
](https://github.com/bisq-network/bisq/issues/3010)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initialization ordering in Tor network settings to ensure persisted values are loaded at the appropriate stage of the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->