### PR TITLE
Remove dead legacy P2SH branches in payout signing

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -826,15 +826,10 @@ public class TradeWalletService {
         // MS redeemScript
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
         // MS output from prev. tx is index 0
-        Sha256Hash sigHash;
         TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
-        if (ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey())) {
-            sigHash = preparedPayoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
-        } else {
-            Coin inputValue = hashedMultiSigOutput.getValue();
-            sigHash = preparedPayoutTx.hashForWitnessSignature(0, redeemScript,
-                    inputValue, Transaction.SigHash.ALL, false);
-        }
+        Coin inputValue = hashedMultiSigOutput.getValue();
+        Sha256Hash sigHash = preparedPayoutTx.hashForWitnessSignature(0, redeemScript,
+                inputValue, Transaction.SigHash.ALL, false);
         checkNotNull(multiSigKeyPair, "multiSigKeyPair must not be null");
         if (multiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -878,15 +873,9 @@ public class TradeWalletService {
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
         // MS output from prev. tx is index 0
         TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
-        boolean hashedMultiSigOutputIsLegacy = ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
-        Sha256Hash sigHash;
-        if (hashedMultiSigOutputIsLegacy) {
-            sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
-        } else {
-            Coin inputValue = hashedMultiSigOutput.getValue();
-            sigHash = payoutTx.hashForWitnessSignature(0, redeemScript,
-                    inputValue, Transaction.SigHash.ALL, false);
-        }
+        Coin inputValue = hashedMultiSigOutput.getValue();
+        Sha256Hash sigHash = payoutTx.hashForWitnessSignature(0, redeemScript,
+                inputValue, Transaction.SigHash.ALL, false);
         checkNotNull(multiSigKeyPair, "multiSigKeyPair must not be null");
         if (multiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -897,14 +886,8 @@ public class TradeWalletService {
         TransactionSignature sellerTxSig = new TransactionSignature(sellerSignature, Transaction.SigHash.ALL, false);
         // Take care of order of signatures. Need to be reversed here. See comment below at getMultiSigRedeemScript (seller, buyer)
         TransactionInput input = payoutTx.getInput(0);
-        if (hashedMultiSigOutputIsLegacy) {
-            Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig),
-                    redeemScript);
-            input.setScriptSig(inputScript);
-        } else {
-            input.setScriptSig(ScriptBuilder.createEmpty());
-            input.setWitness(TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig));
-        }
+        input.setScriptSig(ScriptBuilder.createEmpty());
+        input.setWitness(TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig));
         WalletService.printTx("payoutTx", payoutTx);
         WalletService.verifyTransaction(payoutTx);
         WalletService.checkWalletConsistency(wallet);
@@ -933,15 +916,9 @@ public class TradeWalletService {
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
         // MS output from prev. tx is index 0
         TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
-        boolean hashedMultiSigOutputIsLegacy = ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
-        Sha256Hash sigHash;
-        if (hashedMultiSigOutputIsLegacy) {
-            sigHash = preparedPayoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
-        } else {
-            Coin inputValue = hashedMultiSigOutput.getValue();
-            sigHash = preparedPayoutTx.hashForWitnessSignature(0, redeemScript,
-                    inputValue, Transaction.SigHash.ALL, false);
-        }
+        Coin inputValue = hashedMultiSigOutput.getValue();
+        Sha256Hash sigHash = preparedPayoutTx.hashForWitnessSignature(0, redeemScript,
+                inputValue, Transaction.SigHash.ALL, false);
         checkNotNull(myMultiSigKeyPair, "myMultiSigKeyPair must not be null");
         if (myMultiSigKeyPair.isEncrypted()) {
             checkNotNull(aesKey);
@@ -973,105 +950,10 @@ public class TradeWalletService {
         TransactionSignature sellerTxSig = new TransactionSignature(ECKey.ECDSASignature.decodeFromDER(sellerSignature),
                 Transaction.SigHash.ALL, false);
         // Take care of order of signatures. Need to be reversed here. See comment below at getMultiSigRedeemScript (seller, buyer)
-        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
-        boolean hashedMultiSigOutputIsLegacy = ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
         TransactionInput input = payoutTx.getInput(0);
-        if (hashedMultiSigOutputIsLegacy) {
-            Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(sellerTxSig, buyerTxSig),
-                    redeemScript);
-            input.setScriptSig(inputScript);
-        } else {
-            input.setScriptSig(ScriptBuilder.createEmpty());
-            input.setWitness(TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig));
-        }
+        input.setScriptSig(ScriptBuilder.createEmpty());
+        input.setWitness(TransactionWitness.redeemP2WSH(redeemScript, sellerTxSig, buyerTxSig));
         WalletService.printTx("mediated payoutTx", payoutTx);
-        WalletService.verifyTransaction(payoutTx);
-        WalletService.checkWalletConsistency(wallet);
-        WalletService.checkScriptSig(payoutTx, input, 0);
-        checkNotNull(input.getConnectedOutput(), "input.getConnectedOutput() must not be null");
-        input.verify(input.getConnectedOutput());
-        return payoutTx;
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Arbitrated payoutTx
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-    // TODO: Once we have removed legacy arbitrator from dispute domain we can remove that method as well.
-    // Atm it is still used by ArbitrationManager.
-
-    /**
-     * A trader who got the signed tx from the arbitrator finalizes the payout tx.
-     *
-     * @param depositTxSerialized    serialized deposit tx
-     * @param arbitratorSignature    DER encoded canonical signature of arbitrator
-     * @param buyerPayoutAmount      payout amount of the buyer
-     * @param sellerPayoutAmount     payout amount of the seller
-     * @param buyerAddressString     the address of the buyer
-     * @param sellerAddressString    the address of the seller
-     * @param tradersMultiSigKeyPair the key pair for the MultiSig of the trader who calls that method
-     * @param buyerPubKey            the public key of the buyer
-     * @param sellerPubKey           the public key of the seller
-     * @param arbitratorPubKey       the public key of the arbitrator
-     * @return the completed payout tx
-     * @throws AddressFormatException if the buyer or seller base58 address doesn't parse or its checksum is invalid
-     * @throws TransactionVerificationException if there was an unexpected problem with the payout tx or its signature
-     * @throws WalletException if the trade wallet is null or structurally inconsistent
-     */
-    public Transaction traderSignAndFinalizeDisputedPayoutTx(byte[] depositTxSerialized,
-                                                             byte[] arbitratorSignature,
-                                                             Coin buyerPayoutAmount,
-                                                             Coin sellerPayoutAmount,
-                                                             String buyerAddressString,
-                                                             String sellerAddressString,
-                                                             DeterministicKey tradersMultiSigKeyPair,
-                                                             byte[] buyerPubKey,
-                                                             byte[] sellerPubKey,
-                                                             byte[] arbitratorPubKey)
-            throws AddressFormatException, TransactionVerificationException, WalletException, SignatureDecodeException {
-        Transaction depositTx = new Transaction(params, depositTxSerialized);
-        TransactionOutput hashedMultiSigOutput = depositTx.getOutput(0);
-        Transaction payoutTx = new Transaction(params);
-        payoutTx.addInput(hashedMultiSigOutput);
-        if (buyerPayoutAmount.isPositive()) {
-            payoutTx.addOutput(buyerPayoutAmount, Address.fromString(params, buyerAddressString));
-        }
-        if (sellerPayoutAmount.isPositive()) {
-            payoutTx.addOutput(sellerPayoutAmount, Address.fromString(params, sellerAddressString));
-        }
-
-        // take care of sorting!
-        Script redeemScript = get2of3MultiSigRedeemScript(buyerPubKey, sellerPubKey, arbitratorPubKey);
-        Sha256Hash sigHash;
-        boolean hashedMultiSigOutputIsLegacy = !ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey());
-        if (hashedMultiSigOutputIsLegacy) {
-            sigHash = payoutTx.hashForSignature(0, redeemScript, Transaction.SigHash.ALL, false);
-        } else {
-            Coin inputValue = hashedMultiSigOutput.getValue();
-            sigHash = payoutTx.hashForWitnessSignature(0, redeemScript,
-                    inputValue, Transaction.SigHash.ALL, false);
-        }
-        checkNotNull(tradersMultiSigKeyPair, "tradersMultiSigKeyPair must not be null");
-        if (tradersMultiSigKeyPair.isEncrypted()) {
-            checkNotNull(aesKey);
-        }
-        ECKey.ECDSASignature tradersSignature = LowRSigningKey.from(tradersMultiSigKeyPair).sign(sigHash, aesKey);
-        TransactionSignature tradersTxSig = new TransactionSignature(tradersSignature, Transaction.SigHash.ALL, false);
-        TransactionSignature arbitratorTxSig = new TransactionSignature(ECKey.ECDSASignature.decodeFromDER(arbitratorSignature),
-                Transaction.SigHash.ALL, false);
-        TransactionInput input = payoutTx.getInput(0);
-        // Take care of order of signatures. See comment below at getMultiSigRedeemScript (sort order needed here: arbitrator, seller, buyer)
-        if (hashedMultiSigOutputIsLegacy) {
-            Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(
-                    ImmutableList.of(arbitratorTxSig, tradersTxSig),
-                    redeemScript);
-            input.setScriptSig(inputScript);
-        } else {
-            input.setScriptSig(ScriptBuilder.createEmpty());
-            input.setWitness(TransactionWitness.redeemP2WSH(redeemScript, arbitratorTxSig, tradersTxSig));
-        }
-        WalletService.printTx("disputed payoutTx", payoutTx);
         WalletService.verifyTransaction(payoutTx);
         WalletService.checkWalletConsistency(wallet);
         WalletService.checkScriptSig(payoutTx, input, 0);
@@ -1340,27 +1222,6 @@ public class TradeWalletService {
 
     public boolean isP2WPKH(RawTransactionInput rawTransactionInput) {
         return WalletUtils.isP2WPKH(rawTransactionInput, params);
-    }
-
-    // TODO: Once we have removed legacy arbitrator from dispute domain we can remove that method as well.
-    // Atm it is still used by traderSignAndFinalizeDisputedPayoutTx which is used by ArbitrationManager.
-
-    // Don't use ScriptBuilder.createRedeemScript and ScriptBuilder.createP2SHOutputScript as they use a sorting
-    // (Collections.sort(pubKeys, ECKey.PUBKEY_COMPARATOR);) which can lead to a non-matching list of signatures with pubKeys and the executeMultiSig does
-    // not iterate all possible combinations of sig/pubKeys leading to a verification fault. That nasty bug happens just randomly as the list after sorting
-    // might differ from the provided one or not.
-    // Changing the while loop in executeMultiSig to fix that does not help as the reference implementation seems to behave the same (not iterating all
-    // possibilities) .
-    // Furthermore the executed list is reversed to the provided.
-    // Best practice is to provide the list sorted by the least probable successful candidates first (arbitrator is first -> will be last in execution loop, so
-    // avoiding unneeded expensive ECKey.verify calls)
-    private Script get2of3MultiSigRedeemScript(byte[] buyerPubKey, byte[] sellerPubKey, byte[] arbitratorPubKey) {
-        ECKey buyerKey = ECKey.fromPublicOnly(buyerPubKey);
-        ECKey sellerKey = ECKey.fromPublicOnly(sellerPubKey);
-        ECKey arbitratorKey = ECKey.fromPublicOnly(arbitratorPubKey);
-        // Take care of sorting! Need to reverse to the order we use normally (buyer, seller, arbitrator)
-        List<ECKey> keys = ImmutableList.of(arbitratorKey, sellerKey, buyerKey);
-        return ScriptBuilder.createMultiSigOutputScript(2, keys);
     }
 
     private Script get2of2MultiSigRedeemScript(byte[] buyerPubKey, byte[] sellerPubKey) {

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
@@ -17,13 +17,9 @@
 
 package bisq.core.support.dispute.arbitration;
 
-import bisq.core.btc.exceptions.TransactionVerificationException;
-import bisq.core.btc.exceptions.TxBroadcastException;
-import bisq.core.btc.exceptions.WalletException;
 import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
-import bisq.core.btc.wallet.TxBroadcaster;
 import bisq.core.btc.wallet.WalletService;
 import bisq.core.dao.DaoFacade;
 import bisq.core.locale.Res;
@@ -59,10 +55,7 @@ import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 
-import org.bitcoinj.core.AddressFormatException;
-import org.bitcoinj.core.SignatureDecodeException;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.crypto.DeterministicKey;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -265,43 +258,16 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
                 }
 
                 if (payoutTx == null) {
-                    if (dispute.getDepositTxSerialized() != null) {
-                        byte[] multiSigPubKey = isBuyer ? contract.getBuyerMultiSigPubKey() : contract.getSellerMultiSigPubKey();
-                        DeterministicKey multiSigKeyPair = btcWalletService.getMultiSigKeyPair(tradeId, multiSigPubKey);
-                        Transaction signedDisputedPayoutTx = tradeWalletService.traderSignAndFinalizeDisputedPayoutTx(
-                                dispute.getDepositTxSerialized(),
-                                disputeResult.getArbitratorSignature(),
-                                disputeResult.getBuyerPayoutAmount(),
-                                disputeResult.getSellerPayoutAmount(),
-                                contract.getBuyerPayoutAddressString(),
-                                contract.getSellerPayoutAddressString(),
-                                multiSigKeyPair,
-                                contract.getBuyerMultiSigPubKey(),
-                                contract.getSellerMultiSigPubKey(),
-                                disputeResult.getArbitratorPubKey()
-                        );
-                        Transaction committedDisputedPayoutTx = WalletService.maybeAddSelfTxToWallet(signedDisputedPayoutTx, btcWalletService.getWallet());
-                        tradeWalletService.broadcastTx(committedDisputedPayoutTx, new TxBroadcaster.Callback() {
-                            @Override
-                            public void onSuccess(Transaction transaction) {
-                                // after successful publish we send peer the tx
-                                dispute.setDisputePayoutTxId(transaction.getTxId().toString());
-                                sendPeerPublishedPayoutTxMessage(transaction, dispute, contract);
-                                updateTradeOrOpenOfferManager(tradeId);
-                            }
-
-                            @Override
-                            public void onFailure(TxBroadcastException exception) {
-                                log.error(exception.getMessage());
-                            }
-                        }, 15);
-
-                        success = true;
-                    } else {
-                        errorMessage = "DepositTx is null. TradeId = " + tradeId;
-                        log.warn(errorMessage);
-                        success = false;
-                    }
+                    // Legacy arbitrator publishing path was removed: it relied on
+                    // traderSignAndFinalizeDisputedPayoutTx, which has been broken since
+                    // the P2WSH switch in 1.5.0 (inverted isP2SH polarity made every
+                    // produced tx fail input.verify) and corresponded to the legacy
+                    // arbitrator role that has been deprecated for years. Close the
+                    // dispute locally and ack; no tx broadcast.
+                    errorMessage = "Legacy arbitrator dispute payout publishing is no longer supported. TradeId = " + tradeId;
+                    log.warn(errorMessage);
+                    updateTradeOrOpenOfferManager(tradeId);
+                    success = false;
                 } else {
                     log.warn("We already got a payout tx. That might be the case if the other peer did not get the " +
                             "payout tx and opened a dispute. TradeId = " + tradeId);
@@ -319,21 +285,6 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
 
                 success = true;
             }
-        } catch (TransactionVerificationException e) {
-            errorMessage = "Error at traderSignAndFinalizeDisputedPayoutTx " + e.toString();
-            log.error(errorMessage, e);
-            success = false;
-
-            // We prefer to close the dispute in that case. If there was no deposit tx and a random tx was used
-            // we get a TransactionVerificationException. No reason to keep that dispute open...
-            updateTradeOrOpenOfferManager(tradeId);
-
-            throw new RuntimeException(errorMessage);
-        } catch (AddressFormatException | WalletException | SignatureDecodeException e) {
-            errorMessage = "Error at traderSignAndFinalizeDisputedPayoutTx " + e.toString();
-            log.error(errorMessage, e);
-            success = false;
-            throw new RuntimeException(errorMessage);
         } finally {
             // We use the chatMessage as we only persist those not the disputeResultMessage.
             // If we would use the disputeResultMessage we could not lookup for the msg when we receive the AckMessage.


### PR DESCRIPTION
# Remove dead legacy P2SH branches in payout signing

## Summary

Deposit outputs have been P2WSH-only since Bisq v1.5.0. PR #7676 made `get2of2MultiSigOutputScript` unconditionally `createP2WSHOutputScript`, and the defense gate `verifyDepositTxMultiSigOutput` (commit dbb568fa1e) actively rejects any deposit whose `output[0]` is not the agreed P2WSH script. Every `ScriptPattern.isP2SH(hashedMultiSigOutput.getScriptPubKey())` branch in regular payout signing is therefore unreachable. This PR removes that dead code.

## What changed

### `core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java`

Removed legacy P2SH branches in regular payout signing:

- `buyerSignsPayoutTx` — dropped the `if (isP2SH) hashForSignature else hashForWitnessSignature` split. Witness-only.
- `sellerSignsAndFinalizesPayoutTx` — dropped both the sigHash split and the `createP2SHMultiSigInputScript` vs `redeemP2WSH` scriptSig split.
- `signMediatedPayoutTx` — dropped sigHash split.
- `finalizeMediatedPayoutTx` — dropped scriptSig split.

Removed entirely:

- `traderSignAndFinalizeDisputedPayoutTx` — legacy arbitrator dispute finalize. Only caller was the legacy-arbitrator branch in `ArbitrationManager` (see below). Has been broken since v1.5.0 due to inverted `isP2SH` polarity (`hashedMultiSigOutputIsLegacy = !ScriptPattern.isP2SH(...)`), causing every produced tx to fail `input.verify`.
- `get2of3MultiSigRedeemScript` — only used by the deleted method.

### `core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java`

`onDisputeResultMessage` legacy-arbitrator publishing branch replaced with a graceful warn-and-close: log a warning, run `updateTradeOrOpenOfferManager`, ack. Unused imports (`TransactionVerificationException`, `TxBroadcastException`, `WalletException`, `TxBroadcaster`, `AddressFormatException`, `SignatureDecodeException`, `DeterministicKey`) and corresponding `catch` blocks removed.

## Out of scope (intentionally kept)

- **Emergency support tools** — `emergencyBuildPayoutTxFrom2of2MultiSig`, `emergencyGenerateSignature`, `emergencyApplySignatureToPayoutTxFrom2of2MultiSig` still accept a `hashedMultiSigOutputIsLegacy` flag. The desktop `BuildPane` / `SignPane` keep the "Legacy" checkbox. These are user-driven recovery tools, not part of the protocol path, and may be used to spend arbitrary deposits.

## Why this is safe

1. **No path produces a legacy output.** Post-#7676 `get2of2MultiSigOutputScript` is unconditionally P2WSH. Pre-#7676, every caller passed `legacy=false` hardcoded.
2. **Defense gate refuses non-P2WSH deposits.** `verifyDepositTxMultiSigOutput` is called from every payout-signing task before signing; an attacker-substituted P2SH deposit would be rejected before reaching the removed branches.
3. **In-flight trades are unaffected.** Any active trade with a pending payout has a P2WSH deposit (Bisq has been P2WSH since v1.5.0).
4. **Legacy arbitrator was already broken.** The deleted `ArbitrationManager` branch threw on every invocation since v1.5.0 due to inverted `isP2SH` polarity. New behavior (warn + close) is a strict improvement over the previous `RuntimeException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined payout transaction signing by removing legacy verification methods, improving code clarity and reducing maintenance overhead.
  * Simplified dispute payment handling by eliminating legacy arbitration payout support, streamlining the resolution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->