### PR TITLE
Validate offer availability response peer

### DIFF
--- a/core/src/main/java/bisq/core/offer/availability/OfferAvailabilityProtocol.java
+++ b/core/src/main/java/bisq/core/offer/availability/OfferAvailabilityProtocol.java
@@ -70,7 +70,8 @@ public class OfferAvailabilityProtocol {
                 OfferMessage offerMessage = (OfferMessage) networkEnvelope;
                 Validator.nonEmptyStringOf(offerMessage.offerId);
                 if (networkEnvelope instanceof OfferAvailabilityResponse
-                        && model.getOffer().getId().equals(offerMessage.offerId)) {
+                        && model.getOffer().getId().equals(offerMessage.offerId)
+                        && peersNodeAddress.equals(model.getPeerNodeAddress())) {
                     handleOfferAvailabilityResponse((OfferAvailabilityResponse) networkEnvelope, peersNodeAddress);
                 }
             }


### PR DESCRIPTION
Only process offer availability responses from the expected maker node for the offer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation in the offer availability protocol to ensure incoming messages originate from the expected peer, improving the security and reliability of offer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->