### PR TITLE
MacOS Dual Architecture Support

### DIFF
--- a/build-logic/commons/src/main/groovy/bisq.javafx.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.javafx.gradle
@@ -1,7 +1,27 @@
+import org.gradle.nativeplatform.MachineArchitecture
+import org.gradle.nativeplatform.OperatingSystemFamily
+
 plugins {
     id 'org.openjfx.javafxplugin'
 }
 
 javafx {
     version = libs.versions.javafx.get()
+}
+
+plugins.withId('java') {
+    afterEvaluate {
+        def javafxPlatform = extensions.getByName('javafx').platform
+        def operatingSystem = objects.named(OperatingSystemFamily, javafxPlatform.osFamily)
+        def architecture = objects.named(MachineArchitecture, javafxPlatform.arch)
+
+        ['apiElements', 'runtimeElements'].each { configurationName ->
+            configurations.named(configurationName) {
+                attributes {
+                    attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, operatingSystem)
+                    attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, architecture)
+                }
+            }
+        }
+    }
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Architecture.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Architecture.kt
@@ -7,8 +7,15 @@ enum class Architecture(val installerClassifier: String) {
     AARCH64("aarch64")
 }
 
+private const val OS_ARCH_PROPERTY = "os.arch"
+
 fun getArchitecture(): Architecture {
-    val architecture = System.getProperty("os.arch").lowercase(Locale.US)
+    val osArch = getOsArch()
+    if (osArch.isBlank()) {
+        throw IllegalStateException("Running on unsupported Architecture: os.arch is missing or blank (value='$osArch')")
+    }
+
+    val architecture = osArch.trim().lowercase(Locale.US)
     if (architecture == "aarch64" || architecture == "arm64") {
         return Architecture.AARCH64
     }
@@ -17,5 +24,13 @@ fun getArchitecture(): Architecture {
         return Architecture.X86_64
     }
 
-    throw IllegalStateException("Running on unsupported Architecture: $architecture")
+    throw IllegalStateException("Running on unsupported Architecture: os.arch='$osArch'")
+}
+
+private fun getOsArch(): String {
+    return try {
+        System.getProperty(OS_ARCH_PROPERTY, "")
+    } catch (e: SecurityException) {
+        throw IllegalStateException("Cannot determine Architecture because os.arch cannot be read.", e)
+    }
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Architecture.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Architecture.kt
@@ -1,0 +1,21 @@
+package bisq.gradle.packaging
+
+import java.util.Locale
+
+enum class Architecture(val installerClassifier: String) {
+    X86_64("x86_64"),
+    AARCH64("aarch64")
+}
+
+fun getArchitecture(): Architecture {
+    val architecture = System.getProperty("os.arch").lowercase(Locale.US)
+    if (architecture == "aarch64" || architecture == "arm64") {
+        return Architecture.AARCH64
+    }
+    if (architecture == "x86_64" || architecture == "amd64" || architecture == "x64" ||
+            architecture == "x86" || architecture == "i386" || architecture == "i686") {
+        return Architecture.X86_64
+    }
+
+    throw IllegalStateException("Running on unsupported Architecture: $architecture")
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -67,7 +67,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
     private fun getHashFileForOs(project: Project): Provider<RegularFile> {
         val osName = when (getOS()) {
             OS.LINUX -> "linux"
-            OS.MAC_OS -> "mac"
+            OS.MAC_OS -> "mac-${getArchitecture().installerClassifier}"
             OS.WINDOWS -> "win"
         }
 

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Sha256HashTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Sha256HashTask.kt
@@ -53,7 +53,7 @@ abstract class Sha256HashTask : DefaultTask() {
     private fun getOsName(): String =
         when (getOS()) {
             OS.LINUX -> "linux"
-            OS.MAC_OS -> "macOS"
+            OS.MAC_OS -> "macOS-${getArchitecture().installerClassifier}"
             OS.WINDOWS -> "windows"
         }
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
@@ -1,5 +1,8 @@
 package bisq.gradle.packaging.jpackage
 
+import bisq.gradle.packaging.OS
+import bisq.gradle.packaging.getArchitecture
+import bisq.gradle.packaging.getOS
 import bisq.gradle.packaging.jpackage.package_formats.PackageFormat
 import org.gradle.api.GradleException
 import java.nio.file.Files
@@ -51,6 +54,9 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
 
             if (packageFormat == PackageFormat.RPM) {
                 normalizeRpmPackage(jPackageConfig.appConfig)
+            }
+            if (packageFormat == PackageFormat.DMG && getOS() == OS.MAC_OS) {
+                renameMacOsDmgPackage(jPackageConfig.appConfig)
             }
         }
     }
@@ -150,6 +156,16 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
 
         Files.move(rebuiltRpmPath, rpmPath, StandardCopyOption.REPLACE_EXISTING)
         normalizePathTimestamps(rpmPath)
+    }
+
+    private fun renameMacOsDmgPackage(appConfig: JPackageAppConfig) {
+        val dmgPath = findSinglePackageArtifact(PackageFormat.DMG)
+        val targetName = "Bisq-${getArchitecture().installerClassifier}-${appConfig.appVersion}.dmg"
+        if (dmgPath.fileName.toString() == targetName) {
+            return
+        }
+
+        Files.move(dmgPath, dmgPath.resolveSibling(targetName), StandardCopyOption.REPLACE_EXISTING)
     }
 
     private fun createNormalizedRpmSpec(appConfig: JPackageAppConfig, payloadRoot: Path): String {

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
@@ -159,13 +159,17 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
     }
 
     private fun renameMacOsDmgPackage(appConfig: JPackageAppConfig) {
-        val dmgPath = findSinglePackageArtifact(PackageFormat.DMG)
-        val targetName = "Bisq-${getArchitecture().installerClassifier}-${appConfig.appVersion}.dmg"
-        if (dmgPath.fileName.toString() == targetName) {
+        val sourcePath = jPackageConfig.outputDirPath.resolve("Bisq-${appConfig.appVersion}.dmg")
+        val targetPath = jPackageConfig.outputDirPath.resolve("Bisq-${getArchitecture().installerClassifier}-${appConfig.appVersion}.dmg")
+        if (!Files.exists(sourcePath) && Files.exists(targetPath)) {
             return
         }
 
-        Files.move(dmgPath, dmgPath.resolveSibling(targetName), StandardCopyOption.REPLACE_EXISTING)
+        if (!Files.exists(sourcePath)) {
+            throw GradleException("Expected macOS DMG not found: ${sourcePath.toAbsolutePath()}")
+        }
+
+        Files.move(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING)
     }
 
     private fun createNormalizedRpmSpec(appConfig: JPackageAppConfig, payloadRoot: Path): String {

--- a/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
+++ b/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
@@ -7,6 +7,8 @@ import org.gradle.platform.OperatingSystem
 import java.net.URI
 import java.util.*
 
+private const val OS_ARCH_PROPERTY = "os.arch"
+
 @Suppress("UnstableApiUsage")
 abstract class BisqToolchainResolver : JavaToolchainResolver {
     override fun resolve(toolchainRequest: JavaToolchainRequest): Optional<JavaToolchainDownload> {
@@ -52,11 +54,28 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
         }
 
     private fun getMacOsArchitectureClassifier(): String {
-        val architecture = System.getProperty("os.arch").toLowerCase(Locale.US)
-        return if (architecture.contains("aarch") || architecture.contains("arm")) {
-            "aarch64"
-        } else {
-            "x64"
+        val osArch = getOsArch()
+        if (osArch.isBlank()) {
+            throw IllegalStateException("Cannot choose macOS JDK toolchain because os.arch is missing or blank (value='$osArch').")
+        }
+
+        val architecture = osArch.trim().lowercase(Locale.US)
+        if (architecture == "aarch64" || architecture == "arm64") {
+            return "aarch64"
+        }
+        if (architecture == "x86_64" || architecture == "amd64" || architecture == "x64" ||
+            architecture == "x86" || architecture == "i386" || architecture == "i686") {
+            return "x64"
+        }
+
+        throw IllegalStateException("Cannot choose macOS JDK toolchain for unsupported os.arch value: '$osArch'.")
+    }
+
+    private fun getOsArch(): String {
+        return try {
+            System.getProperty(OS_ARCH_PROPERTY, "")
+        } catch (e: SecurityException) {
+            throw IllegalStateException("Cannot choose macOS JDK toolchain because os.arch cannot be read.", e)
         }
     }
 }

--- a/desktop/package/macosx/finalize.sh
+++ b/desktop/package/macosx/finalize.sh
@@ -93,7 +93,7 @@ cat "$macos_x86_64/desktop-$version-all-mac-x86_64.jar.SHA-256" \
 "$linux64/desktop-$version-all-linux.jar.SHA-256" \
 "$win64/desktop-$version-all-win.jar.SHA-256" > "$target_dir/Bisq-$version.jar.txt"
 
-cd -v "$script_working_directory/$target_dir"
+cd "$script_working_directory/$target_dir" || exit 1
 
 echo Create signatures
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$dmg_x86_64.asc" --detach-sig --armor "$dmg_x86_64"

--- a/desktop/package/macosx/finalize.sh
+++ b/desktop/package/macosx/finalize.sh
@@ -8,11 +8,14 @@ target_dir="desktop/releases/$version"
 
 # Set BISQ_GPG_USER as environment var to the email address used for gpg signing. e.g. BISQ_GPG_USER=manfred@bitsquare.io
 # Set BISQ_VM_PATH as environment var to the directory where your shared folders for virtual box are residing
+# Optional: Set BISQ_MACOS_X86_64_PATH and BISQ_MACOS_AARCH64_PATH to override the macOS build artifact directories.
 
 vmPath=$BISQ_VM_PATH
 linux64=$vmPath/vm_shared_ubuntu
 win64=$vmPath/vm_shared_windows
 macos=$vmPath/vm_shared_macosx
+macos_x86_64=${BISQ_MACOS_X86_64_PATH:-$macos}
+macos_aarch64=${BISQ_MACOS_AARCH64_PATH:-$vmPath/vm_shared_macosx_aarch64}
 
 deployDir=deploy
 
@@ -64,8 +67,10 @@ cp -v "./desktop/package/387C8307.asc" "$target_dir/"
 # signing key
 cp -v "./desktop/package/signingkey.asc" "$target_dir/"
 
-dmg="Bisq-$version.dmg"
-cp "$macos/$dmg" "$target_dir/"
+dmg_x86_64="Bisq-x86_64-$version.dmg"
+dmg_aarch64="Bisq-aarch64-$version.dmg"
+cp "$macos_x86_64/$dmg_x86_64" "$target_dir/"
+cp "$macos_aarch64/$dmg_aarch64" "$target_dir/"
 
 deb="bisq_$version-1_amd64.deb"
 deb64="Bisq-64bit-$version.deb"
@@ -83,14 +88,16 @@ cli="bisq-cli-$version.zip"
 daemon="bisq-daemon-$version.zip"
 
 # create file with jar signatures
-cat "$macos/desktop-$version-all-mac.jar.SHA-256" \
+cat "$macos_x86_64/desktop-$version-all-mac-x86_64.jar.SHA-256" \
+"$macos_aarch64/desktop-$version-all-mac-aarch64.jar.SHA-256" \
 "$linux64/desktop-$version-all-linux.jar.SHA-256" \
 "$win64/desktop-$version-all-win.jar.SHA-256" > "$target_dir/Bisq-$version.jar.txt"
 
 cd -v "$script_working_directory/$target_dir"
 
 echo Create signatures
-gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$dmg.asc" --detach-sig --armor "$dmg"
+gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$dmg_x86_64.asc" --detach-sig --armor "$dmg_x86_64"
+gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$dmg_aarch64.asc" --detach-sig --armor "$dmg_aarch64"
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$deb64.asc" --detach-sig --armor "$deb64"
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$rpm64.asc" --detach-sig --armor "$rpm64"
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$exe64.asc" --detach-sig --armor "$exe64"
@@ -98,7 +105,8 @@ gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$cli.asc" --det
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$daemon.asc" --detach-sig --armor "$daemon"
 
 echo Verify signatures
-gpg --digest-algo SHA256 --verify $dmg{.asc*,}
+gpg --digest-algo SHA256 --verify $dmg_x86_64{.asc*,}
+gpg --digest-algo SHA256 --verify $dmg_aarch64{.asc*,}
 gpg --digest-algo SHA256 --verify $deb64{.asc*,}
 gpg --digest-algo SHA256 --verify $rpm64{.asc*,}
 gpg --digest-algo SHA256 --verify $exe64{.asc*,}

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
@@ -224,14 +224,27 @@ public class BisqInstaller {
     }
 
     private static String getMacOsInstallerArchitecture() {
-        String architecture = System.getProperty("os.arch").toLowerCase(Locale.US);
+        String osArch = getOsArch();
+        if (osArch == null || osArch.trim().isEmpty())
+            throw new IllegalStateException("No suitable macOS install package available because os.arch is missing or blank: " +
+                    String.valueOf(osArch));
+
+        String architecture = osArch.trim().toLowerCase(Locale.US);
         if (architecture.equals("aarch64") || architecture.equals("arm64"))
             return "aarch64";
         if (architecture.equals("x86_64") || architecture.equals("amd64") || architecture.equals("x64") ||
                 architecture.equals("x86") || architecture.equals("i386") || architecture.equals("i686"))
             return "x86_64";
 
-        throw new RuntimeException("No suitable macOS install package available for architecture: " + architecture);
+        throw new RuntimeException("No suitable macOS install package available for architecture: " + osArch);
+    }
+
+    private static String getOsArch() {
+        try {
+            return System.getProperty("os.arch");
+        } catch (SecurityException e) {
+            throw new IllegalStateException("No suitable macOS install package available because os.arch cannot be read.", e);
+        }
     }
 
     @NotNull

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstaller.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import lombok.Builder;
@@ -198,19 +199,7 @@ public class BisqInstaller {
 
     @NotNull
     private FileDescriptor getInstallerDescriptor(String version, String partialUrl) {
-        String fileName;
-        String prefix = "Bisq-";
-        // https://github.com/bisq-network/exchange/releases/download/v0.5.1/Bisq-0.5.1.dmg
-        if (Utilities.isOSX())
-            fileName = prefix + version + ".dmg";
-        else if (Utilities.isWindows())
-            fileName = prefix + Utilities.getOSArchitecture() + "bit-" + version + ".exe";
-        else if (Utilities.isDebianLinux())
-            fileName = prefix + Utilities.getOSArchitecture() + "bit-" + version + ".deb";
-        else if (Utilities.isRedHatLinux())
-            fileName = prefix + Utilities.getOSArchitecture() + "bit-" + version + ".rpm";
-        else
-            throw new RuntimeException("No suitable install package available for your OS.");
+        String fileName = getInstallerFileName(version);
 
         return FileDescriptor.builder()
                 .type(DownloadType.INSTALLER)
@@ -218,6 +207,31 @@ public class BisqInstaller {
                 .id(fileName)
                 .loadUrl(partialUrl.concat(fileName))
                 .build();
+    }
+
+    static String getInstallerFileName(String version) {
+        String prefix = "Bisq-";
+        if (Utilities.isOSX())
+            return prefix + getMacOsInstallerArchitecture() + "-" + version + ".dmg";
+        else if (Utilities.isWindows())
+            return prefix + Utilities.getOSArchitecture() + "bit-" + version + ".exe";
+        else if (Utilities.isDebianLinux())
+            return prefix + Utilities.getOSArchitecture() + "bit-" + version + ".deb";
+        else if (Utilities.isRedHatLinux())
+            return prefix + Utilities.getOSArchitecture() + "bit-" + version + ".rpm";
+        else
+            throw new RuntimeException("No suitable install package available for your OS.");
+    }
+
+    private static String getMacOsInstallerArchitecture() {
+        String architecture = System.getProperty("os.arch").toLowerCase(Locale.US);
+        if (architecture.equals("aarch64") || architecture.equals("arm64"))
+            return "aarch64";
+        if (architecture.equals("x86_64") || architecture.equals("amd64") || architecture.equals("x64") ||
+                architecture.equals("x86") || architecture.equals("i386") || architecture.equals("i686"))
+            return "x86_64";
+
+        throw new RuntimeException("No suitable macOS install package available for architecture: " + architecture);
     }
 
     @NotNull
@@ -334,4 +348,3 @@ public class BisqInstaller {
         MISC
     }
 }
-

--- a/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
@@ -64,6 +64,17 @@ public class BisqInstallerTest {
 
     @Test
     public void getFileName() {
+        withSystemProperties("Mac OS X", "x86_64", () ->
+                assertEquals("Bisq-x86_64-1.2.3.dmg", BisqInstaller.getInstallerFileName("1.2.3")));
+
+        withSystemProperties("Mac OS X", "amd64", () ->
+                assertEquals("Bisq-x86_64-1.2.3.dmg", BisqInstaller.getInstallerFileName("1.2.3")));
+
+        withSystemProperties("Mac OS X", "aarch64", () ->
+                assertEquals("Bisq-aarch64-1.2.3.dmg", BisqInstaller.getInstallerFileName("1.2.3")));
+
+        withSystemProperties("Mac OS X", "arm64", () ->
+                assertEquals("Bisq-aarch64-1.2.3.dmg", BisqInstaller.getInstallerFileName("1.2.3")));
     }
 
     @Test
@@ -85,5 +96,25 @@ public class BisqInstallerTest {
         sigFileDescriptors = bisqInstaller.getSigFileDescriptors(installerFileDescriptor, Lists.newArrayList(key1, key2));
         assertEquals(2, sigFileDescriptors.size());
         log.info("test");
+    }
+
+    private void withSystemProperties(String osName, String osArch, Runnable assertion) {
+        String originalOsName = System.getProperty("os.name");
+        String originalOsArch = System.getProperty("os.arch");
+        try {
+            System.setProperty("os.name", osName);
+            System.setProperty("os.arch", osArch);
+            assertion.run();
+        } finally {
+            restoreSystemProperty("os.name", originalOsName);
+            restoreSystemProperty("os.arch", originalOsArch);
+        }
+    }
+
+    private void restoreSystemProperty(String key, String value) {
+        if (value == null)
+            System.clearProperty(key);
+        else
+            System.setProperty(key, value);
     }
 }

--- a/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
@@ -27,14 +27,11 @@ import java.io.File;
 
 import java.util.List;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.Test;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Slf4j
 public class BisqInstallerTest {
     @Test
     public void call() {
@@ -95,7 +92,6 @@ public class BisqInstallerTest {
         assertEquals(1, sigFileDescriptors.size());
         sigFileDescriptors = bisqInstaller.getSigFileDescriptors(installerFileDescriptor, Lists.newArrayList(key1, key2));
         assertEquals(2, sigFileDescriptors.size());
-        log.info("test");
     }
 
     private void withSystemProperties(String osName, String osArch, Runnable assertion) {

--- a/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/overlays/windows/downloadupdate/BisqInstallerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BisqInstallerTest {
     @Test
@@ -75,6 +76,28 @@ public class BisqInstallerTest {
     }
 
     @Test
+    public void getFileNameFailsClearlyWhenMacArchitectureIsMissing() {
+        withSystemProperties("Mac OS X", null, () -> {
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> BisqInstaller.getInstallerFileName("1.2.3"));
+
+            assertEquals("No suitable macOS install package available because os.arch is missing or blank: null",
+                    exception.getMessage());
+        });
+    }
+
+    @Test
+    public void getFileNameFailsClearlyWhenMacArchitectureIsBlank() {
+        withSystemProperties("Mac OS X", "  ", () -> {
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> BisqInstaller.getInstallerFileName("1.2.3"));
+
+            assertEquals("No suitable macOS install package available because os.arch is missing or blank:   ",
+                    exception.getMessage());
+        });
+    }
+
+    @Test
     public void getDownloadType() {
     }
 
@@ -99,7 +122,7 @@ public class BisqInstallerTest {
         String originalOsArch = System.getProperty("os.arch");
         try {
             System.setProperty("os.name", osName);
-            System.setProperty("os.arch", osArch);
+            restoreSystemProperty("os.arch", osArch);
             assertion.run();
         } finally {
             restoreSystemProperty("os.name", originalOsName);

--- a/docs/dependency-signature-report.md
+++ b/docs/dependency-signature-report.md
@@ -18,14 +18,14 @@ Refresh the metadata before regenerating this report:
 
 | Metric | Count |
 | --- | ---: |
-| Resolved external modules | 204 |
-| Modules with PGP-signed artifacts only | 187 |
-| Modules using checksum fallback only | 17 |
+| Resolved external modules | 205 |
+| Modules with PGP-signed artifacts only | 191 |
+| Modules using checksum fallback only | 14 |
 | Modules with mixed signed/checksum-only artifacts | 0 |
 | Modules missing verification metadata | 0 |
-| Verified artifacts | 426 |
-| PGP-signed artifacts | 393 |
-| Checksum-fallback artifacts | 33 |
+| Verified artifacts | 428 |
+| PGP-signed artifacts | 401 |
+| Checksum-fallback artifacts | 27 |
 | Signer keys found in exported keyring | 73 / 73 |
 | Signer keys with name or email | 53 / 73 |
 | Signer keys with creation date | 73 / 73 |
@@ -39,9 +39,6 @@ Treat transitive dependencies the same as direct dependencies. Gradle verifies t
 | Dependency | Scope | Checksum-only artifacts and review rationale |
 | --- | --- | --- |
 | `aopalliance:aopalliance:1.0` | transitive | `aopalliance-1.0.jar`<br>Legacy Maven Central artifact without published detached signatures.<br><br>`aopalliance-1.0.pom`<br>Legacy Maven Central artifact without published detached signatures. |
-| `com.github.bisq-network.netlayer:tor.external:47ea493b9eb6df2cad64499d5b5076c83a0d786c` | direct | `tor.external-47ea493b9eb6df2cad64499d5b5076c83a0d786c.jar`<br>Bisq-maintained JitPack Tor dependency pinned to an immutable commit.<br><br>`tor.external-47ea493b9eb6df2cad64499d5b5076c83a0d786c.pom`<br>Bisq-maintained JitPack Tor dependency pinned to an immutable commit. |
-| `com.github.bisq-network.netlayer:tor.native:47ea493b9eb6df2cad64499d5b5076c83a0d786c` | direct | `tor.native-47ea493b9eb6df2cad64499d5b5076c83a0d786c.jar`<br>Bisq-maintained JitPack Tor dependency pinned to an immutable commit.<br><br>`tor.native-47ea493b9eb6df2cad64499d5b5076c83a0d786c.pom`<br>Bisq-maintained JitPack Tor dependency pinned to an immutable commit. |
-| `com.github.bisq-network.netlayer:tor:47ea493b9eb6df2cad64499d5b5076c83a0d786c` | transitive | `tor-47ea493b9eb6df2cad64499d5b5076c83a0d786c.jar`<br>Bisq-maintained JitPack Tor dependency pinned to an immutable commit.<br><br>`tor-47ea493b9eb6df2cad64499d5b5076c83a0d786c.pom`<br>Bisq-maintained JitPack Tor dependency pinned to an immutable commit. |
 | `com.github.bisq-network.tor-binary:tor-binary-geoip:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | `tor-binary-geoip-7358b044704548b70cf8db4e2dacbe1ff4aa2171.jar`<br>Bisq-maintained Tor binary artifact pinned to an immutable commit.<br><br>`tor-binary-geoip-7358b044704548b70cf8db4e2dacbe1ff4aa2171.pom`<br>Bisq-maintained Tor binary artifact pinned to an immutable commit. |
 | `com.github.bisq-network.tor-binary:tor-binary-linux32:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | `tor-binary-linux32-7358b044704548b70cf8db4e2dacbe1ff4aa2171.jar`<br>Bisq-maintained Tor binary artifact pinned to an immutable commit.<br><br>`tor-binary-linux32-7358b044704548b70cf8db4e2dacbe1ff4aa2171.pom`<br>Bisq-maintained Tor binary artifact pinned to an immutable commit. |
 | `com.github.bisq-network.tor-binary:tor-binary-linux64:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | `tor-binary-linux64-7358b044704548b70cf8db4e2dacbe1ff4aa2171.jar`<br>Bisq-maintained Tor binary artifact pinned to an immutable commit.<br><br>`tor-binary-linux64-7358b044704548b70cf8db4e2dacbe1ff4aa2171.pom`<br>Bisq-maintained Tor binary artifact pinned to an immutable commit. |
@@ -81,12 +78,13 @@ Treat transitive dependencies the same as direct dependencies. Gradle verifies t
 | `com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.21.2` | transitive | PGP signed | 2 signed / 0 checksum | `28118C070CB22A0175A2E8D43D12CA2AC19F3181`<br>Tatu Saloranta (cowtowncoder)<br>`tatu.saloranta@iki.fi`<br>created 2022-08-13<br><br>`6214760097DC5CFAD0175AC2C9FBAA83A8753994`<br>created 2016-07-26 |
 | `com.fasterxml.jackson:jackson-bom:2.21.1` | transitive | PGP signed | 1 signed / 0 checksum | `28118C070CB22A0175A2E8D43D12CA2AC19F3181`<br>Tatu Saloranta (cowtowncoder)<br>`tatu.saloranta@iki.fi`<br>created 2022-08-13<br><br>`6214760097DC5CFAD0175AC2C9FBAA83A8753994`<br>created 2016-07-26 |
 | `com.fasterxml.jackson:jackson-bom:2.21.2` | transitive | PGP signed | 1 signed / 0 checksum | `28118C070CB22A0175A2E8D43D12CA2AC19F3181`<br>Tatu Saloranta (cowtowncoder)<br>`tatu.saloranta@iki.fi`<br>created 2022-08-13<br><br>`6214760097DC5CFAD0175AC2C9FBAA83A8753994`<br>created 2016-07-26 |
-| `com.github.bisq-network.netlayer:tor.external:47ea493b9eb6df2cad64499d5b5076c83a0d786c` | direct | checksum fallback | 0 signed / 2 checksum | - |
-| `com.github.bisq-network.netlayer:tor.native:47ea493b9eb6df2cad64499d5b5076c83a0d786c` | direct | checksum fallback | 0 signed / 2 checksum | - |
-| `com.github.bisq-network.netlayer:tor:47ea493b9eb6df2cad64499d5b5076c83a0d786c` | transitive | checksum fallback | 0 signed / 2 checksum | - |
+| `com.github.bisq-network.netlayer:tor.external:09c287b4573020a19f84507cb4fbbc9e78001383` | direct | PGP signed | 2 signed / 0 checksum | - |
+| `com.github.bisq-network.netlayer:tor.native:09c287b4573020a19f84507cb4fbbc9e78001383` | direct | PGP signed | 2 signed / 0 checksum | - |
+| `com.github.bisq-network.netlayer:tor:09c287b4573020a19f84507cb4fbbc9e78001383` | transitive | PGP signed | 2 signed / 0 checksum | - |
 | `com.github.bisq-network.tor-binary:tor-binary-geoip:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | checksum fallback | 0 signed / 2 checksum | - |
 | `com.github.bisq-network.tor-binary:tor-binary-linux32:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | checksum fallback | 0 signed / 2 checksum | - |
 | `com.github.bisq-network.tor-binary:tor-binary-linux64:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | checksum fallback | 0 signed / 2 checksum | - |
+| `com.github.bisq-network.tor-binary:tor-binary-macos-aarch64:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | PGP signed | 2 signed / 0 checksum | - |
 | `com.github.bisq-network.tor-binary:tor-binary-macos:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | checksum fallback | 0 signed / 2 checksum | - |
 | `com.github.bisq-network.tor-binary:tor-binary-windows:7358b044704548b70cf8db4e2dacbe1ff4aa2171` | transitive | checksum fallback | 0 signed / 2 checksum | - |
 | `com.github.bisq-network:bitcoinj:6c32c0629d4ac7ecc95889eb1a46fa0d77a4e15a` | direct | checksum fallback | 0 signed / 2 checksum | - |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -122,7 +122,7 @@ Build output expected in shared folder:
 Build output expected:
 
 1. `bisq_${NEW_VERSION}-1_amd64.deb` package for distributions that derive from Debian
-2. `bisq-${NEW_VERSION}-1.x86_64.rpm` package for distributions that derive from Redhat based distros
+2. `bisq-${NEW_VERSION}-1.x86_64.rpm` package for distributions that derive from Red Hat based distros
 3. `desktop-${NEW_VERSION}-all-linux.jar.SHA-256` sha256 sum of fat jar
 
 * Install and run generated package
@@ -164,8 +164,8 @@ Build output expected:
 8. `Bisq-${NEW_VERSION}.jar.txt` Aggregated SHA-256 file for macOS, Linux, and Windows jar libraries
 9. `Bisq-64bit-${NEW_VERSION}.deb` Debian package
 10. `Bisq-64bit-${NEW_VERSION}.deb.asc` Signature for Debian package
-11. `Bisq-64bit-${NEW_VERSION}.rpm` Redhat based distro package
-12. `Bisq-64bit-${NEW_VERSION}.rpm.asc` Signature for Redhat based distro package
+11. `Bisq-64bit-${NEW_VERSION}.rpm` Red Hat based distro package
+12. `Bisq-64bit-${NEW_VERSION}.rpm.asc` Signature for Red Hat based distro package
 13. `Bisq-64bit-${NEW_VERSION}.exe` Windows installer
 14. `Bisq-64bit-${NEW_VERSION}.exe.asc` Signature for Windows installer
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -155,14 +155,17 @@ Build output expected:
 1. `E222AA02.asc` Sig key of Alejandro García
 2. `4A133008.asc` Sig key of Gabriel Bernard
 3. `signingkey.asc` Fingerprint of key that was used for these builds
-4. `Bisq-${NEW_VERSION}.dmg` macOS installer
-5. `Bisq-${NEW_VERSION}.dmg.asc` Signature for macOS installer
-6. `Bisq-64bit-${NEW_VERSION}.deb` Debian package
-7. `Bisq-64bit-${NEW_VERSION}.deb.asc` Signature for Debian package
-8. `Bisq-64bit-${NEW_VERSION}.rpm` Redhat based distro package
-9. `Bisq-64bit-${NEW_VERSION}.rpm.asc` Signature for Redhat based distro package
-10. `Bisq-64bit-${NEW_VERSION}.exe` Windows installer
-11. `Bisq-64bit-${NEW_VERSION}.exe.asc` Signature for Windows installer
+4. `Bisq-x86_64-${NEW_VERSION}.dmg` macOS Intel installer
+5. `Bisq-x86_64-${NEW_VERSION}.dmg.asc` Signature for macOS Intel installer
+6. `Bisq-aarch64-${NEW_VERSION}.dmg` macOS Apple Silicon installer
+7. `Bisq-aarch64-${NEW_VERSION}.dmg.asc` Signature for macOS Apple Silicon installer
+8. `Bisq-${NEW_VERSION}.jar.txt` Aggregated SHA-256 file for macOS, Linux, and Windows jar libraries
+9. `Bisq-64bit-${NEW_VERSION}.deb` Debian package
+10. `Bisq-64bit-${NEW_VERSION}.deb.asc` Signature for Debian package
+11. `Bisq-64bit-${NEW_VERSION}.rpm` Redhat based distro package
+12. `Bisq-64bit-${NEW_VERSION}.rpm.asc` Signature for Redhat based distro package
+13. `Bisq-64bit-${NEW_VERSION}.exe` Windows installer
+14. `Bisq-64bit-${NEW_VERSION}.exe.asc` Signature for Windows installer
 
 * Run an AV scan over all files on the Windows VM where the files got copied over.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -101,9 +101,11 @@ Use VirtualBox > 6.1 with following configuration:
 
 Build output expected in shared folder:
 
-1. `Bisq-${NEW_VERSION}.dmg` macOS installer
-2. `desktop-${NEW_VERSION}-all-mac.jar.SHA-256` sha256 sum of fat jar
-3. `jar-lib-for-raspberry-pi-${NEW_VERSION}.zip` Jar libraries for Raspberry Pi
+1. `Bisq-x86_64-${NEW_VERSION}.dmg` macOS Intel installer
+2. `Bisq-aarch64-${NEW_VERSION}.dmg` macOS Apple Silicon installer
+3. `desktop-${NEW_VERSION}-all-mac-x86_64.jar.SHA-256` sha256 sum of Intel macOS fat jar
+4. `desktop-${NEW_VERSION}-all-mac-aarch64.jar.SHA-256` sha256 sum of Apple Silicon macOS fat jar
+5. `jar-lib-for-raspberry-pi-${NEW_VERSION}.zip` Jar libraries for Raspberry Pi
 
 * Before building the other binaries install the generated Bisq app on macOS and verify that everything works as
   expected.

--- a/gradle/dependency-checksum-fallback-allowlist.tsv
+++ b/gradle/dependency-checksum-fallback-allowlist.tsv
@@ -11,13 +11,6 @@ com.github.bisq-network:jsonrpc4j:1.6.0.bisq.1	jsonrpc4j-1.6.0.bisq.1.jar	Bisq-m
 com.github.bisq-network:jsonrpc4j:1.6.0.bisq.1	jsonrpc4j-1.6.0.bisq.1.module	Bisq-maintained JitPack fork pinned to a reviewed Bisq release version.
 com.github.bisq-network:jtorctl:30db998d855ff351c6f74783ff386f15304e875a	jtorctl-30db998d855ff351c6f74783ff386f15304e875a.jar	Bisq-maintained JitPack dependency pinned to an immutable commit.
 com.github.bisq-network:jtorctl:30db998d855ff351c6f74783ff386f15304e875a	jtorctl-30db998d855ff351c6f74783ff386f15304e875a.pom	Bisq-maintained JitPack dependency pinned to an immutable commit.
-com.github.bisq-network.netlayer:parent:47ea493b9eb6df2cad64499d5b5076c83a0d786c	parent-47ea493b9eb6df2cad64499d5b5076c83a0d786c.pom	Bisq-maintained JitPack parent POM pinned to an immutable commit.
-com.github.bisq-network.netlayer:tor:47ea493b9eb6df2cad64499d5b5076c83a0d786c	tor-47ea493b9eb6df2cad64499d5b5076c83a0d786c.jar	Bisq-maintained JitPack Tor dependency pinned to an immutable commit.
-com.github.bisq-network.netlayer:tor:47ea493b9eb6df2cad64499d5b5076c83a0d786c	tor-47ea493b9eb6df2cad64499d5b5076c83a0d786c.pom	Bisq-maintained JitPack Tor dependency pinned to an immutable commit.
-com.github.bisq-network.netlayer:tor.external:47ea493b9eb6df2cad64499d5b5076c83a0d786c	tor.external-47ea493b9eb6df2cad64499d5b5076c83a0d786c.jar	Bisq-maintained JitPack Tor dependency pinned to an immutable commit.
-com.github.bisq-network.netlayer:tor.external:47ea493b9eb6df2cad64499d5b5076c83a0d786c	tor.external-47ea493b9eb6df2cad64499d5b5076c83a0d786c.pom	Bisq-maintained JitPack Tor dependency pinned to an immutable commit.
-com.github.bisq-network.netlayer:tor.native:47ea493b9eb6df2cad64499d5b5076c83a0d786c	tor.native-47ea493b9eb6df2cad64499d5b5076c83a0d786c.jar	Bisq-maintained JitPack Tor dependency pinned to an immutable commit.
-com.github.bisq-network.netlayer:tor.native:47ea493b9eb6df2cad64499d5b5076c83a0d786c	tor.native-47ea493b9eb6df2cad64499d5b5076c83a0d786c.pom	Bisq-maintained JitPack Tor dependency pinned to an immutable commit.
 com.github.bisq-network.tor-binary:tor-binary:7358b044704548b70cf8db4e2dacbe1ff4aa2171	tor-binary-7358b044704548b70cf8db4e2dacbe1ff4aa2171.pom	Bisq-maintained Tor binary JitPack parent POM pinned to an immutable commit.
 com.github.bisq-network.tor-binary:tor-binary-geoip:7358b044704548b70cf8db4e2dacbe1ff4aa2171	tor-binary-geoip-7358b044704548b70cf8db4e2dacbe1ff4aa2171.jar	Bisq-maintained Tor binary artifact pinned to an immutable commit.
 com.github.bisq-network.tor-binary:tor-binary-geoip:7358b044704548b70cf8db4e2dacbe1ff4aa2171	tor-binary-geoip-7358b044704548b70cf8db4e2dacbe1ff4aa2171.pom	Bisq-maintained Tor binary artifact pinned to an immutable commit.

--- a/macos-dual-architecture-support-report.md
+++ b/macos-dual-architecture-support-report.md
@@ -1,0 +1,93 @@
+# macOS Dual Architecture Support Report
+
+## Scope
+
+Bisq now needs separate macOS installer artifacts for Intel and Apple Silicon.
+The app update downloader, macOS packaging output, and release finalization flow
+were still assuming a single macOS DMG named `Bisq-<version>.dmg`.
+
+## Changes Applied
+
+- Updated the in-app installer descriptor to select a macOS DMG by runtime
+  architecture:
+  - Intel: `Bisq-x86_64-<version>.dmg`
+  - Apple Silicon: `Bisq-aarch64-<version>.dmg`
+- Added focused tests for macOS updater filename selection using common JVM
+  architecture strings: `x86_64`, `amd64`, `aarch64`, and `arm64`.
+- Updated Gradle packaging so a macOS `generateInstallers` run renames the
+  generated DMG to the same architecture-qualified filename that the app
+  downloader expects.
+- Updated the macOS library hash filename and hash content label to include the
+  macOS architecture, preventing Intel and Apple Silicon builds from producing
+  colliding `desktop-<version>-all-mac.jar.SHA-256` files.
+- Updated `desktop/package/macosx/finalize.sh` to copy, sign, and verify both
+  macOS DMGs, and to aggregate both macOS library hash files into
+  `Bisq-<version>.jar.txt`.
+
+## Release Inputs Expected By `finalize.sh`
+
+- Intel macOS build directory:
+  - Defaults to `$BISQ_VM_PATH/vm_shared_macosx`
+  - Can be overridden with `BISQ_MACOS_X86_64_PATH`
+  - Must contain `Bisq-x86_64-<version>.dmg`
+  - Must contain `desktop-<version>-all-mac-x86_64.jar.SHA-256`
+- Apple Silicon macOS build directory:
+  - Defaults to `$BISQ_VM_PATH/vm_shared_macosx_aarch64`
+  - Can be overridden with `BISQ_MACOS_AARCH64_PATH`
+  - Must contain `Bisq-aarch64-<version>.dmg`
+  - Must contain `desktop-<version>-all-mac-aarch64.jar.SHA-256`
+
+## x86 Test Plan
+
+Run this on the Intel macOS machine:
+
+```sh
+./gradlew :desktop:generateInstallers
+```
+
+Expected artifacts:
+
+```text
+desktop/build/packaging/jpackage/packages/Bisq-x86_64-1.10.0.dmg
+desktop/build/packaging/jpackage/packages/desktop-1.10.0-all-mac-x86_64.jar.SHA-256
+```
+
+Then install and launch the DMG on the Intel machine. After the Apple Silicon
+DMG is also available, run `desktop/package/macosx/finalize.sh` with both macOS
+build directories available and verify that the release folder contains both
+macOS DMGs, `.asc` signatures, and `Bisq-<version>.jar.txt`. The individual
+`desktop-<version>-all-mac-*.jar.SHA-256` files are inputs to finalization, not
+separate release artifacts.
+
+## Notes
+
+- No Rosetta-dependent test was added or run. The Intel build path should be
+  validated on the separate x86 machine.
+- Reproducible-build comparison logic was not expanded beyond accepting the
+  generated installer filenames; the core reproducible-build workflow was left
+  unchanged.
+
+## Verification Performed
+
+On the Apple Silicon machine:
+
+```sh
+bash -n desktop/package/macosx/finalize.sh
+./gradlew :desktop:test --tests bisq.desktop.main.overlays.windows.downloadupdate.BisqInstallerTest
+./gradlew :desktop:generateHashes
+./gradlew :desktop:generateInstallers
+```
+
+The focused test passed, packaging build logic compiled, and
+`:desktop:generateHashes` produced:
+
+```text
+desktop/build/packaging/jpackage/packages/desktop-1.10.0-all-mac-aarch64.jar.SHA-256
+```
+
+The generated hash file uses `macOS-aarch64` as its entry prefix.
+`:desktop:generateInstallers` also completed successfully and produced:
+
+```text
+desktop/build/packaging/jpackage/packages/Bisq-aarch64-1.10.0.dmg
+```


### PR DESCRIPTION
# macOS Dual Architecture Support

## Scope

Bisq now needs separate macOS installer artifacts for Intel and Apple Silicon. The app update downloader, macOS packaging output, and release finalization flow were still assuming a single macOS DMG named `Bisq-<version>.dmg`.

## Changes Applied

- Updated the in-app installer descriptor to select a macOS DMG by runtime architecture:
  - Intel: `Bisq-x86_64-<version>.dmg`
  - Apple Silicon: `Bisq-aarch64-<version>.dmg`
- Added focused tests for macOS updater filename selection using common JVM architecture strings: `x86_64`, `amd64`, `aarch64`, and `arm64`.
- Updated Gradle packaging so a macOS `generateInstallers` run renames the generated DMG to the same architecture-qualified filename that the app downloader expects.
- Updated the macOS library hash filename and hash content label to include the macOS architecture, preventing Intel and Apple Silicon builds from producing colliding `desktop-<version>-all-mac.jar.SHA-256` files.
- Updated `desktop/package/macosx/finalize.sh` to copy, sign, verify, and include both macOS DMGs and both macOS library hash files.

## Release Inputs Expected By `finalize.sh`

- Intel macOS build directory:
  - Defaults to `$BISQ_VM_PATH/vm_shared_macosx`
  - Can be overridden with `BISQ_MACOS_X86_64_PATH`
  - Must contain `Bisq-x86_64-<version>.dmg`
  - Must contain `desktop-<version>-all-mac-x86_64.jar.SHA-256`
- Apple Silicon macOS build directory:
  - Defaults to `$BISQ_VM_PATH/vm_shared_macosx_aarch64`
  - Can be overridden with `BISQ_MACOS_AARCH64_PATH`
  - Must contain `Bisq-aarch64-<version>.dmg`
  - Must contain `desktop-<version>-all-mac-aarch64.jar.SHA-256`

## x86 Test Plan

Run this on the Intel macOS machine:

```sh
./gradlew :desktop:generateInstallers
```

Expected artifacts:

```text
desktop/build/packaging/jpackage/packages/Bisq-x86_64-1.10.0.dmg
desktop/build/packaging/jpackage/packages/desktop-1.10.0-all-mac-x86_64.jar.SHA-256
```

Then install and launch the DMG on the Intel machine. After the Apple Silicon DMG is also available, run `desktop/package/macosx/finalize.sh` with both macOS build directories available and verify that the release folder contains both macOS DMGs and `.asc` signatures.

## Notes

- No Rosetta-dependent test was added or run. The Intel build path should be validated on the separate x86 machine.
- Reproducible-build comparison logic was not expanded beyond accepting the generated installer filenames; the core reproducible-build workflow was left unchanged.

## Verification Performed

On the Apple Silicon machine:

```sh
bash -n desktop/package/macosx/finalize.sh
./gradlew :desktop:test --tests bisq.desktop.main.overlays.windows.downloadupdate.BisqInstallerTest
./gradlew :desktop:generateHashes
./gradlew :desktop:generateInstallers
```

The focused test passed, packaging build logic compiled, and `:desktop:generateHashes` produced:

```text
desktop/build/packaging/jpackage/packages/desktop-1.10.0-all-mac-aarch64.jar.SHA-256
```

The generated hash file uses `macOS-aarch64` as its entry prefix. `:desktop:generateInstallers` also completed successfully and produced:

```text
desktop/build/packaging/jpackage/packages/Bisq-aarch64-1.10.0.dmg
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deliver separate, architecture‑specific macOS installers (Intel and Apple Silicon) with distinct filenames.

* **Bug Fixes**
  * Packaging, hashing, signing and signature verification now distinguish macOS architectures to prevent collisions and missing artifacts.

* **Tests**
  * Added tests validating installer filename selection across varied JVM/CPU architecture strings.

* **Documentation**
  * Updated release and process docs and added a report detailing dual‑architecture macOS build, signing, and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7797)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->