### PR TITLE
Unreserve open offer when take-offer request fails

### DIFF
--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -746,6 +746,13 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         requestPersistence();
     }
 
+    public void unreserveOpenOffer(OpenOffer openOffer) {
+        if (openOffer.getState() == OpenOffer.State.RESERVED) {
+            openOffer.setState(OpenOffer.State.AVAILABLE);
+            requestPersistence();
+        }
+    }
+
     public boolean cannotActivateOffer(Offer offer) {
         return openOffers.stream()
                 .filter(openOffer -> !openOffer.getOffer().isBsqSwapOffer())    // We only handle non-BSQ offers

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -368,6 +368,8 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         initTradeAndProtocol(trade, tradeProtocol);
 
         ((MakerProtocol) tradeProtocol).handleTakeOfferRequest(inputsForDepositTxRequest, peer, errorMessage -> {
+            // Free the offer immediately on failure so a retry does not have to wait for the RESERVED timeout.
+            openOfferManager.unreserveOpenOffer(openOffer);
             if (takeOfferRequestErrorMessageHandler != null)
                 takeOfferRequestErrorMessageHandler.handleErrorMessage(errorMessage);
         });


### PR DESCRIPTION
If MakerProcessesInputsForDepositTxRequest (or any subsequent task in MakerProtocol.handleTakeOfferRequest) fails after TradeManager has already called reserveOpenOffer, the offer stayed RESERVED for the full OpenOffer.TIMEOUT (60s) before self-healing.

This window is reachable in practice because TradeManager re-runs the full InputsForDepositTxRequest validation a second time inside the task (intentional defense-in-depth from PR #7644). Block-height advances or price-feed updates between the two validations can flip a request from valid to invalid, leaving the offer stuck.

Add OpenOfferManager.unreserveOpenOffer and call it from the error handler so a retry can proceed immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to unreserve open offers, making them available for trading again.

* **Bug Fixes**
  * Improved offer availability handling when trade requests fail—offers now become available faster without waiting for timeout expiration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7738)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->