### PR TITLE
Bound taker-supplied trade tx fee

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
@@ -19,6 +19,7 @@ package bisq.core.trade.protocol.bisq_v1.messages;
 
 import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.trade.protocol.TradeMessage;
+import bisq.core.trade.validation.TradeValidation;
 
 import bisq.network.p2p.DirectMessage;
 import bisq.network.p2p.NodeAddress;
@@ -142,7 +143,8 @@ public final class InputsForDepositTxRequest extends TradeMessage
         checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
         checkArgument(tradeAmount > 0, "tradeAmount must be positive");
         checkArgument(tradePrice > 0, "tradePrice must be positive");
-        checkArgument(txFee > 0, "txFee must be positive");
+        // Bound the taker-supplied trade tx fee. Single source of truth in TradeValidation.
+        TradeValidation.checkTradeTxFee(txFee);
         checkArgument(takerFee > 0, "takerFee must be positive");
         checkList(rawTransactionInputs, true, "rawTransactionInputs");
         checkNonEmptyBytes(takerMultiSigPubKey, "takerMultiSigPubKey");

--- a/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
@@ -379,13 +379,31 @@ public class TradeValidation {
         return checkValueInTolerance(actualValue, expectedValue, MAX_FEE_DEVIATION_FACTOR);
     }
 
+    // Bound the taker-supplied trade tx fee. A tiny value can leave the deposit tx
+    // unconfirmable (locking maker funds); a huge value can drain miner fees from the maker.
+    // Envelope derived from realistic miner-fee range 1..600 sat/vB over up to ~600 vB
+    // (headroom above the stored average of taker-fee-tx ~192 vB and deposit-tx ~233 vB).
+    // The tighter check is checkTradeTxFeeIsInTolerance; these are absolute sanity bounds.
+    public static final long MIN_TRADE_TX_FEE_SAT = 250L;
+    public static final long MAX_TRADE_TX_FEE_SAT = 360_000L;
+
     public static Coin checkTradeTxFee(Coin tradeTxFee) {
         checkIsPositive(tradeTxFee, "tradeTxFee");
+        checkTradeTxFeeBounds(tradeTxFee.getValue());
         return tradeTxFee;
     }
 
     public static long checkTradeTxFee(long tradeTxFee) {
-        return checkIsPositive(tradeTxFee, "tradeTxFee");
+        checkIsPositive(tradeTxFee, "tradeTxFee");
+        checkTradeTxFeeBounds(tradeTxFee);
+        return tradeTxFee;
+    }
+
+    private static void checkTradeTxFeeBounds(long tradeTxFee) {
+        checkArgument(tradeTxFee >= MIN_TRADE_TX_FEE_SAT,
+                "tradeTxFee too low (must be >= %s sat). Got: %s", MIN_TRADE_TX_FEE_SAT, tradeTxFee);
+        checkArgument(tradeTxFee <= MAX_TRADE_TX_FEE_SAT,
+                "tradeTxFee too high (must be <= %s sat). Got: %s", MAX_TRADE_TX_FEE_SAT, tradeTxFee);
     }
 
     public static long checkTradeTxFeeIsInTolerance(long tradeTxFee, FeeService feeService) {
@@ -393,7 +411,7 @@ public class TradeValidation {
     }
 
     public static Coin checkTradeTxFeeIsInTolerance(Coin tradeTxFee, FeeService feeService) {
-        checkIsPositive(tradeTxFee, "tradeTxFee");
+        checkTradeTxFee(tradeTxFee);
         checkNotNull(feeService, "feeService must not be null");
         Coin txFeePerVbyte = feeService.getTxFeePerVbyte();
         Coin expectedTradeTxFee = TradeFeeFactory.getTradeTxFee(txFeePerVbyte);
@@ -401,7 +419,7 @@ public class TradeValidation {
     }
 
     public static Coin checkTradeTxFeeIsInTolerance(Coin tradeTxFee, Coin expectedTradeTxFee) {
-        checkIsPositive(tradeTxFee, "tradeTxFee");
+        checkTradeTxFee(tradeTxFee);
         checkIsPositive(expectedTradeTxFee, "expectedTradeTxFee");
         checkFeeIsInTolerance(tradeTxFee.getValue(), expectedTradeTxFee.getValue());
         return tradeTxFee;

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
@@ -237,6 +237,20 @@ public class BisqV1MessageIntegrityTest {
     }
 
     @Test
+    void inputsForDepositTxRequestRejectsTxFeeOutsideBounds() {
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = 249L));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = 360_001L));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = 0L));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = -1L));
+    }
+
+    @Test
+    void inputsForDepositTxRequestAcceptsTxFeeAtBounds() {
+        newRequest(args -> args.txFee = 250L);
+        newRequest(args -> args.txFee = 360_000L);
+    }
+
+    @Test
     void inputsForDepositTxRequestRejectsInvalidInputLists() {
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.rawTransactionInputs = List.of()));
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.acceptedMediatorNodeAddresses =

--- a/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
@@ -895,6 +895,28 @@ public class TradeValidationTest {
     }
 
     @Test
+    void checkTradeTxFeeRejectsFeesBelowMinBound() {
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkTradeTxFee(Coin.valueOf(249)));
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkTradeTxFee(249L));
+    }
+
+    @Test
+    void checkTradeTxFeeRejectsFeesAboveMaxBound() {
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkTradeTxFee(Coin.valueOf(360_001)));
+        assertThrows(IllegalArgumentException.class, () -> TradeValidation.checkTradeTxFee(360_001L));
+    }
+
+    @Test
+    void checkTradeTxFeeAcceptsBoundaryValues() {
+        Coin min = Coin.valueOf(TradeValidation.MIN_TRADE_TX_FEE_SAT);
+        Coin max = Coin.valueOf(TradeValidation.MAX_TRADE_TX_FEE_SAT);
+        assertSame(min, TradeValidation.checkTradeTxFee(min));
+        assertSame(max, TradeValidation.checkTradeTxFee(max));
+        assertEquals(TradeValidation.MIN_TRADE_TX_FEE_SAT, TradeValidation.checkTradeTxFee(TradeValidation.MIN_TRADE_TX_FEE_SAT));
+        assertEquals(TradeValidation.MAX_TRADE_TX_FEE_SAT, TradeValidation.checkTradeTxFee(TradeValidation.MAX_TRADE_TX_FEE_SAT));
+    }
+
+    @Test
     void checkTradeTxFeeAcceptsCalculatedTxFee() {
         Coin txFee = TradeFeeFactory.getTradeTxFee(Coin.valueOf(2));
 
@@ -1191,7 +1213,7 @@ public class TradeValidationTest {
         String offerId = "offer-id";
         Coin tradeAmount = Coin.valueOf(3_000);
         Coin expectedTakerFee = Coin.valueOf(100);
-        FeeService feeService = configureTradeFeeService(Coin.valueOf(77), expectedTakerFee);
+        FeeService feeService = configureTradeFeeService(Coin.valueOf(77), expectedTakerFee, 2);
         Coin tradeTxFee = TradeFeeFactory.getTradeTxFee(feeService.getTxFeePerVbyte());
         NodeAddress mediatorNodeAddress = new NodeAddress("mediator.onion", 9999);
         BtcWalletService btcWalletService = btcWalletService(MainNetParams.get());


### PR DESCRIPTION
# AI analyisis

## Reasoning behind the chosen bounds

`MIN_TRADE_TX_FEE_SAT = 250`, `MAX_TRADE_TX_FEE_SAT = 360_000`.

The envelope is derived from two inputs: the realistic miner-fee-rate range observed on Bitcoin mainnet, and the actual transaction sizes produced by Bisq's 2-of-2 multisig trade protocol.

### 1. Fee-rate range

The codebase already documents a 1–600 sat/vB working range (see `FeeService.java:47`: *"Miner fees are between 1-600 sat/vbyte"*). That range matches the historical Bitcoin Core relay floor and the upper end of normal-to-congested mempool conditions:

- **Lower edge.** The Bitcoin Core default `minrelaytxfee` was **1 sat/vB** for many years. It was reduced to **0.1 sat/vB** in Bitcoin Core 29.1 (released 2025-09-04). Sources: [Bitcoin Optech — Default minimum transaction relay feerates](https://bitcoinops.org/en/topics/default-minimum-transaction-relay-feerates/), [Bitget News — Bitcoin Core 29.1 cuts default relay fee to 0.1 sat/vB](https://www.bitget.com/news/detail/12560604967589). For our purposes the 1 sat/vB floor remains the practical inclusion threshold under any non-trivial mempool, since most reachable nodes still run with the historical default.
- **Upper edge.** During major demand events the network has clearly exceeded 600 sat/vB, but only briefly:
  - **2024-04-20** (halving + Runes launch): the median fee rate peaked at roughly **1,805 sat/vB**, and a single transaction in block 840 000 paid **~3,604,819 sat/vB**. Source: [CoinDesk — Bitcoin Miners Reap Windfall as 'Runes' Debut Sends Transaction Fees to Record Highs (2024-04-21)](https://www.coindesk.com/tech/2024/04/21/bitcoin-miners-reap-windfall-as-runes-debut-sends-transaction-fees-to-record-highs).
  - **2023-12-16** (Ordinals / BRC-20 wave): average fee rate around **385 sat/vB**. Source: [Decrypt — Bitcoin Daily Transactions Hit All-Time High With 3 Million Ordinals Inscriptions (2023-12)](https://decrypt.co/138668/bitcoin-daily-fees-hit-all-time-high-with-3-million-ordinals-inscriptions).

These spike periods were short-lived (hours) and during them normal Bitcoin usage essentially halts; widening the bound to fit them would weaken the attack surface for negligible benefit, since trades are not generally being initiated under those conditions. The 600 sat/vB ceiling therefore reflects the upper edge of *economically reasonable trade activity*, not the absolute historical peak. Live and historical data: [mempool.space — Block fee rates](https://mempool.space/graphs/mining/block-fee-rates).

### 2. Effective vsize, accounting for the 2-of-2 multisig structure

The stored `tradeTxFee` is the **average vsize across the taker-fee tx and the deposit tx**: 192 vB and 233 vB respectively (`TradeFeeFactory.TAKER_FEE_TX_VSIZE` and `DEPOSIT_TX_VSIZE`). The deposit tx is larger than a single-party tx because:

- It consumes inputs from **both** maker and taker, not just one party.
- Its primary output is a **2-of-2 P2WSH multisig** (the trade lock), whose script is heavier than a P2WPKH output.

The payout tx, although not directly priced into the stored `tradeTxFee`, spends that 2-of-2 multisig and carries a witness containing two ECDSA signatures plus the 2-of-2 redeem script — significantly heavier than a P2WPKH spend. The protocol code reflects this by applying the stored `tradeTxFee` multiplicatively (`trade.getTradeTxFee().multiply(2)`) in several seller/buyer task classes (e.g. `BuyerAsMakerCreatesAndSignsDepositTx`, `SellerAsTakerSignsDepositTx`), since the same per-tx average is reused for both the deposit tx and the payout tx that follows.

Two consequences for the bounds:

1. **Real deposit txs can exceed the 233 vB nominal.** With many inputs (a wallet funding the deposit from numerous small UTXOs), the deposit tx grows above its average. Allowing headroom up to ~600 vB on the absolute ceiling is a margin against this, not an arbitrary number.
2. **The absolute ceiling effectively governs two transactions.** Because `tradeTxFee` is reused for both the deposit and payout txs, a maliciously inflated value at the upper bound costs the maker up to `360_000 × 2 = 720_000 sat` of drained miner fees before the dynamic `checkTradeTxFeeIsInTolerance` check kicks in.

### 3. Resulting envelope

- **Lower bound, 250 sat:** ~1 sat/vB applied to the ~212 vB stored average. Below this, the deposit tx risks not being relayed or confirmed, which would lock maker funds in the multisig.
- **Upper bound, 360_000 sat:** 600 sat/vB × 600 vB. Generous for an honest tx under normal-to-moderately-congested conditions; clearly outside the envelope of economically reasonable trade activity for anything else.

These constants are intentionally a wide *sanity* envelope. The tighter, dynamic check is `checkTradeTxFeeIsInTolerance`, which compares the supplied fee against the live `FeeService` rate within the configured deviation factor. The role of the absolute bounds is to reject obviously absurd values at the message layer before any tolerance check runs, so that the protocol message itself is well-formed regardless of validator state. Both `InputsForDepositTxRequest.validate()` and the validator now call `TradeValidation.checkTradeTxFee(...)`, keeping the constants in a single place.

---

## Why no amount-relative percentage cap (yet)

For a small trade (the 10 000 sat protocol minimum, see `Restrictions.MIN_TRADE_AMOUNT`), even a 360 000 sat miner fee is economically nonsensical and amounts to a maker-fund drain. A natural defense is `cap = max(MIN_FLOOR, min(MAX_ABS, tradeAmount × p))`. In practice `p` is hard to choose safely:

1. **Lower-edge conflict.** At the protocol minimum trade amount of 10 000 sat, 1 % is 100 sat — below the network's effective relay floor of 1 sat/vB applied to a 2-of-2 multisig deposit tx of ~212 vB (= 212 sat). A strict 1 % cap would be infeasible on small trades; the absolute floor would always dominate, defeating the purpose of the percentage.
2. **Spike vs. attack confusion.** During genuine fee spikes — e.g. the 385 sat/vB average reached on 2023-12-16 ([Decrypt](https://decrypt.co/138668/bitcoin-daily-fees-hit-all-time-high-with-3-million-ordinals-inscriptions)) — a legitimate ~212 vB tx really costs around 80 000 sat. For a 0.01 BTC trade (1 000 000 sat) that is ~8 %. A 1 % cap would reject honest trades during congestion; a 5 % cap survives most spikes but does little on small trades. No single percentage is both attack-tight and spike-tolerant across the full amount range.
3. **Oracle dependence.** Any percentage rule that uses the live fee feed re-introduces the very oracle dependence the threat model assumes is manipulable. A rule keyed only to `tradeAmount` avoids that, but reintroduces problem (2).
4. **The absolute ceiling already implies an amount-independent maximum.** 600 sat/vB × 600 vB ≈ the worst case for an honest, economically reasonable trade tx of any plausible size. The remaining gap is only the small-trade case, where relative caps are hardest to set safely.

Given these trade-offs, the safer near-term choice is the absolute envelope plus the dynamic tolerance check. An amount-relative cap is worth a follow-up — likely a piecewise rule (flat absolute cap below some amount threshold, percentage above it), tuned against measured Bisq deposit-tx sizes and historical fee data, with automatic widening during sustained congestion. That belongs in a separate change so it can be reviewed on its own merits.

---

### Sources

- [Bitcoin Optech — Default minimum transaction relay feerates](https://bitcoinops.org/en/topics/default-minimum-transaction-relay-feerates/)
- [Bitget News — Bitcoin Core 29.1 May Cut Default Relay Fee to 0.1 sat/vB](https://www.bitget.com/news/detail/12560604967589)
- [CoinDesk — Bitcoin Miners Reap Windfall as 'Runes' Debut Sends Transaction Fees to Record Highs (2024-04-21)](https://www.coindesk.com/tech/2024/04/21/bitcoin-miners-reap-windfall-as-runes-debut-sends-transaction-fees-to-record-highs)
- [Decrypt — Bitcoin Daily Transactions Hit All-Time High With 3 Million Ordinals Inscriptions](https://decrypt.co/138668/bitcoin-daily-fees-hit-all-time-high-with-3-million-ordinals-inscriptions)
- [mempool.space — Block fee rates (live and historical)](https://mempool.space/graphs/mining/block-fee-rates)


## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction fee validation to enforce explicit satoshi bounds (100–600,000) during trade transactions, preventing out-of-range fees from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction fee validation with defined minimum and maximum satoshi bounds (250–360,000 satoshis) to prevent invalid fee values during trade execution.

* **Tests**
  * Added comprehensive test coverage for transaction fee boundary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->