### PR TITLE
Add DPT receiver allow list

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -80,6 +80,7 @@ public class Config {
     public static final String WALLET_DIR = "walletDir";
     public static final String USE_DEV_PRIVILEGE_KEYS = "useDevPrivilegeKeys";
     public static final String DUMP_STATISTICS = "dumpStatistics";
+    public static final String DUMP_BURNING_MAN_DATA = "dumpBurningManData";
     public static final String IGNORE_DEV_MSG = "ignoreDevMsg";
     public static final String PROVIDERS = "providers";
     public static final String SEED_NODES = "seedNodes";
@@ -189,6 +190,7 @@ public class Config {
     public final boolean useDevModeHeader;
     public final boolean useDevPrivilegeKeys;
     public final boolean dumpStatistics;
+    public final boolean dumpBurningManData;
     public final boolean ignoreDevMsg;
     public final List<String> providers;
     public final List<String> seedNodes;
@@ -426,6 +428,13 @@ public class Config {
 
         ArgumentAcceptingOptionSpec<Boolean> dumpStatisticsOpt =
                 parser.accepts(DUMP_STATISTICS, "If set to true dump trade statistics to a json file in appDataDir")
+                        .withRequiredArg()
+                        .ofType(boolean.class)
+                        .defaultsTo(false);
+
+        ArgumentAcceptingOptionSpec<Boolean> dumpBurningManDataOpt =
+                parser.accepts(DUMP_BURNING_MAN_DATA,
+                                "If set to true dump active Burning Man receiver data to a json file in the data dir")
                         .withRequiredArg()
                         .ofType(boolean.class)
                         .defaultsTo(false);
@@ -848,6 +857,7 @@ public class Config {
             this.useDevModeHeader = options.valueOf(useDevModeHeaderOpt);
             this.useDevPrivilegeKeys = options.valueOf(useDevPrivilegeKeysOpt);
             this.dumpStatistics = options.valueOf(dumpStatisticsOpt);
+            this.dumpBurningManData = options.valueOf(dumpBurningManDataOpt);
             this.ignoreDevMsg = options.valueOf(ignoreDevMsgOpt);
             this.providers = options.valuesOf(providersOpt);
             this.seedNodes = options.valuesOf(seedNodesOpt);

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -81,7 +81,6 @@ public class Config {
     public static final String USE_DEV_PRIVILEGE_KEYS = "useDevPrivilegeKeys";
     public static final String DUMP_STATISTICS = "dumpStatistics";
     public static final String DUMP_BURNING_MAN_DATA = "dumpBurningManData";
-    public static final String DUMP_BURNING_MAN_DATA_VERSION = "dumpBurningManDataVersion";
     public static final String IGNORE_DEV_MSG = "ignoreDevMsg";
     public static final String PROVIDERS = "providers";
     public static final String SEED_NODES = "seedNodes";
@@ -192,7 +191,6 @@ public class Config {
     public final boolean useDevPrivilegeKeys;
     public final boolean dumpStatistics;
     public final boolean dumpBurningManData;
-    public final int dumpBurningManDataVersion;
     public final boolean ignoreDevMsg;
     public final List<String> providers;
     public final List<String> seedNodes;
@@ -440,14 +438,6 @@ public class Config {
                         .withRequiredArg()
                         .ofType(boolean.class)
                         .defaultsTo(false);
-
-        ArgumentAcceptingOptionSpec<Integer> dumpBurningManDataVersionOpt =
-                parser.accepts(DUMP_BURNING_MAN_DATA_VERSION,
-                                "Version tag used when dumping Burning Man receiver data. " +
-                                        "If unset, latest bundled version + 1 is used.")
-                        .withRequiredArg()
-                        .ofType(int.class)
-                        .defaultsTo(0);
 
         ArgumentAcceptingOptionSpec<Boolean> ignoreDevMsgOpt =
                 parser.accepts(IGNORE_DEV_MSG, "If set to true all signed " +
@@ -868,7 +858,6 @@ public class Config {
             this.useDevPrivilegeKeys = options.valueOf(useDevPrivilegeKeysOpt);
             this.dumpStatistics = options.valueOf(dumpStatisticsOpt);
             this.dumpBurningManData = options.valueOf(dumpBurningManDataOpt);
-            this.dumpBurningManDataVersion = options.valueOf(dumpBurningManDataVersionOpt);
             this.ignoreDevMsg = options.valueOf(ignoreDevMsgOpt);
             this.providers = options.valuesOf(providersOpt);
             this.seedNodes = options.valuesOf(seedNodesOpt);

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -81,6 +81,7 @@ public class Config {
     public static final String USE_DEV_PRIVILEGE_KEYS = "useDevPrivilegeKeys";
     public static final String DUMP_STATISTICS = "dumpStatistics";
     public static final String DUMP_BURNING_MAN_DATA = "dumpBurningManData";
+    public static final String DUMP_BURNING_MAN_DATA_VERSION = "dumpBurningManDataVersion";
     public static final String IGNORE_DEV_MSG = "ignoreDevMsg";
     public static final String PROVIDERS = "providers";
     public static final String SEED_NODES = "seedNodes";
@@ -191,6 +192,7 @@ public class Config {
     public final boolean useDevPrivilegeKeys;
     public final boolean dumpStatistics;
     public final boolean dumpBurningManData;
+    public final int dumpBurningManDataVersion;
     public final boolean ignoreDevMsg;
     public final List<String> providers;
     public final List<String> seedNodes;
@@ -434,10 +436,18 @@ public class Config {
 
         ArgumentAcceptingOptionSpec<Boolean> dumpBurningManDataOpt =
                 parser.accepts(DUMP_BURNING_MAN_DATA,
-                                "If set to true dump active Burning Man receiver data to a json file in the data dir")
+                                "If set to true dump active Burning Man receiver data to a json file in appDataDir")
                         .withRequiredArg()
                         .ofType(boolean.class)
                         .defaultsTo(false);
+
+        ArgumentAcceptingOptionSpec<Integer> dumpBurningManDataVersionOpt =
+                parser.accepts(DUMP_BURNING_MAN_DATA_VERSION,
+                                "Version tag used when dumping Burning Man receiver data. " +
+                                        "If unset, latest bundled version + 1 is used.")
+                        .withRequiredArg()
+                        .ofType(int.class)
+                        .defaultsTo(0);
 
         ArgumentAcceptingOptionSpec<Boolean> ignoreDevMsgOpt =
                 parser.accepts(IGNORE_DEV_MSG, "If set to true all signed " +
@@ -858,6 +868,7 @@ public class Config {
             this.useDevPrivilegeKeys = options.valueOf(useDevPrivilegeKeysOpt);
             this.dumpStatistics = options.valueOf(dumpStatisticsOpt);
             this.dumpBurningManData = options.valueOf(dumpBurningManDataOpt);
+            this.dumpBurningManDataVersion = options.valueOf(dumpBurningManDataVersionOpt);
             this.ignoreDevMsg = options.valueOf(ignoreDevMsgOpt);
             this.providers = options.valuesOf(providersOpt);
             this.seedNodes = options.valuesOf(seedNodesOpt);

--- a/core/src/main/java/bisq/core/app/CoreModule.java
+++ b/core/src/main/java/bisq/core/app/CoreModule.java
@@ -35,8 +35,8 @@ import bisq.core.util.coin.ImmutableCoinFormatter;
 
 import bisq.network.crypto.EncryptionServiceModule;
 import bisq.network.p2p.P2PModule;
-import bisq.network.p2p.network.BridgeAddressProvider;
 import bisq.network.p2p.network.BanFilter;
+import bisq.network.p2p.network.BridgeAddressProvider;
 import bisq.network.p2p.seed.SeedNodeRepository;
 
 import bisq.common.app.AppModule;
@@ -68,6 +68,7 @@ public class CoreModule extends AppModule {
         bind(SeedNodeRepository.class).to(DefaultSeedNodeRepository.class);
         bind(BanFilter.class).to(CoreBanFilter.class).in(Singleton.class);
 
+        bind(File.class).annotatedWith(named(APP_DATA_DIR)).toInstance(config.appDataDir);
         bind(File.class).annotatedWith(named(STORAGE_DIR)).toInstance(config.storageDir);
 
         CoinFormatter btcFormatter = new ImmutableCoinFormatter(config.networkParameters.getMonetaryFormat());

--- a/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ModuleForAppWithP2p.java
@@ -83,6 +83,7 @@ public class ModuleForAppWithP2p extends AppModule {
         CoinFormatter btcFormatter = new ImmutableCoinFormatter(config.networkParameters.getMonetaryFormat());
         bind(CoinFormatter.class).annotatedWith(named(FormattingUtils.BTC_FORMATTER_KEY)).toInstance(btcFormatter);
 
+        bind(File.class).annotatedWith(named(APP_DATA_DIR)).toInstance(config.appDataDir);
         bind(File.class).annotatedWith(named(STORAGE_DIR)).toInstance(config.storageDir);
         bind(File.class).annotatedWith(named(KEY_STORAGE_DIR)).toInstance(config.keyStorageDir);
 

--- a/core/src/main/java/bisq/core/dao/DaoModule.java
+++ b/core/src/main/java/bisq/core/dao/DaoModule.java
@@ -17,6 +17,7 @@
 
 package bisq.core.dao;
 
+import bisq.core.dao.burningman.BurningManDataExportService;
 import bisq.core.dao.governance.asset.AssetService;
 import bisq.core.dao.governance.ballot.BallotListPresentation;
 import bisq.core.dao.governance.ballot.BallotListService;
@@ -128,6 +129,7 @@ public class DaoModule extends AppModule {
         bind(UnconfirmedBsqChangeOutputListService.class).in(Singleton.class);
 
         bind(ExportJsonFilesService.class).in(Singleton.class);
+        bind(BurningManDataExportService.class).in(Singleton.class);
 
         // Period
         bind(CycleService.class).in(Singleton.class);
@@ -221,6 +223,7 @@ public class DaoModule extends AppModule {
         bindConstant().annotatedWith(named(Config.RPC_BLOCK_NOTIFICATION_PORT)).to(config.rpcBlockNotificationPort);
         bindConstant().annotatedWith(named(Config.RPC_BLOCK_NOTIFICATION_HOST)).to(config.rpcBlockNotificationHost);
         bindConstant().annotatedWith(named(Config.DUMP_BLOCKCHAIN_DATA)).to(config.dumpBlockchainData);
+        bindConstant().annotatedWith(named(Config.DUMP_BURNING_MAN_DATA)).to(config.dumpBurningManData);
         bindConstant().annotatedWith(named(Config.FULL_DAO_NODE)).to(config.fullDaoNode);
         bindConstant().annotatedWith(named(Config.IS_BM_FULL_NODE)).to(config.isBmFullNode);
         bindConstant().annotatedWith(named(Config.BM_ORACLE_NODE_PUB_KEY)).to(config.bmOracleNodePubKey);
@@ -228,4 +231,3 @@ public class DaoModule extends AppModule {
         bindConstant().annotatedWith(named(Config.USE_FULL_MODE_DAO_MONITOR)).to(config.useFullModeDaoMonitor);
     }
 }
-

--- a/core/src/main/java/bisq/core/dao/DaoModule.java
+++ b/core/src/main/java/bisq/core/dao/DaoModule.java
@@ -226,7 +226,6 @@ public class DaoModule extends AppModule {
         bindConstant().annotatedWith(named(Config.RPC_BLOCK_NOTIFICATION_HOST)).to(config.rpcBlockNotificationHost);
         bindConstant().annotatedWith(named(Config.DUMP_BLOCKCHAIN_DATA)).to(config.dumpBlockchainData);
         bindConstant().annotatedWith(named(Config.DUMP_BURNING_MAN_DATA)).to(config.dumpBurningManData);
-        bindConstant().annotatedWith(named(Config.DUMP_BURNING_MAN_DATA_VERSION)).to(config.dumpBurningManDataVersion);
         bindConstant().annotatedWith(named(Config.FULL_DAO_NODE)).to(config.fullDaoNode);
         bindConstant().annotatedWith(named(Config.IS_BM_FULL_NODE)).to(config.isBmFullNode);
         bindConstant().annotatedWith(named(Config.BM_ORACLE_NODE_PUB_KEY)).to(config.bmOracleNodePubKey);

--- a/core/src/main/java/bisq/core/dao/DaoModule.java
+++ b/core/src/main/java/bisq/core/dao/DaoModule.java
@@ -17,6 +17,7 @@
 
 package bisq.core.dao;
 
+import bisq.core.dao.burningman.BurningManAddressListService;
 import bisq.core.dao.burningman.BurningManDataExportService;
 import bisq.core.dao.governance.asset.AssetService;
 import bisq.core.dao.governance.ballot.BallotListPresentation;
@@ -129,6 +130,7 @@ public class DaoModule extends AppModule {
         bind(UnconfirmedBsqChangeOutputListService.class).in(Singleton.class);
 
         bind(ExportJsonFilesService.class).in(Singleton.class);
+        bind(BurningManAddressListService.class).in(Singleton.class);
         bind(BurningManDataExportService.class).in(Singleton.class);
 
         // Period
@@ -224,6 +226,7 @@ public class DaoModule extends AppModule {
         bindConstant().annotatedWith(named(Config.RPC_BLOCK_NOTIFICATION_HOST)).to(config.rpcBlockNotificationHost);
         bindConstant().annotatedWith(named(Config.DUMP_BLOCKCHAIN_DATA)).to(config.dumpBlockchainData);
         bindConstant().annotatedWith(named(Config.DUMP_BURNING_MAN_DATA)).to(config.dumpBurningManData);
+        bindConstant().annotatedWith(named(Config.DUMP_BURNING_MAN_DATA_VERSION)).to(config.dumpBurningManDataVersion);
         bindConstant().annotatedWith(named(Config.FULL_DAO_NODE)).to(config.fullDaoNode);
         bindConstant().annotatedWith(named(Config.IS_BM_FULL_NODE)).to(config.isBmFullNode);
         bindConstant().annotatedWith(named(Config.BM_ORACLE_NODE_PUB_KEY)).to(config.bmOracleNodePubKey);

--- a/core/src/main/java/bisq/core/dao/DaoSetup.java
+++ b/core/src/main/java/bisq/core/dao/DaoSetup.java
@@ -17,6 +17,7 @@
 
 package bisq.core.dao;
 
+import bisq.core.dao.burningman.BurningManDataExportService;
 import bisq.core.dao.burningman.accounting.BurningManAccountingService;
 import bisq.core.dao.burningman.accounting.node.AccountingNode;
 import bisq.core.dao.burningman.accounting.node.AccountingNodeProvider;
@@ -85,6 +86,7 @@ public class DaoSetup {
                     ProposalStateMonitoringService proposalStateMonitoringService,
                     BlindVoteStateMonitoringService blindVoteStateMonitoringService,
                     DaoStateSnapshotService daoStateSnapshotService,
+                    BurningManDataExportService burningManDataExportService,
                     BurningManAccountingService burningManAccountingService) {
 
         bsqNode = bsqNodeProvider.getBsqNode();
@@ -114,6 +116,7 @@ public class DaoSetup {
         daoSetupServices.add(proposalStateMonitoringService);
         daoSetupServices.add(blindVoteStateMonitoringService);
         daoSetupServices.add(daoStateSnapshotService);
+        daoSetupServices.add(burningManDataExportService);
         daoSetupServices.add(burningManAccountingService);
 
         daoSetupServices.add(bsqNode);

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManAddressList.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManAddressList.java
@@ -21,7 +21,9 @@ import bisq.common.config.Config;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -77,6 +79,14 @@ public final class BurningManAddressList {
         Set<String> allowedAddresses = getReceiverAddresses();
         allowedAddresses.add(legacyBurningManAddress);
         return allowedAddresses;
+    }
+
+    public Map<String, Double> getCappedBurnAmountShareByAddress() {
+        return entries.stream()
+                .collect(Collectors.toMap(Entry::getReceiverAddress,
+                        Entry::getCappedBurnAmountShare,
+                        (first, second) -> first,
+                        TreeMap::new));
     }
 
     @Getter

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManAddressList.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManAddressList.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.burningman;
+
+import bisq.common.config.Config;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public final class BurningManAddressList {
+    public static final int SCHEMA_VERSION = 1;
+
+    private int schemaVersion;
+    private int listVersion;
+    private String network;
+    private int chainHeight;
+    private int burningManSelectionHeight;
+    private String legacyBurningManAddress;
+    private List<Entry> entries;
+
+    @SuppressWarnings("unused")
+    private BurningManAddressList() {
+    }
+
+    public BurningManAddressList(int schemaVersion,
+                                 int listVersion,
+                                 String network,
+                                 int chainHeight,
+                                 int burningManSelectionHeight,
+                                 String legacyBurningManAddress,
+                                 List<Entry> entries) {
+        this.schemaVersion = schemaVersion;
+        this.listVersion = listVersion;
+        this.network = network;
+        this.chainHeight = chainHeight;
+        this.burningManSelectionHeight = burningManSelectionHeight;
+        this.legacyBurningManAddress = legacyBurningManAddress;
+        this.entries = entries.stream()
+                .sorted(Comparator.comparing(Entry::getReceiverAddress))
+                .collect(Collectors.toList());
+    }
+
+    public boolean isForCurrentNetwork() {
+        return Config.baseCurrencyNetwork().name().equals(network);
+    }
+
+    public Set<String> getReceiverAddresses() {
+        return entries.stream()
+                .map(Entry::getReceiverAddress)
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    public Set<String> getAllowedAddresses() {
+        Set<String> allowedAddresses = getReceiverAddresses();
+        allowedAddresses.add(legacyBurningManAddress);
+        return allowedAddresses;
+    }
+
+    @Getter
+    @EqualsAndHashCode
+    public static final class Entry {
+        private String receiverAddress;
+        private double cappedBurnAmountShare;
+
+        @SuppressWarnings("unused")
+        private Entry() {
+        }
+
+        public Entry(String receiverAddress, double cappedBurnAmountShare) {
+            this.receiverAddress = receiverAddress;
+            this.cappedBurnAmountShare = cappedBurnAmountShare;
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManAddressListService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManAddressListService.java
@@ -266,8 +266,10 @@ public class BurningManAddressListService {
                 "receiverAddress values must be unique in %s", fileName);
         checkArgument(new ArrayList<>(new TreeSet<>(receiverAddresses)).equals(receiverAddresses),
                 "entries must be sorted by receiverAddress in %s", fileName);
-        checkArgument(addressList.getEntries().stream().allMatch(entry -> entry.getCappedBurnAmountShare() >= 0),
-                "cappedBurnAmountShare must not be negative in %s", fileName);
+        checkArgument(addressList.getEntries().stream()
+                        .allMatch(entry -> Double.isFinite(entry.getCappedBurnAmountShare()) &&
+                                entry.getCappedBurnAmountShare() >= 0),
+                "cappedBurnAmountShare must be finite and not negative in %s", fileName);
     }
 
     private static boolean isBlank(String value) {

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManAddressListService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManAddressListService.java
@@ -1,0 +1,276 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.burningman;
+
+import bisq.common.config.Config;
+
+import com.google.gson.Gson;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import java.net.JarURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Slf4j
+@Singleton
+public class BurningManAddressListService {
+    public static final String RESOURCE_DIR = "burningman";
+    public static final String FILE_NAME_PREFIX = "bm-addresses-v";
+    public static final String FILE_NAME_SUFFIX = ".json";
+
+    private static final Pattern FILE_NAME_PATTERN = Pattern.compile(FILE_NAME_PREFIX + "(\\d{4,})\\" + FILE_NAME_SUFFIX);
+    private static final Gson GSON = new Gson();
+
+    @Getter
+    private final NavigableMap<Integer, BurningManAddressList> addressListsByVersion;
+
+    @Inject
+    public BurningManAddressListService() {
+        NavigableMap<Integer, BurningManAddressList> loadedAddressListsByVersion = loadAddressLists();
+        String currentNetwork = Config.baseCurrencyNetwork().name();
+        NavigableMap<Integer, BurningManAddressList> currentNetworkAddressListsByVersion = loadedAddressListsByVersion.entrySet().stream()
+                .filter(entry -> currentNetwork.equals(entry.getValue().getNetwork()))
+                .collect(Collectors.toMap(Entry::getKey,
+                        Entry::getValue,
+                        (first, second) -> first,
+                        TreeMap::new));
+
+        if (!currentNetworkAddressListsByVersion.isEmpty()) {
+            addressListsByVersion = Collections.unmodifiableNavigableMap(currentNetworkAddressListsByVersion);
+        } else {
+            checkArgument(!Config.baseCurrencyNetwork().isMainnet(),
+                    "No Burning Man address list resources found for network " + currentNetwork);
+            log.warn("No Burning Man address list resources found for network {}. " +
+                    "Using bundled versions without applying address filtering.", currentNetwork);
+            addressListsByVersion = Collections.unmodifiableNavigableMap(loadedAddressListsByVersion);
+        }
+
+        log.info("Loaded Burning Man address list versions {}", addressListsByVersion.keySet());
+    }
+
+    public List<Integer> getSupportedVersions() {
+        return new ArrayList<>(addressListsByVersion.keySet());
+    }
+
+    public int getLatestVersion() {
+        checkArgument(!addressListsByVersion.isEmpty(), "No Burning Man address list versions are available");
+        return addressListsByVersion.lastKey();
+    }
+
+    public int getNextVersion() {
+        return getLatestVersion() + 1;
+    }
+
+    public BurningManAddressList getAddressList(int version) {
+        BurningManAddressList addressList = addressListsByVersion.get(version);
+        checkArgument(addressList != null, "Burning Man address list version %s is not supported", version);
+        return addressList;
+    }
+
+    public int selectHighestCommonVersion(Collection<Integer> peerVersions) {
+        List<Integer> checkedPeerVersions = getValidatedSupportedVersions(peerVersions);
+        Set<Integer> supportedVersions = new TreeSet<>(addressListsByVersion.keySet());
+        return checkedPeerVersions.stream()
+                .filter(supportedVersions::contains)
+                .max(Integer::compareTo)
+                .orElseThrow(() -> new IllegalArgumentException("No common Burning Man address list version. " +
+                        "localVersions=" + supportedVersions + ", peerVersions=" + checkedPeerVersions));
+    }
+
+    public static List<Integer> getValidatedSupportedVersions(Collection<Integer> versions) {
+        checkNotNull(versions, "Burning Man address list versions must not be null");
+        checkArgument(!versions.isEmpty(), "Burning Man address list versions must not be empty");
+
+        List<Integer> sortedDistinctVersions = new ArrayList<>(new TreeSet<>(versions));
+        checkArgument(sortedDistinctVersions.size() == versions.size(),
+                "Burning Man address list versions must not contain duplicates");
+        checkArgument(sortedDistinctVersions.stream().allMatch(version -> version > 0),
+                "Burning Man address list versions must be positive");
+        checkArgument(sortedDistinctVersions.equals(new ArrayList<>(versions)),
+                "Burning Man address list versions must be sorted");
+        return sortedDistinctVersions;
+    }
+
+    private NavigableMap<Integer, BurningManAddressList> loadAddressLists() {
+        TreeMap<Integer, BurningManAddressList> result = new TreeMap<>();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = BurningManAddressListService.class.getClassLoader();
+        }
+
+        try {
+            Enumeration<URL> resourceDirs = classLoader.getResources(RESOURCE_DIR);
+            while (resourceDirs.hasMoreElements()) {
+                URL resourceDir = resourceDirs.nextElement();
+                loadAddressListsFromResourceDir(resourceDir, result);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not load Burning Man address list resources", e);
+        }
+
+        checkArgument(!result.isEmpty(), "No Burning Man address list resources found");
+        return result;
+    }
+
+    private void loadAddressListsFromResourceDir(URL resourceDir,
+                                                 TreeMap<Integer, BurningManAddressList> result) {
+        try {
+            if ("file".equals(resourceDir.getProtocol())) {
+                loadAddressListsFromFileSystem(Paths.get(resourceDir.toURI()), result);
+            } else if ("jar".equals(resourceDir.getProtocol())) {
+                loadAddressListsFromJar(resourceDir, result);
+            } else {
+                log.warn("Unsupported Burning Man address list resource protocol {} at {}",
+                        resourceDir.getProtocol(), resourceDir);
+            }
+        } catch (IOException | URISyntaxException e) {
+            throw new IllegalStateException("Could not load Burning Man address list resources from " + resourceDir, e);
+        }
+    }
+
+    private void loadAddressListsFromFileSystem(Path resourceDir,
+                                                TreeMap<Integer, BurningManAddressList> result) throws IOException {
+        try (Stream<Path> paths = Files.list(resourceDir)) {
+            paths.filter(Files::isRegularFile)
+                    .forEach(path -> loadAddressList(path, result));
+        }
+    }
+
+    private void loadAddressList(Path path,
+                                 TreeMap<Integer, BurningManAddressList> result) {
+        String fileName = path.getFileName().toString();
+        if (!FILE_NAME_PATTERN.matcher(fileName).matches()) {
+            return;
+        }
+
+        try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            loadAddressList(fileName, reader, result);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not load Burning Man address list resource " + path, e);
+        }
+    }
+
+    private void loadAddressListsFromJar(URL resourceDir,
+                                         TreeMap<Integer, BurningManAddressList> result) throws IOException {
+        JarURLConnection connection = (JarURLConnection) resourceDir.openConnection();
+        connection.setUseCaches(false);
+        String resourceEntryName = connection.getEntryName();
+        try (JarFile jarFile = connection.getJarFile()) {
+            Enumeration<JarEntry> jarEntries = jarFile.entries();
+            while (jarEntries.hasMoreElements()) {
+                JarEntry jarEntry = jarEntries.nextElement();
+                String entryName = jarEntry.getName();
+                if (jarEntry.isDirectory() ||
+                        !entryName.startsWith(resourceEntryName + "/") ||
+                        entryName.indexOf('/', resourceEntryName.length() + 1) >= 0) {
+                    continue;
+                }
+
+                String fileName = entryName.substring(entryName.lastIndexOf('/') + 1);
+                if (!FILE_NAME_PATTERN.matcher(fileName).matches()) {
+                    continue;
+                }
+
+                try (Reader reader = new InputStreamReader(jarFile.getInputStream(jarEntry), StandardCharsets.UTF_8)) {
+                    loadAddressList(fileName, reader, result);
+                }
+            }
+        }
+    }
+
+    private void loadAddressList(String fileName,
+                                 Reader reader,
+                                 TreeMap<Integer, BurningManAddressList> result) {
+        Matcher matcher = FILE_NAME_PATTERN.matcher(fileName);
+        checkArgument(matcher.matches(), "Invalid Burning Man address list file name " + fileName);
+        int versionFromFileName = Integer.parseInt(matcher.group(1));
+        BurningManAddressList addressList = GSON.fromJson(reader, BurningManAddressList.class);
+        validateAddressList(fileName, versionFromFileName, addressList);
+        BurningManAddressList previous = result.put(addressList.getListVersion(), addressList);
+        checkArgument(previous == null,
+                "Duplicate Burning Man address list version %s in %s", addressList.getListVersion(), fileName);
+    }
+
+    private void validateAddressList(String fileName,
+                                     int versionFromFileName,
+                                     BurningManAddressList addressList) {
+        checkNotNull(addressList, "Burning Man address list must not be null");
+        checkArgument(addressList.getSchemaVersion() == BurningManAddressList.SCHEMA_VERSION,
+                "Invalid schemaVersion in %s", fileName);
+        checkArgument(addressList.getListVersion() == versionFromFileName,
+                "listVersion in %s must match file name version", fileName);
+        checkArgument(!isBlank(addressList.getNetwork()), "network must not be blank in %s", fileName);
+        checkArgument(addressList.getChainHeight() > 0, "chainHeight must be positive in %s", fileName);
+        checkArgument(addressList.getBurningManSelectionHeight() > 0,
+                "burningManSelectionHeight must be positive in %s", fileName);
+        checkArgument(!isBlank(addressList.getLegacyBurningManAddress()),
+                "legacyBurningManAddress must not be blank in %s", fileName);
+        checkArgument(addressList.getEntries() != null && !addressList.getEntries().isEmpty(),
+                "entries must not be empty in %s", fileName);
+
+        List<String> receiverAddresses = addressList.getEntries().stream()
+                .map(BurningManAddressList.Entry::getReceiverAddress)
+                .collect(Collectors.toList());
+        checkArgument(receiverAddresses.stream().noneMatch(BurningManAddressListService::isBlank),
+                "receiverAddress must not be blank in %s", fileName);
+        checkArgument(new TreeSet<>(receiverAddresses).size() == receiverAddresses.size(),
+                "receiverAddress values must be unique in %s", fileName);
+        checkArgument(new ArrayList<>(new TreeSet<>(receiverAddresses)).equals(receiverAddresses),
+                "entries must be sorted by receiverAddress in %s", fileName);
+        checkArgument(addressList.getEntries().stream().allMatch(entry -> entry.getCappedBurnAmountShare() >= 0),
+                "cappedBurnAmountShare must not be negative in %s", fileName);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
@@ -42,23 +42,28 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Singleton
 public class BurningManDataExportService implements DaoSetupService, DaoStateListener {
-    private static final String FILE_NAME = "burning_man_data";
-    private static final int SCHEMA_VERSION = 1;
+    private static final String FILE_NAME_FORMAT = BurningManAddressListService.FILE_NAME_PREFIX + "%04d";
 
     private final DaoStateService daoStateService;
     private final BurningManService burningManService;
+    private final BurningManAddressListService burningManAddressListService;
     private final boolean dumpBurningManData;
+    private final int dumpBurningManDataVersion;
     private final JsonFileManager jsonFileManager;
 
     @Inject
     public BurningManDataExportService(DaoStateService daoStateService,
                                        BurningManService burningManService,
-                                       @Named(Config.STORAGE_DIR) File storageDir,
-                                       @Named(Config.DUMP_BURNING_MAN_DATA) boolean dumpBurningManData) {
+                                       BurningManAddressListService burningManAddressListService,
+                                       @Named(Config.APP_DATA_DIR) File appDataDir,
+                                       @Named(Config.DUMP_BURNING_MAN_DATA) boolean dumpBurningManData,
+                                       @Named(Config.DUMP_BURNING_MAN_DATA_VERSION) int dumpBurningManDataVersion) {
         this.daoStateService = daoStateService;
         this.burningManService = burningManService;
+        this.burningManAddressListService = burningManAddressListService;
         this.dumpBurningManData = dumpBurningManData;
-        jsonFileManager = new JsonFileManager(storageDir);
+        this.dumpBurningManDataVersion = dumpBurningManDataVersion;
+        jsonFileManager = new JsonFileManager(appDataDir);
     }
 
     @Override
@@ -89,19 +94,24 @@ public class BurningManDataExportService implements DaoSetupService, DaoStateLis
                 chainHeight,
                 DelayedPayoutTxReceiverService.SNAPSHOT_SELECTION_GRID_SIZE,
                 DelayedPayoutTxReceiverService.MIN_SNAPSHOT_HEIGHT);
-        List<BurningManDataEntry> entries = getEntries(burningManSelectionHeight);
-        BurningManData burningManData = new BurningManData(SCHEMA_VERSION,
+        int listVersion = dumpBurningManDataVersion > 0 ?
+                dumpBurningManDataVersion :
+                burningManAddressListService.getNextVersion();
+        List<BurningManAddressList.Entry> entries = getEntries(burningManSelectionHeight);
+        BurningManAddressList burningManAddressList = new BurningManAddressList(BurningManAddressList.SCHEMA_VERSION,
+                listVersion,
                 Config.baseCurrencyNetwork().name(),
                 chainHeight,
                 burningManSelectionHeight,
                 burningManService.getLegacyBurningManAddress(burningManSelectionHeight),
                 entries);
 
-        jsonFileManager.writeToDisc(JsonUtil.objectToJson(burningManData), FILE_NAME);
-        log.info("Exported {} Burning Man receiver entries to {}.json", entries.size(), FILE_NAME);
+        String fileName = String.format(FILE_NAME_FORMAT, listVersion);
+        jsonFileManager.writeToDisc(JsonUtil.objectToJson(burningManAddressList), fileName);
+        log.info("Exported {} Burning Man receiver entries to {}.json", entries.size(), fileName);
     }
 
-    private List<BurningManDataEntry> getEntries(int chainHeight) {
+    private List<BurningManAddressList.Entry> getEntries(int chainHeight) {
         Map<String, Double> shareByAddress = new TreeMap<>();
         burningManService.getActiveBurningManCandidates(chainHeight).stream()
                 .filter(candidate -> candidate.getReceiverAddress().isPresent())
@@ -111,40 +121,7 @@ public class BurningManDataExportService implements DaoSetupService, DaoStateLis
                 });
 
         return shareByAddress.entrySet().stream()
-                .map(entry -> new BurningManDataEntry(entry.getKey(), entry.getValue()))
+                .map(entry -> new BurningManAddressList.Entry(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
-    }
-
-    private static class BurningManData {
-        private final int schemaVersion;
-        private final String baseCurrencyNetwork;
-        private final int chainHeight;
-        private final int burningManSelectionHeight;
-        private final String legacyBurningManAddress;
-        private final List<BurningManDataEntry> entries;
-
-        private BurningManData(int schemaVersion,
-                               String baseCurrencyNetwork,
-                               int chainHeight,
-                               int burningManSelectionHeight,
-                               String legacyBurningManAddress,
-                               List<BurningManDataEntry> entries) {
-            this.schemaVersion = schemaVersion;
-            this.baseCurrencyNetwork = baseCurrencyNetwork;
-            this.chainHeight = chainHeight;
-            this.burningManSelectionHeight = burningManSelectionHeight;
-            this.legacyBurningManAddress = legacyBurningManAddress;
-            this.entries = entries;
-        }
-    }
-
-    private static class BurningManDataEntry {
-        private final String receiverAddress;
-        private final double cappedBurnAmountShare;
-
-        private BurningManDataEntry(String receiverAddress, double cappedBurnAmountShare) {
-            this.receiverAddress = receiverAddress;
-            this.cappedBurnAmountShare = cappedBurnAmountShare;
-        }
     }
 }

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
@@ -48,7 +48,6 @@ public class BurningManDataExportService implements DaoSetupService, DaoStateLis
     private final BurningManService burningManService;
     private final BurningManAddressListService burningManAddressListService;
     private final boolean dumpBurningManData;
-    private final int dumpBurningManDataVersion;
     private final JsonFileManager jsonFileManager;
 
     @Inject
@@ -56,13 +55,11 @@ public class BurningManDataExportService implements DaoSetupService, DaoStateLis
                                        BurningManService burningManService,
                                        BurningManAddressListService burningManAddressListService,
                                        @Named(Config.APP_DATA_DIR) File appDataDir,
-                                       @Named(Config.DUMP_BURNING_MAN_DATA) boolean dumpBurningManData,
-                                       @Named(Config.DUMP_BURNING_MAN_DATA_VERSION) int dumpBurningManDataVersion) {
+                                       @Named(Config.DUMP_BURNING_MAN_DATA) boolean dumpBurningManData) {
         this.daoStateService = daoStateService;
         this.burningManService = burningManService;
         this.burningManAddressListService = burningManAddressListService;
         this.dumpBurningManData = dumpBurningManData;
-        this.dumpBurningManDataVersion = dumpBurningManDataVersion;
         jsonFileManager = new JsonFileManager(appDataDir);
     }
 
@@ -94,9 +91,7 @@ public class BurningManDataExportService implements DaoSetupService, DaoStateLis
                 chainHeight,
                 DelayedPayoutTxReceiverService.SNAPSHOT_SELECTION_GRID_SIZE,
                 DelayedPayoutTxReceiverService.MIN_SNAPSHOT_HEIGHT);
-        int listVersion = dumpBurningManDataVersion > 0 ?
-                dumpBurningManDataVersion :
-                burningManAddressListService.getNextVersion();
+        int listVersion = burningManAddressListService.getNextVersion();
         List<BurningManAddressList.Entry> entries = getEntries(burningManSelectionHeight);
         BurningManAddressList burningManAddressList = new BurningManAddressList(BurningManAddressList.SCHEMA_VERSION,
                 listVersion,

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
@@ -111,9 +111,9 @@ public class BurningManDataExportService implements DaoSetupService, DaoStateLis
         log.info("Exported {} Burning Man receiver entries to {}.json", entries.size(), fileName);
     }
 
-    private List<BurningManAddressList.Entry> getEntries(int chainHeight) {
+    private List<BurningManAddressList.Entry> getEntries(int burningManSelectionHeight) {
         Map<String, Double> shareByAddress = new TreeMap<>();
-        burningManService.getActiveBurningManCandidates(chainHeight).stream()
+        burningManService.getActiveBurningManCandidates(burningManSelectionHeight).stream()
                 .filter(candidate -> candidate.getReceiverAddress().isPresent())
                 .forEach(candidate -> {
                     String address = candidate.getReceiverAddress().get();

--- a/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManDataExportService.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.burningman;
+
+import bisq.core.dao.DaoSetupService;
+import bisq.core.dao.state.DaoStateListener;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.util.JsonUtil;
+
+import bisq.common.config.Config;
+import bisq.common.file.JsonFileManager;
+
+import com.google.inject.Inject;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.File;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Singleton
+public class BurningManDataExportService implements DaoSetupService, DaoStateListener {
+    private static final String FILE_NAME = "burning_man_data";
+    private static final int SCHEMA_VERSION = 1;
+
+    private final DaoStateService daoStateService;
+    private final BurningManService burningManService;
+    private final boolean dumpBurningManData;
+    private final JsonFileManager jsonFileManager;
+
+    @Inject
+    public BurningManDataExportService(DaoStateService daoStateService,
+                                       BurningManService burningManService,
+                                       @Named(Config.STORAGE_DIR) File storageDir,
+                                       @Named(Config.DUMP_BURNING_MAN_DATA) boolean dumpBurningManData) {
+        this.daoStateService = daoStateService;
+        this.burningManService = burningManService;
+        this.dumpBurningManData = dumpBurningManData;
+        jsonFileManager = new JsonFileManager(storageDir);
+    }
+
+    @Override
+    public void addListeners() {
+        if (dumpBurningManData) {
+            daoStateService.addDaoStateListener(this);
+        }
+    }
+
+    @Override
+    public void start() {
+        maybeExport();
+    }
+
+    @Override
+    public void onParseBlockChainComplete() {
+        maybeExport();
+    }
+
+    private void maybeExport() {
+        if (!dumpBurningManData || !daoStateService.isParseBlockChainComplete()) {
+            return;
+        }
+
+        int chainHeight = daoStateService.getChainHeight();
+        int burningManSelectionHeight = DelayedPayoutTxReceiverService.getSnapshotHeight(
+                daoStateService.getGenesisBlockHeight(),
+                chainHeight,
+                DelayedPayoutTxReceiverService.SNAPSHOT_SELECTION_GRID_SIZE,
+                DelayedPayoutTxReceiverService.MIN_SNAPSHOT_HEIGHT);
+        List<BurningManDataEntry> entries = getEntries(burningManSelectionHeight);
+        BurningManData burningManData = new BurningManData(SCHEMA_VERSION,
+                Config.baseCurrencyNetwork().name(),
+                chainHeight,
+                burningManSelectionHeight,
+                burningManService.getLegacyBurningManAddress(burningManSelectionHeight),
+                entries);
+
+        jsonFileManager.writeToDisc(JsonUtil.objectToJson(burningManData), FILE_NAME);
+        log.info("Exported {} Burning Man receiver entries to {}.json", entries.size(), FILE_NAME);
+    }
+
+    private List<BurningManDataEntry> getEntries(int chainHeight) {
+        Map<String, Double> shareByAddress = new TreeMap<>();
+        burningManService.getActiveBurningManCandidates(chainHeight).stream()
+                .filter(candidate -> candidate.getReceiverAddress().isPresent())
+                .forEach(candidate -> {
+                    String address = candidate.getReceiverAddress().get();
+                    shareByAddress.merge(address, candidate.getCappedBurnAmountShare(), Double::sum);
+                });
+
+        return shareByAddress.entrySet().stream()
+                .map(entry -> new BurningManDataEntry(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private static class BurningManData {
+        private final int schemaVersion;
+        private final String baseCurrencyNetwork;
+        private final int chainHeight;
+        private final int burningManSelectionHeight;
+        private final String legacyBurningManAddress;
+        private final List<BurningManDataEntry> entries;
+
+        private BurningManData(int schemaVersion,
+                               String baseCurrencyNetwork,
+                               int chainHeight,
+                               int burningManSelectionHeight,
+                               String legacyBurningManAddress,
+                               List<BurningManDataEntry> entries) {
+            this.schemaVersion = schemaVersion;
+            this.baseCurrencyNetwork = baseCurrencyNetwork;
+            this.chainHeight = chainHeight;
+            this.burningManSelectionHeight = burningManSelectionHeight;
+            this.legacyBurningManAddress = legacyBurningManAddress;
+            this.entries = entries;
+        }
+    }
+
+    private static class BurningManDataEntry {
+        private final String receiverAddress;
+        private final double cappedBurnAmountShare;
+
+        private BurningManDataEntry(String receiverAddress, double cappedBurnAmountShare) {
+            this.receiverAddress = receiverAddress;
+            this.cappedBurnAmountShare = cappedBurnAmountShare;
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -34,6 +34,8 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -73,12 +75,16 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
 
     private final DaoStateService daoStateService;
     private final BurningManService burningManService;
+    private final BurningManAddressListService burningManAddressListService;
     private int currentChainHeight;
 
     @Inject
-    public DelayedPayoutTxReceiverService(DaoStateService daoStateService, BurningManService burningManService) {
+    public DelayedPayoutTxReceiverService(DaoStateService daoStateService,
+                                          BurningManService burningManService,
+                                          BurningManAddressListService burningManAddressListService) {
         this.daoStateService = daoStateService;
         this.burningManService = burningManService;
+        this.burningManAddressListService = burningManAddressListService;
 
         daoStateService.addDaoStateListener(this);
         daoStateService.getLastBlock().ifPresent(this::applyBlock);
@@ -116,12 +122,18 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
                 SNAPSHOT_SELECTION_GRID_SIZE);
     }
 
-
     public List<Tuple2<Long, String>> getReceivers(int burningManSelectionHeight,
                                                    long inputAmount,
-                                                   long tradeTxFee) {
+                                                   long tradeTxFee,
+                                                   int burningManAddressListVersion) {
         checkArgument(burningManSelectionHeight >= MIN_SNAPSHOT_HEIGHT, "Selection height must be >= " + MIN_SNAPSHOT_HEIGHT);
-        Collection<BurningManCandidate> burningManCandidates = burningManService.getActiveBurningManCandidates(burningManSelectionHeight);
+        Collection<BurningManCandidate> allBurningManCandidates = burningManService.getActiveBurningManCandidates(burningManSelectionHeight);
+
+        Optional<BurningManAddressList> optionalAddressList = getEnforceableAddressList(burningManAddressListVersion);
+        List<BurningManCandidate> burningManCandidates = filterCandidates(allBurningManCandidates, optionalAddressList);
+        String legacyBurningManAddress = optionalAddressList
+                .map(BurningManAddressList::getLegacyBurningManAddress)
+                .orElseGet(() -> burningManService.getLegacyBurningManAddress(burningManSelectionHeight));
 
         // We need to use the same txFeePerVbyte value for both traders.
         // We use the tradeTxFee value which is calculated from the average of taker fee tx size and deposit tx size.
@@ -140,7 +152,7 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
         if (burningManCandidates.isEmpty()) {
             // If there are no compensation requests (e.g. at dev testing) we fall back to the legacy BM
             long spendableAmount = getSpendableAmount(1, inputAmount, txFeePerVbyte);
-            return List.of(new Tuple2<>(spendableAmount, burningManService.getLegacyBurningManAddress(burningManSelectionHeight)));
+            return List.of(new Tuple2<>(spendableAmount, legacyBurningManAddress));
         }
 
         long spendableAmount = getSpendableAmount(burningManCandidates.size(), inputAmount, txFeePerVbyte);
@@ -181,10 +193,77 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
             // If the available is larger than DPT_MIN_REMAINDER_TO_LEGACY_BM we send it to legacy BM
             // Otherwise we use it as miner fee
             if (available > DPT_MIN_REMAINDER_TO_LEGACY_BM) {
-                receivers.add(new Tuple2<>(available, burningManService.getLegacyBurningManAddress(burningManSelectionHeight)));
+                receivers.add(new Tuple2<>(available, legacyBurningManAddress));
             }
         }
         return receivers;
+    }
+
+    public List<Integer> getSupportedBurningManAddressListVersions() {
+        return burningManAddressListService.getSupportedVersions();
+    }
+
+    public int selectBurningManAddressListVersion(Collection<Integer> peerVersions) {
+        return burningManAddressListService.selectHighestCommonVersion(peerVersions);
+    }
+
+    public void validateDelayedPayoutTxReceivers(List<Tuple2<Long, String>> receivers,
+                                                 int burningManAddressListVersion) {
+        if (burningManAddressListVersion <= 0) {
+            return;
+        }
+
+        Optional<BurningManAddressList> optionalAddressList = getEnforceableAddressList(burningManAddressListVersion);
+        if (optionalAddressList.isEmpty()) {
+            return;
+        }
+
+        BurningManAddressList addressList = optionalAddressList.get();
+        Set<String> allowedAddresses = addressList.getAllowedAddresses();
+        receivers.forEach(receiver -> checkArgument(allowedAddresses.contains(receiver.second),
+                "Delayed payout tx receiver %s is not part of Burning Man address list version %s",
+                receiver.second,
+                burningManAddressListVersion));
+    }
+
+    private Optional<BurningManAddressList> getEnforceableAddressList(int burningManAddressListVersion) {
+        if (burningManAddressListVersion <= 0) {
+            return Optional.empty();
+        }
+
+        BurningManAddressList addressList = burningManAddressListService.getAddressList(burningManAddressListVersion);
+        if (!addressList.isForCurrentNetwork()) {
+            log.warn("Burning Man address list version {} is for network {}, but current network is {}. " +
+                            "Skipping Burning Man address list filtering.",
+                    burningManAddressListVersion,
+                    addressList.getNetwork(),
+                    Config.baseCurrencyNetwork().name());
+            return Optional.empty();
+        }
+        return Optional.of(addressList);
+    }
+
+    private List<BurningManCandidate> filterCandidates(Collection<BurningManCandidate> candidates,
+                                                       Optional<BurningManAddressList> optionalAddressList) {
+        if (optionalAddressList.isEmpty()) {
+            return candidates.stream().collect(Collectors.toList());
+        }
+
+        BurningManAddressList addressList = optionalAddressList.get();
+        Set<String> allowedAddresses = addressList.getAllowedAddresses();
+        return candidates.stream()
+                .filter(candidate -> candidate.getReceiverAddress().isPresent())
+                .filter(candidate -> {
+                    String receiverAddress = candidate.getReceiverAddress().get();
+                    boolean allowed = allowedAddresses.contains(receiverAddress);
+                    if (!allowed) {
+                        log.warn("Skipping Burning Man receiver {} because it is not in address list version {}",
+                                receiverAddress,
+                                addressList.getListVersion());
+                    }
+                    return allowed;
+                })
+                .collect(Collectors.toList());
     }
 
     private static long getSpendableAmount(int numOutputs, long inputAmount, long txFeePerVbyte) {

--- a/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverService.java
@@ -34,6 +34,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -72,6 +73,8 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
     // We prefer a rather high fee rate to not risk that the DPT gets stuck if required fee rate would
     // spike when opening arbitration.
     private static final long DPT_MIN_TX_FEE_RATE = 10;
+    @VisibleForTesting
+    static final double BM_ADDRESS_LIST_SHARE_RANGE_TOLERANCE = 0.5;
 
     private final DaoStateService daoStateService;
     private final BurningManService burningManService;
@@ -251,6 +254,7 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
 
         BurningManAddressList addressList = optionalAddressList.get();
         Set<String> allowedAddresses = addressList.getAllowedAddresses();
+        Map<String, Double> cappedBurnAmountShareByAddress = addressList.getCappedBurnAmountShareByAddress();
         return candidates.stream()
                 .filter(candidate -> candidate.getReceiverAddress().isPresent())
                 .filter(candidate -> {
@@ -263,7 +267,41 @@ public class DelayedPayoutTxReceiverService implements DaoStateListener {
                     }
                     return allowed;
                 })
+                .filter(candidate -> isCappedBurnAmountShareInRange(candidate, addressList, cappedBurnAmountShareByAddress))
                 .collect(Collectors.toList());
+    }
+
+    private boolean isCappedBurnAmountShareInRange(BurningManCandidate candidate,
+                                                   BurningManAddressList addressList,
+                                                   Map<String, Double> cappedBurnAmountShareByAddress) {
+        String receiverAddress = candidate.getReceiverAddress().orElseThrow();
+        Double referenceShare = cappedBurnAmountShareByAddress.get(receiverAddress);
+        if (referenceShare == null && receiverAddress.equals(addressList.getLegacyBurningManAddress())) {
+            return true;
+        }
+
+        if (referenceShare == null) {
+            log.warn("Skipping Burning Man receiver {} because no cappedBurnAmountShare exists in address list version {}",
+                    receiverAddress,
+                    addressList.getListVersion());
+            return false;
+        }
+
+        double cappedBurnAmountShare = candidate.getCappedBurnAmountShare();
+        double lowerBound = Math.max(0, referenceShare * (1 - BM_ADDRESS_LIST_SHARE_RANGE_TOLERANCE));
+        double upperBound = referenceShare * (1 + BM_ADDRESS_LIST_SHARE_RANGE_TOLERANCE);
+        boolean inRange = cappedBurnAmountShare >= lowerBound && cappedBurnAmountShare <= upperBound;
+        if (!inRange) {
+            log.warn("Skipping Burning Man receiver {} because cappedBurnAmountShare {} is outside address list " +
+                            "version {} range [{}, {}] with reference share {}",
+                    receiverAddress,
+                    cappedBurnAmountShare,
+                    addressList.getListVersion(),
+                    lowerBound,
+                    upperBound,
+                    referenceShare);
+        }
+        return inRange;
     }
 
     private static long getSpendableAmount(int numOutputs, long inputAmount, long txFeePerVbyte) {

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -332,11 +332,17 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
         long inputAmount = depositTx.getOutput(0).getValue().value;
         int selectionHeight = dispute.getBurningManSelectionHeight();
 
+        int burningManAddressListVersion = dispute.getContract().getBurningManAddressListVersion();
         List<Tuple2<Long, String>> delayedPayoutTxReceivers = delayedPayoutTxReceiverService.getReceivers(
                 selectionHeight,
                 inputAmount,
-                dispute.getTradeTxFee());
-        log.info("Verify delayedPayoutTx using selectionHeight {} and receivers {}", selectionHeight, delayedPayoutTxReceivers);
+                dispute.getTradeTxFee(),
+                burningManAddressListVersion);
+        delayedPayoutTxReceiverService.validateDelayedPayoutTxReceivers(
+                delayedPayoutTxReceivers,
+                burningManAddressListVersion);
+        log.info("Verify delayedPayoutTx using selectionHeight {}, BM address list version {} and receivers {}",
+                selectionHeight, burningManAddressListVersion, delayedPayoutTxReceivers);
         checkArgument(delayedPayoutTx.getOutputs().size() == delayedPayoutTxReceivers.size(),
                 "Size of outputs and delayedPayoutTxReceivers must be the same");
 

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
@@ -155,6 +155,9 @@ public final class Contract implements NetworkPayload {
         this.takerPaymentMethodId = takerPaymentMethodId;
         this.burningManAddressListVersion = burningManAddressListVersion;
 
+        checkArgument(burningManAddressListVersion >= 0,
+                "burningManAddressListVersion must not be negative");
+
         // Either makerPaymentMethodId is set, or obtained from offerPayload.
         if (makerPaymentMethodId == null) {
             makerPaymentMethodId = checkNotNull(offerPayload).getPaymentMethodId();

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
@@ -102,6 +102,8 @@ public final class Contract implements NetworkPayload {
     @Nullable
     private final String takerPaymentMethodId;
 
+    private final int burningManAddressListVersion;
+
     public Contract(OfferPayload offerPayload,
                     long tradeAmount,
                     long tradePrice,
@@ -125,7 +127,8 @@ public final class Contract implements NetworkPayload {
                     @Nullable byte[] hashOfMakersPaymentAccountPayload,
                     @Nullable byte[] hashOfTakersPaymentAccountPayload,
                     @Nullable String makerPaymentMethodId,
-                    @Nullable String takerPaymentMethodId) {
+                    @Nullable String takerPaymentMethodId,
+                    int burningManAddressListVersion) {
         this.offerPayload = offerPayload;
         this.tradeAmount = tradeAmount;
         this.tradePrice = tradePrice;
@@ -150,6 +153,7 @@ public final class Contract implements NetworkPayload {
         this.hashOfTakersPaymentAccountPayload = hashOfTakersPaymentAccountPayload;
         this.makerPaymentMethodId = makerPaymentMethodId;
         this.takerPaymentMethodId = takerPaymentMethodId;
+        this.burningManAddressListVersion = burningManAddressListVersion;
 
         // Either makerPaymentMethodId is set, or obtained from offerPayload.
         if (makerPaymentMethodId == null) {
@@ -203,7 +207,8 @@ public final class Contract implements NetworkPayload {
                 ProtoUtil.byteArrayOrNullFromProto(proto.getHashOfMakersPaymentAccountPayload()),
                 ProtoUtil.byteArrayOrNullFromProto(proto.getHashOfTakersPaymentAccountPayload()),
                 ProtoUtil.stringOrNullFromProto(proto.getMakerPaymentMethodId()),
-                ProtoUtil.stringOrNullFromProto(proto.getTakerPaymentMethodId())
+                ProtoUtil.stringOrNullFromProto(proto.getTakerPaymentMethodId()),
+                proto.getBurningManAddressListVersion()
         );
     }
 
@@ -240,6 +245,9 @@ public final class Contract implements NetworkPayload {
                 .ifPresent(e -> builder.setTakerPaymentAccountPayload((protobuf.PaymentAccountPayload) takerPaymentAccountPayload.toProtoMessage()));
         Optional.ofNullable(makerPaymentMethodId).ifPresent(e -> builder.setMakerPaymentMethodId(makerPaymentMethodId));
         Optional.ofNullable(takerPaymentMethodId).ifPresent(e -> builder.setTakerPaymentMethodId(takerPaymentMethodId));
+        if (burningManAddressListVersion > 0) {
+            builder.setBurningManAddressListVersion(burningManAddressListVersion);
+        }
         return builder.build();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxRequest.java
@@ -18,6 +18,7 @@
 package bisq.core.trade.protocol.bisq_v1.messages;
 
 import bisq.core.btc.model.RawTransactionInput;
+import bisq.core.dao.burningman.BurningManAddressListService;
 import bisq.core.trade.protocol.TradeMessage;
 
 import bisq.network.p2p.DirectMessage;
@@ -85,6 +86,7 @@ public final class InputsForDepositTxRequest extends TradeMessage
 
     // Added in v 1.9.7
     private final int burningManSelectionHeight;
+    private final List<Integer> supportedBurningManAddressListVersions;
 
     public InputsForDepositTxRequest(String tradeId,
                                      NodeAddress senderNodeAddress,
@@ -111,7 +113,8 @@ public final class InputsForDepositTxRequest extends TradeMessage
                                      long currentDate,
                                      byte[] hashOfTakersPaymentAccountPayload,
                                      String takersPaymentMethodId,
-                                     int burningManSelectionHeight) {
+                                     int burningManSelectionHeight,
+                                     List<Integer> supportedBurningManAddressListVersions) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
         this.tradeAmount = tradeAmount;
@@ -136,6 +139,7 @@ public final class InputsForDepositTxRequest extends TradeMessage
         this.hashOfTakersPaymentAccountPayload = hashOfTakersPaymentAccountPayload;
         this.takersPaymentMethodId = takersPaymentMethodId;
         this.burningManSelectionHeight = burningManSelectionHeight;
+        this.supportedBurningManAddressListVersions = supportedBurningManAddressListVersions;
 
         validate();
     }
@@ -163,6 +167,7 @@ public final class InputsForDepositTxRequest extends TradeMessage
         checkNonEmptyBytes(hashOfTakersPaymentAccountPayload, "hashOfTakersPaymentAccountPayload");
         checkNonBlankString(takersPaymentMethodId, "takersPaymentMethodId");
         checkArgument(burningManSelectionHeight > 0, "burningManSelectionHeight must be positive");
+        BurningManAddressListService.getValidatedSupportedVersions(supportedBurningManAddressListVersions);
     }
 
     @Override
@@ -205,6 +210,7 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 .setAccountAgeWitnessSignatureOfOfferId(ByteString.copyFrom(accountAgeWitnessSignatureOfOfferId))
                 .setCurrentDate(currentDate)
                 .setBurningManSelectionHeight(burningManSelectionHeight)
+                .addAllSupportedBurningManAddressListVersions(supportedBurningManAddressListVersions)
                 .setHashOfTakersPaymentAccountPayload(ByteString.copyFrom(hashOfTakersPaymentAccountPayload))
                 .setTakersPayoutMethodId(takersPaymentMethodId);
 
@@ -250,7 +256,8 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 proto.getCurrentDate(),
                 proto.getHashOfTakersPaymentAccountPayload().toByteArray(),
                 proto.getTakersPayoutMethodId(),
-                proto.getBurningManSelectionHeight());
+                proto.getBurningManSelectionHeight(),
+                proto.getSupportedBurningManAddressListVersionsList());
     }
 
     @Override
@@ -279,6 +286,7 @@ public final class InputsForDepositTxRequest extends TradeMessage
                 ",\n     hashOfTakersPaymentAccountPayload=" + Utilities.bytesAsHexString(hashOfTakersPaymentAccountPayload) +
                 ",\n     takersPaymentMethodId=" + takersPaymentMethodId +
                 ",\n     burningManSelectionHeight=" + burningManSelectionHeight +
+                ",\n     supportedBurningManAddressListVersions=" + supportedBurningManAddressListVersions +
                 "\n} " + super.toString();
     }
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/messages/InputsForDepositTxResponse.java
@@ -18,6 +18,7 @@
 package bisq.core.trade.protocol.bisq_v1.messages;
 
 import bisq.core.btc.model.RawTransactionInput;
+import bisq.core.dao.burningman.BurningManAddressListService;
 import bisq.core.proto.CoreProtoResolver;
 import bisq.core.trade.protocol.TradeMessage;
 
@@ -62,6 +63,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
     // Added at 1.7.0
     private final byte[] hashOfMakersPaymentAccountPayload;
     private final String makersPaymentMethodId;
+    private final List<Integer> supportedBurningManAddressListVersions;
 
     public InputsForDepositTxResponse(String tradeId,
                                       String makerAccountId,
@@ -77,7 +79,8 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                                       long currentDate,
                                       long lockTime,
                                       byte[] hashOfMakersPaymentAccountPayload,
-                                      String makersPaymentMethodId) {
+                                      String makersPaymentMethodId,
+                                      List<Integer> supportedBurningManAddressListVersions) {
         this(tradeId,
                 makerAccountId,
                 makerMultiSigPubKey,
@@ -93,7 +96,8 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 currentDate,
                 lockTime,
                 hashOfMakersPaymentAccountPayload,
-                makersPaymentMethodId);
+                makersPaymentMethodId,
+                supportedBurningManAddressListVersions);
     }
 
 
@@ -117,7 +121,8 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                                        long currentDate,
                                        long lockTime,
                                        byte[] hashOfMakersPaymentAccountPayload,
-                                       String makersPaymentMethodId) {
+                                       String makersPaymentMethodId,
+                                       List<Integer> supportedBurningManAddressListVersions) {
         super(messageVersion, tradeId, uid);
         this.makerAccountId = makerAccountId;
         this.makerMultiSigPubKey = makerMultiSigPubKey;
@@ -132,6 +137,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
         this.lockTime = lockTime;
         this.hashOfMakersPaymentAccountPayload = hashOfMakersPaymentAccountPayload;
         this.makersPaymentMethodId = makersPaymentMethodId;
+        this.supportedBurningManAddressListVersions = supportedBurningManAddressListVersions;
 
         validate();
     }
@@ -151,6 +157,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
         checkArgument(lockTime > 0, "lockTime must be positive");
         checkNonEmptyBytes(hashOfMakersPaymentAccountPayload, "hashOfMakersPaymentAccountPayload");
         checkNonBlankString(makersPaymentMethodId, "makersPaymentMethodId");
+        BurningManAddressListService.getValidatedSupportedVersions(supportedBurningManAddressListVersions);
     }
 
     @Override
@@ -170,6 +177,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 .setAccountAgeWitnessSignatureOfPreparedDepositTx(ByteString.copyFrom(accountAgeWitnessSignatureOfPreparedDepositTx))
                 .setHashOfMakersPaymentAccountPayload(ByteString.copyFrom(hashOfMakersPaymentAccountPayload))
                 .setMakersPayoutMethodId(makersPaymentMethodId)
+                .addAllSupportedBurningManAddressListVersions(supportedBurningManAddressListVersions)
                 .setCurrentDate(currentDate);
 
         return getNetworkEnvelopeBuilder()
@@ -199,7 +207,8 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 proto.getCurrentDate(),
                 proto.getLockTime(),
                 proto.getHashOfMakersPaymentAccountPayload().toByteArray(),
-                proto.getMakersPayoutMethodId());
+                proto.getMakersPayoutMethodId(),
+                proto.getSupportedBurningManAddressListVersionsList());
     }
 
     @Override
@@ -219,6 +228,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 ",\n     lockTime=" + lockTime +
                 ",\n     hashOfMakersPaymentAccountPayload=" + Utilities.bytesAsHexString(hashOfMakersPaymentAccountPayload) +
                 ",\n     makersPaymentMethodId=" + makersPaymentMethodId +
+                ",\n     supportedBurningManAddressListVersions=" + supportedBurningManAddressListVersions +
                 "\n} " + super.toString();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
@@ -171,6 +171,9 @@ public class ProcessModel implements ProtocolModel<TradingPeer> {
     @Setter
     @Getter
     private int burningManSelectionHeight;
+    @Setter
+    @Getter
+    private int burningManAddressListVersion;
 
     public ProcessModel(String offerId, String accountId, PubKeyRing pubKeyRing) {
         this(offerId, accountId, pubKeyRing, new TradingPeer());
@@ -213,7 +216,8 @@ public class ProcessModel implements ProtocolModel<TradingPeer> {
                 .setPaymentStartedMessageState(paymentStartedMessageStateProperty.get().name())
                 .setBuyerPayoutAmountFromMediation(buyerPayoutAmountFromMediation)
                 .setSellerPayoutAmountFromMediation(sellerPayoutAmountFromMediation)
-                .setBurningManSelectionHeight(burningManSelectionHeight);
+                .setBurningManSelectionHeight(burningManSelectionHeight)
+                .setBurningManAddressListVersion(burningManAddressListVersion);
 
         Optional.ofNullable(takeOfferFeeTxId).ifPresent(builder::setTakeOfferFeeTxId);
         Optional.ofNullable(payoutTxSignature).ifPresent(e -> builder.setPayoutTxSignature(ByteString.copyFrom(payoutTxSignature)));
@@ -253,6 +257,7 @@ public class ProcessModel implements ProtocolModel<TradingPeer> {
         MessageState paymentStartedMessageState = ProtoUtil.enumFromProto(MessageState.class, paymentStartedMessageStateString);
         processModel.setPaymentStartedMessageState(paymentStartedMessageState);
         processModel.setBurningManSelectionHeight(proto.getBurningManSelectionHeight());
+        processModel.setBurningManAddressListVersion(proto.getBurningManAddressListVersion());
 
         if (proto.hasPaymentAccount()) {
             processModel.setPaymentAccount(PaymentAccount.fromProto(proto.getPaymentAccount(), coreProtoResolver));

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/TradingPeer.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/TradingPeer.java
@@ -90,6 +90,8 @@ public final class TradingPeer implements TradePeer {
     private byte[] hashOfPaymentAccountPayload;
     @Nullable
     private String paymentMethodId;
+    @Nullable
+    private List<Integer> supportedBurningManAddressListVersions;
 
     public TradingPeer() {
     }
@@ -111,6 +113,8 @@ public final class TradingPeer implements TradePeer {
         Optional.ofNullable(accountAgeWitnessSignature).ifPresent(e -> builder.setAccountAgeWitnessSignature(ByteString.copyFrom(e)));
         Optional.ofNullable(mediatedPayoutTxSignature).ifPresent(e -> builder.setMediatedPayoutTxSignature(ByteString.copyFrom(e)));
         Optional.ofNullable(hashOfPaymentAccountPayload).ifPresent(e -> builder.setHashOfPaymentAccountPayload(ByteString.copyFrom(e)));
+        Optional.ofNullable(supportedBurningManAddressListVersions)
+                .ifPresent(builder::addAllSupportedBurningManAddressListVersions);
         builder.setCurrentDate(currentDate);
         return builder.build();
     }
@@ -139,6 +143,9 @@ public final class TradingPeer implements TradePeer {
             tradingPeer.setCurrentDate(proto.getCurrentDate());
             tradingPeer.setMediatedPayoutTxSignature(ProtoUtil.byteArrayOrNullFromProto(proto.getMediatedPayoutTxSignature()));
             tradingPeer.setHashOfPaymentAccountPayload(ProtoUtil.byteArrayOrNullFromProto(proto.getHashOfPaymentAccountPayload()));
+            tradingPeer.setSupportedBurningManAddressListVersions(proto.getSupportedBurningManAddressListVersionsList().isEmpty() ?
+                    null :
+                    proto.getSupportedBurningManAddressListVersionsList());
             return tradingPeer;
         }
     }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerVerifiesFinalDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerVerifiesFinalDelayedPayoutTx.java
@@ -18,6 +18,7 @@
 package bisq.core.trade.protocol.bisq_v1.tasks.buyer;
 
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
@@ -46,6 +47,7 @@ public class BuyerVerifiesFinalDelayedPayoutTx extends TradeTask {
             runInterceptHook();
 
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            DelayedPayoutTxReceiverService delayedPayoutTxReceiverService = processModel.getDelayedPayoutTxReceiverService();
             Transaction finalDelayedPayoutTx = trade.getDelayedPayoutTx();
             checkNotNull(finalDelayedPayoutTx, "trade.getDelayedPayoutTx() must not be null");
 
@@ -62,11 +64,17 @@ public class BuyerVerifiesFinalDelayedPayoutTx extends TradeTask {
             long inputAmount = depositTx.getOutput(0).getValue().value;
             long tradeTxFeeAsLong = trade.getTradeTxFeeAsLong();
             int selectionHeight = processModel.getBurningManSelectionHeight();
-            List<Tuple2<Long, String>> delayedPayoutTxReceivers = processModel.getDelayedPayoutTxReceiverService().getReceivers(
+            int burningManAddressListVersion = processModel.getBurningManAddressListVersion();
+            List<Tuple2<Long, String>> delayedPayoutTxReceivers = delayedPayoutTxReceiverService.getReceivers(
                     selectionHeight,
                     inputAmount,
-                    tradeTxFeeAsLong);
-            log.info("Verify delayedPayoutTx using selectionHeight {} and receivers {}", selectionHeight, delayedPayoutTxReceivers);
+                    tradeTxFeeAsLong,
+                    burningManAddressListVersion);
+            delayedPayoutTxReceiverService.validateDelayedPayoutTxReceivers(
+                    delayedPayoutTxReceivers,
+                    burningManAddressListVersion);
+            log.info("Verify delayedPayoutTx using selectionHeight {}, BM address list version {} and receivers {}",
+                    selectionHeight, burningManAddressListVersion, delayedPayoutTxReceivers);
             long lockTime = trade.getLockTime();
             Transaction buyersDelayedPayoutTx = processModel.getTradeWalletService().createDelayedUnsignedPayoutTx(
                     depositTx,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerVerifiesPreparedDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerVerifiesPreparedDelayedPayoutTx.java
@@ -75,10 +75,15 @@ public class BuyerVerifiesPreparedDelayedPayoutTx extends TradeTask {
             Transaction peersPreparedDelayedPayoutTx = checkNotNull(processModel.getPreparedDelayedPayoutTx());
             checkDelayedPayoutTx(peersPreparedDelayedPayoutTx, trade, btcWalletService);
 
-            List<Tuple2<Long, String>> delayedPayoutTxReceivers = processModel.getDelayedPayoutTxReceiverService().getReceivers(
+            int burningManAddressListVersion = processModel.getBurningManAddressListVersion();
+            List<Tuple2<Long, String>> delayedPayoutTxReceivers = delayedPayoutTxReceiverService.getReceivers(
                     burningManSelectionHeight,
                     inputAmount,
-                    tradeTxFeeAsLong);
+                    tradeTxFeeAsLong,
+                    burningManAddressListVersion);
+            delayedPayoutTxReceiverService.validateDelayedPayoutTxReceivers(
+                    delayedPayoutTxReceivers,
+                    burningManAddressListVersion);
 
             boolean isAltcoin = offer.getPaymentMethod().isBlockchain();
             long lockTime = checkLockTime(trade.getLockTime(), isAltcoin, btcWalletService);

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerCreateAndSignContract.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerCreateAndSignContract.java
@@ -98,7 +98,8 @@ public class MakerCreateAndSignContract extends TradeTask {
                     hashOfMakersPaymentAccountPayload,
                     hashOfTakersPaymentAccountPayload,
                     makersPaymentMethodId,
-                    takersPaymentMethodId
+                    takersPaymentMethodId,
+                    processModel.getBurningManAddressListVersion()
             );
             String contractAsJson = JsonUtil.objectToJson(contract);
             String signature = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), contractAsJson);

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -112,6 +112,11 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
 
             int takersBurningManSelectionHeight = DelayedPayoutTxValidation.checkBurningManSelectionHeight(request.getBurningManSelectionHeight(), delayedPayoutTxReceiverService);
             processModel.setBurningManSelectionHeight(takersBurningManSelectionHeight);
+            List<Integer> supportedBurningManAddressListVersions = request.getSupportedBurningManAddressListVersions();
+            tradingPeer.setSupportedBurningManAddressListVersions(supportedBurningManAddressListVersions);
+            int burningManAddressListVersion = delayedPayoutTxReceiverService.selectBurningManAddressListVersion(
+                    supportedBurningManAddressListVersions);
+            processModel.setBurningManAddressListVersion(burningManAddressListVersion);
 
             // We set the taker fee only in the processModel yet not in the trade as the tx was only created but not
             // published yet. Once it was published we move it to trade. The takerFeeTx should be sent in a later

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerSendsInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerSendsInputsForDepositTxResponse.java
@@ -79,6 +79,8 @@ public abstract class MakerSendsInputsForDepositTxResponse extends TradeTask {
             byte[] hashOfMakersPaymentAccountPayload = makersPaymentAccountPayload.getHashForContract();
 
             String makersPaymentMethodId = makersPaymentAccountPayload.getPaymentMethodId();
+            var supportedBurningManAddressListVersions =
+                    processModel.getDelayedPayoutTxReceiverService().getSupportedBurningManAddressListVersions();
             InputsForDepositTxResponse message = new InputsForDepositTxResponse(
                     processModel.getOfferId(),
                     processModel.getAccountId(),
@@ -94,7 +96,8 @@ public abstract class MakerSendsInputsForDepositTxResponse extends TradeTask {
                     new Date().getTime(),
                     trade.getLockTime(),
                     hashOfMakersPaymentAccountPayload,
-                    makersPaymentMethodId);
+                    makersPaymentMethodId,
+                    supportedBurningManAddressListVersions);
 
             trade.setState(Trade.State.MAKER_SENT_PUBLISH_DEPOSIT_TX_REQUEST);
             processModel.getTradeManager().requestPersistence();

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerCreatesDelayedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerCreatesDelayedPayoutTx.java
@@ -18,6 +18,7 @@
 package bisq.core.trade.protocol.bisq_v1.tasks.seller;
 
 import bisq.core.btc.wallet.TradeWalletService;
+import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
 
@@ -46,16 +47,24 @@ public class SellerCreatesDelayedPayoutTx extends TradeTask {
             runInterceptHook();
 
             TradeWalletService tradeWalletService = processModel.getTradeWalletService();
+            DelayedPayoutTxReceiverService delayedPayoutTxReceiverService = processModel.getDelayedPayoutTxReceiverService();
             Transaction depositTx = checkNotNull(processModel.getDepositTx());
+
             Transaction preparedDelayedPayoutTx;
             long inputAmount = depositTx.getOutput(0).getValue().value;
             long tradeTxFeeAsLong = trade.getTradeTxFeeAsLong();
             int selectionHeight = processModel.getBurningManSelectionHeight();
-            List<Tuple2<Long, String>> delayedPayoutTxReceivers = processModel.getDelayedPayoutTxReceiverService().getReceivers(
+            int burningManAddressListVersion = processModel.getBurningManAddressListVersion();
+            List<Tuple2<Long, String>> delayedPayoutTxReceivers = delayedPayoutTxReceiverService.getReceivers(
                     selectionHeight,
                     inputAmount,
-                    tradeTxFeeAsLong);
-            log.info("Create delayedPayoutTx using selectionHeight {} and receivers {}", selectionHeight, delayedPayoutTxReceivers);
+                    tradeTxFeeAsLong,
+                    burningManAddressListVersion);
+            delayedPayoutTxReceiverService.validateDelayedPayoutTxReceivers(
+                    delayedPayoutTxReceivers,
+                    burningManAddressListVersion);
+            log.info("Create delayedPayoutTx using selectionHeight {}, BM address list version {} and receivers {}",
+                    selectionHeight, burningManAddressListVersion, delayedPayoutTxReceivers);
             long lockTime = trade.getLockTime();
             preparedDelayedPayoutTx = tradeWalletService.createDelayedUnsignedPayoutTx(
                     depositTx,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerProcessesInputsForDepositTxResponse.java
@@ -19,6 +19,7 @@ package bisq.core.trade.protocol.bisq_v1.tasks.taker;
 
 import bisq.core.btc.model.RawTransactionInput;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
 import bisq.core.offer.Offer;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.messages.InputsForDepositTxResponse;
@@ -59,11 +60,17 @@ public class TakerProcessesInputsForDepositTxResponse extends TradeTask {
             checkNotNull(response);
 
             BtcWalletService btcWalletService = processModel.getBtcWalletService();
+            DelayedPayoutTxReceiverService delayedPayoutTxReceiverService = processModel.getDelayedPayoutTxReceiverService();
             TradingPeer tradingPeer = processModel.getTradePeer();
             Offer offer = checkNotNull(processModel.getOffer(), "Offer must not be null");
 
             tradingPeer.setHashOfPaymentAccountPayload(response.getHashOfMakersPaymentAccountPayload());
             tradingPeer.setPaymentMethodId(response.getMakersPaymentMethodId());
+            List<Integer> supportedBurningManAddressListVersions = response.getSupportedBurningManAddressListVersions();
+            tradingPeer.setSupportedBurningManAddressListVersions(supportedBurningManAddressListVersions);
+            int burningManAddressListVersion = delayedPayoutTxReceiverService.selectBurningManAddressListVersion(
+                    supportedBurningManAddressListVersions);
+            processModel.setBurningManAddressListVersion(burningManAddressListVersion);
 
             tradingPeer.setAccountId(response.getMakerAccountId());
 

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerSendInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerSendInputsForDepositTxRequest.java
@@ -106,6 +106,8 @@ public class TakerSendInputsForDepositTxRequest extends TradeTask {
 
             int burningManSelectionHeight = processModel.getDelayedPayoutTxReceiverService().getBurningManSelectionHeight();
             processModel.setBurningManSelectionHeight(burningManSelectionHeight);
+            List<Integer> supportedBurningManAddressListVersions =
+                    processModel.getDelayedPayoutTxReceiverService().getSupportedBurningManAddressListVersions();
 
 
             String takersPaymentMethodId = takersPaymentAccountPayload.getPaymentMethodId();
@@ -135,7 +137,8 @@ public class TakerSendInputsForDepositTxRequest extends TradeTask {
                     new Date().getTime(),
                     hashOfTakersPaymentAccountPayload,
                     takersPaymentMethodId,
-                    burningManSelectionHeight);
+                    burningManSelectionHeight,
+                    supportedBurningManAddressListVersions);
             log.info("Send {} with offerId {} and uid {} to peer {}",
                     request.getClass().getSimpleName(), request.getTradeId(),
                     request.getUid(), trade.getTradingPeerNodeAddress());

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerVerifyAndSignContract.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerVerifyAndSignContract.java
@@ -112,7 +112,8 @@ public class TakerVerifyAndSignContract extends TradeTask {
                     hashOfMakersPaymentAccountPayload,
                     hashOfTakersPaymentAccountPayload,
                     makersPaymentMethodId,
-                    takersPaymentMethodId
+                    takersPaymentMethodId,
+                    processModel.getBurningManAddressListVersion()
             );
             String contractAsJson = JsonUtil.objectToJson(contract);
 

--- a/core/src/main/java/bisq/core/trade/validation/InputsForDepositTxRequestValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/InputsForDepositTxRequestValidation.java
@@ -75,6 +75,7 @@ public final class InputsForDepositTxRequestValidation {
         PubKeyRing takerPubKeyRing = checkNotNull(request.getTakerPubKeyRing(),
                 "takerPubKeyRing must not be null");
         DelayedPayoutTxValidation.checkBurningManSelectionHeight(request.getBurningManSelectionHeight(), delayedPayoutTxReceiverService);
+        delayedPayoutTxReceiverService.selectBurningManAddressListVersion(request.getSupportedBurningManAddressListVersions());
         TransactionValidation.checkTransactionId(request.getTakerFeeTxId());
         byte[] accountAgeWitnessNonce = checkedOfferId.getBytes(Charsets.UTF_8);
         PublicKey takerSignatureKey = checkNotNull(takerPubKeyRing.getSignaturePubKey(),

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManAddressListServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManAddressListServiceTest.java
@@ -51,4 +51,24 @@ class BurningManAddressListServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> BurningManAddressListService.getValidatedSupportedVersions(List.of(2, 1)));
     }
+
+    @Test
+    void rejectsEmptyPeerVersions() {
+        assertThrows(IllegalArgumentException.class,
+                () -> BurningManAddressListService.getValidatedSupportedVersions(List.of()));
+    }
+
+    @Test
+    void rejectsDuplicatePeerVersions() {
+        assertThrows(IllegalArgumentException.class,
+                () -> BurningManAddressListService.getValidatedSupportedVersions(List.of(1, 1)));
+    }
+
+    @Test
+    void rejectsNonPositivePeerVersions() {
+        assertThrows(IllegalArgumentException.class,
+                () -> BurningManAddressListService.getValidatedSupportedVersions(List.of(0)));
+        assertThrows(IllegalArgumentException.class,
+                () -> BurningManAddressListService.getValidatedSupportedVersions(List.of(-1)));
+    }
 }

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManAddressListServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManAddressListServiceTest.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.burningman;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BurningManAddressListServiceTest {
+    @Test
+    void loadsBundledAddressListsByVersion() {
+        BurningManAddressListService service = new BurningManAddressListService();
+
+        assertEquals(List.of(1), service.getSupportedVersions());
+
+        BurningManAddressList addressList = service.getAddressList(1);
+        assertEquals(1, addressList.getListVersion());
+        assertEquals("BTC_MAINNET", addressList.getNetwork());
+        assertEquals(20, addressList.getReceiverAddresses().size());
+        assertTrue(addressList.getAllowedAddresses().contains("34VLFgtFKAtwTdZ5rengTT2g2zC99sWQLC"));
+    }
+
+    @Test
+    void selectsHighestCommonVersion() {
+        BurningManAddressListService service = new BurningManAddressListService();
+
+        assertEquals(1, service.selectHighestCommonVersion(List.of(1)));
+    }
+
+    @Test
+    void rejectsUnsortedPeerVersions() {
+        assertThrows(IllegalArgumentException.class,
+                () -> BurningManAddressListService.getValidatedSupportedVersions(List.of(2, 1)));
+    }
+}

--- a/core/src/test/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/DelayedPayoutTxReceiverServiceTest.java
@@ -17,12 +17,34 @@
 
 package bisq.core.dao.burningman;
 
+import bisq.core.dao.burningman.model.BurningManCandidate;
+import bisq.core.dao.state.DaoStateService;
+
+import bisq.common.config.Config;
+import bisq.common.util.Tuple2;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DelayedPayoutTxReceiverServiceTest {
+    private static final int SELECTION_HEIGHT = 767950;
+    private static final long INPUT_AMOUNT = 1_000_000L;
+    private static final long TRADE_TX_FEE = 2_780L;
+    private static final String LEGACY_ADDRESS = "legacy";
+    private static final String ALLOWED_ADDRESS_1 = "allowed-1";
+    private static final String ALLOWED_ADDRESS_2 = "allowed-2";
+    private static final String UNLISTED_ADDRESS = "unlisted";
+
     @Test
     public void testGetSnapshotHeight() {
         // up to genesis + 3* grid we use genesis
@@ -52,5 +74,105 @@ public class DelayedPayoutTxReceiverServiceTest {
         assertEquals(150, DelayedPayoutTxReceiverService.getSnapshotHeight(102, 159, 10, 0));
 
         assertEquals(990, DelayedPayoutTxReceiverService.getSnapshotHeight(102, 1000, 10, 0));
+    }
+
+    @Test
+    public void getReceiversFiltersCandidatesNotInSelectedAddressList() {
+        DelayedPayoutTxReceiverService service = newService(
+                addressList(List.of(entry(ALLOWED_ADDRESS_1, 0.05))),
+                List.of(candidate(ALLOWED_ADDRESS_1, 0.05),
+                        candidate(UNLISTED_ADDRESS, 0.05)));
+
+        List<Tuple2<Long, String>> receivers = service.getReceivers(SELECTION_HEIGHT, INPUT_AMOUNT, TRADE_TX_FEE, 1);
+        List<String> receiverAddresses = getReceiverAddresses(receivers);
+
+        assertTrue(receiverAddresses.contains(ALLOWED_ADDRESS_1));
+        assertTrue(receiverAddresses.contains(LEGACY_ADDRESS));
+        assertFalse(receiverAddresses.contains(UNLISTED_ADDRESS));
+    }
+
+    @Test
+    public void getReceiversFiltersCandidatesOutsideReferenceShareRange() {
+        DelayedPayoutTxReceiverService service = newService(
+                addressList(List.of(entry(ALLOWED_ADDRESS_1, 0.05),
+                        entry(ALLOWED_ADDRESS_2, 0.05))),
+                List.of(candidate(ALLOWED_ADDRESS_1, 0.05),
+                        candidate(ALLOWED_ADDRESS_2, 0.08)));
+
+        List<Tuple2<Long, String>> receivers = service.getReceivers(SELECTION_HEIGHT, INPUT_AMOUNT, TRADE_TX_FEE, 1);
+        List<String> receiverAddresses = getReceiverAddresses(receivers);
+
+        assertTrue(receiverAddresses.contains(ALLOWED_ADDRESS_1));
+        assertTrue(receiverAddresses.contains(LEGACY_ADDRESS));
+        assertFalse(receiverAddresses.contains(ALLOWED_ADDRESS_2));
+    }
+
+    @Test
+    public void getReceiversUsesFilteredCandidateCountForSpendableAmount() {
+        DelayedPayoutTxReceiverService service = newService(
+                addressList(List.of(entry(ALLOWED_ADDRESS_1, 0.05))),
+                List.of(candidate(ALLOWED_ADDRESS_1, 0.05),
+                        candidate(UNLISTED_ADDRESS, 0.05)));
+
+        List<Tuple2<Long, String>> receivers = service.getReceivers(SELECTION_HEIGHT, INPUT_AMOUNT, TRADE_TX_FEE, 1);
+
+        assertEquals(49_950L, receivers.stream()
+                .filter(receiver -> ALLOWED_ADDRESS_1.equals(receiver.second))
+                .findFirst()
+                .orElseThrow()
+                .first);
+    }
+
+    @Test
+    public void validateDelayedPayoutTxReceiversRejectsReceiverOutsideSelectedAddressList() {
+        DelayedPayoutTxReceiverService service = newService(
+                addressList(List.of(entry(ALLOWED_ADDRESS_1, 0.05))),
+                List.of());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.validateDelayedPayoutTxReceivers(List.of(new Tuple2<>(1_000L, UNLISTED_ADDRESS)), 1));
+    }
+
+    private static DelayedPayoutTxReceiverService newService(BurningManAddressList addressList,
+                                                             List<BurningManCandidate> candidates) {
+        DaoStateService daoStateService = mock(DaoStateService.class);
+        when(daoStateService.getLastBlock()).thenReturn(Optional.empty());
+        BurningManService burningManService = mock(BurningManService.class);
+        when(burningManService.getActiveBurningManCandidates(SELECTION_HEIGHT)).thenReturn(candidates);
+        when(burningManService.getLegacyBurningManAddress(SELECTION_HEIGHT)).thenReturn(LEGACY_ADDRESS);
+        BurningManAddressListService burningManAddressListService = mock(BurningManAddressListService.class);
+        when(burningManAddressListService.getAddressList(1)).thenReturn(addressList);
+        return new DelayedPayoutTxReceiverService(daoStateService, burningManService, burningManAddressListService);
+    }
+
+    private static BurningManAddressList addressList(List<BurningManAddressList.Entry> entries) {
+        return new BurningManAddressList(BurningManAddressList.SCHEMA_VERSION,
+                1,
+                Config.baseCurrencyNetwork().name(),
+                SELECTION_HEIGHT,
+                SELECTION_HEIGHT,
+                LEGACY_ADDRESS,
+                entries);
+    }
+
+    private static BurningManAddressList.Entry entry(String receiverAddress, double cappedBurnAmountShare) {
+        return new BurningManAddressList.Entry(receiverAddress, cappedBurnAmountShare);
+    }
+
+    private static BurningManCandidate candidate(String receiverAddress, double cappedBurnAmountShare) {
+        return new TestBurningManCandidate(receiverAddress, cappedBurnAmountShare);
+    }
+
+    private static List<String> getReceiverAddresses(List<Tuple2<Long, String>> receivers) {
+        return receivers.stream()
+                .map(receiver -> receiver.second)
+                .collect(Collectors.toList());
+    }
+
+    private static class TestBurningManCandidate extends BurningManCandidate {
+        private TestBurningManCandidate(String receiverAddress, double cappedBurnAmountShare) {
+            this.receiverAddress = Optional.of(receiverAddress);
+            this.cappedBurnAmountShare = cappedBurnAmountShare;
+        }
     }
 }

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
@@ -313,6 +313,30 @@ public class BisqV1MessageIntegrityTest {
         assertThrows(IllegalArgumentException.class, () -> newRequest(args -> args.burningManSelectionHeight = 0));
     }
 
+    @Test
+    void inputsForDepositTxRequestRejectsInvalidBurningManAddressListVersions() {
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.supportedBurningManAddressListVersions = List.of()));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.supportedBurningManAddressListVersions = List.of(0)));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.supportedBurningManAddressListVersions = List.of(1, 1)));
+        assertThrows(IllegalArgumentException.class, () -> newRequest(args ->
+                args.supportedBurningManAddressListVersions = List.of(2, 1)));
+    }
+
+    @Test
+    void inputsForDepositTxResponseRejectsInvalidBurningManAddressListVersions() {
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args ->
+                args.supportedBurningManAddressListVersions = List.of()));
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args ->
+                args.supportedBurningManAddressListVersions = List.of(0)));
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args ->
+                args.supportedBurningManAddressListVersions = List.of(1, 1)));
+        assertThrows(IllegalArgumentException.class, () -> newResponse(args ->
+                args.supportedBurningManAddressListVersions = List.of(2, 1)));
+    }
+
     private static InputsForDepositTxResponse newResponse(Consumer<ResponseArgs> customizer) {
         ResponseArgs args = new ResponseArgs();
         customizer.accept(args);

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
@@ -331,7 +331,8 @@ public class BisqV1MessageIntegrityTest {
                 args.currentDate,
                 args.lockTime,
                 args.hashOfMakersPaymentAccountPayload,
-                args.makersPaymentMethodId);
+                args.makersPaymentMethodId,
+                args.supportedBurningManAddressListVersions);
     }
 
     private static InputsForDepositTxRequest newRequest(Consumer<RequestArgs> customizer) {
@@ -363,7 +364,8 @@ public class BisqV1MessageIntegrityTest {
                 args.currentDate,
                 args.hashOfTakersPaymentAccountPayload,
                 args.takersPaymentMethodId,
-                args.burningManSelectionHeight);
+                args.burningManSelectionHeight,
+                args.supportedBurningManAddressListVersions);
     }
 
     private static protobuf.RefreshTradeStateRequest refreshTradeStateRequest(String tradeId, String uid) {
@@ -424,6 +426,7 @@ public class BisqV1MessageIntegrityTest {
         private long lockTime = 1L;
         private byte[] hashOfMakersPaymentAccountPayload = bytes(20);
         private String makersPaymentMethodId = "SEPA";
+        private List<Integer> supportedBurningManAddressListVersions = List.of(1);
     }
 
     private static class RequestArgs {
@@ -454,5 +457,6 @@ public class BisqV1MessageIntegrityTest {
         private byte[] hashOfTakersPaymentAccountPayload = bytes(24);
         private String takersPaymentMethodId = "SEPA";
         private int burningManSelectionHeight = 1;
+        private List<Integer> supportedBurningManAddressListVersions = List.of(1);
     }
 }

--- a/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
+++ b/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
@@ -140,6 +140,7 @@ class ValidationTestUtils {
     static DelayedPayoutTxReceiverService delayedPayoutTxReceiverService(int burningManSelectionHeight) {
         DelayedPayoutTxReceiverService delayedPayoutTxReceiverService = mock(DelayedPayoutTxReceiverService.class);
         when(delayedPayoutTxReceiverService.getBurningManSelectionHeight()).thenReturn(burningManSelectionHeight);
+        when(delayedPayoutTxReceiverService.selectBurningManAddressListVersion(List.of(1))).thenReturn(1);
         return delayedPayoutTxReceiverService;
     }
 
@@ -294,7 +295,8 @@ class ValidationTestUtils {
                 System.currentTimeMillis(),
                 new byte[]{2},
                 "SEPA",
-                130);
+                130,
+                List.of(1));
         User user = userWithAcceptedMediator(mediatorNodeAddress,
                 mediator(mediatorNodeAddress, pubKeyRing(Sig.generateKeyPair())));
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@
  - [Makefile](../Makefile): (new) Set up a self-contained local Bisq network on Bitcoin regtest
  - [dev-setup.md](dev-setup.md): (deprecated) Set up a self-contained local Bisq network on Bitcoin regtest
  - [dao-setup.md](dao-setup.md): (deprecated) Set up a complete Bisq DAO development environment
+- [burning-man-address-list.md](burning-man-address-list.md): Understand the versioned Burning Man DPT receiver
+  allowlist
  - [testing.md](testing.md): Learn about the Bisq testing process and how you can contribute.
 
 Looking for user-facing documentation? See https://bisq.wiki.

--- a/docs/burning-man-address-list.md
+++ b/docs/burning-man-address-list.md
@@ -1,0 +1,223 @@
+# Burning Man address list protection
+
+This document describes the versioned Burning Man address list used by the Bisq v1 trade protocol to protect delayed
+payout transaction receivers against manipulated DAO data.
+
+## Goal
+
+The delayed payout transaction (DPT) pays Burning Man receivers derived from DAO state. If a trader is eclipsed or
+otherwise receives malicious DAO data, an attacker could try to introduce an attacker-controlled Burning Man receiver
+and make both peers create a DPT paying that address.
+
+The address list protection limits DPT receivers to a release-bundled allowlist. New or manipulated DAO receiver
+addresses are excluded unless they are present in the selected list version.
+
+## Resource files
+
+Bundled address lists are stored under:
+
+```text
+p2p/src/main/resources/burningman/
+```
+
+The file name is versioned independently from the Bisq application version:
+
+```text
+bm-addresses-v0001.json
+bm-addresses-v0002.json
+...
+```
+
+Each file contains:
+
+- `schemaVersion`: JSON schema version.
+- `listVersion`: monotonic BM address list version. This must match the version in the file name.
+- `network`: base currency network, for example `BTC_MAINNET`.
+- `chainHeight`: DAO chain height used for export.
+- `burningManSelectionHeight`: snapshot height used for the exported receiver data.
+- `legacyBurningManAddress`: fallback receiver for legacy BM payments.
+- `entries`: active BM receiver addresses at export time.
+
+Entries are sorted lexicographically by `receiverAddress`. The exporter builds them in sorted order and the loader
+validates that order.
+
+`cappedBurnAmountShare` is included as reference data. It is valid JSON for values to be written in scientific notation,
+for example:
+
+```json
+{
+    "receiverAddress": "bc1q7r6mg67a8verfjj205qnznvk425dlj9krduuuu",
+    "cappedBurnAmountShare": 4.573561114277962E-4
+}
+```
+
+Gson parses that as a normal `double`. The current DPT protection uses the resource file as an address allowlist;
+`cappedBurnAmountShare` from the resource is not used to calculate DPT payouts.
+
+## Export process
+
+A release manager can export the current BM data from a synced mainnet app with:
+
+```text
+--dumpBurningManData=true
+```
+
+The file is written to the app data directory, not into the database storage directory. By default the exporter uses the
+latest bundled BM list version plus one. A specific version can be supplied with:
+
+```text
+--dumpBurningManDataVersion=<version>
+```
+
+Release process:
+
+1. Sync DAO data on mainnet.
+2. Export the current BM address list.
+3. Compare it with the latest bundled list.
+4. Add the new file under `p2p/src/main/resources/burningman/`.
+5. Keep all historical list files. Old trades may need their selected version for verification.
+
+Only append new versions. Do not modify an already released file. As `cappedBurnAmountShare` changes with each block we
+need to update it with each release even if no new addresses have been added.
+
+## Runtime loading
+
+At startup, all bundled address list resources are loaded into a sorted map keyed by `listVersion`. The service exposes:
+
+- supported versions.
+- latest version.
+- lookup by version.
+- highest-common-version selection for trade setup.
+
+Mainnet requires at least one matching mainnet resource file. Non-mainnet modes may load bundled files without applying
+filtering when no resource matches the current network.
+
+## Trade protocol
+
+The first trade protocol messages exchange supported BM address list versions:
+
+- `InputsForDepositTxRequest.supported_burning_man_address_list_versions`
+- `InputsForDepositTxResponse.supported_burning_man_address_list_versions`
+
+The lists must be non-empty, positive, distinct, and sorted.
+
+After receiving the peer list, each side selects the highest common version. The selected version is persisted in:
+
+- `TradingPeer.supportedBurningManAddressListVersions`
+- `ProcessModel.burningManAddressListVersion`
+- `Contract.burningManAddressListVersion`
+
+The contract field is part of the signed contract JSON. If peers do not select the same version, their contract JSON or
+DPT will not match.
+
+## DPT creation and verification
+
+When the DPT receiver list is generated, the selected BM address list version is passed into the receiver service.
+
+The receiver service:
+
+1. Gets active BM candidates from DAO state at the selected snapshot height.
+2. Looks up the selected address list.
+3. Removes candidates whose receiver address is not in the allowlist.
+4. Logs skipped BM receivers.
+5. Builds the DPT receiver outputs from the filtered candidate set.
+6. Validates that every DPT receiver is present in the selected allowlist.
+
+The same selected version is used by:
+
+- seller DPT creation.
+- buyer verification of prepared DPT.
+- buyer verification of final DPT.
+- refund/arbitration DPT receiver verification.
+
+The DPT txid comparison remains the final consensus check between peers. If a peer uses a modified list or different DAO
+data and creates different outputs, the DPT comparison fails.
+
+## Hash support
+
+A content hash is not required for the core protection.
+
+The selected version is part of the signed contract, and both peers independently recreate and compare the DPT outputs.
+A peer cannot profit by claiming a version while using different content, because the resulting contract or DPT will
+differ.
+
+A hash can still be useful as an operational and diagnostic tool:
+
+- detect release packaging mistakes early.
+- help arbitrators identify the exact resource content used.
+- fail earlier in protocol setup if peers support the same version number but have different file content.
+
+If added later, hash canonical content rather than raw pretty-printed JSON. For example, hash a deterministic
+serialization of schema version, list version, network, heights, legacy address, and entries sorted by receiver address.
+Hash support can be kept out of consensus at first by using it only in logs, tests, and release checks.
+
+## Share range filter
+
+The allowlist protects against new attacker-controlled receiver addresses. It does not by itself protect against
+manipulated DAO data that assigns an excessive share to an already-allowed address. To reduce that risk, the receiver
+service applies an additional share range filter after the address allowlist.
+
+The range check is filter-only, not a direct trade failure condition:
+
+1. The resource file stores reference share data per receiver.
+2. The DPT receiver service first applies the address allowlist.
+3. It then compares the DAO-provided `cappedBurnAmountShare` at the selected height against the resource range.
+4. If the share is outside the range, that BM candidate is skipped and logged.
+5. DPT outputs are calculated from the remaining candidates.
+
+With this design a false positive only excludes a BM receiver from that DPT. It does not let an attacker add a receiver,
+and it should not by itself fail the trade unless peers have different DAO data near the threshold and therefore produce
+different DPTs.
+
+Current range model:
+
+```text
+lower = max(0, baselineShare * (1 - relativeTolerance))
+upper = baselineShare * (1 + relativeTolerance)
+```
+
+Where:
+
+- `baselineShare` is the exported `cappedBurnAmountShare`.
+- `relativeTolerance` is currently a constant set to `0.5`, meaning `+/-50%`.
+
+The `+/-50%` value is intentionally a first conservative implementation constant and should be tuned with data. Before
+changing it, run a release check over historical DAO data:
+
+1. For each existing BM address, export shares at regular snapshot heights over a representative period.
+2. Measure absolute and relative movement from the intended release baseline.
+3. Report how many BMs would be skipped for candidate tolerances.
+4. Choose tolerances that would have produced zero or near-zero skips historically.
+
+For very small shares, a future absolute floor may be more appropriate than a pure relative bound. For example, a move
+from `0.0004` to `0.0008` is a 100% relative change but still economically small. The release check should report both
+relative and absolute deviations so tolerances are not biased against low-share contributors.
+
+If explicit min/max range fields are added later, old resource files without those fields should remain valid by
+deriving the range from `cappedBurnAmountShare`.
+
+## Tests worth keeping
+
+The following behavior should be covered by focused tests:
+
+- bundled resource files load by version.
+- file name version and `listVersion` must match.
+- entries must be sorted by `receiverAddress`.
+- supported version lists must be sorted, positive, distinct, and non-empty.
+- highest common version selection returns the expected version.
+- peer messages round-trip supported versions through protobuf.
+- selected version persists in `ProcessModel`, `TradingPeer`, and `Contract`.
+- DPT receiver generation skips unlisted BM addresses.
+- DPT receiver generation skips listed BM addresses whose DAO-provided share is outside the selected list's share range.
+- DPT receiver generation uses the filtered receiver count for fee calculation.
+- receiver validation rejects outputs not present in the selected allowlist.
+- refund/arbitration verification uses the contract's selected version.
+
+## Operational notes
+
+- Keep BM list versions monotonic and independent from Bisq application versions.
+- Keep historical list files immutable.
+- Add a new file with each release as the `cappedBurnAmountShare` changes with each block even if no new addresses have
+  been added.
+- Treat a large address set change as suspicious and review manually before release.
+- Prefer failing early on no common version rather than falling back silently.

--- a/docs/burning-man-address-list.md
+++ b/docs/burning-man-address-list.md
@@ -62,12 +62,8 @@ A release manager can export the current BM data from a synced mainnet app with:
 --dumpBurningManData=true
 ```
 
-The file is written to the app data directory, not into the database storage directory. By default the exporter uses the
-latest bundled BM list version plus one. A specific version can be supplied with:
-
-```text
---dumpBurningManDataVersion=<version>
-```
+The file is written to the app data directory, not into the database storage directory. The exporter uses the latest
+bundled BM list version plus one.
 
 Release process:
 

--- a/docs/burning-man-address-list.md
+++ b/docs/burning-man-address-list.md
@@ -103,7 +103,6 @@ The lists must be non-empty, positive, distinct, and sorted.
 
 After receiving the peer list, each side selects the highest common version. The selected version is persisted in:
 
-- `TradingPeer.supportedBurningManAddressListVersions`
 - `ProcessModel.burningManAddressListVersion`
 - `Contract.burningManAddressListVersion`
 

--- a/p2p/src/main/resources/burningman/bm-addresses-v0001.json
+++ b/p2p/src/main/resources/burningman/bm-addresses-v0001.json
@@ -1,0 +1,90 @@
+{
+    "schemaVersion": 1,
+    "listVersion": 1,
+    "network": "BTC_MAINNET",
+    "chainHeight": 948612,
+    "burningManSelectionHeight": 948600,
+    "legacyBurningManAddress": "34VLFgtFKAtwTdZ5rengTT2g2zC99sWQLC",
+    "entries": [
+        {
+            "receiverAddress": "13SgZBKsUtShvymUyJ5GZe7PWytorfdBhF",
+            "cappedBurnAmountShare": 0.0020922241582778905
+        },
+        {
+            "receiverAddress": "bc1q0nets5gp759parfzvpdjc860nk026dqx9s4229",
+            "cappedBurnAmountShare": 0.03755016017398866
+        },
+        {
+            "receiverAddress": "bc1q4u5hcp3h9shh6samvyhqkvvvenw8935lkgg5d9",
+            "cappedBurnAmountShare": 0.04680023457584215
+        },
+        {
+            "receiverAddress": "bc1q52xu4pz29g58277gwr6t9yf24qflefgn3m87xp",
+            "cappedBurnAmountShare": 0.05342359668234578
+        },
+        {
+            "receiverAddress": "bc1q6w0lyxj3x9mca5vstcafcmzhvhhrzxp6vls0vs",
+            "cappedBurnAmountShare": 0.012567403095492532
+        },
+        {
+            "receiverAddress": "bc1q7r6mg67a8verfjj205qnznvk425dlj9krduuuu",
+            "cappedBurnAmountShare": 4.573561114277962E-4
+        },
+        {
+            "receiverAddress": "bc1q9vx0qffryadadjv3t5k3sz46rfxgp7s0mmqa52",
+            "cappedBurnAmountShare": 0.10315845478986978
+        },
+        {
+            "receiverAddress": "bc1qa9n5347hvg0qwm9zkzep3zf00p6qqj5l6dqls6",
+            "cappedBurnAmountShare": 0.09936129285369719
+        },
+        {
+            "receiverAddress": "bc1qcc9g2fawrtza58h6eam7s3rj0pvzn5z724gwad",
+            "cappedBurnAmountShare": 0.09311077288359158
+        },
+        {
+            "receiverAddress": "bc1qcraad8k7jvqzjjz7pm6lpl5sl9zs6n9tjh28cg",
+            "cappedBurnAmountShare": 0.055766640172942486
+        },
+        {
+            "receiverAddress": "bc1qg5yf89a75g94yqya9z5fmzn3c75v9dgtsu4mnj",
+            "cappedBurnAmountShare": 0.023428896466380283
+        },
+        {
+            "receiverAddress": "bc1qkz6mc2ngeuvp7xvqgpzm8rll8hmv59ps84knyf",
+            "cappedBurnAmountShare": 0.03539096021400674
+        },
+        {
+            "receiverAddress": "bc1ql976ltcylekvmpg3uln7ut474cklqh9rpy65en",
+            "cappedBurnAmountShare": 0.014614223706614896
+        },
+        {
+            "receiverAddress": "bc1qltcdkwryjde3t3kaxl70np70306qcql2y2c3hq",
+            "cappedBurnAmountShare": 0.016183541973626033
+        },
+        {
+            "receiverAddress": "bc1qltx64wft0gkuddprgw3m0ygzxg3wex7rv9hmlp",
+            "cappedBurnAmountShare": 0.10960850927531021
+        },
+        {
+            "receiverAddress": "bc1qmafvhrek2euluajs4jyurreep99g9zw7h7wfg2",
+            "cappedBurnAmountShare": 0.05999679959375291
+        },
+        {
+            "receiverAddress": "bc1qn3td94zx9u5j75sf09wq7lzq9ugl5j27zhrvse",
+            "cappedBurnAmountShare": 0.03371061789015293
+        },
+        {
+            "receiverAddress": "bc1qngfeng667rz2mh496tdcc9un885aj5js4xs393",
+            "cappedBurnAmountShare": 0.008902913258918801
+        },
+        {
+            "receiverAddress": "bc1qrvwaas072xtgkag6ujjsxeyadvtvryeuq20qkl",
+            "cappedBurnAmountShare": 0.09262050991587789
+        },
+        {
+            "receiverAddress": "bc1qzd32m5f3q8rnf03jg9hasg0fg2rxsjhh0569vx",
+            "cappedBurnAmountShare": 0.10125489220788357
+        }
+    ]
+}

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -265,6 +265,7 @@ message InputsForDepositTxRequest {
     bytes hash_of_takers_payment_account_payload = 26;
     string takers_payout_method_id = 27;
     int32 burning_man_selection_height = 28;  // Added in v 1.9.7
+    repeated int32 supported_burning_man_address_list_versions = 29;
 }
 
 message InputsForDepositTxResponse {
@@ -284,6 +285,7 @@ message InputsForDepositTxResponse {
     int64 lock_time = 14;
     bytes hash_of_makers_payment_account_payload = 15;
     string makers_payout_method_id = 16;
+    repeated int32 supported_burning_man_address_list_versions = 17;
 }
 
 message DelayedPayoutTxSignatureRequest {
@@ -1032,6 +1034,7 @@ message Contract {
     bytes hash_of_takers_payment_account_payload = 23;
     string maker_payment_method_id = 24;
     string taker_payment_method_id = 25;
+    int32 burning_man_address_list_version = 26;
 }
 
 message RawTransactionInput {
@@ -1838,6 +1841,7 @@ message ProcessModel {
     int64 seller_payout_amount_from_mediation = 20;
     PaymentAccount payment_account = 21;
     int32 burning_man_selection_height = 22;  // Added in v 1.9.7
+    int32 burning_man_address_list_version = 23;
 }
 
 message TradingPeer {
@@ -1857,6 +1861,7 @@ message TradingPeer {
     int64 current_date = 14;
     bytes mediated_payout_tx_signature = 15;
     bytes hash_of_payment_account_payload = 16;
+    repeated int32 supported_burning_man_address_list_versions = 17;
 }
 
 message BsqSwapProtocolModel {


### PR DESCRIPTION
See burning-man-address-list.md in docs folder for details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Versioned Burning Man address allowlist added to improve delayed-payout receiver selection and validation.
  * Option to export Burning Man receiver data to a JSON file.
  * Trade protocol extended to negotiate and persist supported address-list versions during trades.

* **Documentation**
  * Added guide on managing, versioning, and releasing Burning Man address lists.

* **Tests**
  * Added tests covering address-list validation, version negotiation, and receiver filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->