### PR TITLE
Harden dependency verification follow-ups

### DIFF
--- a/.github/workflows/supply-chain-review.yml
+++ b/.github/workflows/supply-chain-review.yml
@@ -1,0 +1,87 @@
+name: Supply-chain review gate
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  gate:
+    name: Require label for supply-chain changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect supply-chain file changes
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          paths=(
+            "gradle/verification-keyring.keys"
+            "gradle/verification-metadata.xml"
+            "gradle/wrapper/gradle-wrapper.jar"
+            "gradle/wrapper/gradle-wrapper.properties"
+          )
+          changed=""
+          for p in "${paths[@]}"; do
+            if git diff --name-only "$base" "$head" -- "$p" | grep -q .; then
+              changed="$changed $p"
+            fi
+          done
+          changed="${changed# }"
+          echo "files=$changed" >> "$GITHUB_OUTPUT"
+          if [ -n "$changed" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Require supply-chain-reviewed label applied by a maintainer
+        if: steps.changed.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          echo "Changed supply-chain files: ${{ steps.changed.outputs.files }}"
+          target_label="supply-chain-reviewed"
+
+          if ! echo "$LABELS" | grep -q "\"${target_label}\""; then
+            echo "::error::PR modifies supply-chain files but does not carry the '${target_label}' label. A second maintainer must inspect the keyring/metadata diff and apply the label before merging."
+            exit 1
+          fi
+
+          # Find the most recent "labeled" event for the target label.
+          actor=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/events" \
+            --jq "[ .[] | select(.event==\"labeled\" and .label.name==\"${target_label}\") ] | sort_by(.created_at) | last | .actor.login // \"\"")
+
+          if [ -z "$actor" ]; then
+            echo "::error::Label '${target_label}' is present but no labeling event was found in the PR timeline. Re-apply the label so it is auditable."
+            exit 1
+          fi
+
+          role=$(gh api "repos/${REPO}/collaborators/${actor}/permission" --jq '.role_name // .permission // ""' 2>/dev/null || echo "")
+          case "$role" in
+            admin|maintain)
+              echo "Label '${target_label}' applied by ${actor} (role=${role}); gate passes."
+              ;;
+            *)
+              echo "::error::Label '${target_label}' was applied by ${actor} (role=${role:-unknown}), who is not a repository admin or maintainer. Have an admin/maintainer re-apply the label after reviewing the diff."
+              exit 1
+              ;;
+          esac
+
+      - name: Skip when no supply-chain changes
+        if: steps.changed.outputs.has_changes == 'false'
+        run: echo "No supply-chain files touched; gate skipped."

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,22 @@ buildscript {
         maven { url "https://jitpack.io" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
+    dependencies {
+        classpath 'org.bouncycastle:bcpg-jdk18on:1.84'
+    }
 }
 
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
 import org.gradle.jvm.tasks.Jar
+import org.gradle.process.ExecOperations
 
+import javax.inject.Inject
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
@@ -19,7 +31,10 @@ def dependencyVerificationMetadata = layout.projectDirectory.file('gradle/verifi
 def dependencyVerificationKeyring = layout.projectDirectory.file('gradle/verification-keyring.keys')
 def dependencyVerificationBinaryKeyring = layout.projectDirectory.file('gradle/verification-keyring.gpg')
 def dependencySignatureReport = layout.projectDirectory.file('docs/dependency-signature-report.md')
-def gradleWrapperCommand = System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows') ? 'gradlew.bat' : './gradlew'
+// ExecOperations cannot execute .bat files directly; wrap with cmd /c on Windows.
+def gradleWrapperCommand = System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')
+        ? ['cmd', '/c', 'gradlew.bat']
+        : ['./gradlew']
 
 def htmlEscape = { value ->
     value == null
@@ -36,132 +51,6 @@ def keyIdSuffix = { String keyId ->
     normalized.length() > 16 ? normalized.substring(normalized.length() - 16) : normalized
 }
 
-def decodeArmoredPublicKey = { String armoredPublicKey ->
-    def base64Lines = []
-    def inBody = false
-    armoredPublicKey.eachLine { line ->
-        if (line.startsWith('-----BEGIN')) {
-            return
-        }
-        if (!inBody) {
-            if (line.trim().empty) {
-                inBody = true
-            }
-            return
-        }
-        if (line.startsWith('=') || line.startsWith('-----END')) {
-            return
-        }
-        if (!line.trim().empty) {
-            base64Lines << line.trim()
-        }
-    }
-
-    if (base64Lines.empty) {
-        return new byte[0]
-    }
-
-    try {
-        Base64.decoder.decode(base64Lines.join(''))
-    } catch (Exception ignored) {
-        new byte[0]
-    }
-}
-
-def parseOpenPgpPackets = { String armoredPublicKey ->
-    def packets = []
-
-    try {
-        byte[] bytes = decodeArmoredPublicKey(armoredPublicKey)
-        int offset = 0
-        while (offset < bytes.length) {
-            int ctb = bytes[offset++] & 0xff
-            if ((ctb & 0x80) == 0) {
-                return packets
-            }
-
-            int tag
-            long length
-            if ((ctb & 0x40) != 0) {
-                tag = ctb & 0x3f
-                int firstLengthOctet = bytes[offset++] & 0xff
-                if (firstLengthOctet < 192) {
-                    length = firstLengthOctet
-                } else if (firstLengthOctet <= 223) {
-                    length = ((firstLengthOctet - 192) << 8) + (bytes[offset++] & 0xff) + 192
-                } else if (firstLengthOctet == 255) {
-                    length = ((bytes[offset++] & 0xffL) << 24) |
-                            ((bytes[offset++] & 0xffL) << 16) |
-                            ((bytes[offset++] & 0xffL) << 8) |
-                            (bytes[offset++] & 0xffL)
-                } else {
-                    return packets
-                }
-            } else {
-                tag = (ctb >> 2) & 0x0f
-                int lengthType = ctb & 0x03
-                if (lengthType == 0) {
-                    length = bytes[offset++] & 0xff
-                } else if (lengthType == 1) {
-                    length = ((bytes[offset++] & 0xff) << 8) | (bytes[offset++] & 0xff)
-                } else if (lengthType == 2) {
-                    length = ((bytes[offset++] & 0xffL) << 24) |
-                            ((bytes[offset++] & 0xffL) << 16) |
-                            ((bytes[offset++] & 0xffL) << 8) |
-                            (bytes[offset++] & 0xffL)
-                } else {
-                    length = bytes.length - offset
-                }
-            }
-
-            if (length > Integer.MAX_VALUE || offset + (int) length > bytes.length) {
-                return packets
-            }
-
-            packets << [
-                    tag : tag,
-                    body: Arrays.copyOfRange(bytes, offset, offset + (int) length)
-            ]
-            offset += (int) length
-        }
-    } catch (Exception ignored) {
-        return packets
-    }
-
-    packets
-}
-
-def normalizeOpenPgpUserId = { String userId ->
-    userId
-            .replace('\uFFFDamonn McManus <eamonn@mcmanus.net>', '\u00C9amonn McManus <eamonn@mcmanus.net>')
-            .replace('\u003Famonn McManus <eamonn@mcmanus.net>', '\u00C9amonn McManus <eamonn@mcmanus.net>')
-}
-
-def parsePublicKeyUserIds = { String armoredPublicKey ->
-    parseOpenPgpPackets(armoredPublicKey)
-            .findAll { it.tag == 13 }
-            .collect { packet -> normalizeOpenPgpUserId(new String(packet.body, StandardCharsets.UTF_8).trim()) }
-            .findAll { it }
-}
-
-def parsePublicKeyCreatedDate = { String armoredPublicKey ->
-    def publicKeyPacket = parseOpenPgpPackets(armoredPublicKey).find { it.tag == 6 }
-    if (publicKeyPacket?.body == null || publicKeyPacket.body.length < 5) {
-        return null
-    }
-
-    byte[] body = publicKeyPacket.body
-    long created = ((body[1] & 0xffL) << 24) |
-            ((body[2] & 0xffL) << 16) |
-            ((body[3] & 0xffL) << 8) |
-            (body[4] & 0xffL)
-
-    java.time.Instant.ofEpochSecond(created)
-            .atZone(java.time.ZoneOffset.UTC)
-            .toLocalDate()
-            .toString()
-}
-
 def parseSignerUserId = { String userId ->
     def matcher = userId =~ /^(.*?)\s*<([^>]+)>$/
     matcher.matches()
@@ -169,68 +58,73 @@ def parseSignerUserId = { String userId ->
             : [name: userId, email: '', userId: userId]
 }
 
-def loadSignerMetadata = { File keyringFile ->
+// Workaround: the Maven Central key C7BE5BCC9FEC15518CFDA882B0F3710FA64900E7
+// has its UID encoded as Latin-1 'É' (byte 0xC9) rather than UTF-8. When
+// Gradle exports the keyring, the byte is replaced with U+FFFD or '?'.
+// Restore the canonical user ID so the signature report remains readable.
+def normalizeOpenPgpUserId = { String userId ->
+    userId
+            .replace('�amonn McManus <eamonn@mcmanus.net>', 'Éamonn McManus <eamonn@mcmanus.net>')
+            .replace('?amonn McManus <eamonn@mcmanus.net>', 'Éamonn McManus <eamonn@mcmanus.net>')
+}
+
+def decodeUserIdBytes = { byte[] bytes ->
+    def utf8Decoder = StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+            .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+    try {
+        utf8Decoder.decode(java.nio.ByteBuffer.wrap(bytes)).toString()
+    } catch (java.nio.charset.CharacterCodingException ignored) {
+        new String(bytes, StandardCharsets.ISO_8859_1)
+    }
+}
+
+def parsePgpPublicKeyBlock = { String armoredBlock, Map<String, Map> signers, org.gradle.api.logging.Logger taskLogger ->
+    def fingerprintCalculator = new org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator()
+    try {
+        def decoder = org.bouncycastle.openpgp.PGPUtil.getDecoderStream(
+                new ByteArrayInputStream(armoredBlock.getBytes(StandardCharsets.UTF_8)))
+        def rings = new org.bouncycastle.openpgp.PGPPublicKeyRingCollection(decoder, fingerprintCalculator)
+        rings.keyRings.each { ring ->
+            def primary = ring.publicKey
+            def userIds = []
+            primary.rawUserIDs.each { rawBytes ->
+                def uid = normalizeOpenPgpUserId(decodeUserIdBytes(rawBytes).trim())
+                if (uid) userIds << uid
+            }
+            def user = userIds ? parseSignerUserId(userIds[0]) : [name: '', email: '', userId: '']
+            ring.publicKeys.each { key ->
+                def created = key.creationTime
+                        ? key.creationTime.toInstant().atZone(java.time.ZoneOffset.UTC).toLocalDate().toString()
+                        : ''
+                signers[String.format('%016X', key.keyID)] =
+                        user + [keyId: String.format('%016X', key.keyID), created: created]
+            }
+        }
+    } catch (Exception ex) {
+        taskLogger.warn("Failed to parse PGP public key block: ${ex.message}")
+    }
+}
+
+def loadSignerMetadata = { File keyringFile, org.gradle.api.logging.Logger taskLogger ->
     def signers = [:]
     if (!keyringFile.exists()) {
         return signers
     }
 
-    def current = null
-    def saveCurrent = {
-        if (current?.keyId) {
-            def userIds = parsePublicKeyUserIds(current.armor.toString()) ?: current.userIds
-            def user = userIds ? parseSignerUserId(userIds[0]) : [name: '', email: '', userId: '']
-            def signer = user + [
-                    keyId  : current.keyId,
-                    created: parsePublicKeyCreatedDate(current.armor.toString()) ?: ''
-            ]
-            ([current.keyId] + current.subKeyIds).each { keyId ->
-                signers[keyId] = signer
-            }
-        }
-    }
-
+    def armor = null
     keyringFile.eachLine(StandardCharsets.UTF_8.name()) { line ->
-        def pubMatcher = line =~ /^pub\s+([0-9A-Fa-f]+)\s*$/
-        if (pubMatcher.matches()) {
-            saveCurrent()
-            current = [
-                    keyId    : keyIdSuffix(pubMatcher[0][1]),
-                    subKeyIds: [],
-                    userIds  : [],
-                    armor    : new StringBuilder(),
-                    inArmor  : false
-            ]
-            return
-        }
-
-        if (current == null) {
-            return
-        }
-
-        def uidMatcher = line =~ /^uid\s+(.*)$/
-        if (uidMatcher.matches()) {
-            current.userIds << uidMatcher[0][1].trim()
-            return
-        }
-
-        def subMatcher = line =~ /^sub\s+([0-9A-Fa-f]+)\s*$/
-        if (subMatcher.matches()) {
-            current.subKeyIds << keyIdSuffix(subMatcher[0][1])
-            return
-        }
-
         if (line.startsWith('-----BEGIN PGP PUBLIC KEY BLOCK-----')) {
-            current.inArmor = true
+            armor = new StringBuilder()
         }
-        if (current.inArmor) {
-            current.armor << line << '\n'
+        if (armor != null) {
+            armor << line << '\n'
         }
         if (line.startsWith('-----END PGP PUBLIC KEY BLOCK-----')) {
-            current.inArmor = false
+            parsePgpPublicKeyBlock(armor.toString(), signers, taskLogger)
+            armor = null
         }
     }
-    saveCurrent()
 
     signers
 }
@@ -294,39 +188,46 @@ tasks.register('resolveAndVerifyDependencies') {
     }
 }
 
-tasks.register('refreshDependencyVerificationKeyring') {
+abstract class RefreshDependencyVerificationKeyringTask extends DefaultTask {
+    @InputFile abstract RegularFileProperty getMetadataFile()
+    @OutputFile abstract RegularFileProperty getKeyringFile()
+    @Internal abstract RegularFileProperty getBinaryKeyringFile()
+    @Internal abstract ListProperty<String> getWrapperCommand()
+
+    @Inject abstract ExecOperations getExecOperations()
+
+    @TaskAction
+    void refresh() {
+        def keyring = keyringFile.get().asFile
+        def command = wrapperCommand.get() + ['--no-daemon', 'help', '--refresh-keys', '--export-keys']
+        def result = execOperations.exec {
+            commandLine command
+        }
+        result.assertNormalExitValue()
+
+        if (!keyring.exists()) {
+            throw new GradleException("Keyring export reported success but ${keyring} was not written. Check network access to the configured Gradle verification key servers.")
+        }
+
+        def binaryKeyring = binaryKeyringFile.get().asFile
+        if (binaryKeyring.exists()) {
+            logger.warn("Ignoring ${binaryKeyring}; dependency verification is configured to use the armored keyring.")
+        }
+
+        logger.lifecycle("Refreshed ${keyring}.")
+    }
+}
+
+tasks.register('refreshDependencyVerificationKeyring', RefreshDependencyVerificationKeyringTask) {
     group = 'verification'
     description = 'Refreshes dependency verification PGP public keys from key servers and exports the armored keyring.'
 
-    inputs.file(dependencyVerificationMetadata)
-    outputs.file(dependencyVerificationKeyring)
+    metadataFile.set(dependencyVerificationMetadata)
+    keyringFile.set(dependencyVerificationKeyring)
+    binaryKeyringFile.set(dependencyVerificationBinaryKeyring)
+    wrapperCommand.set(gradleWrapperCommand)
+
     outputs.upToDateWhen { false }
-
-    doLast {
-        def keyringFile = dependencyVerificationKeyring.asFile
-        def previousModified = keyringFile.exists() ? keyringFile.lastModified() : 0L
-        def result = exec {
-            commandLine gradleWrapperCommand, '--no-daemon', 'help', '--refresh-keys', '--export-keys'
-            ignoreExitValue = true
-        }
-
-        if (!keyringFile.exists()) {
-            throw new GradleException("Failed to write ${keyringFile}. Check network access to the configured Gradle verification key servers.")
-        }
-
-        if (result.exitValue != 0) {
-            if (keyringFile.lastModified() <= previousModified) {
-                throw new GradleException("Gradle --refresh-keys --export-keys failed with exit code ${result.exitValue} and did not update ${keyringFile}.")
-            }
-            logger.warn("Gradle --refresh-keys --export-keys exited with ${result.exitValue} after updating ${keyringFile}. This can happen in some Gradle/Bouncy Castle combinations.")
-        }
-
-        if (dependencyVerificationBinaryKeyring.asFile.exists()) {
-            logger.warn("Ignoring ${dependencyVerificationBinaryKeyring.asFile}; dependency verification is configured to use the armored keyring.")
-        }
-
-        logger.lifecycle("Refreshed ${keyringFile}.")
-    }
 }
 
 tasks.register('dependencySignatureReport') {
@@ -345,7 +246,7 @@ tasks.register('dependencySignatureReport') {
         if (!metadataFile.exists()) {
             throw new GradleException("Missing ${metadataFile}. Run './gradlew resolveAndVerifyDependencies --write-verification-metadata pgp,sha256' first.")
         }
-        def signerMetadata = loadSignerMetadata(keyringFile)
+        def signerMetadata = loadSignerMetadata(keyringFile, logger)
 
         def metadata = new XmlSlurper(false, false).parse(metadataFile)
         def componentsById = new TreeMap<String, Object>()
@@ -573,6 +474,31 @@ def sha256 = { File file ->
         }
     }
     digest.digest().collect { String.format('%02x', it) }.join()
+}
+
+def gradleWrapperJar = layout.projectDirectory.file('gradle/wrapper/gradle-wrapper.jar')
+def gradleWrapperJarSha256 = '14dfa961b6704bb3decdea06502781edaa796a82e6da41cd2e1962b14fbe21a3'
+
+tasks.register('verifyGradleWrapperJar') {
+    group = 'verification'
+    description = 'Verifies gradle/wrapper/gradle-wrapper.jar against a pinned SHA-256.'
+
+    inputs.file(gradleWrapperJar)
+    inputs.property('expectedSha256', gradleWrapperJarSha256)
+    outputs.upToDateWhen { false }
+
+    doLast {
+        def jar = gradleWrapperJar.asFile
+        if (!jar.exists()) {
+            throw new GradleException("Missing ${jar}.")
+        }
+        def actual = sha256(jar)
+        if (actual != gradleWrapperJarSha256) {
+            throw new GradleException(
+                    "Gradle wrapper JAR SHA-256 mismatch.\n  file:     ${jar}\n  expected: ${gradleWrapperJarSha256}\n  actual:   ${actual}\nIf the wrapper was intentionally updated, regenerate the pinned hash and require a supply-chain review.")
+        }
+        logger.lifecycle("Verified ${jar} (sha256=${actual}).")
+    }
 }
 
 tasks.register('generateJarHashes') {

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -15,7 +15,14 @@
          </trusted-key>
          <trusted-key id="06FAAF08F9E322363ECA5C080F97219EA9EEA989" group="net.glxn" name="qrgen" version="1.4"/>
          <trusted-key id="0785B3EFF60B1B1BEA94E0BB7C25280EAE63EBE5" group="org.apache.httpcomponents"/>
-         <trusted-key id="0B743A794876D3C78AB542A118D239B1CBCD2236" group="^org[.]glassfish[.]jersey($|([.].*))" regex="true"/>
+         <trusted-key id="0B743A794876D3C78AB542A118D239B1CBCD2236">
+            <trusting group="org.glassfish.jersey"/>
+            <trusting group="org.glassfish.jersey.containers"/>
+            <trusting group="org.glassfish.jersey.core"/>
+            <trusting group="org.glassfish.jersey.ext"/>
+            <trusting group="org.glassfish.jersey.inject"/>
+            <trusting group="org.glassfish.jersey.media"/>
+         </trusted-key>
          <trusted-key id="0CC641C3A62453AB390066C4A41F13C999945293" group="commons-logging" name="commons-logging" version="1.2"/>
          <trusted-key id="0F07D1201BDDAB67CFB84EB479752DB6C966F0B8" group="com.google.android" name="annotations" version="4.1.1.4"/>
          <trusted-key id="10F3C7A02ECA55E502BADCF3991EFB94DB91127D" group="org.ow2" name="ow2" version="1.5.1"/>
@@ -26,12 +33,36 @@
             <trusting group="gradle" name="gradle" version="8.9"/>
             <trusting group="org.gradle.kotlin" name="gradle-kotlin-dsl-plugins" version="4.4.0"/>
          </trusted-key>
-         <trusted-key id="1DBB44E80F61493D6369B5FB95C15058A5EDA4F1" group="^com[.]google($|([.].*))" regex="true"/>
+         <trusted-key id="1DBB44E80F61493D6369B5FB95C15058A5EDA4F1">
+            <trusting group="com.google"/>
+            <trusting group="com.google.android"/>
+            <trusting group="com.google.api.grpc"/>
+            <trusting group="com.google.auth"/>
+            <trusting group="com.google.cloud"/>
+            <trusting group="com.google.code.findbugs"/>
+            <trusting group="com.google.code.gson"/>
+            <trusting group="com.google.errorprone"/>
+            <trusting group="com.google.gradle"/>
+            <trusting group="com.google.guava"/>
+            <trusting group="com.google.http-client"/>
+            <trusting group="com.google.inject"/>
+            <trusting group="com.google.j2objc"/>
+            <trusting group="com.google.protobuf"/>
+            <trusting group="com.google.zxing"/>
+         </trusted-key>
          <trusted-key id="1F47744C9B6E14F2049C2857F1F111AF65925306" group="io.github.classgraph" name="classgraph" version="4.8.184"/>
          <trusted-key id="207EEB28C8E18344209ACFBA08D10FD8BAD264C9" group="com.natpryce" name="make-it-easy" version="4.0.1"/>
          <trusted-key id="21D09437979F5953FFEEA59C2753A900612D3FF1" group="jakarta.validation" name="jakarta.validation-api" version="3.1.0"/>
          <trusted-key id="22394BC36212ED3694AEF8DCFB2EA0369C925EE1" group="org.zeromq" name="jeromq" version="0.6.0"/>
-         <trusted-key id="28118C070CB22A0175A2E8D43D12CA2AC19F3181" group="^com[.]fasterxml($|([.].*))" regex="true"/>
+         <trusted-key id="28118C070CB22A0175A2E8D43D12CA2AC19F3181">
+            <trusting group="com.fasterxml"/>
+            <trusting group="com.fasterxml.jackson"/>
+            <trusting group="com.fasterxml.jackson.core"/>
+            <trusting group="com.fasterxml.jackson.dataformat"/>
+            <trusting group="com.fasterxml.jackson.datatype"/>
+            <trusting group="com.fasterxml.jackson.jakarta.rs"/>
+            <trusting group="com.fasterxml.jackson.module"/>
+         </trusted-key>
          <trusted-key id="284C69F182F53A95F3D57966CF152F806378D293" group="com.sparkjava" name="spark-core" version="2.9.4"/>
          <trusted-key id="2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB">
             <trusting group="commons-codec"/>
@@ -47,7 +78,23 @@
          <trusted-key id="4021EEEAFF5DE8404DCD0A270AA3E5C3D232E79B" group="jakarta.inject" name="jakarta.inject-api" version="2.0.1"/>
          <trusted-key id="41CD49B4EF5876F9E9F691DABAC30622339994C4" group="org.jspecify" name="jspecify" version="1.0.0"/>
          <trusted-key id="44FBDBBC1A00FE414F1C1873586654072EAD6677" group="org.sonatype.oss" name="oss-parent" version="9"/>
-         <trusted-key id="47504B76CF89C15C0512D9AFE16AB52D79FD224F" group="^com[.]google($|([.].*))" regex="true"/>
+         <trusted-key id="47504B76CF89C15C0512D9AFE16AB52D79FD224F">
+            <trusting group="com.google"/>
+            <trusting group="com.google.android"/>
+            <trusting group="com.google.api.grpc"/>
+            <trusting group="com.google.auth"/>
+            <trusting group="com.google.cloud"/>
+            <trusting group="com.google.code.findbugs"/>
+            <trusting group="com.google.code.gson"/>
+            <trusting group="com.google.errorprone"/>
+            <trusting group="com.google.gradle"/>
+            <trusting group="com.google.guava"/>
+            <trusting group="com.google.http-client"/>
+            <trusting group="com.google.inject"/>
+            <trusting group="com.google.j2objc"/>
+            <trusting group="com.google.protobuf"/>
+            <trusting group="com.google.zxing"/>
+         </trusted-key>
          <trusted-key id="47EB6836245D2D40E89DFB4136D4E9618F3ADAB5" group="io.github.oshai" name="kotlin-logging-jvm" version="8.0.02"/>
          <trusted-key id="4DB1A49729B053CAF015CEE9A6ADFC93EF34893E" group="org.hamcrest"/>
          <trusted-key id="4F7E32D440EF90A83011A8FC6425559C47CC79C4">
@@ -62,7 +109,15 @@
             <trusting group="ch.qos.logback"/>
             <trusting group="org.slf4j"/>
          </trusted-key>
-         <trusted-key id="6214760097DC5CFAD0175AC2C9FBAA83A8753994" group="^com[.]fasterxml($|([.].*))" regex="true"/>
+         <trusted-key id="6214760097DC5CFAD0175AC2C9FBAA83A8753994">
+            <trusting group="com.fasterxml"/>
+            <trusting group="com.fasterxml.jackson"/>
+            <trusting group="com.fasterxml.jackson.core"/>
+            <trusting group="com.fasterxml.jackson.dataformat"/>
+            <trusting group="com.fasterxml.jackson.datatype"/>
+            <trusting group="com.fasterxml.jackson.jakarta.rs"/>
+            <trusting group="com.fasterxml.jackson.module"/>
+         </trusted-key>
          <trusted-key id="64CD4D429F3BCD7F48BEE410E5CDB6E74294955A" group="org.bitbucket.cowwoc" name="diff-match-patch" version="1.2"/>
          <trusted-key id="694621A7227D8D5289699830ABE9F3126BB741C1" group="com.google.guava" name="guava-parent" version="26.0-android"/>
          <trusted-key id="6DD3B8C64EF75253BEB2C53AD908A43FB7EC07AC" group="jakarta.activation" name="jakarta.activation-api"/>
@@ -88,7 +143,10 @@
          <trusted-key id="A7892505CF1A58076453E52D7999BEFBA1039E8B" group="net.bytebuddy"/>
          <trusted-key id="AA70C7C433D501636392EC02153E7A3C2B4E5118" group="org.eclipse.ee4j" name="project"/>
          <trusted-key id="B02335AA54CCF21E52BBF9ABD9C565AA72BA2FDD" group="io.grpc"/>
-         <trusted-key id="B59B67FD7904984367F931800818D9D68FB67BAC" group="^org[.]eclipse[.]jetty($|([.].*))" regex="true"/>
+         <trusted-key id="B59B67FD7904984367F931800818D9D68FB67BAC">
+            <trusting group="org.eclipse.jetty"/>
+            <trusting group="org.eclipse.jetty.websocket"/>
+         </trusted-key>
          <trusted-key id="BCA1F17506AF088F3A964A9C0459A2B383ED8C11" group="org.eclipse.angus"/>
          <trusted-key id="BDB5FA4FE719D787FB3D3197F6D4A1D411E9D1AE" group="com.google.guava"/>
          <trusted-key id="BE685132AFD2740D9095F9040CC0B712FEE75827" group="org.assertj" name="assertj-core" version="3.27.7"/>
@@ -98,10 +156,17 @@
          <trusted-key id="CE3285F320685193D11FEA01F6CE9695C9318406" group="com.google.zxing"/>
          <trusted-key id="D022218DCC08AAD6EF3AF876B3DE72E647D35161" group="org.testcontainers" name="testcontainers-bom" version="1.16.1"/>
          <trusted-key id="D421D1DF4570BFB13E485D0BF95ADD0A28D2F139" group="org.projectlombok" name="lombok" version="1.18.46"/>
-         <trusted-key id="D4A77129F00F736293BE5A51AFC18A2271EDDFE1" group="^org[.]glassfish[.]hk2($|([.].*))" regex="true"/>
+         <trusted-key id="D4A77129F00F736293BE5A51AFC18A2271EDDFE1">
+            <trusting group="org.glassfish.hk2"/>
+            <trusting group="org.glassfish.hk2.external"/>
+         </trusted-key>
          <trusted-key id="D6F1BC78607808EC8E9F69437A8860944FAD5F62" group="org.apache.commons" name="commons-parent" version="34"/>
          <trusted-key id="D98E48D9AB0116441BBC16CD0F64F95CEF5F0629" group="de.jensd" name="fontawesomefx" version="8.0.0"/>
-         <trusted-key id="DBD744ACE7ADE6AA50DD591F66B50994442D2D40" group="^com[.]squareup($|([.].*))" regex="true"/>
+         <trusted-key id="DBD744ACE7ADE6AA50DD591F66B50994442D2D40">
+            <trusting group="com.squareup.moshi"/>
+            <trusting group="com.squareup.okhttp3"/>
+            <trusting group="com.squareup.okio"/>
+         </trusted-key>
          <trusted-key id="E3A9F95079E84CE201F7CF60BEDE11EAF1164480" group="org.hamcrest" name="hamcrest" version="3.0"/>
          <trusted-key id="E82D2EAF2E83830CE1F7F6BE571A5291E827E1C7" group="net.java" name="jvnet-parent" version="3"/>
          <trusted-key id="E5C3B1929191DF06136CCB2B164779204E106A76" group="org.javassist" name="javassist" version="3.30.2-GA"/>
@@ -122,7 +187,9 @@
             <trusting group="junit" name="junit" version="4.13.2"/>
             <trusting group="org.apiguardian"/>
             <trusting group="org.opentest4j"/>
-            <trusting group="^org[.]junit($|([.].*))" regex="true"/>
+            <trusting group="org.junit"/>
+            <trusting group="org.junit.jupiter"/>
+            <trusting group="org.junit.platform"/>
          </trusted-key>
          <trusted-key id="FFD433E89FCB22C79A8DD011B4BF94F677CAA76F" group="jakarta.ws.rs"/>
       </trusted-keys>


### PR DESCRIPTION
## Summary

  Follow-ups to supply-chain hardening landed in #7766. Three buckets:

  ### 1. Maintainer-gated supply-chain review (`.github/workflows/supply-chain-review.yml`)
  - New PR check that fires when any of `gradle/verification-keyring.keys`,  `gradle/verification-metadata.xml`, `gradle/wrapper/gradle-wrapper.jar`, or  `gradle/wrapper/gradle-wrapper.properties` is touched.
  - Requires the `supply-chain-reviewed` label, and verifies via the issue timeline that an  `admin` or `maintain` collaborator applied it. Self-applied or contributor-applied labels fail  the gate.
  - Skips cleanly when no supply-chain files change.

  ### 2. Replace hand-rolled OpenPGP parser with BouncyCastle (`build.gradle`)
  - Drop ~150 lines of byte-level packet/length parsing (`parseOpenPgpPackets`,  `decodeArmoredPublicKey`, manual UID/creation-time extraction) in favor of  `PGPPublicKeyRingCollection` + `BcKeyFingerprintCalculator` (`bcpg-jdk18on:1.84` added as a  buildscript classpath dep).
  - Each subkey now records its own `keyID` and `creationTime` instead of inheriting the primary  key's, so the signature report shows accurate per-key creation dates when a subkey signs.
   - UID bytes decoded as UTF-8 with strict error reporting and ISO-8859-1 fallback; the `Éamonn McManus` Latin-1 workaround is preserved.
  - `refreshDependencyVerificationKeyring` extracted into a typed `DefaultTask` 
  (`RefreshDependencyVerificationKeyringTask`) using injected `ExecOperations`, so it works with  the configuration cache. Wrapper command on Windows now goes through `cmd /c gradlew.bat` because `ExecOperations` cannot exec `.bat` directly.
  - New `verifyGradleWrapperJar` task pins `gradle/wrapper/gradle-wrapper.jar` to a SHA-256 (`14dfa961…21a3`) and fails loudly on drift.

  ### 3. Narrow regex trusted-key entries (`gradle/verification-metadata.xml`)
  - Replace `regex="true"` group patterns for keys 0B743A79…, 1DBB44E8…, 28118C07…, 47504B76…,
  6214760…, B59B67FD…, etc. with explicit `<trusting group="…"/>` lists covering only the  Glassfish/Jersey, Google, Jackson, Jetty groups actually consumed. Reduces blast radius if any  of those keys is ever compromised or republished against an unrelated coordinate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated verification of the Gradle wrapper JAR against an expected checksum to detect tampering.

* **Chores**
  * Added a supply-chain review gate that requires a `supply-chain-reviewed` label applied by an admin/maintainer for PRs touching supply-chain files.
  * Improved dependency verification and keyring handling; migrated regex-based trust rules to explicit allowlists for multiple package namespaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7768)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->