### PR TITLE
Reject non-P2WPKH maker inputs and non-default sequence/lockTime

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -1315,10 +1315,6 @@ public class TradeWalletService {
                 Coin.valueOf(rawTransactionInput.value));
     }
 
-    public boolean isP2WH(RawTransactionInput rawTransactionInput) {
-        return WalletUtils.isP2WH(rawTransactionInput, params);
-    }
-
     // TODO: Once we have removed legacy arbitrator from dispute domain we can remove that method as well.
     // Atm it is still used by traderSignAndFinalizeDisputedPayoutTx which is used by ArbitrationManager.
 

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -841,8 +841,8 @@ public abstract class WalletService {
                 ScriptPattern.isP2WH(output.getScriptPubKey());
     }
 
-    public boolean isP2WH(RawTransactionInput rawTransactionInput) {
-        return WalletUtils.isP2WH(rawTransactionInput, params);
+    public boolean isP2WPKH(RawTransactionInput rawTransactionInput) {
+        return WalletUtils.isP2WPKH(rawTransactionInput, params);
     }
 
     @Nullable

--- a/core/src/main/java/bisq/core/btc/wallet/WalletUtils.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletUtils.java
@@ -33,7 +33,11 @@ public final class WalletUtils {
     private WalletUtils() {
     }
 
-    public static boolean isP2WH(RawTransactionInput rawTransactionInput, NetworkParameters params) {
+    /**
+     * Strict P2WPKH check. The Bisq trade-protocol funding path is canonically P2WPKH; any
+     * other shape (P2WSH, legacy P2PKH, P2SH-wrapped) is non-canonical for this path.
+     */
+    public static boolean isP2WPKH(RawTransactionInput rawTransactionInput, NetworkParameters params) {
         try {
             TransactionOutput connectedOutput = getConnectedOutPoint(rawTransactionInput, params).getConnectedOutput();
             if (connectedOutput == null) {
@@ -43,9 +47,9 @@ public final class WalletUtils {
             if (scriptPubKey == null) {
                 return false;
             }
-            return ScriptPattern.isP2WH(scriptPubKey);
+            return ScriptPattern.isP2WPKH(scriptPubKey);
         } catch (Exception e) {
-            log.error("isP2WH check failed", e);
+            log.error("isP2WPKH check failed", e);
             return false;
         }
     }

--- a/core/src/main/java/bisq/core/trade/bisq_v1/TradeDataValidation.java
+++ b/core/src/main/java/bisq/core/trade/bisq_v1/TradeDataValidation.java
@@ -17,7 +17,9 @@
 
 package bisq.core.trade.bisq_v1;
 
+import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.WalletUtils;
 import bisq.core.offer.Offer;
 import bisq.core.support.dispute.DisputeValidation;
 import bisq.core.trade.model.bisq_v1.Trade;
@@ -28,6 +30,7 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
+import java.util.List;
 
 import java.util.function.Consumer;
 
@@ -159,12 +162,103 @@ public class TradeDataValidation {
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
+    // Bitcoin tx structural checks
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Throws if the tx has a non-zero lockTime. Strictly, lockTime is ignored when every
+     * input has a final sequence (0xffffffff), so a non-zero lockTime alone does not always
+     * delay mining. We still require lockTime == 0 as a canonical-form / policy invariant:
+     * any non-zero value is non-canonical for this path and a peer setting one would be
+     * either buggy or trying to deviate from the protocol-specified shape.
+     */
+    public static void assertLockTimeIsZero(Transaction tx) throws InvalidTxException {
+        if (tx.getLockTime() != 0) {
+            throw new InvalidTxException("Transaction must have lockTime == 0, got " + tx.getLockTime());
+        }
+    }
+
+    /**
+     * Throws unless every input has BIP125 opt-in RBF disabled (sequence == NO_SEQUENCE - 1
+     * or NO_SEQUENCE). Any lower value opts in to RBF, which lets a third party (or the peer)
+     * replace the broadcast tx with a different one before it confirms — so the txid that
+     * lands on chain may not be the txid we signed for in any downstream binding.
+     */
+    public static void assertInputSequencesDisableRbf(Transaction tx) throws InvalidTxException {
+        for (TransactionInput txIn : tx.getInputs()) {
+            long seq = txIn.getSequenceNumber();
+            if (seq != TransactionInput.NO_SEQUENCE - 1 && seq != TransactionInput.NO_SEQUENCE) {
+                throw new InvalidTxException("Transaction input has RBF-enabled sequence: " + seq);
+            }
+        }
+    }
+
+    /**
+     * Throws unless the tx is version 1. Bisq deposit txs are constructed by bitcoinj at the
+     * default version (1) and have no need for v2 semantics (no relative-locktime / BIP68
+     * use). The version field is part of the serialized tx and therefore part of the txid,
+     * so a peer-supplied tx at any other version would still hash differently than what we
+     * expect. Rejecting non-v1 keeps the funding path canonical and removes a degree of
+     * freedom a peer could otherwise wiggle without us noticing.
+     */
+    public static void assertVersionIsOne(Transaction tx) throws InvalidTxException {
+        if (tx.getVersion() != 1) {
+            throw new InvalidTxException("Transaction must be version 1, got " + tx.getVersion());
+        }
+    }
+
+    /**
+     * Bundles the canonical-shape checks the taker runs against the maker's prepared
+     * deposit tx: version == 1, lockTime == 0, no input opts in to RBF, and every
+     * peer-supplied funding input is P2WPKH. Centralised so both buyer-as-taker and
+     * seller-as-taker apply the same policy (single point to extend with future checks).
+     */
+    public static void assertCanonicalDepositTxShape(Transaction makersDepositTx,
+                                                     List<RawTransactionInput> peerInputs,
+                                                     NetworkParameters params) throws InvalidTxException {
+        assertVersionIsOne(makersDepositTx);
+        assertLockTimeIsZero(makersDepositTx);
+        assertInputSequencesDisableRbf(makersDepositTx);
+        assertAllInputsAreP2WPKH(peerInputs, params);
+    }
+
+    /**
+     * Throws unless every supplied funding input refers to a P2WPKH UTXO. Two reasons:
+     *   - Legacy P2PKH and P2SH-wrapped scripts carry a malleable scriptSig, which is part
+     *     of the txid. A third party can re-sign and rebroadcast with a different txid
+     *     before confirmation, breaking any downstream binding to the original txid.
+     *   - P2WSH (native segwit) is not malleable in that sense, but it allows arbitrary
+     *     peer-controlled script semantics and unpredictable vsize. The Bisq trade-protocol
+     *     funding path is canonically P2WPKH; anything else is non-standard for this path.
+     */
+    public static void assertAllInputsAreP2WPKH(List<RawTransactionInput> inputs,
+                                                NetworkParameters params) throws InvalidTxException {
+        for (RawTransactionInput input : inputs) {
+            if (input == null) {
+                throw new InvalidTxException("Funding input must not be null");
+            }
+            if (!WalletUtils.isP2WPKH(input, params)) {
+                // Avoid re-parsing parentTransaction here — it may be malformed (which is
+                // exactly why isP2WPKH returned false). Surface only the fields we already
+                // hold on the RawTransactionInput.
+                throw new InvalidTxException("Funding input is not P2WPKH (input index="
+                        + input.index + ")");
+            }
+        }
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
     // Exceptions
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static class ValidationException extends Exception {
         ValidationException(String msg) {
             super(msg);
+        }
+
+        ValidationException(String msg, Throwable cause) {
+            super(msg, cause);
         }
     }
 
@@ -177,6 +271,10 @@ public class TradeDataValidation {
     public static class InvalidTxException extends ValidationException {
         InvalidTxException(String msg) {
             super(msg);
+        }
+
+        InvalidTxException(String msg, Throwable cause) {
+            super(msg, cause);
         }
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerVerifiesPreparedDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerVerifiesPreparedDelayedPayoutTx.java
@@ -96,7 +96,10 @@ public class BuyerVerifiesPreparedDelayedPayoutTx extends TradeTask {
         var buyerInputs = checkNotNull(processModel.getRawTransactionInputs());
         var sellerInputs = checkNotNull(processModel.getTradePeer().getRawTransactionInputs());
 
-        return buyerInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH) &&
-                sellerInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH);
+        // P2WPKH is the only canonical Bisq funding shape. Both sides' inputs being P2WPKH
+        // is sufficient for a non-malleable txid, and matches the policy enforced upstream
+        // in the deposit-tx construction and signing tasks.
+        return buyerInputs.stream().allMatch(processModel.getBtcWalletService()::isP2WPKH) &&
+                sellerInputs.stream().allMatch(processModel.getBtcWalletService()::isP2WPKH);
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
@@ -71,8 +71,6 @@ public class BuyerAsMakerCreatesAndSignsDepositTx extends TradeTask {
                     .add(tradeAmount);
 
             List<RawTransactionInput> takerRawTransactionInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
-            checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
-                    "all takerRawTransactionInputs must be P2WH");
             Coin expectedTakersInputAmount = offer.getSellerSecurityDeposit()
                     .add(tradeAmount)
                     .add(trade.getTradeTxFee().multiply(2));

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
@@ -22,6 +22,7 @@ import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
+import bisq.core.trade.bisq_v1.TradeDataValidation;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
@@ -92,6 +93,7 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
                     offer.getAmount(),
                     checkNotNull(trade.getAmount()),
                     sellerInputs);
+            TradeDataValidation.assertCanonicalDepositTxShape(makersDepositTx, sellerInputs, walletService.getParams());
 
             Transaction depositTx = processModel.getTradeWalletService().takerSignsDepositTx(
                     false,
@@ -107,6 +109,12 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
 
             complete();
         } catch (Throwable t) {
+            // The multisig lock may have been set above before this throw; release it so the
+            // funds are not stuck "locked in multisig" against a trade that never proceeds.
+            // Idempotent — a no-op if the lock was never taken.
+            // Use the persisted offerId, not processModel.getOffer() — the latter is transient and
+            // may be null if this task fails before the offer was reattached on a restart.
+            processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(processModel.getOfferId());
             failed(t);
         }
     }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
@@ -80,8 +80,6 @@ public class SellerAsMakerCreatesUnsignedDepositTx extends TradeTask {
                     .add(offer.getBuyerSecurityDeposit());
 
             List<RawTransactionInput> takerRawTransactionInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
-            checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
-                    "all takerRawTransactionInputs must be P2WH");
             Coin expectedTakersInputAmount = offer.getBuyerSecurityDeposit()
                     .add(trade.getTradeTxFee().multiply(2));
             TradePeerTxInputValidator.validatePeersInputs(takerRawTransactionInputs,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
@@ -22,6 +22,7 @@ import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
+import bisq.core.trade.bisq_v1.TradeDataValidation;
 import bisq.core.trade.model.bisq_v1.Contract;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
@@ -80,6 +81,7 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
             List<RawTransactionInput> buyerInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
             Transaction makersDepositTx = new Transaction(walletService.getParams(), checkNotNull(processModel.getPreparedDepositTx()));
             verifyPreparedDepositTxFromBuyerAsMaker(makersDepositTx);
+            TradeDataValidation.assertCanonicalDepositTxShape(makersDepositTx, buyerInputs, walletService.getParams());
 
             Transaction depositTx = processModel.getTradeWalletService().takerSignsDepositTx(
                     true,
@@ -97,6 +99,12 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
 
             complete();
         } catch (Throwable t) {
+            // The multisig lock may have been set above before this throw; release it so the
+            // funds are not stuck "locked in multisig" against a trade that never proceeds.
+            // Idempotent — a no-op if the lock was never taken.
+            // Use the persisted offerId, not processModel.getOffer() — the latter is transient and
+            // may be null if this task fails before the offer was reattached on a restart.
+            processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(processModel.getOfferId());
             Contract contract = trade.getContract();
             if (contract != null)
                 contract.printDiff(processModel.getTradePeer().getContractAsJson());

--- a/core/src/main/java/bisq/core/trade/validation/TradePeerTxInputValidator.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradePeerTxInputValidator.java
@@ -52,7 +52,8 @@ public final class TradePeerTxInputValidator {
             checkNotNull(input, "%s raw transaction input must not be null", peerRole);
             checkArgument(input.value > 0, "%s raw transaction input value must be positive", peerRole);
             input.validate(walletService);
-            checkArgument(walletService.isP2WH(input), "%s input must be P2WH", peerRole);
+            // Strict P2WPKH only — a peer cannot supply a script-controlled funding input.
+            checkArgument(walletService.isP2WPKH(input), "%s input must be P2WPKH", peerRole);
             inputValue = Math.addExact(inputValue, input.value);
         }
         return inputValue;

--- a/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
@@ -1001,7 +1001,7 @@ public class TradeValidationTest {
         transaction.addOutput(inputAmount, ScriptBuilder.createP2WPKHOutputScript(new ECKey()));
 
         when(btcWalletService.getTxFromSerializedTx(parentTransaction)).thenReturn(transaction);
-        when(btcWalletService.isP2WH(rawTransactionInput)).thenReturn(true);
+        when(btcWalletService.isP2WPKH(rawTransactionInput)).thenReturn(true);
 
         return List.of(rawTransactionInput);
     }


### PR DESCRIPTION
same as https://github.com/bisq-network/bisq/pull/7648
to see if it's a bug that causes CI failure or not


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 1.9.24

**New Features**
- Added market price validation for offers to prevent trading at prices outside acceptable tolerance ranges.
- Implemented maximum trade amount cap of 0.125 BTC for enhanced risk management.
- Added warnings for offers with invalid prices to guide user decision-making.

**Improvements**
- Enhanced transaction validation for improved security and reliability.
- Strengthened trade fee calculation and validation mechanisms.

**Chores**
- Updated application version with improved cryptographic key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->