### PR TITLE
Remove flags for support of old bm versions

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -185,7 +185,7 @@ public class BurningManService {
                 .sum();
         burningManCandidates.forEach(candidate -> candidate.calculateShares(totalDecayedCompensationAmounts, totalDecayedBurnAmounts));
 
-        int numRoundsWithCapsApplied = imposeCaps(burningManCandidates, false);
+        int numRoundsWithCapsApplied = imposeCaps(burningManCandidates);
 
         double sumAllCappedBurnAmountShares = burningManCandidates.stream()
                 .filter(candidate -> candidate.getRoundCapped().isPresent())
@@ -346,7 +346,7 @@ public class BurningManService {
         return Math.round(amount * GENESIS_OUTPUT_AMOUNT_FACTOR);
     }
 
-    private static int imposeCaps(Collection<BurningManCandidate> burningManCandidates, boolean limitCappingRounds) {
+    private static int imposeCaps(Collection<BurningManCandidate> burningManCandidates) {
         List<BurningManCandidate> candidatesInDescendingBurnCapRatio = new ArrayList<>(burningManCandidates);
         candidatesInDescendingBurnCapRatio.sort(Comparator.comparing(BurningManCandidate::getBurnCapRatio).reversed());
         double thresholdBurnCapRatio = 1.0;
@@ -356,8 +356,7 @@ public class BurningManService {
         for (BurningManCandidate candidate : candidatesInDescendingBurnCapRatio) {
             double invScaleFactor = remainingBurnShare / remainingCapShare;
             double burnCapRatio = candidate.getBurnCapRatio();
-            if (remainingCapShare <= 0.0 || burnCapRatio <= 0.0 || burnCapRatio < invScaleFactor ||
-                    limitCappingRounds && burnCapRatio < 1.0) {
+            if (remainingCapShare <= 0.0 || burnCapRatio <= 0.0 || burnCapRatio < invScaleFactor) {
                 cappingRound++;
                 break;
             }

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -209,12 +209,9 @@ public class BurningManService {
         return daoStateService.getParamValue(Param.RECIPIENT_BTC_ADDRESS, chainHeight);
     }
 
-    List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight) {
-        return getActiveBurningManCandidates(chainHeight, false);
-    }
 
-    List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight, boolean limitCappingRounds) {
-        return getBurningManCandidatesByName(chainHeight, limitCappingRounds).values().stream()
+    List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight) {
+        return getBurningManCandidatesByName(chainHeight, false).values().stream()
                 .filter(burningManCandidate -> burningManCandidate.getCappedBurnAmountShare() > 0)
                 .filter(BurningManCandidate::isReceiverAddressValid)
                 .collect(Collectors.toList());

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManService.java
@@ -116,10 +116,6 @@ public class BurningManService {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     Map<String, BurningManCandidate> getBurningManCandidatesByName(int chainHeight) {
-        return getBurningManCandidatesByName(chainHeight, false);
-    }
-
-    Map<String, BurningManCandidate> getBurningManCandidatesByName(int chainHeight, boolean limitCappingRounds) {
         Map<String, BurningManCandidate> burningManCandidatesByName = new TreeMap<>();
         Map<P2PDataStorage.ByteArray, Set<TxOutput>> proofOfBurnOpReturnTxOutputByHash = getProofOfBurnOpReturnTxOutputByHash(chainHeight);
 
@@ -189,7 +185,7 @@ public class BurningManService {
                 .sum();
         burningManCandidates.forEach(candidate -> candidate.calculateShares(totalDecayedCompensationAmounts, totalDecayedBurnAmounts));
 
-        int numRoundsWithCapsApplied = imposeCaps(burningManCandidates, limitCappingRounds);
+        int numRoundsWithCapsApplied = imposeCaps(burningManCandidates, false);
 
         double sumAllCappedBurnAmountShares = burningManCandidates.stream()
                 .filter(candidate -> candidate.getRoundCapped().isPresent())
@@ -211,7 +207,7 @@ public class BurningManService {
 
 
     List<BurningManCandidate> getActiveBurningManCandidates(int chainHeight) {
-        return getBurningManCandidatesByName(chainHeight, false).values().stream()
+        return getBurningManCandidatesByName(chainHeight).values().stream()
                 .filter(burningManCandidate -> burningManCandidate.getCappedBurnAmountShare() > 0)
                 .filter(BurningManCandidate::isReceiverAddressValid)
                 .collect(Collectors.toList());

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -25,7 +25,6 @@ import bisq.core.dao.state.model.blockchain.Block;
 
 import bisq.common.config.Config;
 import bisq.common.util.Tuple2;
-import bisq.common.util.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -34,8 +33,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,13 +49,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Slf4j
 @Singleton
 public class DelayedPayoutTxReceiverService implements DaoStateListener {
-    // Activation date for bugfix of receiver addresses getting overwritten by a new compensation
-    // requests change address.
-    // See: https://github.com/bisq-network/bisq/issues/6699
-    public static final Date BUGFIX_6699_ACTIVATION_DATE = Utilities.getUTCDate(2023, GregorianCalendar.JULY, 24);
-    // See: https://github.com/bisq-network/proposals/issues/412
-    public static final Date PROPOSAL_412_ACTIVATION_DATE = Utilities.getUTCDate(2024, GregorianCalendar.MAY, 1);
-
     public static final int SNAPSHOT_SELECTION_GRID_SIZE = 10;
 
     // We don't allow to get further back than 767950 (the block height from Dec. 18th 2022).

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -117,8 +117,7 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
                                                    long inputAmount,
                                                    long tradeTxFee) {
         checkArgument(burningManSelectionHeight >= MIN_SNAPSHOT_HEIGHT, "Selection height must be >= " + MIN_SNAPSHOT_HEIGHT);
-        Collection<BurningManCandidate> burningManCandidates = burningManService.getActiveBurningManCandidates(burningManSelectionHeight,
-                false);
+        Collection<BurningManCandidate> burningManCandidates = burningManService.getActiveBurningManCandidates(burningManSelectionHeight);
 
         // We need to use the same txFeePerVbyte value for both traders.
         // We use the tradeTxFee value which is calculated from the average of taker fee tx size and deposit tx size.

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -112,20 +112,13 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
                 SNAPSHOT_SELECTION_GRID_SIZE);
     }
 
-    public List<Tuple2<Long, String>> getReceivers(int burningManSelectionHeight,
-                                                   long inputAmount,
-                                                   long tradeTxFee) {
-        return getReceivers(burningManSelectionHeight, inputAmount, tradeTxFee, true, true);
-    }
 
     public List<Tuple2<Long, String>> getReceivers(int burningManSelectionHeight,
                                                    long inputAmount,
-                                                   long tradeTxFee,
-                                                   boolean isBugfix6699Activated,
-                                                   boolean isProposal412Activated) {
+                                                   long tradeTxFee) {
         checkArgument(burningManSelectionHeight >= MIN_SNAPSHOT_HEIGHT, "Selection height must be >= " + MIN_SNAPSHOT_HEIGHT);
         Collection<BurningManCandidate> burningManCandidates = burningManService.getActiveBurningManCandidates(burningManSelectionHeight,
-                !isProposal412Activated);
+                false);
 
         // We need to use the same txFeePerVbyte value for both traders.
         // We use the tradeTxFee value which is calculated from the average of taker fee tx size and deposit tx size.
@@ -156,7 +149,7 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
         // We accumulate small amounts which gets filtered out and subtract it from 1 to get an adjustment factor
         // used later to be applied to the remaining burningmen share.
         double adjustment = 1 - burningManCandidates.stream()
-                .filter(candidate -> candidate.getReceiverAddress(isBugfix6699Activated).isPresent())
+                .filter(candidate -> candidate.getReceiverAddress(true).isPresent())
                 .mapToDouble(candidate -> {
                     double cappedBurnAmountShare = candidate.getCappedBurnAmountShare();
                     long amount = Math.round(cappedBurnAmountShare * spendableAmount);
@@ -168,11 +161,11 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
         //  amount just under 1000 sats or 64 * fee-rate could get erroneously included and lead to significant
         //  underpaying of the DPT (by perhaps around 5-10% per erroneously included output).
         List<Tuple2<Long, String>> receivers = burningManCandidates.stream()
-                .filter(candidate -> candidate.getReceiverAddress(isBugfix6699Activated).isPresent())
+                .filter(candidate -> candidate.getReceiverAddress(true).isPresent())
                 .map(candidate -> {
                     double cappedBurnAmountShare = candidate.getCappedBurnAmountShare() / adjustment;
                     return new Tuple2<>(Math.round(cappedBurnAmountShare * spendableAmount),
-                            candidate.getReceiverAddress(isBugfix6699Activated).get());
+                            candidate.getReceiverAddress(true).get());
                 })
                 .filter(tuple -> tuple.first >= minOutputAmount)
                 .filter(tuple -> tuple.first <= maxOutputAmount)

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -149,7 +149,7 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
         // We accumulate small amounts which gets filtered out and subtract it from 1 to get an adjustment factor
         // used later to be applied to the remaining burningmen share.
         double adjustment = 1 - burningManCandidates.stream()
-                .filter(candidate -> candidate.getReceiverAddress(true).isPresent())
+                .filter(candidate -> candidate.getReceiverAddress().isPresent())
                 .mapToDouble(candidate -> {
                     double cappedBurnAmountShare = candidate.getCappedBurnAmountShare();
                     long amount = Math.round(cappedBurnAmountShare * spendableAmount);
@@ -161,11 +161,11 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
         //  amount just under 1000 sats or 64 * fee-rate could get erroneously included and lead to significant
         //  underpaying of the DPT (by perhaps around 5-10% per erroneously included output).
         List<Tuple2<Long, String>> receivers = burningManCandidates.stream()
-                .filter(candidate -> candidate.getReceiverAddress(true).isPresent())
+                .filter(candidate -> candidate.getReceiverAddress().isPresent())
                 .map(candidate -> {
                     double cappedBurnAmountShare = candidate.getCappedBurnAmountShare() / adjustment;
                     return new Tuple2<>(Math.round(cappedBurnAmountShare * spendableAmount),
-                            candidate.getReceiverAddress(true).get());
+                            candidate.getReceiverAddress().get());
                 })
                 .filter(tuple -> tuple.first >= minOutputAmount)
                 .filter(tuple -> tuple.first <= maxOutputAmount)

--- a/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
+++ b/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
@@ -74,10 +74,6 @@ public class BurningManCandidate {
     public BurningManCandidate() {
     }
 
-    public Optional<String> getReceiverAddress() {
-        return receiverAddress;
-    }
-
     public void addBurnOutputModel(BurnOutputModel burnOutputModel) {
         if (burnOutputModels.contains(burnOutputModel)) {
             return;

--- a/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
+++ b/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
@@ -83,11 +83,7 @@ public class BurningManCandidate {
     }
 
     public Optional<String> getReceiverAddress() {
-        return getReceiverAddress(true);
-    }
-
-    public Optional<String> getReceiverAddress(boolean isBugfix6699Activated) {
-        return isBugfix6699Activated ? receiverAddress : mostRecentAddress;
+        return receiverAddress;
     }
 
     public void addBurnOutputModel(BurnOutputModel burnOutputModel) {

--- a/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
+++ b/core/src/main/java/bisq/core/dao/burningman/model/BurningManCandidate.java
@@ -58,14 +58,6 @@ public class BurningManCandidate {
     @Nullable
     private Boolean receiverAddressValid;
 
-    // For deploying a bugfix with mostRecentAddress we need to maintain the old version to avoid breaking the
-    // trade protocol. We use the legacy mostRecentAddress until the activation date where we
-    // enforce the version by the filter to ensure users have updated.
-    // See: https://github.com/bisq-network/bisq/issues/6699
-    @EqualsAndHashCode.Exclude
-    @Getter(AccessLevel.NONE)
-    protected Optional<String> mostRecentAddress = Optional.empty();
-
     private final Set<BurnOutputModel> burnOutputModels = new HashSet<>();
     private final Map<Date, Set<BurnOutputModel>> burnOutputModelsByMonth = new HashMap<>();
     private long accumulatedBurnAmount;
@@ -131,12 +123,6 @@ public class BurningManCandidate {
                             .thenComparing(CompensationModel::getAddress))
                     .map(CompensationModel::getAddress);
         }
-
-        // For backward compatibility reasons we need to maintain the old buggy version.
-        // See: https://github.com/bisq-network/bisq/issues/6699.
-        mostRecentAddress = compensationModels.stream()
-                .max(Comparator.comparing(CompensationModel::getHeight))
-                .map(CompensationModel::getAddress);
     }
 
     public boolean isReceiverAddressValid() {
@@ -228,7 +214,6 @@ public class BurningManCandidate {
                 ",\r\n     compensationShare=" + compensationShare +
                 ",\r\n     receiverAddress=" + receiverAddress +
                 ",\r\n     receiverAddressValid=" + isReceiverAddressValid() +
-                ",\r\n     mostRecentAddress=" + mostRecentAddress +
                 ",\r\n     burnOutputModels=" + burnOutputModels +
                 ",\r\n     accumulatedBurnAmount=" + accumulatedBurnAmount +
                 ",\r\n     accumulatedDecayedBurnAmount=" + accumulatedDecayedBurnAmount +

--- a/core/src/main/java/bisq/core/dao/burningman/model/LegacyBurningMan.java
+++ b/core/src/main/java/bisq/core/dao/burningman/model/LegacyBurningMan.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 @EqualsAndHashCode(callSuper = true)
 public final class LegacyBurningMan extends BurningManCandidate {
     public LegacyBurningMan(String address) {
-        receiverAddress = mostRecentAddress = Optional.of(address);
+        receiverAddress = Optional.of(address);
     }
 
     public void applyBurnAmountShare(double burnAmountShare) {

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -334,9 +334,7 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
         List<Tuple2<Long, String>> delayedPayoutTxReceivers = delayedPayoutTxReceiverService.getReceivers(
                 selectionHeight,
                 inputAmount,
-                dispute.getTradeTxFee(),
-                true,
-                true);
+                dispute.getTradeTxFee());
         log.info("Verify delayedPayoutTx using selectionHeight {} and receivers {}", selectionHeight, delayedPayoutTxReceivers);
         checkArgument(delayedPayoutTx.getOutputs().size() == delayedPayoutTxReceivers.size(),
                 "Size of outputs and delayedPayoutTxReceivers must be the same");

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -331,14 +331,12 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
         long inputAmount = depositTx.getOutput(0).getValue().value;
         int selectionHeight = dispute.getBurningManSelectionHeight();
 
-        boolean wasBugfix6699ActivatedAtTradeDate = dispute.getTradeDate().after(DelayedPayoutTxReceiverService.BUGFIX_6699_ACTIVATION_DATE);
-        boolean wasProposal412ActivatedAtTradeDate = dispute.getTradeDate().after(DelayedPayoutTxReceiverService.PROPOSAL_412_ACTIVATION_DATE);
         List<Tuple2<Long, String>> delayedPayoutTxReceivers = delayedPayoutTxReceiverService.getReceivers(
                 selectionHeight,
                 inputAmount,
                 dispute.getTradeTxFee(),
-                wasBugfix6699ActivatedAtTradeDate,
-                wasProposal412ActivatedAtTradeDate);
+                true,
+                true);
         log.info("Verify delayedPayoutTx using selectionHeight {} and receivers {}", selectionHeight, delayedPayoutTxReceivers);
         checkArgument(delayedPayoutTx.getOutputs().size() == delayedPayoutTxReceivers.size(),
                 "Size of outputs and delayedPayoutTxReceivers must be the same");

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -60,8 +60,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -143,9 +141,8 @@ public class BurningManServiceTest {
             addCompensationIssuanceAndPayloads(Arrays.asList(tuples));
         }
 
-        @ValueSource(booleans = {true, false})
-        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
-        public void testGetBurningManCandidatesByName_invalidReceiverAddresses(boolean limitCappingRounds) {
+        @Test
+        public void testGetBurningManCandidatesByName_invalidReceiverAddresses() {
             addCompensationIssuanceAndPayloads(
                     compensationIssuanceAndPayload("alice", "0000", 790000, 10000, VALID_P2SH_ADDRESS),
                     compensationIssuanceAndPayload("bob", "0001", 790000, 10000, VALID_P2WPKH_ADDRESS),
@@ -160,7 +157,7 @@ public class BurningManServiceTest {
                     proofOfBurnTx("dave", "1003", 790000, 10000),
                     proofOfBurnTx("earl", "1004", 790000, 10000)
             );
-            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
 
             assertEquals(0.11, candidateMap.get("alice").getMaxBoostedCompensationShare());
             assertEquals(0.11, candidateMap.get("bob").getMaxBoostedCompensationShare());
@@ -174,9 +171,8 @@ public class BurningManServiceTest {
             }));
         }
 
-        @ValueSource(booleans = {true, false})
-        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
-        public void testGetBurningManCandidatesByName_inactiveAndExpiredCandidates(boolean limitCappingRounds) {
+        @Test
+        public void testGetBurningManCandidatesByName_inactiveAndExpiredCandidates() {
             addCompensationIssuanceAndPayloads(
                     compensationIssuanceAndPayload("alice", "0000", 760000, 10000),
                     compensationIssuanceAndPayload("bob", "0001", 690000, 20000), // expired
@@ -188,7 +184,7 @@ public class BurningManServiceTest {
                     proofOfBurnTx("bob", "1001", 790000, 300000),
                     proofOfBurnTx("carol", "1002", 740000, 300000) // expired
             );
-            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
 
             assertEquals(0.11, candidateMap.get("alice").getMaxBoostedCompensationShare());
             assertEquals(0.0, candidateMap.get("bob").getMaxBoostedCompensationShare());
@@ -216,9 +212,8 @@ public class BurningManServiceTest {
             assertEquals(-1, candidateMap.get("dave").getRoundCapped().orElse(-1));
         }
 
-        @ValueSource(booleans = {true, false})
-        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
-        public void testGetBurningManCandidatesByName_capsSumToLessThanUnity_allCapped_oneCappingRoundNeeded(boolean limitCappingRounds) {
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToLessThanUnity_allCapped_oneCappingRoundNeeded() {
             addCompensationIssuanceAndPayloads(
                     compensationIssuanceAndPayload("alice", "0000", 760000, 10000),
                     compensationIssuanceAndPayload("bob", "0001", 770000, 20000)
@@ -227,7 +222,7 @@ public class BurningManServiceTest {
                     proofOfBurnTx("alice", "1000", 780000, 400000),
                     proofOfBurnTx("bob", "1001", 790000, 300000)
             );
-            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
 
             assertEquals(0.5, candidateMap.get("alice").getBurnAmountShare());
             assertEquals(0.5, candidateMap.get("bob").getBurnAmountShare());
@@ -242,9 +237,8 @@ public class BurningManServiceTest {
             assertEquals(0, candidateMap.get("bob").getRoundCapped().orElse(-1));
         }
 
-        @ValueSource(booleans = {true, false})
-        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
-        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_noneCapped_oneCappingRoundNeeded(boolean limitCappingRounds) {
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_noneCapped_oneCappingRoundNeeded() {
             addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
                     compensationIssuanceAndPayload("alice" + i, "000" + i, 710000, 100000)
             ).collect(Collectors.toList()));
@@ -253,7 +247,7 @@ public class BurningManServiceTest {
                     proofOfBurnTx("alice" + i, "100" + i, 760000, 400000)
             ).toArray(Tx[]::new));
 
-            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
 
             assertAll(IntStream.range(0, 10).mapToObj(i -> () -> {
                 var candidate = candidateMap.get("alice" + i);
@@ -265,9 +259,8 @@ public class BurningManServiceTest {
             }));
         }
 
-        @ValueSource(booleans = {true, false})
-        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
-        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_someCapped_twoCappingRoundsNeeded(boolean limitCappingRounds) {
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_someCapped_twoCappingRoundsNeeded() {
             addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
                     compensationIssuanceAndPayload("alice" + i, "000" + i, 710000, 100000)
             ).collect(Collectors.toList()));
@@ -276,7 +269,7 @@ public class BurningManServiceTest {
                     proofOfBurnTx("alice" + i, "100" + i, 760000, i < 6 ? 400000 : 200000)
             ).toArray(Tx[]::new));
 
-            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
 
             // Note the expected rounding error below. To prevent DPT verification failures, the
             // capping algorithm output must be well defined to the nearest floating point ULP.
@@ -294,9 +287,8 @@ public class BurningManServiceTest {
             assertEquals(1.0, burnShareTotal);
         }
 
-        @ValueSource(booleans = {true, false})
-        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
-        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_someCapped_threeCappingRoundsNeeded(boolean limitCappingRounds) {
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToMoreThanUnity_someCapped_threeCappingRoundsNeeded() {
             addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
                     compensationIssuanceAndPayload("alice" + i, "000" + i, 710000, i < 8 ? 123250 : 7000)
             ).collect(Collectors.toList()));
@@ -305,7 +297,7 @@ public class BurningManServiceTest {
                     proofOfBurnTx("alice" + i, "100" + i, 760000, i < 6 ? 400000 : 200000)
             ).toArray(Tx[]::new));
 
-            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
 
             // Note the expected rounding errors below. To prevent DPT verification failures, the
             // capping algorithm output must be well defined to the nearest floating point ULP.
@@ -313,30 +305,19 @@ public class BurningManServiceTest {
                 var candidate = candidateMap.get("alice" + i);
                 assertEquals(i < 8 ? 0.11 : 0.07, candidate.getMaxBoostedCompensationShare());
                 assertEquals(i < 6 ? 0.125 : 0.0625, candidate.getBurnAmountShare());
-                if (limitCappingRounds) {
-                    assertEquals(i < 6 ? 0.125 : 0.085, candidate.getAdjustedBurnAmountShare(), 1e-10);
-                    assertEquals(i < 6 ? 0.11 : i < 8 ? 0.08499999999999999 : 0.07, candidate.getCappedBurnAmountShare());
-                } else {
-                    assertEquals(i < 6 ? 0.125 : i < 8 ? 0.1 : 0.085, candidate.getAdjustedBurnAmountShare(), 1e-10);
-                    assertEquals(i < 6 ? 0.11 : i < 8 ? 0.09999999999999998 : 0.07, candidate.getCappedBurnAmountShare());
-                }
+                assertEquals(i < 6 ? 0.125 : i < 8 ? 0.1 : 0.085, candidate.getAdjustedBurnAmountShare(), 1e-10);
+                assertEquals(i < 6 ? 0.11 : i < 8 ? 0.09999999999999998 : 0.07, candidate.getCappedBurnAmountShare());
                 assertEquals(i < 6 ? 0 : i < 8 ? -1 : 1, candidate.getRoundCapped().orElse(-1));
             }));
-            // Three capping rounds are required to achieve a burn share total of 100%, but our
-            // algorithm only applies two when `limitCappingRounds` is true (that is, prior to
-            // the activation of the capping algorithm change), so 3% ends up going to the LBM in
-            // that case, instead of being distributed between `alice6` & `alice7`. The caps sum
-            // to more than 100%, however, so we could have avoided giving him any.
+            // Three capping rounds are required to achieve a burn share total of 100%.
             double capTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getMaxBoostedCompensationShare).sum();
             double burnShareTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getCappedBurnAmountShare).sum();
             assertEquals(1.02, capTotal);
-            assertEquals(limitCappingRounds ? 0.97 : 1.0, burnShareTotal);
+            assertEquals(1.0, burnShareTotal);
         }
 
-        @ValueSource(booleans = {true, false})
-        @ParameterizedTest(name = "[{index}] limitCappingRounds={0}")
-        public void testGetBurningManCandidatesByName_capsSumToLessThanUnity_allShouldBeCapped_fourCappingRoundsNeeded(
-                boolean limitCappingRounds) {
+        @Test
+        public void testGetBurningManCandidatesByName_capsSumToLessThanUnity_allShouldBeCapped_fourCappingRoundsNeeded() {
             addCompensationIssuanceAndPayloads(IntStream.range(0, 10).mapToObj(i ->
                     compensationIssuanceAndPayload("alice" + i, "000" + i, 710000,
                             i < 6 ? 483200 : i == 6 ? 31800 : i == 7 ? 27000 : 21000)
@@ -346,7 +327,7 @@ public class BurningManServiceTest {
                     proofOfBurnTx("alice" + i, "100" + i, 760000, i < 6 ? 400000 : 200000)
             ).toArray(Tx[]::new));
 
-            var candidateMap = burningManService.getBurningManCandidatesByName(800000, limitCappingRounds);
+            var candidateMap = burningManService.getBurningManCandidatesByName(800000);
 
             // Note the expected rounding error below. To prevent DPT verification failures, the
             // capping algorithm output must be well defined to the nearest floating point ULP.
@@ -354,26 +335,16 @@ public class BurningManServiceTest {
                 var candidate = candidateMap.get("alice" + i);
                 assertEquals(i < 6 ? 0.11 : i == 6 ? 0.106 : i == 7 ? 0.09 : 0.07, candidate.getMaxBoostedCompensationShare());
                 assertEquals(i < 6 ? 0.125 : 0.0625, candidate.getBurnAmountShare());
-                if (limitCappingRounds) {
-                    assertEquals(i < 6 ? 0.125 : 0.085, candidate.getAdjustedBurnAmountShare(), 1e-10);
-                    assertEquals(i < 6 ? 0.11 : i < 8 ? 0.08499999999999999 : 0.07, candidate.getCappedBurnAmountShare());
-                    assertEquals(i < 6 ? 0 : i < 8 ? -1 : 1, candidate.getRoundCapped().orElse(-1));
-                } else {
-                    assertEquals(i < 6 ? 0.125 : i == 6 ? 0.11 : i == 7 ? 0.1 : 0.085, candidate.getAdjustedBurnAmountShare(), 1e-10);
-                    assertEquals(candidate.getMaxBoostedCompensationShare(), candidate.getCappedBurnAmountShare());
-                    assertEquals(i < 6 ? 0 : i == 6 ? 3 : i == 7 ? 2 : 1, candidate.getRoundCapped().orElse(-1));
-                }
+                assertEquals(i < 6 ? 0.125 : i == 6 ? 0.11 : i == 7 ? 0.1 : 0.085, candidate.getAdjustedBurnAmountShare(), 1e-10);
+                assertEquals(candidate.getMaxBoostedCompensationShare(), candidate.getCappedBurnAmountShare());
+                assertEquals(i < 6 ? 0 : i == 6 ? 3 : i == 7 ? 2 : 1, candidate.getRoundCapped().orElse(-1));
             }));
             // Four capping rounds are required to achieve a maximum possible burn share total of
-            // 99.6%, with all the contributors being capped. But our algorithm only applies two
-            // rounds when `limitCappingRounds` is true (that is, prior to the activation of the
-            // capping algorithm change), so 3% ends up going to the LBM in that case, instead of
-            // the minimum possible amount of 0.4% (100% less the cap sum). Contributors `alice6`
-            // & `alice7` therefore receive less than they could have done.
+            // 99.6%, with all the contributors being capped.
             double capTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getMaxBoostedCompensationShare).sum();
             double burnShareTotal = candidateMap.values().stream().mapToDouble(BurningManCandidate::getCappedBurnAmountShare).sum();
             assertEquals(0.996, capTotal);
-            assertEquals(limitCappingRounds ? 0.97 : capTotal, burnShareTotal);
+            assertEquals(capTotal, burnShareTotal);
         }
     }
 


### PR DESCRIPTION
Access to related methods is only from trades, not from persisted historical data. Thus it is safe to remove those flags and activation data lies long back. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Burning Man receiver selection by removing legacy compatibility code and consolidating method variants, reducing complexity while maintaining existing reward distribution functionality.
  * Streamlined candidate generation logic and removed date-based branching from receiver address selection.

* **Tests**
  * Updated tests to reflect simplified receiver selection behavior and candidate generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->