### PR TITLE
Cleanup fields from 1.7.0 changes

### DIFF
--- a/core/src/main/java/bisq/core/trade/TradeValidation.java
+++ b/core/src/main/java/bisq/core/trade/TradeValidation.java
@@ -68,6 +68,7 @@ public class TradeValidation {
     public static final double MAX_TRADE_PRICE_DEVIATION = 1.5;
     public static final int MAX_LOCKTIME_BLOCK_DEVIATION = 3;
 
+
     /* --------------------------------------------------------------------- */
     // Offer
     /* --------------------------------------------------------------------- */

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
@@ -18,7 +18,6 @@
 package bisq.core.trade.protocol.bisq_v1.messages;
 
 import bisq.core.btc.model.RawTransactionInput;
-import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.proto.CoreProtoResolver;
 import bisq.core.trade.protocol.TradeMessage;
 
@@ -45,7 +44,10 @@ import lombok.Getter;
 
 import javax.annotation.Nullable;
 
-import static bisq.core.util.Validator.*;
+import static bisq.core.util.Validator.checkList;
+import static bisq.core.util.Validator.checkNonBlankString;
+import static bisq.core.util.Validator.checkNonEmptyBytes;
+import static bisq.core.util.Validator.checkNonEmptyString;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -63,11 +65,6 @@ public final class InputsForDepositTxRequest extends TradeMessage
     private final byte[] takerMultiSigPubKey;
     private final String takerPayoutAddressString;
     private final PubKeyRing takerPubKeyRing;
-
-    // Removed with 1.7.0
-    @Nullable
-    private final PaymentAccountPayload takerPaymentAccountPayload;
-
     private final String takerAccountId;
     private final String takerFeeTxId;
     private final List<NodeAddress> acceptedArbitratorNodeAddresses;
@@ -82,9 +79,7 @@ public final class InputsForDepositTxRequest extends TradeMessage
     private final long currentDate;
 
     // Added at 1.7.0
-    @Nullable
     private final byte[] hashOfTakersPaymentAccountPayload;
-    @Nullable
     private final String takersPaymentMethodId;
 
     // Added in v 1.9.7
@@ -101,7 +96,6 @@ public final class InputsForDepositTxRequest extends TradeMessage
                                      byte[] takerMultiSigPubKey,
                                      String takerPayoutAddressString,
                                      PubKeyRing takerPubKeyRing,
-                                     @Nullable PaymentAccountPayload takerPaymentAccountPayload,
                                      String takerAccountId,
                                      String takerFeeTxId,
                                      List<NodeAddress> acceptedArbitratorNodeAddresses,
@@ -114,8 +108,8 @@ public final class InputsForDepositTxRequest extends TradeMessage
                                      int messageVersion,
                                      byte[] accountAgeWitnessSignatureOfOfferId,
                                      long currentDate,
-                                     @Nullable byte[] hashOfTakersPaymentAccountPayload,
-                                     @Nullable String takersPaymentMethodId,
+                                     byte[] hashOfTakersPaymentAccountPayload,
+                                     String takersPaymentMethodId,
                                      int burningManSelectionHeight) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
@@ -128,7 +122,6 @@ public final class InputsForDepositTxRequest extends TradeMessage
         this.takerMultiSigPubKey = takerMultiSigPubKey;
         this.takerPayoutAddressString = takerPayoutAddressString;
         this.takerPubKeyRing = takerPubKeyRing;
-        this.takerPaymentAccountPayload = takerPaymentAccountPayload;
         this.takerAccountId = takerAccountId;
         this.takerFeeTxId = takerFeeTxId;
         this.acceptedArbitratorNodeAddresses = acceptedArbitratorNodeAddresses;
@@ -165,8 +158,8 @@ public final class InputsForDepositTxRequest extends TradeMessage
         checkNotNull(refundAgentNodeAddress, "refundAgentNodeAddress must not be null");
         checkNonEmptyBytes(accountAgeWitnessSignatureOfOfferId, "accountAgeWitnessSignatureOfOfferId");
         checkArgument(currentDate > 0, "currentDate must be positive");
-        checkNullableBytes(hashOfTakersPaymentAccountPayload, "hashOfTakersPaymentAccountPayload");
-        checkNullableString(takersPaymentMethodId, "takersPaymentMethodId");
+        checkNonEmptyBytes(hashOfTakersPaymentAccountPayload, "hashOfTakersPaymentAccountPayload");
+        checkNonBlankString(takersPaymentMethodId, "takersPaymentMethodId");
         // burningManSelectionHeight was added in v1.9.7 which cannot be used for trading anymore, though old persisted
         // trades might carry that field thus we do not enforce positive values.
         checkArgument(burningManSelectionHeight >= 0, "burningManSelectionHeight must be positive");
@@ -213,7 +206,6 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 .setBurningManSelectionHeight(burningManSelectionHeight);
 
         Optional.ofNullable(arbitratorNodeAddress).ifPresent(e -> builder.setArbitratorNodeAddress(arbitratorNodeAddress.toProtoMessage()));
-        Optional.ofNullable(takerPaymentAccountPayload).ifPresent(e -> builder.setTakerPaymentAccountPayload((protobuf.PaymentAccountPayload) takerPaymentAccountPayload.toProtoMessage()));
         Optional.ofNullable(hashOfTakersPaymentAccountPayload).ifPresent(e -> builder.setHashOfTakersPaymentAccountPayload(ByteString.copyFrom(hashOfTakersPaymentAccountPayload)));
         Optional.ofNullable(takersPaymentMethodId).ifPresent(e -> builder.setTakersPayoutMethodId(takersPaymentMethodId));
         return getNetworkEnvelopeBuilder().setInputsForDepositTxRequest(builder).build();
@@ -232,10 +224,6 @@ public final class InputsForDepositTxRequest extends TradeMessage
         List<NodeAddress> acceptedRefundAgentNodeAddresses = proto.getAcceptedRefundAgentNodeAddressesList().stream()
                 .map(NodeAddress::fromProto).collect(Collectors.toList());
 
-        PaymentAccountPayload takerPaymentAccountPayload = proto.hasTakerPaymentAccountPayload() ?
-                coreProtoResolver.fromProto(proto.getTakerPaymentAccountPayload()) : null;
-        byte[] hashOfTakersPaymentAccountPayload = ProtoUtil.byteArrayOrNullFromProto(proto.getHashOfTakersPaymentAccountPayload());
-
         return new InputsForDepositTxRequest(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getTradeAmount(),
@@ -247,7 +235,6 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 proto.getTakerMultiSigPubKey().toByteArray(),
                 proto.getTakerPayoutAddressString(),
                 PubKeyRing.fromProto(proto.getTakerPubKeyRing()),
-                takerPaymentAccountPayload,
                 proto.getTakerAccountId(),
                 proto.getTakerFeeTxId(),
                 acceptedArbitratorNodeAddresses,
@@ -260,8 +247,8 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 messageVersion,
                 ProtoUtil.byteArrayOrNullFromProto(proto.getAccountAgeWitnessSignatureOfOfferId()),
                 proto.getCurrentDate(),
-                hashOfTakersPaymentAccountPayload,
-                ProtoUtil.stringOrNullFromProto(proto.getTakersPayoutMethodId()),
+                proto.getHashOfTakersPaymentAccountPayload().toByteArray(),
+                proto.getTakersPayoutMethodId(),
                 proto.getBurningManSelectionHeight());
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -40,7 +40,6 @@ import com.google.common.base.Charsets;
 import java.security.PublicKey;
 
 import java.util.List;
-import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -67,13 +66,8 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
             User user = checkNotNull(processModel.getUser(), "User must not be null");
             PriceFeedService priceFeedService = processModel.getTradeManager().getPriceFeedService();
 
-            // 1.7.0: We do not expect the payment account anymore but in case peer has not updated we still process it.
-            Optional.ofNullable(request.getTakerPaymentAccountPayload())
-                    .ifPresent(e -> tradingPeer.setPaymentAccountPayload(request.getTakerPaymentAccountPayload()));
-            Optional.ofNullable(request.getHashOfTakersPaymentAccountPayload())
-                    .ifPresent(e -> tradingPeer.setHashOfPaymentAccountPayload(request.getHashOfTakersPaymentAccountPayload()));
-            Optional.ofNullable(request.getTakersPaymentMethodId())
-                    .ifPresent(e -> tradingPeer.setPaymentMethodId(request.getTakersPaymentMethodId()));
+            tradingPeer.setHashOfPaymentAccountPayload(request.getHashOfTakersPaymentAccountPayload());
+            tradingPeer.setPaymentMethodId(request.getTakersPaymentMethodId());
 
             Coin tradeAmount = checkTradeAmount(request.getTradeAmountAsCoin(), offer.getMinAmount(), offer.getAmount());
             trade.setAmount(tradeAmount);

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
@@ -57,8 +57,12 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
             Offer offer = checkNotNull(processModel.getOffer(), "Offer must not be null");
 
             // 1.7.0: We do not expect the payment account anymore but in case peer has not updated we still process it.
+            // TODO This is now always null and the field can be removed from the message
             Optional.ofNullable(response.getMakerPaymentAccountPayload())
                     .ifPresent(e -> tradingPeer.setPaymentAccountPayload(response.getMakerPaymentAccountPayload()));
+
+            // Those 2 fields are actually not null anymore as old versions cannot trade anymore
+            // TODO remove the nullable annotation
             Optional.ofNullable(response.getHashOfMakersPaymentAccountPayload())
                     .ifPresent(e -> tradingPeer.setHashOfPaymentAccountPayload(response.getHashOfMakersPaymentAccountPayload()));
             Optional.ofNullable(response.getMakersPaymentMethodId())

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerSendInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerSendInputsForDepositTxRequest.java
@@ -121,7 +121,6 @@ public class TakerSendInputsForDepositTxRequest extends TradeTask {
                     takerMultiSigPubKey,
                     takerPayoutAddressString,
                     processModel.getPubKeyRing(),
-                    null,
                     processModel.getAccountId(),
                     takerFeeTxId,
                     acceptedArbitratorAddresses,

--- a/core/src/test/java/bisq/core/trade/TradeValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/TradeValidationTest.java
@@ -751,7 +751,6 @@ public class TradeValidationTest {
                 new ECKey().getPubKey(),
                 SegwitAddress.fromKey(MainNetParams.get(), new ECKey()).toString(),
                 takerPubKeyRing,
-                null,
                 "taker-account-id",
                 VALID_TRANSACTION_ID,
                 List.of(),

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
@@ -271,7 +271,6 @@ public class BisqV1MessageIntegrityTest {
                 args.takerMultiSigPubKey,
                 args.takerPayoutAddressString,
                 args.takerPubKeyRing,
-                null,
                 args.takerAccountId,
                 args.takerFeeTxId,
                 args.acceptedArbitratorNodeAddresses,

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -250,8 +250,7 @@ message InputsForDepositTxRequest {
     bytes taker_multi_sig_pub_key = 11;
     string taker_payout_address_string = 12;
     PubKeyRing taker_pub_key_ring = 13;
-    // Not used anymore from 1.7.0 but kept for backward compatibility.
-    PaymentAccountPayload taker_payment_account_payload = 14;
+    PaymentAccountPayload taker_payment_account_payload = 14 [deprecated = true]; // Removed in v1.9.24
     string taker_account_id = 15;
     string taker_fee_tx_id = 16;
     repeated NodeAddress accepted_arbitrator_node_addresses = 17;


### PR DESCRIPTION
Remove takerPaymentAccountPayload field
Remove @Nullable annotation for hashOfTakersPaymentAccountPayload and takersPaymentMethodId

Those changes are from old versions which cannot be used for trading anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated payment account handling in deposit transaction requests to use hashed representation and payment method identifier instead of full payload object.

* **Deprecation**
  * Marked legacy payment account payload field as deprecated in protocol definitions.

* **Tests**
  * Updated test fixtures and validation logic to reflect updated message structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->