### PR TITLE
Add extra check for multi sig pub key

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSetupDepositTxListener.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSetupDepositTxListener.java
@@ -20,6 +20,7 @@ package bisq.core.trade.protocol.bisq_v1.tasks.buyer;
 import bisq.core.btc.listeners.AddressConfidenceListener;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
@@ -45,6 +46,7 @@ import javax.annotation.Nullable;
 
 import static bisq.core.trade.validation.DepositTxValidation.checkCanonicalDepositTxFields;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class BuyerSetupDepositTxListener extends TradeTask {
@@ -121,7 +123,10 @@ public class BuyerSetupDepositTxListener extends TradeTask {
             return false;
         }
 
-        Transaction walletTx = processModel.getTradeWalletService().getWalletTx(confidence.getTransactionHash());
+        TradeWalletService tradeWalletService = processModel.getTradeWalletService();
+
+        Transaction walletTx = checkNotNull(tradeWalletService.getWalletTx(confidence.getTransactionHash()),
+                "WalletTx must not be null");
         try {
             checkCanonicalDepositTxFields(walletTx);
         } catch (IllegalArgumentException e) {

--- a/core/src/main/java/bisq/core/trade/validation/TransactionValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TransactionValidation.java
@@ -42,6 +42,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class TransactionValidation {
+    private static final byte[] SECP256K1_GENERATOR_PUB_KEY = ECKey.CURVE.getG().getEncoded(true);
+
     private TransactionValidation() {
     }
 
@@ -168,9 +170,15 @@ public final class TransactionValidation {
     public static byte[] checkMultiSigPubKey(byte[] multiSigPubKey) {
         checkNonEmptyBytes(multiSigPubKey, "multiSigPubKey");
         checkArgument(multiSigPubKey.length == 33, "multiSigPubKey must be compressed");
+        checkArgument(multiSigPubKey[0] == 0x02 || multiSigPubKey[0] == 0x03,
+                "multiSigPubKey must use a valid compressed public key prefix");
+        checkArgument(!Arrays.equals(multiSigPubKey, SECP256K1_GENERATOR_PUB_KEY),
+                "multiSigPubKey must not be the secp256k1 generator point");
 
         // Check that the multisig key decompresses to a valid curve point:
-        ECKey.fromPublicOnly(multiSigPubKey);
+        ECKey key = ECKey.fromPublicOnly(multiSigPubKey);
+        checkArgument(key.isCompressed(), "multiSigPubKey must be compressed");
+        checkArgument(!key.getPubKeyPoint().isInfinity(), "multiSigPubKey must not be point at infinity");
         return multiSigPubKey;
     }
 }

--- a/core/src/test/java/bisq/core/trade/validation/TransactionValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TransactionValidationTest.java
@@ -286,6 +286,28 @@ class TransactionValidationTest {
     }
 
     @Test
+    void checkMultiSigPubKeyRejectsInvalidCompressedPublicKeyPrefix() {
+        byte[] publicKeyWithInvalidPrefix = Arrays.copyOf(new ECKey().getPubKey(), 33);
+        publicKeyWithInvalidPrefix[0] = 0x04;
+
+        assertThrows(IllegalArgumentException.class, () -> TransactionValidation.checkMultiSigPubKey(publicKeyWithInvalidPrefix));
+    }
+
+    @Test
+    void checkMultiSigPubKeyRejectsStandardPointAtInfinityEncoding() {
+        byte[] pointAtInfinityEncoding = new byte[]{0x00};
+
+        assertThrows(IllegalArgumentException.class, () -> TransactionValidation.checkMultiSigPubKey(pointAtInfinityEncoding));
+    }
+
+    @Test
+    void checkMultiSigPubKeyRejectsGeneratorPoint() {
+        byte[] generatorPoint = ECKey.CURVE.getG().getEncoded(true);
+
+        assertThrows(IllegalArgumentException.class, () -> TransactionValidation.checkMultiSigPubKey(generatorPoint));
+    }
+
+    @Test
     void checkMultiSigPubKeyRejectsMalformedCompressedPublicKey() {
         byte[] malformedCompressedPubKey = new byte[33];
         Arrays.fill(malformedCompressedPubKey, (byte) 0xff);


### PR DESCRIPTION
Add additional checks for MultiSigPubKey

Require compressed pubkey prefix 0x02 or 0x03.

Reject the secp256k1 generator point.

Keep decode-based curve validation.

Add explicit compressed/infinity assertions after decode.

Added focused negative tests in TransactionValidationTest.java.
MakerProcessesInputsForDepositTxRequest already routes the untrusted taker key through TransactionValidation.checkMultiSigPubKey(...), so no caller change was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for deposit transaction identification to verify canonical deposit fields.
  * Strengthened secp256k1 compressed multisig public key validation with stricter prefix and curve-point checks.

* **Tests**
  * Added test coverage for multisig public key validation edge cases, including invalid prefix bytes, point-at-infinity, and generator point encoding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7717)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->