### PR TITLE
Validate maker change before taker signs deposit tx

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -524,7 +524,7 @@ public class TradeWalletService {
      * The taker signs the deposit transaction he received from the maker and publishes it.
      *
      * @param takerIsSeller             the flag indicating if we are in the taker as seller role or the opposite
-     * @param makersDepositTxSerialized the prepared deposit transaction signed by the maker
+     * @param makersDepositTx           the prepared deposit transaction signed by the maker
      * @param msOutputAmount            the MultiSig output amount, as determined by the taker
      * @param buyerInputs               the connected outputs for all inputs of the buyer
      * @param sellerInputs              the connected outputs for all inputs of the seller
@@ -536,16 +536,15 @@ public class TradeWalletService {
      * final deposit tx or its signatures
      * @throws WalletException if the taker's wallet is null or structurally inconsistent
      */
+
     public Transaction takerSignsDepositTx(boolean takerIsSeller,
-                                           byte[] makersDepositTxSerialized,
+                                           Transaction makersDepositTx,
                                            Coin msOutputAmount,
                                            List<RawTransactionInput> buyerInputs,
                                            List<RawTransactionInput> sellerInputs,
                                            byte[] buyerPubKey,
                                            byte[] sellerPubKey)
             throws SigningException, TransactionVerificationException, WalletException {
-        Transaction makersDepositTx = new Transaction(params, makersDepositTxSerialized);
-
         checkArgument(!buyerInputs.isEmpty());
         checkArgument(!sellerInputs.isEmpty());
 
@@ -621,7 +620,6 @@ public class TradeWalletService {
 
         return depositTx;
     }
-
 
     public void sellerAsMakerFinalizesDepositTx(Transaction myDepositTx,
                                                 Transaction takersDepositTx,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
@@ -19,6 +19,7 @@ package bisq.core.trade.protocol.bisq_v1.tasks.buyer_as_taker;
 
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.model.RawTransactionInput;
+import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
 import bisq.core.trade.model.bisq_v1.Trade;
@@ -84,9 +85,17 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
 
             List<RawTransactionInput> sellerInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
             byte[] sellerMultiSigPubKey = tradingPeer.getMultiSigPubKey();
+            Transaction makersDepositTx = new Transaction(walletService.getParams(), checkNotNull(processModel.getPreparedDepositTx()));
+            verifyPreparedDepositTxFromSellerAsMaker(makersDepositTx,
+                    offer.getSellerSecurityDeposit(),
+                    offer.getMinAmount(),
+                    offer.getAmount(),
+                    checkNotNull(trade.getAmount()),
+                    sellerInputs);
+
             Transaction depositTx = processModel.getTradeWalletService().takerSignsDepositTx(
                     false,
-                    processModel.getPreparedDepositTx(),
+                    makersDepositTx,
                     msOutputAmount,
                     buyerInputs,
                     sellerInputs,
@@ -99,6 +108,40 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
             complete();
         } catch (Throwable t) {
             failed(t);
+        }
+    }
+
+    static void verifyPreparedDepositTxFromSellerAsMaker(Transaction makersDepositTx,
+                                                     Coin sellerSecurityDeposit,
+                                                     Coin offerMinAmount,
+                                                     Coin offerAmount,
+                                                     Coin tradeAmount,
+                                                     List<RawTransactionInput> sellerInputs)
+            throws TransactionVerificationException {
+        checkArgument(!tradeAmount.isLessThan(offerMinAmount),
+                "tradeAmount must not be less than offerMinAmount");
+        checkArgument(!tradeAmount.isGreaterThan(offerAmount),
+                "tradeAmount must not be greater than offerAmount");
+        Coin sellerInput = Coin.valueOf(sellerInputs.stream().mapToLong(input -> input.value).sum());
+        Coin expectedMakerChange = sellerInput.subtract(sellerSecurityDeposit.add(tradeAmount));
+        checkArgument(!expectedMakerChange.isNegative(), "expectedMakerChange must not be negative");
+        checkArgument(!expectedMakerChange.isGreaterThan(offerAmount.subtract(tradeAmount)),
+                "expectedMakerChange must not be greater than remaining offer amount");
+        int outputCount = makersDepositTx.getOutputs().size();
+        if (expectedMakerChange.isZero()) {
+            if (outputCount != 1) {
+                throw new TransactionVerificationException("Maker's preparedDepositTx must not have a change output");
+            }
+            return;
+        }
+
+        if (outputCount != 2) {
+            throw new TransactionVerificationException("Maker's preparedDepositTx must have exactly one change output");
+        }
+
+        Coin makerChangeOutput = makersDepositTx.getOutput(1).getValue();
+        if (!makerChangeOutput.equals(expectedMakerChange)) {
+            throw new TransactionVerificationException("Maker's preparedDepositTx change output value does not match the expected maker change");
         }
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
@@ -19,6 +19,7 @@ package bisq.core.trade.protocol.bisq_v1.tasks.seller_as_taker;
 
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.model.RawTransactionInput;
+import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
 import bisq.core.trade.model.bisq_v1.Contract;
@@ -76,12 +77,15 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
                     .add(checkNotNull(trade.getAmount()));
 
             TradingPeer tradingPeer = processModel.getTradePeer();
+            List<RawTransactionInput> buyerInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
+            Transaction makersDepositTx = new Transaction(walletService.getParams(), checkNotNull(processModel.getPreparedDepositTx()));
+            verifyPreparedDepositTxFromBuyerAsMaker(makersDepositTx);
 
             Transaction depositTx = processModel.getTradeWalletService().takerSignsDepositTx(
                     true,
-                    processModel.getPreparedDepositTx(),
+                    makersDepositTx,
                     msOutputAmount,
-                    checkNotNull(tradingPeer.getRawTransactionInputs()),
+                    buyerInputs,
                     sellerInputs,
                     tradingPeer.getMultiSigPubKey(),
                     sellerMultiSigPubKey);
@@ -97,6 +101,14 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
             if (contract != null)
                 contract.printDiff(processModel.getTradePeer().getContractAsJson());
             failed(t);
+        }
+    }
+
+    static void verifyPreparedDepositTxFromBuyerAsMaker(Transaction makersDepositTx)
+            throws TransactionVerificationException {
+        int outputCount = makersDepositTx.getOutputs().size();
+        if (outputCount != 1) {
+            throw new TransactionVerificationException("Maker's preparedDepositTx must not have a change output");
         }
     }
 }

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTxTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTxTest.java
@@ -1,0 +1,177 @@
+package bisq.core.trade.protocol.bisq_v1.tasks.buyer_as_taker;
+
+import bisq.core.btc.exceptions.TransactionVerificationException;
+import bisq.core.btc.model.RawTransactionInput;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.SegwitAddress;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.params.RegTestParams;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BuyerAsTakerSignsDepositTxTest {
+    private static final NetworkParameters PARAMS = RegTestParams.get();
+    private static final Coin SELLER_SECURITY_DEPOSIT = Coin.valueOf(20_000);
+    private static final Coin OFFER_MIN_AMOUNT = Coin.valueOf(10_000);
+    private static final Coin OFFER_AMOUNT = Coin.valueOf(150_000);
+    private static final Coin TRADE_AMOUNT = Coin.valueOf(100_000);
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerAcceptsNoMakerChange() {
+        Transaction makersDepositTx = txWithOutputs(140_000);
+
+        assertDoesNotThrow(() -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                makersDepositTx,
+                SELLER_SECURITY_DEPOSIT,
+                OFFER_MIN_AMOUNT,
+                OFFER_AMOUNT,
+                TRADE_AMOUNT,
+                sellerInputs(120_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerAcceptsExpectedMakerChange() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 5_000);
+
+        assertDoesNotThrow(() -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                makersDepositTx,
+                SELLER_SECURITY_DEPOSIT,
+                OFFER_MIN_AMOUNT,
+                OFFER_AMOUNT,
+                TRADE_AMOUNT,
+                sellerInputs(125_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsMissingExpectedMakerChange() {
+        Transaction makersDepositTx = txWithOutputs(140_000);
+
+        assertThrows(TransactionVerificationException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        TRADE_AMOUNT,
+                        sellerInputs(125_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsChangeOutputWhenNoMakerChangeExpected() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 0);
+
+        assertThrows(TransactionVerificationException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        TRADE_AMOUNT,
+                        sellerInputs(120_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsUnexpectedMakerChangeValue() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 10_000);
+
+        assertThrows(TransactionVerificationException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        TRADE_AMOUNT,
+                        sellerInputs(125_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsMoreThanOneExtraOutput() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 5_000, 1_000);
+
+        assertThrows(TransactionVerificationException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        TRADE_AMOUNT,
+                        sellerInputs(125_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsNegativeExpectedMakerChange() {
+        Transaction makersDepositTx = txWithOutputs(140_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        TRADE_AMOUNT,
+                        sellerInputs(119_999)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsChangeGreaterThanRemainingOfferAmount() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 60_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        TRADE_AMOUNT,
+                        sellerInputs(180_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsTradeAmountBelowOfferMinimum() {
+        Transaction makersDepositTx = txWithOutputs(140_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        Coin.valueOf(9_999),
+                        sellerInputs(120_000)));
+    }
+
+    @Test
+    void preparedDepositTxFromSellerAsMakerRejectsTradeAmountAboveOfferAmount() {
+        Transaction makersDepositTx = txWithOutputs(140_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> BuyerAsTakerSignsDepositTx.verifyPreparedDepositTxFromSellerAsMaker(
+                        makersDepositTx,
+                        SELLER_SECURITY_DEPOSIT,
+                        OFFER_MIN_AMOUNT,
+                        OFFER_AMOUNT,
+                        Coin.valueOf(150_001),
+                        sellerInputs(170_001)));
+    }
+
+    private static List<RawTransactionInput> sellerInputs(long value) {
+        return Collections.singletonList(new RawTransactionInput(0, new byte[]{}, value));
+    }
+
+    private static Transaction txWithOutputs(long... outputValues) {
+        Transaction tx = new Transaction(PARAMS);
+        for (long outputValue : outputValues) {
+            tx.addOutput(Coin.valueOf(outputValue), SegwitAddress.fromKey(PARAMS, new ECKey()));
+        }
+        return tx;
+    }
+}

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTxTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTxTest.java
@@ -1,0 +1,58 @@
+package bisq.core.trade.protocol.bisq_v1.tasks.seller_as_taker;
+
+import bisq.core.btc.exceptions.TransactionVerificationException;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.SegwitAddress;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.params.RegTestParams;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SellerAsTakerSignsDepositTxTest {
+    private static final NetworkParameters PARAMS = RegTestParams.get();
+
+    @Test
+    void preparedDepositTxFromBuyerAsMakerAcceptsNoMakerChange() {
+        Transaction makersDepositTx = txWithOutputs(140_000);
+
+        assertDoesNotThrow(() -> SellerAsTakerSignsDepositTx.verifyPreparedDepositTxFromBuyerAsMaker(makersDepositTx));
+    }
+
+    @Test
+    void preparedDepositTxFromBuyerAsMakerRejectsMakerChangeOutput() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 5_000);
+
+        assertThrows(TransactionVerificationException.class,
+                () -> SellerAsTakerSignsDepositTx.verifyPreparedDepositTxFromBuyerAsMaker(makersDepositTx));
+    }
+
+    @Test
+    void preparedDepositTxFromBuyerAsMakerRejectsZeroValuedSecondOutput() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 0);
+
+        assertThrows(TransactionVerificationException.class,
+                () -> SellerAsTakerSignsDepositTx.verifyPreparedDepositTxFromBuyerAsMaker(makersDepositTx));
+    }
+
+    @Test
+    void preparedDepositTxFromBuyerAsMakerRejectsMoreThanOneExtraOutput() {
+        Transaction makersDepositTx = txWithOutputs(140_000, 5_000, 1_000);
+
+        assertThrows(TransactionVerificationException.class,
+                () -> SellerAsTakerSignsDepositTx.verifyPreparedDepositTxFromBuyerAsMaker(makersDepositTx));
+    }
+
+    private static Transaction txWithOutputs(long... outputValues) {
+        Transaction tx = new Transaction(PARAMS);
+        for (long outputValue : outputValues) {
+            tx.addOutput(Coin.valueOf(outputValue), SegwitAddress.fromKey(PARAMS, new ECKey()));
+        }
+        return tx;
+    }
+}


### PR DESCRIPTION
Adds a taker-side validation for maker-prepared deposit transactions. The taker now calculates the maker’s expected BTC change from the maker input sum and role-specific required contribution, then TradeWalletService rejects prepared deposit txs with unexpected maker change or extra outputs before signing local taker inputs.