### PR TITLE
fix: harden httpclient

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -90,6 +90,7 @@ public class Config {
     public static final String SOCKS_5_PROXY_BTC_ADDRESS = "socks5ProxyBtcAddress";
     public static final String SOCKS_5_PROXY_HTTP_ADDRESS = "socks5ProxyHttpAddress";
     public static final String USE_TOR_FOR_BTC = "useTorForBtc";
+    public static final String ALLOW_LAN_FOR_HTTP_REQUESTS = "allowLanForHttpRequests";
     public static final String TORRC_FILE = "torrcFile";
     public static final String TORRC_OPTIONS = "torrcOptions";
     public static final String TOR_CONTROL_HOST = "torControlHost";
@@ -212,6 +213,7 @@ public class Config {
     public final List<String> btcNodes;
     public final boolean useTorForBtc;
     public final boolean useTorForBtcOptionSetExplicitly;
+    public final boolean allowLanForHttpRequests;
     public final String socks5DiscoverMode;
     public final boolean useAllProvidedNodes;
     public final String userAgent;
@@ -576,6 +578,16 @@ public class Config {
                         .ofType(Boolean.class)
                         .defaultsTo(false);
 
+        ArgumentAcceptingOptionSpec<Boolean> allowLanForHttpRequestsOpt =
+                parser.accepts(ALLOW_LAN_FOR_HTTP_REQUESTS,
+                                "If true, HTTP requests to RFC1918 private IP ranges (10/8, 172.16/12, " +
+                                        "192.168/16), IPv4 link-local (169.254/16) and IPv6 unique-local/link-local " +
+                                        "addresses bypass Tor. Default false: only loopback bypasses Tor. " +
+                                        "Enable only if you run Bitcoin/XMR/explorer services on a trusted LAN.")
+                        .withRequiredArg()
+                        .ofType(Boolean.class)
+                        .defaultsTo(false);
+
         ArgumentAcceptingOptionSpec<String> socks5DiscoverModeOpt =
                 parser.accepts(SOCKS5_DISCOVER_MODE, "Specify discovery mode for Bitcoin nodes. " +
                                 "One or more of: [ADDR, DNS, ONION, ALL] (comma separated, they get OR'd together).")
@@ -863,6 +875,7 @@ public class Config {
             this.btcNodes = options.valuesOf(btcNodesOpt);
             this.useTorForBtc = options.valueOf(useTorForBtcOpt);
             this.useTorForBtcOptionSetExplicitly = options.has(useTorForBtcOpt);
+            this.allowLanForHttpRequests = options.valueOf(allowLanForHttpRequestsOpt);
             this.socks5DiscoverMode = options.valueOf(socks5DiscoverModeOpt);
             this.useAllProvidedNodes = options.valueOf(useAllProvidedNodesOpt);
             this.userAgent = options.valueOf(userAgentOpt);

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -266,7 +266,7 @@ public class BisqSetup {
         this.refundManager = refundManager;
         this.arbitrationManager = arbitrationManager;
 
-        MemPoolSpaceTxBroadcaster.init(socks5ProxyProvider, preferences, localBitcoinNode);
+        MemPoolSpaceTxBroadcaster.init(socks5ProxyProvider, preferences, localBitcoinNode, config.allowLanForHttpRequests);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/btc/wallet/http/MemPoolSpaceTxBroadcaster.java
+++ b/core/src/main/java/bisq/core/btc/wallet/http/MemPoolSpaceTxBroadcaster.java
@@ -52,15 +52,18 @@ public class MemPoolSpaceTxBroadcaster {
     private static Socks5ProxyProvider socks5ProxyProvider;
     private static Preferences preferences;
     private static LocalBitcoinNode localBitcoinNode;
+    private static boolean allowLanForHttpRequests;
     private static final ListeningExecutorService executorService = Utilities.getListeningExecutorService(
             "MemPoolSpaceTxBroadcaster", 3, 5, 10 * 60);
 
     public static void init(Socks5ProxyProvider socks5ProxyProvider,
                             Preferences preferences,
-                            LocalBitcoinNode localBitcoinNode) {
+                            LocalBitcoinNode localBitcoinNode,
+                            boolean allowLanForHttpRequests) {
         MemPoolSpaceTxBroadcaster.socks5ProxyProvider = socks5ProxyProvider;
         MemPoolSpaceTxBroadcaster.preferences = preferences;
         MemPoolSpaceTxBroadcaster.localBitcoinNode = localBitcoinNode;
+        MemPoolSpaceTxBroadcaster.allowLanForHttpRequests = allowLanForHttpRequests;
     }
 
     public static void broadcastTx(Transaction tx) {
@@ -105,7 +108,7 @@ public class MemPoolSpaceTxBroadcaster {
     }
 
     private static void broadcastTx(String serviceAddress, String txIdToSend, String rawTx) {
-        TxBroadcastHttpClient httpClient = new TxBroadcastHttpClient(socks5ProxyProvider);
+        TxBroadcastHttpClient httpClient = new TxBroadcastHttpClient(socks5ProxyProvider, allowLanForHttpRequests);
         httpClient.setBaseUrl(serviceAddress);
         httpClient.setIgnoreSocks5Proxy(false);
 

--- a/core/src/main/java/bisq/core/btc/wallet/http/TxBroadcastHttpClient.java
+++ b/core/src/main/java/bisq/core/btc/wallet/http/TxBroadcastHttpClient.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class TxBroadcastHttpClient extends HttpClientImpl implements AssetTxProofHttpClient {
-    TxBroadcastHttpClient(Socks5ProxyProvider socks5ProxyProvider) {
-        super(socks5ProxyProvider);
+    TxBroadcastHttpClient(Socks5ProxyProvider socks5ProxyProvider, boolean allowLanForHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/provider/FeeHttpClient.java
+++ b/core/src/main/java/bisq/core/provider/FeeHttpClient.java
@@ -20,7 +20,10 @@ package bisq.core.provider;
 import bisq.network.Socks5ProxyProvider;
 import bisq.network.http.HttpClientImpl;
 
+import bisq.common.config.Config;
+
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import javax.annotation.Nullable;
@@ -28,7 +31,8 @@ import javax.annotation.Nullable;
 @Singleton
 public class FeeHttpClient extends HttpClientImpl {
     @Inject
-    public FeeHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider) {
-        super(socks5ProxyProvider);
+    public FeeHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider,
+                         @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/provider/MempoolHttpClient.java
+++ b/core/src/main/java/bisq/core/provider/MempoolHttpClient.java
@@ -21,8 +21,10 @@ import bisq.network.Socks5ProxyProvider;
 import bisq.network.http.HttpClientImpl;
 
 import bisq.common.app.Version;
+import bisq.common.config.Config;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.io.IOException;
@@ -34,8 +36,9 @@ import javax.annotation.Nullable;
 @Singleton
 public class MempoolHttpClient extends HttpClientImpl {
     @Inject
-    public MempoolHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider) {
-        super(socks5ProxyProvider);
+    public MempoolHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider,
+                             @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests);
     }
 
     // returns JSON of the transaction details

--- a/core/src/main/java/bisq/core/provider/PriceHttpClient.java
+++ b/core/src/main/java/bisq/core/provider/PriceHttpClient.java
@@ -20,7 +20,10 @@ package bisq.core.provider;
 import bisq.network.Socks5ProxyProvider;
 import bisq.network.http.HttpClientImpl;
 
+import bisq.common.config.Config;
+
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import javax.annotation.Nullable;
@@ -28,7 +31,8 @@ import javax.annotation.Nullable;
 @Singleton
 public class PriceHttpClient extends HttpClientImpl {
     @Inject
-    public PriceHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider) {
-        super(socks5ProxyProvider);
+    public PriceHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider,
+                           @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/provider/mempool/MempoolRequest.java
+++ b/core/src/main/java/bisq/core/provider/mempool/MempoolRequest.java
@@ -49,9 +49,11 @@ public class MempoolRequest {
     private final List<String> txBroadcastServices = new ArrayList<>();
     private final MempoolHttpClient mempoolHttpClient;
 
-    public MempoolRequest(Preferences preferences, Socks5ProxyProvider socks5ProxyProvider) {
+    public MempoolRequest(Preferences preferences,
+                          Socks5ProxyProvider socks5ProxyProvider,
+                          boolean allowLanForHttpRequests) {
         this.txBroadcastServices.addAll(preferences.getDefaultTxBroadcastServices());
-        this.mempoolHttpClient = new MempoolHttpClient(socks5ProxyProvider);
+        this.mempoolHttpClient = new MempoolHttpClient(socks5ProxyProvider, allowLanForHttpRequests);
     }
 
     public void getTxStatus(SettableFuture<String> mempoolServiceCallback, String txId) {

--- a/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
+++ b/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
@@ -106,7 +106,7 @@ public class MempoolService {
             UserThread.runAfter(() -> resultHandler.accept(txValidator.endResult(FeeValidationStatus.ACK_CHECK_BYPASSED)), 1);
             return;
         }
-        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider);
+        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests);
         validateOfferMakerTx(mempoolRequest, txValidator, resultHandler);
     }
 
@@ -120,7 +120,7 @@ public class MempoolService {
             UserThread.runAfter(() -> resultHandler.accept(txValidator.endResult(FeeValidationStatus.ACK_CHECK_BYPASSED)), 1);
             return;
         }
-        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider);
+        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests);
         validateOfferTakerTx(mempoolRequest, txValidator, resultHandler);
     }
 
@@ -130,7 +130,7 @@ public class MempoolService {
             UserThread.runAfter(() -> resultHandler.accept(txValidator.endResult(FeeValidationStatus.ACK_CHECK_BYPASSED)), 1);
             return;
         }
-        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider);
+        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests);
         SettableFuture<String> future = SettableFuture.create();
         Futures.addCallback(future, callbackForTxRequest(mempoolRequest, txValidator, resultHandler), MoreExecutors.directExecutor());
         mempoolRequest.getTxStatus(future, txId);
@@ -138,7 +138,7 @@ public class MempoolService {
 
     public CompletableFuture<String> requestTxAsHex(String txId) {
         outstandingRequests++;
-        return new MempoolRequest(preferences, socks5ProxyProvider)
+        return new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests)
                 .requestTxAsHex(txId)
                 .whenComplete((result, throwable) -> outstandingRequests--);
     }

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofHttpClient.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofHttpClient.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class XmrTxProofHttpClient extends HttpClientImpl implements AssetTxProofHttpClient {
-    XmrTxProofHttpClient(Socks5ProxyProvider socks5ProxyProvider) {
-        super(socks5ProxyProvider);
+    XmrTxProofHttpClient(Socks5ProxyProvider socks5ProxyProvider, boolean allowLanForHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequest.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequest.java
@@ -163,25 +163,24 @@ class XmrTxProofRequest implements AssetTxProofRequest<XmrTxProofRequest.Result>
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     XmrTxProofRequest(Socks5ProxyProvider socks5ProxyProvider,
-                      XmrTxProofModel model) {
+                      XmrTxProofModel model,
+                      boolean allowLanForHttpRequests) {
         txProofParser = new XmrTxProofParser();
         rawTxParser = new XmrRawTxParser();
         this.model = model;
 
-        httpClient = new XmrTxProofHttpClient(socks5ProxyProvider);
+        httpClient = new XmrTxProofHttpClient(socks5ProxyProvider, allowLanForHttpRequests);
 
-        // localhost, LAN address, or *.local FQDN starts with http://, don't use Tor
-        if (model.getServiceAddress().regionMatches(0, "http:", 0, 5)) {
-            httpClient.setBaseUrl(model.getServiceAddress());
-            httpClient.setIgnoreSocks5Proxy(true);
-            // any non-onion FQDN starts with https://, use Tor
-        } else if (model.getServiceAddress().regionMatches(0, "https:", 0, 6)) {
-            httpClient.setBaseUrl(model.getServiceAddress());
-            httpClient.setIgnoreSocks5Proxy(false);
-            // it's a raw onion so add http:// and use Tor proxy
+        // The HttpClient itself decides whether to bypass Tor based on URL parsing
+        // (loopback always bypasses; LAN bypasses iff allowLanForHttpRequests=true).
+        // We only normalise the URL: a raw onion address has no scheme prefix.
+        String address = model.getServiceAddress();
+        if (address.regionMatches(true, 0, "http:", 0, 5)
+                || address.regionMatches(true, 0, "https:", 0, 6)) {
+            httpClient.setBaseUrl(address);
         } else {
-            httpClient.setBaseUrl("http://" + model.getServiceAddress());
-            httpClient.setIgnoreSocks5Proxy(false);
+            // bare onion → assume http
+            httpClient.setBaseUrl("http://" + address);
         }
 
         terminated = false;

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
@@ -59,6 +59,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
     private final FilterManager filterManager;
     private final RefundManager refundManager;
     private final Socks5ProxyProvider socks5ProxyProvider;
+    private final boolean allowLanForHttpRequests;
 
     private int numRequiredSuccessResults;
     private final Set<XmrTxProofRequest> requests = new HashSet<>();
@@ -78,13 +79,15 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
                                AutoConfirmSettings autoConfirmSettings,
                                MediationManager mediationManager,
                                FilterManager filterManager,
-                               RefundManager refundManager) {
+                               RefundManager refundManager,
+                               boolean allowLanForHttpRequests) {
         this.socks5ProxyProvider = socks5ProxyProvider;
         this.trade = trade;
         this.autoConfirmSettings = autoConfirmSettings;
         this.mediationManager = mediationManager;
         this.filterManager = filterManager;
         this.refundManager = refundManager;
+        this.allowLanForHttpRequests = allowLanForHttpRequests;
     }
 
 
@@ -161,7 +164,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
 
         for (String serviceAddress : serviceAddresses) {
             XmrTxProofModel model = new XmrTxProofModel(trade, serviceAddress, autoConfirmSettings);
-            XmrTxProofRequest request = new XmrTxProofRequest(socks5ProxyProvider, model);
+            XmrTxProofRequest request = new XmrTxProofRequest(socks5ProxyProvider, model, allowLanForHttpRequests);
 
             log.info("{} created", request);
             requests.add(request);

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
@@ -40,6 +40,9 @@ import bisq.network.p2p.BootstrapListener;
 import bisq.network.p2p.P2PService;
 
 import bisq.common.app.DevEnv;
+import bisq.common.config.Config;
+
+import javax.inject.Named;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -80,6 +83,7 @@ public class XmrTxProofService implements AssetTxProofService {
     private final P2PService p2PService;
     private final WalletsSetup walletsSetup;
     private final Socks5ProxyProvider socks5ProxyProvider;
+    private final boolean allowLanForHttpRequests;
     private final Map<String, XmrTxProofRequestsPerTrade> servicesByTradeId = new HashMap<>();
     private AutoConfirmSettings autoConfirmSettings;
     private final Map<String, ChangeListener<Trade.State>> tradeStateListenerMap = new HashMap<>();
@@ -104,7 +108,8 @@ public class XmrTxProofService implements AssetTxProofService {
                              RefundManager refundManager,
                              P2PService p2PService,
                              WalletsSetup walletsSetup,
-                             Socks5ProxyProvider socks5ProxyProvider) {
+                             Socks5ProxyProvider socks5ProxyProvider,
+                             @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
         this.filterManager = filterManager;
         this.preferences = preferences;
         this.tradeManager = tradeManager;
@@ -115,6 +120,7 @@ public class XmrTxProofService implements AssetTxProofService {
         this.p2PService = p2PService;
         this.walletsSetup = walletsSetup;
         this.socks5ProxyProvider = socks5ProxyProvider;
+        this.allowLanForHttpRequests = allowLanForHttpRequests;
     }
 
 
@@ -266,7 +272,8 @@ public class XmrTxProofService implements AssetTxProofService {
                 autoConfirmSettings,
                 mediationManager,
                 filterManager,
-                refundManager);
+                refundManager,
+                allowLanForHttpRequests);
         servicesByTradeId.put(trade.getId(), service);
         service.requestFromAllServices(
                 assetTxProofResult -> {

--- a/p2p/src/main/java/bisq/network/http/FakeDnsResolver.java
+++ b/p2p/src/main/java/bisq/network/http/FakeDnsResolver.java
@@ -27,7 +27,12 @@ import java.net.UnknownHostException;
 class FakeDnsResolver implements DnsResolver {
     @Override
     public InetAddress[] resolve(String host) throws UnknownHostException {
-        // Return some fake DNS record for every request, we won't be using it
-        return new InetAddress[]{InetAddress.getByAddress(new byte[]{1, 1, 1, 1})};
+        // The custom socket factories never use this resolver — DNS is handled by
+        // the SOCKS proxy. We still must return a non-null value because Apache's
+        // connection manager requires it. Return the unspecified address (0.0.0.0)
+        // so that any accidental connect attempt fails locally rather than reaching
+        // a real host (the previous 1.1.1.1 placeholder was a public Cloudflare IP
+        // and could mask leaks during testing).
+        return new InetAddress[]{InetAddress.getByAddress(new byte[]{0, 0, 0, 0})};
     }
 }

--- a/p2p/src/main/java/bisq/network/http/HttpClientImpl.java
+++ b/p2p/src/main/java/bisq/network/http/HttpClientImpl.java
@@ -20,13 +20,17 @@ package bisq.network.http;
 import bisq.network.Socks5ProxyProvider;
 
 import bisq.common.app.Version;
+import bisq.common.config.Config;
 import bisq.common.util.Utilities;
+
+import javax.inject.Named;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -43,6 +47,7 @@ import javax.inject.Inject;
 
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.URL;
 
 import java.nio.charset.StandardCharsets;
@@ -55,9 +60,9 @@ import java.io.UnsupportedEncodingException;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -65,45 +70,103 @@ import javax.annotation.Nullable;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// TODO close connection if failing
+/**
+ * HTTP client used for any external query (price feed, fee estimation, BSQ
+ * explorer, mempool broadcast, XMR proof, …).
+ *
+ * Hardening invariants enforced here:
+ *   - URL must parse as a valid http/https URI with a non-empty host (no file://,
+ *     no userinfo, no schemes outside http/https).
+ *   - Requests addressed to a non-local destination MUST go through the SOCKS5
+ *     (Tor) proxy. If the proxy is missing the request is rejected — we
+ *     fail-closed rather than leaking traffic to the clearnet.
+ *   - "Local" means a loopback IP literal or the literal hostname "localhost"
+ *     (or IPv6 equivalents). Hostnames that would require a DNS lookup are not
+ *     treated as local because answering would leak the lookup.
+ *   - The {@link #setIgnoreSocks5Proxy(boolean)} escape hatch is honoured only
+ *     when the URL is local. Setting the flag for a non-local URL is a bug and
+ *     is refused at request time.
+ *   - Conservative timeouts (80 s connect / 60 s read) and a 512 KiB response
+ *     body cap bound the damage of a malicious or misbehaving server.
+ *   - Bodies are decoded as UTF-8; size accounting is byte-exact.
+ */
 @Slf4j
 public class HttpClientImpl implements HttpClient {
+    // Connect=80s covers Tor circuit setup + onion-service rendezvous on a cold
+    // start; read=60s is per-byte inactivity, generous for any healthy server
+    // once the circuit is up.
+    static final int CONNECT_TIMEOUT_SEC = 80;
+    static final int READ_TIMEOUT_SEC = 60;
+    // 512 KiB is well above any legitimate response from price feeds, fee
+    // estimators, mempool/explorer JSON, or XMR proof endpoints. A larger cap
+    // just widens the memory-exhaustion window without enabling any real use.
+    static final long MAX_RESPONSE_BYTES = 512L * 1024;
+
     @Nullable
-    private Socks5ProxyProvider socks5ProxyProvider;
+    private final Socks5ProxyProvider socks5ProxyProvider;
+    private final boolean allowLanForHttpRequests;
     @Nullable
-    private HttpURLConnection connection;
+    private volatile HttpURLConnection connection;
     @Nullable
-    private CloseableHttpClient closeableHttpClient;
+    private volatile CloseableHttpClient closeableHttpClient;
 
     @Getter
-    @Setter
-    private String baseUrl;
-    @Setter
-    private boolean ignoreSocks5Proxy;
+    private volatile String baseUrl;
+    private volatile boolean ignoreSocks5Proxy;
     @Getter
     private final String uid;
-    private boolean hasPendingRequest;
+    private final AtomicBoolean hasPendingRequest = new AtomicBoolean(false);
 
     @Inject
-    public HttpClientImpl(@Nullable Socks5ProxyProvider socks5ProxyProvider) {
+    public HttpClientImpl(@Nullable Socks5ProxyProvider socks5ProxyProvider,
+                          @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
         this.socks5ProxyProvider = socks5ProxyProvider;
+        this.allowLanForHttpRequests = allowLanForHttpRequests;
         uid = UUID.randomUUID().toString();
     }
 
+    public HttpClientImpl(@Nullable Socks5ProxyProvider socks5ProxyProvider) {
+        // Test/legacy entry point. Defaults to strict loopback-only.
+        this(socks5ProxyProvider, false);
+    }
+
     public HttpClientImpl(String baseUrl) {
-        this.baseUrl = baseUrl;
+        this.socks5ProxyProvider = null;
+        this.allowLanForHttpRequests = false;
+        setBaseUrl(baseUrl);
         uid = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void setBaseUrl(String baseUrl) {
+        // Validate up-front so misconfiguration surfaces at injection time, not at
+        // first request time.
+        UrlSafetyChecker.parseAndValidate(baseUrl);
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public void setIgnoreSocks5Proxy(boolean ignoreSocks5Proxy) {
+        this.ignoreSocks5Proxy = ignoreSocks5Proxy;
     }
 
     @Override
     public void shutDown() {
         try {
-            if (connection != null) {
-                connection.getInputStream().close();
-                connection.disconnect();
+            HttpURLConnection c = connection;
+            if (c != null) {
+                try {
+                    InputStream is = c.getInputStream();
+                    if (is != null) is.close();
+                } catch (IOException ignore) {
+                }
+                c.disconnect();
+                connection = null;
             }
-            if (closeableHttpClient != null) {
-                closeableHttpClient.close();
+            CloseableHttpClient client = closeableHttpClient;
+            if (client != null) {
+                client.close();
+                closeableHttpClient = null;
             }
         } catch (IOException ignore) {
         }
@@ -111,7 +174,7 @@ public class HttpClientImpl implements HttpClient {
 
     @Override
     public boolean hasPendingRequest() {
-        return hasPendingRequest;
+        return hasPendingRequest.get();
     }
 
     @Override
@@ -133,14 +196,52 @@ public class HttpClientImpl implements HttpClient {
                              @Nullable String headerKey,
                              @Nullable String headerValue) throws IOException {
         checkNotNull(baseUrl, "baseUrl must be set before calling doRequest");
-        checkArgument(!hasPendingRequest, "We got called on the same HttpClient again while a request is still open.");
+        checkArgument(hasPendingRequest.compareAndSet(false, true),
+                "We got called on the same HttpClient again while a request is still open.");
+        try {
+            // Validate the *effective* URL the network stack will see. For GET we
+            // append param to baseUrl, so a baseUrl with no trailing slash plus a
+            // param starting with '@', '?', or '#' could shift the effective host
+            // (e.g. baseUrl="http://localhost" + param="@evil.com" → host=evil.com).
+            // Re-parsing the concatenation closes that bypass: parseAndValidate
+            // rejects userinfo, and the host we hand to isLocal is the real target.
+            String effectiveSpec = httpMethod == HttpMethod.GET ? baseUrl + param : baseUrl;
+            URI uri;
+            try {
+                uri = UrlSafetyChecker.parseAndValidate(effectiveSpec);
+            } catch (UrlSafetyChecker.InvalidUrlException e) {
+                // Surface URL-validation failures as IOException so callers (which
+                // declare `throws IOException`) handle them like any other request
+                // failure rather than via runtime-exception propagation.
+                throw new IOException(e.getMessage());
+            }
+            boolean local = UrlSafetyChecker.isLocal(uri, allowLanForHttpRequests);
+            Socks5Proxy socks5Proxy = getSocks5Proxy(socks5ProxyProvider);
 
-        hasPendingRequest = true;
-        Socks5Proxy socks5Proxy = getSocks5Proxy(socks5ProxyProvider);
-        if (ignoreSocks5Proxy || socks5Proxy == null || baseUrl.contains("localhost")) {
-            return requestWithoutProxy(baseUrl, param, httpMethod, headerKey, headerValue);
-        } else {
+            if (local) {
+                // localhost/loopback only — direct connection is correct.
+                return requestWithoutProxy(baseUrl, param, httpMethod, headerKey, headerValue);
+            }
+
+            if (ignoreSocks5Proxy) {
+                // Caller explicitly opted out of Tor for a non-local URL. Refuse —
+                // this would leak the request and historically has been a source of
+                // bugs (e.g. a misconfigured XMR proof service URL).
+                throw new IOException("ignoreSocks5Proxy is only allowed for local URLs, " +
+                        "refusing to send " + httpMethod + " to non-local " + baseUrl);
+            }
+
+            if (socks5Proxy == null) {
+                // Fail closed: rather than fall back to clearnet (the previous
+                // behaviour), refuse to send the request. The caller decides
+                // whether to retry once Tor is up.
+                throw new IOException("No SOCKS5 proxy available, refusing to send "
+                        + httpMethod + " to non-local " + baseUrl);
+            }
+
             return doRequestWithProxy(baseUrl, param, httpMethod, socks5Proxy, headerKey, headerValue);
+        } finally {
+            hasPendingRequest.set(false);
         }
     }
 
@@ -153,35 +254,39 @@ public class HttpClientImpl implements HttpClient {
         log.debug("requestWithoutProxy: URL={}, param={}, httpMethod={}", baseUrl, param, httpMethod);
         try {
             String spec = httpMethod == HttpMethod.GET ? baseUrl + param : baseUrl;
-            URL url = new URL(spec);
-            connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod(httpMethod.name());
-            connection.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(120));
-            connection.setReadTimeout((int) TimeUnit.SECONDS.toMillis(120));
-            connection.setRequestProperty("User-Agent", "bisq/" + Version.VERSION);
+            // URI.toURL forces well-formed URLs and rejects characters that the
+            // legacy URL constructor accepts silently.
+            URL url = new URI(spec).toURL();
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            connection = conn;
+            conn.setInstanceFollowRedirects(false);
+            conn.setRequestMethod(httpMethod.name());
+            conn.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(CONNECT_TIMEOUT_SEC));
+            conn.setReadTimeout((int) TimeUnit.SECONDS.toMillis(READ_TIMEOUT_SEC));
+            conn.setRequestProperty("User-Agent", "bisq/" + Version.VERSION);
             if (headerKey != null && headerValue != null) {
-                connection.setRequestProperty(headerKey, headerValue);
+                conn.setRequestProperty(headerKey, headerValue);
             }
 
             if (httpMethod == HttpMethod.POST) {
-                connection.setDoOutput(true);
-                connection.getOutputStream().write(param.getBytes(StandardCharsets.UTF_8));
+                conn.setDoOutput(true);
+                conn.getOutputStream().write(param.getBytes(StandardCharsets.UTF_8));
             }
 
-            int responseCode = connection.getResponseCode();
-            if (responseCode == 200) {
-                String response = convertInputStreamToString(connection.getInputStream());
+            int responseCode = conn.getResponseCode();
+            if (isSuccess(responseCode)) {
+                String response = readBoundedUtf8(conn.getInputStream());
                 log.debug("Response from {} with param {} took {} ms. Data size:{}, response: {}",
                         baseUrl,
                         param,
                         System.currentTimeMillis() - ts,
-                        Utilities.readableFileSize(response.getBytes().length),
+                        Utilities.readableFileSize(response.getBytes(StandardCharsets.UTF_8).length),
                         Utilities.toTruncatedString(response));
                 return response;
             } else {
-                InputStream errorStream = connection.getErrorStream();
+                InputStream errorStream = conn.getErrorStream();
                 if (errorStream != null) {
-                    String error = convertInputStreamToString(errorStream);
+                    String error = readBoundedUtf8(errorStream);
                     errorStream.close();
                     log.info("Received errorMsg '{}' with responseCode {} from {}. Response took: {} ms. param: {}",
                             error,
@@ -199,20 +304,23 @@ public class HttpClientImpl implements HttpClient {
                     throw new HttpException("Request failed", responseCode);
                 }
             }
-        } catch (Throwable t) {
-            String message = "Error at requestWithoutProxy with url " + baseUrl + " and param " + param +
-                    ". Throwable=" + t.getMessage();
-            throw new IOException(message, t);
+        } catch (Exception e) {
+            // HttpException ends up here too; callers retrieve it via getCause().
+            throw new IOException("Direct request to " + baseUrl + " failed: " + rootCauseMessage(e), e);
         } finally {
-            try {
-                if (connection != null) {
-                    connection.getInputStream().close();
-                    connection.disconnect();
-                    connection = null;
+            HttpURLConnection c = connection;
+            if (c != null) {
+                try {
+                    InputStream is = c.getInputStream();
+                    if (is != null) is.close();
+                } catch (Throwable ignore) {
                 }
-            } catch (Throwable ignore) {
+                try {
+                    c.disconnect();
+                } catch (Throwable ignore) {
+                }
+                connection = null;
             }
-            hasPendingRequest = false;
         }
     }
 
@@ -224,22 +332,40 @@ public class HttpClientImpl implements HttpClient {
                                       @Nullable String headerValue) throws IOException {
         long ts = System.currentTimeMillis();
         log.debug("doRequestWithProxy: baseUrl={}, param={}, httpMethod={}", baseUrl, param, httpMethod);
-        // This code is adapted from:
-        //  http://stackoverflow.com/a/25203021/5616248
 
-        // Register our own SocketFactories to override createSocket() and connectSocket().
-        // connectSocket does NOT resolve hostname before passing it to proxy.
+        // Register socket factories that pass the unresolved hostname through to
+        // the SOCKS proxy so DNS resolution happens on the Tor exit, never on the
+        // client. See SocksConnectionSocketFactory / SocksSSLConnectionSocketFactory.
         Registry<ConnectionSocketFactory> reg = RegistryBuilder.<ConnectionSocketFactory>create()
                 .register("http", new SocksConnectionSocketFactory())
                 .register("https", new SocksSSLConnectionSocketFactory(SSLContexts.createSystemDefault())).build();
 
-        // Use FakeDNSResolver if not resolving DNS locally.
-        // This prevents a local DNS lookup (which would be ignored anyway)
+        // Belt-and-braces: even though the registered SocketFactories never
+        // consult DnsResolver, force any accidental call to fail rather than
+        // silently leak a lookup. Apache requires a non-null result; we return
+        // an unspecified address that cannot route.
         PoolingHttpClientConnectionManager cm = socks5Proxy.resolveAddrLocally() ?
                 new PoolingHttpClientConnectionManager(reg) :
                 new PoolingHttpClientConnectionManager(reg, new FakeDnsResolver());
         try {
-            closeableHttpClient = checkNotNull(HttpClients.custom().setConnectionManager(cm).build());
+            // Mirror the timeouts and redirect policy of the direct path:
+            //   - Apache defaults to following 3xx for GET/HEAD, which would let a
+            //     validated host redirect to an unvalidated target and bypass
+            //     UrlSafetyChecker. Disable redirect handling.
+            //   - Apache defaults to no socket / connect timeout. Without this a
+            //     stalled circuit pins the request until the JVM gives up.
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setRedirectsEnabled(false)
+                    .setConnectTimeout((int) TimeUnit.SECONDS.toMillis(CONNECT_TIMEOUT_SEC))
+                    .setConnectionRequestTimeout((int) TimeUnit.SECONDS.toMillis(CONNECT_TIMEOUT_SEC))
+                    .setSocketTimeout((int) TimeUnit.SECONDS.toMillis(READ_TIMEOUT_SEC))
+                    .build();
+            CloseableHttpClient client = checkNotNull(HttpClients.custom()
+                    .setConnectionManager(cm)
+                    .setDefaultRequestConfig(requestConfig)
+                    .disableRedirectHandling()
+                    .build());
+            closeableHttpClient = client;
             InetSocketAddress socksAddress = new InetSocketAddress(socks5Proxy.getInetAddress(), socks5Proxy.getPort());
 
             // remove me: Use this to test with system-wide Tor proxy, or change port for another proxy.
@@ -253,14 +379,17 @@ public class HttpClientImpl implements HttpClient {
                 request.setHeader(headerKey, headerValue);
             }
 
-            try (CloseableHttpResponse httpResponse = closeableHttpClient.execute(request, context)) {
-                String response = convertInputStreamToString(httpResponse.getEntity().getContent());
+            try (CloseableHttpResponse httpResponse = client.execute(request, context)) {
                 int statusCode = httpResponse.getStatusLine().getStatusCode();
-                if (statusCode == 200) {
+                // Per HttpResponse contract, getEntity() may return null for bodyless
+                // responses (204 No Content, 304 Not Modified, HEAD, …).
+                HttpEntity entity = httpResponse.getEntity();
+                String response = entity != null ? readBoundedUtf8(entity.getContent()) : "";
+                if (isSuccess(statusCode)) {
                     log.debug("Response from {} took {} ms. Data size:{}, response: {}, param: {}",
                             baseUrl,
                             System.currentTimeMillis() - ts,
-                            Utilities.readableFileSize(response.getBytes().length),
+                            Utilities.readableFileSize(response.getBytes(StandardCharsets.UTF_8).length),
                             Utilities.toTruncatedString(response),
                             param);
                     return response;
@@ -274,16 +403,18 @@ public class HttpClientImpl implements HttpClient {
                     throw new HttpException(response, statusCode);
                 }
             }
-        } catch (Throwable t) {
-            String message = "Error at doRequestWithProxy with url " + baseUrl + " and param " + param +
-                    ". Throwable=" + t.getMessage();
-            throw new IOException(message, t);
+        } catch (Exception e) {
+            // HttpException ends up here too; callers retrieve it via getCause().
+            throw new IOException("Request via SOCKS proxy to " + baseUrl + " failed: " + rootCauseMessage(e), e);
         } finally {
-            if (closeableHttpClient != null) {
-                closeableHttpClient.close();
+            CloseableHttpClient client = closeableHttpClient;
+            if (client != null) {
+                try {
+                    client.close();
+                } catch (Throwable ignore) {
+                }
                 closeableHttpClient = null;
             }
-            hasPendingRequest = false;
         }
     }
 
@@ -304,7 +435,7 @@ public class HttpClientImpl implements HttpClient {
     }
 
     @Nullable
-    private Socks5Proxy getSocks5Proxy(Socks5ProxyProvider socks5ProxyProvider) {
+    private Socks5Proxy getSocks5Proxy(@Nullable Socks5ProxyProvider socks5ProxyProvider) {
         if (socks5ProxyProvider == null) {
             return null;
         }
@@ -320,14 +451,71 @@ public class HttpClientImpl implements HttpClient {
         return socks5ProxyProvider.getSocks5Proxy();
     }
 
-    private String convertInputStreamToString(InputStream inputStream) throws IOException {
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-        StringBuilder stringBuilder = new StringBuilder();
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            stringBuilder.append(line);
+    static boolean isSuccess(int statusCode) {
+        return statusCode >= 200 && statusCode < 300;
+    }
+
+    private static String rootCauseMessage(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) {
+            cur = cur.getCause();
         }
-        return stringBuilder.toString();
+        String msg = cur.getMessage();
+        return msg != null ? msg : cur.getClass().getSimpleName();
+    }
+
+    /**
+     * Reads {@code inputStream} as UTF-8, refusing more than {@link #MAX_RESPONSE_BYTES}
+     * bytes. The cap defends against memory-exhaustion via an unbounded server response.
+     */
+    static String readBoundedUtf8(InputStream inputStream) throws IOException {
+        BoundedInputStream bounded = new BoundedInputStream(inputStream, MAX_RESPONSE_BYTES);
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(bounded, StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            char[] buf = new char[4096];
+            int n;
+            while ((n = reader.read(buf)) >= 0) {
+                sb.append(buf, 0, n);
+            }
+            return sb.toString();
+        }
+    }
+
+    private static final class BoundedInputStream extends InputStream {
+        private final InputStream delegate;
+        private final long max;
+        private long count;
+
+        BoundedInputStream(InputStream delegate, long max) {
+            this.delegate = delegate;
+            this.max = max;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = delegate.read();
+            if (b == -1) return -1;
+            if (++count > max) {
+                throw new IOException("Response exceeded " + max + " bytes");
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int n = delegate.read(b, off, len);
+            if (n == -1) return -1;
+            count += n;
+            if (count > max) {
+                throw new IOException("Response exceeded " + max + " bytes");
+            }
+            return n;
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/http/UrlSafetyChecker.java
+++ b/p2p/src/main/java/bisq/network/http/UrlSafetyChecker.java
@@ -1,0 +1,186 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.http;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Locale;
+
+/**
+ * Validates URLs before they are dispatched and decides whether a request can be
+ * sent in the clear (loopback/link-local only) or must be routed via Tor.
+ *
+ * The matcher purposefully does NOT perform DNS lookups for non-numeric hosts;
+ * doing so would leak the destination to the system resolver before Tor sees it.
+ */
+public final class UrlSafetyChecker {
+
+    public static final class InvalidUrlException extends RuntimeException {
+        public InvalidUrlException(String msg) {
+            super(msg);
+        }
+    }
+
+    private UrlSafetyChecker() {
+    }
+
+    /**
+     * Parses {@code baseUrl} and returns the resulting URI. Only http and https are
+     * accepted; the URI must carry an absolute, non-empty host. All other inputs
+     * (file://, javascript:, ftp://, gopher://, missing host, userinfo, …) are
+     * rejected so they cannot reach the network stack.
+     */
+    public static URI parseAndValidate(String baseUrl) {
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            throw new InvalidUrlException("baseUrl must not be null or empty");
+        }
+        URI uri;
+        try {
+            uri = new URI(baseUrl);
+        } catch (URISyntaxException e) {
+            // Do not echo the raw input — it may be a malformed credential string
+            // and exception messages routinely end up in logs and crash reports.
+            throw new InvalidUrlException("Malformed URL");
+        }
+        if (!uri.isAbsolute()) {
+            throw new InvalidUrlException("URL must be absolute");
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            throw new InvalidUrlException("URL is missing a scheme");
+        }
+        scheme = scheme.toLowerCase(Locale.ROOT);
+        if (!scheme.equals("http") && !scheme.equals("https")) {
+            // scheme itself is safe to echo — credentials live in userinfo, not the scheme.
+            throw new InvalidUrlException("Unsupported URL scheme: " + scheme);
+        }
+        String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            throw new InvalidUrlException("URL is missing a host");
+        }
+        if (uri.getUserInfo() != null) {
+            // userinfo can be used to smuggle a different effective host past naïve
+            // checks. Reject the URL but never echo it: the userinfo portion may
+            // be a real password.
+            throw new InvalidUrlException("Userinfo is not permitted in baseUrl");
+        }
+        return uri;
+    }
+
+    /**
+     * Default: only loopback (127.0.0.0/8, ::1, "localhost") is treated as local.
+     * Private LAN ranges still go through Tor. See
+     * {@link #isLocal(URI, boolean)} to opt in to private ranges.
+     */
+    public static boolean isLocal(URI uri) {
+        return isLocal(uri, false);
+    }
+
+    /**
+     * Returns true iff {@code uri}'s host is on this machine or, when
+     * {@code allowPrivateRanges} is true, on a private/link-local network
+     * reachable directly without traversing the public Internet:
+     *   - always: the literal "localhost" (and IPv6 equivalents) plus any
+     *     loopback IP literal (127.0.0.0/8, ::1);
+     *   - only if {@code allowPrivateRanges}:
+     *       RFC1918 private IPv4 (10/8, 172.16/12, 192.168/16),
+     *       IPv4 link-local (169.254/16),
+     *       IPv6 link-local (fe80::/10),
+     *       IPv6 unique-local (fc00::/7).
+     *
+     * Hostnames that would require a DNS lookup are NEVER considered local —
+     * they could resolve to anything and answering would leak the lookup
+     * outside Tor.
+     */
+    public static boolean isLocal(URI uri, boolean allowPrivateRanges) {
+        String host = uri.getHost();
+        if (host == null) {
+            return false;
+        }
+        // strip the brackets URI keeps around IPv6 literals
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host = host.substring(1, host.length() - 1);
+        }
+        String lower = host.toLowerCase(Locale.ROOT);
+        if (lower.equals("localhost") || lower.equals("ip6-localhost") || lower.equals("ip6-loopback")) {
+            return true;
+        }
+        if (!isNumericIp(host)) {
+            return false;
+        }
+        try {
+            InetAddress addr = InetAddress.getByName(host);
+            if (addr.isLoopbackAddress()) {
+                return true;
+            }
+            if (!allowPrivateRanges) {
+                return false;
+            }
+            if (addr.isLinkLocalAddress() || addr.isSiteLocalAddress()) {
+                // isSiteLocalAddress covers RFC1918 IPv4 (10/8, 172.16/12, 192.168/16)
+                // and the deprecated IPv6 fec0::/10. isLinkLocalAddress covers
+                // 169.254/16 and fe80::/10.
+                return true;
+            }
+            // IPv6 unique-local fc00::/7 (RFC4193) — not flagged by InetAddress.
+            byte[] bytes = addr.getAddress();
+            return bytes.length == 16 && (bytes[0] & 0xfe) == 0xfc;
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Convenience: parses {@code baseUrl} then returns {@link #isLocal(URI)}.
+     */
+    public static boolean isLocal(String baseUrl) {
+        return isLocal(parseAndValidate(baseUrl));
+    }
+
+    private static boolean isNumericIp(String host) {
+        // IPv6 literal contains a colon and only hex/digits/colons/dots
+        if (host.indexOf(':') >= 0) {
+            for (int i = 0; i < host.length(); i++) {
+                char c = host.charAt(i);
+                boolean ok = (c >= '0' && c <= '9')
+                        || (c >= 'a' && c <= 'f')
+                        || (c >= 'A' && c <= 'F')
+                        || c == ':' || c == '.';
+                if (!ok) return false;
+            }
+            return true;
+        }
+        // IPv4 literal: four dot-separated decimal octets in [0,255]
+        String[] parts = host.split("\\.", -1);
+        if (parts.length != 4) {
+            return false;
+        }
+        for (String p : parts) {
+            if (p.isEmpty() || p.length() > 3) return false;
+            for (int i = 0; i < p.length(); i++) {
+                char c = p.charAt(i);
+                if (c < '0' || c > '9') return false;
+            }
+            int v = Integer.parseInt(p);
+            if (v < 0 || v > 255) return false;
+        }
+        return true;
+    }
+}

--- a/p2p/src/main/java/bisq/network/p2p/P2PModule.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PModule.java
@@ -74,6 +74,7 @@ public class P2PModule extends AppModule {
         requestStaticInjection(Connection.class);
 
         bindConstant().annotatedWith(named(USE_LOCALHOST_FOR_P2P)).to(config.useLocalhostForP2P);
+        bindConstant().annotatedWith(named(ALLOW_LAN_FOR_HTTP_REQUESTS)).to(config.allowLanForHttpRequests);
 
         bind(File.class).annotatedWith(named(TOR_DIR)).toInstance(config.torDir);
 

--- a/p2p/src/test/java/bisq/network/http/HttpClientImplFailClosedTest.java
+++ b/p2p/src/test/java/bisq/network/http/HttpClientImplFailClosedTest.java
@@ -1,0 +1,280 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.http;
+
+import bisq.network.Socks5ProxyProvider;
+import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the most security-relevant behaviour of {@link HttpClientImpl}: that
+ * non-local requests cannot escape Tor.
+ *
+ * The clearnet HTTP path is exercised against an in-process loopback server so
+ * that no actual network I/O leaves the host.
+ */
+class HttpClientImplFailClosedTest {
+
+    @Test
+    void rejectsNonLocalUrlWhenProxyMissing() {
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        client.setBaseUrl("http://example.com/");
+        IOException ex = assertThrows(IOException.class,
+                () -> client.get("/foo", null, null));
+        assertTrue(ex.getMessage().toLowerCase().contains("socks5"),
+                "expected fail-closed message, got: " + ex.getMessage());
+    }
+
+    @Test
+    void rejectsNonLocalUrlEvenWhenIgnoreProxyTrue() {
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        client.setBaseUrl("http://example.com/");
+        client.setIgnoreSocks5Proxy(true);
+        IOException ex = assertThrows(IOException.class,
+                () -> client.get("/foo", null, null));
+        assertTrue(ex.getMessage().toLowerCase().contains("non-local"),
+                "expected non-local refusal, got: " + ex.getMessage());
+    }
+
+    @Test
+    void rejectsNonLocalUrlEvenWhenProxyProviderReturnsNull() {
+        Socks5ProxyProvider provider = mock(Socks5ProxyProvider.class);
+        when(provider.getSocks5Proxy()).thenReturn(null);
+        when(provider.getSocks5ProxyHttp()).thenReturn(null);
+
+        HttpClientImpl client = new HttpClientImpl(provider);
+        client.setBaseUrl("https://api.example.com/");
+        IOException ex = assertThrows(IOException.class,
+                () -> client.get("/foo", null, null));
+        assertTrue(ex.getMessage().toLowerCase().contains("socks5"),
+                "expected fail-closed message, got: " + ex.getMessage());
+    }
+
+    @Test
+    void doesNotConsultProxyForOnionAddresses_butStillRejectsWithoutProxy() {
+        // Onion addresses MUST go via Tor. If no proxy is configured we refuse.
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        client.setBaseUrl("http://expyuzz4wqqyqhjn.onion/");
+        assertThrows(IOException.class, () -> client.get("/foo", null, null));
+    }
+
+    @Test
+    void rejectsInvalidSchemeAtSetBaseUrl() {
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> client.setBaseUrl("file:///etc/passwd"));
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> client.setBaseUrl("javascript:alert(1)"));
+    }
+
+    @Test
+    void rejectsLocalhostSpoofViaUserinfo() {
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        // http://localhost@evil.com/ would historically have been treated as local
+        // by a contains("localhost") check. Now it is rejected outright.
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> client.setBaseUrl("http://localhost@evil.com/"));
+    }
+
+    @Test
+    void rejectsGetParamHostSmuggling() {
+        // baseUrl="http://localhost" + param="@evil.com" → effective host = evil.com.
+        // Earlier code parsed only baseUrl and would have treated this as "local";
+        // doRequest now re-parses baseUrl+param for GET so the effective host is
+        // checked. The UserInfo guard in UrlSafetyChecker rejects the result.
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        client.setBaseUrl("http://localhost");
+        assertThrows(IOException.class, () -> client.get("@evil.com/foo", null, null));
+    }
+
+    @Test
+    void rejectsGetParamSchemeSmuggling() {
+        // Param starting with " #" or " ?" doesn't change host, but starting with
+        // "@" or with characters that re-enter the authority section would. Catch
+        // any malformed concatenation, not just the userinfo flavour.
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        client.setBaseUrl("http://localhost");
+        assertThrows(IOException.class, () -> client.get(" attacker.com", null, null));
+    }
+
+    @Test
+    void rejectsLocalhostSpoofViaPath() throws IOException {
+        // A URL whose path contains "localhost" must NOT bypass Tor.
+        HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+        client.setBaseUrl("http://attacker.com/");
+        IOException ex = assertThrows(IOException.class,
+                () -> client.get("/localhost/data", null, null));
+        assertTrue(ex.getMessage().toLowerCase().contains("socks5"));
+    }
+
+    @Test
+    void localhostRequestSucceedsWithoutProxy() throws Exception {
+        try (TinyHttpServer server = TinyHttpServer.start("hello")) {
+            HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+            client.setBaseUrl("http://127.0.0.1:" + server.port() + "/");
+            String body = client.get("foo", null, null);
+            assertEquals("hello", body);
+        }
+    }
+
+    @Test
+    void localhostRequestSucceedsEvenWithBrokenProxyProvider() throws Exception {
+        // ignoreSocks5Proxy is unnecessary for loopback URLs, but if a caller
+        // sets it the local request must still go through.
+        Socks5ProxyProvider provider = mock(Socks5ProxyProvider.class);
+        Socks5Proxy proxy = mock(Socks5Proxy.class);
+        when(provider.getSocks5Proxy()).thenReturn(proxy);
+
+        try (TinyHttpServer server = TinyHttpServer.start("ok")) {
+            HttpClientImpl client = new HttpClientImpl(provider);
+            client.setBaseUrl("http://localhost:" + server.port() + "/");
+            client.setIgnoreSocks5Proxy(true);
+            String body = client.get("foo", null, null);
+            assertEquals("ok", body);
+        }
+    }
+
+    @Test
+    void responseSizeIsCapped() throws Exception {
+        // Build a payload larger than the cap and verify the client refuses to
+        // buffer it. We send the cap + 1 KiB so the server stays bounded.
+        long cap = HttpClientImpl.MAX_RESPONSE_BYTES;
+        byte[] payload = new byte[(int) cap + 1024];
+        for (int i = 0; i < payload.length; i++) payload[i] = 'A';
+
+        try (TinyHttpServer server = TinyHttpServer.startBytes(payload)) {
+            HttpClientImpl client = new HttpClientImpl((Socks5ProxyProvider) null);
+            client.setBaseUrl("http://127.0.0.1:" + server.port() + "/");
+            IOException ex = assertThrows(IOException.class,
+                    () -> client.get("foo", null, null));
+            // Make sure we caught the cap, not some unrelated IOException.
+            String msg = rootCauseMessage(ex);
+            assertNotNull(msg);
+            assertTrue(msg.contains("exceeded") && msg.contains(String.valueOf(cap)),
+                    "expected size-cap message, got: " + msg);
+        }
+    }
+
+    private static String rootCauseMessage(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) cur = cur.getCause();
+        return cur.getMessage();
+    }
+
+    /**
+     * Minimal HTTP/1.0 server bound to loopback. Returns a single response then
+     * closes the socket. Sufficient for asserting that local URLs reach the
+     * stack and that response handling honours its bounds.
+     */
+    static final class TinyHttpServer implements AutoCloseable {
+        private final ServerSocket server;
+        private final ExecutorService exec;
+
+        private TinyHttpServer(ServerSocket server, ExecutorService exec) {
+            this.server = server;
+            this.exec = exec;
+        }
+
+        static TinyHttpServer start(String body) throws IOException {
+            return startBytes(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        static TinyHttpServer startBytes(byte[] body) throws IOException {
+            ServerSocket server = new ServerSocket(0, 0, java.net.InetAddress.getLoopbackAddress());
+            ExecutorService exec = Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "TinyHttpServer");
+                t.setDaemon(true);
+                return t;
+            });
+            exec.submit(() -> {
+                try (Socket s = server.accept()) {
+                    // Bound the test: a malformed client must not hang the suite.
+                    s.setSoTimeout(5_000);
+                    InputStream in = s.getInputStream();
+                    // Drain request line + headers, capped at 64 KiB so a runaway
+                    // client cannot push us into unbounded buffering.
+                    byte[] buf = new byte[4096];
+                    int totalRead = 0;
+                    final int requestCap = 64 * 1024;
+                    // Track the \r\n\r\n header terminator across read() boundaries
+                    // so a split delivery doesn't leave us waiting for the timeout.
+                    int read;
+                    int matched = 0;
+                    while (totalRead < requestCap && (read = in.read(buf)) > 0) {
+                        totalRead += read;
+                        for (int i = 0; i < read && matched < 4; i++) {
+                            byte b = buf[i];
+                            switch (matched) {
+                                case 0:
+                                    matched = b == '\r' ? 1 : 0;
+                                    break;
+                                case 1:
+                                    matched = b == '\n' ? 2 : (b == '\r' ? 1 : 0);
+                                    break;
+                                case 2:
+                                    matched = b == '\r' ? 3 : 0;
+                                    break;
+                                case 3:
+                                    matched = b == '\n' ? 4 : (b == '\r' ? 1 : 0);
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                        if (matched == 4) break;
+                    }
+                    String headers = "HTTP/1.0 200 OK\r\nContent-Length: " + body.length + "\r\nConnection: close\r\n\r\n";
+                    s.getOutputStream().write(headers.getBytes(StandardCharsets.US_ASCII));
+                    s.getOutputStream().write(body);
+                    s.getOutputStream().flush();
+                } catch (IOException ignore) {
+                }
+                return null;
+            });
+            return new TinyHttpServer(server, exec);
+        }
+
+        int port() {
+            return server.getLocalPort();
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                server.close();
+            } finally {
+                exec.shutdownNow();
+            }
+        }
+    }
+}

--- a/p2p/src/test/java/bisq/network/http/UrlSafetyCheckerTest.java
+++ b/p2p/src/test/java/bisq/network/http/UrlSafetyCheckerTest.java
@@ -1,0 +1,395 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.http;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UrlSafetyCheckerTest {
+
+    // -- parseAndValidate: rejects unsafe inputs ---------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "file:///etc/passwd",
+            "ftp://example.com/",
+            "gopher://example.com/",
+            "javascript:alert(1)",
+            "data:text/plain,hello",
+            "jar:http://x/!/",
+            "ssh://example.com",
+            "ws://example.com/",
+            "wss://example.com/",
+    })
+    void rejectsNonHttpSchemes(String url) {
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/relative/path",
+            "example.com",
+            "http://",
+            "https://",
+            "http:///path",
+            "://example.com",
+    })
+    void rejectsMalformedOrRelative(String url) {
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://user:pass@evil.com/",
+            "https://attacker@example.com/",
+    })
+    void rejectsUserinfo(String url) {
+        // userinfo can be used to confuse naïve "contains" host checks
+        // (e.g. http://localhost@evil.com/ would historically have been treated as local)
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+    })
+    void rejectsEmpty(String url) {
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @Test
+    void rejectsNull() {
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://example.com/",
+            "https://example.com/path?q=1",
+            "http://127.0.0.1:8080/",
+            "http://localhost:9999/api",
+            "https://expyuzz4wqqyqhjn.onion/",
+            "http://[::1]:1234/path",
+            "HTTP://Example.COM/",
+    })
+    void acceptsValidHttpUrls(String url) {
+        UrlSafetyChecker.parseAndValidate(url); // does not throw
+    }
+
+    // -- isLocal: only loopback / "localhost" pass -------------------------------
+
+    // Default (strict): only loopback / "localhost" --------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://localhost/",
+            "http://LOCALHOST:8080/",
+            "http://127.0.0.1/",
+            "http://127.0.0.1:9050/",
+            "http://127.1.2.3/",            // entire 127.0.0.0/8 is loopback
+            "http://[::1]/",
+            "http://[::1]:8080/api",
+            "http://ip6-localhost/",
+            "http://ip6-loopback/",
+    })
+    void defaultModeTreatsLoopbackAsLocal(String url) {
+        assertTrue(UrlSafetyChecker.isLocal(url), url);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // private/LAN: NOT local in default mode — must traverse Tor
+            "http://10.0.0.1/",
+            "http://172.16.0.1/",
+            "http://192.168.1.5:18081/",
+            "http://169.254.169.254/",
+            "http://[fe80::1]/",
+            "http://[fc00::1]/",
+            // bypass attempts and public addresses
+            "http://localhost.attacker.com/",     // suffix attack
+            "http://attacker.com/localhost",      // path contains "localhost"
+            "http://attacker.com/?h=localhost",   // query contains "localhost"
+            "http://example.com.localhost.io/",   // fake local TLD
+            "http://8.8.8.8/",                    // public IP
+            "https://api.example.com/",
+            "http://[2001:db8::1]/",              // public IPv6 (documentation prefix)
+            "http://localhosT.evil.com/",         // case + suffix
+    })
+    void defaultModeTreatsEverythingElseAsRemote(String url) {
+        assertFalse(UrlSafetyChecker.isLocal(url), url);
+    }
+
+    // allowPrivateRanges=true: LAN / link-local / unique-local count as local -------
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // loopback (still local)
+            "http://localhost/",
+            "http://127.0.0.1/",
+            "http://[::1]/",
+            // RFC1918 private IPv4
+            "http://10.0.0.1/",
+            "http://10.255.255.255/",
+            "http://172.16.0.1/",
+            "http://172.31.255.254/",
+            "http://192.168.0.1/",
+            "http://192.168.1.5:18081/",
+            // link-local IPv4
+            "http://169.254.0.1/",
+            "http://169.254.169.254/",
+            // IPv6 link-local + unique-local
+            "http://[fe80::1]/",
+            "http://[fc00::1]/",
+            "http://[fd00:abcd::1]/",
+    })
+    void privateModeTreatsLanAsLocal(String url) {
+        assertTrue(UrlSafetyChecker.isLocal(java.net.URI.create(url), true), url);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // even with allowPrivateRanges, public addresses must still go via Tor
+            "http://8.8.8.8/",
+            "http://1.1.1.1/",
+            "http://172.15.0.1/",                 // just outside 172.16/12
+            "http://172.32.0.1/",
+            "http://192.169.0.1/",
+            "http://9.255.255.255/",
+            "https://api.example.com/",
+            "http://[2001:db8::1]/",
+            "http://attacker.com/localhost",
+    })
+    void privateModeStillRejectsPublicAndSpoofs(String url) {
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create(url), true), url);
+    }
+
+    @Test
+    void onionAddressIsNotLocal() {
+        // Onion addresses must always traverse Tor — never short-circuit them
+        assertFalse(UrlSafetyChecker.isLocal("http://expyuzz4wqqyqhjn.onion/"));
+    }
+
+    // -- Edge cases & adversarial inputs (deny by default) -----------------------
+    //
+    // Threat model: an attacker controls (or partially controls) a configuration
+    // string that ends up as baseUrl — e.g. an XMR proof service list seeded over
+    // P2P, an explorer URL pulled from preferences, etc. Goals tested below:
+    //   1. Trick the parser into treating a remote host as local (deanonymise).
+    //   2. Use an alternate IP encoding that bypasses naive equality on
+    //      "127.0.0.1" / "192.168.x" but still routes to a LAN/loopback target.
+    //   3. Smuggle control characters to confuse logs / downstream consumers.
+    //   4. Parse-mismatch attacks — Java URI vs. server's URL parser disagreeing
+    //      about hostname.
+    // Each case asserts the safe outcome.
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // CR/LF/NUL/tab smuggling: java.net.URI rejects bare control chars in
+            // the host portion. Verify we do NOT silently accept them.
+            "http://evil.com\rlocalhost/",
+            "http://evil.com\nlocalhost/",
+            "http://localhost .evil.com/",
+            "http://local\thost/",
+            "http://localhost /",                    // trailing space
+            "http:// localhost/",                    // leading space
+            // Backslash variants — RFC 3986 disallows but some clients normalise.
+            // URI treats backslash as part of host → invalid.
+            "http:\\\\evil.com\\",
+    })
+    void rejectsControlCharsAndBackslash(String url) {
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://@evil.com/",          // empty userinfo
+            "http://%00@evil.com/",       // percent-encoded NUL in userinfo
+            "https://evil.com:80@trusted.com/",   // confusable: looks like host:port to some readers
+    })
+    void rejectsAnyUserinfoForm(String url) {
+        // Even an empty userinfo is suspicious — most legitimate URLs don't have one
+        // and accepting it makes it trivial to confuse a "contains(localhost)" reader.
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Forms that java.net.URI rejects outright at parse time — the
+            // hardest defence: these never even reach isLocal().
+            "http://0x7f.0x0.0x0.0x1/",          // hex octets
+            "http://127.1/",                      // BSD short-form (1-,2-,3-octet)
+            "http://127.0.1/",
+    })
+    void uriParserRejectsNonCanonicalIpv4(String url) {
+        // We rely on URI's strictness here. If a future Java release relaxes
+        // this, the tests below (rejectsNonCanonicalLocalLookalikes) take over.
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // IPv4 alternate encodings that DO parse as URIs but which our
+            // isNumericIp() refuses to treat as a numeric IP. They fall through
+            // to "not a numeric IP, not localhost" → REMOTE. That is the safe
+            // outcome: a non-canonical loopback literal in user config is more
+            // likely an attack than a legitimate setting.
+            "http://2130706433/",                 // 127.0.0.1 in 32-bit integer form
+            "http://0177.0.0.1/",                 // octal octet
+            "http://0/",                          // shorthand for 0.0.0.0
+            "http://0.0.0.0/",                    // unspecified addr — Linux maps to loopback
+            "http://255.255.255.255/",            // limited broadcast
+            "http://224.0.0.1/",                  // multicast
+            "http://[ff02::1]/",                  // IPv6 link-local multicast
+            "http://100.64.0.1/",                 // RFC6598 carrier-grade NAT
+    })
+    void rejectsNonCanonicalLocalLookalikes(String url) {
+        // Default mode is strict: only canonical loopback / "localhost" is local.
+        assertFalse(UrlSafetyChecker.isLocal(url), url);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://[::ffff:127.0.0.1]/",        // IPv4-mapped IPv6 (mixed notation)
+            "http://[::ffff:7f00:1]/",           // IPv4-mapped IPv6 (hex form)
+            "http://[::ffff:7f00:0001]/",        // IPv4-mapped IPv6 (hex zero-padded)
+            "http://[0:0:0:0:0:0:0:1]/",         // expanded ::1
+    })
+    void treatsIpv4MappedAndExpandedLoopbackAsLocal(String url) {
+        // These ARE recognised by isNumericIp (contain ':') and InetAddress
+        // reports them as loopback. They round-trip cleanly to ::1 / 127.0.0.1.
+        assertTrue(UrlSafetyChecker.isLocal(url), url);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://localhost./",                 // trailing dot (DNS root anchor)
+            "http://LocalHost/",
+            "http://LOCALHOST/",
+    })
+    void localhostTrailingDot(String url) {
+        // Trailing-dot is the DNS-root-anchored form; many resolvers treat it as
+        // identical to "localhost". We are stricter: only the bare literal
+        // "localhost" (case-insensitive) qualifies. A user wanting LAN bypass
+        // should configure 127.0.0.1.
+        if (url.contains(".")) {
+            assertFalse(UrlSafetyChecker.isLocal(url), url);
+        } else {
+            assertTrue(UrlSafetyChecker.isLocal(url), url);
+        }
+    }
+
+    @Test
+    void rejectsPunycode() {
+        // Punycode parses as a valid URI host but isn't "localhost", so it's remote.
+        assertFalse(UrlSafetyChecker.isLocal("http://xn--80ak6aa92e.com/"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://localhostε.example/",                    // greek epsilon suffix
+            "http://lоcalhost/",                             // cyrillic 'о' instead of 'o'
+    })
+    void uriRejectsRawUnicodeHosts(String url) {
+        // Java URI rejects raw unicode in the host (must be punycoded) — extra
+        // defence against homograph attacks at parse time.
+        assertThrows(UrlSafetyChecker.InvalidUrlException.class,
+                () -> UrlSafetyChecker.parseAndValidate(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://localhost:0/",                // port 0
+            "http://localhost:65535/api",         // max port
+            "http://localhost/#localhost",        // fragment
+            "http://localhost/?x=1&y=2",          // query
+            "http://localhost//../etc/passwd",    // path traversal noise — still local host
+            "http://localhost/very/deep/path/",
+    })
+    void localhostStaysLocalAcrossUrlComponents(String url) {
+        assertTrue(UrlSafetyChecker.isLocal(url), url);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://attacker.com/#localhost",     // fragment containing literal
+            "http://attacker.com/?h=127.0.0.1",   // query containing IP literal
+            "http://attacker.com/127.0.0.1",      // path containing IP literal
+            "http://attacker.com:80/localhost",   // port + path
+    })
+    void componentsOutsideHostNeverChangeLocality(String url) {
+        // The ONLY thing that determines locality is the host. Path/query/fragment
+        // contents must not influence it.
+        assertFalse(UrlSafetyChecker.isLocal(url), url);
+    }
+
+    @Test
+    void parseAndValidatePreservesHost() {
+        // Sanity: the parsed URI must expose the literal host so downstream code
+        // (cache keys, logs, allowlists) sees the same value the network stack uses.
+        java.net.URI uri = UrlSafetyChecker.parseAndValidate("http://Example.COM:8080/api");
+        // URI does not lower-case the host; we only lower-case for our local-check.
+        assertTrue(uri.getHost().equalsIgnoreCase("example.com"));
+        assertTrue(uri.getPort() == 8080);
+    }
+
+    @Test
+    void privateModeRejectsCgNatAndBroadcast() {
+        // RFC6598 carrier-grade NAT is *not* "your" LAN — it's the ISP's. Same
+        // for broadcast/multicast: connecting to them from a config string is
+        // never the right thing.
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://100.64.0.1/"), true));
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://255.255.255.255/"), true));
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://224.0.0.1/"), true));
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://[ff02::1]/"), true));
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://0.0.0.0/"), true));
+    }
+
+    @Test
+    void privateModeStillRejectsNonCanonicalLoopback() {
+        // Even when LAN is allowed, alternate IPv4 encodings remain rejected
+        // because they're a strong signal of an attacker hand-crafting a URL.
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://2130706433/"), true));
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://0177.0.0.1/"), true));
+        assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://127.1/"), true));
+    }
+
+    @Test
+    void hostnameNeverTriggersDnsLookup() {
+        // Implementation invariant: a non-numeric, non-"localhost" host MUST NOT
+        // be resolved. The only way to test this without intercepting DNS is by
+        // observing that names which would resolve to loopback in /etc/hosts are
+        // still treated as remote. We pick a name that no resolver would return.
+        // (This test will fail if anyone "improves" isLocal to do hostname
+        // resolution — that change would be a regression.)
+        assertFalse(UrlSafetyChecker.isLocal(
+                "http://this-host-must-never-be-resolved.invalid/"));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configuration option to allow HTTP requests to LAN addresses (off by default)

* **Security Improvements**
  * Stricter URL validation and fail-closed routing: non-local requests require proxying; local access restricted by default
  * Tighter networking: reduced allowed response sizes, hardened DNS handling, and shorter connection/read timeouts to limit leaks and resource exposure

* **Tests**
  * Added tests covering fail-closed network/security behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->