### PR TITLE
Add a BSQ swap kill switch to the filter to allow for selective deact…

### DIFF
--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -139,6 +139,9 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
     // the ExcludeForHash annotated fields.
     private final String uid;
 
+    // Added at v1.9.24
+    private final boolean disableBsqSwap;
+
     // After we have created the signature from the filter data we clone it and apply the signature
     static Filter cloneWithSig(Filter filter, String signatureAsBase64) {
         return new Filter(filter.getBannedOfferIds(),
@@ -179,7 +182,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getDelayedPayoutPaymentAccounts(),
                 filter.getAddedBtcNodes(),
                 filter.getAddedSeedNodes(),
-                filter.getUid());
+                filter.getUid(),
+                filter.isDisableBsqSwap());
     }
 
     // Used for signature verification as we created the sig without the signatureAsBase64 field we set it to null again
@@ -222,7 +226,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getDelayedPayoutPaymentAccounts(),
                 filter.getAddedBtcNodes(),
                 filter.getAddedSeedNodes(),
-                filter.getUid());
+                filter.getUid(),
+                filter.isDisableBsqSwap());
     }
 
     public Filter(List<String> bannedOfferIds,
@@ -260,7 +265,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                   List<PaymentAccountFilter> delayedPayoutPaymentAccounts,
                   List<String> addedBtcNodes,
                   List<String> addedSeedNodes,
-                  String uid) {
+                  String uid,
+                  boolean disableBsqSwap) {
         this(bannedOfferIds,
                 nodeAddressesBannedFromTrading,
                 bannedPaymentAccounts,
@@ -299,7 +305,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 delayedPayoutPaymentAccounts,
                 addedBtcNodes,
                 addedSeedNodes,
-                uid);
+                uid,
+                disableBsqSwap);
     }
 
 
@@ -346,7 +353,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                   List<PaymentAccountFilter> delayedPayoutPaymentAccounts,
                   List<String> addedBtcNodes,
                   List<String> addedSeedNodes,
-                  String uid) {
+                  String uid,
+                  boolean disableBsqSwap) {
         this.bannedOfferIds = bannedOfferIds;
         this.nodeAddressesBannedFromTrading = nodeAddressesBannedFromTrading;
         this.bannedPaymentAccounts = bannedPaymentAccounts;
@@ -386,6 +394,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
         this.addedBtcNodes = addedBtcNodes;
         this.addedSeedNodes = addedSeedNodes;
         this.uid = uid;
+        this.disableBsqSwap = disableBsqSwap;
 
         // ownerPubKeyBytes can be null when called from tests
         if (ownerPubKeyBytes != null) {
@@ -458,7 +467,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 .addAllDelayedPayoutPaymentAccounts(delayedPayoutPaymentAccountList)
                 .addAllAddedBtcNodes(addedBtcNodes)
                 .addAllAddedSeedNodes(addedSeedNodes)
-                .setUid(uid);
+                .setUid(uid)
+                .setDisableBsqSwap(disableBsqSwap);
 
         Optional.ofNullable(signatureAsBase64).ifPresent(builder::setSignatureAsBase64);
         Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
@@ -512,7 +522,8 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 delayedPayoutPaymentAccounts,
                 ProtoUtil.protocolStringListToList(proto.getAddedBtcNodesList()),
                 ProtoUtil.protocolStringListToList(proto.getAddedSeedNodesList()),
-                proto.getUid()
+                proto.getUid(),
+                proto.getDisableBsqSwap()
         );
     }
 
@@ -573,6 +584,7 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 ",\n     takerFeeBsq=" + takerFeeBsq +
                 ",\n     addedBtcNodes=" + addedBtcNodes +
                 ",\n     addedSeedNodes=" + addedSeedNodes +
+                ",\n     disableBsqSwap=" + disableBsqSwap +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -426,6 +426,10 @@ public class FilterManager {
                         .anyMatch(e -> e.equals(nodeAddress.getFullAddress()));
     }
 
+    public boolean isBsqSwapDisabled() {
+        return getFilter() != null && getFilter().isDisableBsqSwap();
+    }
+
     public boolean isPriceInBounds(Offer offer) {
         // We allow 5% tolerance to the max allowed price percentage to avoid filtering offers in
         // high volatility environments

--- a/core/src/main/java/bisq/core/offer/OfferFilterService.java
+++ b/core/src/main/java/bisq/core/offer/OfferFilterService.java
@@ -80,6 +80,7 @@ public class OfferFilterService {
         REQUIRE_UPDATE_TO_NEW_VERSION,
         IS_INSUFFICIENT_COUNTERPARTY_TRADE_LIMIT,
         IS_MY_INSUFFICIENT_TRADE_LIMIT,
+        IS_BSQ_SWAP_DISABLED,
         HIDE_BSQ_SWAPS_DUE_DAO_DEACTIVATED;
 
         @Getter
@@ -97,6 +98,9 @@ public class OfferFilterService {
     public Result canTakeOffer(Offer offer, boolean isTakerApiUser) {
         if (isTakerApiUser && filterManager.getFilter() != null && filterManager.getFilter().isDisableApi()) {
             return Result.API_DISABLED;
+        }
+        if (isBsqSwapDisabled(offer)) {
+            return Result.IS_BSQ_SWAP_DISABLED;
         }
         if (!isAnyPaymentAccountValidForOffer(offer)) {
             return Result.HAS_NO_PAYMENT_ACCOUNT_VALID_FOR_OFFER;
@@ -160,6 +164,10 @@ public class OfferFilterService {
 
     public boolean isNodeAddressBanned(Offer offer) {
         return filterManager.isNodeAddressBanned(offer.getMakerNodeAddress());
+    }
+
+    public boolean isBsqSwapDisabled(Offer offer) {
+        return offer.isBsqSwapOffer() && filterManager.isBsqSwapDisabled();
     }
 
     public boolean requireUpdateToNewVersion() {

--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -402,6 +402,8 @@ public class OfferUtil {
                 Res.get("offerbook.warning.currencyBanned"));
         checkArgument(!filterManager.isPaymentMethodBanned(paymentMethod),
                 Res.get("offerbook.warning.paymentMethodBanned"));
+        checkArgument(!PaymentMethod.BSQ_SWAP.equals(paymentMethod) || !filterManager.isBsqSwapDisabled(),
+                Res.get("offerbook.warning.bsqSwapDisabled"));
     }
 
     // Returns an edited payload: a merge of the original offerPayload and

--- a/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapTakeOfferModel.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapTakeOfferModel.java
@@ -108,6 +108,8 @@ public class BsqSwapTakeOfferModel extends BsqSwapOfferModel {
             warningHandler.handleErrorMessage(Res.get("offerbook.warning.offerBlocked"));
         } else if (filterManager.isNodeAddressBanned(offer.getMakerNodeAddress())) {
             warningHandler.handleErrorMessage(Res.get("offerbook.warning.nodeBlocked"));
+        } else if (filterManager.isBsqSwapDisabled()) {
+            warningHandler.handleErrorMessage(Res.get("offerbook.warning.bsqSwapDisabled"));
         } else if (filterManager.requireUpdateToNewVersionForTrading()) {
             warningHandler.handleErrorMessage(Res.get("offerbook.warning.requireUpdateToNewVersion"));
         } else if (tradeManager.wasOfferAlreadyUsedInTrade(offer.getId())) {

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -448,6 +448,7 @@ offerbook.warning.requireUpdateToNewVersion=Your version of Bisq is not compatib
   Please update to the latest Bisq version at [HYPERLINK:https://bisq.network/downloads].
 offerbook.warning.offerWasAlreadyUsedInTrade=You cannot take this offer because you already took it earlier. \
   It could be that your previous take-offer attempt resulted in a failed trade.
+offerbook.warning.bsqSwapDisabled=BSQ swaps are currently disabled by the Bisq developers.\nPlease visit the Bisq Forum for more information.
 offerbook.warning.hideBsqSwapsDueDaoDeactivated=You cannot take this offer because you have deactivated the DAO
 
 offerbook.info.sellAtMarketPrice=You will sell at market price (updated every minute).
@@ -3081,6 +3082,7 @@ filterWindow.remove=Remove filter
 filterWindow.btcFeeReceiverAddresses=BTC fee receiver addresses
 filterWindow.disableApi=Disable API
 filterWindow.disableMempoolValidation=Disable Mempool Validation
+filterWindow.disableBsqSwap=Disable BSQ swaps
 filterWindow.disablePowMessage=Disable messages requiring Proof of Work
 filterWindow.powDifficulty=Proof of work difficulty (BSQ swap offers)
 filterWindow.enabledPowVersions=Enabled proof of work versions (comma sep. integers)
@@ -4643,4 +4645,3 @@ validation.phone.invalidDialingCode=Country dialing code for number {0} is inval
   The correct dialing code is {2}.
 validation.invalidAddressList=Must be comma separated list of valid addresses
 validation.capitual.invalidFormat=Must be a valid CAP code of format: CAP-XXXXXX (6 alphanumeric characters)
-

--- a/core/src/test/java/bisq/core/filter/TestFilter.java
+++ b/core/src/test/java/bisq/core/filter/TestFilter.java
@@ -108,7 +108,8 @@ public class TestFilter {
                 Collections.emptyList(),
                 List.of("test1.onion:1221"),
                 List.of("test2.onion:1221"),
-                UUID.randomUUID().toString()
+                UUID.randomUUID().toString(),
+                false
         );
     }
 

--- a/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
+++ b/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
@@ -81,7 +81,8 @@ public class UserPayloadModelVOTest {
                 Lists.newArrayList(),
                 Lists.newArrayList(),
                 Lists.newArrayList(),
-                UUID.randomUUID().toString()));
+                UUID.randomUUID().toString(),
+                false));
 
         vo.setRegisteredArbitrator(ArbitratorTest.getArbitratorMock());
         vo.setRegisteredMediator(MediatorTest.getMediatorMock());

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -704,6 +704,9 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
                             "isInsufficientTradeLimit case.");
                 }
                 break;
+            case IS_BSQ_SWAP_DISABLED:
+                new Popup().warning(Res.get("offerbook.warning.bsqSwapDisabled")).show();
+                break;
             case HIDE_BSQ_SWAPS_DUE_DAO_DEACTIVATED:
                 new Popup().warning(Res.get("offerbook.warning.hideBsqSwapsDueDaoDeactivated")).show();
                 break;

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/FilterWindow.java
@@ -197,6 +197,8 @@ public class FilterWindow extends Overlay<FilterWindow> {
                 Res.get("filterWindow.disableMempoolValidation"), 15);
         CheckBox disableApiCheckBox = addLabelCheckBox(gridPane, ++rowIndex,
                 Res.get("filterWindow.disableApi"));
+        CheckBox disableBsqSwapCheckBox = addLabelCheckBox(gridPane, ++rowIndex,
+                Res.get("filterWindow.disableBsqSwap"));
         CheckBox disablePowMessage = addLabelCheckBox(gridPane, ++rowIndex,
                 Res.get("filterWindow.disablePowMessage"));
         InputTextField powDifficultyTF = addInputTextField(gridPane, ++rowIndex,
@@ -243,6 +245,7 @@ public class FilterWindow extends Overlay<FilterWindow> {
             disableTradeBelowVersionTF.setText(filter.getDisableTradeBelowVersion());
             disableMempoolValidationCheckBox.setSelected(filter.isDisableMempoolValidation());
             disableApiCheckBox.setSelected(filter.isDisableApi());
+            disableBsqSwapCheckBox.setSelected(filter.isDisableBsqSwap());
             disablePowMessage.setSelected(filter.isDisablePowMessage());
             powDifficultyTF.setText(String.valueOf(filter.getPowDifficulty()));
 
@@ -299,7 +302,8 @@ public class FilterWindow extends Overlay<FilterWindow> {
                         readAsPaymentAccountFiltersList(delayedPayoutTF),
                         readAsList(addedBtcNodesTF),
                         readAsList(addedSeedNodesTF),
-                        uidTF.getText()
+                        uidTF.getText(),
+                        disableBsqSwapCheckBox.isSelected()
                 );
 
                 // We remove first the old filter

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -768,6 +768,7 @@ message Filter {
     repeated string addedBtcNodes = 37;
     repeated string addedSeedNodes = 38;
     string uid = 39;
+    bool disable_bsq_swap = 40;
 }
 
 /* Deprecated */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network filter setting to disable BSQ swap functionality across the network.
  * Users attempting to take BSQ swap offers now receive clear warning messages when the feature is disabled.

* **UI Improvements**
  * Filter management window now includes a toggle to control BSQ swap availability.
  * Enhanced offer book validation with dedicated messaging for disabled BSQ swap scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->