### PR TITLE
Follow-up from #7665 payment account hash review

### DIFF
--- a/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
@@ -163,7 +163,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
         return null;
     }
 
-    public byte[] getHashForContract() {
+    public final byte[] getHashForContract() {
         return Hash.getRipemd160hash(serializeForHash());
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessShareBuyerPaymentAccountMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerProcessShareBuyerPaymentAccountMessage.java
@@ -73,13 +73,15 @@ public class SellerProcessShareBuyerPaymentAccountMessage extends TradeTask {
             PaymentAccountPayload myPaymentAccountPayload = checkNotNull(processModel.getPaymentAccountPayload(trade),
                     "Payment account payload cannot be null for trade: " + trade.getId());
 
-            PaymentAccountPayload peersPaymentAccountPayload = message.getBuyerPaymentAccountPayload();
+            PaymentAccountPayload peersPaymentAccountPayload = checkNotNull(message.getBuyerPaymentAccountPayload(),
+                    "buyerPaymentAccountPayload must not be null for trade: " + trade.getId());
             byte[] peersHashFromAccountPayload = peersPaymentAccountPayload.getHashForContract();
             byte[] peersCommittedHashFromContract = contract.getHashOfPeersPaymentAccountPayload(myPubKeyRing);
 
             // Check if the hash of the provided payment account payload matches the hash from the contract
             // which the peer committed in early stages of the trade protocol.
-            checkHashFromContract(peersHashFromAccountPayload, peersCommittedHashFromContract);
+            checkHashFromContract(peersHashFromAccountPayload, peersCommittedHashFromContract,
+                    "peersPaymentAccountPayloadHash");
 
             processModel.getTradePeer().setPaymentAccountPayload(peersPaymentAccountPayload);
 

--- a/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeValidation.java
@@ -87,12 +87,12 @@ public final class TradeValidation {
     // Contract hash
     /* --------------------------------------------------------------------- */
 
-    public static byte[] checkHashFromContract(byte[] current, byte[] expected) {
-        checkNonEmptyBytes(current, "current");
-        checkNonEmptyBytes(expected, "expected");
+    public static byte[] checkHashFromContract(byte[] current, byte[] expected, String label) {
+        checkNonEmptyBytes(current, label + " (current)");
+        checkNonEmptyBytes(expected, label + " (expected)");
         checkArgument(Arrays.equals(current, expected),
-                "current is not matching expected. " +
-                        "current=%s, expected=%s",
+                "%s mismatch. current=%s, expected=%s",
+                label,
                 Utilities.toTruncatedString(Hex.encode(current), 8),
                 Utilities.toTruncatedString(Hex.encode(expected), 8));
         return current;

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/messages/BisqV1MessageIntegrityTest.java
@@ -392,14 +392,6 @@ public class BisqV1MessageIntegrityTest {
                 args.supportedBurningManAddressListVersions);
     }
 
-    private static protobuf.RefreshTradeStateRequest refreshTradeStateRequest(String tradeId, String uid) {
-        return protobuf.RefreshTradeStateRequest.newBuilder()
-                .setTradeId(tradeId)
-                .setUid(uid)
-                .setSenderNodeAddress(NODE_ADDRESS.toProtoMessage())
-                .build();
-    }
-
     private static SignedWitness signedWitness() {
         return new SignedWitness(SignedWitness.VerificationMethod.TRADE,
                 bytes(12),

--- a/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeValidationTest.java
@@ -118,27 +118,27 @@ class TradeValidationTest {
     void checkHashFromContractAcceptsMatchingByteArrays() {
         byte[] current = new byte[]{1, 2, 3};
 
-        assertSame(current, TradeValidation.checkHashFromContract(current, new byte[]{1, 2, 3}));
+        assertSame(current, TradeValidation.checkHashFromContract(current, new byte[]{1, 2, 3}, "testHash"));
     }
 
     @Test
     void checkHashFromContractRejectsMismatchingByteArrays() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> TradeValidation.checkHashFromContract(new byte[]{1, 2, 3}, new byte[]{1, 2, 4}));
+                () -> TradeValidation.checkHashFromContract(new byte[]{1, 2, 3}, new byte[]{1, 2, 4}, "testHash"));
 
-        assertEquals("current is not matching expected. current=010203, expected=010204", exception.getMessage());
+        assertEquals("testHash mismatch. current=010203, expected=010204", exception.getMessage());
     }
 
     @Test
     void checkHashFromContractRejectsNullAndEmptyByteArrays() {
         assertThrows(NullPointerException.class,
-                () -> TradeValidation.checkHashFromContract(null, new byte[]{1}));
+                () -> TradeValidation.checkHashFromContract(null, new byte[]{1}, "testHash"));
         assertThrows(NullPointerException.class,
-                () -> TradeValidation.checkHashFromContract(new byte[]{1}, null));
+                () -> TradeValidation.checkHashFromContract(new byte[]{1}, null, "testHash"));
         assertThrows(IllegalArgumentException.class,
-                () -> TradeValidation.checkHashFromContract(new byte[0], new byte[]{1}));
+                () -> TradeValidation.checkHashFromContract(new byte[0], new byte[]{1}, "testHash"));
         assertThrows(IllegalArgumentException.class,
-                () -> TradeValidation.checkHashFromContract(new byte[]{1}, new byte[0]));
+                () -> TradeValidation.checkHashFromContract(new byte[]{1}, new byte[0], "testHash"));
     }
 
     /* --------------------------------------------------------------------- */


### PR DESCRIPTION
nits from reviewing #7665 

- Make PaymentAccountPayload#getHashForContract final to prevent subclass override forking the contract hash
- Null-check peer payload in SellerProcessShareBuyerPaymentAccountMessage before computing its hash, replacing implicit NPE with explicit precondition message.
- Add label parameter to TradeValidation#checkHashFromContract so failure messages identify which hash mismatched.
- Remove dead refreshTradeStateRequest test helper left over after the RefreshTradeStateRequest class removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of payment account information during trade processing with more explicit error reporting.
  * Improved hash verification error messages to include contextual labels and truncated values for easier debugging.

* **Refactor**
  * Strengthened integrity controls to prevent accidental modification of critical hash computation logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7744)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->