### PR TITLE
Fix API payment account deserialization

### DIFF
--- a/apitest/src/test/java/bisq/apitest/method/payment/CreatePaymentAccountTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/payment/CreatePaymentAccountTest.java
@@ -924,7 +924,7 @@ public class CreatePaymentAccountTest extends AbstractPaymentAccountTest {
                 PROPERTY_NAME_EMAIL);
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_PAYMENT_METHOD_ID, TRANSFERWISE_ID);
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_ACCOUNT_NAME, "Transferwise Acct");
-        COMPLETED_FORM_MAP.put(PROPERTY_NAME_TRADE_CURRENCIES, "ARS,CAD,HRK,CZK,EUR,HKD,IDR,JPY,CHF,NZD");
+        COMPLETED_FORM_MAP.put(PROPERTY_NAME_TRADE_CURRENCIES, "ARS,CAD,AUD,CZK,EUR,HKD,IDR,JPY,CHF,NZD");
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_SELECTED_TRADE_CURRENCY, "CHF");
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_EMAIL, "jane@doe.info");
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_SALT, "");
@@ -935,7 +935,7 @@ public class CreatePaymentAccountTest extends AbstractPaymentAccountTest {
         List<TradeCurrency> expectedTradeCurrencies = new ArrayList<>() {{
             add(getTradeCurrency("ARS").get()); // 1st in list = selected ccy
             add(getTradeCurrency("CAD").get());
-            add(getTradeCurrency("HRK").get());
+            add(getTradeCurrency("AUD").get());
             add(getTradeCurrency("CZK").get());
             add(getTradeCurrency(EUR).get());
             add(getTradeCurrency("HKD").get());
@@ -979,21 +979,21 @@ public class CreatePaymentAccountTest extends AbstractPaymentAccountTest {
     }
 
     @Test
-    public void testCreateTransferwiseAccountWithInvalidBrlTradeCurrencyShouldThrowException(TestInfo testInfo) {
+    public void testCreateTransferwiseAccountWithInvalidUsdTradeCurrencyShouldThrowException(TestInfo testInfo) {
         File emptyForm = getEmptyForm(testInfo, TRANSFERWISE_ID);
         verifyEmptyForm(emptyForm,
                 TRANSFERWISE_ID,
                 PROPERTY_NAME_EMAIL);
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_PAYMENT_METHOD_ID, TRANSFERWISE_ID);
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_ACCOUNT_NAME, "Transferwise Acct");
-        COMPLETED_FORM_MAP.put(PROPERTY_NAME_TRADE_CURRENCIES, "eur, hkd, idr, jpy, chf, nzd, brl, gbp");
+        COMPLETED_FORM_MAP.put(PROPERTY_NAME_TRADE_CURRENCIES, "eur, hkd, idr, jpy, chf, nzd, usd, gbp");
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_EMAIL, "jane@doe.info");
         COMPLETED_FORM_MAP.put(PROPERTY_NAME_SALT, "");
         String jsonString = getCompletedFormAsJsonString();
 
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 createPaymentAccount(aliceClient, jsonString));
-        assertEquals("INVALID_ARGUMENT: BRL is not a member of valid currencies list",
+        assertEquals("INVALID_ARGUMENT: USD is not a member of valid currencies list",
                 exception.getMessage());
     }
 
@@ -1012,7 +1012,7 @@ public class CreatePaymentAccountTest extends AbstractPaymentAccountTest {
 
         Throwable exception = assertThrows(StatusRuntimeException.class, () ->
                 createPaymentAccount(aliceClient, jsonString));
-        assertEquals("INVALID_ARGUMENT: no trade currency defined for transferwise payment account",
+        assertEquals("INVALID_ARGUMENT: no trade currency defined for wise payment account",
                 exception.getMessage());
     }
 

--- a/apitest/src/test/java/bisq/apitest/scenario/PaymentAccountTest.java
+++ b/apitest/src/test/java/bisq/apitest/scenario/PaymentAccountTest.java
@@ -76,7 +76,7 @@ public class PaymentAccountTest extends AbstractPaymentAccountTest {
         test.testCreateTransferwiseAccountWith1TradeCurrency(testInfo);
         test.testCreateTransferwiseAccountWith10TradeCurrencies(testInfo);
         test.testCreateTransferwiseAccountWithSupportedTradeCurrencies(testInfo);
-        test.testCreateTransferwiseAccountWithInvalidBrlTradeCurrencyShouldThrowException(testInfo);
+        test.testCreateTransferwiseAccountWithInvalidUsdTradeCurrencyShouldThrowException(testInfo);
         test.testCreateTransferwiseAccountWithoutTradeCurrenciesShouldThrowException(testInfo);
 
         test.testCreateUpholdAccount(testInfo);

--- a/core/src/main/java/bisq/core/api/model/PaymentAccountTypeAdapter.java
+++ b/core/src/main/java/bisq/core/api/model/PaymentAccountTypeAdapter.java
@@ -281,12 +281,22 @@ class PaymentAccountTypeAdapter extends TypeAdapter<PaymentAccount> {
     }
 
     private boolean isSetterOnPaymentAccountClass(Method setter, PaymentAccount account) {
-        return isSetterOnClass(setter, account.getClass())  || isSetterOnClass(setter, account.getClass().getSuperclass());
+        return isSetterOnClassHierarchy(setter, account.getClass());
     }
 
     private boolean isSetterOnPaymentAccountPayloadClass(Method setter, PaymentAccount account) {
-        return isSetterOnClass(setter, account.getPaymentAccountPayload().getClass())
-                || isSetterOnClass(setter, account.getPaymentAccountPayload().getClass().getSuperclass());
+        return isSetterOnClassHierarchy(setter, account.getPaymentAccountPayload().getClass());
+    }
+
+    private boolean isSetterOnClassHierarchy(Method setter, Class<?> clazz) {
+        Class<?> currentClass = clazz;
+        while (currentClass != null && currentClass != Object.class) {
+            if (isSetterOnClass(setter, currentClass)) {
+                return true;
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+        return false;
     }
 
     private Map<Field, Optional<Method>> getFieldSetterMap() {


### PR DESCRIPTION
## Summary

This PR fixes API payment-account creation for account types whose setters are declared above the direct superclass of the concrete account or payload class.

`PaymentAccountTypeAdapter` previously checked only the concrete class and one superclass when deciding whether a JSON field setter belongs to the `PaymentAccount` or its payload. Bank-style payment account payloads can inherit setters from higher-level base classes, which caused API JSON deserialization to fail during payment-account creation.

The adapter now walks the full class hierarchy up to `Object` when resolving setter ownership.

## Test updates

- Update Wise/TransferWise payment-account fixtures to match the current supported currency list.
- Update the corresponding negative test from BRL to USD, because BRL is now supported and USD is not.
- Update the expected no-currency error text from `transferwise` to `wise`.

## Testing

- `./gradlew :apitest:test --tests bisq.apitest.scenario.PaymentAccountTest -DrunApiTests=true`
- Result: `2 tests, 2 passed, 0 failed, 0 skipped`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Transferwise payment account tests to validate USD currency validation instead of BRL.
  * Refined test error message expectations for Transferwise account creation.

* **Refactor**
  * Improved internal logic for determining setter methods in payment account class hierarchies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7769)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->