### PR TITLE
fix: raise xmr min confirmations to 2

### DIFF
--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrRawTxParser.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrRawTxParser.java
@@ -77,7 +77,7 @@ public class XmrRawTxParser implements AssetTxProofParser<XmrTxProofRequest.Resu
                 }
             }
             return XmrTxProofRequest.Result.SUCCESS.with(XmrTxProofRequest.Detail.SUCCESS);
-        } catch (JsonParseException | NullPointerException e) {
+        } catch (JsonParseException | NullPointerException | NumberFormatException | IllegalStateException e) {
             return XmrTxProofRequest.Result.ERROR.with(XmrTxProofRequest.Detail.API_INVALID.error(e.toString()));
         }
     }

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofParser.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofParser.java
@@ -18,6 +18,7 @@
 package bisq.core.trade.txproof.xmr;
 
 import bisq.core.trade.txproof.AssetTxProofParser;
+import bisq.core.user.AutoConfirmSettings;
 
 import bisq.asset.CryptoNoteUtils;
 
@@ -166,14 +167,16 @@ public class XmrTxProofParser implements AssetTxProofParser<XmrTxProofRequest.Re
                 return XmrTxProofRequest.Result.FAILED.with(XmrTxProofRequest.Detail.AMOUNT_NOT_MATCHING);
             }
 
-            int confirmsRequired = model.getNumRequiredConfirmations();
+            int confirmsRequired = Math.max(
+                    AutoConfirmSettings.MIN_REQUIRED_CONFIRMATIONS,
+                    model.getNumRequiredConfirmations());
             if (confirmations < confirmsRequired) {
                 return XmrTxProofRequest.Result.PENDING.with(XmrTxProofRequest.Detail.PENDING_CONFIRMATIONS.numConfirmations(confirmations));
             } else {
                 return XmrTxProofRequest.Result.SUCCESS.with(XmrTxProofRequest.Detail.SUCCESS.numConfirmations(confirmations));
             }
 
-        } catch (JsonParseException | NullPointerException e) {
+        } catch (JsonParseException | NullPointerException | NumberFormatException | IllegalStateException e) {
             return XmrTxProofRequest.Result.ERROR.with(XmrTxProofRequest.Detail.API_INVALID.error(e.toString()));
         } catch (CryptoNoteUtils.CryptoNoteException e) {
             return XmrTxProofRequest.Result.ERROR.with(XmrTxProofRequest.Detail.ADDRESS_INVALID.error(e.toString()));

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
@@ -38,9 +38,11 @@ import javafx.beans.value.ChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -60,10 +62,12 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
     private final RefundManager refundManager;
     private final Socks5ProxyProvider socks5ProxyProvider;
 
-    private int numRequiredSuccessResults;
-    private final Set<XmrTxProofRequest> requests = new HashSet<>();
-
-    private int numSuccessResults;
+    private volatile int numRequiredSuccessResults;
+    // Concurrent + AtomicBoolean termination so callbacks cannot race past the guard
+    // even if a future change moves result callbacks off the single UserThread.
+    private final Set<XmrTxProofRequest> requests = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean terminated = new AtomicBoolean(false);
+    private final AtomicInteger numSuccessResults = new AtomicInteger();
     private ChangeListener<Trade.State> tradeStateListener;
     private AutoConfirmSettings.Listener autoConfirmSettingsListener;
     private ListChangeListener<Dispute> mediationListener, refundListener;
@@ -150,6 +154,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
                     return true;
                 })
                 .collect(Collectors.toList());
+        // Trust model: N-of-N quorum of explorers; client does not verify the proof crypto independently.
         numRequiredSuccessResults = serviceAddresses.size();
 
         if (numRequiredSuccessResults == 0) {
@@ -186,10 +191,10 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
                                 assetTxProofResult = getAssetTxProofResultForPending(result);
                                 break;
                             case SUCCESS:
-                                numSuccessResults++;
-                                if (numSuccessResults < numRequiredSuccessResults) {
+                                int successCount = numSuccessResults.incrementAndGet();
+                                if (successCount < numRequiredSuccessResults) {
                                     // Request is success but not all have completed yet.
-                                    int remaining = numRequiredSuccessResults - numSuccessResults;
+                                    int remaining = numRequiredSuccessResults - successCount;
                                     log.info("{} succeeded. We have {} remaining request(s) open.",
                                             request, remaining);
                                     assetTxProofResult = getAssetTxProofResultForPending(result);
@@ -200,7 +205,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
                                             numRequiredSuccessResults, trade.getShortId());
                                     XmrTxProofRequest.Detail detail = result.getDetail();
                                     assetTxProofResult = AssetTxProofResult.COMPLETED
-                                            .numSuccessResults(numSuccessResults)
+                                            .numSuccessResults(successCount)
                                             .numRequiredSuccessResults(numRequiredSuccessResults)
                                             .numConfirmations(detail != null ? detail.getNumConfirmations() : 0)
                                             .numRequiredConfirmations(autoConfirmSettings.getRequiredConfirmations());
@@ -232,7 +237,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
     }
 
     private boolean wasTerminated() {
-        return requests.isEmpty();
+        return terminated.get();
     }
 
     private void addSettingsListener(Consumer<AssetTxProofResult> resultHandler) {
@@ -277,6 +282,9 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
 
     @Override
     public void terminate() {
+        if (!terminated.compareAndSet(false, true)) {
+            return;
+        }
         requests.forEach(XmrTxProofRequest::terminate);
         requests.clear();
 
@@ -304,6 +312,9 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
 
     private void callResultHandlerAndMaybeTerminate(Consumer<AssetTxProofResult> resultHandler,
                                                     AssetTxProofResult assetTxProofResult) {
+        if (wasTerminated()) {
+            return;
+        }
         resultHandler.accept(assetTxProofResult);
         if (assetTxProofResult.isTerminal()) {
             terminate();
@@ -326,7 +337,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
         }
 
         return AssetTxProofResult.PENDING
-                .numSuccessResults(numSuccessResults)
+                .numSuccessResults(numSuccessResults.get())
                 .numRequiredSuccessResults(numRequiredSuccessResults)
                 .numConfirmations(detail != null ? detail.getNumConfirmations() : 0)
                 .numRequiredConfirmations(autoConfirmSettings.getRequiredConfirmations())

--- a/core/src/main/java/bisq/core/user/AutoConfirmSettings.java
+++ b/core/src/main/java/bisq/core/user/AutoConfirmSettings.java
@@ -47,6 +47,9 @@ public final class AutoConfirmSettings implements PersistablePayload {
     private String currencyCode;
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();
 
+    public static final int MIN_REQUIRED_CONFIRMATIONS = 2;
+    public static final long DEFAULT_XMR_TRADE_LIMIT = Coin.COIN.value / 8; // 0.125 BTC
+
     @SuppressWarnings("SameParameterValue")
     static Optional<AutoConfirmSettings> getDefault(List<String> serviceAddresses, String currencyCode) {
         //noinspection SwitchStatementWithTooFewBranches
@@ -55,7 +58,7 @@ public final class AutoConfirmSettings implements PersistablePayload {
                 return Optional.of(new AutoConfirmSettings(
                         false,
                         5,
-                        Coin.COIN.value,
+                        DEFAULT_XMR_TRADE_LIMIT,
                         serviceAddresses,
                         "XMR"));
             default:
@@ -70,7 +73,7 @@ public final class AutoConfirmSettings implements PersistablePayload {
                                List<String> serviceAddresses,
                                String currencyCode) {
         this.enabled = enabled;
-        this.requiredConfirmations = requiredConfirmations;
+        this.requiredConfirmations = Math.max(MIN_REQUIRED_CONFIRMATIONS, requiredConfirmations);
         this.tradeLimit = tradeLimit;
         this.serviceAddresses = serviceAddresses;
         this.currencyCode = currencyCode;
@@ -121,7 +124,7 @@ public final class AutoConfirmSettings implements PersistablePayload {
     }
 
     public void setRequiredConfirmations(int requiredConfirmations) {
-        this.requiredConfirmations = requiredConfirmations;
+        this.requiredConfirmations = Math.max(MIN_REQUIRED_CONFIRMATIONS, requiredConfirmations);
         notifyListeners();
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -53,6 +53,7 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.TradeLimits;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.fee.FeeService;
+import bisq.core.user.AutoConfirmSettings;
 import bisq.core.user.DontShowAgainLookup;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
@@ -794,7 +795,9 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         autoConfirmXmrToggle = addSlideToggleButton(autoConfirmGridPane, localRowIndex, Res.get("setting.preferences.autoConfirmEnabled"), Layout.FIRST_ROW_DISTANCE);
 
         autoConfRequiredConfirmationsTf = addInputTextField(autoConfirmGridPane, ++localRowIndex, Res.get("setting.preferences.autoConfirmRequiredConfirmations"));
-        autoConfRequiredConfirmationsTf.setValidator(new IntegerValidator(1, DevEnv.isDevMode() ? 100000000 : 1000));
+        autoConfRequiredConfirmationsTf.setValidator(new IntegerValidator(
+                AutoConfirmSettings.MIN_REQUIRED_CONFIRMATIONS,
+                DevEnv.isDevMode() ? 100000000 : 1000));
 
         autoConfTradeLimitTf = addInputTextField(autoConfirmGridPane, ++localRowIndex, Res.get("setting.preferences.autoConfirmMaxTradeSize"));
         autoConfTradeLimitTf.setValidator(new BtcValidator(formatter));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of XMR transaction proof validation with enhanced error handling for edge cases.
  * Strengthened thread-safety for concurrent transaction proof request processing.

* **Updates**
  * Adjusted minimum required confirmations to 2 for auto-confirmation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->