### PR TITLE
Restore JFXProgressBarSkin shadow class

### DIFF
--- a/desktop/src/main/java/com/jfoenix/skins/JFXProgressBarSkin.java
+++ b/desktop/src/main/java/com/jfoenix/skins/JFXProgressBarSkin.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.jfoenix.skins;
+
+import com.jfoenix.controls.JFXProgressBar;
+import com.jfoenix.utils.JFXNodeUtils;
+
+import javafx.beans.InvalidationListener;
+
+import javafx.animation.Animation;
+import javafx.animation.Interpolator;
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
+
+import javafx.scene.Node;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.control.skin.ProgressIndicatorSkin;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+
+import com.sun.javafx.scene.NodeHelper;
+
+import javafx.geometry.Insets;
+
+import javafx.util.Duration;
+
+/**
+ * Local compatibility copy of JFoenix' progress-bar skin.
+ * <p>
+ * JFoenix 9.0.10 calls NodeHelper.treeShowingProperty, which was removed after
+ * JavaFX 16. The skin already observes visible, parent, and scene changes, so
+ * those listeners are enough to keep the animation state in sync on JavaFX 21.
+ */
+public class JFXProgressBarSkin extends ProgressIndicatorSkin {
+
+    private StackPane track;
+    private StackPane secondaryBar;
+    private StackPane bar;
+    private double barWidth = 0;
+    private double secondaryBarWidth = 0;
+    private Animation indeterminateTransition;
+    private Region clip;
+    private boolean wasIndeterminate = false;
+    private final InvalidationListener widthListener = observable -> {
+        updateProgress();
+        updateSecondaryProgress();
+    };
+
+    public JFXProgressBarSkin(JFXProgressBar bar) {
+        super(bar);
+        bar.widthProperty().addListener(widthListener);
+
+        registerChangeListener(bar.progressProperty(), obs -> updateProgress());
+        registerChangeListener(bar.secondaryProgressProperty(), obs -> updateSecondaryProgress());
+        registerChangeListener(bar.visibleProperty(), obs -> updateAnimation());
+        registerChangeListener(bar.parentProperty(), obs -> updateAnimation());
+        registerChangeListener(bar.sceneProperty(), obs -> updateAnimation());
+        registerChangeListener(bar.indeterminateProperty(), obs -> initialize());
+
+        initialize();
+
+        getSkinnable().requestLayout();
+    }
+
+    protected void initialize() {
+        track = new StackPane();
+        track.getStyleClass().setAll("track");
+
+        bar = new StackPane();
+        bar.getStyleClass().setAll("bar");
+
+        secondaryBar = new StackPane();
+        secondaryBar.getStyleClass().setAll("secondary-bar");
+
+        clip = new Region();
+        clip.setBackground(new Background(new BackgroundFill(Color.BLACK, CornerRadii.EMPTY, Insets.EMPTY)));
+        bar.backgroundProperty().addListener(observable -> JFXNodeUtils.updateBackground(bar.getBackground(), clip));
+
+        getChildren().setAll(track, secondaryBar, bar);
+    }
+
+    @Override
+    public double computeBaselineOffset(double topInset, double rightInset, double bottomInset, double leftInset) {
+        return Node.BASELINE_OFFSET_SAME_AS_HEIGHT;
+    }
+
+    @Override
+    protected double computePrefWidth(double height,
+                                      double topInset,
+                                      double rightInset,
+                                      double bottomInset,
+                                      double leftInset) {
+        return Math.max(100, leftInset + bar.prefWidth(getSkinnable().getWidth()) + rightInset);
+    }
+
+    @Override
+    protected double computePrefHeight(double width,
+                                       double topInset,
+                                       double rightInset,
+                                       double bottomInset,
+                                       double leftInset) {
+        return topInset + bar.prefHeight(width) + bottomInset;
+    }
+
+    @Override
+    protected double computeMaxWidth(double height,
+                                     double topInset,
+                                     double rightInset,
+                                     double bottomInset,
+                                     double leftInset) {
+        return getSkinnable().prefWidth(height);
+    }
+
+    @Override
+    protected double computeMaxHeight(double width,
+                                      double topInset,
+                                      double rightInset,
+                                      double bottomInset,
+                                      double leftInset) {
+        return getSkinnable().prefHeight(width);
+    }
+
+    @Override
+    protected void layoutChildren(double x, double y, double w, double h) {
+        track.resizeRelocate(x, y, w, h);
+        secondaryBar.resizeRelocate(x, y, secondaryBarWidth, h);
+        bar.resizeRelocate(x, y, getSkinnable().isIndeterminate() ? w : barWidth, h);
+        clip.resizeRelocate(0, 0, w, h);
+
+        if (getSkinnable().isIndeterminate()) {
+            createIndeterminateTimeline();
+            if (NodeHelper.isTreeShowing(getSkinnable())) {
+                indeterminateTransition.play();
+            }
+            bar.setClip(clip);
+        } else if (indeterminateTransition != null) {
+            clearAnimation();
+            bar.setClip(null);
+        }
+    }
+
+    protected void updateSecondaryProgress() {
+        final JFXProgressBar control = (JFXProgressBar) getSkinnable();
+        secondaryBarWidth = ((int) (control.getWidth() - snappedLeftInset() - snappedRightInset()) * 2
+                * Math.min(1, Math.max(0, control.getSecondaryProgress()))) / 2.0F;
+        control.requestLayout();
+    }
+
+    protected void pauseTimeline(boolean pause) {
+        if (getSkinnable().isIndeterminate()) {
+            if (indeterminateTransition == null) {
+                createIndeterminateTimeline();
+            }
+            if (pause) {
+                indeterminateTransition.pause();
+            } else {
+                indeterminateTransition.play();
+            }
+        }
+    }
+
+    private void updateAnimation() {
+        ProgressIndicator control = getSkinnable();
+        final boolean isTreeVisible = control.isVisible() &&
+                control.getParent() != null &&
+                control.getScene() != null;
+        if (indeterminateTransition != null) {
+            pauseTimeline(!isTreeVisible);
+        } else if (isTreeVisible) {
+            createIndeterminateTimeline();
+        }
+    }
+
+    private void updateProgress() {
+        final ProgressIndicator control = getSkinnable();
+        final boolean isIndeterminate = control.isIndeterminate();
+        if (!(isIndeterminate && wasIndeterminate)) {
+            barWidth = ((int) (control.getWidth() - snappedLeftInset() - snappedRightInset()) * 2
+                    * Math.min(1, Math.max(0, control.getProgress()))) / 2.0F;
+            control.requestLayout();
+        }
+        wasIndeterminate = isIndeterminate;
+    }
+
+    private void createIndeterminateTimeline() {
+        if (indeterminateTransition != null) {
+            clearAnimation();
+        }
+        double dur = 1;
+        ProgressIndicator control = getSkinnable();
+        final double w = control.getWidth() - (snappedLeftInset() + snappedRightInset());
+        indeterminateTransition = new Timeline(new KeyFrame(
+                Duration.ZERO,
+                new KeyValue(clip.scaleXProperty(), 0.0, Interpolator.EASE_IN),
+                new KeyValue(clip.translateXProperty(), -w / 2, Interpolator.LINEAR)
+        ),
+                new KeyFrame(
+                        Duration.seconds(0.5 * dur),
+                        new KeyValue(clip.scaleXProperty(), 0.4, Interpolator.LINEAR)
+                ),
+                new KeyFrame(
+                        Duration.seconds(0.9 * dur),
+                        new KeyValue(clip.translateXProperty(), w / 2, Interpolator.LINEAR)
+                ),
+                new KeyFrame(
+                        Duration.seconds(1 * dur),
+                        new KeyValue(clip.scaleXProperty(), 0.0, Interpolator.EASE_OUT)
+                ));
+        indeterminateTransition.setCycleCount(Timeline.INDEFINITE);
+    }
+
+    private void clearAnimation() {
+        indeterminateTransition.stop();
+        ((Timeline) indeterminateTransition).getKeyFrames().clear();
+        indeterminateTransition = null;
+    }
+
+    @Override
+    public void dispose() {
+        JFXProgressBar bar = (JFXProgressBar) getSkinnable();
+        if (bar != null) {
+            bar.widthProperty().removeListener(widthListener);
+        }
+
+        super.dispose();
+
+        if (indeterminateTransition != null) {
+            clearAnimation();
+        }
+    }
+}


### PR DESCRIPTION
Restore the file from a16fdc4735

without this the app crashes on launch as it's where the first progress bar is used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new progress bar skin with layered visuals, supporting determinate progress and an indeterminate animated mode with masked animation.
* **Performance / Stability**
  * Animations now start only when the control is visible and stop/cleanup when not shown; improved layout, sizing and disposal behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7741)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->