### PR TITLE
Add delayed payout tx signature validation

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -72,6 +72,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.btc.wallet.validation.DelayedPayoutTxSignatureValidation.checkCanonicalDelayedPayoutTxSignature;
 import static bisq.core.btc.wallet.validation.WitnessValidation.checkCanonicalP2WpkhWitness;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -751,8 +752,8 @@ public class TradeWalletService {
             throws AddressFormatException, TransactionVerificationException, SignatureDecodeException {
 
         Script redeemScript = get2of2MultiSigRedeemScript(buyerPubKey, sellerPubKey);
-        ECKey.ECDSASignature buyerECDSASignature = ECKey.ECDSASignature.decodeFromDER(buyerSignature).toCanonicalised();
-        ECKey.ECDSASignature sellerECDSASignature = ECKey.ECDSASignature.decodeFromDER(sellerSignature).toCanonicalised();
+        ECKey.ECDSASignature buyerECDSASignature = checkCanonicalDelayedPayoutTxSignature(buyerSignature, "buyer");
+        ECKey.ECDSASignature sellerECDSASignature = checkCanonicalDelayedPayoutTxSignature(sellerSignature, "seller");
         TransactionSignature buyerTxSig = new TransactionSignature(buyerECDSASignature, Transaction.SigHash.ALL, false);
         TransactionSignature sellerTxSig = new TransactionSignature(sellerECDSASignature, Transaction.SigHash.ALL, false);
         TransactionInput input = delayedPayoutTx.getInput(0);

--- a/core/src/main/java/bisq/core/btc/wallet/validation/DelayedPayoutTxSignatureValidation.java
+++ b/core/src/main/java/bisq/core/btc/wallet/validation/DelayedPayoutTxSignatureValidation.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.btc.wallet.validation;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.SignatureDecodeException;
+
+import java.math.BigInteger;
+
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class DelayedPayoutTxSignatureValidation {
+    private DelayedPayoutTxSignatureValidation() {
+    }
+
+    public static ECKey.ECDSASignature checkCanonicalDelayedPayoutTxSignature(byte[] signature,
+                                                                              String signer) {
+        byte[] checkedSignature = checkNotNull(signature,
+                "%s delayed payout tx signature must not be null",
+                signer);
+        try {
+            ECKey.ECDSASignature decodedSignature = ECKey.ECDSASignature.decodeFromDER(checkedSignature);
+            checkArgument(Arrays.equals(checkedSignature, decodedSignature.encodeToDER()),
+                    "%s delayed payout tx signature must be strictly DER encoded",
+                    signer);
+            checkArgument(isValidSignatureValue(decodedSignature.r),
+                    "%s delayed payout tx signature r value is outside of allowed range",
+                    signer);
+            checkArgument(isValidSignatureValue(decodedSignature.s),
+                    "%s delayed payout tx signature s value is outside of allowed range",
+                    signer);
+            checkArgument(decodedSignature.isCanonical(),
+                    "%s delayed payout tx signature must be canonical (low-S)",
+                    signer);
+            return decodedSignature;
+        } catch (SignatureDecodeException e) {
+            throw new IllegalArgumentException("Invalid " + signer + " delayed payout tx signature", e);
+        }
+    }
+
+    private static boolean isValidSignatureValue(BigInteger value) {
+        return value.signum() > 0 && value.compareTo(ECKey.CURVE.getN()) < 0;
+    }
+}

--- a/core/src/main/java/bisq/core/btc/wallet/validation/WitnessValidation.java
+++ b/core/src/main/java/bisq/core/btc/wallet/validation/WitnessValidation.java
@@ -24,12 +24,9 @@ import org.bitcoinj.core.TransactionWitness;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.TransactionSignature;
 
-import lombok.extern.slf4j.Slf4j;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-@Slf4j
 public final class WitnessValidation {
     private static final int P2WPKH_WITNESS_PUSH_COUNT = 2;
     private static final int MAX_DER_SIGNATURE_WITH_SIGHASH_LENGTH = 73;

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/buyer/ProcessBsqSwapFinalizeTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/buyer/ProcessBsqSwapFinalizeTxRequest.java
@@ -120,8 +120,8 @@ public abstract class ProcessBsqSwapFinalizeTxRequest extends BsqSwapTask {
                 log.warn("Sellers BTC change is not as expected. This can happen if fee estimation for buyersBsqInputs did not " +
                         "succeed (e.g. dust change, max. iterations reached,...");
                 log.warn("buyersBtcPayout={}, sumInputs={}, sellersTxFee={}, buyersTxFee={}, expectedChange={}, change={}",
-                        buyersBtcPayout.toFriendlyString(), sumInputs.toFriendlyString(), sellersTxFee.toFriendlyString(),
-                        buyersTxFee.toFriendlyString(), expectedChange.toFriendlyString(), change);
+                        buyersBtcPayout.getValue(), sumInputs.getValue(), sellersTxFee.getValue(),
+                        buyersTxFee.getValue(), expectedChange.getValue(), change);
             }
             // By enforcing that it must not be larger than expectedChange we guarantee that peer did not cheat on
             // tx fees.

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/seller/ProcessTxInputsMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/seller/ProcessTxInputsMessage.java
@@ -109,8 +109,8 @@ public abstract class ProcessTxInputsMessage extends BsqSwapTask {
                         "The change would be used as miner fee in such cases.");
                 log.warn("sellersBsqPayoutAmount={}, sumInputs={}, getBuyersTradeFee={}, " +
                                 "getSellersTradeFee={}, expectedChange={},change={}",
-                        sellersBsqPayoutAmount.toFriendlyString(), sumInputs.toFriendlyString(), getBuyersTradeFee(),
-                        getSellersTradeFee(), expectedChange.toFriendlyString(), change);
+                        sellersBsqPayoutAmount.getValue(), sumInputs.getValue(), getBuyersTradeFee(),
+                        getSellersTradeFee(), expectedChange.getValue(), change);
             }
             // By enforcing that it must not be larger than expectedChange we guarantee that peer did not cheat on
             // trade fees.

--- a/core/src/test/java/bisq/core/btc/wallet/validation/DelayedPayoutTxSignatureValidationTest.java
+++ b/core/src/test/java/bisq/core/btc/wallet/validation/DelayedPayoutTxSignatureValidationTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.btc.wallet.validation;
+
+import org.bitcoinj.core.ECKey;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DelayedPayoutTxSignatureValidationTest {
+    @Test
+    void checkCanonicalDelayedPayoutTxSignatureAcceptsCanonicalSignature() {
+        byte[] signature = canonicalSignature();
+
+        ECKey.ECDSASignature checkedSignature =
+                DelayedPayoutTxSignatureValidation.checkCanonicalDelayedPayoutTxSignature(signature, "buyer");
+
+        assertEquals(BigInteger.ONE, checkedSignature.r);
+        assertEquals(BigInteger.ONE, checkedSignature.s);
+    }
+
+    @Test
+    void checkCanonicalDelayedPayoutTxSignatureRejectsHighSBuyerSignature() {
+        assertThrows(IllegalArgumentException.class,
+                () -> DelayedPayoutTxSignatureValidation.checkCanonicalDelayedPayoutTxSignature(highSSignature(),
+                        "buyer"));
+    }
+
+    @Test
+    void checkCanonicalDelayedPayoutTxSignatureRejectsHighSSellerSignature() {
+        assertThrows(IllegalArgumentException.class,
+                () -> DelayedPayoutTxSignatureValidation.checkCanonicalDelayedPayoutTxSignature(highSSignature(),
+                        "seller"));
+    }
+
+    private static byte[] canonicalSignature() {
+        return new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.ONE).encodeToDER();
+    }
+
+    private static byte[] highSSignature() {
+        return new ECKey.ECDSASignature(BigInteger.ONE, ECKey.CURVE.getN().subtract(BigInteger.ONE)).encodeToDER();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced delayed payout transaction signature validation to enforce canonical ECDSA signatures, improving transaction security and reliability.

* **Chores**
  * Improved logging output clarity in transaction processing messages by displaying numeric values directly.
  * Removed unnecessary logging annotations for cleaner codebase maintenance.

* **Tests**
  * Added comprehensive test coverage for delayed payout transaction signature validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->