### PR TITLE
Enforce max price deviation in offers and trade

### DIFF
--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -21,9 +21,11 @@ import bisq.core.btc.nodes.BtcNodes;
 import bisq.core.crypto.LowRSigningKey;
 import bisq.core.locale.Res;
 import bisq.core.offer.Offer;
+import bisq.core.offer.OfferValidation;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.PriceFeedNodeAddressProvider;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
@@ -103,6 +105,7 @@ public class FilterManager {
     private final Preferences preferences;
     private final ConfigFileEditor configFileEditor;
     private final PriceFeedNodeAddressProvider priceFeedNodeAddressProvider;
+    private final PriceFeedService priceFeedService;
     private final boolean ignoreDevMsg;
     private final ObjectProperty<Filter> filterProperty = new SimpleObjectProperty<>();
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();
@@ -124,6 +127,7 @@ public class FilterManager {
                          Config config,
                          PriceFeedNodeAddressProvider priceFeedNodeAddressProvider,
                          BanFilter banFilter,
+                         PriceFeedService priceFeedService,
                          @Named(Config.IGNORE_DEV_MSG) boolean ignoreDevMsg,
                          @Named(Config.USE_DEV_PRIVILEGE_KEYS) boolean useDevPrivilegeKeys) {
         this.p2PService = p2PService;
@@ -132,6 +136,7 @@ public class FilterManager {
         this.preferences = preferences;
         this.configFileEditor = new ConfigFileEditor(config.getConfigFile());
         this.priceFeedNodeAddressProvider = priceFeedNodeAddressProvider;
+        this.priceFeedService = priceFeedService;
         this.ignoreDevMsg = ignoreDevMsg;
 
         publicKeys = useDevPrivilegeKeys ?
@@ -419,6 +424,12 @@ public class FilterManager {
         return getFilter() != null &&
                 getFilter().getNodeAddressesBannedFromTrading().stream()
                         .anyMatch(e -> e.equals(nodeAddress.getFullAddress()));
+    }
+
+    public boolean isPriceInBounds(Offer offer) {
+        // We allow 5% tolerance to the max allowed price percentage to avoid filtering offers in
+        // high volatility environments
+        return OfferValidation.isPriceInBounds(priceFeedService, offer, 1.05);
     }
 
     public boolean isNodeAddressBannedFromNetwork(NodeAddress nodeAddress) {

--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -142,6 +142,14 @@ public class OfferBookService {
             return;
         }
 
+        // We allow 10% tolerance to the max allowed price percentage to avoid ignoring offers in
+        // high volatility environments
+        if (!OfferValidation.isPriceInBounds(priceFeedService, offer, 1.1)) {
+            log.warn("Offer has invalid price. {}", offer);
+            errorMessageHandler.handleErrorMessage("Add offer failed: price is out of bounds");
+            return;
+        }
+
         boolean result = p2PService.addProtectedStorageEntry(offer.getOfferPayloadBase());
         if (result) {
             resultHandler.handleResult();

--- a/core/src/main/java/bisq/core/offer/OfferValidation.java
+++ b/core/src/main/java/bisq/core/offer/OfferValidation.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.offer;
+
+import bisq.core.monetary.Price;
+import bisq.core.provider.price.MarketPrice;
+import bisq.core.provider.price.PriceFeedService;
+import bisq.core.user.Preferences;
+import bisq.core.util.PriceUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Slf4j
+public class OfferValidation {
+    public static boolean isPriceInBounds(PriceFeedService priceFeedService, Offer offer,
+                                          double tolerance) {
+        try {
+            verifyPriceInBounds(priceFeedService, offer, tolerance);
+            return true;
+        } catch (IllegalArgumentException e) {
+            log.debug("Offer isPriceInBounds check failed: {}", e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.warn("Unexpected failure during isPriceInBounds check", e);
+            return false;
+        }
+    }
+
+    public static void verifyPriceInBounds(PriceFeedService priceFeedService,
+                                           Offer offer,
+                                           double tolerance) throws IllegalArgumentException {
+        checkNotNull(priceFeedService, "priceFeedService must not be null");
+        checkNotNull(offer, "offer must not be null");
+
+        if (offer.isUseMarketBasedPrice()) {
+            double percentagePrice = offer.getMarketPriceMargin();
+            verifyPriceDeviation(tolerance, percentagePrice);
+            return;
+        }
+
+        // If we do not have a market price we do not apply the validation
+        if (!PriceUtil.hasMarketPrice(priceFeedService, offer)) {
+            log.debug("Market price not available for {}", offer.getCurrencyCode());
+            return;
+        }
+
+        String currencyCode = offer.getCurrencyCode();
+        MarketPrice marketPrice = priceFeedService.getMarketPrice(currencyCode);
+        if (marketPrice == null) {
+            // If we do not have a market price we do not apply the validation
+            log.debug("Market price not available for {}", offer.getCurrencyCode());
+            return;
+        }
+
+        Price offerPrice = offer.getPrice();
+        double marketPriceAsDouble = marketPrice.getPrice();
+        double percentagePrice = PriceUtil.calculatePercentage(currencyCode, offerPrice, marketPriceAsDouble, offer.getDirection())
+                .orElseThrow(() -> new IllegalArgumentException("Offer price percentage could not be calculated"));
+
+        verifyPriceDeviation(tolerance, percentagePrice);
+    }
+
+    private static void verifyPriceDeviation(double tolerance, double percentagePrice) {
+        double maxAllowedDeviation = Preferences.MAX_PRICE_DISTANCE * tolerance;
+        checkArgument(Math.abs(percentagePrice) <= maxAllowedDeviation,
+                String.format("Offer price is outside of tolerated max percentage price: " +
+                                "observed deviation=%s, max allowed deviation=%s, applied tolerance=%s",
+                        percentagePrice, maxAllowedDeviation, tolerance));
+    }
+}

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -69,6 +69,7 @@ import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
+import bisq.common.app.DevEnv;
 import bisq.common.app.Version;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
@@ -139,11 +140,14 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     private final Map<String, OpenOffer> offersToBeEdited = new HashMap<>();
     private final TradableList<OpenOffer> openOffers = new TradableList<>();
     private boolean stopped;
-    private Timer periodicRepublishOffersTimer, periodicRefreshOffersTimer, retryRepublishOffersTimer;
+    private Timer periodicRepublishOffersTimer, periodicRefreshOffersTimer, retryRepublishOffersTimer,
+            handleOffersWithInvalidPriceTime;
     @Setter
     private Consumer<String> chainNotSyncedHandler;
     @Getter
     private final ObservableList<Tuple2<OpenOffer, String>> invalidOffers = FXCollections.observableArrayList();
+    @Getter
+    private final ObservableList<OpenOffer> offersWithInvalidPrice = FXCollections.observableArrayList();
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -255,6 +259,18 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 .forEach(openOffer ->
                         OfferUtil.getInvalidMakerFeeTxErrorMessage(openOffer.getOffer(), btcWalletService)
                                 .ifPresent(errorMsg -> invalidOffers.add(new Tuple2<>(openOffer, errorMsg))));
+
+        int delayInSec = DevEnv.isDevMode() ? 5 : 30;
+        stopHandleOffersWithInvalidPriceTime();
+        handleOffersWithInvalidPriceTime = UserThread.runAfter(() -> {
+            // We use 0% tolerance to the max allowed price percentage to motivate users to edit the offer
+            openOffers.stream()
+                    .filter(openOffer -> !OfferValidation.isPriceInBounds(priceFeedService, openOffer.getOffer(), 1))
+                    .forEach(openOffer -> {
+                        log.warn("Invalid offer found: {}", openOffer);
+                        offersWithInvalidPrice.add(openOffer);
+                    });
+        }, delayInSec);
     }
 
     private void cleanUpAddressEntries() {
@@ -281,6 +297,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         stopPeriodicRefreshOffersTimer();
         stopPeriodicRepublishOffersTimer();
         stopRetryRepublishOffersTimer();
+        stopHandleOffersWithInvalidPriceTime();
 
         // we remove own offers from offerbook when we go offline
         // Normally we use a delay for broadcasting to the peers, but at shut down we want to get it fast out
@@ -822,6 +839,11 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                                 // in trade price between the peers. Also here poor connectivity might cause market price API connection
                                 // losses and therefore an outdated market price.
                                 offer.verifyTakersTradePrice(request.getTakersTradePrice());
+
+                                // We allow 10% tolerance to the max allowed price percentage to avoid failing requests in
+                                // high volatility environments
+                                OfferValidation.verifyPriceInBounds(priceFeedService, offer, 1.1);
+
                                 availabilityResult = AvailabilityResult.AVAILABLE;
                             } catch (TradePriceOutOfToleranceException e) {
                                 log.warn("Trade price check failed because takers price is outside out tolerance.");
@@ -829,7 +851,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                             } catch (MarketPriceNotAvailableException e) {
                                 log.warn(e.getMessage());
                                 availabilityResult = AvailabilityResult.MARKET_PRICE_NOT_AVAILABLE;
-                            } catch (Throwable e) {
+                            } catch (Exception e) {
                                 log.warn("Trade price check failed. " + e.getMessage());
                                 availabilityResult = AvailabilityResult.PRICE_CHECK_FAILED;
                             }
@@ -1234,6 +1256,13 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         if (retryRepublishOffersTimer != null) {
             retryRepublishOffersTimer.stop();
             retryRepublishOffersTimer = null;
+        }
+    }
+
+    private void stopHandleOffersWithInvalidPriceTime() {
+        if (handleOffersWithInvalidPriceTime != null) {
+            handleOffersWithInvalidPriceTime.stop();
+            handleOffersWithInvalidPriceTime = null;
         }
     }
 

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -148,6 +148,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     private final BsqSwapTradeManager bsqSwapTradeManager;
     private final FailedTradesManager failedTradesManager;
     private final P2PService p2PService;
+    @Getter
     private final PriceFeedService priceFeedService;
     private final TradeStatisticsManager tradeStatisticsManager;
     private final TradeUtil tradeUtil;

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -20,6 +20,8 @@ package bisq.core.trade.protocol.bisq_v1.tasks.maker;
 import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 import bisq.core.offer.Offer;
+import bisq.core.offer.OfferValidation;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.dispute.mediation.mediator.Mediator;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.InputsForDepositTxRequest;
@@ -126,6 +128,12 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
             Offer offer = checkNotNull(trade.getOffer(), "Offer must not be null");
             long takersTradePrice = request.getTradePrice();
             offer.verifyTakersTradePrice(takersTradePrice);
+
+            PriceFeedService priceFeedService = processModel.getTradeManager().getPriceFeedService();
+            // We allow 50% tolerance to the max allowed price percentage to avoid failing trades in
+            // high volatility environments
+            OfferValidation.verifyPriceInBounds(priceFeedService, offer, 1.5);
+
             trade.setPriceAsLong(takersTradePrice);
 
             checkArgument(request.getTxFee() > 0, "Trade tx fee must be positive");
@@ -150,7 +158,7 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
     }
 
     public static boolean verifyBurningManSelectionHeight(int takersBurningManSelectionHeight,
-                                                   int makersBurningManSelectionHeight) {
+                                                          int makersBurningManSelectionHeight) {
         if (takersBurningManSelectionHeight == makersBurningManSelectionHeight) {
             return true;
 

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -80,6 +80,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 @Singleton
 public final class Preferences implements PersistedDataHost, BridgeAddressProvider {
+    public final static double DEFAULT_PRICE_DISTANCE = 0.15;
+    public final static double MAX_PRICE_DISTANCE = 0.25;
+
+    public static double getClampedMaxPriceDistanceInPercent(double maxPriceDistanceInPercent) {
+        return Math.min(MAX_PRICE_DISTANCE, Math.max(0, maxPriceDistanceInPercent));
+    }
 
     private static final ArrayList<BlockChainExplorer> BTC_MAIN_NET_EXPLORERS = new ArrayList<>(Arrays.asList(
             new BlockChainExplorer("mempool.space (@wiz)", "https://mempool.space/tx/", "https://mempool.space/address/"),
@@ -542,6 +548,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     }
 
     public void setMaxPriceDistanceInPercent(double maxPriceDistanceInPercent) {
+        maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(maxPriceDistanceInPercent);
         prefPayload.setMaxPriceDistanceInPercent(maxPriceDistanceInPercent);
         requestPersistence();
     }

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -45,6 +45,8 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 import static bisq.core.btc.wallet.Restrictions.getDefaultBuyerSecurityDepositAsPercent;
+import static bisq.core.user.Preferences.DEFAULT_PRICE_DISTANCE;
+import static bisq.core.user.Preferences.getClampedMaxPriceDistanceInPercent;
 
 @Slf4j
 @Data
@@ -69,7 +71,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
     private TradeCurrency preferredTradeCurrency;
     private long withdrawalTxFeeInVbytes = 100;
     private boolean useCustomWithdrawalTxFee = false;
-    private double maxPriceDistanceInPercent = 0.3;
+    private double maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(DEFAULT_PRICE_DISTANCE);
     @Nullable
     private String offerBookChartScreenCurrencyCode;
     @Nullable
@@ -257,6 +259,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
         if (proto.hasSelectedPaymentAccountForCreateOffer() && proto.getSelectedPaymentAccountForCreateOffer().hasPaymentMethod())
             paymentAccount = PaymentAccount.fromProto(proto.getSelectedPaymentAccountForCreateOffer(), coreProtoResolver);
 
+        double maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(proto.getMaxPriceDistanceInPercent());
         return new PreferencesPayload(
                 proto.getUserLanguage(),
                 Country.fromProto(userCountry),
@@ -280,7 +283,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.hasPreferredTradeCurrency() ? TradeCurrency.fromProto(proto.getPreferredTradeCurrency()) : null,
                 proto.getWithdrawalTxFeeInVbytes(),
                 proto.getUseCustomWithdrawalTxFee(),
-                proto.getMaxPriceDistanceInPercent(),
+                maxPriceDistanceInPercent,
                 ProtoUtil.stringOrNullFromProto(proto.getOfferBookChartScreenCurrencyCode()),
                 ProtoUtil.stringOrNullFromProto(proto.getTradeChartsScreenCurrencyCode()),
                 ProtoUtil.stringOrNullFromProto(proto.getBuyScreenCurrencyCode()),

--- a/core/src/main/java/bisq/core/util/PriceUtil.java
+++ b/core/src/main/java/bisq/core/util/PriceUtil.java
@@ -85,7 +85,7 @@ public class PriceUtil {
         }
 
         long triggerPriceAsLong = PriceUtil.getMarketPriceAsLong(triggerPriceAsString, marketPrice.getCurrencyCode());
-        long marketPriceAsLong = PriceUtil.getMarketPriceAsLong("" +  marketPrice.getPrice(), marketPrice.getCurrencyCode());
+        long marketPriceAsLong = PriceUtil.getMarketPriceAsLong("" + marketPrice.getPrice(), marketPrice.getCurrencyCode());
         String marketPriceAsString = FormattingUtils.formatMarketPrice(marketPrice.getPrice(), marketPrice.getCurrencyCode());
 
         if ((isSellOffer && isFiatCurrency) || (!isSellOffer && !isFiatCurrency)) {
@@ -139,6 +139,10 @@ public class PriceUtil {
     }
 
     public boolean hasMarketPrice(Offer offer) {
+        return hasMarketPrice(priceFeedService, offer);
+    }
+
+    public static boolean hasMarketPrice(PriceFeedService priceFeedService, Offer offer) {
         String currencyCode = offer.getCurrencyCode();
         checkNotNull(priceFeedService, "priceFeed must not be null");
         MarketPrice marketPrice = priceFeedService.getMarketPrice(currencyCode);
@@ -178,9 +182,17 @@ public class PriceUtil {
     public static Optional<Double> calculatePercentage(Offer offer,
                                                        double marketPrice,
                                                        OfferDirection direction) {
+        return calculatePercentage(offer.getCurrencyCode(),
+                offer.getPrice(),
+                marketPrice, direction
+        );
+    }
+
+    public static Optional<Double> calculatePercentage(String currencyCode,
+                                                       Price price,
+                                                       double marketPrice,
+                                                       OfferDirection direction) {
         // If the offer did not use % price we calculate % from current market price
-        String currencyCode = offer.getCurrencyCode();
-        Price price = offer.getPrice();
         int precision = CurrencyUtil.isCryptoCurrency(currencyCode) ?
                 Altcoin.SMALLEST_UNIT_EXPONENT :
                 Fiat.SMALLEST_UNIT_EXPONENT;

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -640,6 +640,7 @@ openOffer.triggered=Offer {0} has been deactivated because the market price reac
 openOffer.deactivated.feeValidationIssue=Offer \"{0}\" is deactivated, due to: {1}
 
 openOffer.bsqSwap.missingFunds=Open BSQ swap offer is disabled because there are not sufficient funds in the wallet
+openOffer.invalidPrice.outOfTolerance=Price is outside the allowed price tolerance of {0}%
 
 editOffer.setPrice=Set price
 editOffer.confirmEdit=Confirm: Edit offer

--- a/core/src/test/java/bisq/core/filter/FilterManagerAddFilterToNetworkTests.java
+++ b/core/src/test/java/bisq/core/filter/FilterManagerAddFilterToNetworkTests.java
@@ -18,6 +18,7 @@
 package bisq.core.filter;
 
 import bisq.core.provider.PriceFeedNodeAddressProvider;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
@@ -108,6 +109,7 @@ public class FilterManagerAddFilterToNetworkTests {
                 config,
                 mock(PriceFeedNodeAddressProvider.class),
                 mock(BanFilter.class),
+                mock(PriceFeedService.class),
                 false,
                 true
         );

--- a/core/src/test/java/bisq/core/filter/FilterManagerInitializationTests.java
+++ b/core/src/test/java/bisq/core/filter/FilterManagerInitializationTests.java
@@ -19,6 +19,7 @@ package bisq.core.filter;
 
 import bisq.core.locale.Res;
 import bisq.core.provider.PriceFeedNodeAddressProvider;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
@@ -63,6 +64,7 @@ public class FilterManagerInitializationTests {
                 mock(Config.class),
                 mock(PriceFeedNodeAddressProvider.class),
                 mock(BanFilter.class),
+                mock(PriceFeedService.class),
                 false,
                 true
         );
@@ -101,6 +103,7 @@ public class FilterManagerInitializationTests {
                 mock(Config.class),
                 mock(PriceFeedNodeAddressProvider.class),
                 mock(BanFilter.class),
+                mock(PriceFeedService.class),
                 true,
                 true
         );

--- a/core/src/test/java/bisq/core/filter/FilterManagerMockedPrivilegeKeysTests.java
+++ b/core/src/test/java/bisq/core/filter/FilterManagerMockedPrivilegeKeysTests.java
@@ -18,6 +18,7 @@
 package bisq.core.filter;
 
 import bisq.core.provider.PriceFeedNodeAddressProvider;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
@@ -111,6 +112,7 @@ public class FilterManagerMockedPrivilegeKeysTests {
                     config,
                     mock(PriceFeedNodeAddressProvider.class),
                     mock(BanFilter.class),
+                    mock(PriceFeedService.class),
                     false,
                     true
             );

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -38,6 +38,7 @@ import bisq.desktop.main.overlays.windows.downloadupdate.DisplayUpdateDownloadWi
 import bisq.desktop.main.portfolio.PortfolioView;
 import bisq.desktop.main.portfolio.bsqswaps.UnconfirmedBsqSwapsView;
 import bisq.desktop.main.portfolio.closedtrades.ClosedTradesView;
+import bisq.desktop.main.portfolio.editoffer.EditOfferView;
 import bisq.desktop.main.presentation.AccountPresentation;
 import bisq.desktop.main.presentation.DaoPresentation;
 import bisq.desktop.main.presentation.MarketPricePresentation;
@@ -733,12 +734,22 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
 
     private void setupInvalidOpenOffersHandler() {
         openOfferManager.getInvalidOffers().addListener((ListChangeListener<Tuple2<OpenOffer, String>>) c -> {
-            c.next();
-            if (c.wasAdded()) {
-                handleInvalidOpenOffers(c.getAddedSubList());
+            while (c.next()) {
+                if (c.wasAdded()) {
+                    handleInvalidOpenOffers(c.getAddedSubList());
+                }
             }
         });
         handleInvalidOpenOffers(openOfferManager.getInvalidOffers());
+
+        openOfferManager.getOffersWithInvalidPrice().addListener((ListChangeListener<OpenOffer>) c -> {
+            while (c.next()) {
+                if (c.wasAdded()) {
+                    handleOffersWithInvalidPrice(c.getAddedSubList());
+                }
+            }
+        });
+        handleOffersWithInvalidPrice(openOfferManager.getOffersWithInvalidPrice());
     }
 
     private void handleInvalidOpenOffers(List<? extends Tuple2<OpenOffer, String>> list) {
@@ -754,6 +765,17 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                         }, log::error);
 
                     })
+                    .hideCloseButton()
+                    .show();
+        });
+    }
+
+    private void handleOffersWithInvalidPrice(List<? extends OpenOffer> list) {
+        list.forEach(openOffer -> {
+            new Popup()
+                    .warning(Res.get("openOffer.invalidPrice.outOfTolerance", Preferences.MAX_PRICE_DISTANCE * 100))
+                    .actionButtonText(Res.get("shared.editOffer"))
+                    .onAction(() -> navigation.navigateToWithData(openOffer, MainView.class, PortfolioView.class, EditOfferView.class))
                     .hideCloseButton()
                     .show();
         });

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
@@ -21,12 +21,16 @@ import bisq.core.filter.FilterManager;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferBookService;
 import bisq.core.offer.OfferRestrictions;
+import bisq.core.provider.price.PriceFeedService;
 
 import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.network.utils.Utils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -56,6 +60,7 @@ public class OfferBook {
     private final Map<String, Integer> buyOfferCountMap = new HashMap<>();
     private final Map<String, Integer> sellOfferCountMap = new HashMap<>();
     private final FilterManager filterManager;
+    private final InvalidationListener priceFeedServiceUpdateListener;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -63,9 +68,21 @@ public class OfferBook {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    OfferBook(OfferBookService offerBookService, FilterManager filterManager) {
+    OfferBook(OfferBookService offerBookService, FilterManager filterManager, PriceFeedService priceFeedService) {
         this.offerBookService = offerBookService;
         this.filterManager = filterManager;
+
+        priceFeedServiceUpdateListener = new InvalidationListener() {
+            @Override
+            public void invalidated(Observable observable) {
+                List<OfferBookListItem> toRemove = offerBookListItems.stream()
+                        .filter(item -> !filterManager.isPriceInBounds(item.getOffer()))
+                        .collect(Collectors.toList());
+                toRemove.forEach(offerBookListItems::remove);
+                log.info("We got a price feed service ready and run the isPriceValid check and remove invalid offers. toRemove {}", toRemove);
+                priceFeedService.updateCounterProperty().removeListener(priceFeedServiceUpdateListener);
+            }
+        };
 
         offerBookService.addOfferBookChangedListener(new OfferBookService.OfferBookChangedListener() {
             @Override
@@ -124,6 +141,8 @@ public class OfferBook {
                 onProofOfWorkDifficultyChanged();
             }
         });
+
+        priceFeedService.updateCounterProperty().addListener(priceFeedServiceUpdateListener);
     }
 
     private void onProofOfWorkDifficultyChanged() {
@@ -255,6 +274,9 @@ public class OfferBook {
     }
 
     private boolean isOfferAllowed(Offer offer) {
+        if (!filterManager.isPriceInBounds(offer)) {
+            return false;
+        }
         boolean isBanned = filterManager.isOfferIdBanned(offer.getId())
                 || filterManager.isNodeAddressBanned(offer.getMakerNodeAddress());
         boolean isV3NodeAddressCompliant = !OfferRestrictions.requiresNodeAddressUpdate()

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -357,21 +357,21 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         deviationListener = (observable, oldValue, newValue) -> {
             try {
                 double value = ParsingUtils.parsePercentStringToDouble(newValue);
-                final double maxDeviation = 0.5;
+                double maxDeviation = Preferences.MAX_PRICE_DISTANCE;
                 if (value <= maxDeviation) {
                     preferences.setMaxPriceDistanceInPercent(value);
                 } else {
                     new Popup().warning(Res.get("setting.preferences.deviationToLarge", maxDeviation * 100)).show();
-                    UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                    UserThread.runAfter(() -> deviationInputTextField.setText(getFormattedPersistedDeviation()), 100, TimeUnit.MILLISECONDS);
                 }
             } catch (NumberFormatException t) {
                 log.error("Exception at parseDouble deviation: {}", t.toString());
-                UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                UserThread.runAfter(() -> deviationInputTextField.setText(getFormattedPersistedDeviation()), 100, TimeUnit.MILLISECONDS);
             }
         };
         deviationFocusedListener = (observable1, oldValue1, newValue1) -> {
             if (oldValue1 && !newValue1)
-                UserThread.runAfter(() -> deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent())), 100, TimeUnit.MILLISECONDS);
+                UserThread.runAfter(() -> deviationInputTextField.setText(getFormattedPersistedDeviation()), 100, TimeUnit.MILLISECONDS);
         };
 
         // ignoreTraders
@@ -453,6 +453,10 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
             tooltip.setHideDelay(Duration.millis(0));
             Tooltip.install(useBisqWalletForFundingToggle, tooltip);
         }
+    }
+
+    private String getFormattedPersistedDeviation() {
+        return FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent());
     }
 
     private void initializeSeparator() {
@@ -1002,7 +1006,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         btcExplorerTextField.setText(preferences.getBlockChainExplorer().getName());
         bsqExplorerTextField.setText(preferences.getBsqBlockChainExplorer().getName());
 
-        deviationInputTextField.setText(FormattingUtils.formatToPercentWithSymbol(preferences.getMaxPriceDistanceInPercent()));
+        deviationInputTextField.setText(getFormattedPersistedDeviation());
         deviationInputTextField.textProperty().addListener(deviationListener);
         deviationInputTextField.focusedProperty().addListener(deviationFocusedListener);
 


### PR DESCRIPTION
Enforce price to be inside the max price bounds of 25%.

Makers offers which are outside the boundary will trigger a popup to tell the user to edit the offer to adjust the price.

Offers in offerbook outside the boundary will get filtered out.

At take offer requests and at trade we fail if the offers price is outside of boundary. 

We apply different tolerance levels depending on the use case.
Trade: 50%
My offers: 0%
Accept take offer: 10 %
Filter offers: 5 %
Added offers: 10%

Those tolerance level should avoid that market price fluctuations have too much impact on the boundary calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offer prices are now validated to ensure they remain within market-based bounds.
  * Users receive warnings when their open offers fall outside acceptable price ranges, with guidance to edit affected offers.

* **Bug Fixes**
  * Price deviation settings are now clamped to valid ranges to prevent invalid configurations.

* **Tests**
  * Updated test infrastructure to support new price validation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->