### PR TITLE
Reduce  max price deviation to 25%.

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -80,6 +80,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 @Singleton
 public final class Preferences implements PersistedDataHost, BridgeAddressProvider {
+    public final static double DEFAULT_PRICE_DISTANCE = 0.15;
+    public final static double MAX_PRICE_DISTANCE = 0.25;
+
+    public static double getClampedMaxPriceDistanceInPercent(double maxPriceDistanceInPercent) {
+        return Math.min(MAX_PRICE_DISTANCE, Math.max(0, maxPriceDistanceInPercent));
+    }
 
     private static final ArrayList<BlockChainExplorer> BTC_MAIN_NET_EXPLORERS = new ArrayList<>(Arrays.asList(
             new BlockChainExplorer("mempool.space (@wiz)", "https://mempool.space/tx/", "https://mempool.space/address/"),
@@ -542,6 +548,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     }
 
     public void setMaxPriceDistanceInPercent(double maxPriceDistanceInPercent) {
+        maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(maxPriceDistanceInPercent);
         prefPayload.setMaxPriceDistanceInPercent(maxPriceDistanceInPercent);
         requestPersistence();
     }

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -45,6 +45,8 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 import static bisq.core.btc.wallet.Restrictions.getDefaultBuyerSecurityDepositAsPercent;
+import static bisq.core.user.Preferences.DEFAULT_PRICE_DISTANCE;
+import static bisq.core.user.Preferences.getClampedMaxPriceDistanceInPercent;
 
 @Slf4j
 @Data
@@ -69,7 +71,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
     private TradeCurrency preferredTradeCurrency;
     private long withdrawalTxFeeInVbytes = 100;
     private boolean useCustomWithdrawalTxFee = false;
-    private double maxPriceDistanceInPercent = 0.3;
+    private double maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(DEFAULT_PRICE_DISTANCE);
     @Nullable
     private String offerBookChartScreenCurrencyCode;
     @Nullable
@@ -257,6 +259,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
         if (proto.hasSelectedPaymentAccountForCreateOffer() && proto.getSelectedPaymentAccountForCreateOffer().hasPaymentMethod())
             paymentAccount = PaymentAccount.fromProto(proto.getSelectedPaymentAccountForCreateOffer(), coreProtoResolver);
 
+        double maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(proto.getMaxPriceDistanceInPercent());
         return new PreferencesPayload(
                 proto.getUserLanguage(),
                 Country.fromProto(userCountry),
@@ -280,7 +283,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.hasPreferredTradeCurrency() ? TradeCurrency.fromProto(proto.getPreferredTradeCurrency()) : null,
                 proto.getWithdrawalTxFeeInVbytes(),
                 proto.getUseCustomWithdrawalTxFee(),
-                proto.getMaxPriceDistanceInPercent(),
+                maxPriceDistanceInPercent,
                 ProtoUtil.stringOrNullFromProto(proto.getOfferBookChartScreenCurrencyCode()),
                 ProtoUtil.stringOrNullFromProto(proto.getTradeChartsScreenCurrencyCode()),
                 ProtoUtil.stringOrNullFromProto(proto.getBuyScreenCurrencyCode()),

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -357,21 +357,21 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         deviationListener = (observable, oldValue, newValue) -> {
             try {
                 double value = ParsingUtils.parsePercentStringToDouble(newValue);
-                final double maxDeviation = 0.5;
+                double maxDeviation = Preferences.MAX_PRICE_DISTANCE;
                 if (value <= maxDeviation) {
                     preferences.setMaxPriceDistanceInPercent(value);
                 } else {
                     new Popup().warning(Res.get("setting.preferences.deviationToLarge", maxDeviation * 100)).show();
-                    UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                    UserThread.runAfter(() -> deviationInputTextField.setText(getFormattedPersistedDeviation()), 100, TimeUnit.MILLISECONDS);
                 }
             } catch (NumberFormatException t) {
                 log.error("Exception at parseDouble deviation: {}", t.toString());
-                UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                UserThread.runAfter(() -> deviationInputTextField.setText(getFormattedPersistedDeviation()), 100, TimeUnit.MILLISECONDS);
             }
         };
         deviationFocusedListener = (observable1, oldValue1, newValue1) -> {
             if (oldValue1 && !newValue1)
-                UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                UserThread.runAfter(() -> deviationInputTextField.setText(getFormattedPersistedDeviation()), 100, TimeUnit.MILLISECONDS);
         };
 
         // ignoreTraders
@@ -453,6 +453,10 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             tooltip.setHideDelay(Duration.millis(0));
             Tooltip.install(useBisqWalletForFundingToggle, tooltip);
         }
+    }
+
+    private String getFormattedPersistedDeviation() {
+        return FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent());
     }
 
     private void initializeSeparator() {
@@ -1002,7 +1006,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         btcExplorerTextField.setText(preferences.getBlockChainExplorer().getName());
         bsqExplorerTextField.setText(preferences.getBsqBlockChainExplorer().getName());
 
-        deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent()));
+        deviationInputTextField.setText(getFormattedPersistedDeviation());
         deviationInputTextField.textProperty().addListener(deviationListener);
         deviationInputTextField.focusedProperty().addListener(deviationFocusedListener);
 


### PR DESCRIPTION
Reduce  max price deviation to 25%.

Change default max price deviation to 15%.
Also overwrites preference setting if > 25% to 25%.

This change is only UI side at create offer. Existing offers are not verified against that limit nor are trades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Price deviation preferences are now properly validated and automatically constrained to the allowed range during app initialization, when loading saved configurations from storage, and whenever users modify their preference settings.

* **Refactor**
  * Enhanced the preference interface to ensure consistent value formatting and apply centralized validation constraints for price deviation configuration across all application components, data persistence layers, and UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->