### PR TITLE
Check if deposit tx is valid before taker publish the taker fee tx

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
@@ -31,6 +31,8 @@ import bisq.core.trade.validation.TransactionValidation;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.taskrunner.TaskRunner;
 
+import org.bitcoinj.core.Transaction;
+
 import java.security.PublicKey;
 
 import java.util.List;
@@ -83,6 +85,16 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
 
             // We expect the prepared deposit transaction to be unsigned
             byte[] preparedDepositTx = DepositTxValidation.checkTransactionIsUnsigned(response.getPreparedDepositTx(), btcWalletService);
+            Transaction parsedPreparedDepositTx = TransactionValidation.toVerifiedTransaction(preparedDepositTx, btcWalletService);
+            DepositTxValidation.checkMakersPreparedDepositTx(parsedPreparedDepositTx,
+                    offer,
+                    checkNotNull(trade.getAmount(), "trade.getAmount() must not be null"),
+                    trade.getTradeTxFee(),
+                    makerRawTransactionInputs,
+                    checkNotNull(processModel.getRawTransactionInputs(), "takerRawTransactionInputs must not be null"),
+                    makerMultiSigPubKey,
+                    checkNotNull(processModel.getMyMultiSigPubKey(), "processModel.getMyMultiSigPubKey() must not be null"),
+                    btcWalletService.getParams());
             processModel.setPreparedDepositTx(preparedDepositTx);
 
             boolean isAltcoin = offer.getPaymentMethod().isBlockchain();

--- a/core/src/main/java/bisq/core/trade/validation/DepositTxValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/DepositTxValidation.java
@@ -27,14 +27,19 @@ import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.validation.exceptions.InvalidTxException;
 
 import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.TransactionWitness;
+import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,6 +66,75 @@ public final class DepositTxValidation {
 
         NetworkParameters params = checkNotNull(btcWalletService.getParams(), "params must not be null");
         return checkDepositTxMatchesIgnoringWitnessesAndScriptSigs(depositTx, expectedDepositTx, params);
+    }
+
+    public static Transaction checkMakersPreparedDepositTx(Transaction preparedDepositTx,
+                                                           Offer offer,
+                                                           Coin tradeAmount,
+                                                           Coin tradeTxFee,
+                                                           List<RawTransactionInput> makerInputs,
+                                                           List<RawTransactionInput> takerInputs,
+                                                           byte[] makerMultiSigPubKey,
+                                                           byte[] takerMultiSigPubKey,
+                                                           NetworkParameters params) {
+        Transaction checkedPreparedDepositTx = checkTransaction(checkNotNull(preparedDepositTx,
+                "preparedDepositTx must not be null"));
+        Offer checkedOffer = checkNotNull(offer, "offer must not be null");
+        Coin checkedTradeAmount = checkNotNull(tradeAmount, "tradeAmount must not be null");
+        Coin checkedTradeTxFee = checkNotNull(tradeTxFee, "tradeTxFee must not be null");
+        List<RawTransactionInput> checkedMakerInputs = checkNotNull(makerInputs, "makerInputs must not be null");
+        List<RawTransactionInput> checkedTakerInputs = checkNotNull(takerInputs, "takerInputs must not be null");
+        byte[] checkedMakerMultiSigPubKey = TransactionValidation.checkMultiSigPubKey(makerMultiSigPubKey);
+        byte[] checkedTakerMultiSigPubKey = TransactionValidation.checkMultiSigPubKey(takerMultiSigPubKey);
+        NetworkParameters checkedParams = checkNotNull(params, "params must not be null");
+        Coin offerMinAmount = checkNotNull(checkedOffer.getMinAmount(), "offer.getMinAmount() must not be null");
+        Coin offerAmount = checkNotNull(checkedOffer.getAmount(), "offer.getAmount() must not be null");
+        Coin buyerSecurityDeposit = checkNotNull(checkedOffer.getBuyerSecurityDeposit(),
+                "offer.getBuyerSecurityDeposit() must not be null");
+        Coin sellerSecurityDeposit = checkNotNull(checkedOffer.getSellerSecurityDeposit(),
+                "offer.getSellerSecurityDeposit() must not be null");
+
+        checkArgument(!checkedTradeAmount.isLessThan(offerMinAmount),
+                "tradeAmount must not be less than offerMinAmount");
+        checkArgument(!checkedTradeAmount.isGreaterThan(offerAmount),
+                "tradeAmount must not be greater than offerAmount");
+        checkArgument(checkedTradeTxFee.isPositive(), "tradeTxFee must be positive");
+
+        checkCanonicalDepositTxShape(checkedPreparedDepositTx,
+                combinedInputs(checkedMakerInputs, checkedTakerInputs),
+                checkedParams);
+        checkPreparedDepositTxInputOrder(checkedPreparedDepositTx,
+                checkedOffer.isBuyOffer(),
+                checkedMakerInputs,
+                checkedTakerInputs,
+                checkedParams);
+        checkPreparedDepositTxInputAmounts(checkedOffer.isBuyOffer(),
+                offerAmount,
+                buyerSecurityDeposit,
+                sellerSecurityDeposit,
+                checkedTradeAmount,
+                checkedTradeTxFee,
+                checkedMakerInputs,
+                checkedTakerInputs);
+
+        byte[] buyerPubKey = checkedOffer.isBuyOffer() ? checkedMakerMultiSigPubKey : checkedTakerMultiSigPubKey;
+        byte[] sellerPubKey = checkedOffer.isBuyOffer() ? checkedTakerMultiSigPubKey : checkedMakerMultiSigPubKey;
+        Coin expectedMsOutputAmount = buyerSecurityDeposit
+                .add(sellerSecurityDeposit)
+                .add(checkedTradeTxFee)
+                .add(checkedTradeAmount);
+        checkPreparedDepositTxOutputs(checkedPreparedDepositTx,
+                checkedOffer,
+                offerAmount,
+                sellerSecurityDeposit,
+                checkedTradeAmount,
+                checkedTradeTxFee,
+                checkedMakerInputs,
+                checkedTakerInputs,
+                expectedMsOutputAmount,
+                buyerPubKey,
+                sellerPubKey);
+        return checkedPreparedDepositTx;
     }
 
 
@@ -222,6 +296,159 @@ public final class DepositTxValidation {
     private static void stripWitnessAndScriptSig(TransactionInput input) {
         input.setScriptSig(ScriptBuilder.createEmpty());
         input.setWitness(TransactionWitness.EMPTY);
+    }
+
+    private static List<RawTransactionInput> combinedInputs(List<RawTransactionInput> makerInputs,
+                                                            List<RawTransactionInput> takerInputs) {
+        List<RawTransactionInput> inputs = new ArrayList<>(makerInputs.size() + takerInputs.size());
+        inputs.addAll(makerInputs);
+        inputs.addAll(takerInputs);
+        return inputs;
+    }
+
+    private static void checkPreparedDepositTxInputOrder(Transaction preparedDepositTx,
+                                                         boolean makerIsBuyer,
+                                                         List<RawTransactionInput> makerInputs,
+                                                         List<RawTransactionInput> takerInputs,
+                                                         NetworkParameters params) {
+        int expectedInputCount = makerInputs.size() + takerInputs.size();
+        checkArgument(preparedDepositTx.getInputs().size() == expectedInputCount,
+                "Prepared deposit tx input count mismatch. txInputs=%s, makerInputs=%s, takerInputs=%s",
+                preparedDepositTx.getInputs().size(),
+                makerInputs.size(),
+                takerInputs.size());
+
+        if (makerIsBuyer) {
+            checkInputOutpoints(preparedDepositTx, 0, makerInputs, params, "maker");
+            checkInputOutpoints(preparedDepositTx, makerInputs.size(), takerInputs, params, "taker");
+        } else {
+            checkInputOutpoints(preparedDepositTx, 0, takerInputs, params, "taker");
+            checkInputOutpoints(preparedDepositTx, takerInputs.size(), makerInputs, params, "maker");
+        }
+    }
+
+    private static void checkInputOutpoints(Transaction preparedDepositTx,
+                                            int startIndex,
+                                            List<RawTransactionInput> expectedInputs,
+                                            NetworkParameters params,
+                                            String inputOwner) {
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            RawTransactionInput expectedInput = checkNotNull(expectedInputs.get(i),
+                    "%s input at position %s must not be null",
+                    inputOwner,
+                    i);
+            TransactionOutPoint expectedOutpoint = WalletUtils.getConnectedOutPoint(expectedInput, params);
+            TransactionOutPoint actualOutpoint = preparedDepositTx.getInput(startIndex + i).getOutpoint();
+            checkArgument(actualOutpoint.getIndex() == expectedOutpoint.getIndex() &&
+                            actualOutpoint.getHash().equals(expectedOutpoint.getHash()),
+                    "Prepared deposit tx input %s does not match expected %s input %s",
+                    startIndex + i,
+                    inputOwner,
+                    i);
+        }
+    }
+
+    private static void checkPreparedDepositTxInputAmounts(boolean makerIsBuyer,
+                                                           Coin offerAmount,
+                                                           Coin buyerSecurityDeposit,
+                                                           Coin sellerSecurityDeposit,
+                                                           Coin tradeAmount,
+                                                           Coin tradeTxFee,
+                                                           List<RawTransactionInput> makerInputs,
+                                                           List<RawTransactionInput> takerInputs) {
+        Coin expectedMakerInputAmount = makerIsBuyer
+                ? buyerSecurityDeposit
+                : sellerSecurityDeposit.add(offerAmount);
+        Coin makerInputAmount = sumInputValues(makerInputs);
+        checkArgument(makerInputAmount.equals(expectedMakerInputAmount),
+                "Maker input amount mismatch. actual=%s, expected=%s",
+                makerInputAmount,
+                expectedMakerInputAmount);
+
+        Coin expectedTakerInputAmount = makerIsBuyer
+                ? sellerSecurityDeposit.add(tradeAmount).add(tradeTxFee.multiply(2))
+                : buyerSecurityDeposit.add(tradeTxFee.multiply(2));
+        Coin takerInputAmount = sumInputValues(takerInputs);
+        checkArgument(takerInputAmount.equals(expectedTakerInputAmount),
+                "Taker input amount mismatch. actual=%s, expected=%s",
+                takerInputAmount,
+                expectedTakerInputAmount);
+    }
+
+    private static void checkPreparedDepositTxOutputs(Transaction preparedDepositTx,
+                                                      Offer offer,
+                                                      Coin offerAmount,
+                                                      Coin sellerSecurityDeposit,
+                                                      Coin tradeAmount,
+                                                      Coin tradeTxFee,
+                                                      List<RawTransactionInput> makerInputs,
+                                                      List<RawTransactionInput> takerInputs,
+                                                      Coin expectedMsOutputAmount,
+                                                      byte[] buyerPubKey,
+                                                      byte[] sellerPubKey) {
+        checkArgument(!preparedDepositTx.getOutputs().isEmpty(),
+                "Prepared deposit tx must have at least the multisig output");
+
+        TransactionOutput multisigOutput = preparedDepositTx.getOutput(0);
+        checkArgument(multisigOutput.getValue().equals(expectedMsOutputAmount),
+                "Prepared deposit tx multisig output amount mismatch. actual=%s, expected=%s",
+                multisigOutput.getValue(),
+                expectedMsOutputAmount);
+        Script expectedMultiSigOutputScript = get2of2MultiSigOutputScript(buyerPubKey, sellerPubKey);
+        checkArgument(multisigOutput.getScriptPubKey().equals(expectedMultiSigOutputScript),
+                "Prepared deposit tx multisig output script does not match expected trade multisig script");
+
+        Coin expectedMakerChange = offer.isBuyOffer()
+                ? Coin.ZERO
+                : sumInputValues(makerInputs)
+                .subtract(sellerSecurityDeposit)
+                .subtract(tradeAmount);
+        checkArgument(!expectedMakerChange.isNegative(), "expectedMakerChange must not be negative");
+        checkArgument(offer.isBuyOffer() ||
+                        !expectedMakerChange.isGreaterThan(offerAmount.subtract(tradeAmount)),
+                "expectedMakerChange must not be greater than remaining offer amount");
+
+        int expectedOutputCount = expectedMakerChange.isZero() ? 1 : 2;
+        checkArgument(preparedDepositTx.getOutputs().size() == expectedOutputCount,
+                expectedMakerChange.isZero()
+                        ? "Maker's preparedDepositTx must not have a change output"
+                        : "Maker's preparedDepositTx must have exactly one change output");
+        if (!expectedMakerChange.isZero()) {
+            Coin makerChangeOutput = preparedDepositTx.getOutput(1).getValue();
+            checkArgument(makerChangeOutput.equals(expectedMakerChange),
+                    "Maker's preparedDepositTx change output value does not match the expected maker change");
+        }
+
+        Coin inputTotal = sumInputValues(makerInputs).add(sumInputValues(takerInputs));
+        Coin outputTotal = preparedDepositTx.getOutputs().stream()
+                .map(TransactionOutput::getValue)
+                .reduce(Coin.ZERO, Coin::add);
+        Coin actualTxFee = inputTotal.subtract(outputTotal);
+        checkArgument(actualTxFee.equals(tradeTxFee),
+                "Prepared deposit tx fee mismatch. actual=%s, expected=%s",
+                actualTxFee,
+                tradeTxFee);
+    }
+
+    private static Coin sumInputValues(List<RawTransactionInput> inputs) {
+        Coin sum = Coin.ZERO;
+        for (int i = 0; i < inputs.size(); i++) {
+            RawTransactionInput input = checkNotNull(inputs.get(i),
+                    "input at position %s must not be null",
+                    i);
+            checkArgument(input.value > 0,
+                    "input at position %s must have positive value",
+                    i);
+            sum = sum.add(Coin.valueOf(input.value));
+        }
+        return sum;
+    }
+
+    private static Script get2of2MultiSigOutputScript(byte[] buyerPubKey, byte[] sellerPubKey) {
+        ECKey buyerKey = ECKey.fromPublicOnly(buyerPubKey);
+        ECKey sellerKey = ECKey.fromPublicOnly(sellerPubKey);
+        return ScriptBuilder.createP2WSHOutputScript(
+                ScriptBuilder.createMultiSigOutputScript(2, Arrays.asList(sellerKey, buyerKey)));
     }
 
 

--- a/core/src/test/java/bisq/core/trade/validation/DepositTxValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/DepositTxValidationTest.java
@@ -67,6 +67,8 @@ class DepositTxValidationTest {
             "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
     private static final String OTHER_TX_ID =
             "1111111111111111111111111111111111111111111111111111111111111111";
+    private static final ECKey BUYER_MULTI_SIG_KEY = new ECKey();
+    private static final ECKey SELLER_MULTI_SIG_KEY = new ECKey();
 
     private static final String MAKER_ROLE = "Maker";
     private static final String TAKER_ROLE = "Taker";
@@ -207,6 +209,220 @@ class DepositTxValidationTest {
         assertThrows(NullPointerException.class,
                 () -> DepositTxValidation.checkCanonicalDepositTxShape(canonicalTx(),
                         Collections.singletonList(null),
+                        PARAMS));
+    }
+
+    /* --------------------------------------------------------------------- */
+    // Maker prepared deposit tx
+    /* --------------------------------------------------------------------- */
+
+    @Test
+    void checkMakersPreparedDepositTxAcceptsBuyerAsMakerTx() {
+        Offer offer = offer(true,
+                Coin.valueOf(10_000),
+                Coin.valueOf(20_000),
+                Coin.valueOf(10_000),
+                Coin.valueOf(150_000));
+        Coin tradeAmount = Coin.valueOf(100_000);
+        Coin tradeTxFee = Coin.valueOf(5_000);
+        List<RawTransactionInput> makerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(10_000)));
+        List<RawTransactionInput> takerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(130_000)));
+        Transaction preparedDepositTx = preparedDepositTx(
+                orderedInputs(makerInputs, takerInputs, true),
+                BUYER_MULTI_SIG_KEY.getPubKey(),
+                SELLER_MULTI_SIG_KEY.getPubKey(),
+                135_000);
+
+        assertSame(preparedDepositTx,
+                DepositTxValidation.checkMakersPreparedDepositTx(preparedDepositTx,
+                        offer,
+                        tradeAmount,
+                        tradeTxFee,
+                        makerInputs,
+                        takerInputs,
+                        BUYER_MULTI_SIG_KEY.getPubKey(),
+                        SELLER_MULTI_SIG_KEY.getPubKey(),
+                        PARAMS));
+    }
+
+    @Test
+    void checkMakersPreparedDepositTxAcceptsSellerAsMakerTxWithExpectedChange() {
+        Offer offer = offer(false,
+                Coin.valueOf(10_000),
+                Coin.valueOf(20_000),
+                Coin.valueOf(10_000),
+                Coin.valueOf(150_000));
+        Coin tradeAmount = Coin.valueOf(100_000);
+        Coin tradeTxFee = Coin.valueOf(5_000);
+        List<RawTransactionInput> makerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(170_000)));
+        List<RawTransactionInput> takerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(20_000)));
+        Transaction preparedDepositTx = preparedDepositTx(
+                orderedInputs(makerInputs, takerInputs, false),
+                BUYER_MULTI_SIG_KEY.getPubKey(),
+                SELLER_MULTI_SIG_KEY.getPubKey(),
+                135_000,
+                50_000);
+
+        assertSame(preparedDepositTx,
+                DepositTxValidation.checkMakersPreparedDepositTx(preparedDepositTx,
+                        offer,
+                        tradeAmount,
+                        tradeTxFee,
+                        makerInputs,
+                        takerInputs,
+                        SELLER_MULTI_SIG_KEY.getPubKey(),
+                        BUYER_MULTI_SIG_KEY.getPubKey(),
+                        PARAMS));
+    }
+
+    @Test
+    void checkMakersPreparedDepositTxRejectsWrongInputOrder() {
+        Offer offer = offer(false,
+                Coin.valueOf(10_000),
+                Coin.valueOf(20_000),
+                Coin.valueOf(10_000),
+                Coin.valueOf(150_000));
+        Coin tradeAmount = Coin.valueOf(100_000);
+        Coin tradeTxFee = Coin.valueOf(5_000);
+        List<RawTransactionInput> makerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(170_000)));
+        List<RawTransactionInput> takerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(20_000)));
+        Transaction preparedDepositTx = preparedDepositTx(
+                orderedInputs(makerInputs, takerInputs, true),
+                BUYER_MULTI_SIG_KEY.getPubKey(),
+                SELLER_MULTI_SIG_KEY.getPubKey(),
+                135_000,
+                50_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkMakersPreparedDepositTx(preparedDepositTx,
+                        offer,
+                        tradeAmount,
+                        tradeTxFee,
+                        makerInputs,
+                        takerInputs,
+                        SELLER_MULTI_SIG_KEY.getPubKey(),
+                        BUYER_MULTI_SIG_KEY.getPubKey(),
+                        PARAMS));
+    }
+
+    @Test
+    void checkMakersPreparedDepositTxRejectsWrongMultisigOutputAmount() {
+        Offer offer = offer(false,
+                Coin.valueOf(10_000),
+                Coin.valueOf(20_000),
+                Coin.valueOf(10_000),
+                Coin.valueOf(150_000));
+        Coin tradeAmount = Coin.valueOf(100_000);
+        Coin tradeTxFee = Coin.valueOf(5_000);
+        List<RawTransactionInput> makerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(170_000)));
+        List<RawTransactionInput> takerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(20_000)));
+        Transaction preparedDepositTx = preparedDepositTx(
+                orderedInputs(makerInputs, takerInputs, false),
+                BUYER_MULTI_SIG_KEY.getPubKey(),
+                SELLER_MULTI_SIG_KEY.getPubKey(),
+                134_999,
+                50_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkMakersPreparedDepositTx(preparedDepositTx,
+                        offer,
+                        tradeAmount,
+                        tradeTxFee,
+                        makerInputs,
+                        takerInputs,
+                        SELLER_MULTI_SIG_KEY.getPubKey(),
+                        BUYER_MULTI_SIG_KEY.getPubKey(),
+                        PARAMS));
+    }
+
+    @Test
+    void checkMakersPreparedDepositTxRejectsWrongMultisigOutputScript() {
+        Offer offer = offer(false,
+                Coin.valueOf(10_000),
+                Coin.valueOf(20_000),
+                Coin.valueOf(10_000),
+                Coin.valueOf(150_000));
+        Coin tradeAmount = Coin.valueOf(100_000);
+        Coin tradeTxFee = Coin.valueOf(5_000);
+        List<RawTransactionInput> makerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(170_000)));
+        List<RawTransactionInput> takerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(20_000)));
+        Transaction preparedDepositTx = preparedDepositTx(
+                orderedInputs(makerInputs, takerInputs, false),
+                new ECKey().getPubKey(),
+                SELLER_MULTI_SIG_KEY.getPubKey(),
+                135_000,
+                50_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkMakersPreparedDepositTx(preparedDepositTx,
+                        offer,
+                        tradeAmount,
+                        tradeTxFee,
+                        makerInputs,
+                        takerInputs,
+                        SELLER_MULTI_SIG_KEY.getPubKey(),
+                        BUYER_MULTI_SIG_KEY.getPubKey(),
+                        PARAMS));
+    }
+
+    @Test
+    void checkMakersPreparedDepositTxRejectsExtraSiphonOutput() {
+        Offer offer = offer(false,
+                Coin.valueOf(10_000),
+                Coin.valueOf(20_000),
+                Coin.valueOf(10_000),
+                Coin.valueOf(150_000));
+        Coin tradeAmount = Coin.valueOf(100_000);
+        Coin tradeTxFee = Coin.valueOf(5_000);
+        List<RawTransactionInput> makerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(170_000)));
+        List<RawTransactionInput> takerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(20_000)));
+        Transaction preparedDepositTx = preparedDepositTx(
+                orderedInputs(makerInputs, takerInputs, false),
+                BUYER_MULTI_SIG_KEY.getPubKey(),
+                SELLER_MULTI_SIG_KEY.getPubKey(),
+                135_000,
+                50_000,
+                1_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkMakersPreparedDepositTx(preparedDepositTx,
+                        offer,
+                        tradeAmount,
+                        tradeTxFee,
+                        makerInputs,
+                        takerInputs,
+                        SELLER_MULTI_SIG_KEY.getPubKey(),
+                        BUYER_MULTI_SIG_KEY.getPubKey(),
+                        PARAMS));
+    }
+
+    @Test
+    void checkMakersPreparedDepositTxRejectsWrongTradeFee() {
+        Offer offer = offer(false,
+                Coin.valueOf(10_000),
+                Coin.valueOf(20_000),
+                Coin.valueOf(10_000),
+                Coin.valueOf(150_000));
+        Coin tradeAmount = Coin.valueOf(100_000);
+        Coin tradeTxFee = Coin.valueOf(5_000);
+        List<RawTransactionInput> makerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(170_000)));
+        List<RawTransactionInput> takerInputs = Collections.singletonList(rawInput(parentTxWithP2wpkhOutput(21_000)));
+        Transaction preparedDepositTx = preparedDepositTx(
+                orderedInputs(makerInputs, takerInputs, false),
+                BUYER_MULTI_SIG_KEY.getPubKey(),
+                SELLER_MULTI_SIG_KEY.getPubKey(),
+                135_000,
+                50_000);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkMakersPreparedDepositTx(preparedDepositTx,
+                        offer,
+                        tradeAmount,
+                        tradeTxFee,
+                        makerInputs,
+                        takerInputs,
+                        SELLER_MULTI_SIG_KEY.getPubKey(),
+                        BUYER_MULTI_SIG_KEY.getPubKey(),
                         PARAMS));
     }
 
@@ -582,6 +798,54 @@ class DepositTxValidationTest {
             }
         });
         return btcWalletService;
+    }
+
+    private static Offer offer(boolean isBuyOffer,
+                               Coin buyerSecurityDeposit,
+                               Coin sellerSecurityDeposit,
+                               Coin offerMinAmount,
+                               Coin offerAmount) {
+        Offer offer = ValidationTestUtils.offer(isBuyOffer,
+                buyerSecurityDeposit,
+                sellerSecurityDeposit,
+                offerAmount);
+        when(offer.getMinAmount()).thenReturn(offerMinAmount);
+        return offer;
+    }
+
+    private static List<RawTransactionInput> orderedInputs(List<RawTransactionInput> makerInputs,
+                                                           List<RawTransactionInput> takerInputs,
+                                                           boolean makerFirst) {
+        if (makerFirst) {
+            return Arrays.asList(makerInputs.get(0), takerInputs.get(0));
+        }
+        return Arrays.asList(takerInputs.get(0), makerInputs.get(0));
+    }
+
+    private static Transaction preparedDepositTx(List<RawTransactionInput> orderedInputs,
+                                                 byte[] buyerPubKey,
+                                                 byte[] sellerPubKey,
+                                                 long... outputValues) {
+        Transaction tx = new Transaction(PARAMS);
+        for (RawTransactionInput input : orderedInputs) {
+            tx.addInput(new TransactionInput(PARAMS,
+                    tx,
+                    new byte[]{},
+                    WalletUtils.getConnectedOutPoint(input, PARAMS),
+                    Coin.valueOf(input.value)));
+        }
+
+        tx.addOutput(Coin.valueOf(outputValues[0]), multiSigOutputScript(buyerPubKey, sellerPubKey));
+        for (int i = 1; i < outputValues.length; i++) {
+            tx.addOutput(Coin.valueOf(outputValues[i]), SegwitAddress.fromKey(PARAMS, new ECKey()));
+        }
+        return tx;
+    }
+
+    private static Script multiSigOutputScript(byte[] buyerPubKey, byte[] sellerPubKey) {
+        return ScriptBuilder.createP2WSHOutputScript(
+                ScriptBuilder.createMultiSigOutputScript(2,
+                        Arrays.asList(ECKey.fromPublicOnly(sellerPubKey), ECKey.fromPublicOnly(buyerPubKey))));
     }
 
     private static BtcWalletService walletServiceFor(RawTransactionInput rawTransactionInput) {


### PR DESCRIPTION
The check at TakerProcessesInputsForDepositTxResponse.java:85 happened before TakerPublishFeeTx, and it only verified “unsigned,” so a bad maker tx could still make the taker publish their fee and then fail later.
Implemented the early fix:

Added DepositTxValidation.checkMakersPreparedDepositTx(...) in DepositTxValidation.java.

Wired it into TakerProcessesInputsForDepositTxResponse.java, before processModel.setPreparedDepositTx(...) and before fee publication.

Validation now checks canonical tx shape, input count/order/outpoints, maker/taker input amounts, multisig output script and value, maker change output rules, output count, and implied deposit tx fee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated validation layer for maker-prepared deposit transactions, performing comprehensive verification of transaction structure, input composition, output configuration, multisig script validity, and fee calculations

* **Tests**
  * Added extensive test coverage for deposit transaction validation scenarios, including multiple acceptance and rejection cases across different trading configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->