### PR TITLE
Add validation to buyer process deposit tx and delayed payout tx message

### DIFF
--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -161,7 +161,7 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case REFRESH_TRADE_STATE_REQUEST:
                     return RefreshTradeStateRequest.fromProto(proto.getRefreshTradeStateRequest(), messageVersion);
                 case INPUTS_FOR_DEPOSIT_TX_REQUEST:
-                    return InputsForDepositTxRequest.fromProto(proto.getInputsForDepositTxRequest(), this, messageVersion);
+                    return InputsForDepositTxRequest.fromProto(proto.getInputsForDepositTxRequest(), messageVersion);
                 case INPUTS_FOR_DEPOSIT_TX_RESPONSE:
                     return InputsForDepositTxResponse.fromProto(proto.getInputsForDepositTxResponse(), this, messageVersion);
                 case DEPOSIT_TX_MESSAGE:

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
@@ -18,7 +18,6 @@
 package bisq.core.trade.protocol.bisq_v1.messages;
 
 import bisq.core.btc.model.RawTransactionInput;
-import bisq.core.proto.CoreProtoResolver;
 import bisq.core.trade.protocol.TradeMessage;
 
 import bisq.network.p2p.DirectMessage;
@@ -213,7 +212,6 @@ public final class InputsForDepositTxRequest extends TradeMessage
     }
 
     public static InputsForDepositTxRequest fromProto(protobuf.InputsForDepositTxRequest proto,
-                                                      CoreProtoResolver coreProtoResolver,
                                                       int messageVersion) {
         List<RawTransactionInput> rawTransactionInputs = proto.getRawTransactionInputsList().stream()
                 .map(RawTransactionInput::fromProto)

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
@@ -17,8 +17,10 @@
 
 package bisq.core.trade.protocol.bisq_v1.tasks.buyer;
 
+import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.DelayedPayoutTxSignatureRequest;
+import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
@@ -27,6 +29,8 @@ import org.bitcoinj.core.Transaction;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.trade.validation.TradeValidation.checkDerEncodedEcdsaSignature;
+import static bisq.core.trade.validation.TradeValidation.toVerifiedTransaction;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -39,12 +43,18 @@ public class BuyerProcessDelayedPayoutTxSignatureRequest extends TradeTask {
     protected void run() {
         try {
             runInterceptHook();
+
             DelayedPayoutTxSignatureRequest request = (DelayedPayoutTxSignatureRequest) processModel.getTradeMessage();
             checkNotNull(request);
-            byte[] delayedPayoutTxAsBytes = checkNotNull(request.getDelayedPayoutTx());
-            Transaction preparedDelayedPayoutTx = processModel.getBtcWalletService().getTxFromSerializedTx(delayedPayoutTxAsBytes);
+
+            BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            TradingPeer tradePeer = processModel.getTradePeer();
+
+            Transaction preparedDelayedPayoutTx = toVerifiedTransaction(request.getDelayedPayoutTx(), btcWalletService);
             processModel.setPreparedDelayedPayoutTx(preparedDelayedPayoutTx);
-            processModel.getTradePeer().setDelayedPayoutTxSignature(checkNotNull(request.getDelayedPayoutTxSellerSignature()));
+
+            byte[] delayedPayoutTxSellerSignature = checkDerEncodedEcdsaSignature(request.getDelayedPayoutTxSellerSignature());
+            tradePeer.setDelayedPayoutTxSignature(delayedPayoutTxSellerSignature);
 
             // When we receive that message the taker has published the taker fee, so we apply it to the trade.
             // The takerFeeTx was sent in the first message. It should be part of DelayedPayoutTxSignatureRequest

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -46,6 +46,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_RECEIVED_DEPOSIT_TX_PUBLISHED_MSG;
 import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_SAW_DEPOSIT_TX_IN_NETWORK;
+import static bisq.core.trade.validation.TradeValidation.checkSerializedTransaction;
+import static bisq.core.trade.validation.TradeValidation.toVerifiedTransaction;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -68,8 +70,7 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             TradingPeer tradePeer = processModel.getTradePeer();
             PubKeyRing pubKeyRing = processModel.getPubKeyRing();
 
-            byte[] depositTxBytes = checkNotNull(message.getDepositTx());
-            Transaction depositTx = btcWalletService.getTxFromSerializedTx(depositTxBytes);
+            Transaction depositTx = toVerifiedTransaction(message.getDepositTx(), btcWalletService);
 
             // To access tx confidence we need to add that tx into our wallet.
             Transaction committedDepositTx = WalletService.maybeAddSelfTxToWallet(depositTx, wallet);
@@ -78,7 +79,7 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             // update with full tx
             trade.applyDepositTx(committedDepositTx);
 
-            byte[] delayedPayoutTxBytes = checkNotNull(message.getDelayedPayoutTx());
+            byte[] delayedPayoutTxBytes = checkSerializedTransaction(message.getDelayedPayoutTx(), btcWalletService);
             checkArgument(Arrays.equals(delayedPayoutTxBytes, trade.getDelayedPayoutTxBytes()),
                     "mismatch between delayedPayoutTx received from peer and our one." +
                             "\n Expected: " + Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()) +

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -38,6 +38,8 @@ import bisq.common.util.Utilities;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.wallet.Wallet;
 
+import java.security.PrivateKey;
+
 import java.util.Arrays;
 
 import lombok.extern.slf4j.Slf4j;
@@ -66,15 +68,16 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             TradingPeer tradePeer = processModel.getTradePeer();
             PubKeyRing pubKeyRing = processModel.getPubKeyRing();
 
-            // To access tx confidence we need to add that tx into our wallet.
             byte[] depositTxBytes = checkNotNull(message.getDepositTx());
             Transaction depositTx = btcWalletService.getTxFromSerializedTx(depositTxBytes);
-            // update with full tx
-            Transaction committedDepositTx = WalletService.maybeAddSelfTxToWallet(depositTx, wallet);
-            trade.applyDepositTx(committedDepositTx);
-            BtcWalletService.printTx("depositTx received from peer", committedDepositTx);
 
             // To access tx confidence we need to add that tx into our wallet.
+            Transaction committedDepositTx = WalletService.maybeAddSelfTxToWallet(depositTx, wallet);
+            BtcWalletService.printTx("depositTx received from peer", committedDepositTx);
+
+            // update with full tx
+            trade.applyDepositTx(committedDepositTx);
+
             byte[] delayedPayoutTxBytes = checkNotNull(message.getDelayedPayoutTx());
             checkArgument(Arrays.equals(delayedPayoutTxBytes, trade.getDelayedPayoutTxBytes()),
                     "mismatch between delayedPayoutTx received from peer and our one." +
@@ -95,14 +98,14 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
 
 
                 tradePeer.setPaymentAccountPayload(sellerPaymentAccountPayload);
-                contract.setPaymentAccountPayloads(sellerPaymentAccountPayload,
-                        processModel.getPaymentAccountPayload(trade),
-                        pubKeyRing);
+                PaymentAccountPayload paymentAccountPayload = processModel.getPaymentAccountPayload(trade);
+                contract.setPaymentAccountPayloads(sellerPaymentAccountPayload, paymentAccountPayload, pubKeyRing);
 
                 // As we have added the payment accounts we need to update the json. We also update the signature
                 // thought that has less relevance with the changes of 1.7.0
                 String contractAsJson = checkNotNull(JsonUtil.objectToJson(contract));
-                String signature = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), contractAsJson);
+                PrivateKey privateKey = processModel.getKeyRing().getSignatureKeyPair().getPrivate();
+                String signature = Sig.sign(privateKey, contractAsJson);
                 trade.setContractAsJson(contractAsJson);
                 if (contract.isBuyerMakerAndSellerTaker()) {
                     trade.setMakerContractSignature(signature);

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -25,10 +25,12 @@ import bisq.core.trade.model.bisq_v1.Contract;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.DepositTxAndDelayedPayoutTxMessage;
 import bisq.core.trade.protocol.bisq_v1.model.ProcessModel;
+import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.core.util.JsonUtil;
 
 import bisq.common.crypto.Hash;
+import bisq.common.crypto.PubKeyRing;
 import bisq.common.crypto.Sig;
 import bisq.common.taskrunner.TaskRunner;
 import bisq.common.util.Utilities;
@@ -59,11 +61,15 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             var message = (DepositTxAndDelayedPayoutTxMessage) processModel.getTradeMessage();
             checkNotNull(message);
 
+            BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            Wallet wallet = btcWalletService.getWallet();
+            TradingPeer tradePeer = processModel.getTradePeer();
+            PubKeyRing pubKeyRing = processModel.getPubKeyRing();
+
             // To access tx confidence we need to add that tx into our wallet.
             byte[] depositTxBytes = checkNotNull(message.getDepositTx());
-            Transaction depositTx = processModel.getBtcWalletService().getTxFromSerializedTx(depositTxBytes);
+            Transaction depositTx = btcWalletService.getTxFromSerializedTx(depositTxBytes);
             // update with full tx
-            Wallet wallet = processModel.getBtcWalletService().getWallet();
             Transaction committedDepositTx = WalletService.maybeAddSelfTxToWallet(depositTx, wallet);
             trade.applyDepositTx(committedDepositTx);
             BtcWalletService.printTx("depositTx received from peer", committedDepositTx);
@@ -82,14 +88,16 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             if (sellerPaymentAccountPayload != null) {
                 byte[] sellerPaymentAccountPayloadHash = ProcessModel.hashOfPaymentAccountPayload(sellerPaymentAccountPayload);
                 Contract contract = checkNotNull(trade.getContract());
-                byte[] peersPaymentAccountPayloadHash = contract.getHashOfPeersPaymentAccountPayload(processModel.getPubKeyRing());
+
+                byte[] peersPaymentAccountPayloadHash = contract.getHashOfPeersPaymentAccountPayload(pubKeyRing);
                 checkArgument(Arrays.equals(sellerPaymentAccountPayloadHash, peersPaymentAccountPayloadHash),
                         "Hash of payment account is invalid");
 
-                processModel.getTradePeer().setPaymentAccountPayload(sellerPaymentAccountPayload);
+
+                tradePeer.setPaymentAccountPayload(sellerPaymentAccountPayload);
                 contract.setPaymentAccountPayloads(sellerPaymentAccountPayload,
                         processModel.getPaymentAccountPayload(trade),
-                        processModel.getPubKeyRing());
+                        pubKeyRing);
 
                 // As we have added the payment accounts we need to update the json. We also update the signature
                 // thought that has less relevance with the changes of 1.7.0
@@ -111,7 +119,7 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
                 trade.setState(BUYER_RECEIVED_DEPOSIT_TX_PUBLISHED_MSG);
             }
 
-            processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(trade.getId(),
+            btcWalletService.swapTradeEntryToAvailableEntry(trade.getId(),
                     AddressEntry.Context.RESERVED_FOR_TRADE);
 
             processModel.getTradeManager().requestPersistence();

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -55,7 +55,8 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
     protected void run() {
         try {
             runInterceptHook();
-            var message = checkNotNull((DepositTxAndDelayedPayoutTxMessage) processModel.getTradeMessage());
+
+            var message = (DepositTxAndDelayedPayoutTxMessage) processModel.getTradeMessage();
             checkNotNull(message);
 
             // To access tx confidence we need to add that tx into our wallet.
@@ -80,8 +81,8 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             PaymentAccountPayload sellerPaymentAccountPayload = message.getSellerPaymentAccountPayload();
             if (sellerPaymentAccountPayload != null) {
                 byte[] sellerPaymentAccountPayloadHash = ProcessModel.hashOfPaymentAccountPayload(sellerPaymentAccountPayload);
-                Contract contract = trade.getContract();
-                byte[] peersPaymentAccountPayloadHash = checkNotNull(contract).getHashOfPeersPaymentAccountPayload(processModel.getPubKeyRing());
+                Contract contract = checkNotNull(trade.getContract());
+                byte[] peersPaymentAccountPayloadHash = contract.getHashOfPeersPaymentAccountPayload(processModel.getPubKeyRing());
                 checkArgument(Arrays.equals(sellerPaymentAccountPayloadHash, peersPaymentAccountPayloadHash),
                         "Hash of payment account is invalid");
 
@@ -92,7 +93,7 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
 
                 // As we have added the payment accounts we need to update the json. We also update the signature
                 // thought that has less relevance with the changes of 1.7.0
-                String contractAsJson = JsonUtil.objectToJson(contract);
+                String contractAsJson = checkNotNull(JsonUtil.objectToJson(contract));
                 String signature = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), contractAsJson);
                 trade.setContractAsJson(contractAsJson);
                 if (contract.isBuyerMakerAndSellerTaker()) {
@@ -101,7 +102,7 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
                     trade.setTakerContractSignature(signature);
                 }
 
-                byte[] contractHash = Hash.getSha256Hash(checkNotNull(contractAsJson));
+                byte[] contractHash = Hash.getSha256Hash(contractAsJson);
                 trade.setContractHash(contractHash);
             }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -70,21 +70,22 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             TradingPeer tradePeer = processModel.getTradePeer();
             PubKeyRing pubKeyRing = processModel.getPubKeyRing();
 
-            Transaction depositTx = toVerifiedTransaction(message.getDepositTx(), btcWalletService);
+            Transaction peersDepositTx = toVerifiedTransaction(message.getDepositTx(), btcWalletService);
 
             // To access tx confidence we need to add that tx into our wallet.
-            Transaction committedDepositTx = WalletService.maybeAddSelfTxToWallet(depositTx, wallet);
-            BtcWalletService.printTx("depositTx received from peer", committedDepositTx);
+            Transaction committedDepositTx = WalletService.maybeAddSelfTxToWallet(peersDepositTx, wallet);
+            BtcWalletService.printTx("peersDepositTx received from peer", committedDepositTx);
 
             // update with full tx
             trade.applyDepositTx(committedDepositTx);
 
-            byte[] delayedPayoutTxBytes = checkSerializedTransaction(message.getDelayedPayoutTx(), btcWalletService);
-            checkArgument(Arrays.equals(delayedPayoutTxBytes, trade.getDelayedPayoutTxBytes()),
-                    "mismatch between delayedPayoutTx received from peer and our one." +
-                            "\n Expected: " + Utilities.bytesAsHexString(trade.getDelayedPayoutTxBytes()) +
-                            "\n Received: " + Utilities.bytesAsHexString(delayedPayoutTxBytes));
-            trade.applyDelayedPayoutTxBytes(delayedPayoutTxBytes);
+            byte[] peersDelayedPayoutTxBytes = checkSerializedTransaction(message.getDelayedPayoutTx(), btcWalletService);
+            byte[] myDelayedPayoutTxBytes = trade.getDelayedPayoutTxBytes();
+            checkArgument(Arrays.equals(peersDelayedPayoutTxBytes, myDelayedPayoutTxBytes),
+                    "peersDelayedPayoutTx and myDelayedPayoutTx must be the same" +
+                            "\n myDelayedPayoutTx: " + Utilities.bytesAsHexString(myDelayedPayoutTxBytes) +
+                            "\n peersDelayedPayoutTx: " + Utilities.bytesAsHexString(peersDelayedPayoutTxBytes));
+            trade.applyDelayedPayoutTxBytes(peersDelayedPayoutTxBytes);
 
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
@@ -96,7 +97,6 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
                 byte[] peersPaymentAccountPayloadHash = contract.getHashOfPeersPaymentAccountPayload(pubKeyRing);
                 checkArgument(Arrays.equals(sellerPaymentAccountPayloadHash, peersPaymentAccountPayloadHash),
                         "Hash of payment account is invalid");
-
 
                 tradePeer.setPaymentAccountPayload(sellerPaymentAccountPayload);
                 PaymentAccountPayload paymentAccountPayload = processModel.getPaymentAccountPayload(trade);

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSendsDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSendsDepositTxMessage.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade.protocol.bisq_v1.tasks.buyer_as_taker;
 
+import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.DepositTxMessage;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
@@ -26,9 +27,14 @@ import bisq.network.p2p.SendDirectMessageListener;
 
 import bisq.common.taskrunner.TaskRunner;
 
+import org.bitcoinj.core.Transaction;
+
 import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
+
+import static bisq.core.trade.validation.TradeValidation.checkTransactionIsUnsigned;
+
 
 @Slf4j
 public class BuyerAsTakerSendsDepositTxMessage extends TradeTask {
@@ -40,13 +46,21 @@ public class BuyerAsTakerSendsDepositTxMessage extends TradeTask {
     protected void run() {
         try {
             runInterceptHook();
-            if (processModel.getDepositTx() != null) {
+
+            Transaction signedDepositTx = processModel.getDepositTx();
+            if (signedDepositTx != null) {
+                BtcWalletService btcWalletService = processModel.getBtcWalletService();
+
                 // Remove witnesses from the sent depositTx, so that the seller can still compute the final
                 // tx id, but cannot publish it before providing the buyer with a signed delayed payout tx.
+                // With setting useSegwit to false in bitcoinSerialize(false) we remove the witnesses from the transaction
+                byte[] unsignedDepositTx = signedDepositTx.bitcoinSerialize(false);
+                byte[] depositTxWithoutWitnesses = checkTransactionIsUnsigned(unsignedDepositTx, btcWalletService);
+
                 DepositTxMessage message = new DepositTxMessage(UUID.randomUUID().toString(),
                         processModel.getOfferId(),
                         processModel.getMyNodeAddress(),
-                        processModel.getDepositTx().bitcoinSerialize(false));
+                        depositTxWithoutWitnesses);
 
                 NodeAddress peersNodeAddress = trade.getTradingPeerNodeAddress();
                 log.info("Send {} to peer {}. tradeId={}, uid={}",
@@ -74,7 +88,7 @@ public class BuyerAsTakerSendsDepositTxMessage extends TradeTask {
                         }
                 );
             } else {
-                log.error("processModel.getDepositTx() = {}", processModel.getDepositTx());
+                log.error("processModel.getDepositTx() = {}", signedDepositTx);
                 failed("DepositTx is null");
             }
         } catch (Throwable t) {

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
@@ -17,14 +17,21 @@
 
 package bisq.core.trade.protocol.bisq_v1.tasks.seller;
 
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.DelayedPayoutTxSignatureResponse;
+import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
 import bisq.common.taskrunner.TaskRunner;
 
+import org.bitcoinj.core.Transaction;
+
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.trade.validation.TradeValidation.checkDerEncodedEcdsaSignature;
+import static bisq.core.trade.validation.TradeValidation.checkSerializedTransaction;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -37,15 +44,21 @@ public class SellerProcessDelayedPayoutTxSignatureResponse extends TradeTask {
     protected void run() {
         try {
             runInterceptHook();
+
             DelayedPayoutTxSignatureResponse response = (DelayedPayoutTxSignatureResponse) processModel.getTradeMessage();
             checkNotNull(response);
 
-            processModel.getTradePeer().setDelayedPayoutTxSignature(checkNotNull(response.getDelayedPayoutTxBuyerSignature()));
+            TradeWalletService tradeWalletService = processModel.getTradeWalletService();
+            BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            TradingPeer tradePeer = processModel.getTradePeer();
 
-            processModel.getTradeWalletService().sellerAddsBuyerWitnessesToDepositTx(
-                    processModel.getDepositTx(),
-                    processModel.getBtcWalletService().getTxFromSerializedTx(response.getDepositTx())
-            );
+            byte[] delayedPayoutTxBuyerSignature = checkDerEncodedEcdsaSignature(response.getDelayedPayoutTxBuyerSignature());
+            tradePeer.setDelayedPayoutTxSignature(delayedPayoutTxBuyerSignature);
+
+            byte[] depositTx = checkSerializedTransaction(response.getDepositTx(), btcWalletService);
+            Transaction buyersDepositTxWithWitnesses = btcWalletService.getTxFromSerializedTx(depositTx);
+            Transaction myDepositTx = processModel.getDepositTx();
+            tradeWalletService.sellerAddsBuyerWitnessesToDepositTx(myDepositTx, buyersDepositTxWithWitnesses);
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerProcessDepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerProcessDepositTxMessage.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade.protocol.bisq_v1.tasks.seller_as_maker;
 
+import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.DepositTxMessage;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
@@ -25,6 +26,7 @@ import bisq.common.taskrunner.TaskRunner;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.trade.validation.TradeValidation.checkTransactionIsUnsigned;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -40,13 +42,17 @@ public class SellerAsMakerProcessDepositTxMessage extends TradeTask {
             DepositTxMessage message = (DepositTxMessage) processModel.getTradeMessage();
             checkNotNull(message);
 
-            processModel.getTradePeer().setPreparedDepositTx(checkNotNull(message.getDepositTxWithoutWitnesses()));
-            trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
+            BtcWalletService btcWalletService = processModel.getBtcWalletService();
+
+            byte[] depositTxWithoutWitnesses = checkTransactionIsUnsigned(message.getDepositTxWithoutWitnesses(), btcWalletService);
+            processModel.getTradePeer().setPreparedDepositTx(depositTxWithoutWitnesses);
 
             // When we receive that message the taker has published the taker fee, so we apply it to the trade.
             // The takerFeeTx was sent in the first message. It should be part of DelayedPayoutTxSignatureRequest
             // but that cannot be changed due backward compatibility issues. It is a left over from the old trade protocol.
             trade.setTakerFeeTxId(processModel.getTakeOfferFeeTxId());
+
+            trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
             processModel.getTradeManager().requestPersistence();
 

--- a/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
@@ -46,13 +46,19 @@ import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.SignatureDecodeException;
 import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.VerificationException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 
 import java.security.PublicKey;
 
+import java.math.BigInteger;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -188,21 +194,71 @@ public class TradeValidation {
         }
     }
 
+    public static byte[] checkTransactionIsUnsigned(byte[] signedSerializedTransaction,
+                                                    BtcWalletService btcWalletService) {
+        checkNonEmptyBytes(signedSerializedTransaction, "signedSerializedTransaction");
+        checkNotNull(btcWalletService, "btcWalletService must not be null");
+        Transaction signedTransaction = toVerifiedTransaction(signedSerializedTransaction, btcWalletService);
+        checkArgument(signedTransaction.getInputs().stream().noneMatch(TradeValidation::hasSignatureData),
+                "signedSerializedTransaction must not be signed");
+        return signedSerializedTransaction;
+    }
+
+    @VisibleForTesting
+    static boolean hasSignatureData(TransactionInput input) {
+        return input.getScriptBytes().length > 0 || input.hasWitness();
+    }
+
+    public static byte[] checkDerEncodedEcdsaSignature(byte[] bitcoinSignature) {
+        checkNonEmptyBytes(bitcoinSignature, "bitcoinSignature");
+        try {
+            ECKey.ECDSASignature signature = ECKey.ECDSASignature.decodeFromDER(bitcoinSignature);
+            checkArgument(Arrays.equals(bitcoinSignature, signature.encodeToDER()),
+                    "bitcoinSignature must be strictly DER encoded");
+            checkArgument(isValidSignatureValue(signature.r),
+                    "bitcoinSignature r value is outside of allowed range");
+            checkArgument(isValidSignatureValue(signature.s),
+                    "bitcoinSignature s value is outside of allowed range");
+            checkArgument(signature.isCanonical(),
+                    "bitcoinSignature must use low-S canonical encoding");
+            return bitcoinSignature;
+        } catch (SignatureDecodeException e) {
+            throw new IllegalArgumentException("Invalid bitcoin signature", e);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isValidSignatureValue(BigInteger value) {
+        return value.signum() > 0 && value.compareTo(ECKey.CURVE.getN()) < 0;
+    }
+
+    public static Transaction checkTransaction(Transaction transaction) {
+        checkNotNull(transaction, "transaction must not be null");
+        try {
+            transaction.verify();
+        } catch (VerificationException e) {
+            throw new IllegalArgumentException("Invalid transaction", e);
+        }
+        return transaction;
+    }
+
     public static byte[] checkSerializedTransaction(byte[] serializedTransaction,
                                                     BtcWalletService btcWalletService) {
         checkNonEmptyBytes(serializedTransaction, "serializedTransaction");
         checkNotNull(btcWalletService, "btcWalletService must not be null");
-        toTransaction(serializedTransaction, btcWalletService);
+        toVerifiedTransaction(serializedTransaction, btcWalletService);
         return serializedTransaction;
     }
 
-    public static Transaction toTransaction(byte[] serializedTransaction,
-                                            BtcWalletService btcWalletService) {
+    public static Transaction toVerifiedTransaction(byte[] serializedTransaction,
+                                                    BtcWalletService btcWalletService) {
         checkNonEmptyBytes(serializedTransaction, "serializedTransaction");
         checkNotNull(btcWalletService, "btcWalletService must not be null");
 
         try {
-            return new Transaction(btcWalletService.getParams(), serializedTransaction);
+            Transaction transaction = new Transaction(btcWalletService.getParams(), serializedTransaction);
+            transaction.verify();
+            return transaction;
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid serialized transaction", e);
         }

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/TradePeerTxInputValidatorTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/TradePeerTxInputValidatorTest.java
@@ -20,6 +20,7 @@ package bisq.core.trade.protocol.bisq_v1.tasks;
 import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.WalletUtils;
+import bisq.core.trade.validation.TradePeerTxInputValidator;
 
 import com.google.protobuf.ByteString;
 
@@ -36,12 +37,12 @@ import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
@@ -53,6 +53,7 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionWitness;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.ScriptBuilder;
@@ -61,17 +62,15 @@ import java.security.KeyPair;
 
 import java.nio.charset.StandardCharsets;
 
+import java.math.BigInteger;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -331,12 +330,62 @@ public class TradeValidationTest {
     }
 
     @Test
-    void toTransactionParsesValidSerializedTransaction() {
+    void toTransactionParsesValidSerializedVerifiedTransaction() {
         byte[] serializedTransaction = serializedTransaction();
 
         assertArrayEquals(serializedTransaction,
-                TradeValidation.toTransaction(serializedTransaction, btcWalletService(MainNetParams.get()))
+                TradeValidation.toVerifiedTransaction(serializedTransaction, btcWalletService(MainNetParams.get()))
                         .bitcoinSerialize());
+    }
+
+    @Test
+    void checkTransactionIsUnsignedAcceptsValidUnsignedTransaction() {
+        byte[] depositTxWithoutWitnesses = serializedTransaction();
+
+        assertSame(depositTxWithoutWitnesses,
+                TradeValidation.checkTransactionIsUnsigned(depositTxWithoutWitnesses,
+                        btcWalletService(MainNetParams.get())));
+    }
+
+    @Test
+    void checkTransactionIsUnsignedRejectsMalformedSerializedTransaction() {
+        assertThrows(RuntimeException.class, () -> TradeValidation.checkTransactionIsUnsigned(
+                new byte[]{1, 2, 3},
+                btcWalletService(MainNetParams.get())));
+    }
+
+    @Test
+    void checkTransactionIsUnsignedRejectsStructurallyInvalidTransaction() {
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkTransactionIsUnsigned(
+                serializedTransactionWithoutOutputs(),
+                btcWalletService(MainNetParams.get())));
+    }
+
+    @Test
+    void checkTransactionIsUnsignedRejectsTransactionWithScriptSig() {
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkTransactionIsUnsigned(
+                serializedTransactionWithScriptSig(),
+                btcWalletService(MainNetParams.get())));
+    }
+
+    @Test
+    void checkTransactionIsUnsignedRejectsTransactionWithWitness() {
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkTransactionIsUnsigned(
+                serializedTransactionWithWitness(),
+                btcWalletService(MainNetParams.get())));
+    }
+
+    @Test
+    void checkTransactionIsUnsignedRejectsNullTransaction() {
+        assertThrows(NullPointerException.class, () -> TradeValidation.checkTransactionIsUnsigned(null,
+                btcWalletService(MainNetParams.get())));
+    }
+
+    @Test
+    void checkTransactionIsUnsignedRejectsNullWalletService() {
+        assertThrows(NullPointerException.class, () -> TradeValidation.checkTransactionIsUnsigned(
+                serializedTransaction(),
+                null));
     }
 
     @Test
@@ -366,6 +415,57 @@ public class TradeValidationTest {
     @Test
     void checkTransactionIdRejectsNullTransactionId() {
         assertThrows(NullPointerException.class, () -> TradeValidation.checkTransactionId(null));
+    }
+
+    @Test
+    void checkDerEncodedEcdsaSignatureAcceptsStrictDerEncodedCanonicalSignature() {
+        byte[] bitcoinSignature = bitcoinSignature(BigInteger.ONE, BigInteger.ONE);
+
+        assertSame(bitcoinSignature, TradeValidation.checkDerEncodedEcdsaSignature(bitcoinSignature));
+    }
+
+    @Test
+    void checkDerEncodedEcdsaSignatureRejectsNullSignature() {
+        assertThrows(NullPointerException.class, () -> TradeValidation.checkDerEncodedEcdsaSignature(null));
+    }
+
+    @Test
+    void checkDerEncodedEcdsaSignatureRejectsEmptySignature() {
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkDerEncodedEcdsaSignature(new byte[0]));
+    }
+
+    @Test
+    void checkDerEncodedEcdsaSignatureRejectsMalformedSignature() {
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkDerEncodedEcdsaSignature(new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    void checkDerEncodedEcdsaSignatureRejectsNonStrictDerEncoding() {
+        byte[] bitcoinSignature = bitcoinSignature(BigInteger.ONE, BigInteger.ONE);
+        byte[] bitcoinSignatureWithTrailingData = Arrays.copyOf(bitcoinSignature, bitcoinSignature.length + 1);
+        bitcoinSignatureWithTrailingData[bitcoinSignature.length] = 1;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> TradeValidation.checkDerEncodedEcdsaSignature(bitcoinSignatureWithTrailingData));
+    }
+
+    @Test
+    void checkDerEncodedEcdsaSignatureRejectsValuesOutsideCurveOrder() {
+        assertThrows(IllegalArgumentException.class,
+                () -> TradeValidation.checkDerEncodedEcdsaSignature(bitcoinSignature(BigInteger.ZERO, BigInteger.ONE)));
+        assertThrows(IllegalArgumentException.class,
+                () -> TradeValidation.checkDerEncodedEcdsaSignature(bitcoinSignature(BigInteger.ONE, BigInteger.ZERO)));
+        assertThrows(IllegalArgumentException.class,
+                () -> TradeValidation.checkDerEncodedEcdsaSignature(bitcoinSignature(ECKey.CURVE.getN(), BigInteger.ONE)));
+        assertThrows(IllegalArgumentException.class,
+                () -> TradeValidation.checkDerEncodedEcdsaSignature(bitcoinSignature(BigInteger.ONE, ECKey.CURVE.getN())));
+    }
+
+    @Test
+    void checkDerEncodedEcdsaSignatureRejectsNonCanonicalSValue() {
+        byte[] bitcoinSignature = bitcoinSignature(BigInteger.ONE, ECKey.CURVE.getN().subtract(BigInteger.ONE));
+
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkDerEncodedEcdsaSignature(bitcoinSignature));
     }
 
     @Test
@@ -939,14 +1039,44 @@ public class TradeValidationTest {
     }
 
     private static byte[] serializedTransaction() {
+        return transaction(new byte[]{}).bitcoinSerialize();
+    }
+
+    private static byte[] serializedTransactionWithoutOutputs() {
         Transaction transaction = new Transaction(MainNetParams.get());
         transaction.addInput(new TransactionInput(MainNetParams.get(),
                 transaction,
                 new byte[]{},
                 new TransactionOutPoint(MainNetParams.get(), 0, Sha256Hash.ZERO_HASH),
                 Coin.valueOf(2_000)));
-        transaction.addOutput(Coin.valueOf(1_000), ScriptBuilder.createP2WPKHOutputScript(new ECKey()));
         return transaction.bitcoinSerialize();
+    }
+
+    private static byte[] serializedTransactionWithScriptSig() {
+        return transaction(new byte[]{1, 1}).bitcoinSerialize();
+    }
+
+    private static byte[] serializedTransactionWithWitness() {
+        Transaction transaction = transaction(new byte[]{});
+        TransactionWitness witness = new TransactionWitness(1);
+        witness.setPush(0, new byte[]{1});
+        transaction.getInput(0).setWitness(witness);
+        return transaction.bitcoinSerialize();
+    }
+
+    private static Transaction transaction(byte[] scriptSigProgram) {
+        Transaction transaction = new Transaction(MainNetParams.get());
+        transaction.addInput(new TransactionInput(MainNetParams.get(),
+                transaction,
+                scriptSigProgram,
+                new TransactionOutPoint(MainNetParams.get(), 0, Sha256Hash.ZERO_HASH),
+                Coin.valueOf(2_000)));
+        transaction.addOutput(Coin.valueOf(1_000), ScriptBuilder.createP2WPKHOutputScript(new ECKey()));
+        return transaction;
+    }
+
+    private static byte[] bitcoinSignature(BigInteger r, BigInteger s) {
+        return new ECKey.ECDSASignature(r, s).encodeToDER();
     }
 
     private static InputsForDepositTxRequestValidationFixture inputsForDepositTxRequestValidationFixture(


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq/pull/7655

As that class was messy and rather large, I made small commits to allow reviewers to follow steps and to reduce risks that anything got broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction and signature validation throughout the trading protocol to improve data integrity and error detection.

* **Refactoring**
  * Improved internal transaction processing flow with better service dependencies and clearer verification logic.

* **Tests**
  * Expanded test coverage for transaction verification, signature validation, and unsigned transaction checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->