### PR TITLE
Re-clamp trade amount against MAX_TRADE_AMOUNT in checkTradeAmount

### DIFF
--- a/core/src/main/java/bisq/core/trade/validation/TradeAmountValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeAmountValidation.java
@@ -17,6 +17,8 @@
 
 package bisq.core.trade.validation;
 
+import bisq.core.payment.TradeLimits;
+
 import org.bitcoinj.core.Coin;
 
 import static bisq.core.util.Validator.checkIsPositive;
@@ -45,6 +47,13 @@ public final class TradeAmountValidation {
         checkArgument(!tradeAmount.isGreaterThan(offerMaxAmount),
                 "Trade amount must not be higher than maximum offer amount. tradeAmount=%s, offerMaxAmount=%s",
                 tradeAmount.toFriendlyString(), offerMaxAmount.toFriendlyString());
+        // Re-clamp against the post-hotfix max trade amount. The 0.125 BTC cap is enforced at
+        // offer creation, but pre-hotfix offers persisted with a larger amount must not be
+        // takeable above the cap. Without this, the legacy offer's offerMaxAmount bound is
+        // the only ceiling.
+        checkArgument(!tradeAmount.isGreaterThan(TradeLimits.MAX_TRADE_AMOUNT),
+                "Trade amount must not exceed the network max trade amount. tradeAmount=%s, max=%s",
+                tradeAmount.toFriendlyString(), TradeLimits.MAX_TRADE_AMOUNT.toFriendlyString());
         return tradeAmount;
     }
 }

--- a/core/src/test/java/bisq/core/trade/validation/TradeAmountValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeAmountValidationTest.java
@@ -17,6 +17,8 @@
 
 package bisq.core.trade.validation;
 
+import bisq.core.payment.TradeLimits;
+
 import org.bitcoinj.core.Coin;
 
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,68 @@ class TradeAmountValidationTest {
 
         assertEquals("Trade amount must not be higher than maximum offer amount. " +
                         "tradeAmount=0.00005001 BTC, offerMaxAmount=0.00005 BTC",
+                exception.getMessage());
+    }
+
+    @Test
+    void checkTradeAmountRejectsAmountsAboveMaxTradeAmount() {
+        // Pre-hotfix offers may persist with offer.getAmount() above MAX_TRADE_AMOUNT.
+        // Re-clamp must reject regardless of offer bounds.
+        Coin overCap = TradeLimits.MAX_TRADE_AMOUNT.add(Coin.valueOf(1));
+        Coin offerMax = overCap.add(Coin.valueOf(1));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> TradeAmountValidation.checkTradeAmount(overCap, OFFER_MIN_AMOUNT, offerMax));
+
+        assertEquals("Trade amount must not exceed the network max trade amount. " +
+                        "tradeAmount=" + overCap.toFriendlyString() +
+                        ", max=" + TradeLimits.MAX_TRADE_AMOUNT.toFriendlyString(),
+                exception.getMessage());
+    }
+
+    @Test
+    void checkTradeAmountAcceptsMaxTradeAmount() {
+        Coin offerMax = TradeLimits.MAX_TRADE_AMOUNT;
+        assertSame(offerMax,
+                TradeAmountValidation.checkTradeAmount(offerMax, OFFER_MIN_AMOUNT, offerMax));
+    }
+
+    @Test
+    void checkTradeAmountAcceptsPartialTakeOfLegacyOverCapOffer() {
+        // Legacy pre-hotfix offer with offer.getAmount() above the cap. Taker requesting
+        // an amount at-or-below the cap must still succeed (partial take of legacy offer).
+        Coin offerMax = TradeLimits.MAX_TRADE_AMOUNT.add(Coin.valueOf(1_000_000));
+        Coin underCap = TradeLimits.MAX_TRADE_AMOUNT.subtract(Coin.valueOf(1));
+
+        assertSame(underCap,
+                TradeAmountValidation.checkTradeAmount(underCap, OFFER_MIN_AMOUNT, offerMax));
+        assertSame(TradeLimits.MAX_TRADE_AMOUNT,
+                TradeAmountValidation.checkTradeAmount(TradeLimits.MAX_TRADE_AMOUNT, OFFER_MIN_AMOUNT, offerMax));
+    }
+
+    @Test
+    void checkTradeAmountRejectsExactlyOneSatoshiAboveMaxTradeAmount() {
+        // Boundary: MAX + 1 sat must be rejected even when offer bounds permit it.
+        Coin overCapByOneSat = TradeLimits.MAX_TRADE_AMOUNT.add(Coin.valueOf(1));
+        Coin offerMax = overCapByOneSat.add(Coin.valueOf(1));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> TradeAmountValidation.checkTradeAmount(overCapByOneSat, OFFER_MIN_AMOUNT, offerMax));
+    }
+
+    @Test
+    void checkTradeAmountChecksOfferMaxBeforeNetworkCap() {
+        // Precedence: when both per-offer max and network cap would reject, the per-offer
+        // message wins (more specific). Guards against future reordering breaking UX.
+        Coin offerMax = TradeLimits.MAX_TRADE_AMOUNT.add(Coin.valueOf(1_000));
+        Coin tradeAmount = offerMax.add(Coin.valueOf(1));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> TradeAmountValidation.checkTradeAmount(tradeAmount, OFFER_MIN_AMOUNT, offerMax));
+
+        assertEquals("Trade amount must not be higher than maximum offer amount. " +
+                        "tradeAmount=" + tradeAmount.toFriendlyString() +
+                        ", offerMaxAmount=" + offerMax.toFriendlyString(),
                 exception.getMessage());
     }
 


### PR DESCRIPTION
The 0.125 BTC cap (TradeLimits.MAX_TRADE_AMOUNT) is enforced at offer creation but not at take-offer. Legacy offers persisted with a larger amount can still be taken at the old size, defeating the cap.

Apply the cap in TradeAmountValidation.checkTradeAmount, which is invoked by both InputsForDepositTxRequestValidation (taker path via TradeManager) and MakerProcessesInputsForDepositTxRequest (maker path), covering both sides of the take-offer flow.


## Cleaner Alternative: Bump trade protocol version to invalidate old offers.

the approach in this PR doesnt seem good to me, but old existing offers would avoid the cap otherwise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced trade amount validation to enforce a network-wide maximum limit, preventing trades from exceeding the established cap. This ensures consistency across all trades, including those from legacy offers with higher individual maximums.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7734)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->