### PR TITLE
Add cold storage reminder popup for high wallet balances

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -4651,3 +4651,10 @@ validation.phone.invalidDialingCode=Country dialing code for number {0} is inval
 validation.invalidAddressList=Must be comma separated list of valid addresses
 validation.capitual.invalidFormat=Must be a valid CAP code of format: CAP-XXXXXX (6 alphanumeric characters)
 
+popup.warning.coldStorage.headline=Move idle funds to cold storage
+popup.warning.coldStorage.msg=Your Bisq wallet currently holds {0}, which is above the {1} threshold.\n\n\
+  Please treat your Bisq wallet as a hot wallet. It is connected to the internet and exposed to any future security flaw in Bisq or its dependencies. \
+  A single zero-day vulnerability could put all funds in this wallet at risk.\n\n\
+  Keep only the amount you need for active trading in Bisq. Move the rest to a cold wallet (hardware wallet or offline storage) you control.\n\n\
+  This reminder will keep appearing on every launch and during navigation until your Bisq wallet balance is below {1}.
+

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -28,6 +28,7 @@ import bisq.desktop.main.overlays.notifications.Notification;
 import bisq.desktop.main.overlays.notifications.NotificationCenter;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.popups.PopupManager;
+import bisq.desktop.main.overlays.popups.WalletColdStorageReminder;
 import bisq.desktop.main.overlays.windows.DisplayAlertMessageWindow;
 import bisq.desktop.main.overlays.windows.TacWindow;
 import bisq.desktop.main.overlays.windows.TorNetworkSettingsWindow;
@@ -157,6 +158,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
     private final CorruptedStorageFileHandler corruptedStorageFileHandler;
     private final ClockWatcher clockWatcher;
     private final Navigation navigation;
+    private final WalletColdStorageReminder walletColdStorageReminder;
 
     @Getter
     private final BooleanProperty showAppScreen = new SimpleBooleanProperty();
@@ -204,7 +206,8 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
                          TorNetworkSettingsWindow torNetworkSettingsWindow,
                          CorruptedStorageFileHandler corruptedStorageFileHandler,
                          ClockWatcher clockWatcher,
-                         Navigation navigation) {
+                         Navigation navigation,
+                         WalletColdStorageReminder walletColdStorageReminder) {
         this.bisqSetup = bisqSetup;
         this.walletsSetup = walletsSetup;
         this.bsqWalletService = bsqWalletService;
@@ -233,6 +236,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         this.corruptedStorageFileHandler = corruptedStorageFileHandler;
         this.clockWatcher = clockWatcher;
         this.navigation = navigation;
+        this.walletColdStorageReminder = walletColdStorageReminder;
 
         TxIdTextField.setWalletService(btcWalletService);
 
@@ -357,6 +361,8 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         notificationCenter.onAllServicesAndViewsInitialized();
 
         maybeShowPopupsFromQueue();
+
+        walletColdStorageReminder.onAppStarted();
     }
 
     void onOpenDownloadWindow() {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/popups/WalletColdStorageReminder.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/popups/WalletColdStorageReminder.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.overlays.popups;
+
+import bisq.desktop.Navigation;
+
+import bisq.core.btc.Balances;
+import bisq.core.locale.Res;
+import bisq.core.util.FormattingUtils;
+import bisq.core.util.coin.CoinFormatter;
+
+import org.bitcoinj.core.Coin;
+
+import javax.inject.Named;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import java.util.concurrent.TimeUnit;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reminds users with significant on-wallet BTC to treat the Bisq wallet as a hot
+ * wallet and move idle funds to cold storage. Triggers on app launch and on every
+ * navigation event with a cooldown so it stays visible (and annoying) until the
+ * user reduces their wallet balance below the threshold.
+ */
+@Singleton
+@Slf4j
+public class WalletColdStorageReminder {
+
+    // Threshold above which the reminder fires. Tune by editing this constant.
+    private static final Coin THRESHOLD = Coin.parseCoin("0.5");
+
+    // Re-show interval for the navigation trigger.
+    private static final long COOLDOWN_MS = TimeUnit.HOURS.toMillis(6);
+
+    private final Balances balances;
+    private final Navigation navigation;
+    private final CoinFormatter btcFormatter;
+
+    private long lastShownMs = 0L;
+    private boolean navListenerRegistered = false;
+
+    @Inject
+    public WalletColdStorageReminder(Balances balances,
+                                     Navigation navigation,
+                                     @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter) {
+        this.balances = balances;
+        this.navigation = navigation;
+        this.btcFormatter = btcFormatter;
+    }
+
+    /** Call once after splash screen removal. Always shows on launch when above threshold. */
+    public void onAppStarted() {
+        registerNavListener();
+        maybeShow(true);
+    }
+
+    private void registerNavListener() {
+        if (navListenerRegistered) return;
+        navListenerRegistered = true;
+        navigation.addListener((path, data) -> maybeShow(false));
+    }
+
+    private void maybeShow(boolean ignoreCooldown) {
+        Coin total = totalBalance();
+        if (!total.isGreaterThan(THRESHOLD)) return;
+
+        long now = System.currentTimeMillis();
+        if (!ignoreCooldown && now - lastShownMs < COOLDOWN_MS) return;
+        lastShownMs = now;
+
+        new Popup()
+                .headLine(Res.get("popup.warning.coldStorage.headline"))
+                .warning(Res.get("popup.warning.coldStorage.msg",
+                        btcFormatter.formatCoinWithCode(total),
+                        btcFormatter.formatCoinWithCode(THRESHOLD)))
+                .show();
+    }
+
+    private Coin totalBalance() {
+        return orZero(balances.getAvailableBalance().get())
+                .add(orZero(balances.getReservedBalance().get()))
+                .add(orZero(balances.getLockedBalance().get()));
+    }
+
+    private static Coin orZero(Coin c) {
+        return c == null ? Coin.ZERO : c;
+    }
+}


### PR DESCRIPTION
Warns users holding more than 0.5 BTC in their Bisq wallet to treat it as a hot wallet and move idle funds to cold storage. Threshold and cooldown are constants in WalletColdStorageReminder for easy tuning.

Triggers:
- On every app launch (after splash) when total wallet balance exceeds the threshold.
- On every navigation event, throttled by a 6-hour cooldown.

This is intentionally persistent until the user reduces the on-wallet balance, given the elevated risk of a future Bisq-side zero-day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a localized cold-storage reminder that appears on app launch and during navigation when your Bisq wallet BTC balance exceeds a configured threshold. The popup shows the current balance and the threshold, advises moving excess funds to cold storage, and will reappear periodically until the balance drops below the threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->