### PR TITLE
Reject legacy UTXOs at deposit funding to prevent mid-trade abort

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TradeWalletService.java
@@ -362,6 +362,7 @@ public class TradeWalletService {
                 "Reserve amount does not equal input amount");
         dummyTX.addInput(reservedForTradeOutput);
 
+        WalletService.assertAllInputsSpendP2WPKH(dummyTX);
         WalletService.verifyTransaction(dummyTX);
 
         //WalletService.printTx("dummyTX", dummyTX);
@@ -447,6 +448,7 @@ public class TradeWalletService {
         TransactionOutput dummyOutput = new TransactionOutput(params, dummyTx, makerInputAmount, SegwitAddress.fromKey(params, new ECKey()));
         dummyTx.addOutput(dummyOutput);
         addAvailableInputsAndChangeOutputs(dummyTx, makerAddress, makerChangeAddress);
+        WalletService.assertAllInputsSpendP2WPKH(dummyTx);
         // Normally we have only 1 input but we support multiple inputs if the user has paid in with several transactions.
         List<TransactionInput> makerInputs = dummyTx.getInputs();
         TransactionOutput makerOutput = null;

--- a/core/src/main/java/bisq/core/btc/wallet/WalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/WalletService.java
@@ -260,6 +260,24 @@ public abstract class WalletService {
         }
     }
 
+    // Bisq deposit-tx flows witness-strip but not scriptSig-strip on the buyer side
+    // before peer validation. Legacy P2PK/P2PKH inputs leave scriptSig populated
+    // after witness-strip, which the peer's checkTransactionIsUnsigned rejects.
+    // Fail early at the local funding step instead of mid-trade with the peer.
+    public static void assertAllInputsSpendP2WPKH(Transaction transaction) {
+        for (TransactionInput input : transaction.getInputs()) {
+            TransactionOutput connectedOutput = input.getConnectedOutput();
+            checkNotNull(connectedOutput, "connectedOutput must not be null for input %s", input);
+            Script scriptPubKey = connectedOutput.getScriptPubKey();
+            if (!ScriptPattern.isP2WPKH(scriptPubKey)) {
+                throw new IllegalStateException(
+                        "Your wallet contains a non-SegWit (legacy) UTXO that cannot be used for trading. " +
+                                "Please consolidate your funds to a SegWit (bech32, bc1...) address before " +
+                                "creating or taking offers. Offending input scriptPubKey: " + scriptPubKey);
+            }
+        }
+    }
+
     public static void checkAllScriptSignaturesForTx(Transaction transaction) throws TransactionVerificationException {
         for (int i = 0; i < transaction.getInputs().size(); i++) {
             WalletService.checkScriptSig(transaction, transaction.getInputs().get(i), i);

--- a/core/src/main/java/bisq/core/trade/validation/TransactionValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TransactionValidation.java
@@ -134,6 +134,10 @@ public final class TransactionValidation {
     // Bitcoin signature
     /* --------------------------------------------------------------------- */
 
+    // Expects raw DER-encoded ECDSA signature without a trailing sighash byte
+    // (e.g. the output of ECKey.ECDSASignature.encodeToDER()). Signatures extracted
+    // from a scriptSig or witness stack include a sighash byte and must have it
+    // stripped before being passed here.
     public static byte[] checkDerEncodedEcdsaSignature(byte[] bitcoinSignature) {
         toVerifiedDerEncodedEcdsaSignature(bitcoinSignature);
         return bitcoinSignature;

--- a/core/src/test/java/bisq/core/trade/validation/DepositTxValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/DepositTxValidationTest.java
@@ -568,6 +568,17 @@ class DepositTxValidationTest {
                 btcWalletService()));
     }
 
+    // Regression: buyer-as-taker funded from a legacy P2PKH UTXO signs the input,
+    // then bitcoinSerialize(false) strips witness but the scriptSig remains.
+    // Validator rejects → trade aborts mid-protocol. The wallet must gate this
+    // earlier; this test pins current validator behavior.
+    @Test
+    void checkTransactionIsUnsignedRejectsLegacyP2pkhSignedInputAfterWitnessStrip() {
+        assertThrows(IllegalArgumentException.class, () -> DepositTxValidation.checkTransactionIsUnsigned(
+                ValidationTestUtils.serializedTransactionWithLegacyP2pkhSignedInputAfterWitnessStrip(),
+                btcWalletService()));
+    }
+
     @Test
     void checkTransactionIsUnsignedRejectsNullTransaction() {
         assertThrows(NullPointerException.class, () -> DepositTxValidation.checkTransactionIsUnsigned(null,

--- a/core/src/test/java/bisq/core/trade/validation/TransactionValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TransactionValidationTest.java
@@ -152,6 +152,13 @@ class TransactionValidationTest {
     }
 
     @Test
+    void toVerifiedTransactionRejectsTransactionWithDuplicateOutpoints() {
+        assertThrows(IllegalArgumentException.class, () -> TransactionValidation.toVerifiedTransaction(
+                ValidationTestUtils.serializedTransactionWithDuplicateOutpoints(),
+                btcWalletService()));
+    }
+
+    @Test
     void toVerifiedTransactionRejectsNullSerializedTransaction() {
         assertThrows(NullPointerException.class, () -> TransactionValidation.toVerifiedTransaction(null,
                 btcWalletService()));

--- a/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
+++ b/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
@@ -49,6 +49,7 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionWitness;
+import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.script.ScriptBuilder;
 
@@ -180,6 +181,19 @@ class ValidationTestUtils {
         return transaction.bitcoinSerialize();
     }
 
+    // Mimics buyer-as-taker path when a legacy P2PKH UTXO is signed:
+    // wallet sets a real DER sig + pubkey push in scriptSig, then
+    // bitcoinSerialize(false) strips witness but keeps scriptSig.
+    static byte[] serializedTransactionWithLegacyP2pkhSignedInputAfterWitnessStrip() {
+        ECKey key = new ECKey();
+        byte[] dummyHash = new byte[32];
+        ECKey.ECDSASignature sig = key.sign(Sha256Hash.wrap(dummyHash));
+        TransactionSignature txSig = new TransactionSignature(
+                sig, Transaction.SigHash.ALL, false);
+        byte[] scriptSigProgram = ScriptBuilder.createInputScript(txSig, key).getProgram();
+        return transaction(scriptSigProgram).bitcoinSerialize(false);
+    }
+
     static Transaction transaction(byte[] scriptSigProgram) {
         Transaction transaction = new Transaction(MainNetParams.get());
         transaction.addInput(new TransactionInput(MainNetParams.get(),
@@ -189,6 +203,17 @@ class ValidationTestUtils {
                 Coin.valueOf(2_000)));
         transaction.addOutput(Coin.valueOf(1_000), ScriptBuilder.createP2WPKHOutputScript(new ECKey()));
         return transaction;
+    }
+
+    static byte[] serializedTransactionWithDuplicateOutpoints() {
+        Transaction transaction = new Transaction(MainNetParams.get());
+        TransactionOutPoint outPoint = new TransactionOutPoint(MainNetParams.get(), 0, Sha256Hash.ZERO_HASH);
+        transaction.addInput(new TransactionInput(MainNetParams.get(),
+                transaction, new byte[]{}, outPoint, Coin.valueOf(2_000)));
+        transaction.addInput(new TransactionInput(MainNetParams.get(),
+                transaction, new byte[]{}, outPoint, Coin.valueOf(2_000)));
+        transaction.addOutput(Coin.valueOf(1_000), ScriptBuilder.createP2WPKHOutputScript(new ECKey()));
+        return transaction.bitcoinSerialize();
     }
 
     static Transaction transactionWithoutOutputs() {


### PR DESCRIPTION
issues discovered during review of #7655 (not directly related)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented additional validation to ensure deposit transactions use native SegWit addresses only. Users with legacy address types will receive guidance to consolidate funds before trading.

* **Tests**
  * Added regression and unit tests covering transaction validation edge cases.

* **Documentation**
  * Clarified signature validation requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7743)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->