### PR TITLE
Validate canonical deposit tx fields at final boundaries

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerProcessDepositTxAndDelayedPayoutTxMessage.java
@@ -45,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_RECEIVED_DEPOSIT_TX_PUBLISHED_MSG;
 import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_SAW_DEPOSIT_TX_IN_NETWORK;
+import static bisq.core.trade.validation.DepositTxValidation.checkCanonicalDepositTxFields;
 import static bisq.core.trade.validation.DepositTxValidation.checkDepositTxMatchesIgnoringWitnessesAndScriptSigs;
 import static bisq.core.trade.validation.TransactionValidation.checkSerializedTransaction;
 import static bisq.core.trade.validation.TransactionValidation.toVerifiedTransaction;
@@ -70,7 +71,8 @@ public class BuyerProcessDepositTxAndDelayedPayoutTxMessage extends TradeTask {
             TradingPeer tradePeer = processModel.getTradePeer();
             PubKeyRing pubKeyRing = processModel.getPubKeyRing();
 
-            Transaction peersDepositTx = toVerifiedTransaction(message.getDepositTx(), btcWalletService);
+            Transaction peersDepositTx = checkCanonicalDepositTxFields(toVerifiedTransaction(message.getDepositTx(),
+                    btcWalletService));
             Transaction myDepositTx = checkNotNull(processModel.getDepositTx(),
                     "processModel.getDepositTx() must not be null");
             checkDepositTxMatchesIgnoringWitnessesAndScriptSigs(peersDepositTx,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSetupDepositTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSetupDepositTxListener.java
@@ -43,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.trade.validation.DepositTxValidation.checkCanonicalDepositTxFields;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -121,6 +122,14 @@ public class BuyerSetupDepositTxListener extends TradeTask {
         }
 
         Transaction walletTx = processModel.getTradeWalletService().getWalletTx(confidence.getTransactionHash());
+        try {
+            checkCanonicalDepositTxFields(walletTx);
+        } catch (IllegalArgumentException e) {
+            log.warn("We got a transactionConfidenceTx with non-canonical deposit tx fields. " +
+                    "transactionConfidenceTx={}", walletTx, e);
+            return false;
+        }
+
         long numInputMatches = walletTx.getInputs().stream()
                 .map(TransactionInput::getOutpoint)
                 .filter(Objects::nonNull)

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTx.java
@@ -29,6 +29,8 @@ import org.bitcoinj.core.Transaction;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.trade.validation.DepositTxValidation.checkCanonicalDepositTxFields;
+
 @Slf4j
 public class SellerPublishesDepositTx extends TradeTask {
     public SellerPublishesDepositTx(TaskRunner<Trade> taskHandler, Trade trade) {
@@ -40,7 +42,7 @@ public class SellerPublishesDepositTx extends TradeTask {
         try {
             runInterceptHook();
 
-            final Transaction depositTx = processModel.getDepositTx();
+            Transaction depositTx = checkCanonicalDepositTxFields(processModel.getDepositTx());
             processModel.getTradeWalletService().broadcastTx(depositTx,
                     new TxBroadcaster.Callback() {
                         @Override

--- a/core/src/main/java/bisq/core/trade/validation/DepositTxValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/DepositTxValidation.java
@@ -144,10 +144,19 @@ public final class DepositTxValidation {
     public static Transaction checkCanonicalDepositTxShape(Transaction transaction,
                                                            List<RawTransactionInput> peerInputs,
                                                            NetworkParameters params) {
-        Transaction checkedTransaction = checkVersionIsOne(transaction);
-        checkLockTimeIsZero(checkedTransaction);
-        checkInputSequencesDisableRbf(checkedTransaction);
+        Transaction checkedTransaction = checkCanonicalDepositTxFields(transaction);
         checkAllInputsAreP2WPKH(peerInputs, params);
+        return checkedTransaction;
+    }
+
+    /**
+     * Checks canonical transaction-level fields that must remain true for the
+     * final signed deposit tx as well as the prepared tx.
+     */
+    public static Transaction checkCanonicalDepositTxFields(Transaction transaction) {
+        Transaction checkedTransaction = checkVersionIsOne(transaction);
+        checkedTransaction = checkLockTimeIsZero(checkedTransaction);
+        checkedTransaction = checkInputSequencesDisableRbf(checkedTransaction);
         return checkedTransaction;
     }
 

--- a/core/src/test/java/bisq/core/trade/validation/DepositTxValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/DepositTxValidationTest.java
@@ -305,6 +305,45 @@ class DepositTxValidationTest {
                         PARAMS));
     }
 
+
+    /* --------------------------------------------------------------------- */
+    // Canonical final deposit tx fields
+    /* --------------------------------------------------------------------- */
+
+    @Test
+    void checkCanonicalDepositTxFieldsAcceptsCanonicalTx() {
+        Transaction tx = canonicalTx();
+
+        assertSame(tx, DepositTxValidation.checkCanonicalDepositTxFields(tx));
+    }
+
+    @Test
+    void checkCanonicalDepositTxFieldsRejectsNonV1Tx() {
+        Transaction tx = canonicalTx();
+        tx.setVersion(2);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkCanonicalDepositTxFields(tx));
+    }
+
+    @Test
+    void checkCanonicalDepositTxFieldsRejectsNonZeroLockTime() {
+        Transaction tx = canonicalTx();
+        tx.setLockTime(1);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkCanonicalDepositTxFields(tx));
+    }
+
+    @Test
+    void checkCanonicalDepositTxFieldsRejectsRbfEnabledSequence() {
+        Transaction tx = canonicalTx();
+        tx.getInput(0).setSequenceNumber(0);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> DepositTxValidation.checkCanonicalDepositTxFields(tx));
+    }
+
     @Test
     void checkMakersPreparedDepositTxRejectsWrongMultisigOutputAmount() {
         Offer offer = offer(false,


### PR DESCRIPTION
Add DepositTxValidation.checkCanonicalDepositTxFields for the transaction-level invariants shared by prepared and final deposit txs: version 1, zero locktime, and non-RBF input sequences.

Apply the check before the seller broadcasts the deposit tx, when the buyer accepts the seller's deposit tx message, and when the buyer detects the deposit tx from wallet confidence. Reuse the same check from checkCanonicalDepositTxShape and add focused validation tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deposit transaction validation across the trade protocol to enforce canonical format requirements, ensuring all transactions meet version, locktime, and sequence policy standards before broadcasting and processing during trade settlement.

* **Tests**
  * Added comprehensive unit test coverage for canonical deposit transaction validation, including acceptance and rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->