### PR TITLE
Apply patch provided by @hiciefte to fix the protocol exploit

### DIFF
--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -343,8 +343,12 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         try {
             long tradeAmount = inputsForDepositTxRequest.getTradeAmount();
             checkArgument(inputsForDepositTxRequest.getTxFee() > 0, "Trade tx fee must be positive");
-            checkArgument(inputsForDepositTxRequest.getChangeOutputValue() >= 0,
+            long changeOutputValue = inputsForDepositTxRequest.getChangeOutputValue();
+            checkArgument(changeOutputValue >= 0,
                     "Taker change output value must not be negative");
+            if (changeOutputValue > 0) {
+                Validator.nonEmptyStringOf(inputsForDepositTxRequest.getChangeOutputAddress());
+            }
             checkArgument(tradeAmount >= offer.getMinAmount().value,
                     "Trade amount must be at least offer minimum amount. tradeAmount=%s, minAmount=%s",
                     tradeAmount, offer.getMinAmount().value);
@@ -352,7 +356,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                     "Trade amount must not exceed offer amount. tradeAmount=%s, offerAmount=%s",
                     tradeAmount, offer.getAmount().value);
             return true;
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.warn("Invalid inputsForDepositTxRequest with tradeId {} and uid {}: {}",
                     inputsForDepositTxRequest.getTradeId(),
                     inputsForDepositTxRequest.getUid(),

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -296,6 +296,10 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         }
 
         Offer offer = openOffer.getOffer();
+        if (!isValidInputsForDepositTxRequest(offer, inputsForDepositTxRequest)) {
+            return;
+        }
+
         openOfferManager.reserveOpenOffer(openOffer);
         Trade trade;
         if (offer.isBuyOffer()) {
@@ -332,6 +336,29 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         });
 
         requestPersistence();
+    }
+
+    private boolean isValidInputsForDepositTxRequest(Offer offer,
+                                                     InputsForDepositTxRequest inputsForDepositTxRequest) {
+        try {
+            long tradeAmount = inputsForDepositTxRequest.getTradeAmount();
+            checkArgument(inputsForDepositTxRequest.getTxFee() > 0, "Trade tx fee must be positive");
+            checkArgument(inputsForDepositTxRequest.getChangeOutputValue() >= 0,
+                    "Taker change output value must not be negative");
+            checkArgument(tradeAmount >= offer.getMinAmount().value,
+                    "Trade amount must be at least offer minimum amount. tradeAmount=%s, minAmount=%s",
+                    tradeAmount, offer.getMinAmount().value);
+            checkArgument(tradeAmount <= offer.getAmount().value,
+                    "Trade amount must not exceed offer amount. tradeAmount=%s, offerAmount=%s",
+                    tradeAmount, offer.getAmount().value);
+            return true;
+        } catch (Throwable t) {
+            log.warn("Invalid inputsForDepositTxRequest with tradeId {} and uid {}: {}",
+                    inputsForDepositTxRequest.getTradeId(),
+                    inputsForDepositTxRequest.getUid(),
+                    t.getMessage());
+            return false;
+        }
     }
 
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/TradePeerTxInputValidator.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/TradePeerTxInputValidator.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.bisq_v1.tasks;
+
+import bisq.core.btc.model.RawTransactionInput;
+import bisq.core.btc.wallet.BtcWalletService;
+
+import org.bitcoinj.core.Coin;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class TradePeerTxInputValidator {
+    private TradePeerTxInputValidator() {
+    }
+
+    public static long getValidatedInputValue(List<RawTransactionInput> rawTransactionInputs,
+                                              BtcWalletService walletService,
+                                              String peerRole) {
+        checkNotNull(rawTransactionInputs, "%s raw transaction inputs must not be null", peerRole);
+        checkArgument(!rawTransactionInputs.isEmpty(), "%s raw transaction inputs must not be empty", peerRole);
+
+        long inputValue = 0;
+        for (RawTransactionInput input : rawTransactionInputs) {
+            checkNotNull(input, "%s raw transaction input must not be null", peerRole);
+            checkArgument(input.value > 0, "%s raw transaction input value must be positive", peerRole);
+            input.validate(walletService);
+            inputValue = Math.addExact(inputValue, input.value);
+        }
+        return inputValue;
+    }
+
+    public static void validateContribution(List<RawTransactionInput> rawTransactionInputs,
+                                            long changeOutputValue,
+                                            Coin expectedContribution,
+                                            BtcWalletService walletService,
+                                            String peerRole) {
+        checkArgument(changeOutputValue >= 0, "%s change output value must not be negative", peerRole);
+        checkNotNull(expectedContribution, "%s expected contribution must not be null", peerRole);
+        checkArgument(expectedContribution.isPositive(), "%s expected contribution must be positive", peerRole);
+
+        long inputValue = getValidatedInputValue(rawTransactionInputs, walletService, peerRole);
+        long actualContribution = Math.subtractExact(inputValue, changeOutputValue);
+        checkArgument(actualContribution == expectedContribution.value,
+                "%s contribution mismatch. inputValue=%s, changeOutputValue=%s, actualContribution=%s, expectedContribution=%s",
+                peerRole, inputValue, changeOutputValue, actualContribution, expectedContribution.value);
+    }
+}

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
@@ -24,6 +24,7 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
+import bisq.core.trade.protocol.bisq_v1.tasks.TradePeerTxInputValidator;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
@@ -75,6 +76,14 @@ public class BuyerAsMakerCreatesAndSignsDepositTx extends TradeTask {
             checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
                     "all takerRawTransactionInputs must be P2WH");
             long takerChangeOutputValue = tradingPeer.getChangeOutputValue();
+            Coin expectedTakerContribution = offer.getSellerSecurityDeposit()
+                    .add(tradeAmount)
+                    .add(trade.getTradeTxFee().multiply(2));
+            TradePeerTxInputValidator.validateContribution(takerRawTransactionInputs,
+                    takerChangeOutputValue,
+                    expectedTakerContribution,
+                    walletService,
+                    "Taker");
             @Nullable String takerChangeAddressString = tradingPeer.getChangeOutputAddress();
             Address makerAddress = walletService.getOrCreateAddressEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE).getAddress();
             Address makerChangeAddress = walletService.getFreshAddressEntry().getAddress();

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -17,12 +17,14 @@
 
 package bisq.core.trade.protocol.bisq_v1.tasks.maker;
 
+import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 import bisq.core.offer.Offer;
 import bisq.core.support.dispute.mediation.mediator.Mediator;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.InputsForDepositTxRequest;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
+import bisq.core.trade.protocol.bisq_v1.tasks.TradePeerTxInputValidator;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.core.user.User;
 
@@ -34,6 +36,7 @@ import org.bitcoinj.core.Coin;
 
 import com.google.common.base.Charsets;
 
+import java.util.List;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
@@ -67,10 +70,17 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
             Optional.ofNullable(request.getTakersPaymentMethodId())
                     .ifPresent(e -> tradingPeer.setPaymentMethodId(request.getTakersPaymentMethodId()));
 
-            tradingPeer.setRawTransactionInputs(checkNotNull(request.getRawTransactionInputs()));
-            checkArgument(request.getRawTransactionInputs().size() > 0);
+            List<RawTransactionInput> takerRawTransactionInputs = checkNotNull(request.getRawTransactionInputs());
+            TradePeerTxInputValidator.getValidatedInputValue(takerRawTransactionInputs,
+                    processModel.getBtcWalletService(),
+                    "Taker");
+            tradingPeer.setRawTransactionInputs(takerRawTransactionInputs);
 
-            tradingPeer.setChangeOutputValue(request.getChangeOutputValue());
+            long changeOutputValue = request.getChangeOutputValue();
+            checkArgument(changeOutputValue >= 0, "Taker change output value must not be negative");
+            if (changeOutputValue > 0)
+                nonEmptyStringOf(request.getChangeOutputAddress());
+            tradingPeer.setChangeOutputValue(changeOutputValue);
             tradingPeer.setChangeOutputAddress(request.getChangeOutputAddress());
 
             tradingPeer.setMultiSigPubKey(checkNotNull(request.getTakerMultiSigPubKey()));
@@ -118,8 +128,16 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
             offer.verifyTakersTradePrice(takersTradePrice);
             trade.setPriceAsLong(takersTradePrice);
 
-            checkArgument(request.getTradeAmount() > 0);
-            trade.setAmount(Coin.valueOf(request.getTradeAmount()));
+            checkArgument(request.getTxFee() > 0, "Trade tx fee must be positive");
+
+            long tradeAmount = request.getTradeAmount();
+            checkArgument(tradeAmount >= offer.getMinAmount().value,
+                    "Trade amount must be at least offer minimum amount. tradeAmount=%s, minAmount=%s",
+                    tradeAmount, offer.getMinAmount().value);
+            checkArgument(tradeAmount <= offer.getAmount().value,
+                    "Trade amount must not exceed offer amount. tradeAmount=%s, offerAmount=%s",
+                    tradeAmount, offer.getAmount().value);
+            trade.setAmount(Coin.valueOf(tradeAmount));
 
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
@@ -24,6 +24,7 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
+import bisq.core.trade.protocol.bisq_v1.tasks.TradePeerTxInputValidator;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
 import bisq.common.crypto.Hash;
@@ -82,6 +83,13 @@ public class SellerAsMakerCreatesUnsignedDepositTx extends TradeTask {
             checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
                     "all takerRawTransactionInputs must be P2WH");
             long takerChangeOutputValue = tradingPeer.getChangeOutputValue();
+            Coin expectedTakerContribution = offer.getBuyerSecurityDeposit()
+                    .add(trade.getTradeTxFee().multiply(2));
+            TradePeerTxInputValidator.validateContribution(takerRawTransactionInputs,
+                    takerChangeOutputValue,
+                    expectedTakerContribution,
+                    walletService,
+                    "Taker");
             String takerChangeAddressString = tradingPeer.getChangeOutputAddress();
             Address makerAddress = walletService.getOrCreateAddressEntry(id, AddressEntry.Context.RESERVED_FOR_TRADE).getAddress();
             Address makerChangeAddress = walletService.getFreshAddressEntry().getAddress();

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
@@ -17,15 +17,18 @@
 
 package bisq.core.trade.protocol.bisq_v1.tasks.taker;
 
+import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.Restrictions;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.InputsForDepositTxResponse;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
+import bisq.core.trade.protocol.bisq_v1.tasks.TradePeerTxInputValidator;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
 import bisq.common.config.Config;
 import bisq.common.taskrunner.TaskRunner;
 
+import java.util.List;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +67,11 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
             tradingPeer.setContractAsJson(nonEmptyStringOf(response.getMakerContractAsJson()));
             tradingPeer.setContractSignature(nonEmptyStringOf(response.getMakerContractSignature()));
             tradingPeer.setPayoutAddressString(nonEmptyStringOf(response.getMakerPayoutAddressString()));
-            tradingPeer.setRawTransactionInputs(checkNotNull(response.getMakerInputs()));
+            List<RawTransactionInput> makerInputs = checkNotNull(response.getMakerInputs());
+            TradePeerTxInputValidator.getValidatedInputValue(makerInputs,
+                    processModel.getBtcWalletService(),
+                    "Maker");
+            tradingPeer.setRawTransactionInputs(makerInputs);
             byte[] preparedDepositTx = checkNotNull(response.getPreparedDepositTx());
             processModel.setPreparedDepositTx(preparedDepositTx);
             long lockTime = response.getLockTime();
@@ -87,8 +94,6 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
             tradingPeer.setAccountAgeWitnessSignature(checkNotNull(response.getAccountAgeWitnessSignatureOfPreparedDepositTx()));
 
             tradingPeer.setCurrentDate(response.getCurrentDate());
-
-            checkArgument(response.getMakerInputs().size() > 0);
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());


### PR DESCRIPTION
This applied a patch provided by @hiciefte to fix the protocol exploit.

I could reproduce the exploit for both taker as buyer and taker as seller variants and could verify that the patch fixes it.

We will add additional PRs with additional hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized transaction-input validator used across maker and taker flows.
* **Bug Fixes**
  * Strengthened validation to reject trades with invalid fees, change values/addresses, or contribution/amount mismatches against offer bounds before processing; failures are logged and processing stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->