### PR TITLE
fix(offer): address issues from #7636 max price deviation enforcement

### DIFF
--- a/core/src/main/java/bisq/core/offer/OfferValidation.java
+++ b/core/src/main/java/bisq/core/offer/OfferValidation.java
@@ -23,25 +23,19 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.user.Preferences;
 import bisq.core.util.PriceUtil;
 
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class OfferValidation {
-    public static boolean isPriceInBounds(PriceFeedService priceFeedService, Offer offer,
-                                          double tolerance) {
-        try {
-            verifyPriceInBounds(priceFeedService, offer, tolerance);
-            return true;
-        } catch (IllegalArgumentException e) {
-            log.debug("Offer isPriceInBounds check failed: {}", e.getMessage());
-            return false;
-        } catch (Exception e) {
-            log.warn("Unexpected failure during isPriceInBounds check", e);
+    public static boolean isPriceInBounds(PriceFeedService priceFeedService, Offer offer, double tolerance) {
+        if (priceFeedService == null || offer == null) {
             return false;
         }
+        return findPriceBoundsViolation(priceFeedService, offer, tolerance) == null;
     }
 
     public static void verifyPriceInBounds(PriceFeedService priceFeedService,
@@ -49,40 +43,48 @@ public class OfferValidation {
                                            double tolerance) throws IllegalArgumentException {
         checkNotNull(priceFeedService, "priceFeedService must not be null");
         checkNotNull(offer, "offer must not be null");
+        String error = findPriceBoundsViolation(priceFeedService, offer, tolerance);
+        if (error != null) {
+            throw new IllegalArgumentException(error);
+        }
+    }
 
+    // Returns null if the offer's price is in bounds, or the check is skipped because no recent
+    // market price is available. Returns a human-readable reason if the price is out of bounds.
+    // Skip semantics intentionally mirror PriceUtil.hasMarketPrice (recent external price required).
+    private static String findPriceBoundsViolation(PriceFeedService priceFeedService,
+                                                   Offer offer,
+                                                   double tolerance) {
         if (offer.isUseMarketBasedPrice()) {
-            double percentagePrice = offer.getMarketPriceMargin();
-            verifyPriceDeviation(tolerance, percentagePrice);
-            return;
-        }
-
-        // If we do not have a market price we do not apply the validation
-        if (!PriceUtil.hasMarketPrice(priceFeedService, offer)) {
-            log.debug("Market price not available for {}", offer.getCurrencyCode());
-            return;
-        }
-
-        String currencyCode = offer.getCurrencyCode();
-        MarketPrice marketPrice = priceFeedService.getMarketPrice(currencyCode);
-        if (marketPrice == null) {
-            // If we do not have a market price we do not apply the validation
-            log.debug("Market price not available for {}", offer.getCurrencyCode());
-            return;
+            return findDeviationViolation(tolerance, offer.getMarketPriceMargin());
         }
 
         Price offerPrice = offer.getPrice();
-        double marketPriceAsDouble = marketPrice.getPrice();
-        double percentagePrice = PriceUtil.calculatePercentage(currencyCode, offerPrice, marketPriceAsDouble, offer.getDirection())
-                .orElseThrow(() -> new IllegalArgumentException("Offer price percentage could not be calculated"));
+        if (offerPrice == null) {
+            return null;
+        }
+        String currencyCode = offer.getCurrencyCode();
+        MarketPrice marketPrice = priceFeedService.getMarketPrice(currencyCode);
+        if (marketPrice == null || !marketPrice.isRecentExternalPriceAvailable()) {
+            log.debug("Recent market price not available for {}", currencyCode);
+            return null;
+        }
 
-        verifyPriceDeviation(tolerance, percentagePrice);
+        Optional<Double> percentage = PriceUtil.calculatePercentage(currencyCode,
+                offerPrice, marketPrice.getPrice(), offer.getDirection());
+        if (!percentage.isPresent()) {
+            return "Offer price percentage could not be calculated";
+        }
+        return findDeviationViolation(tolerance, percentage.get());
     }
 
-    private static void verifyPriceDeviation(double tolerance, double percentagePrice) {
+    private static String findDeviationViolation(double tolerance, double percentagePrice) {
         double maxAllowedDeviation = Preferences.MAX_PRICE_DISTANCE * tolerance;
-        checkArgument(Math.abs(percentagePrice) <= maxAllowedDeviation,
-                String.format("Offer price is outside of tolerated max percentage price: " +
-                                "observed deviation=%s, max allowed deviation=%s, applied tolerance=%s",
-                        percentagePrice, maxAllowedDeviation, tolerance));
+        if (Math.abs(percentagePrice) <= maxAllowedDeviation) {
+            return null;
+        }
+        return String.format("Offer price is outside of tolerated max percentage price: " +
+                        "observed deviation=%s, max allowed deviation=%s, applied tolerance=%s",
+                percentagePrice, maxAllowedDeviation, tolerance);
     }
 }

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -40,6 +40,7 @@ import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.offer.placeoffer.bisq_v1.PlaceOfferModel;
 import bisq.core.offer.placeoffer.bisq_v1.PlaceOfferProtocol;
 import bisq.core.provider.mempool.FeeValidationStatus;
+import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 import bisq.core.support.dispute.mediation.mediator.MediatorManager;
@@ -82,6 +83,8 @@ import bisq.common.util.Tuple2;
 import org.bitcoinj.core.Coin;
 
 import javax.inject.Inject;
+
+import javafx.beans.InvalidationListener;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -141,13 +144,14 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     private final TradableList<OpenOffer> openOffers = new TradableList<>();
     private boolean stopped;
     private Timer periodicRepublishOffersTimer, periodicRefreshOffersTimer, retryRepublishOffersTimer,
-            handleOffersWithInvalidPriceTime;
+            handleOffersWithInvalidPriceTimer;
     @Setter
     private Consumer<String> chainNotSyncedHandler;
     @Getter
     private final ObservableList<Tuple2<OpenOffer, String>> invalidOffers = FXCollections.observableArrayList();
     @Getter
     private final ObservableList<OpenOffer> offersWithInvalidPrice = FXCollections.observableArrayList();
+    private final InvalidationListener invalidPriceFeedListener = observable -> checkOffersForInvalidPrice();
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -260,17 +264,44 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                         OfferUtil.getInvalidMakerFeeTxErrorMessage(openOffer.getOffer(), btcWalletService)
                                 .ifPresent(errorMsg -> invalidOffers.add(new Tuple2<>(openOffer, errorMsg))));
 
+        startInvalidPriceCheck();
+    }
+
+    // Initial run after a short delay (covers the no-internet case where the feed never ticks)
+    // plus a long-lived listener so newly arrived market prices for offers in currencies that
+    // were not yet tocked still get validated. The listener auto-deregisters once every open
+    // offer has been resolved against a recent market price (or already flagged).
+    private void startInvalidPriceCheck() {
         int delayInSec = DevEnv.isDevMode() ? 5 : 30;
-        stopHandleOffersWithInvalidPriceTime();
-        handleOffersWithInvalidPriceTime = UserThread.runAfter(() -> {
-            // We use 0% tolerance to the max allowed price percentage to motivate users to edit the offer
-            openOffers.stream()
-                    .filter(openOffer -> !OfferValidation.isPriceInBounds(priceFeedService, openOffer.getOffer(), 1))
-                    .forEach(openOffer -> {
-                        log.warn("Invalid offer found: {}", openOffer);
-                        offersWithInvalidPrice.add(openOffer);
-                    });
-        }, delayInSec);
+        stopHandleOffersWithInvalidPriceTimer();
+        handleOffersWithInvalidPriceTimer = UserThread.runAfter(this::checkOffersForInvalidPrice, delayInSec);
+        priceFeedService.updateCounterProperty().addListener(invalidPriceFeedListener);
+    }
+
+    private void checkOffersForInvalidPrice() {
+        // We use 0% tolerance to the max allowed price percentage to motivate users to edit the offer
+        openOffers.stream()
+                .filter(openOffer -> !offersWithInvalidPrice.contains(openOffer))
+                .filter(openOffer -> !OfferValidation.isPriceInBounds(priceFeedService, openOffer.getOffer(), 1))
+                .forEach(openOffer -> {
+                    log.warn("Invalid offer found: id={}", openOffer.getId());
+                    offersWithInvalidPrice.add(openOffer);
+                });
+
+        // Once every open offer has been either flagged or evaluated against a recent market price
+        // (or uses market-based pricing, which does not depend on the feed) we can stop listening.
+        // Recency check mirrors OfferValidation's skip semantics so we do not deregister while
+        // OfferValidation is still skipping due to stale prices.
+        boolean allEvaluated = openOffers.stream().allMatch(openOffer -> {
+            if (offersWithInvalidPrice.contains(openOffer) || openOffer.getOffer().isUseMarketBasedPrice()) {
+                return true;
+            }
+            MarketPrice marketPrice = priceFeedService.getMarketPrice(openOffer.getOffer().getCurrencyCode());
+            return marketPrice != null && marketPrice.isRecentExternalPriceAvailable();
+        });
+        if (allEvaluated) {
+            priceFeedService.updateCounterProperty().removeListener(invalidPriceFeedListener);
+        }
     }
 
     private void cleanUpAddressEntries() {
@@ -297,7 +328,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         stopPeriodicRefreshOffersTimer();
         stopPeriodicRepublishOffersTimer();
         stopRetryRepublishOffersTimer();
-        stopHandleOffersWithInvalidPriceTime();
+        stopHandleOffersWithInvalidPriceTimer();
 
         // we remove own offers from offerbook when we go offline
         // Normally we use a delay for broadcasting to the peers, but at shut down we want to get it fast out
@@ -852,6 +883,8 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                                 log.warn(e.getMessage());
                                 availabilityResult = AvailabilityResult.MARKET_PRICE_NOT_AVAILABLE;
                             } catch (Exception e) {
+                                // Intentionally narrower than Throwable: JVM Errors (OOM, StackOverflow, ...)
+                                // must propagate instead of being downgraded to a price-check failure.
                                 log.warn("Trade price check failed. " + e.getMessage());
                                 availabilityResult = AvailabilityResult.PRICE_CHECK_FAILED;
                             }
@@ -1251,11 +1284,12 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         }
     }
 
-    private void stopHandleOffersWithInvalidPriceTime() {
-        if (handleOffersWithInvalidPriceTime != null) {
-            handleOffersWithInvalidPriceTime.stop();
-            handleOffersWithInvalidPriceTime = null;
+    private void stopHandleOffersWithInvalidPriceTimer() {
+        if (handleOffersWithInvalidPriceTimer != null) {
+            handleOffersWithInvalidPriceTimer.stop();
+            handleOffersWithInvalidPriceTimer = null;
         }
+        priceFeedService.updateCounterProperty().removeListener(invalidPriceFeedListener);
     }
 
     private void addOpenOfferToList(OpenOffer openOffer) {

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -150,7 +150,6 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     private final BsqSwapTradeManager bsqSwapTradeManager;
     private final FailedTradesManager failedTradesManager;
     private final P2PService p2PService;
-    @Getter
     private final PriceFeedService priceFeedService;
     private final DelayedPayoutTxReceiverService delayedPayoutTxReceiverService;
     private final TradeStatisticsManager tradeStatisticsManager;

--- a/core/src/main/java/bisq/core/trade/protocol/Provider.java
+++ b/core/src/main/java/bisq/core/trade/protocol/Provider.java
@@ -28,6 +28,7 @@ import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 import bisq.core.filter.FilterManager;
 import bisq.core.offer.OpenOfferManager;
 import bisq.core.provider.fee.FeeService;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 import bisq.core.support.dispute.mediation.mediator.MediatorManager;
 import bisq.core.support.dispute.refund.refundagent.RefundAgentManager;
@@ -64,6 +65,7 @@ public class Provider {
     private final FeeService feeService;
     private final BtcFeeReceiverService btcFeeReceiverService;
     private final DelayedPayoutTxReceiverService delayedPayoutTxReceiverService;
+    private final PriceFeedService priceFeedService;
 
     @Inject
     public Provider(OpenOfferManager openOfferManager,
@@ -84,7 +86,8 @@ public class Provider {
                     KeyRing keyRing,
                     FeeService feeService,
                     BtcFeeReceiverService btcFeeReceiverService,
-                    DelayedPayoutTxReceiverService delayedPayoutTxReceiverService) {
+                    DelayedPayoutTxReceiverService delayedPayoutTxReceiverService,
+                    PriceFeedService priceFeedService) {
 
         this.openOfferManager = openOfferManager;
         this.p2PService = p2PService;
@@ -105,5 +108,6 @@ public class Provider {
         this.feeService = feeService;
         this.btcFeeReceiverService = btcFeeReceiverService;
         this.delayedPayoutTxReceiverService = delayedPayoutTxReceiverService;
+        this.priceFeedService = priceFeedService;
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
@@ -33,6 +33,7 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.proto.CoreProtoResolver;
 import bisq.core.provider.fee.FeeService;
+import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 import bisq.core.support.dispute.mediation.mediator.MediatorManager;
 import bisq.core.support.dispute.refund.refundagent.RefundAgentManager;
@@ -420,5 +421,9 @@ public class ProcessModel implements ProtocolModel<TradingPeer> {
 
     public FeeService getFeeService() {
         return provider.getFeeService();
+    }
+
+    public PriceFeedService getPriceFeedService() {
+        return provider.getPriceFeedService();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -76,7 +76,7 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
             DelayedPayoutTxReceiverService delayedPayoutTxReceiverService = processModel.getDelayedPayoutTxReceiverService();
             User user = checkNotNull(processModel.getUser(), "User must not be null");
-            PriceFeedService priceFeedService = processModel.getTradeManager().getPriceFeedService();
+            PriceFeedService priceFeedService = processModel.getPriceFeedService();
             FeeService feeService = processModel.getFeeService();
 
             tradingPeer.setHashOfPaymentAccountPayload(request.getHashOfTakersPaymentAccountPayload());

--- a/core/src/main/java/bisq/core/trade/validation/TradePriceValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradePriceValidation.java
@@ -27,6 +27,8 @@ import static bisq.core.util.Validator.checkIsPositive;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class TradePriceValidation {
+    // Tolerance multiplier applied to Preferences.MAX_PRICE_DISTANCE.
+    // Effective absolute deviation = MAX_PRICE_DISTANCE * MAX_TRADE_PRICE_DEVIATION = 0.25 * 1.5 = 0.375 (37.5%).
     public static final double MAX_TRADE_PRICE_DEVIATION = 1.5;
 
     private TradePriceValidation() {

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -255,7 +255,12 @@ public final class PreferencesPayload implements PersistableEnvelope {
         if (proto.hasSelectedPaymentAccountForCreateOffer() && proto.getSelectedPaymentAccountForCreateOffer().hasPaymentMethod())
             paymentAccount = PaymentAccount.fromProto(proto.getSelectedPaymentAccountForCreateOffer(), coreProtoResolver);
 
-        double maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(proto.getMaxPriceDistanceInPercent());
+        double persistedMaxPriceDistanceInPercent = proto.getMaxPriceDistanceInPercent();
+        double maxPriceDistanceInPercent = getClampedMaxPriceDistanceInPercent(persistedMaxPriceDistanceInPercent);
+        if (Double.compare(persistedMaxPriceDistanceInPercent, maxPriceDistanceInPercent) != 0) {
+            log.warn("Persisted maxPriceDistanceInPercent {} is outside the allowed range and was clamped to {}.",
+                    persistedMaxPriceDistanceInPercent, maxPriceDistanceInPercent);
+        }
         return new PreferencesPayload(
                 proto.getUserLanguage(),
                 Country.fromProto(userCountry),

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBook.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -72,15 +71,16 @@ public class OfferBook {
         this.offerBookService = offerBookService;
         this.filterManager = filterManager;
 
-        priceFeedServiceUpdateListener = new InvalidationListener() {
-            @Override
-            public void invalidated(Observable observable) {
-                List<OfferBookListItem> toRemove = offerBookListItems.stream()
-                        .filter(item -> !filterManager.isPriceInBounds(item.getOffer()))
-                        .collect(Collectors.toList());
+        // Re-evaluate on every price feed update (not just the first one).
+        // Otherwise offers in currencies whose market price arrived after the first tick
+        // would never be pruned, and stale state could survive feed recovery.
+        priceFeedServiceUpdateListener = observable -> {
+            List<OfferBookListItem> toRemove = offerBookListItems.stream()
+                    .filter(item -> !filterManager.isPriceInBounds(item.getOffer()))
+                    .collect(Collectors.toList());
+            if (!toRemove.isEmpty()) {
                 toRemove.forEach(offerBookListItems::remove);
-                log.info("We got a price feed service ready and run the isPriceValid check and remove invalid offers. toRemove {}", toRemove);
-                priceFeedService.updateCounterProperty().removeListener(priceFeedServiceUpdateListener);
+                log.info("Price feed update: removed {} offer(s) outside the allowed price bounds.", toRemove.size());
             }
         };
 


### PR DESCRIPTION
This branch addresses found issues from PR #7636 review.

## Correctness

**OpenOfferManager invalid-price detection was best-effort.** Original code ran a single 30s post-init timer. If `PriceFeedService` had not yet delivered a market price for an offer's currency at that moment, `OfferValidation` silently returned "valid" and the user never saw the warning popup. Fix: keep the 30s timer as a no-internet fallback, and additionally drive the check off `priceFeedService.updateCounterProperty()` so every newly arrived market price triggers re-evaluation. Listener auto-deregisters once every open offer has been resolved against a *recent* market price (or already flagged), matching `OfferValidation`'s skip semantics so it does not deregister while the validator is still skipping due to stale prices.

**OfferBook pruned offers exactly once.** The `priceFeedServiceUpdateListener` removed itself on the first invalidation. Two failure modes:
- Offers in currencies whose market price arrived *after* the first tick were never validated → invalid offers stayed visible indefinitely.
- If the price feed dropped and recovered later, no re-prune happened.

Fix: keep the listener attached; re-prune on every tick. Cheap (filter is O(offers)) and self-correcting. `OfferBook` is a `@Singleton` — no leak. Logging gated on `!toRemove.isEmpty()` to avoid noise on every tick.

**Silent preference migration was invisible.** Existing users with `maxPriceDistanceInPercent = 0.3` (old default) get clamped to `0.25` on load with no record of it. Operators investigating "why did my offer percentage change?" had nothing to grep for. Fix: `log.warn` when the persisted value differs from the clamped value.

## Robustness

**Exception-as-control-flow on a hot path.** `isPriceInBounds` was called per-offer from `OfferBook.isOfferAllowed` and `FilterManager.isPriceInBounds`. Each `false` result threw and caught an `IllegalArgumentException` complete with stack trace, just to signal a boolean. Fix: refactor internals around a private helper returning a nullable error string (`findPriceBoundsViolation`). `isPriceInBounds` becomes a null-check; `verifyPriceInBounds` (assertion-style) wraps the helper output into an exception only on failure. Public API and behavior unchanged.

**Skip-condition parity with `PriceUtil.hasMarketPrice`.** The validator must skip price-bounds checks when no recent external market price is available — otherwise it would compare offers against stale or missing data. The original PR called `PriceUtil.hasMarketPrice(...)` for this. Refactor preserves this exactly: `marketPrice == null || !marketPrice.isRecentExternalPriceAvailable()` → skip. `offer.getPrice() != null` guard preserved. (Caught during self-review — first refactor pass had inadvertently weakened to `isPriceAvailable()` which omits the recency check.)

**Null wiring caught at wrong log level.** `checkNotNull(priceFeedService, ...)` raised NPE which fell into the generic `Exception` branch and logged `warn`, while a real validation failure logged `debug`. Inverted severity. Fix: explicit early-return `false` on null inputs in `isPriceInBounds`; the throwing variant `verifyPriceInBounds` keeps `checkNotNull` as a precondition assertion.

**`String.format` ran on every successful check.** `verifyPriceDeviation` built the failure-message string before evaluating `checkArgument`. For valid offers (the common case) the string was thrown away. Fix: build only on the failure branch.

## Code smell / maintainability

**`@Getter` on `TradeManager.priceFeedService`** was added solely so a maker-side task could reach it via `processModel.getTradeManager().getPriceFeedService()`. Bypasses the existing `Provider` → `ProcessModel` plumbing every other task-side service uses, and exposes `TradeManager` internals more broadly than needed. Fix: add `priceFeedService` to `Provider`, expose `ProcessModel.getPriceFeedService()`, switch caller. Matches the pattern used for `FeeService`, `BtcWalletService`, etc.

**`Throwable` → `Exception` narrowing in `handleOfferAvailabilityRequest`** was deliberate (do not downgrade OOM/StackOverflow to `PRICE_CHECK_FAILED`) but undocumented. Future readers would assume typo and "fix" it back. Fix: comment explaining intent.

**`TradePriceValidation.MAX_TRADE_PRICE_DEVIATION = 1.5`** is a tolerance multiplier; the *absolute* deviation it permits is `0.25 * 1.5 = 37.5%`. Easy to misread as "we allow 50% off market." Fix: comment spelling out resulting absolute percentage.

**Field typo**: `handleOffersWithInvalidPriceTime` → `…Timer` (typo on a PR-introduced field; matching method renamed for consistency). No other pre-existing names changed.

## UX-goal alignment

| Original PR UX goal | Status after this PR |
|---|---|
| Filter offerbook to hide invalid offers from takers | **Strengthened** — re-prune on every tick, not one-shot |
| Warn maker about own invalid-price offers | **Strengthened** — listener-driven, retries until resolved |
| Clamp persisted preference to 25% | Unchanged + now logged |

No UX regressions. Two reliability improvements that align more strictly with the original UX intent than the original implementation.

## Risk

Behavior changes are net-additive (listener fires more often, log records clamp) or pure refactor (validation internals, dependency plumbing). No protocol-level changes. No persistence format changes.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Continuous real-time validation of open offers against market price bounds; offers are now actively monitored for price validity as market conditions change.

* **Bug Fixes**
  * Enhanced price feed monitoring to dynamically flag invalid offers instead of one-time checking.

* **Documentation**
  * Improved logging visibility when price distance preferences are adjusted to stay within allowed ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->