### PR TITLE
feat: add allowClearnetHttpRequests feature flag

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -92,6 +92,7 @@ public class Config {
     public static final String SOCKS_5_PROXY_HTTP_ADDRESS = "socks5ProxyHttpAddress";
     public static final String USE_TOR_FOR_BTC = "useTorForBtc";
     public static final String ALLOW_LAN_FOR_HTTP_REQUESTS = "allowLanForHttpRequests";
+    public static final String ALLOW_CLEARNET_HTTP_REQUESTS = "allowClearnetHttpRequests";
     public static final String TORRC_FILE = "torrcFile";
     public static final String TORRC_OPTIONS = "torrcOptions";
     public static final String TOR_CONTROL_HOST = "torControlHost";
@@ -216,6 +217,7 @@ public class Config {
     public final boolean useTorForBtc;
     public final boolean useTorForBtcOptionSetExplicitly;
     public final boolean allowLanForHttpRequests;
+    public final boolean allowClearnetHttpRequests;
     public final String socks5DiscoverMode;
     public final boolean useAllProvidedNodes;
     public final String userAgent;
@@ -597,6 +599,17 @@ public class Config {
                         .ofType(Boolean.class)
                         .defaultsTo(false);
 
+        ArgumentAcceptingOptionSpec<Boolean> allowClearnetHttpRequestsOpt =
+                parser.accepts(ALLOW_CLEARNET_HTTP_REQUESTS,
+                                "If true, HTTP requests to non-local destinations are sent directly " +
+                                        "over the clearnet, bypassing Tor. Intended for development and " +
+                                        "testing against a known endpoint (e.g. a self-hosted price node). " +
+                                        "WARNING: leaks your IP address to the destination server. " +
+                                        "Do not enable on mainnet with real funds.")
+                        .withRequiredArg()
+                        .ofType(Boolean.class)
+                        .defaultsTo(false);
+
         ArgumentAcceptingOptionSpec<String> socks5DiscoverModeOpt =
                 parser.accepts(SOCKS5_DISCOVER_MODE, "Specify discovery mode for Bitcoin nodes. " +
                                 "One or more of: [ADDR, DNS, ONION, ALL] (comma separated, they get OR'd together).")
@@ -886,6 +899,7 @@ public class Config {
             this.useTorForBtc = options.valueOf(useTorForBtcOpt);
             this.useTorForBtcOptionSetExplicitly = options.has(useTorForBtcOpt);
             this.allowLanForHttpRequests = options.valueOf(allowLanForHttpRequestsOpt);
+            this.allowClearnetHttpRequests = options.valueOf(allowClearnetHttpRequestsOpt);
             this.socks5DiscoverMode = options.valueOf(socks5DiscoverModeOpt);
             this.useAllProvidedNodes = options.valueOf(useAllProvidedNodesOpt);
             this.userAgent = options.valueOf(userAgentOpt);

--- a/common/src/main/java/bisq/common/setup/CommonSetup.java
+++ b/common/src/main/java/bisq/common/setup/CommonSetup.java
@@ -54,6 +54,9 @@ public class CommonSetup {
         AsciiLogo.showAsciiLogo();
         Version.setBaseCryptoNetworkId(config.getBaseCurrencyNetwork().ordinal());
         Version.printVersion();
+        if (config.allowClearnetHttpRequests && config.getBaseCurrencyNetwork().isMainnet()) {
+            log.warn("allowClearnetHttpRequests is enabled on mainnet — HTTP requests may bypass Tor and leak your IP address.");
+        }
         maybePrintPathOfCodeSource();
         Profiler.printSystemLoad();
 

--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -266,7 +266,8 @@ public class BisqSetup {
         this.refundManager = refundManager;
         this.arbitrationManager = arbitrationManager;
 
-        MemPoolSpaceTxBroadcaster.init(socks5ProxyProvider, preferences, localBitcoinNode, config.allowLanForHttpRequests);
+        MemPoolSpaceTxBroadcaster.init(socks5ProxyProvider, preferences, localBitcoinNode,
+                config.allowLanForHttpRequests, config.allowClearnetHttpRequests);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/btc/wallet/http/MemPoolSpaceTxBroadcaster.java
+++ b/core/src/main/java/bisq/core/btc/wallet/http/MemPoolSpaceTxBroadcaster.java
@@ -53,17 +53,20 @@ public class MemPoolSpaceTxBroadcaster {
     private static Preferences preferences;
     private static LocalBitcoinNode localBitcoinNode;
     private static boolean allowLanForHttpRequests;
+    private static boolean allowClearnetHttpRequests;
     private static final ListeningExecutorService executorService = Utilities.getListeningExecutorService(
             "MemPoolSpaceTxBroadcaster", 3, 5, 10 * 60);
 
     public static void init(Socks5ProxyProvider socks5ProxyProvider,
                             Preferences preferences,
                             LocalBitcoinNode localBitcoinNode,
-                            boolean allowLanForHttpRequests) {
+                            boolean allowLanForHttpRequests,
+                            boolean allowClearnetHttpRequests) {
         MemPoolSpaceTxBroadcaster.socks5ProxyProvider = socks5ProxyProvider;
         MemPoolSpaceTxBroadcaster.preferences = preferences;
         MemPoolSpaceTxBroadcaster.localBitcoinNode = localBitcoinNode;
         MemPoolSpaceTxBroadcaster.allowLanForHttpRequests = allowLanForHttpRequests;
+        MemPoolSpaceTxBroadcaster.allowClearnetHttpRequests = allowClearnetHttpRequests;
     }
 
     public static void broadcastTx(Transaction tx) {
@@ -108,7 +111,8 @@ public class MemPoolSpaceTxBroadcaster {
     }
 
     private static void broadcastTx(String serviceAddress, String txIdToSend, String rawTx) {
-        TxBroadcastHttpClient httpClient = new TxBroadcastHttpClient(socks5ProxyProvider, allowLanForHttpRequests);
+        TxBroadcastHttpClient httpClient = new TxBroadcastHttpClient(socks5ProxyProvider,
+                allowLanForHttpRequests, allowClearnetHttpRequests);
         httpClient.setBaseUrl(serviceAddress);
         httpClient.setIgnoreSocks5Proxy(false);
 

--- a/core/src/main/java/bisq/core/btc/wallet/http/TxBroadcastHttpClient.java
+++ b/core/src/main/java/bisq/core/btc/wallet/http/TxBroadcastHttpClient.java
@@ -26,7 +26,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class TxBroadcastHttpClient extends HttpClientImpl implements AssetTxProofHttpClient {
-    TxBroadcastHttpClient(Socks5ProxyProvider socks5ProxyProvider, boolean allowLanForHttpRequests) {
-        super(socks5ProxyProvider, allowLanForHttpRequests);
+    TxBroadcastHttpClient(Socks5ProxyProvider socks5ProxyProvider,
+                          boolean allowLanForHttpRequests,
+                          boolean allowClearnetHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests, allowClearnetHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/provider/FeeHttpClient.java
+++ b/core/src/main/java/bisq/core/provider/FeeHttpClient.java
@@ -32,7 +32,8 @@ import javax.annotation.Nullable;
 public class FeeHttpClient extends HttpClientImpl {
     @Inject
     public FeeHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider,
-                         @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
-        super(socks5ProxyProvider, allowLanForHttpRequests);
+                         @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests,
+                         @Named(Config.ALLOW_CLEARNET_HTTP_REQUESTS) boolean allowClearnetHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests, allowClearnetHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/provider/MempoolHttpClient.java
+++ b/core/src/main/java/bisq/core/provider/MempoolHttpClient.java
@@ -37,8 +37,9 @@ import javax.annotation.Nullable;
 public class MempoolHttpClient extends HttpClientImpl {
     @Inject
     public MempoolHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider,
-                             @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
-        super(socks5ProxyProvider, allowLanForHttpRequests);
+                             @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests,
+                             @Named(Config.ALLOW_CLEARNET_HTTP_REQUESTS) boolean allowClearnetHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests, allowClearnetHttpRequests);
     }
 
     // returns JSON of the transaction details

--- a/core/src/main/java/bisq/core/provider/PriceHttpClient.java
+++ b/core/src/main/java/bisq/core/provider/PriceHttpClient.java
@@ -32,7 +32,8 @@ import javax.annotation.Nullable;
 public class PriceHttpClient extends HttpClientImpl {
     @Inject
     public PriceHttpClient(@Nullable Socks5ProxyProvider socks5ProxyProvider,
-                           @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
-        super(socks5ProxyProvider, allowLanForHttpRequests);
+                           @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests,
+                           @Named(Config.ALLOW_CLEARNET_HTTP_REQUESTS) boolean allowClearnetHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests, allowClearnetHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/provider/mempool/MempoolRequest.java
+++ b/core/src/main/java/bisq/core/provider/mempool/MempoolRequest.java
@@ -51,9 +51,10 @@ public class MempoolRequest {
 
     public MempoolRequest(Preferences preferences,
                           Socks5ProxyProvider socks5ProxyProvider,
-                          boolean allowLanForHttpRequests) {
+                          boolean allowLanForHttpRequests,
+                          boolean allowClearnetHttpRequests) {
         this.txBroadcastServices.addAll(preferences.getDefaultTxBroadcastServices());
-        this.mempoolHttpClient = new MempoolHttpClient(socks5ProxyProvider, allowLanForHttpRequests);
+        this.mempoolHttpClient = new MempoolHttpClient(socks5ProxyProvider, allowLanForHttpRequests, allowClearnetHttpRequests);
     }
 
     public void getTxStatus(SettableFuture<String> mempoolServiceCallback, String txId) {

--- a/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
+++ b/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
@@ -106,7 +106,7 @@ public class MempoolService {
             UserThread.runAfter(() -> resultHandler.accept(txValidator.endResult(FeeValidationStatus.ACK_CHECK_BYPASSED)), 1);
             return;
         }
-        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests);
+        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests, config.allowClearnetHttpRequests);
         validateOfferMakerTx(mempoolRequest, txValidator, resultHandler);
     }
 
@@ -120,7 +120,7 @@ public class MempoolService {
             UserThread.runAfter(() -> resultHandler.accept(txValidator.endResult(FeeValidationStatus.ACK_CHECK_BYPASSED)), 1);
             return;
         }
-        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests);
+        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests, config.allowClearnetHttpRequests);
         validateOfferTakerTx(mempoolRequest, txValidator, resultHandler);
     }
 
@@ -130,7 +130,7 @@ public class MempoolService {
             UserThread.runAfter(() -> resultHandler.accept(txValidator.endResult(FeeValidationStatus.ACK_CHECK_BYPASSED)), 1);
             return;
         }
-        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests);
+        MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests, config.allowClearnetHttpRequests);
         SettableFuture<String> future = SettableFuture.create();
         Futures.addCallback(future, callbackForTxRequest(mempoolRequest, txValidator, resultHandler), MoreExecutors.directExecutor());
         mempoolRequest.getTxStatus(future, txId);
@@ -138,7 +138,7 @@ public class MempoolService {
 
     public CompletableFuture<String> requestTxAsHex(String txId) {
         outstandingRequests++;
-        return new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests)
+        return new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests, config.allowClearnetHttpRequests)
                 .requestTxAsHex(txId)
                 .whenComplete((result, throwable) -> outstandingRequests--);
     }

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofHttpClient.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofHttpClient.java
@@ -26,7 +26,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class XmrTxProofHttpClient extends HttpClientImpl implements AssetTxProofHttpClient {
-    XmrTxProofHttpClient(Socks5ProxyProvider socks5ProxyProvider, boolean allowLanForHttpRequests) {
-        super(socks5ProxyProvider, allowLanForHttpRequests);
+    XmrTxProofHttpClient(Socks5ProxyProvider socks5ProxyProvider,
+                         boolean allowLanForHttpRequests,
+                         boolean allowClearnetHttpRequests) {
+        super(socks5ProxyProvider, allowLanForHttpRequests, allowClearnetHttpRequests);
     }
 }

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequest.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequest.java
@@ -164,12 +164,13 @@ class XmrTxProofRequest implements AssetTxProofRequest<XmrTxProofRequest.Result>
 
     XmrTxProofRequest(Socks5ProxyProvider socks5ProxyProvider,
                       XmrTxProofModel model,
-                      boolean allowLanForHttpRequests) {
+                      boolean allowLanForHttpRequests,
+                      boolean allowClearnetHttpRequests) {
         txProofParser = new XmrTxProofParser();
         rawTxParser = new XmrRawTxParser();
         this.model = model;
 
-        httpClient = new XmrTxProofHttpClient(socks5ProxyProvider, allowLanForHttpRequests);
+        httpClient = new XmrTxProofHttpClient(socks5ProxyProvider, allowLanForHttpRequests, allowClearnetHttpRequests);
 
         // The HttpClient itself decides whether to bypass Tor based on URL parsing
         // (loopback always bypasses; LAN bypasses iff allowLanForHttpRequests=true).

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofRequestsPerTrade.java
@@ -62,6 +62,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
     private final RefundManager refundManager;
     private final Socks5ProxyProvider socks5ProxyProvider;
     private final boolean allowLanForHttpRequests;
+    private final boolean allowClearnetHttpRequests;
 
     private volatile int numRequiredSuccessResults;
     // Concurrent + AtomicBoolean termination so callbacks cannot race past the guard
@@ -84,7 +85,8 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
                                MediationManager mediationManager,
                                FilterManager filterManager,
                                RefundManager refundManager,
-                               boolean allowLanForHttpRequests) {
+                               boolean allowLanForHttpRequests,
+                               boolean allowClearnetHttpRequests) {
         this.socks5ProxyProvider = socks5ProxyProvider;
         this.trade = trade;
         this.autoConfirmSettings = autoConfirmSettings;
@@ -92,6 +94,7 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
         this.filterManager = filterManager;
         this.refundManager = refundManager;
         this.allowLanForHttpRequests = allowLanForHttpRequests;
+        this.allowClearnetHttpRequests = allowClearnetHttpRequests;
     }
 
 
@@ -169,7 +172,8 @@ class XmrTxProofRequestsPerTrade implements AssetTxProofRequestsPerTrade {
 
         for (String serviceAddress : serviceAddresses) {
             XmrTxProofModel model = new XmrTxProofModel(trade, serviceAddress, autoConfirmSettings);
-            XmrTxProofRequest request = new XmrTxProofRequest(socks5ProxyProvider, model, allowLanForHttpRequests);
+            XmrTxProofRequest request = new XmrTxProofRequest(socks5ProxyProvider, model,
+                    allowLanForHttpRequests, allowClearnetHttpRequests);
 
             log.info("{} created", request);
             requests.add(request);

--- a/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
+++ b/core/src/main/java/bisq/core/trade/txproof/xmr/XmrTxProofService.java
@@ -84,6 +84,7 @@ public class XmrTxProofService implements AssetTxProofService {
     private final WalletsSetup walletsSetup;
     private final Socks5ProxyProvider socks5ProxyProvider;
     private final boolean allowLanForHttpRequests;
+    private final boolean allowClearnetHttpRequests;
     private final Map<String, XmrTxProofRequestsPerTrade> servicesByTradeId = new HashMap<>();
     private AutoConfirmSettings autoConfirmSettings;
     private final Map<String, ChangeListener<Trade.State>> tradeStateListenerMap = new HashMap<>();
@@ -109,7 +110,8 @@ public class XmrTxProofService implements AssetTxProofService {
                              P2PService p2PService,
                              WalletsSetup walletsSetup,
                              Socks5ProxyProvider socks5ProxyProvider,
-                             @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
+                             @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests,
+                             @Named(Config.ALLOW_CLEARNET_HTTP_REQUESTS) boolean allowClearnetHttpRequests) {
         this.filterManager = filterManager;
         this.preferences = preferences;
         this.tradeManager = tradeManager;
@@ -121,6 +123,7 @@ public class XmrTxProofService implements AssetTxProofService {
         this.walletsSetup = walletsSetup;
         this.socks5ProxyProvider = socks5ProxyProvider;
         this.allowLanForHttpRequests = allowLanForHttpRequests;
+        this.allowClearnetHttpRequests = allowClearnetHttpRequests;
     }
 
 
@@ -273,7 +276,8 @@ public class XmrTxProofService implements AssetTxProofService {
                 mediationManager,
                 filterManager,
                 refundManager,
-                allowLanForHttpRequests);
+                allowLanForHttpRequests,
+                allowClearnetHttpRequests);
         servicesByTradeId.put(trade.getId(), service);
         service.requestFromAllServices(
                 assetTxProofResult -> {

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -61,6 +61,8 @@ Here is an overview:
  - `--nodePort`: Port number for localhost mode. For seed nodes there is a convention with the last digit is marking the network type and there is a list of hard coded seed nodes addresses (see: `DefaultSeedNodeAddresses.java`). For regtest: 2002 and 3002. For testnet 2001, 3001 and 4001 and for mainnet:  2000, 3000 and 4000. For normal nodes the port can be chosen freely.
  - `--useDevPrivilegeKeys`: Important for dev testing to allow the developer key for arbitration registration
  - `--appName`: Custom application name which is used for the data directory. It is important to separate your nodes to not interfere. If not set, it uses the default `Bisq` directory.
+ - `--allowLanForHttpRequests=true`: Allow HTTP requests to RFC1918 private IP ranges (10/8, 172.16/12, 192.168/16) and link-local/unique-local addresses to bypass Tor. Default `false` (only loopback bypasses Tor). Useful if you run a price/fee/explorer service on a trusted LAN.
+ - `--allowClearnetHttpRequests=true`: Fallback escape hatch when no SOCKS5/Tor proxy is running. Lets HTTP requests to non-local clearnet hosts (e.g. a self-hosted price node like `http://1.2.3.4:8080/getAllMarketPrices`) go directly over the clearnet. Has **no effect** when Tor is up — Tor is always preferred. Onion hosts are always rejected without a proxy. **WARNING:** leaks your IP address to the destination server; do not enable on mainnet with real funds.
 
 
 ## Run Bisq seednode

--- a/p2p/src/main/java/bisq/network/http/HttpClientImpl.java
+++ b/p2p/src/main/java/bisq/network/http/HttpClientImpl.java
@@ -105,6 +105,7 @@ public class HttpClientImpl implements HttpClient {
     @Nullable
     private final Socks5ProxyProvider socks5ProxyProvider;
     private final boolean allowLanForHttpRequests;
+    private final boolean allowClearnetHttpRequests;
     @Nullable
     private volatile HttpURLConnection connection;
     @Nullable
@@ -119,20 +120,27 @@ public class HttpClientImpl implements HttpClient {
 
     @Inject
     public HttpClientImpl(@Nullable Socks5ProxyProvider socks5ProxyProvider,
-                          @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests) {
+                          @Named(Config.ALLOW_LAN_FOR_HTTP_REQUESTS) boolean allowLanForHttpRequests,
+                          @Named(Config.ALLOW_CLEARNET_HTTP_REQUESTS) boolean allowClearnetHttpRequests) {
         this.socks5ProxyProvider = socks5ProxyProvider;
         this.allowLanForHttpRequests = allowLanForHttpRequests;
+        this.allowClearnetHttpRequests = allowClearnetHttpRequests;
+        if (allowClearnetHttpRequests) {
+            log.warn("allowClearnetHttpRequests is enabled: HTTP requests to non-local destinations will " +
+                    "bypass Tor and leak your IP address. Use only for development/testing.");
+        }
         uid = UUID.randomUUID().toString();
     }
 
     public HttpClientImpl(@Nullable Socks5ProxyProvider socks5ProxyProvider) {
         // Test/legacy entry point. Defaults to strict loopback-only.
-        this(socks5ProxyProvider, false);
+        this(socks5ProxyProvider, false, false);
     }
 
     public HttpClientImpl(String baseUrl) {
         this.socks5ProxyProvider = null;
         this.allowLanForHttpRequests = false;
+        this.allowClearnetHttpRequests = false;
         setBaseUrl(baseUrl);
         uid = UUID.randomUUID().toString();
     }
@@ -216,6 +224,7 @@ public class HttpClientImpl implements HttpClient {
                 throw new IOException(e.getMessage());
             }
             boolean local = UrlSafetyChecker.isLocal(uri, allowLanForHttpRequests);
+            boolean onion = UrlSafetyChecker.isOnion(uri);
             Socks5Proxy socks5Proxy = getSocks5Proxy(socks5ProxyProvider);
 
             if (local) {
@@ -231,15 +240,31 @@ public class HttpClientImpl implements HttpClient {
                         "refusing to send " + httpMethod + " to non-local " + baseUrl);
             }
 
-            if (socks5Proxy == null) {
-                // Fail closed: rather than fall back to clearnet (the previous
-                // behaviour), refuse to send the request. The caller decides
-                // whether to retry once Tor is up.
-                throw new IOException("No SOCKS5 proxy available, refusing to send "
-                        + httpMethod + " to non-local " + baseUrl);
+            if (socks5Proxy != null) {
+                // Tor available — always prefer it for non-local destinations,
+                // even when allowClearnetHttpRequests=true. The flag is a
+                // last-resort fallback, not a global Tor disable.
+                return doRequestWithProxy(baseUrl, param, httpMethod, socks5Proxy, headerKey, headerValue);
             }
 
-            return doRequestWithProxy(baseUrl, param, httpMethod, socks5Proxy, headerKey, headerValue);
+            // No proxy available.
+            if (onion) {
+                // Onion hosts are only reachable through Tor; a direct attempt
+                // would leak the lookup to the system DNS resolver and fail.
+                throw new IOException("No SOCKS5 proxy available, refusing to send "
+                        + httpMethod + " to onion host " + baseUrl);
+            }
+
+            if (allowClearnetHttpRequests) {
+                // Dev/testing escape hatch: send directly without Tor.
+                log.info("No SOCKS5 proxy available; sending {} clearnet (no Tor) to non-local {} " +
+                                "because allowClearnetHttpRequests=true",
+                        httpMethod, baseUrl);
+                return requestWithoutProxy(baseUrl, param, httpMethod, headerKey, headerValue);
+            }
+
+            throw new IOException("No SOCKS5 proxy available, refusing to send "
+                    + httpMethod + " to non-local " + baseUrl);
         } finally {
             hasPendingRequest.set(false);
         }

--- a/p2p/src/main/java/bisq/network/http/UrlSafetyChecker.java
+++ b/p2p/src/main/java/bisq/network/http/UrlSafetyChecker.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Validates URLs before they are dispatched and decides whether a request can be
@@ -37,6 +38,8 @@ public final class UrlSafetyChecker {
             super(msg);
         }
     }
+
+    private static final Pattern TRAILING_DOTS = Pattern.compile("\\.+$");
 
     private UrlSafetyChecker() {
     }
@@ -152,6 +155,21 @@ public final class UrlSafetyChecker {
      */
     public static boolean isLocal(String baseUrl) {
         return isLocal(parseAndValidate(baseUrl));
+    }
+
+    /**
+     * True iff {@code uri}'s host is a Tor onion address. Onion hosts are only
+     * resolvable through a Tor circuit, so callers must never attempt direct
+     * connection nor system DNS resolution for them.
+     */
+    public static boolean isOnion(URI uri) {
+        String host = uri.getHost();
+        if (host == null) return false;
+        // Strip trailing dots (FQDN form). "host.onion." resolves to the same
+        // destination as "host.onion"; treating it as non-onion would let a
+        // clearnet attempt leak the lookup to the system DNS resolver.
+        String lower = TRAILING_DOTS.matcher(host.toLowerCase(Locale.ROOT)).replaceFirst("");
+        return lower.endsWith(".onion");
     }
 
     private static boolean isNumericIp(String host) {

--- a/p2p/src/main/java/bisq/network/p2p/P2PModule.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PModule.java
@@ -75,6 +75,7 @@ public class P2PModule extends AppModule {
 
         bindConstant().annotatedWith(named(USE_LOCALHOST_FOR_P2P)).to(config.useLocalhostForP2P);
         bindConstant().annotatedWith(named(ALLOW_LAN_FOR_HTTP_REQUESTS)).to(config.allowLanForHttpRequests);
+        bindConstant().annotatedWith(named(ALLOW_CLEARNET_HTTP_REQUESTS)).to(config.allowClearnetHttpRequests);
 
         bind(File.class).annotatedWith(named(TOR_DIR)).toInstance(config.torDir);
 

--- a/p2p/src/test/java/bisq/network/http/UrlSafetyCheckerTest.java
+++ b/p2p/src/test/java/bisq/network/http/UrlSafetyCheckerTest.java
@@ -381,6 +381,69 @@ class UrlSafetyCheckerTest {
         assertFalse(UrlSafetyChecker.isLocal(java.net.URI.create("http://127.1/"), true));
     }
 
+    // -- isOnion -----------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://expyuzz4wqqyqhjn.onion/",
+            "https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/",
+            "http://example.onion:8080/path?query=1",
+            "https://EXPYUZZ4WQQYQHJN.ONION/",
+            "http://Mixed.OnIoN/",
+            "http://sub.domain.example.onion/",
+    })
+    void isOnionRecognisesOnionHosts(String url) {
+        assertTrue(UrlSafetyChecker.isOnion(UrlSafetyChecker.parseAndValidate(url)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://example.com/",
+            "https://example.org/onion",
+            "http://onion.example.com/",
+            "http://127.0.0.1/",
+            "http://localhost/",
+            "http://[::1]/",
+            "http://192.168.1.1/",
+            "http://example.onion.evil.com/",
+            "http://onion/",
+            "http://onionx/",
+            "http://example.onionx/",
+    })
+    void isOnionRejectsNonOnionHosts(String url) {
+        assertFalse(UrlSafetyChecker.isOnion(UrlSafetyChecker.parseAndValidate(url)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://expyuzz4wqqyqhjn.onion./",
+            "https://example.onion./path",
+            "http://EXAMPLE.ONION./",
+    })
+    void isOnionMatchesTrailingDotFqdn(String url) {
+        // FQDN form (one or more trailing dots) resolves to the same destination.
+        // Must match so a no-proxy clearnet attempt cannot leak the lookup.
+        // Note: consecutive-dot labels (e.g. "host.onion..") are not tested here
+        // because Java's URI parser returns host=null for them, and
+        // parseAndValidate rejects null-host URIs upstream — they never reach
+        // isOnion. The trailing-dot strip in isOnion is still a defence in depth
+        // for the single-dot FQDN case the URI parser does accept.
+        assertTrue(UrlSafetyChecker.isOnion(java.net.URI.create(url)));
+    }
+
+    @Test
+    void isOnionRejectsHostThatEqualsOnion() {
+        // ".onion" alone (no label) is not a valid v2/v3 onion address; URI
+        // parsing rejects an empty label, but bare "onion" must not match.
+        assertFalse(UrlSafetyChecker.isOnion(java.net.URI.create("http://onion/")));
+    }
+
+    @Test
+    void isOnionFalseForUriWithoutHost() {
+        // Defensive: URI with no host (e.g. "http:/foo") — host() returns null.
+        assertFalse(UrlSafetyChecker.isOnion(java.net.URI.create("http:/foo")));
+    }
+
     @Test
     void hostnameNeverTriggersDnsLookup() {
         // Implementation invariant: a non-numeric, non-"localhost" host MUST NOT


### PR DESCRIPTION
Allows safe use of clear net price feed during development

You can add `--allowClearnetHttpRequests=true` to your launch params and price feed will work again in dev env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New runtime option to permit clearnet HTTP fallback when no SOCKS5/Tor proxy is available, with safer routing and explicit IP-leak warnings (esp. on mainnet).
  * Improved HTTP handling to refuse onion targets without a proxy.

* **Tests**
  * Added thorough tests for onion-host detection, including edge cases and format variants.

* **Documentation**
  * Updated developer setup guide with the new HTTP configuration options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7727)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->