### PR TITLE
Verify sender address at network layer

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/accounting/node/messages/GetAccountingBlocksRequest.java
+++ b/core/src/main/java/bisq/core/dao/burningman/accounting/node/messages/GetAccountingBlocksRequest.java
@@ -20,7 +20,7 @@ package bisq.core.dao.burningman.accounting.node.messages;
 import bisq.network.p2p.DirectMessage;
 import bisq.network.p2p.InitialDataRequest;
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.SendersNodeAddressMessage;
+import bisq.network.p2p.SendersNodeAddressAwareEnvelope;
 import bisq.network.p2p.SupportedCapabilitiesMessage;
 
 import bisq.common.app.Capabilities;
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @EqualsAndHashCode(callSuper = true)
 @Getter
 @Slf4j
-public final class GetAccountingBlocksRequest extends NetworkEnvelope implements DirectMessage, SendersNodeAddressMessage,
+public final class GetAccountingBlocksRequest extends NetworkEnvelope implements DirectMessage, SendersNodeAddressAwareEnvelope,
         SupportedCapabilitiesMessage, InitialDataRequest {
     private final int fromBlockHeight;
     private final int nonce;

--- a/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
+++ b/core/src/main/java/bisq/core/dao/node/messages/GetBlocksRequest.java
@@ -20,7 +20,7 @@ package bisq.core.dao.node.messages;
 import bisq.network.p2p.DirectMessage;
 import bisq.network.p2p.InitialDataRequest;
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.SendersNodeAddressMessage;
+import bisq.network.p2p.SendersNodeAddressAwareEnvelope;
 import bisq.network.p2p.SupportedCapabilitiesMessage;
 
 import bisq.common.app.Capabilities;
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode(callSuper = true)
 @Getter
 @Slf4j
-public final class GetBlocksRequest extends NetworkEnvelope implements DirectMessage, SendersNodeAddressMessage,
+public final class GetBlocksRequest extends NetworkEnvelope implements DirectMessage, SendersNodeAddressAwareEnvelope,
         SupportedCapabilitiesMessage, InitialDataRequest {
     private final int fromBlockHeight;
     private final int nonce;

--- a/core/src/main/java/bisq/core/trade/protocol/TradeMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeMessage.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade.protocol;
 
+import bisq.network.p2p.SendersNodeAddressAwarePayload;
 import bisq.network.p2p.UidMessage;
 
 import bisq.common.proto.network.NetworkEnvelope;
@@ -27,10 +28,16 @@ import lombok.ToString;
 
 import static bisq.core.util.Validator.checkNonEmptyString;
 
+/**
+ * Base class for trade-related messages exchanged between peers.
+ * As the TradeMessage is wrapped into a PrefixedSealedAndSignedMessage we use the SendersNodeAddressAwarePayload
+ * to allow network level validation that the senders node address matches the address from the outer
+ * SendersNodeAddressAwareEnvelope.
+ */
 @EqualsAndHashCode(callSuper = true)
 @Getter
 @ToString
-public abstract class TradeMessage extends NetworkEnvelope implements UidMessage {
+public abstract class TradeMessage extends NetworkEnvelope implements UidMessage, SendersNodeAddressAwarePayload {
     protected final String tradeId;
     protected final String uid;
 

--- a/p2p/src/main/java/bisq/network/p2p/AckMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/AckMessage.java
@@ -43,7 +43,8 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode(callSuper = true, exclude = {"uid"})
 @Value
 @Slf4j
-public final class AckMessage extends NetworkEnvelope implements MailboxMessage, PersistablePayload, ExpirablePayload {
+public final class AckMessage extends NetworkEnvelope implements MailboxMessage, SendersNodeAddressAwareEnvelope,
+        PersistablePayload, ExpirablePayload {
     public static final long TTL = TimeUnit.DAYS.toMillis(7);
 
     private final String uid;

--- a/p2p/src/main/java/bisq/network/p2p/FileTransferPart.java
+++ b/p2p/src/main/java/bisq/network/p2p/FileTransferPart.java
@@ -27,7 +27,7 @@ import lombok.Value;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
-public class FileTransferPart extends NetworkEnvelope implements ExtendedDataSizePermission, SendersNodeAddressMessage {
+public class FileTransferPart extends NetworkEnvelope implements ExtendedDataSizePermission, SendersNodeAddressAwareEnvelope {
     NodeAddress senderNodeAddress;
     public String uid;
     public String tradeId;

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -376,21 +376,68 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             PrefixedSealedAndSignedMessage sealedMsg = (PrefixedSealedAndSignedMessage) networkEnvelope;
             try {
                 DecryptedMessageWithPubKey decryptedMsg = encryptionService.decryptAndVerify(sealedMsg.getSealedAndSigned());
-                connection.maybeHandleSupportedCapabilitiesMessage(decryptedMsg.getNetworkEnvelope());
-                connection.getPeersNodeAddressOptional().ifPresentOrElse(nodeAddress ->
-                                decryptedDirectMessageListeners.forEach(e -> e.onDirectMessage(decryptedMsg, nodeAddress)),
-                        () -> {
-                            log.error("peersNodeAddress is expected to be available at onMessage for " +
-                                    "processing PrefixedSealedAndSignedMessage.");
-                        });
+                NetworkEnvelope decryptedPayload = decryptedMsg.getNetworkEnvelope();
+                if (decryptedPayload == null) {
+                    log.error("Decrypted payload must not be null at processing PrefixedSealedAndSignedMessage.");
+                    return;
+                }
+
+                NodeAddress senderNodeAddress = getVerifiedDirectMessageSenderNodeAddress(decryptedPayload, sealedMsg,
+                        connection);
+                if (senderNodeAddress == null) {
+                    return;
+                }
+
+                connection.maybeHandleSupportedCapabilitiesMessage(decryptedPayload);
+                decryptedDirectMessageListeners.forEach(e -> e.onDirectMessage(decryptedMsg, senderNodeAddress));
             } catch (CryptoException e) {
                 log.warn("Decryption of a direct message failed. This is not expected as the " +
-                        "direct message was sent to our node.");
+                        "direct message was sent to our node.", e);
             } catch (ProtobufferException e) {
-                log.error("ProtobufferException at decryptAndVerify: {}", e.toString());
-                e.getStackTrace();
+                log.error("ProtobufferException at decryptAndVerify", e);
             }
         }
+    }
+
+    @Nullable
+    private NodeAddress getVerifiedDirectMessageSenderNodeAddress(NetworkEnvelope decryptedPayload,
+                                                                  PrefixedSealedAndSignedMessage sealedMsg,
+                                                                  Connection connection) {
+        NodeAddress senderNodeAddress = sealedMsg.getSenderNodeAddress();
+        if (senderNodeAddress == null) {
+            log.error("Sender node address of outer envelope must not be null at processing " +
+                    "PrefixedSealedAndSignedMessage.");
+            return null;
+        }
+
+        if (decryptedPayload instanceof SendersNodeAddressAwarePayload) {
+            SendersNodeAddressAwarePayload nodeAddressAwarePayload =
+                    (SendersNodeAddressAwarePayload) decryptedPayload;
+            NodeAddress payloadSenderNodeAddress = nodeAddressAwarePayload.getSenderNodeAddress();
+            if (!SendersNodeAddressAwarePayload.isSenderNodeAddressMatching(payloadSenderNodeAddress,
+                    senderNodeAddress)) {
+                log.error("Sender node address of decrypted payload {} does not match sender node address " +
+                                "of outer envelope {}",
+                        payloadSenderNodeAddress, senderNodeAddress);
+                return null;
+            }
+        }
+
+        Optional<NodeAddress> connectionSenderNodeAddressOptional = connection.getPeersNodeAddressOptional();
+        if (connectionSenderNodeAddressOptional.isEmpty()) {
+            log.error("peersNodeAddress is expected to be available at onMessage for " +
+                    "processing PrefixedSealedAndSignedMessage.");
+            return null;
+        }
+
+        NodeAddress connectionSenderNodeAddress = connectionSenderNodeAddressOptional.get();
+        if (!connectionSenderNodeAddress.equals(senderNodeAddress)) {
+            log.error("Connection peer node address {} does not match sender node address of outer envelope {}",
+                    connectionSenderNodeAddress, senderNodeAddress);
+            return null;
+        }
+
+        return connectionSenderNodeAddress;
     }
 
 
@@ -399,11 +446,11 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     // TODO OfferAvailabilityResponse is called twice!
-    public void sendEncryptedDirectMessage(NodeAddress peerNodeAddress, PubKeyRing pubKeyRing, NetworkEnvelope message,
+    public void sendEncryptedDirectMessage(NodeAddress peerNodeAddress, PubKeyRing pubKeyRing, NetworkEnvelope payload,
                                            SendDirectMessageListener sendDirectMessageListener) {
         checkNotNull(peerNodeAddress, "PeerAddress must not be null (sendEncryptedDirectMessage)");
         if (isBootstrapped()) {
-            doSendEncryptedDirectMessage(peerNodeAddress, pubKeyRing, message, sendDirectMessageListener);
+            doSendEncryptedDirectMessage(peerNodeAddress, pubKeyRing, payload, sendDirectMessageListener);
         } else {
             throw new NetworkNotReadyException();
         }
@@ -411,27 +458,41 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
 
     private void doSendEncryptedDirectMessage(@NotNull NodeAddress peersNodeAddress,
                                               PubKeyRing pubKeyRing,
-                                              NetworkEnvelope message,
+                                              NetworkEnvelope payload,
                                               SendDirectMessageListener sendDirectMessageListener) {
         log.debug("Send encrypted direct message {} to peer {}",
-                message.getClass().getSimpleName(), peersNodeAddress);
+                payload.getClass().getSimpleName(), peersNodeAddress);
 
         checkNotNull(peersNodeAddress, "Peer node address must not be null at doSendEncryptedDirectMessage");
 
-        checkNotNull(networkNode.getNodeAddress(), "My node address must not be null at doSendEncryptedDirectMessage");
+        NodeAddress senderNodeAddress = networkNode.getNodeAddress();
+        checkNotNull(senderNodeAddress, "My node address must not be null at doSendEncryptedDirectMessage");
 
-        if (CapabilityUtils.capabilityRequiredAndCapabilityNotSupported(peersNodeAddress, message, peerManager)) {
+        if (CapabilityUtils.capabilityRequiredAndCapabilityNotSupported(peersNodeAddress, payload, peerManager)) {
             sendDirectMessageListener.onFault("We did not send the EncryptedMessage " +
                     "because the peer does not support the capability.");
             return;
+        }
+
+        if (payload instanceof SendersNodeAddressAwarePayload) {
+            SendersNodeAddressAwarePayload nodeAddressAwarePayload = (SendersNodeAddressAwarePayload) payload;
+            NodeAddress payloadSenderNodeAddress = nodeAddressAwarePayload.getSenderNodeAddress();
+            if (!SendersNodeAddressAwarePayload.isSenderNodeAddressMatching(payloadSenderNodeAddress, senderNodeAddress)) {
+                // Sender node address of the SendersNodeAddressAwarePayload to be used for encryption
+                // must match the node address of the sender.
+                log.error("Sender node address {} does not match my node address {}",
+                        payloadSenderNodeAddress, senderNodeAddress);
+                sendDirectMessageListener.onFault("Sender node address of payload is not matching our node address");
+                return;
+            }
         }
 
         try {
             // Prefix is not needed for direct messages but as old code is doing the verification we still need to
             // send it if peer has not updated.
             PrefixedSealedAndSignedMessage sealedMsg = new PrefixedSealedAndSignedMessage(
-                    networkNode.getNodeAddress(),
-                    encryptionService.encryptAndSign(pubKeyRing, message));
+                    senderNodeAddress,
+                    encryptionService.encryptAndSign(pubKeyRing, payload));
 
             SettableFuture<Connection> future = networkNode.sendMessage(peersNodeAddress, sealedMsg);
             Futures.addCallback(future, new FutureCallback<>() {
@@ -449,7 +510,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             }, MoreExecutors.directExecutor());
         } catch (CryptoException e) {
             e.printStackTrace();
-            log.error(message.toString());
+            log.error(payload.toString());
             log.error(e.toString());
             sendDirectMessageListener.onFault(e.toString());
         }

--- a/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
@@ -35,7 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implements MailboxMessage, SendersNodeAddressMessage {
+public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implements MailboxMessage, SendersNodeAddressAwareEnvelope {
     public static final long TTL = TimeUnit.DAYS.toMillis(15);
 
     private final NodeAddress senderNodeAddress;

--- a/p2p/src/main/java/bisq/network/p2p/SendersNodeAddressAwareEnvelope.java
+++ b/p2p/src/main/java/bisq/network/p2p/SendersNodeAddressAwareEnvelope.java
@@ -17,6 +17,9 @@
 
 package bisq.network.p2p;
 
-public interface SendersNodeAddressMessage {
+/**
+ * Interface for network envelopes that carry sender node address information.
+ */
+public interface SendersNodeAddressAwareEnvelope {
     NodeAddress getSenderNodeAddress();
 }

--- a/p2p/src/main/java/bisq/network/p2p/SendersNodeAddressAwarePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/SendersNodeAddressAwarePayload.java
@@ -15,13 +15,18 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.network.p2p.mailbox;
+package bisq.network.p2p;
 
+import javax.annotation.Nullable;
 
-import bisq.network.p2p.DirectMessage;
-import bisq.network.p2p.SendersNodeAddressAwarePayload;
-import bisq.network.p2p.UidMessage;
-import bisq.network.p2p.storage.payload.ExpirablePayload;
+/**
+ * Interface for payloads that include the sender's node address.
+ */
+public interface SendersNodeAddressAwarePayload {
+    NodeAddress getSenderNodeAddress();
 
-public interface MailboxMessage extends DirectMessage, UidMessage, ExpirablePayload, SendersNodeAddressAwarePayload {
+    static boolean isSenderNodeAddressMatching(@Nullable NodeAddress payloadSenderNodeAddress,
+                                               @Nullable NodeAddress expectedSenderNodeAddress) {
+        return payloadSenderNodeAddress != null && payloadSenderNodeAddress.equals(expectedSenderNodeAddress);
+    }
 }

--- a/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxItem.java
+++ b/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxItem.java
@@ -18,9 +18,12 @@
 package bisq.network.p2p.mailbox;
 
 import bisq.network.p2p.DecryptedMessageWithPubKey;
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.SendersNodeAddressAwarePayload;
 import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
 
 import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.proto.persistable.PersistablePayload;
 
@@ -29,19 +32,26 @@ import java.time.Clock;
 import java.util.Optional;
 
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+@Slf4j
 @Value
 public class MailboxItem implements PersistablePayload {
     private final ProtectedMailboxStorageEntry protectedMailboxStorageEntry;
     @Nullable
     private final DecryptedMessageWithPubKey decryptedMessageWithPubKey;
+    private final boolean invalidDecryptedMessage;
 
     public MailboxItem(ProtectedMailboxStorageEntry protectedMailboxStorageEntry,
                        @Nullable DecryptedMessageWithPubKey decryptedMessageWithPubKey) {
         this.protectedMailboxStorageEntry = protectedMailboxStorageEntry;
-        this.decryptedMessageWithPubKey = decryptedMessageWithPubKey;
+        DecryptedMessageWithPubKey validDecryptedMessageWithPubKey = getValidDecryptedMessageWithPubKey(
+                protectedMailboxStorageEntry,
+                decryptedMessageWithPubKey);
+        this.decryptedMessageWithPubKey = validDecryptedMessageWithPubKey;
+        this.invalidDecryptedMessage = decryptedMessageWithPubKey != null && validDecryptedMessageWithPubKey == null;
     }
 
     @Override
@@ -66,6 +76,41 @@ public class MailboxItem implements PersistablePayload {
         return new MailboxItem(ProtectedMailboxStorageEntry.fromProto(proto.getProtectedMailboxStorageEntry(),
                 networkProtoResolver),
                 decryptedMessageWithPubKey);
+    }
+
+    @Nullable
+    private static DecryptedMessageWithPubKey getValidDecryptedMessageWithPubKey(
+            ProtectedMailboxStorageEntry protectedMailboxStorageEntry,
+            @Nullable DecryptedMessageWithPubKey decryptedMessageWithPubKey) {
+        if (decryptedMessageWithPubKey == null) {
+            return null;
+        }
+
+        NetworkEnvelope decryptedPayload = decryptedMessageWithPubKey.getNetworkEnvelope();
+        if (!(decryptedPayload instanceof MailboxMessage)) {
+            log.error("Decrypted mailbox item contained an invalid payload type: {}",
+                    decryptedPayload == null ? "null" : decryptedPayload.getClass().getSimpleName());
+            return null;
+        }
+
+        NodeAddress senderNodeAddress = protectedMailboxStorageEntry
+                .getMailboxStoragePayload()
+                .getPrefixedSealedAndSignedMessage()
+                .getSenderNodeAddress();
+        if (decryptedPayload instanceof SendersNodeAddressAwarePayload) {
+            SendersNodeAddressAwarePayload nodeAddressAwarePayload =
+                    (SendersNodeAddressAwarePayload) decryptedPayload;
+            NodeAddress payloadSenderNodeAddress = nodeAddressAwarePayload.getSenderNodeAddress();
+            if (!SendersNodeAddressAwarePayload.isSenderNodeAddressMatching(payloadSenderNodeAddress,
+                    senderNodeAddress)) {
+                log.error("Decrypted mailbox item sender address mismatch. " +
+                                "senderNodeAddress={}, payloadSenderNodeAddress={}",
+                        senderNodeAddress, payloadSenderNodeAddress);
+                return null;
+            }
+        }
+
+        return decryptedMessageWithPubKey;
     }
 
     public boolean isMine() {

--- a/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxMessageService.java
+++ b/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxMessageService.java
@@ -23,6 +23,7 @@ import bisq.network.p2p.NetworkNotReadyException;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.PrefixedSealedAndSignedMessage;
 import bisq.network.p2p.SendMailboxMessageListener;
+import bisq.network.p2p.SendersNodeAddressAwarePayload;
 import bisq.network.p2p.messaging.DecryptedMailboxListener;
 import bisq.network.p2p.network.Connection;
 import bisq.network.p2p.network.NetworkNode;
@@ -44,7 +45,6 @@ import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.crypto.SealedAndSigned;
 import bisq.common.persistence.PersistenceManager;
-import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.persistable.PersistedDataHost;
 import bisq.common.util.Tuple2;
@@ -278,7 +278,8 @@ public class MailboxMessageService implements HashMapChangedListener, PersistedD
         }
 
         checkNotNull(peer, "PeerAddress must not be null (sendEncryptedMailboxMessage)");
-        checkNotNull(networkNode.getNodeAddress(),
+        NodeAddress senderNodeAddress = networkNode.getNodeAddress();
+        checkNotNull(senderNodeAddress,
                 "My node address must not be null at sendEncryptedMailboxMessage");
         checkArgument(!keyRing.getPubKeyRing().equals(peersPubKeyRing), "We got own keyring instead of that from peer");
 
@@ -292,17 +293,30 @@ public class MailboxMessageService implements HashMapChangedListener, PersistedD
             return;
         }
 
-        NetworkEnvelope networkEnvelope = (NetworkEnvelope) mailboxMessage;
-        if (CapabilityUtils.capabilityRequiredAndCapabilityNotSupported(peer, networkEnvelope, peerManager)) {
+        NetworkEnvelope payload = (NetworkEnvelope) mailboxMessage;
+        if (CapabilityUtils.capabilityRequiredAndCapabilityNotSupported(peer, payload, peerManager)) {
             sendMailboxMessageListener.onFault("We did not send the EncryptedMailboxMessage " +
                     "because the peer does not support the capability.");
             return;
         }
 
+        if (payload instanceof SendersNodeAddressAwarePayload) {
+            SendersNodeAddressAwarePayload nodeAddressAwarePayload = (SendersNodeAddressAwarePayload) payload;
+            NodeAddress payloadSenderNodeAddress = nodeAddressAwarePayload.getSenderNodeAddress();
+            if (!SendersNodeAddressAwarePayload.isSenderNodeAddressMatching(payloadSenderNodeAddress, senderNodeAddress)) {
+                // Sender node address of the SendersNodeAddressAwarePayload to be used for encryption
+                // must match the node address of the sender.
+                log.error("Sender node address {} does not match my node address {}",
+                        payloadSenderNodeAddress, senderNodeAddress);
+                sendMailboxMessageListener.onFault("Sender node address of payload is not matching our node address");
+                return;
+            }
+        }
+
         try {
             PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage = new PrefixedSealedAndSignedMessage(
-                    networkNode.getNodeAddress(),
-                    encryptionService.encryptAndSign(peersPubKeyRing, networkEnvelope));
+                    senderNodeAddress,
+                    encryptionService.encryptAndSign(peersPubKeyRing, payload));
             SettableFuture<Connection> future = networkNode.sendMessage(peer, prefixedSealedAndSignedMessage);
             Futures.addCallback(future, new FutureCallback<>() {
                 @Override
@@ -475,20 +489,25 @@ public class MailboxMessageService implements HashMapChangedListener, PersistedD
         }
         try {
             DecryptedMessageWithPubKey decryptedMessageWithPubKey = encryptionService.decryptAndVerify(sealedAndSigned);
-            checkArgument(decryptedMessageWithPubKey.getNetworkEnvelope() instanceof MailboxMessage);
             return new MailboxItem(protectedMailboxStorageEntry, decryptedMessageWithPubKey);
         } catch (CryptoException ignore) {
             // Expected if message was not intended for us
             // We persist those entries so at the next startup we do not need to try to decrypt it anymore
             ignoredMailboxService.ignore(uid, protectedMailboxStorageEntry.getCreationTimeStamp());
-        } catch (ProtobufferException e) {
-            log.error(e.toString());
-            e.getStackTrace();
+        } catch (Exception e) {
+            log.error("tryDecryptProtectedMailboxStorageEntry failed", e);
         }
         return new MailboxItem(protectedMailboxStorageEntry, null);
     }
 
     private void handleMailboxItem(MailboxItem mailboxItem) {
+        // We might get an invalid flag if network was not ready yet, thus we add that check
+        if (mailboxItem.isInvalidDecryptedMessage() && allServicesInitialized && isBootstrapped) {
+            removeMailboxEntryFromNetwork(mailboxItem.getProtectedMailboxStorageEntry());
+            removeMailboxItemFromLocalStore(mailboxItem.getUid());
+            return;
+        }
+
         String uid = mailboxItem.getUid();
         if (!mailboxItemsByUid.containsKey(uid)) {
             mailboxItemsByUid.put(uid, mailboxItem);
@@ -651,14 +670,11 @@ public class MailboxMessageService implements HashMapChangedListener, PersistedD
 
     private void removeMailboxItemFromLocalStore(String uid) {
         MailboxItem mailboxItem = mailboxItemsByUid.get(uid);
-        mailboxItemsByUid.remove(uid);
-        mailboxMessageList.remove(mailboxItem);
-        log.trace("## removeMailboxItemFromMap uid={}\nhash={}\nmailboxItemsByUid={}",
-                uid,
-                P2PDataStorage.get32ByteHashAsByteArray(mailboxItem.getProtectedMailboxStorageEntry().getProtectedStoragePayload()),
-                mailboxItemsByUid.keySet()
-        );
-        requestPersistence();
+        boolean removedFromMap = mailboxItemsByUid.remove(uid) != null;
+        boolean removedFromList = mailboxMessageList.remove(mailboxItem);
+        if (removedFromMap || removedFromList) {
+            requestPersistence();
+        }
     }
 
     private void requestPersistence() {

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -21,7 +21,7 @@ import bisq.network.p2p.BundleOfEnvelopes;
 import bisq.network.p2p.CloseConnectionMessage;
 import bisq.network.p2p.ExtendedDataSizePermission;
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.SendersNodeAddressMessage;
+import bisq.network.p2p.SendersNodeAddressAwareEnvelope;
 import bisq.network.p2p.SupportedCapabilitiesMessage;
 import bisq.network.p2p.peers.keepalive.messages.KeepAliveMessage;
 import bisq.network.p2p.storage.P2PDataStorage;
@@ -406,9 +406,9 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         Set<NetworkEnvelope> envelopesToProcess = new HashSet<>();
         List<NetworkEnvelope> networkEnvelopes = bundleOfEnvelopes.getEnvelopes();
         for (NetworkEnvelope networkEnvelope : networkEnvelopes) {
-            // If SendersNodeAddressMessage we do some verifications and apply if successful, otherwise we return false.
-            if (networkEnvelope instanceof SendersNodeAddressMessage) {
-                boolean isValid = processSendersNodeAddressMessage((SendersNodeAddressMessage) networkEnvelope);
+            // If SendersNodeAddressAwareEnvelope we do some verifications and apply if successful, otherwise we return false.
+            if (networkEnvelope instanceof SendersNodeAddressAwareEnvelope) {
+                boolean isValid = processSendersNodeAddressAwareEnvelope((SendersNodeAddressAwareEnvelope) networkEnvelope);
                 if (!isValid) {
                     log.warn("Received an invalid {} at processing BundleOfEnvelopes", networkEnvelope.getClass().getSimpleName());
                     continue;
@@ -670,23 +670,23 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
         shutDown(closeConnectionReason);
     }
 
-    private boolean processSendersNodeAddressMessage(SendersNodeAddressMessage sendersNodeAddressMessage) {
-        NodeAddress senderNodeAddress = sendersNodeAddressMessage.getSenderNodeAddress();
+    private boolean processSendersNodeAddressAwareEnvelope(SendersNodeAddressAwareEnvelope sendersNodeAddressAwareEnvelope) {
+        NodeAddress senderNodeAddress = sendersNodeAddressAwareEnvelope.getSenderNodeAddress();
         checkNotNull(senderNodeAddress,
-                "senderNodeAddress must not be null at SendersNodeAddressMessage " +
-                        sendersNodeAddressMessage.getClass().getSimpleName());
+                "senderNodeAddress must not be null at SendersNodeAddressAwareEnvelope " +
+                        sendersNodeAddressAwareEnvelope.getClass().getSimpleName());
         Optional<NodeAddress> existingAddressOptional = getPeersNodeAddressOptional();
         if (existingAddressOptional.isPresent()) {
             // If we have already the peers address we check again if it matches our stored one
             checkArgument(existingAddressOptional.get().equals(senderNodeAddress),
                     "senderNodeAddress not matching connections peer address.\n\t" +
-                            "message=" + sendersNodeAddressMessage);
+                            "message=" + sendersNodeAddressAwareEnvelope);
         } else {
             setPeersNodeAddress(senderNodeAddress);
         }
 
         if (banFilter != null && banFilter.isPeerBanned(senderNodeAddress)) {
-            log.warn("We got a message from a banned peer. message={}", sendersNodeAddressMessage.getClass().getSimpleName());
+            log.warn("We got a message from a banned peer. message={}", sendersNodeAddressAwareEnvelope.getClass().getSimpleName());
             reportInvalidRequest(RuleViolation.PEER_BANNED);
             return false;
         }
@@ -837,16 +837,16 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         if (!(networkEnvelope instanceof KeepAliveMessage))
                             statistic.updateLastActivityTimestamp();
 
-                        // If SendersNodeAddressMessage we do some verifications and apply if successful,
+                        // If SendersNodeAddressAwareEnvelope we do some verifications and apply if successful,
                         // otherwise we return false.
-                        if (networkEnvelope instanceof SendersNodeAddressMessage) {
-                            boolean isValid = processSendersNodeAddressMessage((SendersNodeAddressMessage) networkEnvelope);
+                        if (networkEnvelope instanceof SendersNodeAddressAwareEnvelope) {
+                            boolean isValid = processSendersNodeAddressAwareEnvelope((SendersNodeAddressAwareEnvelope) networkEnvelope);
                             if (!isValid) {
                                 return;
                             }
                         }
 
-                        if (!(networkEnvelope instanceof SendersNodeAddressMessage) && peersNodeAddressOptional.isEmpty()) {
+                        if (!(networkEnvelope instanceof SendersNodeAddressAwareEnvelope) && peersNodeAddressOptional.isEmpty()) {
                             log.info("We got a {} from a peer with yet unknown address on connection with uid={}", networkEnvelope.getClass().getSimpleName(), uid);
                         }
 
@@ -909,8 +909,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
     @Nullable
     private NodeAddress getSenderNodeAddress(NetworkEnvelope networkEnvelope) {
         return getPeersNodeAddressOptional().orElse(
-                networkEnvelope instanceof SendersNodeAddressMessage ?
-                        ((SendersNodeAddressMessage) networkEnvelope).getSenderNodeAddress() :
+                networkEnvelope instanceof SendersNodeAddressAwareEnvelope ?
+                        ((SendersNodeAddressAwareEnvelope) networkEnvelope).getSenderNodeAddress() :
                         null);
     }
 

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
@@ -18,7 +18,7 @@
 package bisq.network.p2p.peers.getdata.messages;
 
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.SendersNodeAddressMessage;
+import bisq.network.p2p.SendersNodeAddressAwareEnvelope;
 
 import bisq.common.app.Version;
 import bisq.common.proto.ProtoUtil;
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
 @Slf4j
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class GetUpdatedDataRequest extends GetDataRequest implements SendersNodeAddressMessage {
+public final class GetUpdatedDataRequest extends GetDataRequest implements SendersNodeAddressAwareEnvelope {
     private final NodeAddress senderNodeAddress;
 
     public GetUpdatedDataRequest(NodeAddress senderNodeAddress,

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersRequest.java
@@ -18,7 +18,7 @@
 package bisq.network.p2p.peers.peerexchange.messages;
 
 import bisq.network.p2p.NodeAddress;
-import bisq.network.p2p.SendersNodeAddressMessage;
+import bisq.network.p2p.SendersNodeAddressAwareEnvelope;
 import bisq.network.p2p.SupportedCapabilitiesMessage;
 import bisq.network.p2p.peers.peerexchange.Peer;
 
@@ -40,7 +40,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class GetPeersRequest extends NetworkEnvelope implements PeerExchangeMessage, SendersNodeAddressMessage, SupportedCapabilitiesMessage {
+public final class GetPeersRequest extends NetworkEnvelope implements PeerExchangeMessage, SendersNodeAddressAwareEnvelope, SupportedCapabilitiesMessage {
     private final NodeAddress senderNodeAddress;
     private final int nonce;
     private final Set<Peer> reportedPeers;

--- a/p2p/src/test/java/bisq/network/p2p/AckMessageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/AckMessageTest.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AckMessageTest {
+    @Test
+    public void ackMessageIsSenderNodeAddressAwareEnvelopeForRawDirectTransferAcks() {
+        NodeAddress senderNodeAddress = new NodeAddress("sender.onion", 9999);
+
+        AckMessage ackMessage = new AckMessage(senderNodeAddress,
+                AckMessageSourceType.LOG_TRANSFER,
+                FileTransferPart.class.getSimpleName(),
+                "sourceUid",
+                "sourceId",
+                true,
+                null);
+
+        assertTrue(ackMessage instanceof SendersNodeAddressAwareEnvelope);
+        assertEquals(senderNodeAddress, ((SendersNodeAddressAwareEnvelope) ackMessage).getSenderNodeAddress());
+    }
+}

--- a/p2p/src/test/java/bisq/network/p2p/P2PServiceTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/P2PServiceTest.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p;
+
+import bisq.network.Socks5ProxyProvider;
+import bisq.network.crypto.EncryptionService;
+import bisq.network.p2p.mailbox.MailboxMessageService;
+import bisq.network.p2p.mocks.MockMailboxPayload;
+import bisq.network.p2p.mocks.MockPayload;
+import bisq.network.p2p.network.Connection;
+import bisq.network.p2p.network.NetworkNode;
+import bisq.network.p2p.peers.Broadcaster;
+import bisq.network.p2p.peers.PeerManager;
+import bisq.network.p2p.peers.getdata.RequestDataManager;
+import bisq.network.p2p.peers.keepalive.KeepAliveManager;
+import bisq.network.p2p.peers.peerexchange.PeerExchangeManager;
+import bisq.network.p2p.storage.P2PDataStorage;
+
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.SealedAndSigned;
+import bisq.common.proto.network.NetworkEnvelope;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class P2PServiceTest {
+    private static final NodeAddress MY_NODE_ADDRESS = new NodeAddress("my.onion", 9999);
+    private static final NodeAddress ENVELOPE_SENDER = new NodeAddress("sender.onion", 9999);
+    private static final NodeAddress OTHER_SENDER = new NodeAddress("other.onion", 9999);
+
+    @Test
+    public void onMessageDispatchesDirectMessageWhenPayloadEnvelopeAndConnectionSendersMatch() throws Exception {
+        DirectReceiveFixture fixture = new DirectReceiveFixture(
+                new MockMailboxPayload("msg", ENVELOPE_SENDER),
+                ENVELOPE_SENDER,
+                ENVELOPE_SENDER);
+        AtomicReference<DecryptedMessageWithPubKey> receivedMessage = new AtomicReference<>();
+        AtomicReference<NodeAddress> receivedSender = new AtomicReference<>();
+        fixture.p2PService.addDecryptedDirectMessageListener((decryptedMessageWithPubKey, senderNodeAddress) -> {
+            receivedMessage.set(decryptedMessageWithPubKey);
+            receivedSender.set(senderNodeAddress);
+        });
+
+        fixture.p2PService.onMessage(fixture.sealedMessage, fixture.connection);
+
+        assertSame(fixture.decryptedMessageWithPubKey, receivedMessage.get());
+        assertEquals(ENVELOPE_SENDER, receivedSender.get());
+        verify(fixture.connection).maybeHandleSupportedCapabilitiesMessage(same(fixture.payload));
+    }
+
+    @Test
+    public void onMessageDropsDirectMessageWhenPayloadSenderDoesNotMatchOuterEnvelopeSender() throws Exception {
+        DirectReceiveFixture fixture = new DirectReceiveFixture(
+                new MockMailboxPayload("msg", OTHER_SENDER),
+                ENVELOPE_SENDER,
+                ENVELOPE_SENDER);
+        AtomicBoolean listenerCalled = new AtomicBoolean();
+        fixture.p2PService.addDecryptedDirectMessageListener((decryptedMessageWithPubKey, senderNodeAddress) ->
+                listenerCalled.set(true));
+
+        fixture.p2PService.onMessage(fixture.sealedMessage, fixture.connection);
+
+        assertFalse(listenerCalled.get());
+        verify(fixture.connection, never()).maybeHandleSupportedCapabilitiesMessage(any(NetworkEnvelope.class));
+    }
+
+    @Test
+    public void onMessageDropsDirectMessageWhenConnectionSenderDoesNotMatchOuterEnvelopeSender() throws Exception {
+        DirectReceiveFixture fixture = new DirectReceiveFixture(
+                new MockMailboxPayload("msg", ENVELOPE_SENDER),
+                ENVELOPE_SENDER,
+                OTHER_SENDER);
+        AtomicBoolean listenerCalled = new AtomicBoolean();
+        fixture.p2PService.addDecryptedDirectMessageListener((decryptedMessageWithPubKey, senderNodeAddress) ->
+                listenerCalled.set(true));
+
+        fixture.p2PService.onMessage(fixture.sealedMessage, fixture.connection);
+
+        assertFalse(listenerCalled.get());
+        verify(fixture.connection, never()).maybeHandleSupportedCapabilitiesMessage(any(NetworkEnvelope.class));
+    }
+
+    @Test
+    public void onMessageDispatchesDirectMessageWithoutPayloadSenderWhenOuterEnvelopeAndConnectionMatch()
+            throws Exception {
+        DirectReceiveFixture fixture = new DirectReceiveFixture(
+                new MockPayload("msg"),
+                ENVELOPE_SENDER,
+                ENVELOPE_SENDER);
+        AtomicReference<NodeAddress> receivedSender = new AtomicReference<>();
+        fixture.p2PService.addDecryptedDirectMessageListener((decryptedMessageWithPubKey, senderNodeAddress) ->
+                receivedSender.set(senderNodeAddress));
+
+        fixture.p2PService.onMessage(fixture.sealedMessage, fixture.connection);
+
+        assertEquals(ENVELOPE_SENDER, receivedSender.get());
+        verify(fixture.connection).maybeHandleSupportedCapabilitiesMessage(same(fixture.payload));
+    }
+
+    @Test
+    public void sendEncryptedDirectMessageFailsBeforeEncryptionWhenPayloadSenderDoesNotMatchLocalNode()
+            throws Exception {
+        DirectSendFixture fixture = new DirectSendFixture();
+        setBootstrapped(fixture.p2PService);
+        SendDirectMessageListener listener = mock(SendDirectMessageListener.class);
+
+        fixture.p2PService.sendEncryptedDirectMessage(ENVELOPE_SENDER,
+                mock(PubKeyRing.class),
+                new MockMailboxPayload("msg", OTHER_SENDER),
+                listener);
+
+        verify(listener).onFault("Sender node address of payload is not matching our node address");
+        verify(fixture.encryptionService, never()).encryptAndSign(any(PubKeyRing.class), any(NetworkEnvelope.class));
+        verify(fixture.networkNode, never()).sendMessage(any(NodeAddress.class), any(NetworkEnvelope.class));
+    }
+
+    private static void setBootstrapped(P2PService p2PService) throws ReflectiveOperationException {
+        Field field = P2PService.class.getDeclaredField("isBootstrapped");
+        field.setAccessible(true);
+        field.setBoolean(p2PService, true);
+    }
+
+    private static P2PService newP2PService(NetworkNode networkNode, EncryptionService encryptionService) {
+        return new P2PService(networkNode,
+                mock(PeerManager.class),
+                mock(P2PDataStorage.class),
+                mock(RequestDataManager.class),
+                mock(PeerExchangeManager.class),
+                mock(KeepAliveManager.class),
+                mock(Broadcaster.class),
+                mock(Socks5ProxyProvider.class),
+                encryptionService,
+                mock(KeyRing.class),
+                mock(MailboxMessageService.class));
+    }
+
+    private static class DirectReceiveFixture {
+        private final NetworkNode networkNode = mock(NetworkNode.class);
+        private final EncryptionService encryptionService = mock(EncryptionService.class);
+        private final Connection connection = mock(Connection.class);
+        private final PrefixedSealedAndSignedMessage sealedMessage = mock(PrefixedSealedAndSignedMessage.class);
+        private final SealedAndSigned sealedAndSigned = mock(SealedAndSigned.class);
+        private final NetworkEnvelope payload;
+        private final DecryptedMessageWithPubKey decryptedMessageWithPubKey;
+        private final P2PService p2PService;
+
+        private DirectReceiveFixture(NetworkEnvelope payload,
+                                     NodeAddress envelopeSender,
+                                     NodeAddress connectionSender) throws Exception {
+            this.payload = payload;
+            decryptedMessageWithPubKey = new DecryptedMessageWithPubKey(payload,
+                    TestUtils.generateKeyPair().getPublic());
+            when(sealedMessage.getSealedAndSigned()).thenReturn(sealedAndSigned);
+            when(sealedMessage.getSenderNodeAddress()).thenReturn(envelopeSender);
+            when(connection.getPeersNodeAddressOptional()).thenReturn(Optional.of(connectionSender));
+            when(encryptionService.decryptAndVerify(sealedAndSigned)).thenReturn(decryptedMessageWithPubKey);
+            p2PService = newP2PService(networkNode, encryptionService);
+        }
+    }
+
+    private static class DirectSendFixture {
+        private final NetworkNode networkNode = mock(NetworkNode.class);
+        private final EncryptionService encryptionService = mock(EncryptionService.class);
+        private final P2PService p2PService;
+
+        private DirectSendFixture() {
+            when(networkNode.getNodeAddress()).thenReturn(MY_NODE_ADDRESS);
+            p2PService = newP2PService(networkNode, encryptionService);
+        }
+    }
+}

--- a/p2p/src/test/java/bisq/network/p2p/SendersNodeAddressAwarePayloadTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/SendersNodeAddressAwarePayloadTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p;
+
+import bisq.network.p2p.mocks.MockMailboxPayload;
+import bisq.network.p2p.mocks.MockPayload;
+
+import bisq.common.proto.network.NetworkEnvelope;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SendersNodeAddressAwarePayloadTest {
+    private static final NodeAddress EXPECTED_SENDER = new NodeAddress("sender.onion", 9999);
+    private static final NodeAddress OTHER_SENDER = new NodeAddress("other.onion", 9999);
+
+    @Test
+    public void payloadWithoutSenderNodeAddressDoesNotImplementInterface() {
+        NetworkEnvelope payload = new MockPayload("msg");
+
+        assertFalse(payload instanceof SendersNodeAddressAwarePayload);
+    }
+
+    @Test
+    public void senderAwarePayloadMatchesExpectedSenderNodeAddress() {
+        MockMailboxPayload payload = new MockMailboxPayload("msg", EXPECTED_SENDER);
+
+        assertTrue(payload instanceof SendersNodeAddressAwarePayload);
+        assertEquals(EXPECTED_SENDER, payload.getSenderNodeAddress());
+        assertTrue(SendersNodeAddressAwarePayload.isSenderNodeAddressMatching(payload.getSenderNodeAddress(),
+                EXPECTED_SENDER));
+    }
+
+    @Test
+    public void senderAwarePayloadDoesNotMatchDifferentSenderNodeAddress() {
+        MockMailboxPayload payload = new MockMailboxPayload("msg", OTHER_SENDER);
+
+        assertFalse(SendersNodeAddressAwarePayload.isSenderNodeAddressMatching(payload.getSenderNodeAddress(),
+                EXPECTED_SENDER));
+    }
+
+    @Test
+    public void senderAwarePayloadDoesNotMatchNullExpectedSenderNodeAddress() {
+        MockMailboxPayload payload = new MockMailboxPayload("msg", EXPECTED_SENDER);
+
+        assertFalse(SendersNodeAddressAwarePayload.isSenderNodeAddressMatching(payload.getSenderNodeAddress(), null));
+    }
+}

--- a/p2p/src/test/java/bisq/network/p2p/mailbox/MailboxItemTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/mailbox/MailboxItemTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.mailbox;
+
+import bisq.network.p2p.DecryptedMessageWithPubKey;
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.PrefixedSealedAndSignedMessage;
+import bisq.network.p2p.TestUtils;
+import bisq.network.p2p.mocks.MockMailboxPayload;
+import bisq.network.p2p.mocks.MockPayload;
+import bisq.network.p2p.storage.payload.MailboxStoragePayload;
+import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
+
+import bisq.common.proto.network.NetworkEnvelope;
+
+import java.security.NoSuchAlgorithmException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MailboxItemTest {
+    private static final NodeAddress ENVELOPE_SENDER = new NodeAddress("sender.onion", 9999);
+    private static final NodeAddress OTHER_SENDER = new NodeAddress("other.onion", 9999);
+
+    @Test
+    public void constructorKeepsDecryptedMessageWhenSenderNodeAddressesMatch() throws NoSuchAlgorithmException {
+        DecryptedMessageWithPubKey decryptedMessageWithPubKey = decryptedMessageWithPubKey(
+                new MockMailboxPayload("msg", ENVELOPE_SENDER));
+
+        MailboxItem mailboxItem = new MailboxItem(protectedMailboxStorageEntry(ENVELOPE_SENDER),
+                decryptedMessageWithPubKey);
+
+        assertTrue(mailboxItem.isMine());
+        assertFalse(mailboxItem.isInvalidDecryptedMessage());
+        assertSame(decryptedMessageWithPubKey, mailboxItem.getDecryptedMessageWithPubKey());
+    }
+
+    @Test
+    public void constructorDropsDecryptedMessageWhenSenderNodeAddressesMismatch() throws NoSuchAlgorithmException {
+        DecryptedMessageWithPubKey decryptedMessageWithPubKey = decryptedMessageWithPubKey(
+                new MockMailboxPayload("msg", OTHER_SENDER));
+
+        MailboxItem mailboxItem = new MailboxItem(protectedMailboxStorageEntry(ENVELOPE_SENDER),
+                decryptedMessageWithPubKey);
+
+        assertFalse(mailboxItem.isMine());
+        assertTrue(mailboxItem.isInvalidDecryptedMessage());
+    }
+
+    @Test
+    public void constructorDropsDecryptedMessageWhenPayloadIsNotMailboxMessage() throws NoSuchAlgorithmException {
+        DecryptedMessageWithPubKey decryptedMessageWithPubKey = decryptedMessageWithPubKey(new MockPayload("msg"));
+
+        MailboxItem mailboxItem = new MailboxItem(protectedMailboxStorageEntry(ENVELOPE_SENDER),
+                decryptedMessageWithPubKey);
+
+        assertFalse(mailboxItem.isMine());
+        assertTrue(mailboxItem.isInvalidDecryptedMessage());
+    }
+
+    private static ProtectedMailboxStorageEntry protectedMailboxStorageEntry(NodeAddress envelopeSenderNodeAddress) {
+        ProtectedMailboxStorageEntry protectedMailboxStorageEntry = mock(ProtectedMailboxStorageEntry.class);
+        MailboxStoragePayload mailboxStoragePayload = mock(MailboxStoragePayload.class);
+        PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage = mock(PrefixedSealedAndSignedMessage.class);
+
+        when(protectedMailboxStorageEntry.getMailboxStoragePayload()).thenReturn(mailboxStoragePayload);
+        when(mailboxStoragePayload.getPrefixedSealedAndSignedMessage()).thenReturn(prefixedSealedAndSignedMessage);
+        when(prefixedSealedAndSignedMessage.getSenderNodeAddress()).thenReturn(envelopeSenderNodeAddress);
+
+        return protectedMailboxStorageEntry;
+    }
+
+    private static DecryptedMessageWithPubKey decryptedMessageWithPubKey(NetworkEnvelope networkEnvelope)
+            throws NoSuchAlgorithmException {
+        return new DecryptedMessageWithPubKey(networkEnvelope, TestUtils.generateKeyPair().getPublic());
+    }
+}

--- a/p2p/src/test/java/bisq/network/p2p/mailbox/MailboxMessageServiceTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/mailbox/MailboxMessageServiceTest.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.mailbox;
+
+import bisq.network.crypto.EncryptionService;
+import bisq.network.p2p.DecryptedMessageWithPubKey;
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.PrefixedSealedAndSignedMessage;
+import bisq.network.p2p.SendMailboxMessageListener;
+import bisq.network.p2p.TestUtils;
+import bisq.network.p2p.mocks.MockMailboxPayload;
+import bisq.network.p2p.network.Connection;
+import bisq.network.p2p.network.NetworkNode;
+import bisq.network.p2p.peers.PeerManager;
+import bisq.network.p2p.storage.P2PDataStorage;
+import bisq.network.p2p.storage.payload.MailboxStoragePayload;
+import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
+import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
+
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.SealedAndSigned;
+import bisq.common.persistence.PersistenceManager;
+import bisq.common.proto.network.NetworkEnvelope;
+
+import java.security.KeyPair;
+import java.security.PublicKey;
+
+import java.time.Clock;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MailboxMessageServiceTest {
+    private static final NodeAddress MY_NODE_ADDRESS = new NodeAddress("my.onion", 9999);
+    private static final NodeAddress PEER_NODE_ADDRESS = new NodeAddress("peer.onion", 9999);
+    private static final NodeAddress OTHER_SENDER = new NodeAddress("other.onion", 9999);
+
+    @Test
+    public void sendEncryptedMailboxMessageFailsBeforeEncryptionWhenPayloadSenderDoesNotMatchLocalNode()
+            throws Exception {
+        NetworkNode networkNode = mock(NetworkNode.class);
+        when(networkNode.getNodeAddress()).thenReturn(MY_NODE_ADDRESS);
+        when(networkNode.getAllConnections()).thenReturn(Set.of(mock(Connection.class)));
+        EncryptionService encryptionService = mock(EncryptionService.class);
+        MailboxMessageService mailboxMessageService = newMailboxMessageService(networkNode, encryptionService);
+        mailboxMessageService.onBootstrapped();
+        SendMailboxMessageListener listener = mock(SendMailboxMessageListener.class);
+        PubKeyRing peersPubKeyRing = mock(PubKeyRing.class);
+
+        mailboxMessageService.sendEncryptedMailboxMessage(PEER_NODE_ADDRESS,
+                peersPubKeyRing,
+                new MockMailboxPayload("msg", OTHER_SENDER),
+                listener);
+
+        verify(listener).onFault("Sender node address of payload is not matching our node address");
+        verify(encryptionService, never()).encryptAndSign(any(PubKeyRing.class), any(NetworkEnvelope.class));
+        verify(networkNode, never()).sendMessage(any(NodeAddress.class), any(PrefixedSealedAndSignedMessage.class));
+    }
+
+    @Test
+    public void onAddedRemovesInvalidDecryptedMailboxMessageFromNetwork() throws Exception {
+        NetworkNode networkNode = mock(NetworkNode.class);
+        when(networkNode.getNodeAddress()).thenReturn(MY_NODE_ADDRESS);
+        P2PDataStorage p2PDataStorage = mock(P2PDataStorage.class);
+        EncryptionService encryptionService = mock(EncryptionService.class);
+        KeyRing keyRing = mock(KeyRing.class);
+        KeyPair signatureKeyPair = TestUtils.generateKeyPair();
+        when(keyRing.getSignatureKeyPair()).thenReturn(signatureKeyPair);
+        PublicKey receiversPubKey = TestUtils.generateKeyPair().getPublic();
+
+        ProtectedMailboxStorageEntry protectedMailboxStorageEntry = mock(ProtectedMailboxStorageEntry.class);
+        ProtectedMailboxStorageEntry updatedEntry = mock(ProtectedMailboxStorageEntry.class);
+        MailboxStoragePayload mailboxStoragePayload = mock(MailboxStoragePayload.class);
+        PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage = mock(PrefixedSealedAndSignedMessage.class);
+        SealedAndSigned sealedAndSigned = mock(SealedAndSigned.class);
+
+        when(protectedMailboxStorageEntry.getMailboxStoragePayload()).thenReturn(mailboxStoragePayload);
+        when(protectedMailboxStorageEntry.getProtectedStoragePayload()).thenReturn(mailboxStoragePayload);
+        when(protectedMailboxStorageEntry.getReceiversPubKey()).thenReturn(receiversPubKey);
+        when(mailboxStoragePayload.getPrefixedSealedAndSignedMessage()).thenReturn(prefixedSealedAndSignedMessage);
+        when(mailboxStoragePayload.serializeForHash()).thenReturn("mailboxPayload".getBytes(StandardCharsets.UTF_8));
+        when(prefixedSealedAndSignedMessage.getUid()).thenReturn("uid");
+        when(prefixedSealedAndSignedMessage.getSenderNodeAddress()).thenReturn(PEER_NODE_ADDRESS);
+        when(prefixedSealedAndSignedMessage.getSealedAndSigned()).thenReturn(sealedAndSigned);
+        when(encryptionService.decryptAndVerify(sealedAndSigned)).thenReturn(new DecryptedMessageWithPubKey(
+                new MockMailboxPayload("msg", OTHER_SENDER),
+                TestUtils.generateKeyPair().getPublic()));
+        when(p2PDataStorage.getMailboxDataWithSignedSeqNr(mailboxStoragePayload,
+                signatureKeyPair,
+                receiversPubKey)).thenReturn(updatedEntry);
+        P2PDataStorage.ByteArray hashOfPayload = P2PDataStorage.get32ByteHashAsByteArray(mailboxStoragePayload);
+        Map<P2PDataStorage.ByteArray, ProtectedStorageEntry> map = new HashMap<>();
+        map.put(hashOfPayload, protectedMailboxStorageEntry);
+        when(p2PDataStorage.getMap()).thenReturn(map);
+        when(p2PDataStorage.remove(updatedEntry, MY_NODE_ADDRESS)).thenReturn(true);
+        MailboxMessageService mailboxMessageService = newMailboxMessageService(networkNode,
+                p2PDataStorage,
+                encryptionService,
+                keyRing);
+        mailboxMessageService.onBootstrapped();
+        mailboxMessageService.onAllServicesInitialized();
+
+        mailboxMessageService.onAdded(Set.of(protectedMailboxStorageEntry));
+
+        verify(p2PDataStorage).remove(updatedEntry, MY_NODE_ADDRESS);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static MailboxMessageService newMailboxMessageService(NetworkNode networkNode,
+                                                                  EncryptionService encryptionService) {
+        KeyRing keyRing = mock(KeyRing.class);
+        when(keyRing.getPubKeyRing()).thenReturn(mock(PubKeyRing.class));
+        return newMailboxMessageService(networkNode, mock(P2PDataStorage.class), encryptionService, keyRing);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static MailboxMessageService newMailboxMessageService(NetworkNode networkNode,
+                                                                  P2PDataStorage p2PDataStorage,
+                                                                  EncryptionService encryptionService,
+                                                                  KeyRing keyRing) {
+        return new MailboxMessageService(networkNode,
+                mock(PeerManager.class),
+                p2PDataStorage,
+                encryptionService,
+                mock(IgnoredMailboxService.class),
+                mock(PersistenceManager.class),
+                keyRing,
+                Clock.systemUTC(),
+                false);
+    }
+}


### PR DESCRIPTION
Verify encrypted message sender addresses at network layer

Introduce SendersNodeAddressAwarePayload for encrypted payloads that already
carry a sender node address, and apply it to TradeMessage and MailboxMessage.

Validate sender consistency before dispatching encrypted direct messages:
the decrypted payload sender must match the PrefixedSealedAndSignedMessage
sender, and the outer sender must match the connection peer address. Also
reject outbound encrypted direct and mailbox messages before encryption if
their payload sender does not match the local node address.

Move mailbox decrypted payload validation into MailboxItem so persisted
mailbox entries are checked as well. Invalid decrypted entries are dropped if
the payload is not a MailboxMessage or if its sender address does not match
the enclosing mailbox envelope.

Add focused tests for direct encrypted receive/send validation, sender-aware
payload helper behavior, mailbox outbound rejection, and persisted mailbox
item validation.

Motivation: prevent peers from mixing inconsistent sender identities across
the connection, outer encrypted envelope, and decrypted payload layers. This
hardens messages that already include sender addresses without requiring any
protobuf schema changes.


If that PR is considered too risky for the 1.9.24 hotfix we can keep it for the 1.9.25 release and do the checks if the peer address matches the trade message sender address in the new validation code. 

I will add those validations to not depend on that PR, if we merge this PR we can remove those address checks from the other validation PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified sender-node-address contract across P2P envelopes and payloads; updated message handling and mailbox flows to validate sender addresses.
* **Bug Fixes**
  * Enforced sender-address consistency for direct and mailbox messages with early-fail on mismatches and reduced noisy decryption logging.
* **Features**
  * Mailbox items now track invalid decrypted payloads and auto-cleanup when validation fails.
* **Tests**
  * Added tests for direct-message routing, sender-address matching, mailbox item validation, mailbox send/remove, and ack behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->