### PR TITLE
Trust Gradle source distribution signature

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -22,7 +22,10 @@
          <trusted-key id="147B691A19097624902F4EA9689CBE64F4BC997F" group="org.mockito"/>
          <trusted-key id="19BEAB2D799C020F17C69126B16698A4ADF4D638" group="org.checkerframework" name="checker-qual" version="4.1.0"/>
          <trusted-key id="1A55F091AD28C07F831FA44D7905DE25C78AD456" group="com.google.protobuf"/>
-         <trusted-key id="1BD97A6A154E7810EE0BC832E2F38302C8075E3D" group="org.gradle.kotlin" name="gradle-kotlin-dsl-plugins" version="4.4.0"/>
+         <trusted-key id="1BD97A6A154E7810EE0BC832E2F38302C8075E3D">
+            <trusting group="gradle" name="gradle" version="8.9"/>
+            <trusting group="org.gradle.kotlin" name="gradle-kotlin-dsl-plugins" version="4.4.0"/>
+         </trusted-key>
          <trusted-key id="1DBB44E80F61493D6369B5FB95C15058A5EDA4F1" group="^com[.]google($|([.].*))" regex="true"/>
          <trusted-key id="1F47744C9B6E14F2049C2857F1F111AF65925306" group="io.github.classgraph" name="classgraph" version="4.8.184"/>
          <trusted-key id="207EEB28C8E18344209ACFBA08D10FD8BAD264C9" group="com.natpryce" name="make-it-easy" version="4.0.1"/>
@@ -1651,6 +1654,7 @@
       </component>
       <component group="gradle" name="gradle" version="8.9">
          <artifact name="gradle-8.9-src.zip">
+            <pgp value="1BD97A6A154E7810EE0BC832E2F38302C8075E3D"/>
             <sha256 value="cfeccc3375aa0ea1b7838361ec9acdb291bd36dd10c46ea0777c8508a40684ae" origin="Computed by alvasw"/>
          </artifact>
       </component>


### PR DESCRIPTION
Allow Gradle dependency verification to accept the Gradle 8.9 source distribution requested during IDE sync.

The artifact `gradle:gradle:8.9` / `gradle-8.9-src.zip` was already pinned by SHA-256 in `gradle/verification-metadata.xml`, and the cached file matches the official Gradle distribution checksum:

```text
cfeccc3375aa0ea1b7838361ec9acdb291bd36dd10c46ea0777c8508a40684ae
```

The sync failure was caused by the artifact's detached signature being made by Gradle Inc.'s key `1BD97A6A154E7810EE0BC832E2F38302C8075E3D`, while that key was only trusted for `org.gradle.kotlin:gradle-kotlin-dsl-plugins:4.4.0`.

Scope the same key to `gradle:gradle:8.9` and record the PGP signer on the `gradle-8.9-src.zip` artifact.

Usage:

```bash
./gradlew resolveAndVerifyDependencies
```

The task should report:

```text
Resolved and verified 169 configurations.
```

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gradle build system dependency verification and security configurations to enhance trust verification for gradle components and artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7766)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->