### PR TITLE
Fix DAO monitor hash compatibility with Java 11 seed nodes

### DIFF
--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -256,7 +256,8 @@ public class DaoState implements PersistablePayload {
         // Reorgs are handled by rebuilding the hash chain from last snapshot.
         // Using the full blocks list becomes quite heavy. 7000 blocks are
         // about 1.4 MB and creating the hash takes 30 sec. By using just the last block we reduce the time to 7 sec.
-        return getBsqStateBuilderExcludingBlocks().addBlocks(getLastBlock().toProtoMessage()).build().toByteArray();
+        // Keep the legacy Java 11 HashMap map-entry order for compatibility with old seed node hashes.
+        return LegacyDaoStateHashSerializerV1.serialize(this);
     }
 
     public void addToTxCache(Tx tx) {

--- a/core/src/main/java/bisq/core/dao/state/model/LegacyDaoStateHashSerializerV1.java
+++ b/core/src/main/java/bisq/core/dao/state/model/LegacyDaoStateHashSerializerV1.java
@@ -1,0 +1,620 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model;
+
+import bisq.core.dao.state.model.governance.Cycle;
+import bisq.core.dao.state.model.governance.DecryptedBallotsWithMerits;
+import bisq.core.dao.state.model.governance.EvaluatedProposal;
+import bisq.core.dao.state.model.governance.ParamChange;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Serializes the DAO state monitor input with the map entry order produced by the old Java 11 HashMap path.
+ * The DAO state itself remains canonicalized as TreeMaps; this is only for compatibility with legacy seed hashes.
+ */
+public final class LegacyDaoStateHashSerializerV1 {
+    private static final int DEFAULT_INITIAL_CAPACITY = 16;
+    private static final int MAXIMUM_CAPACITY = 1 << 30;
+    private static final int TREEIFY_THRESHOLD = 8;
+    private static final int UNTREEIFY_THRESHOLD = 6;
+    private static final int MIN_TREEIFY_CAPACITY = 64;
+
+    private LegacyDaoStateHashSerializerV1() {
+    }
+
+    public static byte[] serialize(DaoState daoState) {
+        return getBsqStateBuilderExcludingBlocks(daoState)
+                .addBlocks(daoState.getLastBlock().toProtoMessage())
+                .build()
+                .toByteArray();
+    }
+
+    @VisibleForTesting
+    static protobuf.DaoState.Builder getBsqStateBuilderExcludingBlocks(DaoState daoState) {
+        return protobuf.DaoState.newBuilder()
+                .setChainHeight(daoState.getChainHeight())
+                .addAllCycles(daoState.getCycles().stream()
+                        .map(Cycle::toProtoMessage)
+                        .collect(Collectors.toList()))
+                .putAllUnspentTxOutputMap(toLegacyHashMapIterationOrder(daoState.getUnspentTxOutputMap(),
+                        e -> e.getKey().toString(),
+                        e -> e.getValue().toProtoMessage()))
+                .putAllSpentInfoMap(toLegacyHashMapIterationOrder(daoState.getSpentInfoMap(),
+                        e -> e.getKey().toString(),
+                        e -> e.getValue().toProtoMessage()))
+                .addAllConfiscatedLockupTxList(daoState.getConfiscatedLockupTxList())
+                .putAllIssuanceMap(toLegacyHashMapIterationOrder(daoState.getIssuanceMap(),
+                        Map.Entry::getKey,
+                        e -> e.getValue().toProtoMessage()))
+                .addAllParamChangeList(daoState.getParamChangeList().stream()
+                        .map(ParamChange::toProtoMessage)
+                        .collect(Collectors.toList()))
+                .addAllEvaluatedProposalList(daoState.getEvaluatedProposalList().stream()
+                        .map(EvaluatedProposal::toProtoMessage)
+                        .collect(Collectors.toList()))
+                .addAllDecryptedBallotsWithMeritsList(daoState.getDecryptedBallotsWithMeritsList().stream()
+                        .map(DecryptedBallotsWithMerits::toProtoMessage)
+                        .collect(Collectors.toList()));
+    }
+
+    private static <K, V, P> LinkedHashMap<String, P> toLegacyHashMapIterationOrder(
+            Map<K, V> source,
+            Function<Map.Entry<K, V>, String> keyMapper,
+            Function<Map.Entry<K, V>, P> valueMapper) {
+        List<Map.Entry<String, P>> entries = source.entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleImmutableEntry<>(keyMapper.apply(entry), valueMapper.apply(entry)))
+                .collect(Collectors.toList());
+        return toJava11HashMapIterationOrder(entries);
+    }
+
+    @VisibleForTesting
+    static List<String> getJava11HashMapIterationOrder(Collection<String> keys) {
+        List<Map.Entry<String, Boolean>> entries = keys.stream()
+                .map(key -> new AbstractMap.SimpleImmutableEntry<>(key, Boolean.TRUE))
+                .collect(Collectors.toList());
+        return new ArrayList<>(toJava11HashMapIterationOrder(entries).keySet());
+    }
+
+    @VisibleForTesting
+    static <V> LinkedHashMap<String, V> toJava11HashMapIterationOrder(List<Map.Entry<String, V>> entries) {
+        Java11HashMapIterationOrderBuilder<V> builder = new Java11HashMapIterationOrderBuilder<>();
+        for (Map.Entry<String, V> entry : entries) {
+            builder.put(entry.getKey(), entry.getValue());
+        }
+        return builder.toLinkedHashMap();
+    }
+
+    private static int spreadHash(int hash) {
+        return hash ^ (hash >>> 16);
+    }
+
+    private static final class Java11HashMapIterationOrderBuilder<V> {
+        private HashNode<V>[] table;
+        private int threshold;
+        private int size;
+
+        void put(String key, V value) {
+            int hash = spreadHash(key.hashCode());
+            HashNode<V>[] tab = table;
+            int tableLength;
+            if (tab == null || (tableLength = tab.length) == 0) {
+                tab = resize();
+                tableLength = tab.length;
+            }
+
+            int index = (tableLength - 1) & hash;
+            HashNode<V> first = tab[index];
+            if (first == null) {
+                tab[index] = new HashNode<>(hash, key, value, null);
+            } else if (first instanceof TreeNode) {
+                if (((TreeNode<V>) first).putTreeVal(tab, hash, key, value) != null) {
+                    throw new IllegalStateException("Duplicate key " + key);
+                }
+            } else {
+                HashNode<V> node = first;
+                for (int binCount = 0; ; ++binCount) {
+                    if (node.hash == hash && node.key.equals(key)) {
+                        throw new IllegalStateException("Duplicate key " + key);
+                    }
+
+                    HashNode<V> next = node.next;
+                    if (next == null) {
+                        node.next = new HashNode<>(hash, key, value, null);
+                        if (binCount >= TREEIFY_THRESHOLD - 1) {
+                            treeifyBin(tab, hash);
+                        }
+                        break;
+                    }
+                    node = next;
+                }
+            }
+
+            if (++size > threshold) {
+                resize();
+            }
+        }
+
+        LinkedHashMap<String, V> toLinkedHashMap() {
+            LinkedHashMap<String, V> result = new LinkedHashMap<>();
+            if (table == null) {
+                return result;
+            }
+
+            for (HashNode<V> bucket : table) {
+                for (HashNode<V> node = bucket; node != null; node = node.next) {
+                    result.put(node.key, node.value);
+                }
+            }
+            return result;
+        }
+
+        @SuppressWarnings("unchecked")
+        private HashNode<V>[] resize() {
+            HashNode<V>[] oldTable = table;
+            int oldCapacity = oldTable == null ? 0 : oldTable.length;
+            int oldThreshold = threshold;
+            int newCapacity;
+            int newThreshold = 0;
+
+            if (oldCapacity > 0) {
+                if (oldCapacity >= MAXIMUM_CAPACITY) {
+                    threshold = Integer.MAX_VALUE;
+                    return oldTable;
+                } else if ((newCapacity = oldCapacity << 1) < MAXIMUM_CAPACITY &&
+                        oldCapacity >= DEFAULT_INITIAL_CAPACITY) {
+                    newThreshold = oldThreshold << 1;
+                }
+            } else {
+                newCapacity = DEFAULT_INITIAL_CAPACITY;
+                newThreshold = (int) (0.75f * DEFAULT_INITIAL_CAPACITY);
+            }
+
+            if (newThreshold == 0) {
+                float calculatedThreshold = (float) newCapacity * 0.75f;
+                newThreshold = newCapacity < MAXIMUM_CAPACITY && calculatedThreshold < (float) MAXIMUM_CAPACITY ?
+                        (int) calculatedThreshold :
+                        Integer.MAX_VALUE;
+            }
+
+            threshold = newThreshold;
+            HashNode<V>[] newTable = (HashNode<V>[]) new HashNode[newCapacity];
+            table = newTable;
+
+            if (oldTable != null) {
+                for (int index = 0; index < oldCapacity; ++index) {
+                    HashNode<V> node = oldTable[index];
+                    if (node != null) {
+                        oldTable[index] = null;
+                        if (node.next == null) {
+                            newTable[node.hash & (newCapacity - 1)] = node;
+                        } else if (node instanceof TreeNode) {
+                            ((TreeNode<V>) node).split(newTable, index, oldCapacity);
+                        } else {
+                            splitListBucket(newTable, index, oldCapacity, node);
+                        }
+                    }
+                }
+            }
+
+            return newTable;
+        }
+
+        private void splitListBucket(HashNode<V>[] newTable, int index, int oldCapacity, HashNode<V> node) {
+            HashNode<V> loHead = null;
+            HashNode<V> loTail = null;
+            HashNode<V> hiHead = null;
+            HashNode<V> hiTail = null;
+
+            do {
+                HashNode<V> next = node.next;
+                if ((node.hash & oldCapacity) == 0) {
+                    if (loTail == null) {
+                        loHead = node;
+                    } else {
+                        loTail.next = node;
+                    }
+                    loTail = node;
+                } else {
+                    if (hiTail == null) {
+                        hiHead = node;
+                    } else {
+                        hiTail.next = node;
+                    }
+                    hiTail = node;
+                }
+                node = next;
+            } while (node != null);
+
+            if (loTail != null) {
+                loTail.next = null;
+                newTable[index] = loHead;
+            }
+            if (hiTail != null) {
+                hiTail.next = null;
+                newTable[index + oldCapacity] = hiHead;
+            }
+        }
+
+        private void treeifyBin(HashNode<V>[] tab, int hash) {
+            int tableLength = tab.length;
+            if (tableLength < MIN_TREEIFY_CAPACITY) {
+                resize();
+                return;
+            }
+
+            int index = (tableLength - 1) & hash;
+            HashNode<V> node = tab[index];
+            if (node == null) {
+                return;
+            }
+
+            TreeNode<V> head = null;
+            TreeNode<V> tail = null;
+            do {
+                TreeNode<V> treeNode = new TreeNode<>(node.hash, node.key, node.value, null);
+                if (tail == null) {
+                    head = treeNode;
+                } else {
+                    treeNode.prev = tail;
+                    tail.next = treeNode;
+                }
+                tail = treeNode;
+                node = node.next;
+            } while (node != null);
+
+            tab[index] = head;
+            if (head != null) {
+                head.treeify(tab);
+            }
+        }
+    }
+
+    private static class HashNode<V> {
+        final int hash;
+        final String key;
+        final V value;
+        HashNode<V> next;
+
+        private HashNode(int hash, String key, V value, HashNode<V> next) {
+            this.hash = hash;
+            this.key = key;
+            this.value = value;
+            this.next = next;
+        }
+    }
+
+    private static final class TreeNode<V> extends HashNode<V> {
+        private TreeNode<V> parent;
+        private TreeNode<V> left;
+        private TreeNode<V> right;
+        private TreeNode<V> prev;
+        private boolean red;
+
+        private TreeNode(int hash, String key, V value, HashNode<V> next) {
+            super(hash, key, value, next);
+        }
+
+        private TreeNode<V> root() {
+            TreeNode<V> root = this;
+            while (root.parent != null) {
+                root = root.parent;
+            }
+            return root;
+        }
+
+        private HashNode<V> putTreeVal(HashNode<V>[] tab, int hash, String key, V value) {
+            TreeNode<V> root = parent != null ? root() : this;
+            TreeNode<V> node = root;
+            while (true) {
+                int direction;
+                if (node.hash > hash) {
+                    direction = -1;
+                } else if (node.hash < hash) {
+                    direction = 1;
+                } else if (node.key.equals(key)) {
+                    return node;
+                } else {
+                    direction = node.key.compareTo(key) > 0 ? -1 : 1;
+                }
+
+                TreeNode<V> parentNode = node;
+                node = direction <= 0 ? node.left : node.right;
+                if (node == null) {
+                    HashNode<V> next = parentNode.next;
+                    TreeNode<V> inserted = new TreeNode<>(hash, key, value, next);
+                    if (direction <= 0) {
+                        parentNode.left = inserted;
+                    } else {
+                        parentNode.right = inserted;
+                    }
+                    parentNode.next = inserted;
+                    inserted.parent = parentNode;
+                    inserted.prev = parentNode;
+                    if (next != null) {
+                        ((TreeNode<V>) next).prev = inserted;
+                    }
+                    moveRootToFront(tab, balanceInsertion(root, inserted));
+                    return null;
+                }
+            }
+        }
+
+        private void treeify(HashNode<V>[] tab) {
+            TreeNode<V> root = null;
+            TreeNode<V> node = this;
+            while (node != null) {
+                TreeNode<V> next = (TreeNode<V>) node.next;
+                node.left = null;
+                node.right = null;
+                if (root == null) {
+                    node.parent = null;
+                    node.red = false;
+                    root = node;
+                } else {
+                    int hash = node.hash;
+                    String key = node.key;
+                    TreeNode<V> treeNode = root;
+                    while (true) {
+                        int direction;
+                        if (treeNode.hash > hash) {
+                            direction = -1;
+                        } else if (treeNode.hash < hash) {
+                            direction = 1;
+                        } else {
+                            direction = treeNode.key.compareTo(key) > 0 ? -1 : 1;
+                        }
+
+                        TreeNode<V> parentNode = treeNode;
+                        treeNode = direction <= 0 ? treeNode.left : treeNode.right;
+                        if (treeNode == null) {
+                            node.parent = parentNode;
+                            if (direction <= 0) {
+                                parentNode.left = node;
+                            } else {
+                                parentNode.right = node;
+                            }
+                            root = balanceInsertion(root, node);
+                            break;
+                        }
+                    }
+                }
+                node = next;
+            }
+            moveRootToFront(tab, root);
+        }
+
+        private void split(HashNode<V>[] newTable, int index, int bit) {
+            TreeNode<V> loHead = null;
+            TreeNode<V> loTail = null;
+            TreeNode<V> hiHead = null;
+            TreeNode<V> hiTail = null;
+            int loCount = 0;
+            int hiCount = 0;
+
+            TreeNode<V> node = this;
+            while (node != null) {
+                TreeNode<V> next = (TreeNode<V>) node.next;
+                node.next = null;
+                if ((node.hash & bit) == 0) {
+                    node.prev = loTail;
+                    if (loTail == null) {
+                        loHead = node;
+                    } else {
+                        loTail.next = node;
+                    }
+                    loTail = node;
+                    ++loCount;
+                } else {
+                    node.prev = hiTail;
+                    if (hiTail == null) {
+                        hiHead = node;
+                    } else {
+                        hiTail.next = node;
+                    }
+                    hiTail = node;
+                    ++hiCount;
+                }
+                node = next;
+            }
+
+            if (loHead != null) {
+                if (loCount <= UNTREEIFY_THRESHOLD) {
+                    newTable[index] = loHead.untreeify();
+                } else {
+                    newTable[index] = loHead;
+                    if (hiHead != null) {
+                        loHead.treeify(newTable);
+                    }
+                }
+            }
+            if (hiHead != null) {
+                if (hiCount <= UNTREEIFY_THRESHOLD) {
+                    newTable[index + bit] = hiHead.untreeify();
+                } else {
+                    newTable[index + bit] = hiHead;
+                    if (loHead != null) {
+                        hiHead.treeify(newTable);
+                    }
+                }
+            }
+        }
+
+        private HashNode<V> untreeify() {
+            HashNode<V> head = null;
+            HashNode<V> tail = null;
+            for (HashNode<V> node = this; node != null; node = node.next) {
+                HashNode<V> replacement = new HashNode<>(node.hash, node.key, node.value, null);
+                if (tail == null) {
+                    head = replacement;
+                } else {
+                    tail.next = replacement;
+                }
+                tail = replacement;
+            }
+            return head;
+        }
+
+        private static <V> void moveRootToFront(HashNode<V>[] tab, TreeNode<V> root) {
+            if (root == null || tab == null || tab.length == 0) {
+                return;
+            }
+
+            int index = (tab.length - 1) & root.hash;
+            TreeNode<V> first = (TreeNode<V>) tab[index];
+            if (root != first) {
+                HashNode<V> rootNext = root.next;
+                tab[index] = root;
+                TreeNode<V> rootPrev = root.prev;
+                if (rootNext != null) {
+                    ((TreeNode<V>) rootNext).prev = rootPrev;
+                }
+                if (rootPrev != null) {
+                    rootPrev.next = rootNext;
+                }
+                if (first != null) {
+                    first.prev = root;
+                }
+                root.next = first;
+                root.prev = null;
+            }
+        }
+
+        private static <V> TreeNode<V> balanceInsertion(TreeNode<V> root, TreeNode<V> node) {
+            node.red = true;
+            while (true) {
+                TreeNode<V> parent = node.parent;
+                if (parent == null) {
+                    node.red = false;
+                    return node;
+                }
+                TreeNode<V> grandParent = parent.parent;
+                if (!parent.red || grandParent == null) {
+                    return root;
+                }
+
+                if (parent == grandParent.left) {
+                    TreeNode<V> uncle = grandParent.right;
+                    if (uncle != null && uncle.red) {
+                        uncle.red = false;
+                        parent.red = false;
+                        grandParent.red = true;
+                        node = grandParent;
+                    } else {
+                        if (node == parent.right) {
+                            root = rotateLeft(root, parent);
+                            node = parent;
+                            parent = node.parent;
+                            grandParent = parent == null ? null : parent.parent;
+                        }
+                        if (parent != null) {
+                            parent.red = false;
+                            if (grandParent != null) {
+                                grandParent.red = true;
+                                root = rotateRight(root, grandParent);
+                            }
+                        }
+                    }
+                } else {
+                    TreeNode<V> uncle = grandParent.left;
+                    if (uncle != null && uncle.red) {
+                        uncle.red = false;
+                        parent.red = false;
+                        grandParent.red = true;
+                        node = grandParent;
+                    } else {
+                        if (node == parent.left) {
+                            root = rotateRight(root, parent);
+                            node = parent;
+                            parent = node.parent;
+                            grandParent = parent == null ? null : parent.parent;
+                        }
+                        if (parent != null) {
+                            parent.red = false;
+                            if (grandParent != null) {
+                                grandParent.red = true;
+                                root = rotateLeft(root, grandParent);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static <V> TreeNode<V> rotateLeft(TreeNode<V> root, TreeNode<V> node) {
+            TreeNode<V> right = node.right;
+            if (right != null) {
+                TreeNode<V> rightLeft = right.left;
+                node.right = rightLeft;
+                if (rightLeft != null) {
+                    rightLeft.parent = node;
+                }
+
+                TreeNode<V> parent = node.parent;
+                right.parent = parent;
+                if (parent == null) {
+                    root = right;
+                    root.red = false;
+                } else if (parent.left == node) {
+                    parent.left = right;
+                } else {
+                    parent.right = right;
+                }
+
+                right.left = node;
+                node.parent = right;
+            }
+            return root;
+        }
+
+        private static <V> TreeNode<V> rotateRight(TreeNode<V> root, TreeNode<V> node) {
+            TreeNode<V> left = node.left;
+            if (left != null) {
+                TreeNode<V> leftRight = left.right;
+                node.left = leftRight;
+                if (leftRight != null) {
+                    leftRight.parent = node;
+                }
+
+                TreeNode<V> parent = node.parent;
+                left.parent = parent;
+                if (parent == null) {
+                    root = left;
+                    root.red = false;
+                } else if (parent.right == node) {
+                    parent.right = left;
+                } else {
+                    parent.left = left;
+                }
+
+                left.right = node;
+                node.parent = left;
+            }
+            return root;
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/dao/state/model/LegacyDaoStateHashSerializerV1Test.java
+++ b/core/src/test/java/bisq/core/dao/state/model/LegacyDaoStateHashSerializerV1Test.java
@@ -1,0 +1,194 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model;
+
+import bisq.core.dao.state.model.blockchain.Block;
+import bisq.core.dao.state.model.blockchain.SpentInfo;
+import bisq.core.dao.state.model.blockchain.TxOutput;
+import bisq.core.dao.state.model.blockchain.TxOutputKey;
+import bisq.core.dao.state.model.governance.Issuance;
+import bisq.core.dao.state.model.governance.IssuanceType;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LegacyDaoStateHashSerializerV1Test {
+    private static final int RANDOMIZED_TX_OUTPUT_KEY_COUNT = 50_000;
+    private static final String JAVA_11_RANDOMIZED_TX_OUTPUT_KEY_ORDER_DIGEST =
+            "33ef83bb099ad2ccbcb7ac588b664c8be6770fa71034ea25cec5ce7aef4fb84f";
+    private static final List<String> KEYS = IntStream.range(0, 40)
+            .mapToObj(i -> String.format("k%02d", i))
+            .collect(Collectors.toList());
+    private static final List<String> JAVA_11_HASH_MAP_ORDER = List.of(
+            "k31", "k30", "k11", "k33", "k10", "k32", "k13", "k35", "k12", "k34",
+            "k15", "k37", "k14", "k36", "k17", "k39", "k16", "k38", "k19", "k18",
+            "k20", "k00", "k22", "k21", "k02", "k24", "k01", "k23", "k04", "k26",
+            "k03", "k25", "k06", "k28", "k05", "k27", "k08", "k07", "k29", "k09");
+    private static final List<String> JAVA_11_TX_OUTPUT_KEY_HASH_MAP_ORDER = List.of(
+            "k31:0", "k30:0", "k09:0", "k07:0", "k08:0", "k29:0", "k01:0", "k24:0",
+            "k02:0", "k23:0", "k22:0", "k00:0", "k21:0", "k05:0", "k28:0", "k06:0",
+            "k27:0", "k03:0", "k26:0", "k04:0", "k25:0", "k20:0", "k18:0", "k19:0",
+            "k12:0", "k35:0", "k13:0", "k34:0", "k10:0", "k33:0", "k11:0", "k32:0",
+            "k16:0", "k39:0", "k17:0", "k38:0", "k14:0", "k37:0", "k15:0", "k36:0");
+    private static final List<String> JAVA_11_TREEIFIED_COLLISION_HASH_MAP_ORDER = List.of(
+            "AaAaBBBB", "AaAaAaAa", "AaAaAaBB", "AaAaBBAa", "AaBBAaAa", "AaBBAaBB",
+            "AaBBBBAa", "AaBBBBBB", "BBAaAaAa", "BBAaAaBB", "BBAaBBAa", "BBAaBBBB",
+            "BBBBAaAa", "BBBBAaBB", "BBBBBBAa", "BBBBBBBB");
+
+    @Test
+    void returnsJava11HashMapIterationOrder() {
+        assertEquals(JAVA_11_HASH_MAP_ORDER,
+                LegacyDaoStateHashSerializerV1.getJava11HashMapIterationOrder(KEYS));
+    }
+
+    @Test
+    void preservesJava11HashMapOrderForListHashCollisions() {
+        List<String> collidingKeys = getSameHashStrings(3);
+
+        assertEquals(1, collidingKeys.stream().mapToInt(String::hashCode).distinct().count());
+        assertEquals(collidingKeys, LegacyDaoStateHashSerializerV1.getJava11HashMapIterationOrder(collidingKeys));
+    }
+
+    @Test
+    void preservesJava11HashMapOrderForTreeifiedHashCollisions() {
+        List<String> collidingKeys = getSameHashStrings(4);
+
+        assertEquals(1, collidingKeys.stream().mapToInt(String::hashCode).distinct().count());
+        assertEquals(JAVA_11_TREEIFIED_COLLISION_HASH_MAP_ORDER,
+                LegacyDaoStateHashSerializerV1.getJava11HashMapIterationOrder(collidingKeys));
+    }
+
+    @Test
+    void preservesJava11HashMapOrderForMassiveRandomizedTxOutputKeys() throws Exception {
+        List<String> keys = getRandomizedTxOutputKeyStrings(RANDOMIZED_TX_OUTPUT_KEY_COUNT);
+        List<String> orderedKeys = LegacyDaoStateHashSerializerV1.getJava11HashMapIterationOrder(keys);
+
+        assertEquals(RANDOMIZED_TX_OUTPUT_KEY_COUNT, orderedKeys.size());
+        assertEquals(JAVA_11_RANDOMIZED_TX_OUTPUT_KEY_ORDER_DIGEST, getOrderDigest(orderedKeys));
+    }
+
+    @Test
+    void serializesDaoStateMapsInJava11HashMapIterationOrder() throws Exception {
+        DaoState daoState = getDaoStateWithMaps();
+
+        protobuf.DaoState proto = protobuf.DaoState.parseFrom(LegacyDaoStateHashSerializerV1.serialize(daoState));
+
+        assertEquals(JAVA_11_HASH_MAP_ORDER, new ArrayList<>(proto.getIssuanceMapMap().keySet()));
+        assertEquals(JAVA_11_TX_OUTPUT_KEY_HASH_MAP_ORDER,
+                new ArrayList<>(proto.getUnspentTxOutputMapMap().keySet()));
+        assertEquals(JAVA_11_TX_OUTPUT_KEY_HASH_MAP_ORDER,
+                new ArrayList<>(proto.getSpentInfoMapMap().keySet()));
+    }
+
+    @Test
+    void daoStateHashChainSerializationUsesLegacySerializer() {
+        DaoState daoState = getDaoStateWithMaps();
+
+        assertArrayEquals(LegacyDaoStateHashSerializerV1.serialize(daoState),
+                daoState.getSerializedStateForHashChain());
+    }
+
+    private static DaoState getDaoStateWithMaps() {
+        DaoState daoState = new DaoState();
+        daoState.setChainHeight(100);
+        daoState.addBlock(new Block(100, 1_000, "blockHash", "previousBlockHash"));
+
+        for (int i = 0; i < KEYS.size(); i++) {
+            String key = KEYS.get(i);
+            daoState.getIssuanceMap().put(key,
+                    new Issuance(key, 100, i, "pubKey" + i, IssuanceType.COMPENSATION));
+
+            TxOutputKey txOutputKey = new TxOutputKey(key, 0);
+            daoState.getUnspentTxOutputMap().put(txOutputKey, getTxOutput(key, i));
+            daoState.getSpentInfoMap().put(txOutputKey, new SpentInfo(100, key, i));
+        }
+        return daoState;
+    }
+
+    private static TxOutput getTxOutput(String txId, int index) {
+        protobuf.BaseTxOutput proto = protobuf.BaseTxOutput.newBuilder()
+                .setIndex(0)
+                .setValue(1000 + index)
+                .setTxId(txId)
+                .setBlockHeight(100)
+                .setTxOutput(protobuf.TxOutput.newBuilder()
+                        .setTxOutputType(protobuf.TxOutputType.BSQ_OUTPUT)
+                        .setLockTime(-1)
+                        .setUnlockBlockHeight(0))
+                .build();
+        return TxOutput.fromProto(proto);
+    }
+
+    private static List<String> getSameHashStrings(int parts) {
+        List<String> result = new ArrayList<>();
+        int count = 1 << parts;
+        for (int i = 0; i < count; i++) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int bit = parts - 1; bit >= 0; bit--) {
+                stringBuilder.append(((i >>> bit) & 1) == 0 ? "Aa" : "BB");
+            }
+            result.add(stringBuilder.toString());
+        }
+        Collections.sort(result);
+        return result;
+    }
+
+    private static List<String> getRandomizedTxOutputKeyStrings(int count) {
+        List<String> keys = new ArrayList<>(count);
+        long state = 0x6a09e667f3bcc909L;
+        for (int i = 0; i < count; i++) {
+            StringBuilder txId = new StringBuilder(64);
+            for (int part = 0; part < 4; part++) {
+                state = state * 0x5851f42d4c957f2dL + 0x14057b7ef767814fL;
+                txId.append(toPaddedHex(state));
+            }
+            keys.add(txId + ":" + (i & 3));
+        }
+        Collections.sort(keys);
+        return keys;
+    }
+
+    private static String toPaddedHex(long value) {
+        String hex = Long.toHexString(value);
+        return "0000000000000000".substring(hex.length()) + hex;
+    }
+
+    private static String getOrderDigest(List<String> keys) throws Exception {
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+        for (String key : keys) {
+            messageDigest.update(key.getBytes(StandardCharsets.UTF_8));
+            messageDigest.update((byte) 0);
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        for (byte b : messageDigest.digest()) {
+            stringBuilder.append(String.format("%02x", b));
+        }
+        return stringBuilder.toString();
+    }
+}


### PR DESCRIPTION
DAO state monitoring compares the local DAO state hash chain tip with hashes reported by seed nodes and peers. After moving the client runtime from Java 11 to Java 21, the serialized bytes used as monitor hash input changed because the DAO state proto builder routed TreeMap-backed DAO maps through Collectors.toMap(), which creates a HashMap with runtime-dependent iteration order.

The canonical DAO state itself is not changed by this issue: snapshots and state loading still deserialize protobuf maps into TreeMaps in DaoState.fromProto. The regression only affects the monitor hash byte stream that is hashed and compared with legacy seed nodes.

Add LegacyDaoStateHashSerializerV1 for the monitor hash path. It serializes the DAO state excluding historical blocks, adds the chain-tip block as before, and orders the protobuf map fields using the same default Java 11 HashMap bucket iteration behavior. This keeps hotfix clients compatible with old seed nodes without changing the normal DAO state clone/snapshot serialization path.

DaoState.getSerializedStateForHashChain() now delegates to the legacy serializer and documents why the legacy order must be preserved.

Tests cover:

- Java 11 HashMap iteration order for string tx IDs.
- Java 11 HashMap iteration order for TxOutputKey string map keys.
- DAO monitor serialization using the legacy serializer.

Verified with:

- ./gradlew :core:test --tests bisq.core.dao.state.model.LegacyDaoStateHashSerializerV1Test

<!-- 
- make yourself familiar with the CONTRIBUTING.md if you have not already (https://github.com/bisq-network/bisq/blob/master/CONTRIBUTING.md)
- make sure you follow our [coding style guidelines][https://github.com/bisq-network/style/issues)
- pick a descriptive title
- provide some meaningful PR description below
- create the PR
- in case you receive a "Change request" and/or a NACK, please react within 30 days. If not, we will close your PR and it can not be up for compensation.
- After addressing the change request, __please re-request a review!__ Otherwise we might miss your PR as we tend to only look at pull requests tagged with a "review required".
-->

Fixes #replaceWithIssueNr, fixes #replaceWithIssueNr

Your PR description here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved DAO state hash serialization to preserve legacy compatibility and ensure consistent hash-chain bytes.
* **Tests**
  * Added comprehensive tests to validate legacy ordering and deterministic serialized state outputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7771)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->