### PR TITLE
Uses DatePicker instead of JFXDatePicker

### DIFF
--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -56,7 +56,6 @@ import de.jensd.fx.glyphs.GlyphIcons;
 import de.jensd.fx.glyphs.materialdesignicons.utils.MaterialDesignIconFactory;
 
 import com.jfoenix.controls.JFXComboBox;
-import com.jfoenix.controls.JFXDatePicker;
 import com.jfoenix.controls.JFXTextArea;
 import com.jfoenix.controls.JFXToggleButton;
 
@@ -65,7 +64,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.ContentDisplay;
-import javafx.scene.control.Control;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
@@ -681,11 +679,7 @@ public class FormBuilder {
                                                                   int columnIndex,
                                                                   String title,
                                                                   double top) {
-        DatePicker datePicker = new JFXDatePicker();
-        // fix display issue from github.com/bisq-network/bisq/issues/6216 and github.com/sshahine/JFoenix/issues/1245
-        datePicker.getEditor().setMinWidth(250);
-        datePicker.getEditor().setMaxWidth(Control.USE_PREF_SIZE);
-        datePicker.getEditor().setPrefWidth(Control.USE_PREF_SIZE);
+        DatePicker datePicker = new DatePicker();
         Tuple2<Label, VBox> topLabelWithVBox = addTopLabelWithVBox(gridPane, rowIndex, columnIndex, title, datePicker, top);
         return new Tuple2<>(topLabelWithVBox.first, datePicker);
     }


### PR DESCRIPTION
JFXDatePicker caused exception and style of default DatePicker looks acceptable anyway.

<img width="1031" height="359" alt="Screenshot 2026-05-17 at 09 25 30" src="https://github.com/user-attachments/assets/9cdb0ed8-e185-46cb-90ba-c97c222ae247" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the custom date picker with the native framework date picker, simplifying layout and sizing behavior for a more consistent, streamlined date selection experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->