### PR TITLE
Remove unused fields

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
@@ -203,11 +203,12 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 .setUid(uid)
                 .setAccountAgeWitnessSignatureOfOfferId(ByteString.copyFrom(accountAgeWitnessSignatureOfOfferId))
                 .setCurrentDate(currentDate)
-                .setBurningManSelectionHeight(burningManSelectionHeight);
+                .setBurningManSelectionHeight(burningManSelectionHeight)
+                .setHashOfTakersPaymentAccountPayload(ByteString.copyFrom(hashOfTakersPaymentAccountPayload))
+                .setTakersPayoutMethodId(takersPaymentMethodId);
 
         Optional.ofNullable(arbitratorNodeAddress).ifPresent(e -> builder.setArbitratorNodeAddress(arbitratorNodeAddress.toProtoMessage()));
-        Optional.ofNullable(hashOfTakersPaymentAccountPayload).ifPresent(e -> builder.setHashOfTakersPaymentAccountPayload(ByteString.copyFrom(hashOfTakersPaymentAccountPayload)));
-        Optional.ofNullable(takersPaymentMethodId).ifPresent(e -> builder.setTakersPayoutMethodId(takersPaymentMethodId));
+
         return getNetworkEnvelopeBuilder().setInputsForDepositTxRequest(builder).build();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxResponse.java
@@ -18,7 +18,6 @@
 package bisq.core.trade.protocol.bisq_v1.messages;
 
 import bisq.core.btc.model.RawTransactionInput;
-import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.proto.CoreProtoResolver;
 import bisq.core.trade.protocol.TradeMessage;
 
@@ -26,32 +25,27 @@ import bisq.network.p2p.DirectMessage;
 import bisq.network.p2p.NodeAddress;
 
 import bisq.common.app.Version;
-import bisq.common.proto.ProtoUtil;
 import bisq.common.util.Utilities;
 
 import com.google.protobuf.ByteString;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import javax.annotation.Nullable;
-
-import static bisq.core.util.Validator.*;
+import static bisq.core.util.Validator.checkList;
+import static bisq.core.util.Validator.checkNonBlankString;
+import static bisq.core.util.Validator.checkNonEmptyBytes;
+import static bisq.core.util.Validator.checkNonEmptyString;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Getter
 public final class InputsForDepositTxResponse extends TradeMessage implements DirectMessage {
-    // Removed with 1.7.0
-    @Nullable
-    private final PaymentAccountPayload makerPaymentAccountPayload;
-
     private final String makerAccountId;
     private final byte[] makerMultiSigPubKey;
     private final String makerContractAsJson;
@@ -67,13 +61,10 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
     private final long lockTime;
 
     // Added at 1.7.0
-    @Nullable
     private final byte[] hashOfMakersPaymentAccountPayload;
-    @Nullable
     private final String makersPaymentMethodId;
 
     public InputsForDepositTxResponse(String tradeId,
-                                      @Nullable PaymentAccountPayload makerPaymentAccountPayload,
                                       String makerAccountId,
                                       byte[] makerMultiSigPubKey,
                                       String makerContractAsJson,
@@ -86,10 +77,9 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                                       byte[] accountAgeWitnessSignatureOfPreparedDepositTx,
                                       long currentDate,
                                       long lockTime,
-                                      @Nullable byte[] hashOfMakersPaymentAccountPayload,
-                                      @Nullable String makersPaymentMethodId) {
+                                      byte[] hashOfMakersPaymentAccountPayload,
+                                      String makersPaymentMethodId) {
         this(tradeId,
-                makerPaymentAccountPayload,
                 makerAccountId,
                 makerMultiSigPubKey,
                 makerContractAsJson,
@@ -113,7 +103,6 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private InputsForDepositTxResponse(String tradeId,
-                                       @Nullable PaymentAccountPayload makerPaymentAccountPayload,
                                        String makerAccountId,
                                        byte[] makerMultiSigPubKey,
                                        String makerContractAsJson,
@@ -127,10 +116,9 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                                        byte[] accountAgeWitnessSignatureOfPreparedDepositTx,
                                        long currentDate,
                                        long lockTime,
-                                       @Nullable byte[] hashOfMakersPaymentAccountPayload,
-                                       @Nullable String makersPaymentMethodId) {
+                                       byte[] hashOfMakersPaymentAccountPayload,
+                                       String makersPaymentMethodId) {
         super(messageVersion, tradeId, uid);
-        this.makerPaymentAccountPayload = makerPaymentAccountPayload;
         this.makerAccountId = makerAccountId;
         this.makerMultiSigPubKey = makerMultiSigPubKey;
         this.makerContractAsJson = makerContractAsJson;
@@ -161,8 +149,8 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 "accountAgeWitnessSignatureOfPreparedDepositTx");
         checkArgument(currentDate > 0, "currentDate must be positive");
         checkArgument(lockTime > 0, "lockTime must be positive");
-        checkNullableBytes(hashOfMakersPaymentAccountPayload, "hashOfMakersPaymentAccountPayload");
-        checkNullableString(makersPaymentMethodId, "makersPaymentMethodId");
+        checkNonEmptyBytes(hashOfMakersPaymentAccountPayload, "hashOfMakersPaymentAccountPayload");
+        checkNonBlankString(makersPaymentMethodId, "makersPaymentMethodId");
     }
 
     @Override
@@ -179,12 +167,11 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
                 .setUid(uid)
                 .setLockTime(lockTime)
-                .setAccountAgeWitnessSignatureOfPreparedDepositTx(ByteString.copyFrom(accountAgeWitnessSignatureOfPreparedDepositTx));
+                .setAccountAgeWitnessSignatureOfPreparedDepositTx(ByteString.copyFrom(accountAgeWitnessSignatureOfPreparedDepositTx))
+                .setHashOfMakersPaymentAccountPayload(ByteString.copyFrom(hashOfMakersPaymentAccountPayload))
+                .setMakersPayoutMethodId(makersPaymentMethodId)
+                .setCurrentDate(currentDate);
 
-        builder.setCurrentDate(currentDate);
-        Optional.ofNullable(makerPaymentAccountPayload).ifPresent(e -> builder.setMakerPaymentAccountPayload((protobuf.PaymentAccountPayload) makerPaymentAccountPayload.toProtoMessage()));
-        Optional.ofNullable(hashOfMakersPaymentAccountPayload).ifPresent(e -> builder.setHashOfMakersPaymentAccountPayload(ByteString.copyFrom(hashOfMakersPaymentAccountPayload)));
-        Optional.ofNullable(makersPaymentMethodId).ifPresent(e -> builder.setMakersPayoutMethodId(makersPaymentMethodId));
         return getNetworkEnvelopeBuilder()
                 .setInputsForDepositTxResponse(builder)
                 .build();
@@ -197,12 +184,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 .map(RawTransactionInput::fromProto)
                 .collect(Collectors.toList());
 
-        PaymentAccountPayload makerPaymentAccountPayload = proto.hasMakerPaymentAccountPayload() ?
-                coreProtoResolver.fromProto(proto.getMakerPaymentAccountPayload()) : null;
-        byte[] hashOfMakersPaymentAccountPayload = ProtoUtil.byteArrayOrNullFromProto(proto.getHashOfMakersPaymentAccountPayload());
-
         return new InputsForDepositTxResponse(proto.getTradeId(),
-                makerPaymentAccountPayload,
                 proto.getMakerAccountId(),
                 proto.getMakerMultiSigPubKey().toByteArray(),
                 proto.getMakerContractAsJson(),
@@ -216,8 +198,8 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 proto.getAccountAgeWitnessSignatureOfPreparedDepositTx().toByteArray(),
                 proto.getCurrentDate(),
                 proto.getLockTime(),
-                hashOfMakersPaymentAccountPayload,
-                ProtoUtil.stringOrNullFromProto(proto.getMakersPayoutMethodId()));
+                proto.getHashOfMakersPaymentAccountPayload().toByteArray(),
+                proto.getMakersPayoutMethodId());
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerSendsInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerSendsInputsForDepositTxResponse.java
@@ -80,7 +80,6 @@ public abstract class MakerSendsInputsForDepositTxResponse extends TradeTask {
             String makersPaymentMethodId = checkNotNull(processModel.getPaymentAccountPayload(trade)).getPaymentMethodId();
             InputsForDepositTxResponse message = new InputsForDepositTxResponse(
                     processModel.getOfferId(),
-                    null,
                     processModel.getAccountId(),
                     makerMultiSigPubKey,
                     trade.getContractAsJson(),

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
@@ -31,7 +31,6 @@ import bisq.common.taskrunner.TaskRunner;
 import java.security.PublicKey;
 
 import java.util.List;
-import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,17 +55,8 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
             TradingPeer tradingPeer = processModel.getTradePeer();
             Offer offer = checkNotNull(processModel.getOffer(), "Offer must not be null");
 
-            // 1.7.0: We do not expect the payment account anymore but in case peer has not updated we still process it.
-            // TODO This is now always null and the field can be removed from the message
-            Optional.ofNullable(response.getMakerPaymentAccountPayload())
-                    .ifPresent(e -> tradingPeer.setPaymentAccountPayload(response.getMakerPaymentAccountPayload()));
-
-            // Those 2 fields are actually not null anymore as old versions cannot trade anymore
-            // TODO remove the nullable annotation
-            Optional.ofNullable(response.getHashOfMakersPaymentAccountPayload())
-                    .ifPresent(e -> tradingPeer.setHashOfPaymentAccountPayload(response.getHashOfMakersPaymentAccountPayload()));
-            Optional.ofNullable(response.getMakersPaymentMethodId())
-                    .ifPresent(e -> tradingPeer.setPaymentMethodId(response.getMakersPaymentMethodId()));
+            tradingPeer.setHashOfPaymentAccountPayload(response.getHashOfMakersPaymentAccountPayload());
+            tradingPeer.setPaymentMethodId(response.getMakersPaymentMethodId());
 
             tradingPeer.setAccountId(response.getMakerAccountId());
 

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
@@ -239,7 +239,6 @@ public class BisqV1MessageIntegrityTest {
         customizer.accept(args);
         return new InputsForDepositTxResponse(
                 args.tradeId,
-                null,
                 args.makerAccountId,
                 args.makerMultiSigPubKey,
                 args.makerContractAsJson,

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -250,7 +250,7 @@ message InputsForDepositTxRequest {
     bytes taker_multi_sig_pub_key = 11;
     string taker_payout_address_string = 12;
     PubKeyRing taker_pub_key_ring = 13;
-    PaymentAccountPayload taker_payment_account_payload = 14 [deprecated = true]; // Removed in v1.9.24
+    PaymentAccountPayload taker_payment_account_payload = 14 [deprecated = true]; // Deprecated since v1.9.24
     string taker_account_id = 15;
     string taker_fee_tx_id = 16;
     repeated NodeAddress accepted_arbitrator_node_addresses = 17;
@@ -269,8 +269,7 @@ message InputsForDepositTxRequest {
 
 message InputsForDepositTxResponse {
     string trade_id = 1;
-    // Not used anymore from 1.7.0 but kept for backward compatibility.
-    PaymentAccountPayload maker_payment_account_payload = 2;
+    PaymentAccountPayload maker_payment_account_payload = 2 [deprecated = true]; // Deprecated since v1.9.24
     string maker_account_id = 3;
     string maker_contract_as_json = 4;
     string maker_contract_signature = 5;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated trade protocol message handling to use hashed payment account identifiers and payment method IDs instead of full payment account payloads.

* **Deprecations**
  * Marked legacy payment account payload fields as deprecated in trade protocol specifications starting with version 1.9.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->