### PR TITLE
Disable dispute log file transfer

### DIFF
--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -43,11 +43,8 @@ import bisq.core.trade.protocol.bisq_v1.DisputeProtocol;
 import bisq.core.trade.protocol.bisq_v1.model.ProcessModel;
 
 import bisq.network.p2p.AckMessageSourceType;
-import bisq.network.p2p.FileTransferPart;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
-import bisq.network.p2p.network.Connection;
-import bisq.network.p2p.network.MessageListener;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
@@ -56,7 +53,6 @@ import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
-import bisq.common.proto.network.NetworkEnvelope;
 
 import org.bitcoinj.core.Coin;
 
@@ -76,7 +72,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 @Singleton
-public final class MediationManager extends DisputeManager<MediationDisputeList> implements MessageListener, FileTransferSession.FtpCallback {
+public final class MediationManager extends DisputeManager<MediationDisputeList> {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -98,7 +94,6 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
                             PriceFeedService priceFeedService) {
         super(p2PService, tradeWalletService, walletService, walletsSetup, tradeManager, closedTradableManager, failedTradesManager,
                 openOfferManager, daoFacade, keyRing, mediationDisputeListService, config, priceFeedService);
-        p2PService.getNetworkNode().addMessageListener(this);   // listening for FileTransferPart message
     }
 
 
@@ -286,59 +281,13 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
         tradeManager.requestPersistence();
     }
 
+    /**
+     * @deprecated Log file transfer is disabled. This method remains as a fail-closed guard for stale callers.
+     */
+    @Deprecated
     public FileTransferSender initLogUpload(FileTransferSession.FtpCallback callback,
                                             String tradeId,
                                             int traderId) throws IOException {
-        Dispute dispute = findDispute(tradeId, traderId)
-                .orElseThrow(() -> new IOException("could not locate Dispute for tradeId/traderId"));
-        return dispute.createFileTransferSender(p2PService.getNetworkNode(),
-                dispute.getContract().getMediatorNodeAddress(), callback);
-    }
-
-    private void processFilePartReceived(FileTransferPart ftp) {
-        if (!ftp.isInitialRequest()) {
-            return; // existing sessions are processed by FileTransferSession object directly
-        }
-        // we create a new session which is related to an open dispute from our list
-        Optional<Dispute> dispute = findDispute(ftp.getTradeId(), ftp.getTraderId());
-        if (dispute.isEmpty()) {
-            log.error("Received log upload request for unknown TradeId/TraderId {}/{}", ftp.getTradeId(), ftp.getTraderId());
-            return;
-        }
-        if (dispute.get().isClosed()) {
-            log.error("Received a file transfer request for closed dispute {}", ftp.getTradeId());
-            return;
-        }
-        try {
-            FileTransferReceiver session = dispute.get().createOrGetFileTransferReceiver(
-                    p2PService.getNetworkNode(), ftp.getSenderNodeAddress(), this);
-            session.processFilePartReceived(ftp);
-        } catch (IOException e) {
-            log.error("Unable to process a received file message" + e);
-        }
-    }
-
-    @Override
-    public void onMessage(NetworkEnvelope networkEnvelope, Connection connection) {
-        if (networkEnvelope instanceof FileTransferPart) {              // mediator receiving log file data
-            FileTransferPart ftp = (FileTransferPart) networkEnvelope;
-            processFilePartReceived(ftp);
-        }
-    }
-
-    @Override
-    public void onFtpProgress(double progressPct) {
-        log.trace("ftp progress: {}", progressPct);
-    }
-
-    @Override
-    public void onFtpComplete(FileTransferSession session) {
-        Optional<Dispute> dispute = findDispute(session.getFullTradeId(), session.getTraderId());
-        dispute.ifPresent(d -> addMediationLogsReceivedMessage(d, session.getZipId()));
-    }
-
-    @Override
-    public void onFtpTimeout(String statusMsg, FileTransferSession session) {
-        session.resetSession();
+        throw new IOException("Log file transfer is disabled");
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeChatPopup.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeChatPopup.java
@@ -58,7 +58,6 @@ import lombok.Getter;
 public class DisputeChatPopup {
     public interface ChatCallback {
         void onCloseDisputeFromChatWindow(Dispute dispute);
-        void onSendLogsFromChatWindow(Dispute dispute);
     }
 
     private Stage chatPopupStage;
@@ -119,11 +118,9 @@ public class DisputeChatPopup {
             } else {
                 MenuButton menuButton = new MenuButton(Res.get("support.moreButton"));
                 MenuItem menuItem1 = new MenuItem(Res.get("support.uploadTraderChat"));
-                MenuItem menuItem2 = new MenuItem(Res.get("support.sendLogFiles"));
                 menuItem1.setOnAction(e -> doTextAttachment(chatView));
                 setChatUploadEnabledState(menuItem1);
-                menuItem2.setOnAction(e -> chatCallback.onSendLogsFromChatWindow(selectedDispute));
-                menuButton.getItems().addAll(menuItem1, menuItem2);
+                menuButton.getItems().add(menuItem1);
                 menuButton.getStyleClass().add("jfx-button");
                 menuButton.setStyle("-fx-padding: 0 10 0 10;");
                 chatView.display(concreteDisputeSession, menuButton, pane.widthProperty());

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -28,7 +28,6 @@ import bisq.desktop.components.PeerInfoIconMap;
 import bisq.desktop.main.overlays.popups.Popup;
 import bisq.desktop.main.overlays.windows.ContractWindow;
 import bisq.desktop.main.overlays.windows.DisputeSummaryWindow;
-import bisq.desktop.main.overlays.windows.SendLogFilesWindow;
 import bisq.desktop.main.overlays.windows.SendPrivateNotificationWindow;
 import bisq.desktop.main.overlays.windows.TradeDetailsWindow;
 import bisq.desktop.main.overlays.windows.VerifyDisputeResultSignatureWindow;
@@ -1509,13 +1508,5 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> implements
         } else {
             closeDisputeFromButton();
         }
-    }
-
-    @Override
-    public void onSendLogsFromChatWindow(Dispute dispute) {
-        if (!(disputeManager instanceof MediationManager))
-            return;
-        MediationManager mediationManager = (MediationManager) disputeManager;
-        new SendLogFilesWindow(dispute.getTradeId(), dispute.getTraderId(), mediationManager).show();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fully disabled log file transfer in dispute mediation; attempts to initiate log uploads now fail with a clear error.
  * Removed the "send logs" option from the dispute chat interface and related callbacks, leaving only text attachment support in the chat "more" menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7783)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->