### PR TITLE
Drop asymmetric return values from mediated payout validation

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/mediation/FinalizeMediatedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/mediation/FinalizeMediatedPayoutTx.java
@@ -73,16 +73,14 @@ public class FinalizeMediatedPayoutTx extends TradeTask {
             Coin totalPayoutAmount = offer.getBuyerSecurityDeposit().add(tradeAmount).add(offer.getSellerSecurityDeposit());
             Coin buyerPayoutAmount = Coin.valueOf(processModel.getBuyerPayoutAmountFromMediation());
             Coin sellerPayoutAmount = Coin.valueOf(processModel.getSellerPayoutAmountFromMediation());
-            Coin validatedBuyerPayoutAmount = checkMediatedPayoutAmounts(buyerPayoutAmount,
-                    sellerPayoutAmount,
-                    totalPayoutAmount);
+            checkMediatedPayoutAmounts(buyerPayoutAmount, sellerPayoutAmount, totalPayoutAmount);
 
             String myPayoutAddressString = walletService.getOrCreateAddressEntry(tradeId, AddressEntry.Context.TRADE_PAYOUT).getAddressString();
             String peersPayoutAddressString = tradingPeer.getPayoutAddressString();
             String buyerPayoutAddressString = isMyRoleBuyer ? myPayoutAddressString : peersPayoutAddressString;
             String sellerPayoutAddressString = isMyRoleBuyer ? peersPayoutAddressString : myPayoutAddressString;
-            String validatedBuyerPayoutAddressString = checkMediatedPayoutAddresses(buyerPayoutAddressString,
-                    validatedBuyerPayoutAmount,
+            checkMediatedPayoutAddresses(buyerPayoutAddressString,
+                    buyerPayoutAmount,
                     sellerPayoutAddressString,
                     sellerPayoutAmount,
                     walletService);
@@ -105,9 +103,9 @@ public class FinalizeMediatedPayoutTx extends TradeTask {
                     depositTx,
                     buyerSignature,
                     sellerSignature,
-                    validatedBuyerPayoutAmount,
+                    buyerPayoutAmount,
                     sellerPayoutAmount,
-                    validatedBuyerPayoutAddressString,
+                    buyerPayoutAddressString,
                     sellerPayoutAddressString,
                     multiSigKeyPair,
                     buyerMultiSigPubKey,
@@ -116,9 +114,9 @@ public class FinalizeMediatedPayoutTx extends TradeTask {
 
             Transaction validatedTransaction = checkMediatedPayoutTx(transaction,
                     depositTx,
-                    validatedBuyerPayoutAmount,
+                    buyerPayoutAmount,
                     sellerPayoutAmount,
-                    validatedBuyerPayoutAddressString,
+                    buyerPayoutAddressString,
                     sellerPayoutAddressString,
                     walletService);
             trade.setPayoutTx(validatedTransaction);

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/mediation/SignMediatedPayoutTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/mediation/SignMediatedPayoutTx.java
@@ -68,9 +68,7 @@ public class SignMediatedPayoutTx extends TradeTask {
             Coin buyerPayoutAmount = Coin.valueOf(processModel.getBuyerPayoutAmountFromMediation());
             Coin sellerPayoutAmount = Coin.valueOf(processModel.getSellerPayoutAmountFromMediation());
 
-            Coin validatedBuyerPayoutAmount = checkMediatedPayoutAmounts(buyerPayoutAmount,
-                    sellerPayoutAmount,
-                    totalPayoutAmount);
+            checkMediatedPayoutAmounts(buyerPayoutAmount, sellerPayoutAmount, totalPayoutAmount);
 
             boolean isMyRoleBuyer = contract.isMyRoleBuyer(processModel.getPubKeyRing());
 
@@ -78,8 +76,8 @@ public class SignMediatedPayoutTx extends TradeTask {
             String peersPayoutAddressString = tradingPeer.getPayoutAddressString();
             String buyerPayoutAddressString = isMyRoleBuyer ? myPayoutAddressString : peersPayoutAddressString;
             String sellerPayoutAddressString = isMyRoleBuyer ? peersPayoutAddressString : myPayoutAddressString;
-            String validatedBuyerPayoutAddressString = checkMediatedPayoutAddresses(buyerPayoutAddressString,
-                    validatedBuyerPayoutAmount,
+            checkMediatedPayoutAddresses(buyerPayoutAddressString,
+                    buyerPayoutAmount,
                     sellerPayoutAddressString,
                     sellerPayoutAmount,
                     walletService);
@@ -100,9 +98,9 @@ public class SignMediatedPayoutTx extends TradeTask {
 
             byte[] mediatedPayoutTxSignature = processModel.getTradeWalletService().signMediatedPayoutTx(
                     depositTx,
-                    validatedBuyerPayoutAmount,
+                    buyerPayoutAmount,
                     sellerPayoutAmount,
-                    validatedBuyerPayoutAddressString,
+                    buyerPayoutAddressString,
                     sellerPayoutAddressString,
                     myMultiSigKeyPair,
                     buyerMultiSigPubKey,

--- a/core/src/main/java/bisq/core/trade/validation/MediatedPayoutTxValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/MediatedPayoutTxValidation.java
@@ -48,7 +48,7 @@ public final class MediatedPayoutTxValidation {
     // Mediated payout amounts
     /* --------------------------------------------------------------------- */
 
-    public static Coin checkMediatedPayoutAmounts(Coin buyerPayoutAmount,
+    public static void checkMediatedPayoutAmounts(Coin buyerPayoutAmount,
                                                   Coin sellerPayoutAmount,
                                                   Coin expectedTotalPayoutAmount) {
         Coin checkedBuyerPayoutAmount = checkIsNotNegative(buyerPayoutAmount, "buyerPayoutAmount");
@@ -61,7 +61,6 @@ public final class MediatedPayoutTxValidation {
                 checkedBuyerPayoutAmount.toFriendlyString(),
                 checkedSellerPayoutAmount.toFriendlyString(),
                 checkedExpectedTotalPayoutAmount.toFriendlyString());
-        return checkedBuyerPayoutAmount;
     }
 
 
@@ -69,11 +68,11 @@ public final class MediatedPayoutTxValidation {
     // Mediated payout addresses
     /* --------------------------------------------------------------------- */
 
-    public static String checkMediatedPayoutAddresses(String buyerPayoutAddressString,
-                                                      Coin buyerPayoutAmount,
-                                                      String sellerPayoutAddressString,
-                                                      Coin sellerPayoutAmount,
-                                                      BtcWalletService btcWalletService) {
+    public static void checkMediatedPayoutAddresses(String buyerPayoutAddressString,
+                                                    Coin buyerPayoutAmount,
+                                                    String sellerPayoutAddressString,
+                                                    Coin sellerPayoutAmount,
+                                                    BtcWalletService btcWalletService) {
         String checkedBuyerPayoutAddressString = checkNonBlankString(buyerPayoutAddressString, "buyerPayoutAddressString");
         Coin checkedBuyerPayoutAmount = checkIsNotNegative(buyerPayoutAmount, "buyerPayoutAmount");
         String checkedSellerPayoutAddressString = checkNonBlankString(sellerPayoutAddressString, "sellerPayoutAddressString");
@@ -86,7 +85,6 @@ public final class MediatedPayoutTxValidation {
         if (checkedSellerPayoutAmount.isPositive()) {
             checkBitcoinAddress(checkedSellerPayoutAddressString, btcWalletService);
         }
-        return checkedBuyerPayoutAddressString;
     }
 
 
@@ -110,9 +108,7 @@ public final class MediatedPayoutTxValidation {
         Coin buyerPayoutAmount = Coin.valueOf(processModel.getBuyerPayoutAmountFromMediation());
         Coin sellerPayoutAmount = Coin.valueOf(processModel.getSellerPayoutAmountFromMediation());
         Coin expectedTotalPayoutAmount = getExpectedTotalPayoutAmount(trade);
-        Coin validatedBuyerPayoutAmount = checkMediatedPayoutAmounts(buyerPayoutAmount,
-                sellerPayoutAmount,
-                expectedTotalPayoutAmount);
+        checkMediatedPayoutAmounts(buyerPayoutAmount, sellerPayoutAmount, expectedTotalPayoutAmount);
 
         boolean isMyRoleBuyer = contract.isMyRoleBuyer(processModel.getPubKeyRing());
         String myPayoutAddressString = btcWalletService.getOrCreateAddressEntry(trade.getId(),
@@ -120,17 +116,17 @@ public final class MediatedPayoutTxValidation {
         String peersPayoutAddressString = tradingPeer.getPayoutAddressString();
         String buyerPayoutAddressString = isMyRoleBuyer ? myPayoutAddressString : peersPayoutAddressString;
         String sellerPayoutAddressString = isMyRoleBuyer ? peersPayoutAddressString : myPayoutAddressString;
-        String validatedBuyerPayoutAddressString = checkMediatedPayoutAddresses(buyerPayoutAddressString,
-                validatedBuyerPayoutAmount,
+        checkMediatedPayoutAddresses(buyerPayoutAddressString,
+                buyerPayoutAmount,
                 sellerPayoutAddressString,
                 sellerPayoutAmount,
                 btcWalletService);
 
         return checkMediatedPayoutTx(payoutTx,
                 depositTx,
-                validatedBuyerPayoutAmount,
+                buyerPayoutAmount,
                 sellerPayoutAmount,
-                validatedBuyerPayoutAddressString,
+                buyerPayoutAddressString,
                 sellerPayoutAddressString,
                 params);
     }
@@ -206,9 +202,7 @@ public final class MediatedPayoutTxValidation {
         Coin buyerPayoutAmount = Coin.valueOf(processModel.getBuyerPayoutAmountFromMediation());
         Coin sellerPayoutAmount = Coin.valueOf(processModel.getSellerPayoutAmountFromMediation());
         Coin expectedTotalPayoutAmount = getExpectedTotalPayoutAmount(trade);
-        Coin validatedBuyerPayoutAmount = checkMediatedPayoutAmounts(buyerPayoutAmount,
-                sellerPayoutAmount,
-                expectedTotalPayoutAmount);
+        checkMediatedPayoutAmounts(buyerPayoutAmount, sellerPayoutAmount, expectedTotalPayoutAmount);
 
         boolean isMyRoleBuyer = contract.isMyRoleBuyer(processModel.getPubKeyRing());
         String myPayoutAddressString = btcWalletService.getOrCreateAddressEntry(trade.getId(),
@@ -216,8 +210,8 @@ public final class MediatedPayoutTxValidation {
         String peersPayoutAddressString = tradingPeer.getPayoutAddressString();
         String buyerPayoutAddressString = isMyRoleBuyer ? myPayoutAddressString : peersPayoutAddressString;
         String sellerPayoutAddressString = isMyRoleBuyer ? peersPayoutAddressString : myPayoutAddressString;
-        String validatedBuyerPayoutAddressString = checkMediatedPayoutAddresses(buyerPayoutAddressString,
-                validatedBuyerPayoutAmount,
+        checkMediatedPayoutAddresses(buyerPayoutAddressString,
+                buyerPayoutAmount,
                 sellerPayoutAddressString,
                 sellerPayoutAmount,
                 btcWalletService);
@@ -230,9 +224,9 @@ public final class MediatedPayoutTxValidation {
         return PayoutTxValidation.checkPayoutTxSignature(txSignature,
                 btcWalletService,
                 depositTx,
-                validatedBuyerPayoutAmount,
+                buyerPayoutAmount,
                 sellerPayoutAmount,
-                validatedBuyerPayoutAddressString,
+                buyerPayoutAddressString,
                 sellerPayoutAddressString,
                 peersMultiSigPubKey,
                 buyerMultiSigPubKey,

--- a/core/src/test/java/bisq/core/trade/validation/MediatedPayoutTxValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/MediatedPayoutTxValidationTest.java
@@ -46,14 +46,10 @@ class MediatedPayoutTxValidationTest {
     /* --------------------------------------------------------------------- */
 
     @Test
-    void checkMediatedPayoutAmountsAcceptsMediationResultTotalAndReturnsBuyerAmount() {
-        Coin buyerPayoutAmount = Coin.valueOf(6_000);
-        Coin sellerPayoutAmount = Coin.valueOf(4_000);
-
-        assertEquals(buyerPayoutAmount,
-                checkMediatedPayoutAmounts(buyerPayoutAmount,
-                        sellerPayoutAmount,
-                        Coin.valueOf(10_000)));
+    void checkMediatedPayoutAmountsAcceptsMediationResultTotal() {
+        checkMediatedPayoutAmounts(Coin.valueOf(6_000),
+                Coin.valueOf(4_000),
+                Coin.valueOf(10_000));
     }
 
     @Test
@@ -70,12 +66,11 @@ class MediatedPayoutTxValidationTest {
 
     @Test
     void checkMediatedPayoutAddressesAcceptsValidAddressesForPositiveAmounts() {
-        assertEquals(BUYER_ADDRESS,
-                checkMediatedPayoutAddresses(BUYER_ADDRESS,
-                        Coin.valueOf(6_000),
-                        SELLER_ADDRESS,
-                        Coin.valueOf(4_000),
-                        ValidationTestUtils.btcWalletService()));
+        checkMediatedPayoutAddresses(BUYER_ADDRESS,
+                Coin.valueOf(6_000),
+                SELLER_ADDRESS,
+                Coin.valueOf(4_000),
+                ValidationTestUtils.btcWalletService());
     }
 
     @Test


### PR DESCRIPTION
follow up from review of #7671

## Why
  
  `MediatedPayoutTxValidation.checkMediatedPayoutAmounts` and `checkMediatedPayoutAddresses` validate the buyer and seller sides of a mediated payout together (amount totals, address validity), then return only the buyer's value:
```java
  Coin validatedBuyerPayoutAmount = checkMediatedPayoutAmounts(buyerPayoutAmount, sellerPayoutAmount, totalPayoutAmount);
  String validatedBuyerPayoutAddressString = checkMediatedPayoutAddresses(buyerPayoutAddressString, ...,
  sellerPayoutAddressString, ...);
```

  Callers (`SignMediatedPayoutTx`, `FinalizeMediatedPayoutTx`, and both internal paths in `MediatedPayoutTxValidation` itself) then  `validatedBuyer`... downstream while the seller value continues as the raw input. The naming suggests buyer received extra  that seller did not — but the helpers either throw or return the input unchanged, so the wrapped and raw values are by construction. The asymmetric return is purely cosmetic, and the naming actively misleads.

  Concrete risks of leaving it as-is:

  1. A future reader thinks the seller side is under-validated and adds a redundant check, or worse, adds the "missing" coercion  to only one helper and forgets the other — entrenching the asymmetry.
  2. If the helpers ever start normalizing inputs (e.g. trimming whitespace, canonicalizing addresses), the buyer side would
  silently diverge from the seller side because only the buyer's normalized form is returned. The current asymmetric signature is  a foot-gun for that future change.

##  What

  - checkMediatedPayoutAmounts → void
  - checkMediatedPayoutAddresses → void
  - All four call sites updated to use the original local variables instead of validatedBuyer...
  - One test (`checkMediatedPayoutAmountsAcceptsMediationResultTotalAndReturnsBuyerAmount` →
  `checkMediatedPayoutAcceptsMediationResultTotal`) and another  (`checkMediatedPayoutAddressesAcceptsValidAddressesForPositiveAmounts`) lose their now-meaningless assertEquals on the returned  buyer value; they continue to assert "no exception thrown for valid inputs".

  No behavior change. `Validator.checkNullableString` / `checkNullableBytes` already establish the void precedent for cases where
  there is no single primary value to return; the single-input pass-through helpers (`checkIsPositive`, `checkNonBlankString`, etc.) are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mediated payout transaction validation to ensure amounts and addresses are properly verified during the signing and finalization process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7745)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->