### PR TITLE
Fix listener removal from the wrong property

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSendsShareBuyerPaymentAccountMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSendsShareBuyerPaymentAccountMessage.java
@@ -133,7 +133,7 @@ public class BuyerSendsShareBuyerPaymentAccountMessage extends SendMailboxMessag
             timer.stop();
         }
         if (listener != null) {
-            processModel.getPaymentStartedMessageStateProperty().removeListener(listener);
+            processModel.getDepositTxMessageStateProperty().removeListener(listener);
         }
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerSendsDepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerSendsDepositTxAndDelayedPayoutTxMessage.java
@@ -149,7 +149,7 @@ public class SellerSendsDepositTxAndDelayedPayoutTxMessage extends SendMailboxMe
             timer.stop();
         }
         if (listener != null) {
-            processModel.getPaymentStartedMessageStateProperty().removeListener(listener);
+            processModel.getDepositTxMessageStateProperty().removeListener(listener);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed listener cleanup procedures in buyer and seller trade message handlers by ensuring listeners are properly unregistered from the correct message state properties where they were originally registered. Previously, listeners were being unregistered from incorrect properties. This fix prevents memory leaks and ensures accurate cleanup in payment and deposit transaction operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7720)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->