### PR TITLE
follow-up from #7642 sender pub key verification review

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bsq_swap/messages/BsqSwapRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bsq_swap/messages/BsqSwapRequest.java
@@ -30,6 +30,8 @@ import java.security.PublicKey;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 @EqualsAndHashCode(callSuper = true)
 @Getter
 public abstract class BsqSwapRequest extends TradeMessage
@@ -54,7 +56,7 @@ public abstract class BsqSwapRequest extends TradeMessage
                              long tradeDate) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
-        this.takerPubKeyRing = takerPubKeyRing;
+        this.takerPubKeyRing = checkNotNull(takerPubKeyRing, "takerPubKeyRing must not be null");
         this.tradeAmount = tradeAmount;
         this.txFeePerVbyte = txFeePerVbyte;
         this.makerFee = makerFee;
@@ -64,6 +66,6 @@ public abstract class BsqSwapRequest extends TradeMessage
 
     @Override
     public PublicKey getSenderSignaturePubKey() {
-        return takerPubKeyRing != null ? takerPubKeyRing.getSignaturePubKey() : null;
+        return takerPubKeyRing.getSignaturePubKey();
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -550,7 +550,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             }, MoreExecutors.directExecutor());
         } catch (CryptoException e) {
             log.error("Encrypting direct message {} for peer {} failed",
-                    payload.getClass().getSimpleName(), peersNodeAddress);
+                    payload.getClass().getSimpleName(), peersNodeAddress, e);
             sendDirectMessageListener.onFault(e.toString());
         }
     }

--- a/p2p/src/main/java/bisq/network/p2p/SendersNodeAddressProvidingPayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/SendersNodeAddressProvidingPayload.java
@@ -17,14 +17,16 @@
 
 package bisq.network.p2p;
 
+import javax.annotation.Nullable;
+
 /**
  * Interface for payloads that include the sender's node address.
  */
 public interface SendersNodeAddressProvidingPayload {
     NodeAddress getSenderNodeAddress();
 
-    static boolean isSenderNodeAddressMatching(NodeAddress payloadSenderNodeAddress,
-                                               NodeAddress expectedSenderNodeAddress) {
+    static boolean isSenderNodeAddressMatching(@Nullable NodeAddress payloadSenderNodeAddress,
+                                               @Nullable NodeAddress expectedSenderNodeAddress) {
         return payloadSenderNodeAddress != null && payloadSenderNodeAddress.equals(expectedSenderNodeAddress);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/SendersSignaturePubKeyProvidingPayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/SendersSignaturePubKeyProvidingPayload.java
@@ -19,14 +19,16 @@ package bisq.network.p2p;
 
 import java.security.PublicKey;
 
+import javax.annotation.Nullable;
+
 /**
  * Interface for payloads that include the sender's signature public key.
  */
 public interface SendersSignaturePubKeyProvidingPayload {
     PublicKey getSenderSignaturePubKey();
 
-    static boolean isSenderSignaturePubKeyMatching(PublicKey payloadSenderSignaturePubKey,
-                                                   PublicKey expectedSenderSignaturePubKey) {
+    static boolean isSenderSignaturePubKeyMatching(@Nullable PublicKey payloadSenderSignaturePubKey,
+                                                   @Nullable PublicKey expectedSenderSignaturePubKey) {
         return payloadSenderSignaturePubKey != null &&
                 payloadSenderSignaturePubKey.equals(expectedSenderSignaturePubKey);
     }

--- a/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxItem.java
+++ b/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxItem.java
@@ -101,10 +101,8 @@ public class MailboxItem implements PersistablePayload {
                 .getPrefixedSealedAndSignedMessage()
                 .getSenderNodeAddress();
 
-        // MailboxMessage implements SendersNodeAddressProvidingPayload thus the cast is safe
-        SendersNodeAddressProvidingPayload nodeAddressProvidingPayload =
-                (SendersNodeAddressProvidingPayload) decryptedPayload;
-        NodeAddress payloadSenderNodeAddress = nodeAddressProvidingPayload.getSenderNodeAddress();
+        MailboxMessage mailboxMessage = (MailboxMessage) decryptedPayload;
+        NodeAddress payloadSenderNodeAddress = mailboxMessage.getSenderNodeAddress();
         if (!SendersNodeAddressProvidingPayload.isSenderNodeAddressMatching(payloadSenderNodeAddress,
                 senderNodeAddress)) {
             log.error("Decrypted mailbox item sender address mismatch. " +


### PR DESCRIPTION
follow up from #7642

- BsqSwapRequest: checkNotNull(takerPubKeyRing) in constructor; drop defensive null-guard in getSenderSignaturePubKey to match the InputsForDepositTxRequest convention. Asymmetry was the bug, not the absence of null support: PubKeyRing constructors already enforce non-null signaturePubKey, so the guard was unreachable.

- SendersNodeAddressProvidingPayload, SendersSignaturePubKeyProvidingPayload: restore @Nullable on isSender*Matching parameters lost during the rename refactor. Behavior unchanged; static-analysis hint preserved.

- MailboxItem.getValidDecryptedMessageWithPubKey: cast decryptedPayload to MailboxMessage instead of SendersNodeAddressProvidingPayload. Cast safety becomes a compile-time guarantee (MailboxMessage is already verified via instanceof above) rather than relying on the MailboxMessage interface continuing to extend SendersNodeAddressProvidingPayload.

- P2PService.doSendEncryptedDirectMessage: pass CryptoException to log.error so the stack trace is retained on encryption failure. (our sl4j version supports last arg throwable feature)
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in BSQ swap request validation to prevent potential null reference issues.
  * Enhanced validation for mailbox message payload processing.

* **Improvements**
  * Better error logging for peer-to-peer message encryption failures to aid in troubleshooting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7736)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->