### PR TITLE
Add Gradle release artifact signing tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -700,6 +700,32 @@ def canonicalPath = { File file ->
     rootProject.relativePath(file).replace(File.separatorChar, '/' as char)
 }
 
+def normalizeReleaseVersion = { String rawReleaseVersion ->
+    if (rawReleaseVersion == null || rawReleaseVersion.trim().empty) {
+        throw new GradleException('Missing required -PreleaseVersion=<version>, for example -PreleaseVersion=1.10.0')
+    }
+
+    def releaseVersion = rawReleaseVersion.trim()
+    if (releaseVersion.startsWith('v')) {
+        releaseVersion = releaseVersion.substring(1)
+    }
+    if (!(releaseVersion ==~ /\d+\.\d+\.\d+([.-][A-Za-z0-9_.-]+)?/)) {
+        throw new GradleException("Invalid release version '${rawReleaseVersion}'. Expected a version such as 1.10.0 or v1.10.0.")
+    }
+
+    releaseVersion
+}
+
+def resolveGpgExecutable = {
+    def configuredGpgExecutable = providers.gradleProperty('gpgExecutable').orNull ?:
+            providers.environmentVariable('GPG_EXECUTABLE').orNull
+    configuredGpgExecutable ?: [
+            '/opt/homebrew/bin/gpg',
+            '/usr/local/bin/gpg',
+            '/usr/bin/gpg'
+    ].find { new File(it).canExecute() } ?: 'gpg'
+}
+
 def enabledJarTasks = {
     allprojects.collectMany { project ->
         project.tasks.withType(Jar).findAll { it.enabled }
@@ -2709,6 +2735,179 @@ tasks.register('verifyReleaseBuild') {
     }
 }
 
+tasks.register('createReleaseJarTxt') {
+    group = 'distribution'
+    description = 'Creates Bisq-<version>.jar.txt from the four platform jar SHA-256 files.'
+
+    def releaseVersionProperty = providers.gradleProperty('releaseVersion')
+    def releaseDirProperty = providers.gradleProperty('releaseDir')
+    def jarSha256Inputs = [
+            [property: 'macosX86_64JarSha256', label: 'macOS Intel'],
+            [property: 'macosAarch64JarSha256', label: 'macOS Apple Silicon'],
+            [property: 'linuxJarSha256', label: 'Linux'],
+            [property: 'windowsJarSha256', label: 'Windows']
+    ]
+
+    inputs.property('releaseVersion', releaseVersionProperty.orElse(''))
+    inputs.property('releaseDir', releaseDirProperty.orElse(''))
+    jarSha256Inputs.each { inputSpec ->
+        inputs.property(inputSpec.property, providers.gradleProperty(inputSpec.property).orElse(''))
+    }
+    outputs.upToDateWhen { false }
+
+    doLast {
+        def releaseVersion = normalizeReleaseVersion(releaseVersionProperty.orNull)
+        def rawReleaseDir = releaseDirProperty.orNull
+        if (rawReleaseDir == null || rawReleaseDir.trim().empty) {
+            throw new GradleException('Missing required -PreleaseDir=<directory>, for example -PreleaseDir=/Users/ben/Documents/v1.10.0')
+        }
+
+        def releaseDir = file(rawReleaseDir.trim())
+        if (!releaseDir.exists() && !releaseDir.mkdirs()) {
+            throw new GradleException("Could not create release directory: ${releaseDir}")
+        }
+        if (!releaseDir.directory) {
+            throw new GradleException("Release directory is not a directory: ${releaseDir}")
+        }
+
+        def sourceFiles = jarSha256Inputs.collect { inputSpec ->
+            def rawPath = providers.gradleProperty(inputSpec.property).orNull
+            if (rawPath == null || rawPath.trim().empty) {
+                throw new GradleException("Missing required -P${inputSpec.property}=<path> for the ${inputSpec.label} jar SHA-256 file.")
+            }
+
+            def sourceFile = file(rawPath.trim())
+            if (!sourceFile.file) {
+                throw new GradleException("Missing ${inputSpec.label} jar SHA-256 file: ${sourceFile}")
+            }
+            sourceFile
+        }
+
+        def outputFile = new File(releaseDir, "Bisq-${releaseVersion}.jar.txt")
+        outputFile.withOutputStream { output ->
+            sourceFiles.each { sourceFile ->
+                def bytes = sourceFile.bytes
+                output.write(bytes)
+                if (bytes.length == 0 || bytes[bytes.length - 1] != ((byte) 10)) {
+                    output.write('\n'.getBytes(StandardCharsets.UTF_8.name()))
+                }
+            }
+        }
+
+        logger.lifecycle("Wrote ${outputFile.absolutePath}")
+        logger.lifecycle("Aggregated jar checksum sources:")
+        sourceFiles.each { sourceFile ->
+            logger.lifecycle("  - ${sourceFile.absolutePath}")
+        }
+    }
+}
+
+tasks.register('signReleaseArtifacts') {
+    group = 'distribution'
+    description = 'Signs release binary artifacts and Bisq-<version>.jar.txt in -PreleaseDir with detached armored GPG signatures.'
+
+    def releaseVersionProperty = providers.gradleProperty('releaseVersion')
+    def releaseDirProperty = providers.gradleProperty('releaseDir')
+    def gpgUserProperty = providers.gradleProperty('gpgUser')
+    def bisqGpgUserProperty = providers.gradleProperty('bisqGpgUser')
+    def bisqGpgUserEnvironment = providers.environmentVariable('BISQ_GPG_USER')
+    def gpgExecutableProperty = providers.gradleProperty('gpgExecutable')
+    def gpgExecutableEnvironment = providers.environmentVariable('GPG_EXECUTABLE')
+    def binaryExtensions = ['dmg', 'deb', 'rpm', 'exe', 'zip', 'pkg', 'msi', 'tar.gz', 'tgz']
+
+    inputs.property('releaseVersion', releaseVersionProperty.orElse(''))
+    inputs.property('releaseDir', releaseDirProperty.orElse(''))
+    inputs.property('gpgUser', gpgUserProperty.orElse(bisqGpgUserProperty).orElse(bisqGpgUserEnvironment).orElse(''))
+    inputs.property('gpgExecutable', gpgExecutableProperty.orElse(gpgExecutableEnvironment).orElse(''))
+    outputs.upToDateWhen { false }
+
+    doLast {
+        def releaseVersion = normalizeReleaseVersion(releaseVersionProperty.orNull)
+        def rawReleaseDir = releaseDirProperty.orNull
+        if (rawReleaseDir == null || rawReleaseDir.trim().empty) {
+            throw new GradleException('Missing required -PreleaseDir=<directory>, for example -PreleaseDir=/Users/ben/Documents/v1.10.0')
+        }
+
+        def gpgUser = gpgUserProperty.orNull ?:
+                bisqGpgUserProperty.orNull ?:
+                        bisqGpgUserEnvironment.orNull
+        if (gpgUser == null || gpgUser.trim().empty) {
+            throw new GradleException('Missing required -PgpgUser=<key-id-or-email>. You can also use -PbisqGpgUser=<key-id-or-email> or BISQ_GPG_USER.')
+        }
+        gpgUser = gpgUser.trim()
+
+        def releaseDir = file(rawReleaseDir.trim())
+        if (!releaseDir.directory) {
+            throw new GradleException("Release directory is not a directory: ${releaseDir}")
+        }
+
+        def jarTxtFileName = "Bisq-${releaseVersion}.jar.txt"
+        def jarTxtFile = new File(releaseDir, jarTxtFileName)
+        if (!jarTxtFile.file) {
+            throw new GradleException(
+                    "Missing ${jarTxtFileName} in ${releaseDir}. Create it with the createReleaseJarTxt task or desktop/package/macosx/finalize.sh before signing."
+            )
+        }
+
+        def artifacts = releaseDir.listFiles()
+                .findAll { candidate ->
+                    def signableFile = candidate.file &&
+                            !candidate.name.startsWith('.') &&
+                            !candidate.name.endsWith('.asc')
+                    def lowerName = candidate.name.toLowerCase(Locale.ROOT)
+                    signableFile &&
+                            (candidate.name == jarTxtFileName ||
+                                    binaryExtensions.any { extension -> lowerName.endsWith(".${extension}") })
+                }
+                .sort { left, right -> left.name <=> right.name }
+
+        if (artifacts.empty) {
+            throw new GradleException("No release artifacts found to sign in ${releaseDir}")
+        }
+
+        def gpgExecutable = resolveGpgExecutable()
+        def failureDetails = { result ->
+            [result.stderr, result.stdout]
+                    .findAll { it != null && !it.trim().empty }
+                    .join('\n')
+                    .trim()
+        }
+
+        logger.lifecycle("Signing ${artifacts.size()} release artifact(s) in ${releaseDir.absolutePath}")
+        artifacts.each { artifact ->
+            def signatureFile = new File(artifact.parentFile, "${artifact.name}.asc")
+            def signResult = execResult([
+                    gpgExecutable,
+                    '--yes',
+                    '--digest-algo', 'SHA256',
+                    '--local-user', gpgUser,
+                    '--output', signatureFile.absolutePath,
+                    '--detach-sig',
+                    '--armor',
+                    artifact.absolutePath
+            ])
+            if (signResult.exitValue != 0) {
+                throw new GradleException("Failed to sign ${artifact.name}: ${failureDetails(signResult)}")
+            }
+            if (!signatureFile.file || signatureFile.length() == 0) {
+                throw new GradleException("GPG did not create a non-empty signature file for ${artifact.name}: ${signatureFile}")
+            }
+
+            def verifyResult = execResult([
+                    gpgExecutable,
+                    '--verify',
+                    signatureFile.absolutePath,
+                    artifact.absolutePath
+            ])
+            if (verifyResult.exitValue != 0) {
+                throw new GradleException("Failed to verify ${signatureFile.name}: ${failureDetails(verifyResult)}")
+            }
+
+            logger.lifecycle("Signed and verified ${artifact.name} -> ${signatureFile.name}")
+        }
+    }
+}
+
 tasks.register('verifyGithubReleaseReadiness') {
     group = 'verification'
     description = 'Manually verifies GitHub release assets, Bisq download URLs, versions, and signer keys for -PreleaseVersion=<version>.'
@@ -2898,6 +3097,7 @@ tasks.register('verifyGithubReleaseReadiness') {
                 "Bisq-aarch64-${releaseVersion}.dmg".toString(),
                 "Bisq-aarch64-${releaseVersion}.dmg.asc".toString(),
                 "Bisq-${releaseVersion}.jar.txt".toString(),
+                "Bisq-${releaseVersion}.jar.txt.asc".toString(),
                 "Bisq-64bit-${releaseVersion}.deb".toString(),
                 "Bisq-64bit-${releaseVersion}.deb.asc".toString(),
                 "Bisq-64bit-${releaseVersion}.rpm".toString(),
@@ -2923,6 +3123,7 @@ tasks.register('verifyGithubReleaseReadiness') {
                 "Bisq-64bit-${releaseVersion}.exe".toString(),
                 "Bisq-64bit-${releaseVersion}.exe.asc".toString(),
                 "Bisq-${releaseVersion}.jar.txt".toString(),
+                "Bisq-${releaseVersion}.jar.txt.asc".toString(),
                 'signingkey.asc'
         ].sort()
 

--- a/build.gradle
+++ b/build.gradle
@@ -2849,7 +2849,12 @@ tasks.register('signReleaseArtifacts') {
             )
         }
 
-        def artifacts = releaseDir.listFiles()
+        def releaseDirFiles = releaseDir.listFiles()
+        if (releaseDirFiles == null) {
+            throw new GradleException("Cannot list release directory: ${releaseDir}. Check that it is readable.")
+        }
+
+        def artifacts = releaseDirFiles
                 .findAll { candidate ->
                     def signableFile = candidate.file &&
                             !candidate.name.startsWith('.') &&

--- a/desktop/package/macosx/finalize.sh
+++ b/desktop/package/macosx/finalize.sh
@@ -86,12 +86,13 @@ cp "$win64/$exe" "$target_dir/$exe64"
 
 cli="bisq-cli-$version.zip"
 daemon="bisq-daemon-$version.zip"
+jar_txt="Bisq-$version.jar.txt"
 
-# create file with jar signatures
+# create file with jar checksums
 cat "$macos_x86_64/desktop-$version-all-mac-x86_64.jar.SHA-256" \
 "$macos_aarch64/desktop-$version-all-mac-aarch64.jar.SHA-256" \
 "$linux64/desktop-$version-all-linux.jar.SHA-256" \
-"$win64/desktop-$version-all-win.jar.SHA-256" > "$target_dir/Bisq-$version.jar.txt"
+"$win64/desktop-$version-all-win.jar.SHA-256" > "$target_dir/$jar_txt"
 
 cd "$script_working_directory/$target_dir" || exit 1
 
@@ -103,6 +104,7 @@ gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$rpm64.asc" --d
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$exe64.asc" --detach-sig --armor "$exe64"
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$cli.asc" --detach-sig --armor "$cli"
 gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$daemon.asc" --detach-sig --armor "$daemon"
+gpg --digest-algo SHA256 --local-user "$BISQ_GPG_USER" --output "$jar_txt.asc" --detach-sig --armor "$jar_txt"
 
 echo Verify signatures
 gpg --digest-algo SHA256 --verify $dmg_x86_64{.asc*,}
@@ -112,6 +114,7 @@ gpg --digest-algo SHA256 --verify $rpm64{.asc*,}
 gpg --digest-algo SHA256 --verify $exe64{.asc*,}
 gpg --digest-algo SHA256 --verify $cli{.asc*,}
 gpg --digest-algo SHA256 --verify $daemon{.asc*,}
+gpg --digest-algo SHA256 --verify $jar_txt{.asc*,}
 
 mkdir $win64/$version
 cp -r . $win64/$version

--- a/desktop/package/macosx/finalize.sh
+++ b/desktop/package/macosx/finalize.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 cd ../../../
 
@@ -19,9 +20,9 @@ macos_aarch64=${BISQ_MACOS_AARCH64_PATH:-$vmPath/vm_shared_macosx_aarch64}
 
 deployDir=deploy
 
-rm -r $target_dir
+rm -rf "$target_dir"
 
-mkdir -p $target_dir
+mkdir -p "$target_dir"
 
 # make sure the releases are ready
 ./gradlew cli:build
@@ -93,6 +94,10 @@ cat "$macos_x86_64/desktop-$version-all-mac-x86_64.jar.SHA-256" \
 "$macos_aarch64/desktop-$version-all-mac-aarch64.jar.SHA-256" \
 "$linux64/desktop-$version-all-linux.jar.SHA-256" \
 "$win64/desktop-$version-all-win.jar.SHA-256" > "$target_dir/$jar_txt"
+if [[ ! -s "$target_dir/$jar_txt" ]]; then
+    echo "Missing or empty jar checksum file: $target_dir/$jar_txt" >&2
+    exit 1
+fi
 
 cd "$script_working_directory/$target_dir" || exit 1
 
@@ -116,7 +121,7 @@ gpg --digest-algo SHA256 --verify $cli{.asc*,}
 gpg --digest-algo SHA256 --verify $daemon{.asc*,}
 gpg --digest-algo SHA256 --verify $jar_txt{.asc*,}
 
-mkdir $win64/$version
-cp -r . $win64/$version
+mkdir -p "$win64/$version"
+cp -r . "$win64/$version"
 
 open "./desktop/releases/$version"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -139,7 +139,7 @@ Build output expected:
 Build output expected:
 
 1. `Bisq-${NEW_VERSION}.exe` Windows installer
-2. `desktop-${NEW_VERSION}-all-windows.jar.SHA-256` sha256 sum of fat jar
+2. `desktop-${NEW_VERSION}-all-win.jar.SHA-256` sha256 sum of fat jar
 
 * Install and run generated package
 
@@ -162,12 +162,38 @@ Build output expected:
 6. `Bisq-aarch64-${NEW_VERSION}.dmg` macOS Apple Silicon installer
 7. `Bisq-aarch64-${NEW_VERSION}.dmg.asc` Signature for macOS Apple Silicon installer
 8. `Bisq-${NEW_VERSION}.jar.txt` Aggregated SHA-256 file for macOS, Linux, and Windows jar libraries
-9. `Bisq-64bit-${NEW_VERSION}.deb` Debian package
-10. `Bisq-64bit-${NEW_VERSION}.deb.asc` Signature for Debian package
-11. `Bisq-64bit-${NEW_VERSION}.rpm` Red Hat based distro package
-12. `Bisq-64bit-${NEW_VERSION}.rpm.asc` Signature for Red Hat based distro package
-13. `Bisq-64bit-${NEW_VERSION}.exe` Windows installer
-14. `Bisq-64bit-${NEW_VERSION}.exe.asc` Signature for Windows installer
+9. `Bisq-${NEW_VERSION}.jar.txt.asc` Signature for aggregated SHA-256 file
+10. `Bisq-64bit-${NEW_VERSION}.deb` Debian package
+11. `Bisq-64bit-${NEW_VERSION}.deb.asc` Signature for Debian package
+12. `Bisq-64bit-${NEW_VERSION}.rpm` Red Hat based distro package
+13. `Bisq-64bit-${NEW_VERSION}.rpm.asc` Signature for Red Hat based distro package
+14. `Bisq-64bit-${NEW_VERSION}.exe` Windows installer
+15. `Bisq-64bit-${NEW_VERSION}.exe.asc` Signature for Windows installer
+
+If you need to create and sign the final release directory manually, use the Gradle tasks below. The
+`Bisq-${NEW_VERSION}.jar.txt` file is the concatenation of the four platform jar SHA-256 files produced by
+`./gradlew packageInstallers`; those files are in the VM shared folders / package output directories listed in the
+macOS, Linux, and Windows build sections above. When using `finalize.sh`, the generated file is written to
+`desktop/releases/${NEW_VERSION}/Bisq-${NEW_VERSION}.jar.txt`.
+
+```
+./gradlew createReleaseJarTxt \
+  -PreleaseVersion=${NEW_VERSION} \
+  -PreleaseDir=/path/to/final-release-dir \
+  -PmacosX86_64JarSha256=/path/to/desktop-${NEW_VERSION}-all-mac-x86_64.jar.SHA-256 \
+  -PmacosAarch64JarSha256=/path/to/desktop-${NEW_VERSION}-all-mac-aarch64.jar.SHA-256 \
+  -PlinuxJarSha256=/path/to/desktop-${NEW_VERSION}-all-linux.jar.SHA-256 \
+  -PwindowsJarSha256=/path/to/desktop-${NEW_VERSION}-all-win.jar.SHA-256
+
+./gradlew signReleaseArtifacts \
+  -PreleaseVersion=${NEW_VERSION} \
+  -PreleaseDir=/path/to/final-release-dir \
+  -PgpgUser=${BISQ_GPG_USER}
+```
+
+`signReleaseArtifacts` creates detached armored `.asc` signatures for release binaries (`.dmg`, `.deb`, `.rpm`,
+`.exe`, `.zip`, `.pkg`, `.msi`, `.tar.gz`, `.tgz`) and for `Bisq-${NEW_VERSION}.jar.txt`, then verifies every
+signature it created.
 
 * Run an AV scan over all files on the Windows VM where the files got copied over.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -176,20 +176,18 @@ If you need to create and sign the final release directory manually, use the Gra
 macOS, Linux, and Windows build sections above. When using `finalize.sh`, the generated file is written to
 `desktop/releases/${NEW_VERSION}/Bisq-${NEW_VERSION}.jar.txt`.
 
-```
-./gradlew createReleaseJarTxt \
-  -PreleaseVersion=${NEW_VERSION} \
-  -PreleaseDir=/path/to/final-release-dir \
-  -PmacosX86_64JarSha256=/path/to/desktop-${NEW_VERSION}-all-mac-x86_64.jar.SHA-256 \
-  -PmacosAarch64JarSha256=/path/to/desktop-${NEW_VERSION}-all-mac-aarch64.jar.SHA-256 \
-  -PlinuxJarSha256=/path/to/desktop-${NEW_VERSION}-all-linux.jar.SHA-256 \
-  -PwindowsJarSha256=/path/to/desktop-${NEW_VERSION}-all-win.jar.SHA-256
+    ./gradlew createReleaseJarTxt \
+      -PreleaseVersion=${NEW_VERSION} \
+      -PreleaseDir=/path/to/final-release-dir \
+      -PmacosX86_64JarSha256=/path/to/desktop-${NEW_VERSION}-all-mac-x86_64.jar.SHA-256 \
+      -PmacosAarch64JarSha256=/path/to/desktop-${NEW_VERSION}-all-mac-aarch64.jar.SHA-256 \
+      -PlinuxJarSha256=/path/to/desktop-${NEW_VERSION}-all-linux.jar.SHA-256 \
+      -PwindowsJarSha256=/path/to/desktop-${NEW_VERSION}-all-win.jar.SHA-256
 
-./gradlew signReleaseArtifacts \
-  -PreleaseVersion=${NEW_VERSION} \
-  -PreleaseDir=/path/to/final-release-dir \
-  -PgpgUser=${BISQ_GPG_USER}
-```
+    ./gradlew signReleaseArtifacts \
+      -PreleaseVersion=${NEW_VERSION} \
+      -PreleaseDir=/path/to/final-release-dir \
+      -PgpgUser=${BISQ_GPG_USER}
 
 `signReleaseArtifacts` creates detached armored `.asc` signatures for release binaries (`.dmg`, `.deb`, `.rpm`,
 `.exe`, `.zip`, `.pkg`, `.msi`, `.tar.gz`, `.tgz`) and for `Bisq-${NEW_VERSION}.jar.txt`, then verifies every


### PR DESCRIPTION
Add Gradle release artifact signing tasks

Add createReleaseJarTxt to aggregate platform jar SHA-256 files into Bisq-<version>.jar.txt from explicit Gradle properties.

Add signReleaseArtifacts to sign release binaries and the aggregated jar checksum file with detached armored GPG signatures, then verify each signature.

Update finalize.sh, release readiness expectations, and release-process documentation so Bisq-<version>.jar.txt.asc is produced and documented alongside the other release assets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release packages now include a single combined SHA-256 checksum for all platform jars and automated detached GPG signatures for all release artifacts, with verification during packaging.

* **Documentation**
  * Release process updated with steps to generate the combined checksum, sign/verify artifacts, and updated expected Windows build output naming.

* **Chores**
  * Packaging scripts hardened (safer directory handling and failure-on-sign/verify errors).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->