### PR TITLE
Tighten visibility and document magic vsize constants in fee validation

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
+++ b/core/src/main/java/bisq/core/btc/wallet/Restrictions.java
@@ -22,8 +22,8 @@ import bisq.common.config.Config;
 import org.bitcoinj.core.Coin;
 
 public class Restrictions {
-    public static final int LOCKTIME_FOR_FIAT = 144 * 20;
-    public static final int LOCKTIME_FOR_ALTCOIN = 144 * 10;
+    private static final int LOCKTIME_FOR_FIAT = 144 * 20;
+    private static final int LOCKTIME_FOR_ALTCOIN = 144 * 10;
 
     private static final Coin MIN_TRADE_AMOUNT = Coin.valueOf(10_000);
     private static final Coin MIN_SECURITY_DEPOSIT = Coin.parseCoin("0.0003");

--- a/core/src/main/java/bisq/core/trade/TradeFeeFactory.java
+++ b/core/src/main/java/bisq/core/trade/TradeFeeFactory.java
@@ -26,7 +26,10 @@ import static bisq.core.util.Validator.checkIsNotNegative;
 import static bisq.core.util.Validator.checkIsPositive;
 
 public class TradeFeeFactory {
-    // Average estimated values
+    // Average estimated vsizes for the standard P2WPKH trade-fee tx (single input + change)
+    // and the 2-of-2 multisig deposit tx. Values must be reviewed if input/output script
+    // types or the number of typical inputs change (e.g. taproot migration, mixed wallet
+    // outputs), since they directly affect getTradeTxFee() and downstream tolerance checks.
     public static final int TAKER_FEE_TX_VSIZE = 192;
     public static final int DEPOSIT_TX_VSIZE = 233;
 


### PR DESCRIPTION
foilow up to #7645

- Restrictions.LOCKTIME_FOR_FIAT/ALTCOIN: demote to private. No external callers; getLockTime(boolean) is the only access path. Prevents future drift between helper and constants.
- TradeFeeFactory.TAKER_FEE_TX_VSIZE / DEPOSIT_TX_VSIZE: add comment explaining derivation (P2WPKH single-input + 2-of-2 multisig) and the conditions under which the values must be revisited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restricted internal constant visibility for improved encapsulation.

* **Documentation**
  * Enhanced code comments for trade fee transaction assumptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7739)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->