### PR TITLE
Trade message integrity hardening

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/TradeMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeMessage.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import static bisq.core.util.Validator.checkNonEmptyString;
+import static bisq.core.util.Validator.checkNonBlankString;
 
 /**
  * Base class for trade-related messages exchanged between peers.
@@ -43,7 +43,7 @@ public abstract class TradeMessage extends NetworkEnvelope implements UidMessage
 
     protected TradeMessage(int messageVersion, String tradeId, String uid) {
         super(messageVersion);
-        this.tradeId = checkNonEmptyString(tradeId, "tradeId");
-        this.uid = checkNonEmptyString(uid, "uid");
+        this.tradeId = checkNonBlankString(tradeId, "tradeId");
+        this.uid = checkNonBlankString(uid, "uid");
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/CounterCurrencyTransferStartedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/CounterCurrencyTransferStartedMessage.java
@@ -32,10 +32,10 @@ import lombok.Getter;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNullableNonBlankString;
+import static bisq.core.util.Validator.checkNonBlankString;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static bisq.core.util.Validator.checkNonEmptyString;
-import static bisq.core.util.Validator.checkNullableString;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Getter
@@ -92,11 +92,11 @@ public final class CounterCurrencyTransferStartedMessage extends TradeMailboxMes
     }
 
     private void validate() {
-        checkNonEmptyString(buyerPayoutAddress, "buyerPayoutAddress");
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNonBlankString(buyerPayoutAddress, "buyerPayoutAddress");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkNonEmptyBytes(buyerSignature, "buyerSignature");
-        checkNullableString(counterCurrencyTxId, "counterCurrencyTxId");
-        checkNullableString(counterCurrencyExtraData, "counterCurrencyExtraData");
+        checkNullableNonBlankString(counterCurrencyTxId, "counterCurrencyTxId");
+        checkNullableNonBlankString(counterCurrencyExtraData, "counterCurrencyExtraData");
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DelayedPayoutTxSignatureRequest.java
@@ -30,8 +30,8 @@ import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -72,7 +72,7 @@ public final class DelayedPayoutTxSignatureRequest extends TradeMessage implemen
     }
 
     private void validate() {
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkNonEmptyBytes(delayedPayoutTx, "delayedPayoutTx");
         checkNonEmptyBytes(delayedPayoutTxSellerSignature, "delayedPayoutTxSellerSignature");
     }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DelayedPayoutTxSignatureResponse.java
@@ -30,8 +30,8 @@ import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -72,7 +72,7 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
     }
 
     private void validate() {
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkNonEmptyBytes(delayedPayoutTxBuyerSignature, "delayedPayoutTxBuyerSignature");
         checkNonEmptyBytes(depositTx, "depositTx");
     }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DepositTxAndDelayedPayoutTxMessage.java
@@ -34,8 +34,8 @@ import lombok.Getter;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 // It is the last message in the take offer phase. We use MailboxMessage instead of DirectMessage to add more tolerance
 // in case of network issues and as the message does not trigger further protocol execution.
@@ -86,7 +86,7 @@ public final class DepositTxAndDelayedPayoutTxMessage extends TradeMailboxMessag
     }
 
     private void validate() {
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkNonEmptyBytes(depositTx, "depositTx");
         checkNonEmptyBytes(delayedPayoutTx, "delayedPayoutTx");
     }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/DepositTxMessage.java
@@ -30,8 +30,8 @@ import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 // It is the last message in the take offer phase. We use MailboxMessage instead of DirectMessage to add more tolerance
 // in case of network issues and as the message does not trigger further protocol execution.
@@ -69,7 +69,7 @@ public final class DepositTxMessage extends TradeMessage implements DirectMessag
     }
 
     private void validate() {
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkNonEmptyBytes(depositTxWithoutWitnesses, "depositTxWithoutWitnesses");
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
@@ -19,7 +19,6 @@ package bisq.core.trade.protocol.bisq_v1.messages;
 
 import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.trade.protocol.TradeMessage;
-import bisq.core.trade.validation.MinerFeeValidation;
 
 import bisq.network.p2p.DirectMessage;
 import bisq.network.p2p.NodeAddress;
@@ -44,10 +43,12 @@ import lombok.Getter;
 
 import javax.annotation.Nullable;
 
-import static bisq.core.util.Validator.checkList;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddressList;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNullableNodeAddress;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkRawTransactionInputList;
 import static bisq.core.util.Validator.checkNonBlankString;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static bisq.core.util.Validator.checkNonEmptyString;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -140,23 +141,23 @@ public final class InputsForDepositTxRequest extends TradeMessage
     }
 
     private void validate() {
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkArgument(tradeAmount > 0, "tradeAmount must be positive");
         checkArgument(tradePrice > 0, "tradePrice must be positive");
-        // Bound the taker-supplied trade tx fee. Single source of truth in MinerFeeValidation.
-        MinerFeeValidation.checkTradeTxFee(txFee);
+        checkArgument(txFee > 0, "txFee must be positive");
         checkArgument(takerFee > 0, "takerFee must be positive");
-        checkList(rawTransactionInputs, true, "rawTransactionInputs");
+        checkRawTransactionInputList(rawTransactionInputs, true, "rawTransactionInputs");
         checkNonEmptyBytes(takerMultiSigPubKey, "takerMultiSigPubKey");
-        checkNonEmptyString(takerPayoutAddressString, "takerPayoutAddressString");
+        checkNonBlankString(takerPayoutAddressString, "takerPayoutAddressString");
         checkNotNull(takerPubKeyRing, "takerPubKeyRing must not be null");
-        checkNonEmptyString(takerAccountId, "takerAccountId");
-        checkNonEmptyString(takerFeeTxId, "takerFeeTxId");
-        checkList(acceptedArbitratorNodeAddresses, false, "acceptedArbitratorNodeAddresses");
-        checkList(acceptedMediatorNodeAddresses, false, "acceptedMediatorNodeAddresses");
-        checkList(acceptedRefundAgentNodeAddresses, false, "acceptedRefundAgentNodeAddresses");
-        checkNotNull(mediatorNodeAddress, "mediatorNodeAddress must not be null");
-        checkNotNull(refundAgentNodeAddress, "refundAgentNodeAddress must not be null");
+        checkNonBlankString(takerAccountId, "takerAccountId");
+        checkNonBlankString(takerFeeTxId, "takerFeeTxId");
+        checkNodeAddressList(acceptedArbitratorNodeAddresses, false, "acceptedArbitratorNodeAddresses");
+        checkNodeAddressList(acceptedMediatorNodeAddresses, false, "acceptedMediatorNodeAddresses");
+        checkNodeAddressList(acceptedRefundAgentNodeAddresses, false, "acceptedRefundAgentNodeAddresses");
+        checkNullableNodeAddress(arbitratorNodeAddress, "arbitratorNodeAddress");
+        checkNodeAddress(mediatorNodeAddress, "mediatorNodeAddress");
+        checkNodeAddress(refundAgentNodeAddress, "refundAgentNodeAddress");
         checkNonEmptyBytes(accountAgeWitnessSignatureOfOfferId, "accountAgeWitnessSignatureOfOfferId");
         checkArgument(currentDate > 0, "currentDate must be positive");
         checkNonEmptyBytes(hashOfTakersPaymentAccountPayload, "hashOfTakersPaymentAccountPayload");
@@ -240,7 +241,7 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 acceptedArbitratorNodeAddresses,
                 acceptedMediatorNodeAddresses,
                 acceptedRefundAgentNodeAddresses,
-                NodeAddress.fromProto(proto.getArbitratorNodeAddress()),
+                proto.hasArbitratorNodeAddress() ? NodeAddress.fromProto(proto.getArbitratorNodeAddress()) : null,
                 NodeAddress.fromProto(proto.getMediatorNodeAddress()),
                 NodeAddress.fromProto(proto.getRefundAgentNodeAddress()),
                 proto.getUid(),

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxResponse.java
@@ -36,9 +36,11 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import static bisq.core.util.Validator.*;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkRawTransactionInputList;
+import static bisq.core.util.Validator.checkNonBlankString;
+import static bisq.core.util.Validator.checkNonEmptyBytes;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Getter
@@ -135,14 +137,14 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
     }
 
     private void validate() {
-        checkNonEmptyString(makerAccountId, "makerAccountId");
+        checkNonBlankString(makerAccountId, "makerAccountId");
         checkNonEmptyBytes(makerMultiSigPubKey, "makerMultiSigPubKey");
-        checkNonEmptyString(makerContractAsJson, "makerContractAsJson");
-        checkNonEmptyString(makerContractSignature, "makerContractSignature");
-        checkNonEmptyString(makerPayoutAddressString, "makerPayoutAddressString");
+        checkNonBlankString(makerContractAsJson, "makerContractAsJson");
+        checkNonBlankString(makerContractSignature, "makerContractSignature");
+        checkNonBlankString(makerPayoutAddressString, "makerPayoutAddressString");
         checkNonEmptyBytes(preparedDepositTx, "preparedDepositTx");
-        checkList(makerInputs, true, "makerInputs");
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkRawTransactionInputList(makerInputs, true, "makerInputs");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkNonEmptyBytes(accountAgeWitnessSignatureOfPreparedDepositTx,
                 "accountAgeWitnessSignatureOfPreparedDepositTx");
         checkArgument(currentDate > 0, "currentDate must be positive");

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/MediatedPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/MediatedPayoutTxPublishedMessage.java
@@ -28,8 +28,8 @@ import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -67,7 +67,7 @@ public final class MediatedPayoutTxPublishedMessage extends TradeMailboxMessage 
 
     private void validate() {
         checkNonEmptyBytes(payoutTx, "payoutTx");
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/MediatedPayoutTxSignatureMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/MediatedPayoutTxSignatureMessage.java
@@ -28,8 +28,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 @Value
@@ -68,7 +68,7 @@ public class MediatedPayoutTxSignatureMessage extends TradeMailboxMessage {
 
     private void validate() {
         checkNonEmptyBytes(txSignature, "txSignature");
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/PayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/PayoutTxPublishedMessage.java
@@ -36,8 +36,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static bisq.core.util.Validator.checkNonEmptyBytes;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 @EqualsAndHashCode(callSuper = true)
@@ -83,7 +83,7 @@ public final class PayoutTxPublishedMessage extends TradeMailboxMessage {
 
     private void validate() {
         checkNonEmptyBytes(payoutTx, "payoutTx");
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/PeerPublishedDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/PeerPublishedDelayedPayoutTxMessage.java
@@ -24,7 +24,7 @@ import bisq.common.app.Version;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -56,7 +56,7 @@ public final class PeerPublishedDelayedPayoutTxMessage extends TradeMailboxMessa
     }
 
     private void validate() {
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
     }
 
     @Override

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/ShareBuyerPaymentAccountMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/ShareBuyerPaymentAccountMessage.java
@@ -44,6 +44,7 @@ import bisq.common.app.Version;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import static bisq.core.trade.protocol.bisq_v1.messages.TradeMessageValidator.checkNodeAddress;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 // Added at v1.7.0
@@ -81,7 +82,7 @@ public final class ShareBuyerPaymentAccountMessage extends TradeMailboxMessage {
     }
 
     private void validate() {
-        checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
+        checkNodeAddress(senderNodeAddress, "senderNodeAddress");
         checkNotNull(buyerPaymentAccountPayload, "buyerPaymentAccountPayload must not be null");
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/TradeMessageValidator.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/TradeMessageValidator.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.bisq_v1.messages;
+
+import bisq.core.btc.model.RawTransactionInput;
+
+import bisq.network.p2p.NodeAddress;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import static bisq.core.util.Validator.checkList;
+import static bisq.core.util.Validator.checkNonBlankString;
+import static bisq.core.util.Validator.checkNonEmptyBytes;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+final class TradeMessageValidator {
+    private static final int MAX_PORT = 65535;
+    // Bitcoin transaction output indices (vout) are unsigned 32-bit integers with valid range 0–4,294,967,295
+    private static final long MAX_RAW_INPUT_INDEX = 0xFFFFFFFFL; // (4,294,967,295)
+
+    private TradeMessageValidator() {
+    }
+
+    static NodeAddress checkNodeAddress(NodeAddress nodeAddress, String fieldName) {
+        checkNotNull(nodeAddress, "Node address cannot be null");
+        checkNonBlankString(nodeAddress.getHostName(), fieldName + ".hostName");
+        checkArgument(nodeAddress.getPort() > 0 && nodeAddress.getPort() <= MAX_PORT,
+                "%s.port must be between 1 and %s", fieldName, MAX_PORT);
+        return nodeAddress;
+    }
+
+    static void checkNullableNodeAddress(@Nullable NodeAddress nodeAddress, String fieldName) {
+        if (nodeAddress != null) {
+            checkNodeAddress(nodeAddress, fieldName);
+        }
+    }
+
+    static void checkNodeAddressList(List<NodeAddress> nodeAddresses, boolean requireNonEmpty, String fieldName) {
+        checkList(nodeAddresses, requireNonEmpty, fieldName);
+        for (int i = 0; i < nodeAddresses.size(); i++) {
+            checkNodeAddress(nodeAddresses.get(i), fieldName + "[" + i + "]");
+        }
+    }
+
+    static void checkNullableNonBlankString(@Nullable String value, String fieldName) {
+        if (value != null) {
+            checkNonBlankString(value, fieldName);
+        }
+    }
+
+    static void checkRawTransactionInputList(List<RawTransactionInput> rawTransactionInputs,
+                                             boolean requireNonEmpty,
+                                             String fieldName) {
+        checkList(rawTransactionInputs, requireNonEmpty, fieldName);
+        for (int i = 0; i < rawTransactionInputs.size(); i++) {
+            checkRawTransactionInput(rawTransactionInputs.get(i), fieldName + "[" + i + "]");
+        }
+    }
+
+    private static void checkRawTransactionInput(RawTransactionInput rawTransactionInput, String fieldName) {
+        checkNotNull(rawTransactionInput, "%s must not be null", fieldName);
+        checkArgument(rawTransactionInput.getIndex() >= 0 && rawTransactionInput.getIndex() <= MAX_RAW_INPUT_INDEX,
+                "%s.index must be between 0 and %s", fieldName, MAX_RAW_INPUT_INDEX);
+        checkNonEmptyBytes(rawTransactionInput.getParentTransaction(), fieldName + ".parentTransaction");
+        checkArgument(rawTransactionInput.getValue() >= 0, "%s.value must not be negative", fieldName);
+        checkArgument(rawTransactionInput.getScriptTypeId() >= 0,
+                "%s.scriptTypeId must not be negative", fieldName);
+    }
+}

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
@@ -25,6 +25,8 @@ import bisq.network.p2p.NodeAddress;
 
 import bisq.common.crypto.PubKeyRing;
 
+import com.google.protobuf.ByteString;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -75,6 +77,7 @@ public class BisqV1MessageIntegrityTest {
     @Test
     void constructorsRejectMissingTradeIdentity() {
         assertThrows(IllegalArgumentException.class, () -> new DepositTxMessage(UID, "", NODE_ADDRESS, bytes(1)));
+        assertThrows(IllegalArgumentException.class, () -> new DepositTxMessage(UID, " ", NODE_ADDRESS, bytes(1)));
         assertThrows(IllegalArgumentException.class, () -> new DelayedPayoutTxSignatureRequest("",
                 TRADE_ID,
                 NODE_ADDRESS,
@@ -95,6 +98,7 @@ public class BisqV1MessageIntegrityTest {
         assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.uid = ""));
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.tradeId = ""));
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.uid = ""));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.uid = " "));
     }
 
     @Test
@@ -189,33 +193,58 @@ public class BisqV1MessageIntegrityTest {
     }
 
     @Test
-    void constructorsRejectEmptyMessageStrings() {
+    void constructorsRejectBlankMessageStrings() {
         assertThrows(IllegalArgumentException.class, () -> new CounterCurrencyTransferStartedMessage(TRADE_ID,
-                "",
+                " ",
                 NODE_ADDRESS,
                 bytes(1),
                 null,
                 null,
                 UID));
-        assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.makerAccountId = ""));
-        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.takerAccountId = ""));
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.makerAccountId = " "));
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.makerContractAsJson = " "));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.takerAccountId = " "));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.takerFeeTxId = " "));
     }
 
     @Test
-    void constructorsRejectEmptyOptionalValuesWhenPresent() {
+    void constructorsRejectBlankOptionalValuesWhenPresent() {
         assertThrows(IllegalArgumentException.class, () -> new CounterCurrencyTransferStartedMessage(TRADE_ID,
                 "buyer-payout-address",
                 NODE_ADDRESS,
                 bytes(1),
-                "",
+                " ",
                 null,
                 UID));
-        assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.makersPaymentMethodId = ""));
+        assertThrows(IllegalArgumentException.class, () -> new CounterCurrencyTransferStartedMessage(TRADE_ID,
+                "buyer-payout-address",
+                NODE_ADDRESS,
+                bytes(1),
+                null,
+                " ",
+                UID));
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.makersPaymentMethodId = " "));
         assertThrows(IllegalArgumentException.class,
                 () -> newResponse(args -> args.hashOfMakersPaymentAccountPayload = new byte[0]));
-        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.takersPaymentMethodId = ""));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.takersPaymentMethodId = " "));
         assertThrows(IllegalArgumentException.class,
                 () -> newRequest(args -> args.hashOfTakersPaymentAccountPayload = new byte[0]));
+    }
+
+    @Test
+    void constructorsRejectStructurallyInvalidNodeAddresses() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new DepositTxMessage(UID, TRADE_ID, new NodeAddress("", 9999), bytes(1)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new DepositTxMessage(UID, TRADE_ID, new NodeAddress(" ", 9999), bytes(1)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new DepositTxMessage(UID, TRADE_ID, new NodeAddress("peer.onion", 0), bytes(1)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new DepositTxMessage(UID, TRADE_ID, new NodeAddress("peer.onion", 65_536), bytes(1)));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.acceptedMediatorNodeAddresses =
+                List.of(new NodeAddress("", 9999))));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.arbitratorNodeAddress = new NodeAddress("", 9999)));
     }
 
     @Test
@@ -223,6 +252,12 @@ public class BisqV1MessageIntegrityTest {
         assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.makerInputs = List.of()));
         assertThrows(IllegalArgumentException.class,
                 () -> newResponse(args -> args.makerInputs = Arrays.asList(rawTransactionInput(), null)));
+        assertThrows(IllegalArgumentException.class,
+                () -> newResponse(args -> args.makerInputs = List.of(rawTransactionInput(-1, bytes(16), 100_000L))));
+        assertThrows(IllegalArgumentException.class,
+                () -> newResponse(args -> args.makerInputs = List.of(rawTransactionInput(0, new byte[0], 100_000L))));
+        assertThrows(IllegalArgumentException.class,
+                () -> newResponse(args -> args.makerInputs = List.of(rawTransactionInput(0, bytes(16), -1L))));
     }
 
     @Test
@@ -233,21 +268,24 @@ public class BisqV1MessageIntegrityTest {
     @Test
     void inputsForDepositTxResponseRejectsInvalidDateAndLockTime() {
         assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.currentDate = 0));
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.lockTime = -1));
+    }
+
+    @Test
+    void inputsForDepositTxResponseAcceptsStructurallyValidZeroLockTime() {
         assertThrows(IllegalArgumentException.class, () -> newResponse(args -> args.lockTime = 0));
     }
 
     @Test
-    void inputsForDepositTxRequestRejectsTxFeeOutsideBounds() {
-        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = 249L));
-        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = 360_001L));
+    void inputsForDepositTxRequestRejectsNonPositiveTxFee() {
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = 0L));
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.txFee = -1L));
     }
 
     @Test
-    void inputsForDepositTxRequestAcceptsTxFeeAtBounds() {
-        newRequest(args -> args.txFee = 250L);
-        newRequest(args -> args.txFee = 360_000L);
+    void inputsForDepositTxRequestAcceptsStructurallyPositiveTxFee() {
+        newRequest(args -> args.txFee = 1L);
+        newRequest(args -> args.txFee = 360_001L);
     }
 
     @Test
@@ -255,6 +293,22 @@ public class BisqV1MessageIntegrityTest {
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.rawTransactionInputs = List.of()));
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.acceptedMediatorNodeAddresses =
                 Arrays.asList(args.mediatorNodeAddress, null)));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.rawTransactionInputs = List.of(rawTransactionInput(0, new byte[0], 100_000L))));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.rawTransactionInputs = List.of(rawTransactionInput(Long.MAX_VALUE, bytes(21), 100_000L))));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.rawTransactionInputs = List.of(rawTransactionInput(0, bytes(21), 100_000L, -1))));
+    }
+
+    @Test
+    void inputsForDepositTxRequestRejectsNegativeBurningManSelectionHeight() {
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.burningManSelectionHeight = -1));
+    }
+
+    @Test
+    void inputsForDepositTxRequestAcceptsZeroBurningManSelectionHeightAtMessageLayer() {
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.burningManSelectionHeight = 0));
     }
 
     private static InputsForDepositTxResponse newResponse(Consumer<ResponseArgs> customizer) {
@@ -329,7 +383,23 @@ public class BisqV1MessageIntegrityTest {
     }
 
     private static RawTransactionInput rawTransactionInput() {
-        return new RawTransactionInput(0, bytes(16), 100_000L);
+        return rawTransactionInput(0, bytes(16), 100_000L);
+    }
+
+    private static RawTransactionInput rawTransactionInput(long index, byte[] parentTransaction, long value) {
+        return new RawTransactionInput(index, parentTransaction, value);
+    }
+
+    private static RawTransactionInput rawTransactionInput(long index,
+                                                           byte[] parentTransaction,
+                                                           long value,
+                                                           int scriptTypeId) {
+        return RawTransactionInput.fromProto(protobuf.RawTransactionInput.newBuilder()
+                .setIndex(index)
+                .setParentTransaction(ByteString.copyFrom(parentTransaction))
+                .setValue(value)
+                .setScriptTypeId(scriptTypeId)
+                .build());
     }
 
     private static byte[] bytes(int value) {


### PR DESCRIPTION
Added shared structural validators in TradeMessageValidator.java.

Applied node-address shape checks across all bisq_v1.messages validate methods.

Switched message strings from non-empty to non-blank where applicable.

Added shallow RawTransactionInput shape checks for request/response messages.

Removed the message-layer MinerFeeValidation.checkTradeTxFee policy check; txFee now only needs to be positive at this layer.

Fixed absent optional arbitratorNodeAddress proto handling.

Made base TradeMessage.java reject blank tradeId/uid. Updated tests in BisqV1MessageIntegrityTest.java.

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized validation utilities for protocol messages to standardize checks.
* **Bug Fixes**
  * Tighter validation across trade messages: stricter blank-string rejection, stronger node-address validation, and stricter transaction-input bounds; improved handling of optional fields to reject invalid present values.
* **Tests**
  * Expanded tests to cover the stricter validation rules and additional invalid input cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->