### PR TITLE
Normalize P2A scripts for DAO state hashing

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/full/rpc/DtoPubKeyScript.java
+++ b/core/src/main/java/bisq/core/dao/node/full/rpc/DtoPubKeyScript.java
@@ -19,6 +19,14 @@ import bisq.wallets.bitcoind.rpc.responses.BitcoindScriptPubKey;
 
 @Getter
 public class DtoPubKeyScript {
+    // Pay-to-anchor (P2A) script: OP_1 followed by the two-byte witness program 0x4e73.
+    // Bitcoin Core 29 reports this script as type "anchor", but legacy nodes did not.
+    private static final String PAY_TO_ANCHOR_HEX = "51024e73";
+    // Verified with Bitcoin Knots v27.1.knots20240801:
+    // `decodescript 51024e73` returns asm "1 29518" and type "witness_unknown".
+    // Keep this legacy asm because PubKeyScript.asm is serialized into the DAO state hash.
+    private static final String PAY_TO_ANCHOR_LEGACY_ASM = "1 29518";
+
     private final String asm;
     private final String hex;
     private final ScriptType type;
@@ -26,6 +34,17 @@ public class DtoPubKeyScript {
     private final List<String> addresses;
 
     public DtoPubKeyScript(BitcoindScriptPubKey bitcoindScriptPubKey) {
+        if (isPayToAnchor(bitcoindScriptPubKey)) {
+            // Bitcoin Core 29 returns type "anchor" for the P2A script, while older Core versions returned
+            // "witness_unknown". The DAO state hash must keep the older representation.
+            this.asm = PAY_TO_ANCHOR_LEGACY_ASM;
+            this.hex = PAY_TO_ANCHOR_HEX;
+            this.type = ScriptType.WITNESS_UNKNOWN;
+            this.addresses = Collections.emptyList();
+            this.reqSigs = 0;
+            return;
+        }
+
         this.asm = bitcoindScriptPubKey.getAsm();
         this.hex = bitcoindScriptPubKey.getHex();
         this.type = ScriptType.fromScriptPubKey(bitcoindScriptPubKey);
@@ -55,5 +74,10 @@ public class DtoPubKeyScript {
             // in that case do not provide an address to the RawTxOutput
             return Optional.empty();
         }
+    }
+
+    private boolean isPayToAnchor(BitcoindScriptPubKey bitcoindScriptPubKey) {
+        return PAY_TO_ANCHOR_HEX.equalsIgnoreCase(bitcoindScriptPubKey.getHex()) ||
+                "anchor".equals(bitcoindScriptPubKey.getType());
     }
 }

--- a/core/src/test/java/bisq/core/dao/node/full/rpc/DtoPubKeyScriptTest.java
+++ b/core/src/test/java/bisq/core/dao/node/full/rpc/DtoPubKeyScriptTest.java
@@ -1,0 +1,60 @@
+package bisq.core.dao.node.full.rpc;
+
+import bisq.core.dao.state.model.blockchain.PubKeyScript;
+import bisq.core.dao.state.model.blockchain.ScriptType;
+
+import bisq.wallets.bitcoind.rpc.responses.BitcoindScriptPubKey;
+
+import com.google.gson.Gson;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DtoPubKeyScriptTest {
+    private static final Gson GSON = new Gson();
+
+    @Test
+    void normalizesAnchorScriptToLegacyWitnessUnknown() {
+        DtoPubKeyScript scriptPubKey = new DtoPubKeyScript(scriptPubKey(
+                "1 29518",
+                "51024e73",
+                "anchor"));
+
+        assertLegacyPayToAnchorScript(scriptPubKey);
+    }
+
+    @Test
+    void normalizesPayToAnchorHexEvenWithLegacyScriptType() {
+        DtoPubKeyScript scriptPubKey = new DtoPubKeyScript(scriptPubKey(
+                "OP_1 0x4e73",
+                "51024E73",
+                "witness_unknown"));
+
+        assertLegacyPayToAnchorScript(scriptPubKey);
+    }
+
+    private void assertLegacyPayToAnchorScript(DtoPubKeyScript scriptPubKey) {
+        assertEquals("1 29518", scriptPubKey.getAsm());
+        assertEquals("51024e73", scriptPubKey.getHex());
+        assertEquals(ScriptType.WITNESS_UNKNOWN, scriptPubKey.getType());
+        assertEquals(0, scriptPubKey.getReqSigs());
+        assertTrue(scriptPubKey.getAddresses().isEmpty());
+
+        protobuf.PubKeyScript proto = new PubKeyScript(scriptPubKey).toProtoMessage();
+        assertEquals(protobuf.ScriptType.WITNESS_UNKNOWN, proto.getScriptType());
+        assertEquals(0, proto.getReqSigs());
+        assertEquals("1 29518", proto.getAsm());
+        assertEquals("51024e73", proto.getHex());
+        assertEquals(0, proto.getAddressesCount());
+    }
+
+    private BitcoindScriptPubKey scriptPubKey(String asm, String hex, String type) {
+        return GSON.fromJson("{\"asm\":\"" + asm + "\"," +
+                        "\"hex\":\"" + hex + "\"," +
+                        "\"address\":\"bc1pfeessrawgf\"," +
+                        "\"type\":\"" + type + "\"}",
+                BitcoindScriptPubKey.class);
+    }
+}


### PR DESCRIPTION
Bitcoin Core 29 reports the pay-to-anchor script 51024e73 as type "anchor", while legacy Knots/Core 27 reports the same script as "witness_unknown".

Normalize P2A outputs before they enter the DAO state model so new nodes keep the legacy hash-critical representation: WITNESS_UNKNOWN, asm "1 29518", no addresses, and reqSigs 0.

Add a regression test covering both the Core 29 "anchor" type and the legacy "witness_unknown" type for the same P2A script.

Verified with:
./gradlew :core:test --tests bisq.core.dao.node.full.rpc.DtoPubKeyScriptTest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced anchor script handling to ensure proper normalization and legacy compatibility.

* **Tests**
  * Added test coverage for anchor script processing to verify correct normalization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7773)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->