### PR TITLE
Validation commit pattern cleanup

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDelayedPayoutTxSignatureRequest.java
@@ -51,9 +51,9 @@ public class BuyerProcessDelayedPayoutTxSignatureRequest extends TradeTask {
             TradingPeer tradePeer = processModel.getTradePeer();
 
             Transaction preparedDelayedPayoutTx = toVerifiedTransaction(request.getDelayedPayoutTx(), btcWalletService);
-            processModel.setPreparedDelayedPayoutTx(preparedDelayedPayoutTx);
-
             byte[] delayedPayoutTxSellerSignature = checkDerEncodedEcdsaSignature(request.getDelayedPayoutTxSellerSignature());
+
+            processModel.setPreparedDelayedPayoutTx(preparedDelayedPayoutTx);
             tradePeer.setDelayedPayoutTxSignature(delayedPayoutTxSellerSignature);
 
             // When we receive that message the taker has published the taker fee, so we apply it to the trade.

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -79,7 +79,8 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             trade.applyDepositTx(committedDepositTx);
 
             byte[] peersDelayedPayoutTxBytes = checkSerializedTransaction(message.getDelayedPayoutTx(), btcWalletService);
-            byte[] myDelayedPayoutTxBytes = trade.getDelayedPayoutTxBytes();
+            byte[] myDelayedPayoutTxBytes = checkNotNull(trade.getDelayedPayoutTxBytes(),
+                    "trade.getDelayedPayoutTxBytes() must not be null");
             checkArgument(Arrays.equals(peersDelayedPayoutTxBytes, myDelayedPayoutTxBytes),
                     "peersDelayedPayoutTx and myDelayedPayoutTx must be the same" +
                             "\n myDelayedPayoutTx: " + Utilities.bytesAsHexString(myDelayedPayoutTxBytes) +

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -21,6 +21,7 @@ import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 import bisq.core.offer.Offer;
+import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.InputsForDepositTxRequest;
@@ -28,7 +29,9 @@ import bisq.core.trade.protocol.bisq_v1.model.TradingPeer;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 import bisq.core.trade.validation.DelayedPayoutTxValidation;
 import bisq.core.trade.validation.DepositTxValidation;
+import bisq.core.trade.validation.MinerFeeValidation;
 import bisq.core.trade.validation.TradeAmountValidation;
+import bisq.core.trade.validation.TradeFeeValidation;
 import bisq.core.trade.validation.TradePriceValidation;
 import bisq.core.trade.validation.TransactionValidation;
 import bisq.core.user.User;
@@ -51,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 import static bisq.core.trade.validation.DsaSignatureValidation.checkDSASignature;
 import static bisq.core.trade.validation.TradeValidation.checkPeersDate;
 import static bisq.core.trade.validation.TradeValidation.getCheckedMediatorPubKeyRing;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -63,6 +67,7 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
     protected void run() {
         try {
             runInterceptHook();
+
             InputsForDepositTxRequest request = (InputsForDepositTxRequest) processModel.getTradeMessage();
             checkNotNull(request);
 
@@ -72,17 +77,22 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
             DelayedPayoutTxReceiverService delayedPayoutTxReceiverService = processModel.getDelayedPayoutTxReceiverService();
             User user = checkNotNull(processModel.getUser(), "User must not be null");
             PriceFeedService priceFeedService = processModel.getTradeManager().getPriceFeedService();
+            FeeService feeService = processModel.getFeeService();
 
             tradingPeer.setHashOfPaymentAccountPayload(request.getHashOfTakersPaymentAccountPayload());
             tradingPeer.setPaymentMethodId(request.getTakersPaymentMethodId());
 
             Coin tradeAmount = TradeAmountValidation.checkTradeAmount(request.getTradeAmountAsCoin(), offer.getMinAmount(), offer.getAmount());
+            Coin tradeTxFee = MinerFeeValidation.checkTradeTxFeeIsInTolerance(request.getTxFeeAsCoin(), feeService);
+            checkArgument(tradeTxFee.equals(trade.getTradeTxFee()), "Trade tx fee from message must match tx fee from request");
+            TradeFeeValidation.checkTakerFee(request.getTakerFeeAsCoin(), request.isCurrencyForTakerFeeBtc(), tradeAmount);
+
             trade.setAmount(tradeAmount);
 
             List<RawTransactionInput> takerRawTransactionInputs = DepositTxValidation.checkTakersRawTransactionInputs(request.getRawTransactionInputs(),
                     btcWalletService,
                     offer,
-                    trade.getTradeTxFee(),
+                    tradeTxFee,
                     tradeAmount);
             tradingPeer.setRawTransactionInputs(takerRawTransactionInputs);
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/mediation/ProcessMediatedPayoutSignatureMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/mediation/ProcessMediatedPayoutSignatureMessage.java
@@ -26,6 +26,7 @@ import bisq.common.taskrunner.TaskRunner;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.trade.validation.TransactionValidation.checkDerEncodedEcdsaSignature;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -42,7 +43,8 @@ public class ProcessMediatedPayoutSignatureMessage extends TradeTask {
             MediatedPayoutTxSignatureMessage message = (MediatedPayoutTxSignatureMessage) processModel.getTradeMessage();
             checkNotNull(message);
 
-            processModel.getTradePeer().setMediatedPayoutTxSignature(message.getTxSignature());
+            byte[] txSignature = checkDerEncodedEcdsaSignature(message.getTxSignature());
+            processModel.getTradePeer().setMediatedPayoutTxSignature(txSignature);
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessCounterCurrencyTransferStartedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessCounterCurrencyTransferStartedMessage.java
@@ -28,10 +28,13 @@ import bisq.common.taskrunner.TaskRunner;
 import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.trade.validation.TransactionValidation.checkBitcoinAddress;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class SellerProcessCounterCurrencyTransferStartedMessage extends TradeTask {
+    private static final int MAX_COUNTER_CURRENCY_DATA_LENGTH = 100;
+
     public SellerProcessCounterCurrencyTransferStartedMessage(TaskRunner<Trade> taskHandler, Trade trade) {
         super(taskHandler, trade);
     }
@@ -47,20 +50,27 @@ public class SellerProcessCounterCurrencyTransferStartedMessage extends TradeTas
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
 
             String buyerPayoutAddress = checkBitcoinAddress(message.getBuyerPayoutAddress(), btcWalletService);
-            tradingPeer.setPayoutAddressString(buyerPayoutAddress);
+            byte[] buyerSignature = message.getBuyerSignature();
 
-            tradingPeer.setSignature(checkNotNull(message.getBuyerSignature()));
+            String counterCurrencyTxId = message.getCounterCurrencyTxId();
+            checkArgument(counterCurrencyTxId == null || counterCurrencyTxId.length() < MAX_COUNTER_CURRENCY_DATA_LENGTH,
+                    "counterCurrencyTxId must be shorter than %s chars", MAX_COUNTER_CURRENCY_DATA_LENGTH);
+
+            String counterCurrencyExtraData = message.getCounterCurrencyExtraData();
+            checkArgument(counterCurrencyExtraData == null || counterCurrencyExtraData.length() < MAX_COUNTER_CURRENCY_DATA_LENGTH,
+                    "counterCurrencyExtraData must be shorter than %s chars", MAX_COUNTER_CURRENCY_DATA_LENGTH);
+
+            tradingPeer.setPayoutAddressString(buyerPayoutAddress);
+            tradingPeer.setSignature(buyerSignature);
 
             // update to the latest peer address of our peer if the message is correct
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 
-            String counterCurrencyTxId = message.getCounterCurrencyTxId();
-            if (counterCurrencyTxId != null && counterCurrencyTxId.length() < 100) {
+            if (counterCurrencyTxId != null) {
                 trade.setCounterCurrencyTxId(counterCurrencyTxId);
             }
 
-            String counterCurrencyExtraData = message.getCounterCurrencyExtraData();
-            if (counterCurrencyExtraData != null && counterCurrencyExtraData.length() < 100) {
+            if (counterCurrencyExtraData != null) {
                 trade.setCounterCurrencyExtraData(counterCurrencyExtraData);
             }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessDelayedPayoutTxSignatureResponse.java
@@ -55,13 +55,13 @@ public class SellerProcessDelayedPayoutTxSignatureResponse extends TradeTask {
             Transaction myDepositTx = checkNotNull(processModel.getDepositTx(), "processModel.getDepositTx() must not be null");
 
             byte[] delayedPayoutTxBuyerSignature = checkDerEncodedEcdsaSignature(response.getDelayedPayoutTxBuyerSignature());
-            tradePeer.setDelayedPayoutTxSignature(delayedPayoutTxBuyerSignature);
-
             Transaction parsedBuyersDepositTxWithWitnesses = toVerifiedTransaction(response.getDepositTx(), btcWalletService);
             Transaction buyersDepositTxWithWitnesses = checkDepositTxMatchesIgnoringWitnessesAndScriptSigs(
                     parsedBuyersDepositTxWithWitnesses,
                     myDepositTx,
                     btcWalletService);
+
+            tradePeer.setDelayedPayoutTxSignature(delayedPayoutTxBuyerSignature);
             tradeWalletService.sellerAddsBuyerWitnessesToDepositTx(myDepositTx, buyersDepositTxWithWitnesses);
 
             // update to the latest peer address of our peer if the message is correct

--- a/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
@@ -48,14 +48,27 @@ public final class TradeValidation {
     /* --------------------------------------------------------------------- */
 
     public static String checkTradeId(String tradeId, TradeMessage tradeMessage) {
-        checkArgument(isTradeIdValid(tradeId, tradeMessage), "TradeId %s is not valid", tradeId);
+        checkNotNull(tradeMessage, "tradeMessage must not be null");
+        checkNonBlankString(tradeId, "tradeId");
+        String tradeIdFromMessage = checkNonBlankString(tradeMessage.getTradeId(), "tradeMessage.tradeId");
+        checkArgument(tradeId.equals(tradeIdFromMessage), "TradeId %s is not matching " +
+                "tradeId from message %s", tradeId, tradeIdFromMessage);
         return tradeId;
     }
 
     public static boolean isTradeIdValid(String tradeId, TradeMessage tradeMessage) {
-        checkNonBlankString(tradeId, "tradeId");
-        checkNotNull(tradeMessage, "tradeMessage must not be null");
-        return tradeId.equals(tradeMessage.getTradeId());
+        return isTradeIdValid(tradeMessage, tradeId);
+    }
+
+    public static boolean isTradeIdValid(TradeMessage tradeMessage, String expectedTradeId) {
+        try {
+            checkNotNull(tradeMessage, "tradeMessage must not be null");
+            checkNonBlankString(expectedTradeId, "expectedTradeId");
+            String tradeId = checkNonBlankString(tradeMessage.getTradeId(), "tradeMessage.tradeId");
+            return tradeId.equals(expectedTradeId);
+        } catch (RuntimeException e) {
+            return false;
+        }
     }
 
 

--- a/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
@@ -48,7 +48,7 @@ class TradeValidationTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> TradeValidation.checkTradeId("trade-id", ValidationTestUtils.tradeMessage("other-trade-id")));
 
-        assertEquals("TradeId trade-id is not valid", exception.getMessage());
+        assertEquals("TradeId trade-id is not matching tradeId from message other-trade-id", exception.getMessage());
     }
 
     @Test
@@ -68,12 +68,12 @@ class TradeValidationTest {
 
     @Test
     void isTradeIdValidRejectsNullTradeId() {
-        assertThrows(NullPointerException.class, () -> TradeValidation.isTradeIdValid(null, ValidationTestUtils.tradeMessage("trade-id")));
+        assertFalse(TradeValidation.isTradeIdValid(null, ValidationTestUtils.tradeMessage("trade-id")));
     }
 
     @Test
     void isTradeIdValidRejectsNullTradeMessage() {
-        assertThrows(NullPointerException.class, () -> TradeValidation.isTradeIdValid("trade-id", null));
+        assertFalse(TradeValidation.isTradeIdValid("trade-id", null));
     }
 
     /* --------------------------------------------------------------------- */


### PR DESCRIPTION
Key changes:

Kept message validate() methods structural only; no domain validation moved there.

Reordered maker/taker deposit-input handling so untrusted values are validated first, returned checked values are used, then model fields are committed.

Added missing validation before commit for DER signatures, delayed-payout/deposit tx matching, payout message peer-address updates, counter-currency tx id/extra-data length rejection, and optional payment-account payload hash checks.

Prevented the previous behavior where invalid long counter-currency data was silently ignored while the rest of the message still committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of ECDSA signatures and transaction payloads across deposit, payout, and mediation flows to reject malformed inputs.
  * Added null-safety checks for delayed payout bytes and other critical trade fields.
  * Enforced miner-fee reconciliation so incoming tx fees are validated against local trade fees before acceptance.
* **Tests**
  * Updated trade-id and null-input tests to reflect stricter validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->