### PR TITLE
Harden BSQ swap fee/payout arithmetic

### DIFF
--- a/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
+++ b/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
@@ -24,6 +24,7 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.Restrictions;
 import bisq.core.monetary.Volume;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
+import bisq.core.trade.validation.MinerFeeValidation;
 import bisq.core.util.Validator;
 
 import bisq.common.util.MathUtils;
@@ -114,7 +115,7 @@ public class BsqSwapCalculation {
                                                         long buyerTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long buyersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
+        long buyersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
         return getBuyersBtcPayoutValue(btcTradeAmount.getValue(), buyersTxFee);
     }
 
@@ -153,7 +154,7 @@ public class BsqSwapCalculation {
                                                         long sellersTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long sellersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
+        long sellersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
         return getSellersBtcInputValue(btcTradeAmount.getValue(), sellersTxFee);
     }
 
@@ -236,16 +237,38 @@ public class BsqSwapCalculation {
         Validator.checkIsPositive(txFeePerVbyte, "txFeePerVbyte");
         Validator.checkIsPositive(vBytes, "vBytes");
         Validator.checkIsPositive(tradeFee, "tradeFee");
-        Coin txFeePerVbyteAsCoin = Coin.valueOf(txFeePerVbyte);
-        Coin tradeFeeAsCoin = Coin.valueOf(tradeFee);
-        Validator.checkIsPositive(txFeePerVbyteAsCoin, "txFeePerVbyte");
-        Validator.checkIsPositive(tradeFeeAsCoin, "vBytes");
-
-        Coin adjustedTxFee = txFeePerVbyteAsCoin
+        // tradeFee must be strictly less than miner-fee portion; otherwise buyer payout inverts
+        // (or zeroes buyer fee contribution) and sum-of-outputs >= sum-of-inputs, producing
+        // an unbroadcastable tx. Coin.multiply/subtract use Math.*Exact internally, so overflow
+        // trips loudly if future callers relax current input bounds.
+        Coin adjustedTxFee = Coin.valueOf(txFeePerVbyte)
                 .multiply(vBytes)
-                .subtract(tradeFeeAsCoin);
+                .subtract(Coin.valueOf(tradeFee));
         Validator.checkIsPositive(adjustedTxFee, "adjustedTxFee");
         return adjustedTxFee.value;
+    }
+
+    // Lenient variant for UI estimation paths where a precise value is not required and
+    // throwing would break display when wallet is underfunded. Saturates the output (not
+    // the inputs) at the documented trade-tx-fee upper bound on multiply overflow or
+    // absurd magnitudes, and clamps subtraction underflow to 0.
+    private static long getAdjustedTxFeeForEstimate(long txFeePerVbyte, int vBytes, long tradeFee) {
+        // Coin.multiply uses Math.multiplyExact internally; saturate on overflow at the
+        // documented trade-tx-fee upper bound rather than throwing.
+        Coin minerFeePortion;
+        try {
+            minerFeePortion = Coin.valueOf(txFeePerVbyte).multiply(vBytes);
+        } catch (ArithmeticException e) {
+            minerFeePortion = Coin.valueOf(MinerFeeValidation.MAX_TRADE_TX_FEE_SAT);
+        }
+        // tradeFee is expected to be non-negative; clamp defensively so a negative input
+        // cannot make the subtraction overflow upward. Coin.subtract throws on underflow,
+        // so guard before subtracting and clamp the result to zero.
+        Coin safeTradeFee = Coin.valueOf(Math.max(0L, tradeFee));
+        if (minerFeePortion.isLessThan(safeTradeFee)) {
+            return 0L;
+        }
+        return minerFeePortion.subtract(safeTradeFee).value;
     }
 
     // Convert BTC trade amount to BSQ amount

--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/seller/ProcessTxInputsMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/tasks/seller/ProcessTxInputsMessage.java
@@ -98,6 +98,11 @@ public abstract class ProcessTxInputsMessage extends BsqSwapTask {
             // sellersBsqPayoutAmount is not related to peers inputs but we need it in the following steps so we
             // calculate and set it here.
             Coin sellersBsqPayoutAmount = BsqSwapCalculation.getSellersBsqPayoutValue(trade, getSellersTradeFee());
+            // Guard: non-positive or sub-dust payout produces an unbroadcastable / non-standard tx.
+            // Reject up front rather than commit BSQ inputs in the publish step for a tx miners will drop.
+            checkArgument(Restrictions.isAboveDust(sellersBsqPayoutAmount),
+                    "Sellers BSQ payout is non-positive or below dust: %s. Trade-fee likely exceeds BSQ trade amount.",
+                    sellersBsqPayoutAmount.getValue());
             protocolModel.setPayout(sellersBsqPayoutAmount.getValue());
 
             Coin expectedChange = sumInputs


### PR DESCRIPTION
Fail fast on malformed BSQ swap arithmetic before wallet commits inputs:

- getAdjustedTxFee: use Math.multiplyExact and assert non-negative result. Negative adjusted fee inverts buyer BTC payout, producing tx with outputs > inputs. Add lenient variant for UI estimation paths (BsqSwapOfferModel) so display still works when wallet is underfunded.
- ProcessTxInputsMessage: reject seller BSQ payout that is non-positive or below dust. Sub-dust output is non-standard; without the guard the seller commits BSQ inputs to a tx miners will drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer BSQ swap fee calculations: miner-fee math is protected against overflow and adjusted fees cannot go negative.
  * UI estimation uses clamped fee results to avoid displaying invalid BTC amounts.
  * Up-front validation now rejects trades where the seller payout is non-positive or below dust when fees consume the trade amount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->