### PR TITLE
Fix XMR auto-confirm quorum to exclude filter-banned services

### DIFF
--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -140,14 +141,25 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
         // it will have no impact on serviceAddresses and numRequiredSuccessResults.
         // Though numRequiredConfirmations can be changed during request process and will be read from
         // autoConfirmSettings at result parsing.
-        List<String> serviceAddresses = autoConfirmSettings.getServiceAddresses();
+        List<String> serviceAddresses = autoConfirmSettings.getServiceAddresses().stream()
+                .filter(address -> {
+                    if (filterManager.isAutoConfExplorerBanned(address)) {
+                        log.warn("Filtered out auto-confirmation address: {}", address);
+                        return false;  // #4683: filter for auto-confirm explorers
+                    }
+                    return true;
+                })
+                .collect(Collectors.toList());
         numRequiredSuccessResults = serviceAddresses.size();
 
+        if (numRequiredSuccessResults == 0) {
+            log.warn("All XMR tx proof services are banned by filter; cannot auto-confirm trade {}.",
+                    trade.getShortId());
+            callResultHandlerAndMaybeTerminate(resultHandler, AssetTxProofResult.FAILED);
+            return;
+        }
+
         for (String serviceAddress : serviceAddresses) {
-            if (filterManager.isAutoConfExplorerBanned(serviceAddress)) {
-                log.warn("Filtered out auto-confirmation address: {}", serviceAddress);
-                continue;  // #4683: filter for auto-confirm explorers
-            }
             XmrTxProofModel model = new XmrTxProofModel(trade, serviceAddress, autoConfirmSettings);
             XmrTxProofRequest request = new XmrTxProofRequest(socks5ProxyProvider, model);
 


### PR DESCRIPTION
numRequiredSuccessResults was set from full service list before the ban filter ran, so a banned service made auto-confirm hang at incomplete success instead of completing on the surviving services. Filter first, derive required count from survivors, fail fast if all are banned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XMR transaction proof request handling by filtering out banned auto-confirm explorer services and providing clearer error messaging when no services are available for auto-confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->