### PR TITLE
Surface async offer/wallet failures through the gRPC observer

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,10 @@ on:
       - "proto/**"
       - "apitest/**"
       - "seednode/**"
+      - "build-logic/**"
+      - "build.gradle"
+      - "settings.gradle"
+      - "gradle.properties"
       - ".github/workflows/e2e-tests.yml"
 
 jobs:

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -192,12 +192,14 @@ public class CoreApi {
                                            long amountAsLong,
                                            long minAmountAsLong,
                                            String priceAsString,
-                                           Consumer<Offer> resultHandler) {
+                                           Consumer<Offer> resultHandler,
+                                           Consumer<String> errorHandler) {
         coreOffersService.createAndPlaceBsqSwapOffer(directionAsString,
                 amountAsLong,
                 minAmountAsLong,
                 priceAsString,
-                resultHandler);
+                resultHandler,
+                errorHandler);
     }
 
     public void createAndPlaceOffer(String currencyCode,
@@ -211,7 +213,8 @@ public class CoreApi {
                                     String triggerPrice,
                                     String paymentAccountId,
                                     String makerFeeCurrencyCode,
-                                    Consumer<Offer> resultHandler) {
+                                    Consumer<Offer> resultHandler,
+                                    Consumer<String> errorHandler) {
         coreOffersService.createAndPlaceOffer(currencyCode,
                 directionAsString,
                 useMarketBasedPrice ? "0" : price,
@@ -223,7 +226,8 @@ public class CoreApi {
                 triggerPrice,
                 paymentAccountId,
                 makerFeeCurrencyCode,
-                resultHandler);
+                resultHandler,
+                errorHandler);
     }
 
     public void editOffer(String offerId,
@@ -232,18 +236,22 @@ public class CoreApi {
                           double marketPriceMargin,
                           String triggerPrice,
                           int enable,
-                          EditType editType) {
+                          EditType editType,
+                          Runnable resultHandler,
+                          Consumer<String> errorHandler) {
         coreOffersService.editOffer(offerId,
                 price,
                 useMarketBasedPrice,
                 marketPriceMargin,
                 triggerPrice,
                 enable,
-                editType);
+                editType,
+                resultHandler,
+                errorHandler);
     }
 
-    public void cancelOffer(String id) {
-        coreOffersService.cancelOffer(id);
+    public void cancelOffer(String id, Runnable resultHandler, Consumer<String> errorHandler) {
+        coreOffersService.cancelOffer(id, resultHandler, errorHandler);
     }
 
     public boolean isMyOffer(Offer offer) {

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -315,7 +315,8 @@ class CoreOffersService {
                                     long amountAsLong,
                                     long minAmountAsLong,
                                     String priceAsString,
-                                    Consumer<Offer> resultHandler) {
+                                    Consumer<Offer> resultHandler,
+                                    Consumer<String> errorHandler) {
         coreWalletsService.verifyWalletsAreAvailable();
         coreWalletsService.verifyEncryptedWalletIsUnlocked();
 
@@ -330,7 +331,10 @@ class CoreOffersService {
                 amount,
                 minAmount,
                 price,
-                offer -> placeBsqSwapOffer(offer, () -> resultHandler.accept(offer)));
+                offer -> placeBsqSwapOffer(offer,
+                        () -> resultHandler.accept(offer),
+                        errorHandler),
+                errorHandler);
     }
 
     void createAndPlaceOffer(String currencyCode,
@@ -344,7 +348,8 @@ class CoreOffersService {
                              String triggerPrice,
                              String paymentAccountId,
                              String makerFeeCurrencyCode,
-                             Consumer<Offer> resultHandler) {
+                             Consumer<Offer> resultHandler,
+                             Consumer<String> errorHandler) {
         coreWalletsService.verifyWalletsAreAvailable();
         coreWalletsService.verifyEncryptedWalletIsUnlocked();
         offerUtil.maybeSetFeePaymentCurrencyPreference(makerFeeCurrencyCode);
@@ -394,7 +399,8 @@ class CoreOffersService {
                 scaledBuyerSecurityDepositPct,
                 triggerPrice,
                 useSavingsWallet,
-                transaction -> resultHandler.accept(offer));
+                transaction -> resultHandler.accept(offer),
+                errorHandler);
     }
 
     // Edit a placed offer.
@@ -404,7 +410,9 @@ class CoreOffersService {
                    double editedMarketPriceMargin,
                    String editedTriggerPrice,
                    int editedEnable,
-                   EditType editType) {
+                   EditType editType,
+                   Runnable resultHandler,
+                   Consumer<String> errorHandler) {
         OpenOffer openOffer = getMyOpenOffer(offerId);
         var validator = new EditOfferValidator(openOffer,
                 editedPrice,
@@ -431,39 +439,54 @@ class CoreOffersService {
         priceFeedService.setCurrencyCode(openOffer.getOffer().getCurrencyCode());
         editedOffer.setPriceFeedService(priceFeedService);
         editedOffer.setState(State.AVAILABLE);
-        openOfferManager.editOpenOfferStart(openOffer,
-                () -> log.info("EditOpenOfferStart: offer {}", openOffer.getId()),
-                log::error);
         long triggerPriceAsLong = getMarketPriceAsLong(editedTriggerPrice, editedOffer.getCurrencyCode());
-        openOfferManager.editOpenOfferPublish(editedOffer,
-                triggerPriceAsLong,
-                newOfferState,
-                () -> log.info("EditOpenOfferPublish: offer {}", openOffer.getId()),
-                log::error);
+        openOfferManager.editOpenOfferStart(openOffer,
+                () -> {
+                    log.info("EditOpenOfferStart: offer {}", openOffer.getId());
+                    openOfferManager.editOpenOfferPublish(editedOffer,
+                            triggerPriceAsLong,
+                            newOfferState,
+                            () -> {
+                                log.info("EditOpenOfferPublish: offer {}", openOffer.getId());
+                                resultHandler.run();
+                            },
+                            errorMessage -> {
+                                log.error("EditOpenOfferPublish error for {}: {}",
+                                        openOffer.getId(), errorMessage);
+                                errorHandler.accept(errorMessage);
+                            });
+                },
+                errorMessage -> {
+                    log.error("EditOpenOfferStart error for {}: {}", openOffer.getId(), errorMessage);
+                    errorHandler.accept(errorMessage);
+                });
     }
 
-    void cancelOffer(String id) {
+    void cancelOffer(String id, Runnable resultHandler, Consumer<String> errorHandler) {
         OpenOffer openOffer = getMyOffer(id);
         openOfferManager.removeOffer(openOffer.getOffer(),
-                () -> {
-                },
-                log::error);
+                resultHandler::run,
+                errorMessage -> {
+                    log.error("cancelOffer error for {}: {}", id, errorMessage);
+                    errorHandler.accept(errorMessage);
+                });
     }
 
-    private void placeBsqSwapOffer(Offer offer, Runnable resultHandler) {
+    private void placeBsqSwapOffer(Offer offer, Runnable resultHandler, Consumer<String> errorHandler) {
         openBsqSwapOfferService.placeBsqSwapOffer(offer,
                 resultHandler,
-                log::error);
-
-        if (offer.getErrorMessage() != null)
-            throw new IllegalStateException(offer.getErrorMessage());
+                errorMessage -> {
+                    log.error("placeBsqSwapOffer error: {}", errorMessage);
+                    errorHandler.accept(errorMessage);
+                });
     }
 
     private void placeOffer(Offer offer,
                             double buyerSecurityDepositPct,
                             String triggerPrice,
                             boolean useSavingsWallet,
-                            Consumer<Transaction> resultHandler) {
+                            Consumer<Transaction> resultHandler,
+                            Consumer<String> errorHandler) {
         var triggerPriceAsLong = getMarketPriceAsLong(triggerPrice, offer.getCurrencyCode());
         openOfferManager.placeOffer(offer,
                 buyerSecurityDepositPct,
@@ -471,10 +494,10 @@ class CoreOffersService {
                 false,
                 triggerPriceAsLong,
                 resultHandler::accept,
-                log::error);
-
-        if (offer.getErrorMessage() != null)
-            throw new IllegalStateException(offer.getErrorMessage());
+                errorMessage -> {
+                    log.error("placeOffer error for {}: {}", offer.getId(), errorMessage);
+                    errorHandler.accept(errorMessage);
+                });
     }
 
     private OfferPayload getMergedOfferPayload(EditOfferValidator editOfferValidator,

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -671,6 +671,12 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
             offersToBeEdited.remove(openOffer.getId());
             resultHandler.handleResult();
         } else {
+            // Offer vanished between editOpenOfferStart and editOpenOfferPublish (cancel
+            // / shutdown race). Without clearing the offersToBeEdited entry that Start
+            // added, the next editOpenOfferStart for this id would short-circuit on
+            // the containsKey check, log a warning, signal success without editing, and
+            // leave the offer stuck in edit mode until daemon restart.
+            offersToBeEdited.remove(editedOffer.getId());
             errorMessageHandler.handleErrorMessage("There is no offer with this id existing to be published.");
         }
     }

--- a/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
@@ -184,7 +184,8 @@ public class OpenBsqSwapOfferService {
                                 Coin amount,
                                 Coin minAmount,
                                 Price price,
-                                Consumer<Offer> resultHandler) {
+                                Consumer<Offer> resultHandler,
+                                Consumer<String> errorHandler) {
         log.info("offerId={}, \n" +
                         "direction={}, \n" +
                         "price={}, \n" +
@@ -205,7 +206,11 @@ public class OpenBsqSwapOfferService {
                     // We got called from a non user thread...
                     UserThread.execute(() -> {
                         if (throwable != null) {
-                            log.error(throwable.toString());
+                            // PoW mint runs on a CompletableFuture executor. Without surfacing
+                            // the failure here neither resultHandler nor errorHandler fires
+                            // and the gRPC create-offer call would hang forever.
+                            log.error("PoW mint failed for {}: {}", offerId, throwable.toString(), throwable);
+                            errorHandler.accept("PoW mint failed: " + throwable.getMessage());
                             return;
                         }
 
@@ -234,12 +239,64 @@ public class OpenBsqSwapOfferService {
         PlaceBsqSwapOfferProtocol protocol = new PlaceBsqSwapOfferProtocol(model,
                 () -> {
                     OpenOffer openOffer = new OpenOffer(offer);
+                    // Run the per-service ctor synchronously before signalling success so the
+                    // gRPC reply reflects whether the offer is fully tracked (wallet listeners
+                    // attached, funded-state evaluable). If we let the offerListChangeListener
+                    // do this on UserThread after addOpenBsqSwapOffer, a ctor exception (e.g.
+                    // "tradeFee must be positive") would be logged by the global uncaught-
+                    // exception handler but the gRPC call would still return success on a
+                    // broken offer — the contract has to carry the failure to the caller.
+                    try {
+                        registerOpenBsqSwapOffer(openOffer);
+                    } catch (RuntimeException e) {
+                        log.error("Failed to register OpenBsqSwapOffer for {}: {}",
+                                offer.getId(), e.toString(), e);
+                        if (model.isOfferAddedToOfferBook()) {
+                            offerBookService.removeOffer(offer.getOfferPayloadBase(),
+                                    () -> log.info("Rolled back offer publish after registration failure: {}",
+                                            offer.getId()),
+                                    err -> log.error("Failed to roll back offer publish for {}: {}",
+                                            offer.getId(), err));
+                        }
+                        errorMessageHandler.handleErrorMessage(
+                                "Failed to register open BSQ swap offer: " + e.getMessage());
+                        return;
+                    }
                     openOfferManager.addOpenBsqSwapOffer(openOffer);
                     resultHandler.run();
                 },
                 errorMessageHandler
         );
         protocol.placeOffer();
+    }
+
+    /**
+     * Builds, tracks, and initialises the funded-state of an OpenBsqSwapOffer for
+     * a given OpenOffer. Throws if either the ctor or applyFundingState fails; in
+     * the applyFundingState failure case the map entry + wallet/fee listeners
+     * attached by the ctor are torn down before the exception propagates so a
+     * failed register never leaves orphan state behind. Caller decides whether
+     * to surface the failure (gRPC create path) or let it propagate to the
+     * global UncaughtExceptionHandler (listener path).
+     */
+    private OpenBsqSwapOffer registerOpenBsqSwapOffer(OpenOffer openOffer) {
+        OpenBsqSwapOffer openBsqSwapOffer = new OpenBsqSwapOffer(openOffer,
+                this,
+                feeService,
+                btcWalletService,
+                bsqWalletService);
+        OpenBsqSwapOffer prev = openBsqSwapOffersById.put(openOffer.getId(), openBsqSwapOffer);
+        if (prev != null) {
+            prev.removeListeners();
+        }
+        try {
+            openBsqSwapOffer.applyFundingState();
+        } catch (RuntimeException e) {
+            openBsqSwapOffersById.remove(openOffer.getId(), openBsqSwapOffer);
+            openBsqSwapOffer.removeListeners();
+            throw e;
+        }
+        return openBsqSwapOffer;
     }
 
     public void activateOpenOffer(OpenOffer openOffer,
@@ -297,19 +354,17 @@ public class OpenBsqSwapOfferService {
                     if (isProofOfWorkInvalid(openOffer.getOffer())) {
                         // Avoiding ConcurrentModificationException
                         UserThread.execute(() -> redoProofOfWorkAndRepublish(openOffer));
-                    } else {
-                        OpenBsqSwapOffer openBsqSwapOffer = new OpenBsqSwapOffer(openOffer,
-                                this,
-                                feeService,
-                                btcWalletService,
-                                bsqWalletService);
-                        String offerId = openOffer.getId();
-                        if (openBsqSwapOffersById.containsKey(offerId)) {
-                            openBsqSwapOffersById.get(offerId).removeListeners();
-                        }
-                        openBsqSwapOffersById.put(offerId, openBsqSwapOffer);
-                        openBsqSwapOffer.applyFundingState();
+                        return;
                     }
+                    if (openBsqSwapOffersById.containsKey(openOffer.getId())) {
+                        // Already tracked by placeBsqSwapOffer's synchronous path; skip
+                        // to avoid re-running the ctor + leaking wallet listeners.
+                        return;
+                    }
+                    // No gRPC reply pending on this path. Let any failure propagate to
+                    // CommonSetup's global UncaughtExceptionHandler. The helper itself
+                    // cleans up map/listener state on throw so nothing is orphaned.
+                    registerOpenBsqSwapOffer(openOffer);
                 });
     }
 

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -249,7 +249,8 @@ class GrpcOffersService extends OffersImplBase {
                                 .build();
                         responseObserver.onNext(reply);
                         responseObserver.onCompleted();
-                    });
+                    },
+                    errorMessage -> exceptionHandler.handleErrorMessage(log, errorMessage, responseObserver));
         } catch (Throwable cause) {
             exceptionHandler.handleException(log, cause, responseObserver);
         }
@@ -280,7 +281,8 @@ class GrpcOffersService extends OffersImplBase {
                                 .build();
                         responseObserver.onNext(reply);
                         responseObserver.onCompleted();
-                    });
+                    },
+                    errorMessage -> exceptionHandler.handleErrorMessage(log, errorMessage, responseObserver));
         } catch (Throwable cause) {
             exceptionHandler.handleException(log, cause, responseObserver);
         }
@@ -296,10 +298,13 @@ class GrpcOffersService extends OffersImplBase {
                     req.getMarketPriceMarginPct(),
                     req.getTriggerPrice(),
                     req.getEnable(),
-                    req.getEditType());
-            var reply = EditOfferReply.newBuilder().build();
-            responseObserver.onNext(reply);
-            responseObserver.onCompleted();
+                    req.getEditType(),
+                    () -> {
+                        var reply = EditOfferReply.newBuilder().build();
+                        responseObserver.onNext(reply);
+                        responseObserver.onCompleted();
+                    },
+                    errorMessage -> exceptionHandler.handleErrorMessage(log, errorMessage, responseObserver));
         } catch (Throwable cause) {
             exceptionHandler.handleException(log, cause, responseObserver);
         }
@@ -309,10 +314,13 @@ class GrpcOffersService extends OffersImplBase {
     public void cancelOffer(CancelOfferRequest req,
                             StreamObserver<CancelOfferReply> responseObserver) {
         try {
-            coreApi.cancelOffer(req.getId());
-            var reply = CancelOfferReply.newBuilder().build();
-            responseObserver.onNext(reply);
-            responseObserver.onCompleted();
+            coreApi.cancelOffer(req.getId(),
+                    () -> {
+                        var reply = CancelOfferReply.newBuilder().build();
+                        responseObserver.onNext(reply);
+                        responseObserver.onCompleted();
+                    },
+                    errorMessage -> exceptionHandler.handleErrorMessage(log, errorMessage, responseObserver));
         } catch (Throwable cause) {
             exceptionHandler.handleException(log, cause, responseObserver);
         }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcWalletsService.java
@@ -215,7 +215,11 @@ class GrpcWalletsService extends WalletsImplBase {
 
                         @Override
                         public void onFailure(TxBroadcastException ex) {
-                            throw new IllegalStateException(ex);
+                            // Runs on the broadcast thread, NOT the gRPC handler thread, so a
+                            // thrown exception here is invisible to the surrounding try/catch
+                            // and would leave the gRPC stream open forever. Surface via the
+                            // gRPC observer instead so the client sees the failure.
+                            exceptionHandler.handleException(log, ex, responseObserver);
                         }
                     });
         } catch (Throwable cause) {
@@ -246,14 +250,17 @@ class GrpcWalletsService extends WalletsImplBase {
                                 responseObserver.onNext(reply);
                                 responseObserver.onCompleted();
                             } else {
-                                throw new IllegalStateException("btc transaction is null");
+                                exceptionHandler.handleException(log,
+                                        new IllegalStateException("btc transaction is null"),
+                                        responseObserver);
                             }
                         }
 
                         @Override
                         public void onFailure(@NotNull Throwable t) {
-                            log.error("", t);
-                            throw new IllegalStateException(t);
+                            // Async callback thread — see sendBsq.onFailure note. Throwing here
+                            // would leak; route the failure back through the gRPC observer.
+                            exceptionHandler.handleException(log, t, responseObserver);
                         }
                     });
         } catch (Throwable cause) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bsq_swap/create_offer/BsqSwapCreateOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bsq_swap/create_offer/BsqSwapCreateOfferDataModel.java
@@ -103,7 +103,7 @@ class BsqSwapCreateOfferDataModel extends BsqSwapOfferDataModel {
         applyTradeCurrency();
     }
 
-    protected void requestNewOffer(Consumer<Offer> resultHandler) {
+    protected void requestNewOffer(Consumer<Offer> resultHandler, Consumer<String> errorHandler) {
         openBsqSwapOfferService.requestNewOffer(getOfferId(),
                 getDirection(),
                 getBtcAmount().get(),
@@ -112,7 +112,8 @@ class BsqSwapCreateOfferDataModel extends BsqSwapOfferDataModel {
                 offer -> {
                     this.offer = offer;
                     resultHandler.accept(offer);
-                });
+                },
+                errorHandler);
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bsq_swap/create_offer/BsqSwapCreateOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bsq_swap/create_offer/BsqSwapCreateOfferViewModel.java
@@ -180,6 +180,9 @@ class BsqSwapCreateOfferViewModel extends BsqSwapOfferViewModel<BsqSwapCreateOff
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     void requestNewOffer() {
+        // Clear any error from a prior failed PoW mint so a successful retry doesn't
+        // keep showing a stale message. Mirrors onPlaceOffer's clear-on-entry pattern.
+        errorMessage.set(null);
         // We delay display a bit as pow is mostly very low so it would show flicker quickly
         miningPowTimer = UserThread.runAfter(() -> {
             miningPoW.set(true);
@@ -192,6 +195,13 @@ class BsqSwapCreateOfferViewModel extends BsqSwapOfferViewModel<BsqSwapCreateOff
                 miningPowTimer.stop();
             }
             miningPoW.set(false);
+            updateButtonDisableState();
+        }, errorMsg -> {
+            if (miningPowTimer != null) {
+                miningPowTimer.stop();
+            }
+            miningPoW.set(false);
+            errorMessage.set(errorMsg);
             updateButtonDisableState();
         });
     }


### PR DESCRIPTION
This PR helps catch errors on e2e test properly. I have confirmed that this change now correctly captures the trade fee amount error that was previously silently missed due to the incorrect gRPC early return

## summary
Several gRPC RPCs were returning success while async side-effects continued
on a different thread (a wallet broadcast callback, a UserThread offerbook
listener) — failures on those threads were logged but the gRPC reply had
already been sent, so the client saw a successful create/edit/cancel/send
on a broken outcome. The OpenBsqSwapOffer ctor crash on SELL bsq-swap offers
made this concrete: createBsqSwapOffer always replied OK even though the
wallet listener never got attached.

- OpenBsqSwapOfferService: extract the per-offer registration into
  registerOpenBsqSwapOffer and run it synchronously from placeBsqSwapOffer
  before signalling success; on RuntimeException, roll back the offerbook
  publish and route the error to the gRPC errorMessageHandler. The
  observable-list listener now dedups against the synchronous registration
  to avoid double-construction and leaked wallet listeners.
- CoreApi / CoreOffersService: thread Consumer<String> errorHandler through
  createAndPlaceBsqSwapOffer, createAndPlaceOffer, editOffer, cancelOffer,
  placeOffer, placeBsqSwapOffer; remove the racy post-call
  `offer.getErrorMessage()` checks (the field is set on a later thread).
  editOffer now chains editOpenOfferPublish from editOpenOfferStart's
  success handler so the gRPC reply fires only after both phases land.
- GrpcOffersService: pass an error handler that calls
  exceptionHandler.handleErrorMessage(...) so the client gets onError when
  the async path fails.
- GrpcWalletsService: sendBsq.onFailure and sendBtc.onSuccess(null) /
  .onFailure previously threw new IllegalStateException from the broadcast
  callback thread, which the surrounding try/catch could not see and which
  left the gRPC stream open. Route through exceptionHandler.handleException
  so the client sees the failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting in offer management operations; users now receive clear error messages when offer creation, editing, or cancellation encounters issues.

* **Improvements**
  * Enhanced UI responsiveness with better error state management and user feedback during offer operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7817)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->