### PR TITLE
  Extract compressed multisig pubkey validation helper

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -35,7 +35,6 @@ import bisq.network.p2p.NodeAddress;
 import bisq.common.taskrunner.TaskRunner;
 
 import org.bitcoinj.core.Coin;
-import org.bitcoinj.core.ECKey;
 
 import com.google.common.base.Charsets;
 
@@ -44,6 +43,7 @@ import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.util.Validator.checkCompressedSecp256k1PubKey;
 import static bisq.core.util.Validator.checkTradeId;
 import static bisq.core.util.Validator.nonEmptyStringOf;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -107,10 +107,8 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
 
             tradingPeer.setRawTransactionInputs(takerRawTransactionInputs);
 
-            byte[] takerMultiSigPubKey = checkNotNull(request.getTakerMultiSigPubKey());
-            checkArgument(takerMultiSigPubKey.length == 33, "takerMultiSigPubKey must be compressed");
-            // Check that the taker multisig key decompresses to a valid curve point:
-            ECKey.fromPublicOnly(takerMultiSigPubKey);
+            byte[] takerMultiSigPubKey = checkCompressedSecp256k1PubKey(request.getTakerMultiSigPubKey(),
+                    "takerMultiSigPubKey");
             tradingPeer.setMultiSigPubKey(takerMultiSigPubKey);
 
             tradingPeer.setPayoutAddressString(nonEmptyStringOf(request.getTakerPayoutAddressString()));

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
@@ -30,7 +30,6 @@ import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.common.config.Config;
 import bisq.common.taskrunner.TaskRunner;
 
-import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Coin;
 
 import java.util.List;
@@ -38,6 +37,7 @@ import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.util.Validator.checkCompressedSecp256k1PubKey;
 import static bisq.core.util.Validator.checkTradeId;
 import static bisq.core.util.Validator.nonEmptyStringOf;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -71,10 +71,8 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
 
             tradingPeer.setAccountId(nonEmptyStringOf(response.getMakerAccountId()));
 
-            byte[] makerMultiSigPubKey = checkNotNull(response.getMakerMultiSigPubKey());
-            checkArgument(makerMultiSigPubKey.length == 33, "makerMultiSigPubKey must be compressed");
-            // Check that the maker multisig key decompresses to a valid curve point:
-            ECKey.fromPublicOnly(makerMultiSigPubKey);
+            byte[] makerMultiSigPubKey = checkCompressedSecp256k1PubKey(response.getMakerMultiSigPubKey(),
+                    "makerMultiSigPubKey");
             tradingPeer.setMultiSigPubKey(makerMultiSigPubKey);
 
             tradingPeer.setContractAsJson(nonEmptyStringOf(response.getMakerContractAsJson()));

--- a/core/src/main/java/bisq/core/util/Validator.java
+++ b/core/src/main/java/bisq/core/util/Validator.java
@@ -20,6 +20,7 @@ package bisq.core.util;
 import bisq.core.trade.protocol.TradeMessage;
 
 import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -52,6 +53,14 @@ public class Validator {
     public static byte[] checkNonEmptyBytes(byte[] value, String fieldName) {
         checkNotNull(value, "%s must not be null", fieldName);
         checkArgument(value.length > 0, "%s must not be empty", fieldName);
+        return value;
+    }
+
+    public static byte[] checkCompressedSecp256k1PubKey(byte[] value, String fieldName) {
+        checkNonEmptyBytes(value, fieldName);
+        checkArgument(value.length == 33, "%s must be compressed", fieldName);
+        // Checks that the public key bytes decode to a valid secp256k1 curve point.
+        ECKey.fromPublicOnly(value);
         return value;
     }
 

--- a/core/src/test/java/bisq/core/util/ValidatorTest.java
+++ b/core/src/test/java/bisq/core/util/ValidatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.util;
+
+import org.bitcoinj.core.ECKey;
+
+import org.bouncycastle.util.encoders.Hex;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ValidatorTest {
+    private static final String FIELD_NAME = "multiSigPubKey";
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyAcceptsValidCompressedKey() {
+        byte[] pubKey = new ECKey().getPubKeyPoint().getEncoded(true);
+
+        assertEquals(33, pubKey.length);
+        assertSame(pubKey, Validator.checkCompressedSecp256k1PubKey(pubKey, FIELD_NAME));
+    }
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyRejectsNullKey() {
+        assertThrows(NullPointerException.class,
+                () -> Validator.checkCompressedSecp256k1PubKey(null, FIELD_NAME));
+    }
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyRejectsEmptyKey() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Validator.checkCompressedSecp256k1PubKey(new byte[0], FIELD_NAME));
+    }
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyRejectsUncompressedKey() {
+        byte[] pubKey = new ECKey().getPubKeyPoint().getEncoded(false);
+
+        assertEquals(65, pubKey.length);
+        assertThrows(IllegalArgumentException.class,
+                () -> Validator.checkCompressedSecp256k1PubKey(pubKey, FIELD_NAME));
+    }
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyRejectsMalformedCompressedKey() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Validator.checkCompressedSecp256k1PubKey(new byte[33], FIELD_NAME));
+    }
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyRejectsStructurallyValidCompressedKeyWithInvalidCurvePoint() {
+        byte[] pubKey = new byte[33];
+        pubKey[0] = 0x02;
+
+        assertEquals(33, pubKey.length);
+        assertThrows(IllegalArgumentException.class,
+                () -> Validator.checkCompressedSecp256k1PubKey(pubKey, FIELD_NAME));
+    }
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyAcceptsValidCompressedCurvePoints() {
+        String[] validEncodings = {
+                "020000000000000000000000000000000000000000000000000000000000000001",
+                "020000000000000000000000000000000000000000000000000000000000000002",
+                "020000000000000000000000000000000000000000000000000000000000000003",
+                "020000000000000000000000000000000000000000000000000000000000000004",
+                "020000000000000000000000000000000000000000000000000000000000000006",
+                "020000000000000000000000000000000000000000000000000000000000000008",
+                "02000000000000000000000000000000000000000000000000000000000000000c",
+                "02000000000000000000000000000000000000000000000000000000000000000d",
+                "02000000000000000000000000000000000000000000000000000000000000000e"
+        };
+
+        for (String validEncoding : validEncodings) {
+            byte[] pubKey = Hex.decode(validEncoding);
+            assertDoesNotThrow(() -> Validator.checkCompressedSecp256k1PubKey(pubKey, FIELD_NAME),
+                    validEncoding);
+        }
+    }
+
+    @Test
+    public void checkCompressedSecp256k1PubKeyRejectsInvalidCompressedCurvePoints() {
+        String[] invalidEncodings = {
+                "020000000000000000000000000000000000000000000000000000000000000000",
+                "020000000000000000000000000000000000000000000000000000000000000005",
+                "020000000000000000000000000000000000000000000000000000000000000007",
+                "020000000000000000000000000000000000000000000000000000000000000009",
+                "02000000000000000000000000000000000000000000000000000000000000000a",
+                "02000000000000000000000000000000000000000000000000000000000000000b",
+                "02000000000000000000000000000000000000000000000000000000000000000f"
+        };
+
+        for (String invalidEncoding : invalidEncodings) {
+            byte[] pubKey = Hex.decode(invalidEncoding);
+            assertThrows(IllegalArgumentException.class,
+                    () -> Validator.checkCompressedSecp256k1PubKey(pubKey, FIELD_NAME),
+                    invalidEncoding);
+        }
+    }
+}


### PR DESCRIPTION
  Adds a reusable validator for compressed secp256k1 public keys, uses it in the maker/taker trade tasks that accept peer multisig keys, and adds focused tests for valid, malformed, empty, null, and uncompressed key inputs.
