### PR TITLE
Reject non-P2WPKH maker inputs and non-default sequence/lockTime

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -486,7 +486,7 @@ public class TradeWalletService {
 
 
         // Add MultiSig output
-        Script hashedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey, false);
+        Script hashedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey);
 
         // Tx fee for deposit tx will be paid by buyer.
         TransactionOutput hashedMultiSigOutput = new TransactionOutput(params, preparedDepositTx, msOutputAmount,
@@ -549,7 +549,7 @@ public class TradeWalletService {
         checkArgument(!sellerInputs.isEmpty());
 
         // Check if maker's MultiSig script is identical to the taker's
-        Script hashedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey, false);
+        Script hashedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey);
         if (!makersDepositTx.getOutput(0).getScriptPubKey().equals(hashedMultiSigOutputScript)) {
             throw new TransactionVerificationException("Maker's hashedMultiSigOutputScript does not match taker's hashedMultiSigOutputScript");
         }
@@ -742,7 +742,7 @@ public class TradeWalletService {
         }
         // SegWit validation in Script.correctlySpends is incomplete, as it only checks the witness of P2WPKH inputs.
         // Therefore, we must manually verify both signatures ourselves against the computed sigHash.
-        Script scriptPubKey = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey, false);
+        Script scriptPubKey = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey);
         input.getScriptSig().correctlySpends(delayedPayoutTx, 0, witness, inputValue, scriptPubKey, Script.ALL_VERIFY_FLAGS);
         Sha256Hash sigHash = delayedPayoutTx.hashForWitnessSignature(0, redeemScript,
                 inputValue, Transaction.SigHash.ALL, false);
@@ -1316,8 +1316,8 @@ public class TradeWalletService {
                 Coin.valueOf(rawTransactionInput.value));
     }
 
-    public boolean isP2WH(RawTransactionInput rawTransactionInput) {
-        return WalletUtils.isP2WH(rawTransactionInput, params);
+    public boolean isP2WPKH(RawTransactionInput rawTransactionInput) {
+        return WalletUtils.isP2WPKH(rawTransactionInput, params);
     }
 
     // TODO: Once we have removed legacy arbitrator from dispute domain we can remove that method as well.
@@ -1349,13 +1349,9 @@ public class TradeWalletService {
         return ScriptBuilder.createMultiSigOutputScript(2, keys);
     }
 
-    private Script get2of2MultiSigOutputScript(byte[] buyerPubKey, byte[] sellerPubKey, boolean legacy) {
+    private Script get2of2MultiSigOutputScript(byte[] buyerPubKey, byte[] sellerPubKey) {
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
-        if (legacy) {
-            return ScriptBuilder.createP2SHOutputScript(redeemScript);
-        } else {
-            return ScriptBuilder.createP2WSHOutputScript(redeemScript);
-        }
+        return ScriptBuilder.createP2WSHOutputScript(redeemScript);
     }
 
     private Transaction createPayoutTx(Transaction depositTx,

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -841,8 +841,8 @@ public abstract class WalletService {
                 ScriptPattern.isP2WH(output.getScriptPubKey());
     }
 
-    public boolean isP2WH(RawTransactionInput rawTransactionInput) {
-        return WalletUtils.isP2WH(rawTransactionInput, params);
+    public boolean isP2WPKH(RawTransactionInput rawTransactionInput) {
+        return WalletUtils.isP2WPKH(rawTransactionInput, params);
     }
 
     @Nullable

--- a/core/src/main/java/bisq/core/btc/wallet/WalletUtils.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletUtils.java
@@ -33,7 +33,11 @@ public final class WalletUtils {
     private WalletUtils() {
     }
 
-    public static boolean isP2WH(RawTransactionInput rawTransactionInput, NetworkParameters params) {
+    /**
+     * Strict P2WPKH check. The Bisq trade-protocol funding path is canonically P2WPKH; any
+     * other shape (P2WSH, legacy P2PKH, P2SH-wrapped) is non-canonical for this path.
+     */
+    public static boolean isP2WPKH(RawTransactionInput rawTransactionInput, NetworkParameters params) {
         try {
             TransactionOutput connectedOutput = getConnectedOutPoint(rawTransactionInput, params).getConnectedOutput();
             if (connectedOutput == null) {
@@ -43,9 +47,9 @@ public final class WalletUtils {
             if (scriptPubKey == null) {
                 return false;
             }
-            return ScriptPattern.isP2WH(scriptPubKey);
+            return ScriptPattern.isP2WPKH(scriptPubKey);
         } catch (Exception e) {
-            log.error("isP2WH check failed", e);
+            log.error("isP2WPKH check failed", e);
             return false;
         }
     }

--- a/core/src/main/java/bisq/core/trade/bisq_v1/TradeDataValidation.java
+++ b/core/src/main/java/bisq/core/trade/bisq_v1/TradeDataValidation.java
@@ -17,7 +17,9 @@
 
 package bisq.core.trade.bisq_v1;
 
+import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.WalletUtils;
 import bisq.core.offer.Offer;
 import bisq.core.support.dispute.DisputeValidation;
 import bisq.core.trade.model.bisq_v1.Trade;
@@ -29,6 +31,7 @@ import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -159,12 +162,105 @@ public class TradeDataValidation {
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
+    // Bitcoin tx structural checks
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Throws if the tx has a non-zero lockTime. Strictly, lockTime is ignored when every
+     * input has a final sequence (0xffffffff), so a non-zero lockTime alone does not always
+     * delay mining. We still require lockTime == 0 as a canonical-form / policy invariant:
+     * any non-zero value is non-canonical for this path and a peer setting one would be
+     * either buggy or trying to deviate from the protocol-specified shape.
+     */
+    public static void assertLockTimeIsZero(Transaction tx) throws InvalidTxException {
+        if (tx.getLockTime() != 0) {
+            throw new InvalidTxException("Transaction must have lockTime == 0, got " + tx.getLockTime());
+        }
+    }
+
+    /**
+     * Throws unless every input has BIP125 opt-in RBF disabled (sequence == NO_SEQUENCE - 1
+     * or NO_SEQUENCE). Any lower value opts in to RBF, which lets a third party (or the peer)
+     * replace the broadcast tx with a different one before it confirms — so the txid that
+     * lands on chain may not be the txid we signed for in any downstream binding.
+     */
+    public static void assertInputSequencesDisableRbf(Transaction tx) throws InvalidTxException {
+        for (TransactionInput txIn : tx.getInputs()) {
+            long seq = txIn.getSequenceNumber();
+            if (seq != TransactionInput.NO_SEQUENCE - 1 && seq != TransactionInput.NO_SEQUENCE) {
+                throw new InvalidTxException("Transaction input has RBF-enabled sequence: " + seq);
+            }
+        }
+    }
+
+    /**
+     * Throws unless the tx is version 1. Bisq deposit txs are constructed by bitcoinj at the
+     * default version (1) and have no need for v2 semantics (no relative-locktime / BIP68
+     * use). The version field is part of the serialized tx and therefore part of the txid,
+     * so a peer-supplied tx at any other version would still hash differently than what we
+     * expect. Rejecting non-v1 keeps the funding path canonical and removes a degree of
+     * freedom a peer could otherwise wiggle without us noticing.
+     */
+    public static void assertVersionIsOne(Transaction tx) throws InvalidTxException {
+        if (tx.getVersion() != 1) {
+            throw new InvalidTxException("Transaction must be version 1, got " + tx.getVersion());
+        }
+    }
+
+    /**
+     * Bundles the canonical-shape checks the taker runs against the maker's prepared
+     * deposit tx: version == 1, lockTime == 0, no input opts in to RBF, and every
+     * peer-supplied funding input is P2WPKH. Centralised so both buyer-as-taker and
+     * seller-as-taker apply the same policy (single point to extend with future checks).
+     */
+    public static void assertCanonicalDepositTxShape(Transaction makersDepositTx,
+                                                     List<RawTransactionInput> peerInputs,
+                                                     NetworkParameters params) throws InvalidTxException {
+        assertVersionIsOne(makersDepositTx);
+        assertLockTimeIsZero(makersDepositTx);
+        assertInputSequencesDisableRbf(makersDepositTx);
+        assertAllInputsAreP2WPKH(peerInputs, params);
+    }
+
+    /**
+     * Throws unless every supplied funding input refers to a P2WPKH UTXO. Two reasons:
+     *   - Legacy P2PKH and P2SH-wrapped scripts carry a malleable scriptSig, which is part
+     *     of the txid. A third party can re-sign and rebroadcast with a different txid
+     *     before confirmation, breaking any downstream binding to the original txid.
+     *   - P2WSH (native segwit) is not malleable in that sense, but it allows arbitrary
+     *     peer-controlled script semantics and unpredictable vsize. The Bisq trade-protocol
+     *     funding path is canonically P2WPKH; anything else is non-standard for this path.
+     */
+    public static void assertAllInputsAreP2WPKH(List<RawTransactionInput> inputs,
+                                                NetworkParameters params) throws InvalidTxException {
+        for (RawTransactionInput input : inputs) {
+            if (input == null) {
+                throw new InvalidTxException("Funding input must not be null");
+            }
+            if (!WalletUtils.isP2WPKH(input, params)) {
+                // Avoid re-parsing parentTransaction here — it may be malformed (which is
+                // exactly why isP2WPKH returned false). Surface only the fields we already
+                // hold on the RawTransactionInput.
+                throw new InvalidTxException("Funding input " + input.index +
+                        " is not native segwit P2WPKH (bech32: bc1q on mainnet, tb1q on testnet, bcrt1q on regtest). " +
+                        "Bisq v1 trades require P2WPKH UTXOs; legacy P2PKH, P2SH-wrapped, and P2WSH inputs are rejected. " +
+                        "Move funds to a native segwit address and retry.");
+            }
+        }
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
     // Exceptions
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static class ValidationException extends Exception {
         ValidationException(String msg) {
             super(msg);
+        }
+
+        ValidationException(String msg, Throwable cause) {
+            super(msg, cause);
         }
     }
 
@@ -177,6 +273,10 @@ public class TradeDataValidation {
     public static class InvalidTxException extends ValidationException {
         InvalidTxException(String msg) {
             super(msg);
+        }
+
+        InvalidTxException(String msg, Throwable cause) {
+            super(msg, cause);
         }
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_maker/BuyerAsMakerCreatesAndSignsDepositTx.java
@@ -71,8 +71,6 @@ public class BuyerAsMakerCreatesAndSignsDepositTx extends TradeTask {
                     .add(tradeAmount);
 
             List<RawTransactionInput> takerRawTransactionInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
-            checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
-                    "all takerRawTransactionInputs must be P2WH");
             Coin expectedTakersInputAmount = offer.getSellerSecurityDeposit()
                     .add(tradeAmount)
                     .add(trade.getTradeTxFee().multiply(2));

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer_as_taker/BuyerAsTakerSignsDepositTx.java
@@ -22,6 +22,7 @@ import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
+import bisq.core.trade.bisq_v1.TradeDataValidation;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
@@ -92,6 +93,7 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
                     offer.getAmount(),
                     checkNotNull(trade.getAmount()),
                     sellerInputs);
+            TradeDataValidation.assertCanonicalDepositTxShape(makersDepositTx, sellerInputs, walletService.getParams());
 
             Transaction depositTx = processModel.getTradeWalletService().takerSignsDepositTx(
                     false,
@@ -107,6 +109,12 @@ public class BuyerAsTakerSignsDepositTx extends TradeTask {
 
             complete();
         } catch (Throwable t) {
+            // The multisig lock may have been set above before this throw; release it so the
+            // funds are not stuck "locked in multisig" against a trade that never proceeds.
+            // Idempotent — a no-op if the lock was never taken.
+            // Use the persisted offerId, not processModel.getOffer() — the latter is transient and
+            // may be null if this task fails before the offer was reattached on a restart.
+            processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(processModel.getOfferId());
             failed(t);
         }
     }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_maker/SellerAsMakerCreatesUnsignedDepositTx.java
@@ -80,8 +80,6 @@ public class SellerAsMakerCreatesUnsignedDepositTx extends TradeTask {
                     .add(offer.getBuyerSecurityDeposit());
 
             List<RawTransactionInput> takerRawTransactionInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
-            checkArgument(takerRawTransactionInputs.stream().allMatch(processModel.getTradeWalletService()::isP2WH),
-                    "all takerRawTransactionInputs must be P2WH");
             Coin expectedTakersInputAmount = offer.getBuyerSecurityDeposit()
                     .add(trade.getTradeTxFee().multiply(2));
             TradePeerTxInputValidator.validatePeersInputs(takerRawTransactionInputs,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller_as_taker/SellerAsTakerSignsDepositTx.java
@@ -22,6 +22,7 @@ import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.exceptions.TransactionVerificationException;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.Offer;
+import bisq.core.trade.bisq_v1.TradeDataValidation;
 import bisq.core.trade.model.bisq_v1.Contract;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
@@ -80,6 +81,7 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
             List<RawTransactionInput> buyerInputs = checkNotNull(tradingPeer.getRawTransactionInputs());
             Transaction makersDepositTx = new Transaction(walletService.getParams(), checkNotNull(processModel.getPreparedDepositTx()));
             verifyPreparedDepositTxFromBuyerAsMaker(makersDepositTx);
+            TradeDataValidation.assertCanonicalDepositTxShape(makersDepositTx, buyerInputs, walletService.getParams());
 
             Transaction depositTx = processModel.getTradeWalletService().takerSignsDepositTx(
                     true,
@@ -97,6 +99,12 @@ public class SellerAsTakerSignsDepositTx extends TradeTask {
 
             complete();
         } catch (Throwable t) {
+            // The multisig lock may have been set above before this throw; release it so the
+            // funds are not stuck "locked in multisig" against a trade that never proceeds.
+            // Idempotent — a no-op if the lock was never taken.
+            // Use the persisted offerId, not processModel.getOffer() — the latter is transient and
+            // may be null if this task fails before the offer was reattached on a restart.
+            processModel.getBtcWalletService().resetCoinLockedInMultiSigAddressEntry(processModel.getOfferId());
             Contract contract = trade.getContract();
             if (contract != null)
                 contract.printDiff(processModel.getTradePeer().getContractAsJson());

--- a/core/src/main/java/bisq/core/trade/validation/TradePeerTxInputValidator.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradePeerTxInputValidator.java
@@ -52,7 +52,12 @@ public final class TradePeerTxInputValidator {
             checkNotNull(input, "%s raw transaction input must not be null", peerRole);
             checkArgument(input.value > 0, "%s raw transaction input value must be positive", peerRole);
             input.validate(walletService);
-            checkArgument(walletService.isP2WH(input), "%s input must be P2WH", peerRole);
+            // Strict P2WPKH only — a peer cannot supply a script-controlled funding input.
+            checkArgument(walletService.isP2WPKH(input),
+                    "%s funding input is not native segwit P2WPKH (bech32: bc1q on mainnet, tb1q on testnet, bcrt1q on regtest). " +
+                            "Bisq v1 trades require P2WPKH UTXOs; legacy P2PKH, P2SH-wrapped, and P2WSH inputs are rejected. " +
+                            "Move funds to a native segwit address and retry.",
+                    peerRole);
             inputValue = Math.addExact(inputValue, input.value);
         }
         return inputValue;

--- a/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
@@ -364,7 +364,7 @@ public class TradeValidation {
                                                                                      TradeWalletService tradeWalletService) {
         checkNotNull(rawTransactionInputs, "rawTransactionInputs must not be null");
         checkNotNull(tradeWalletService, "tradeWalletService must not be null");
-        checkArgument(rawTransactionInputs.stream().allMatch(tradeWalletService::isP2WH),
+        checkArgument(rawTransactionInputs.stream().allMatch(tradeWalletService::isP2WPKH),
                 "rawTransactionInputs must not be malleable");
         return rawTransactionInputs;
     }

--- a/core/src/test/java/bisq/core/trade/bisq_v1/TradeDataValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/bisq_v1/TradeDataValidationTest.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.bisq_v1;
+
+import bisq.core.btc.model.RawTransactionInput;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.script.ScriptBuilder;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TradeDataValidationTest {
+    private static final NetworkParameters PARAMS = MainNetParams.get();
+
+    @Test
+    void assertCanonicalDepositTxShapeAcceptsCanonicalTx() {
+        assertDoesNotThrow(() -> TradeDataValidation.assertCanonicalDepositTxShape(
+                canonicalTx(), p2wpkhInputs(), PARAMS));
+    }
+
+    @Test
+    void assertCanonicalDepositTxShapeRejectsNonV1Tx() {
+        Transaction tx = canonicalTx();
+        tx.setVersion(2);
+
+        assertThrows(TradeDataValidation.InvalidTxException.class,
+                () -> TradeDataValidation.assertCanonicalDepositTxShape(tx, p2wpkhInputs(), PARAMS));
+    }
+
+    @Test
+    void assertCanonicalDepositTxShapeRejectsNonZeroLockTime() {
+        Transaction tx = canonicalTx();
+        tx.setLockTime(1);
+
+        assertThrows(TradeDataValidation.InvalidTxException.class,
+                () -> TradeDataValidation.assertCanonicalDepositTxShape(tx, p2wpkhInputs(), PARAMS));
+    }
+
+    @Test
+    void assertCanonicalDepositTxShapeRejectsRbfEnabledSequence() {
+        Transaction tx = canonicalTx();
+        tx.getInput(0).setSequenceNumber(0);
+
+        assertThrows(TradeDataValidation.InvalidTxException.class,
+                () -> TradeDataValidation.assertCanonicalDepositTxShape(tx, p2wpkhInputs(), PARAMS));
+    }
+
+    @Test
+    void assertCanonicalDepositTxShapeAcceptsLockTimeOptInSequence() {
+        // NO_SEQUENCE - 1 (0xFFFFFFFE) keeps RBF disabled while opting in to lockTime; canonical for Bisq.
+        Transaction tx = canonicalTx();
+        tx.getInput(0).setSequenceNumber(TransactionInput.NO_SEQUENCE - 1);
+
+        assertDoesNotThrow(() -> TradeDataValidation.assertCanonicalDepositTxShape(tx, p2wpkhInputs(), PARAMS));
+    }
+
+    @Test
+    void assertCanonicalDepositTxShapeRejectsNonP2WPKHPeerInput() {
+        assertThrows(TradeDataValidation.InvalidTxException.class,
+                () -> TradeDataValidation.assertCanonicalDepositTxShape(canonicalTx(), p2pkhInputs(), PARAMS));
+    }
+
+    @Test
+    void assertCanonicalDepositTxShapeRejectsNullPeerInput() {
+        assertThrows(TradeDataValidation.InvalidTxException.class,
+                () -> TradeDataValidation.assertCanonicalDepositTxShape(canonicalTx(),
+                        java.util.Collections.singletonList(null),
+                        PARAMS));
+    }
+
+    private static Transaction canonicalTx() {
+        Transaction tx = new Transaction(PARAMS);
+        tx.addInput(new TransactionInput(PARAMS,
+                tx,
+                new byte[]{},
+                new TransactionOutPoint(PARAMS, 0, Sha256Hash.ZERO_HASH),
+                Coin.valueOf(2_000)));
+        return tx;
+    }
+
+    private static List<RawTransactionInput> p2wpkhInputs() {
+        return parentTxInputs(ScriptBuilder.createP2WPKHOutputScript(new ECKey()));
+    }
+
+    private static List<RawTransactionInput> p2pkhInputs() {
+        return parentTxInputs(ScriptBuilder.createOutputScript(LegacyAddress.fromKey(PARAMS, new ECKey())));
+    }
+
+    private static List<RawTransactionInput> parentTxInputs(org.bitcoinj.script.Script outputScript) {
+        Transaction parent = new Transaction(PARAMS);
+        // Bitcoinj's segwit serialization requires at least one input; add a dummy.
+        parent.addInput(new TransactionInput(PARAMS,
+                parent,
+                new byte[]{},
+                new TransactionOutPoint(PARAMS, 0, Sha256Hash.ZERO_HASH),
+                Coin.valueOf(2_000)));
+        parent.addOutput(Coin.valueOf(1_000), outputScript);
+        return List.of(new RawTransactionInput(0, parent.bitcoinSerialize(), 1_000));
+    }
+
+}

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/TradePeerTxInputValidatorTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/TradePeerTxInputValidatorTest.java
@@ -63,15 +63,15 @@ public class TradePeerTxInputValidatorTest {
         walletService = mock(BtcWalletService.class);
         when(walletService.getTxFromSerializedTx(any(byte[].class)))
                 .thenAnswer(invocation -> new Transaction(PARAMS, invocation.getArgument(0)));
-        when(walletService.isP2WH(any(RawTransactionInput.class)))
-                .thenAnswer(invocation -> WalletUtils.isP2WH(invocation.getArgument(0), PARAMS));
+        when(walletService.isP2WPKH(any(RawTransactionInput.class)))
+                .thenAnswer(invocation -> WalletUtils.isP2WPKH(invocation.getArgument(0), PARAMS));
     }
 
     @Test
-    void acceptsExactExpectedInputAmountForP2WHInputs() {
+    void acceptsExactExpectedInputAmountForP2WPKHInputs() {
         List<RawTransactionInput> rawTransactionInputs = Arrays.asList(
-                rawInput(parentTxWithP2WHOutput(40_000)),
-                rawInput(parentTxWithP2WHOutput(60_000)));
+                rawInput(parentTxWithP2WPKHOutput(40_000)),
+                rawInput(parentTxWithP2WPKHOutput(60_000)));
 
         assertDoesNotThrow(() -> TradePeerTxInputValidator.validatePeersInputs(
                 rawTransactionInputs,
@@ -83,7 +83,7 @@ public class TradePeerTxInputValidatorTest {
     @Test
     void rejectsInputAmountMismatch() {
         List<RawTransactionInput> rawTransactionInputs = Collections.singletonList(
-                rawInput(parentTxWithP2WHOutput(100_000)));
+                rawInput(parentTxWithP2WPKHOutput(100_000)));
 
         assertThrows(IllegalArgumentException.class,
                 () -> TradePeerTxInputValidator.validatePeersInputs(
@@ -109,7 +109,7 @@ public class TradePeerTxInputValidatorTest {
     void rejectsNullInput() {
         assertThrows(NullPointerException.class,
                 () -> TradePeerTxInputValidator.validatePeersInputs(
-                        Arrays.asList(rawInput(parentTxWithP2WHOutput(1)), null),
+                        Arrays.asList(rawInput(parentTxWithP2WPKHOutput(1)), null),
                         Coin.valueOf(1),
                         walletService,
                         TAKER_ROLE));
@@ -118,7 +118,7 @@ public class TradePeerTxInputValidatorTest {
     @Test
     void rejectsNullExpectedInputAmount() {
         List<RawTransactionInput> rawTransactionInputs = Collections.singletonList(
-                rawInput(parentTxWithP2WHOutput(100_000)));
+                rawInput(parentTxWithP2WPKHOutput(100_000)));
 
         assertThrows(NullPointerException.class,
                 () -> TradePeerTxInputValidator.validatePeersInputs(rawTransactionInputs, null, walletService, MAKER_ROLE));
@@ -127,7 +127,7 @@ public class TradePeerTxInputValidatorTest {
     @Test
     void rejectsNonPositiveExpectedInputAmount() {
         List<RawTransactionInput> rawTransactionInputs = Collections.singletonList(
-                rawInput(parentTxWithP2WHOutput(100_000)));
+                rawInput(parentTxWithP2WPKHOutput(100_000)));
 
         assertThrows(IllegalArgumentException.class,
                 () -> TradePeerTxInputValidator.validatePeersInputs(rawTransactionInputs, Coin.ZERO, walletService, MAKER_ROLE));
@@ -135,7 +135,7 @@ public class TradePeerTxInputValidatorTest {
 
     @Test
     void rejectsInputValueMismatchWithParentTxOutput() {
-        Transaction parentTx = parentTxWithP2WHOutput(100_000);
+        Transaction parentTx = parentTxWithP2WPKHOutput(100_000);
         RawTransactionInput rawTransactionInput = rawInputWithValue(parentTx, 100_001);
 
         assertThrows(IllegalArgumentException.class,
@@ -147,7 +147,7 @@ public class TradePeerTxInputValidatorTest {
     }
 
     @Test
-    void rejectsNonP2WHInput() {
+    void rejectsNonP2WPKHInput() {
         List<RawTransactionInput> rawTransactionInputs = Collections.singletonList(
                 rawInput(parentTxWithP2pkhOutput(100_000)));
 
@@ -191,7 +191,7 @@ public class TradePeerTxInputValidatorTest {
                 .build());
     }
 
-    private static Transaction parentTxWithP2WHOutput(long value) {
+    private static Transaction parentTxWithP2WPKHOutput(long value) {
         Transaction tx = new Transaction(PARAMS);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, ScriptBuilder.createEmpty());
         tx.addOutput(Coin.valueOf(value), SegwitAddress.fromKey(PARAMS, new ECKey()));

--- a/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
@@ -1294,7 +1294,7 @@ public class TradeValidationTest {
         transaction.addOutput(inputAmount, ScriptBuilder.createP2WPKHOutputScript(new ECKey()));
 
         when(btcWalletService.getTxFromSerializedTx(parentTransaction)).thenReturn(transaction);
-        when(btcWalletService.isP2WH(rawTransactionInput)).thenReturn(true);
+        when(btcWalletService.isP2WPKH(rawTransactionInput)).thenReturn(true);
 
         return List.of(rawTransactionInput);
     }


### PR DESCRIPTION
same as https://github.com/bisq-network/bisq/pull/7648
to see if it's a bug that causes CI failure or not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Bitcoin transaction validation to strictly enforce SegWit format, improving transaction integrity and security.
  * Improved error messages to clearly reject non-SegWit inputs and guide users to move funds to compatible addresses.

* **Refactor**
  * Streamlined internal transaction validation methods for consistent SegWit-only handling across deposit and payout flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->