### PR TITLE
Update release notes

### DIFF
--- a/release-notes/1.10.0/full-release-notes.md
+++ b/release-notes/1.10.0/full-release-notes.md
@@ -2,17 +2,19 @@
 
 These notes are written in the same practical style used by Bitcoin Core release notes: user and operator impact first, followed by a complete auditable commit inventory.
 
-Commit range: from `797836cc9d3ef0891a1bd349e18127fe252eb860` through `a33ece9a915dc1eadb45e50960b8dc608a0f09a9`, generated with `git log --reverse 797836cc9d3ef0891a1bd349e18127fe252eb860^..HEAD`. This includes the starting commit `797836cc9d` and ends at `a33ece9a91`. The inventory includes merge commits as separate entries because they are part of the release history.
+Commit range: after `f50c5a4176b5d5ecac864ddf3d52a6ca760996a9` through `a33ece9a915dc1eadb45e50960b8dc608a0f09a9`, generated with `git log --reverse f50c5a4176b5d5ecac864ddf3d52a6ca760996a9..a33ece9a915dc1eadb45e50960b8dc608a0f09a9`. This excludes the v1.9.21 release commit `f50c5a4176` and includes the v1.9.22 hotfix merge `cf887ddf9f` plus the later commits through `a33ece9a91`. The inventory includes merge commits as separate entries because they are part of the release history.
 
-- Total commits: 743
-- Non-merge commits: 542
-- Merge commits: 201
-- Generated on: 2026-05-15
+- Total commits: 748
+- Non-merge commits: 546
+- Merge commits: 202
+- Generated on: 2026-05-17
 
 ## Compatibility Notes
 
 - Bisq version is set to `1.10.0`.
+- The release-note range starts after v1.9.21 because v1.9.22 was a hotfix release based on v1.9.21. v1.9.22 only carried the backported bitcoinj chainwork fix, version/signing-key updates, and its merge; the remaining post-v1.9.21 development changes are included here for v1.10.0.
 - Release builds use Gradle `8.9` and an Azul Java `21.0.6` toolchain. JavaFX is updated to `21.0.10`.
+- The DAO full-node path uses the new bitcoind RPC integration for Bitcoin Core `29.2`.
 - The maximum trade amount is limited to `0.125 BTC` and offer/trade prices are constrained to a `25%` maximum deviation.
 - Dispute chat file attachments and dispute log file transfer are removed.
 - VERSE is deprecated for new payment-account creation, and HRK is removed from active currency lists.
@@ -21,7 +23,7 @@ Commit range: from `797836cc9d3ef0891a1bd349e18127fe252eb860` through `a33ece9a9
 
 ### Trade, Wallet, And Offer Safety
 
-This release contains a large validation hardening pass for Bisq v1 trades. Peer-provided inputs, deposit transactions, payout transactions, delayed payout transactions, mediated payout transactions, fees, trade amounts, prices, multisig public keys, and payment-account hashes are checked earlier and more consistently. Invalid peer data is rejected closer to the point where it enters the trade flow.
+This release contains a large validation hardening pass for Bisq v1 trades. Peer-provided inputs, deposit transactions, payout transactions, delayed payout transactions, mediated payout transactions, fees, trade amounts, prices, multisig public keys, and payment-account hashes are checked earlier and more consistently. Deposit setup now validates peer raw transaction input values, change output values, and expected contribution amounts before maker/taker deposit construction proceeds. Invalid peer data is rejected closer to the point where it enters the trade flow.
 
 The release also rejects legacy UTXOs for deposit funding, bounds and deduplicates peer-supplied inputs, validates canonical deposit transaction shapes at final boundaries, re-verifies multisig outputs before payout signing, hardens BSQ swap arithmetic, hardens Monero transaction proof handling, and unreserves offers when a take-offer request fails.
 
@@ -39,13 +41,13 @@ Payment-account handling is safer and more robust. Swish account creation no lon
 
 ### DAO, Burning Man, API, And Services
 
-The release includes bridge module work with gRPC APIs, account timestamp service support, DAO resync/snapshot fixes, refreshed DAO/network resource snapshots, bitcoind RPC migration work, Burning Man address list and delayed payout receiver validation, DAO CLI/gRPC test coverage, and updates to mediator/refund-agent/network node metadata. Version-tagged resource files are intentionally not bundled in this release to avoid extra requests against seed nodes that still run older versions.
+The release includes bridge module work with gRPC APIs, account timestamp service support, DAO resync/snapshot fixes, refreshed DAO/network resource snapshots, Burning Man address list and delayed payout receiver validation, DAO CLI/gRPC test coverage, and updates to mediator/refund-agent/network node metadata. The 1.9.23 bitcoind work is included: Bisq's DAO full-node RPC path was migrated to the new bitcoind RPC implementation for Bitcoin Core 29.2, older core-side bitcoind DTO/client code was removed, the bitcoind submodule and verification metadata were refreshed through the later release-candidate targets, and regtest coverage gained a second bitcoind node for reorg testing. Version-tagged resource files are intentionally not bundled in this release to avoid extra requests against seed nodes that still run older versions.
 
 API and CLI changes include consistent `payment-account-id` naming, improved `findAvailableOffer`, API-level filtering for BTC addresses with positive balances, support for multiple `btcNodes` command-line values, and removal of the deprecated `getmyoffer` command.
 
 ### Build, Dependencies, And Release Integrity
 
-The build and runtime stack is updated to Java 21/JavaFX 21 with broad dependency updates, newer bitcoinj/bitcoind/netlayer targets, Kotlin alignment, and updated test/build libraries. CI and packaging receive JVM export fixes for JavaFX/JFoenix on macOS, JavaFX variants publish native architecture attributes, and macOS releases support both Apple Silicon and Intel Macs with architecture-qualified DMGs and hash outputs.
+The build and runtime stack is updated to Java 21/JavaFX 21 with broad dependency updates, newer bitcoinj/bitcoind/netlayer targets, Kotlin alignment, and updated test/build libraries. This range also includes the v1.9.22 hotfix branch, which backported the bitcoinj chainwork fix onto the v1.9.21 base without taking the rest of the development branch. CI and packaging receive JVM export fixes for JavaFX/JFoenix on macOS, JavaFX variants publish native architecture attributes, and macOS releases support both Apple Silicon and Intel Macs with architecture-qualified DMGs and hash outputs.
 
 Release verification is significantly expanded. The build now creates and verifies Java payload and installer manifests, records release and installer evidence bundles, pins GitHub Actions and runner/JDK versions, verifies Gradle wrapper inputs, adds dependency signature reporting, adds CVE scanning, documents reproducible release verification, hardens Linux release-builder evidence for Debian/RPM packages, adds a Docker-based DAO/trade end-to-end test workflow, and adds a manual GitHub release-readiness check for uploaded assets, download URLs, and signing keys.
 
@@ -71,6 +73,7 @@ Rows are ordered by `git log --reverse` over the release range. Some commit date
 | 2025-07-28 | [20a8c4ee69](https://github.com/bisq-network/bisq/commit/20a8c4ee696c85a7fb2f8ce6038660f72ab0206f) | Commit | Apply bridge code-review suggestions | HenrikJannsen |
 | 2025-08-26 | [2b542e04d9](https://github.com/bisq-network/bisq/commit/2b542e04d93091d855b75664442cf7e2a19bfd86) | Commit | Bump actions/setup-java from 4.7.1 to 5.0.0 | dependabot[bot] |
 | 2025-09-08 | [70900e2a76](https://github.com/bisq-network/bisq/commit/70900e2a7624d2840ecf788b9641858101ae9d45) | Commit | Bump actions/stale from 9.1.0 to 10.0.0 | dependabot[bot] |
+| 2025-09-16 | [7ee70ec6cc](https://github.com/bisq-network/bisq/commit/7ee70ec6cc4194af836ba8f04adff5588820c341) | Commit | Revert to SNAPSHOT version | Alejandro García |
 | 2025-09-17 | [4c32a4fb99](https://github.com/bisq-network/bisq/commit/4c32a4fb9997b8df88cd4f21fd6e6f23ba3cc124) | Merge | Merge PR #7505: v1.9.21 | Alejandro García |
 | 2025-09-17 | [223403a7d6](https://github.com/bisq-network/bisq/commit/223403a7d64683f30f9d23a86db6070769624981) | Merge | Merge PR #7476: update seed nodes for inventory monitor | Alejandro García |
 | 2025-09-17 | [397b5a26a9](https://github.com/bisq-network/bisq/commit/397b5a26a91de669e0507831f0d74bab7408a1f7) | Merge | Merge PR #7492: add bridge module | Alejandro García |
@@ -192,6 +195,10 @@ Rows are ordered by `git log --reverse` over the release range. Some commit date
 | 2025-12-23 | [45df4ce695](https://github.com/bisq-network/bisq/commit/45df4ce6952fe65df424e9a16a3a03c42ee1b5da) | Commit | Set version 1.9.22 | HenrikJannsen |
 | 2025-12-23 | [b3faaf7e43](https://github.com/bisq-network/bisq/commit/b3faaf7e43e866b7c2e30bcca089812c1eac342d) | Commit | Add Henrik Jannsen's pgp key (387C8307.asc) | HenrikJannsen |
 | 2025-12-23 | [f2fe13d07d](https://github.com/bisq-network/bisq/commit/f2fe13d07def5cf7c57f15d0365c2052d3b9f88d) | Merge | Merge PR #7567: use backported bitcoinj fix | HenrikJannsen |
+| 2025-12-23 | [04c3ef41f4](https://github.com/bisq-network/bisq/commit/04c3ef41f4b993229fcc32841f754c6fa5bd9669) | Commit | Use bitcoinj commit 7dc0851a807857ba19f76824e48d75ab0390eca7 with the backport of the chainwork bugfix. | HenrikJannsen |
+| 2025-12-23 | [158eb02f24](https://github.com/bisq-network/bisq/commit/158eb02f240bc3c0e5ca406216a52a45fd370417) | Commit | Set version 1.9.22 | HenrikJannsen |
+| 2025-12-23 | [98593bfa15](https://github.com/bisq-network/bisq/commit/98593bfa1585a5eadf6683bc482c1a08a62e0ce9) | Commit | Add Henrik Jannsen's pgp key (387C8307.asc) | HenrikJannsen |
+| 2025-12-23 | [cf887ddf9f](https://github.com/bisq-network/bisq/commit/cf887ddf9fce5dea6307a46c8a6d1b94eb9a670a) | Merge | Merge PR #7570: backported bitcoinj hotfix | HenrikJannsen |
 | 2026-01-20 | [d5df6a9359](https://github.com/bisq-network/bisq/commit/d5df6a9359137961cf45d923224b267d97449041) | Commit | Migrate to new bitcoind RPC implementation | Alva Swanson |
 | 2026-01-20 | [2f11a93c6f](https://github.com/bisq-network/bisq/commit/2f11a93c6fafeffa300282d0cfa24bc4f6727739) | Commit | core: Remove unused jackson.databind dependency | Alva Swanson |
 | 2026-01-26 | [a7167cc001](https://github.com/bisq-network/bisq/commit/a7167cc001a13f4276f437eb5aebdc3748a8f814) | Commit | Bump actions/checkout from 6.0.1 to 6.0.2 | dependabot[bot] |
@@ -243,7 +250,7 @@ Rows are ordered by `git log --reverse` over the release range. Some commit date
 | 2026-04-13 | [ba29397860](https://github.com/bisq-network/bisq/commit/ba29397860dceefeb06ce597c3e1f7454ac2d0a4) | Merge | Merge PR #7597: fix bisq launch scripts | Alejandro García |
 | 2026-04-13 | [18dee23785](https://github.com/bisq-network/bisq/commit/18dee2378543f5d4e4e4f40eebb464917abeba81) | Merge | Merge PR #7598: Move seednode JVM arguments to global configuration | Alejandro García |
 | 2026-04-13 | [32c825a393](https://github.com/bisq-network/bisq/commit/32c825a393de64a1f34ecffd5bfcdb69398bfa12) | Merge | Merge PR #7613: update data stores for v1.9.23 | Alejandro García |
-| 2026-05-02 | [797836cc9d](https://github.com/bisq-network/bisq/commit/797836cc9d3ef0891a1bd349e18127fe252eb860) | Commit | Validate trade peer deposit inputs during maker/taker deposit setup | HenrikJannsen |
+| 2026-05-02 | [797836cc9d](https://github.com/bisq-network/bisq/commit/797836cc9d3ef0891a1bd349e18127fe252eb860) | Commit | Apply @hiciefte patch validating trade peer deposit inputs during maker/taker deposit setup | HenrikJannsen |
 | 2026-05-02 | [3ce703d741](https://github.com/bisq-network/bisq/commit/3ce703d74117db0667c90153d517ffac487e0f10) | Commit | Add instruction how to update submodule if not cloned newly | HenrikJannsen |
 | 2026-05-02 | [382e438a87](https://github.com/bisq-network/bisq/commit/382e438a8763fa7b934d99971c7d2052e84014f1) | Commit | Check that changeOutputAddress is not null if changeOutputValue is > 0. | HenrikJannsen |
 | 2026-05-02 | [95fff711ef](https://github.com/bisq-network/bisq/commit/95fff711efdc16fece6c4b62f9afa82f9c3283d1) | Commit | Refactor: rename and extract variable | HenrikJannsen |
@@ -801,4 +808,4 @@ Rows are ordered by `git log --reverse` over the release range. Some commit date
 
 ## Credits
 
-Contributors represented in this commit range: Alejandro García, Alva Swanson, bisqadmin, Christoph Atteneder, dependabot[bot], helixx87, HenrikJannsen, KimStrand, M. Caviar, mustardcaviar, Steven Barclay, suddenwhipvapor, Takahiro Nagasawa, tat twam asi, thecockatiel, viresinnumer1s, wodoro.
+Contributors represented in this commit range: Alejandro García, Alva Swanson, bisqadmin, Christoph Atteneder, dependabot[bot], helixx87, HenrikJannsen, hiciefte, KimStrand, M. Caviar, mustardcaviar, Steven Barclay, suddenwhipvapor, Takahiro Nagasawa, tat twam asi, thecockatiel, viresinnumer1s, wodoro.

--- a/release-notes/1.10.0/notable-changes.md
+++ b/release-notes/1.10.0/notable-changes.md
@@ -4,10 +4,10 @@ This file filters the full release notes down to the most relevant engineering a
 
 ## Trade And Transaction Validation Hardening
 
-Bisq v1 trade handling now validates peer-supplied data much earlier and across more protocol steps. The release adds and reorganizes validation for deposit transactions, payout transactions, delayed payout transactions, mediated payouts, trade amounts, trade prices, maker/taker fees, miner fees, multisig public keys, serialized transactions, raw inputs, signatures, payment-account hashes, and canonical transaction structure.
+Bisq v1 trade handling now validates peer-supplied data much earlier and across more protocol steps. The release adds and reorganizes validation for deposit transactions, payout transactions, delayed payout transactions, mediated payouts, trade amounts, trade prices, maker/taker fees, miner fees, multisig public keys, serialized transactions, raw inputs, signatures, payment-account hashes, and canonical transaction structure. Maker/taker deposit setup now checks peer raw transaction input values, change output values, and expected peer contribution amounts before deposit construction continues.
 
 Related commits:
-- [797836cc9d](https://github.com/bisq-network/bisq/commit/797836cc9d3ef0891a1bd349e18127fe252eb860) - Validate peer deposit inputs during maker/taker deposit setup.
+- [797836cc9d](https://github.com/bisq-network/bisq/commit/797836cc9d3ef0891a1bd349e18127fe252eb860) - Apply @hiciefte patch validating peer deposit inputs and expected contribution amounts during maker/taker deposit setup.
 - [89171806e8](https://github.com/bisq-network/bisq/commit/89171806e8d3ae7a74c34fe6e40948245e1bf761) - Merge the initial exploit-fix validation patch.
 - [3b5ae98849](https://github.com/bisq-network/bisq/commit/3b5ae98849d93ec1570066da8c289ec627a4cb9b) - Require peer inputs to use the expected P2W format.
 - [844aec628f](https://github.com/bisq-network/bisq/commit/844aec628f1c80d6f53fc9dbf1098395ecb04b33) - Prevent invalid delayed payout transactions.
@@ -80,15 +80,17 @@ Related commits:
 - [80f5ed863c](https://github.com/bisq-network/bisq/commit/80f5ed863cbc9ed88131556ac7905817c764450c) - Deprecate VERSE for new payment-account creation.
 - [39e6caa5c1](https://github.com/bisq-network/bisq/commit/39e6caa5c1c4684c0fb49ff5b13f79630e473b5c) - Harden payout address validation.
 
-## DAO, Burning Man, API, And Service Updates
+## DAO, Bitcoind RPC, Burning Man, API, And Services Updates
 
-The release adds bridge/gRPC service work, account timestamp support, DAO snapshot/resync fixes, refreshed DAO/network resource snapshots, Burning Man address-list and receiver validation, updated node/mediator/refund-agent metadata, bitcoind RPC changes, DAO CLI/gRPC test coverage, and API/CLI cleanup. Version-tagged resource files are omitted for this release so older seed nodes do not trigger avoidable resource requests.
+The release adds bridge/gRPC service work, account timestamp support, DAO snapshot/resync fixes, refreshed DAO/network resource snapshots, Burning Man address-list and receiver validation, updated node/mediator/refund-agent metadata, DAO CLI/gRPC test coverage, and API/CLI cleanup. The main 1.9.23 infrastructure work is included here: Bisq's DAO full-node bitcoind RPC path was migrated to the new implementation that supports Bitcoin Core 29.2, the old core-side bitcoind DTO/client code was removed, bitcoind submodule targets and dependency verification metadata were refreshed, and regtest coverage gained a second bitcoind node for reorg testing. Version-tagged resource files are omitted for this release so older seed nodes do not trigger avoidable resource requests.
 
 Related commits:
 - [397b5a26a9](https://github.com/bisq-network/bisq/commit/397b5a26a91de669e0507831f0d74bab7408a1f7) - Merge the bridge module and gRPC API work.
 - [3d4cbe8a83](https://github.com/bisq-network/bisq/commit/3d4cbe8a8347c13abab1c4f081b68a3fb8ca0683) - Add AccountTimestampGrpcService.
 - [a49488a3c8](https://github.com/bisq-network/bisq/commit/a49488a3c81f40ffec14eed034f864db99c4a272) - Fix applying DAO snapshots during resync.
-- [81d375ea64](https://github.com/bisq-network/bisq/commit/81d375ea643f611a1c8690bd3c58cf57046a1c78) - Add bitcoind v29.2 support.
+- [d5df6a9359](https://github.com/bisq-network/bisq/commit/d5df6a9359137961cf45d923224b267d97449041) - Migrate to the new bitcoind RPC implementation for Bitcoin Core 29.2.
+- [81d375ea64](https://github.com/bisq-network/bisq/commit/81d375ea643f611a1c8690bd3c58cf57046a1c78) - Merge bitcoind v29.2 support.
+- [888872e7c9](https://github.com/bisq-network/bisq/commit/888872e7c92b72e92afad59a4a633db25ee7629b) - Add a second bitcoind node for reorg testing.
 - [93911b999e](https://github.com/bisq-network/bisq/commit/93911b999e0745b6ea6da89bcad98e93aabc7c83) - Add Burning Man address-list checkpoint support.
 - [66f04a4d77](https://github.com/bisq-network/bisq/commit/66f04a4d7756fff5d473ad19b1825a004a352b3d) - Refresh DAO and network resource snapshots.
 - [c2a4c8d2de](https://github.com/bisq-network/bisq/commit/c2a4c8d2de4dffd936c76dee8bb62aae78ce64a1) - Remove version-tagged resources for seed-node compatibility.
@@ -101,9 +103,11 @@ Related commits:
 
 ## Runtime, Dependencies, And Network Stack
 
-The build/runtime stack moves to Java 21 with JavaFX 21 and broad dependency updates. bitcoinj, bitcoind, netlayer/Tor, Kotlin, logging, protobuf, Jackson, Guava, Lombok, Jersey, JUnit, Hamcrest, and other libraries are updated or aligned. macOS releases support both Apple Silicon and Intel Macs with architecture-qualified DMGs and release hash files, the in-app updater selects the matching macOS installer architecture, JavaFX variants publish native architecture attributes, and JavaFX/JFoenix packaging receives follow-up fixes.
+The build/runtime stack moves to Java 21 with JavaFX 21 and broad dependency updates. bitcoinj, bitcoind, netlayer/Tor, Kotlin, logging, protobuf, Jackson, Guava, Lombok, Jersey, JUnit, Hamcrest, and other libraries are updated or aligned. The range now starts after v1.9.21 because v1.9.22 was a hotfix branch based on v1.9.21; it only backported the bitcoinj chainwork fix and did not include the rest of the post-v1.9.21 development work. macOS releases support both Apple Silicon and Intel Macs with architecture-qualified DMGs and release hash files, the in-app updater selects the matching macOS installer architecture, JavaFX variants publish native architecture attributes, and JavaFX/JFoenix packaging receives follow-up fixes.
 
 Related commits:
+- [04c3ef41f4](https://github.com/bisq-network/bisq/commit/04c3ef41f4b993229fcc32841f754c6fa5bd9669) - Backport the bitcoinj chainwork fix on the v1.9.22 hotfix branch.
+- [cf887ddf9f](https://github.com/bisq-network/bisq/commit/cf887ddf9fce5dea6307a46c8a6d1b94eb9a670a) - Merge the v1.9.22 bitcoinj hotfix branch based on v1.9.21.
 - [cb0c7ba2f1](https://github.com/bisq-network/bisq/commit/cb0c7ba2f1437ec6c835108f7f13a8680d273fe9) - Merge broad dependency and JavaFX update work.
 - [b6170834c2](https://github.com/bisq-network/bisq/commit/b6170834c285ea8f18452c67e8e52d4dde9201e9) - Update bitcoinj to include the P2WPKH verification fix.
 - [936eeb2e4f](https://github.com/bisq-network/bisq/commit/936eeb2e4f25fed634e43b5c041c037b9e7896e4) - Use updated bitcoinj and metadata.
@@ -111,7 +115,7 @@ Related commits:
 - [d122fdd733](https://github.com/bisq-network/bisq/commit/d122fdd73347344114010dadea9c33e972c0cc48) - Align Kotlin version and dependency verification metadata.
 - [5970e84f75](https://github.com/bisq-network/bisq/commit/5970e84f75a55751525c5e81b121e7f9e12271a2) - Update logback/slf4j and bitcoind target.
 - [62642fb2cd](https://github.com/bisq-network/bisq/commit/62642fb2cd7d745ba09f4f0970d239dfd922cc3f) - Update Guava and Lombok.
-- [7f952fb1e8](https://github.com/bisq-network/bisq/commit/7f952fb1e8a4537acc6ae7fb380baa7ae03f4f87) - Update bitcoind and verification metadata.
+- [7f952fb1e8](https://github.com/bisq-network/bisq/commit/7f952fb1e8a4537acc6ae7fb380baa7ae03f4f87) - Update the bitcoind submodule and dependency verification metadata.
 - [1f6ebda67a](https://github.com/bisq-network/bisq/commit/1f6ebda67a9bdc98c913626d6b9acb873a5bde2f) - Fix packaged macOS JavaFX/JFoenix exports.
 - [081124c57f](https://github.com/bisq-network/bisq/commit/081124c57f87e600c2b4c865d8b31c41dab10b9c) - Update netlayer to the latest target in this range.
 - [3fce2c0bf5](https://github.com/bisq-network/bisq/commit/3fce2c0bf5106a053daaddff0555b213518ad2df) - Add dual-architecture macOS release packaging support.

--- a/release-notes/1.10.0/release-highlights.md
+++ b/release-notes/1.10.0/release-highlights.md
@@ -5,6 +5,7 @@ Short text for GitHub release notes and the in-app update message.
 ## Security And Trade Safety
 
 - Stronger checks before accepting trade messages, deposit transactions, payout transactions, and peer-provided wallet data.
+- Deposit setup verifies peer raw transaction inputs, change outputs, and expected contribution amounts before maker/taker deposit construction continues.
 - Safer offer taking: invalid peer data is rejected earlier, and failed take-offer attempts release the offer again.
 - Additional protection around payment-account matching, payout addresses, trade fees, and trade limits.
 - HTTP and P2P message handling now rejects more unsafe or unexpected network inputs.
@@ -26,6 +27,8 @@ Short text for GitHub release notes and the in-app update message.
 ## Network And Runtime
 
 - Tor/netlayer, bitcoinj, bitcoind, Java, JavaFX, and major libraries were updated.
+- The v1.9.22 bitcoinj chainwork hotfix is included; other post-v1.9.21 development changes were not part of that hotfix release and are covered here.
+- The DAO full-node bitcoind RPC layer was migrated for Bitcoin Core 29.2 support, with updated bitcoind targets and reorg-test coverage.
 - The app version is `1.10.0`; release builds use the Java 21 release build stack.
 - Bundled DAO and network resource snapshots were refreshed for the release.
 - macOS releases now support both Apple Silicon and Intel Macs.


### PR DESCRIPTION
The release notes have been created from the commits after 1.9.23 (797836cc9d3ef0891a1bd349e18127fe252eb860) but as the 1.10.0 includes the 1.9.23 scope that was missing and added now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bitcoin Core 29.2 support via updated bitcoind RPC integration.

* **Bug Fixes**
  * Stronger trade safety: validates peer-provided raw transaction inputs, change outputs, and expected contribution amounts earlier; rejects invalid peer data sooner.

* **Chores**
  * Runtime/tooling updates: Java 21/JavaFX 21 alignment, bitcoinj hotfix backport, improved macOS dual-arch packaging and reorg-test coverage.

* **Documentation**
  * Expanded release notes and credits (added contributor).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->