### PR TITLE
Add witness validation to trade protocol

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -73,12 +73,15 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.btc.wallet.validation.WitnessValidation.checkCanonicalP2WpkhWitness;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TradeWalletService {
     private static final Logger log = LoggerFactory.getLogger(TradeWalletService.class);
     public static final Coin MIN_DELAYED_PAYOUT_TX_FEE = Coin.valueOf(1000);
+    private static final int P2WPKH_WITNESS_PUSH_COUNT = 2;
+    private static final int COMPRESSED_PUB_KEY_LENGTH = 33;
 
     private final WalletsSetup walletsSetup;
     private final Preferences preferences;
@@ -579,7 +582,7 @@ public class TradeWalletService {
                             " is not native segwit P2WPKH (scriptPubKey=" + scriptPubKey + ")");
                 }
                 if (!TransactionWitness.EMPTY.equals(makersInput.getWitness())) {
-                    input.setWitness(makersInput.getWitness());
+                    input.setWitness(checkCanonicalP2WpkhWitness(makersInput.getWitness(), i));
                 }
                 depositTx.addInput(input);
             }
@@ -645,7 +648,7 @@ public class TradeWalletService {
             txInput.setScriptSig(takersScriptSig);
             TransactionWitness witness = takersInput.getWitness();
             if (!TransactionWitness.EMPTY.equals(witness)) {
-                txInput.setWitness(witness);
+                txInput.setWitness(checkCanonicalP2WpkhWitness(witness, i));
             }
         }
 
@@ -672,7 +675,7 @@ public class TradeWalletService {
 
             if (TransactionWitness.EMPTY.equals(txInput.getWitness()) &&
                     !TransactionWitness.EMPTY.equals(witnessFromBuyer)) {
-                txInput.setWitness(witnessFromBuyer);
+                txInput.setWitness(checkCanonicalP2WpkhWitness(witnessFromBuyer, i));
             }
         }
 

--- a/core/src/main/java/bisq/core/btc/wallet/validation/WitnessValidation.java
+++ b/core/src/main/java/bisq/core/btc/wallet/validation/WitnessValidation.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.btc.wallet.validation;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.SignatureDecodeException;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionWitness;
+import org.bitcoinj.core.VerificationException;
+import org.bitcoinj.crypto.TransactionSignature;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Slf4j
+public final class WitnessValidation {
+    private static final int P2WPKH_WITNESS_PUSH_COUNT = 2;
+    private static final int MAX_DER_SIGNATURE_WITH_SIGHASH_LENGTH = 73;
+    private static final int COMPRESSED_PUB_KEY_LENGTH = 33;
+
+    private WitnessValidation() {
+    }
+
+    public static TransactionWitness checkCanonicalP2WpkhWitness(TransactionWitness witness, int inputIndex) {
+        TransactionWitness checkedWitness = checkNotNull(witness,
+                "witness must not be null for input %s", inputIndex);
+        checkArgument(!TransactionWitness.EMPTY.equals(checkedWitness),
+                "witness must not be empty for input %s", inputIndex);
+        checkArgument(checkedWitness.getPushCount() == P2WPKH_WITNESS_PUSH_COUNT,
+                "P2WPKH witness for input %s must have exactly %s pushes. pushCount=%s",
+                inputIndex,
+                P2WPKH_WITNESS_PUSH_COUNT,
+                checkedWitness.getPushCount());
+
+        byte[] signature = checkNotNull(checkedWitness.getPush(0),
+                "witness signature must not be null for input %s", inputIndex);
+        checkArgument(signature.length <= MAX_DER_SIGNATURE_WITH_SIGHASH_LENGTH,
+                "witness signature for input %s exceeds maximum size. size=%s, max=%s",
+                inputIndex,
+                signature.length,
+                MAX_DER_SIGNATURE_WITH_SIGHASH_LENGTH);
+
+        try {
+            TransactionSignature transactionSignature = TransactionSignature.decodeFromBitcoin(signature,
+                    true,
+                    true);
+            checkArgument(transactionSignature.sigHashMode() == Transaction.SigHash.ALL &&
+                            !transactionSignature.anyoneCanPay(),
+                    "witness signature for input %s must use SIGHASH_ALL without ANYONECANPAY",
+                    inputIndex);
+        } catch (SignatureDecodeException | VerificationException e) {
+            throw new IllegalArgumentException("Invalid canonical witness signature for input " + inputIndex, e);
+        }
+
+        byte[] pubKey = checkNotNull(checkedWitness.getPush(1),
+                "witness pubKey must not be null for input %s", inputIndex);
+        checkArgument(pubKey.length == COMPRESSED_PUB_KEY_LENGTH,
+                "witness pubKey for input %s must be compressed. size=%s",
+                inputIndex,
+                pubKey.length);
+        checkArgument(ECKey.fromPublicOnly(pubKey).isCompressed(),
+                "witness pubKey for input %s must be a compressed valid curve point",
+                inputIndex);
+
+        return checkedWitness;
+    }
+}

--- a/core/src/test/java/bisq/core/btc/wallet/validation/WitnessValidationTest.java
+++ b/core/src/test/java/bisq/core/btc/wallet/validation/WitnessValidationTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.btc.wallet.validation;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionWitness;
+import org.bitcoinj.crypto.TransactionSignature;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class WitnessValidationTest {
+    @Test
+    void checkCanonicalP2WpkhWitnessAcceptsCanonicalWitness() {
+        TransactionWitness witness = canonicalP2wpkhWitness();
+
+        assertSame(witness, WitnessValidation.checkCanonicalP2WpkhWitness(witness, 0));
+    }
+
+    @Test
+    void checkCanonicalP2WpkhWitnessRejectsEmptyWitness() {
+        assertThrows(IllegalArgumentException.class,
+                () -> WitnessValidation.checkCanonicalP2WpkhWitness(TransactionWitness.EMPTY, 0));
+    }
+
+    @Test
+    void checkCanonicalP2WpkhWitnessRejectsUnexpectedPushCount() {
+        TransactionWitness witness = new TransactionWitness(3);
+        witness.setPush(0, canonicalSignature(Transaction.SigHash.ALL, false));
+        witness.setPush(1, new ECKey().getPubKey());
+        witness.setPush(2, new byte[]{});
+
+        assertThrows(IllegalArgumentException.class,
+                () -> WitnessValidation.checkCanonicalP2WpkhWitness(witness, 0));
+    }
+
+    @Test
+    void checkCanonicalP2WpkhWitnessRejectsOversizedSignaturePush() {
+        TransactionWitness witness = new TransactionWitness(2);
+        witness.setPush(0, new byte[74]);
+        witness.setPush(1, new ECKey().getPubKey());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> WitnessValidation.checkCanonicalP2WpkhWitness(witness, 0));
+    }
+
+    @Test
+    void checkCanonicalP2WpkhWitnessRejectsNonAllSignatureHashMode() {
+        TransactionWitness witness = new TransactionWitness(2);
+        witness.setPush(0, canonicalSignature(Transaction.SigHash.SINGLE, false));
+        witness.setPush(1, new ECKey().getPubKey());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> WitnessValidation.checkCanonicalP2WpkhWitness(witness, 0));
+    }
+
+    @Test
+    void checkCanonicalP2WpkhWitnessRejectsAnyoneCanPaySignature() {
+        TransactionWitness witness = new TransactionWitness(2);
+        witness.setPush(0, canonicalSignature(Transaction.SigHash.ALL, true));
+        witness.setPush(1, new ECKey().getPubKey());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> WitnessValidation.checkCanonicalP2WpkhWitness(witness, 0));
+    }
+
+    @Test
+    void checkCanonicalP2WpkhWitnessRejectsUncompressedPubKey() {
+        ECKey key = new ECKey();
+        TransactionWitness witness = new TransactionWitness(2);
+        witness.setPush(0, canonicalSignature(Transaction.SigHash.ALL, false));
+        witness.setPush(1, key.decompress().getPubKey());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> WitnessValidation.checkCanonicalP2WpkhWitness(witness, 0));
+    }
+
+    private static TransactionWitness canonicalP2wpkhWitness() {
+        ECKey key = new ECKey();
+        return TransactionWitness.redeemP2WPKH(canonicalTransactionSignature(Transaction.SigHash.ALL, false), key);
+    }
+
+    private static byte[] canonicalSignature(Transaction.SigHash sigHash, boolean anyoneCanPay) {
+        return canonicalTransactionSignature(sigHash, anyoneCanPay).encodeToBitcoin();
+    }
+
+    private static TransactionSignature canonicalTransactionSignature(Transaction.SigHash sigHash,
+                                                                      boolean anyoneCanPay) {
+        ECKey key = new ECKey();
+        ECKey.ECDSASignature signature = key.sign(Sha256Hash.ZERO_HASH).toCanonicalised();
+        return new TransactionSignature(signature, sigHash, anyoneCanPay);
+    }
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of Bitcoin transaction signatures to enforce canonical SegWit encoding standards
  * Enhanced deposit transaction workflows with improved signature verification during taker and seller operations
  * Added comprehensive validation checks for signature format, public key validity, and encoding compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->