### PR TITLE
Relax t64 dependencies in generated .deb

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
@@ -55,6 +55,9 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
             if (packageFormat == PackageFormat.RPM) {
                 normalizeRpmPackage(jPackageConfig.appConfig)
             }
+            if (packageFormat == PackageFormat.DEB) {
+                relaxDebT64Dependencies()
+            }
             if (packageFormat == PackageFormat.DMG && getOS() == OS.MAC_OS) {
                 renameMacOsDmgPackage(jPackageConfig.appConfig)
             }
@@ -158,6 +161,55 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
         normalizePathTimestamps(rpmPath)
     }
 
+    // Debian/Ubuntu 24.04 renamed many libraries during the 64-bit time_t transition,
+    // appending a `t64` suffix (e.g. libasound2 -> libasound2t64). jpackage inherits
+    // whatever names dpkg-shlibdeps picks up on the build host, so a .deb produced on
+    // a t64-transitioned system pins `libasound2t64` and refuses to install on Ubuntu
+    // 22.04 where only the un-suffixed name exists. Rewrite the Depends field so each
+    // `<pkg>t64` entry becomes `<pkg>t64 | <pkg>`, satisfying both old and new releases.
+    private fun relaxDebT64Dependencies() {
+        val debPath = findSinglePackageArtifact(PackageFormat.DEB)
+        val repackRoot = jPackageConfig.temporaryDirPath.resolve("deb-repack")
+        repackRoot.toFile().deleteRecursively()
+        val payloadRoot = repackRoot.resolve("payload")
+        Files.createDirectories(repackRoot)
+
+        runProcess(
+                ProcessBuilder(
+                        "dpkg-deb", "-R",
+                        debPath.toAbsolutePath().toString(),
+                        payloadRoot.toAbsolutePath().toString()
+                ),
+                "extract DEB payload"
+        )
+
+        val controlFile = payloadRoot.resolve("DEBIAN").resolve("control")
+        if (!Files.isRegularFile(controlFile)) {
+            throw GradleException("DEB control file not found after extraction: ${controlFile.toAbsolutePath()}")
+        }
+        val original = Files.readString(controlFile)
+        val updated = relaxT64Dependencies(original)
+        if (updated == original) {
+            return
+        }
+        Files.writeString(controlFile, updated)
+
+        val rebuiltDebPath = repackRoot.resolve(debPath.fileName)
+        runProcess(
+                ProcessBuilder(
+                        "dpkg-deb",
+                        "--root-owner-group",
+                        "--build",
+                        payloadRoot.toAbsolutePath().toString(),
+                        rebuiltDebPath.toAbsolutePath().toString()
+                ),
+                "rebuild DEB with relaxed dependencies"
+        )
+
+        Files.move(rebuiltDebPath, debPath, StandardCopyOption.REPLACE_EXISTING)
+        normalizePathTimestamps(debPath)
+    }
+
     private fun renameMacOsDmgPackage(appConfig: JPackageAppConfig) {
         val sourcePath = jPackageConfig.outputDirPath.resolve("Bisq-${appConfig.appVersion}.dmg")
         val targetPath = jPackageConfig.outputDirPath.resolve("Bisq-${getArchitecture().installerClassifier}-${appConfig.appVersion}.dmg")
@@ -224,6 +276,57 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
             %defattr(-,root,root,-)
             /opt
         """.trimIndent() + "\n"
+    }
+
+    private fun relaxT64Dependencies(controlFileContent: String): String {
+        val lines = controlFileContent.split("\n")
+        val result = StringBuilder()
+        var i = 0
+        while (i < lines.size) {
+            val line = lines[i]
+            if (line.startsWith("Depends:", ignoreCase = true)) {
+                val colonIdx = line.indexOf(':')
+                val deps = StringBuilder(line.substring(colonIdx + 1).trim())
+                var j = i + 1
+                while (j < lines.size && lines[j].isNotEmpty() && (lines[j][0] == ' ' || lines[j][0] == '\t')) {
+                    if (deps.isNotEmpty()) deps.append(' ')
+                    deps.append(lines[j].trim())
+                    j++
+                }
+                result.append(line.substring(0, colonIdx + 1))
+                        .append(' ')
+                        .append(relaxDepsList(deps.toString()))
+                i = j
+            } else {
+                result.append(line)
+                i++
+            }
+            if (i < lines.size) {
+                result.append('\n')
+            }
+        }
+        return result.toString()
+    }
+
+    private fun relaxDepsList(deps: String): String {
+        if (deps.isBlank()) return deps
+        return deps.split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .joinToString(", ") { relaxT64Dependency(it) }
+    }
+
+    private fun relaxT64Dependency(dep: String): String {
+        if (dep.contains("|")) {
+            return dep
+        }
+        val nameEndIdx = dep.indexOfAny(charArrayOf(' ', '\t', ':', '('))
+        val pkgName = if (nameEndIdx == -1) dep else dep.substring(0, nameEndIdx)
+        if (!pkgName.endsWith("t64") || pkgName.length <= 3) {
+            return dep
+        }
+        val baseName = pkgName.dropLast(3)
+        return "$dep | $baseName"
     }
 
     private fun findSinglePackageArtifact(packageFormat: PackageFormat): Path {

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
@@ -326,7 +326,8 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
             return dep
         }
         val baseName = pkgName.dropLast(3)
-        return "$dep | $baseName"
+        val suffix = dep.removePrefix(pkgName)
+        return "$dep | $baseName$suffix"
     }
 
     private fun findSinglePackageArtifact(packageFormat: PackageFormat): Path {


### PR DESCRIPTION
Debian/Ubuntu 24.04 renamed many libraries during the 64-bit time_t transition, appending a `t64` suffix (e.g. libasound2 -> libasound2t64). jpackage inherits whatever names dpkg-shlibdeps picks up on the build host, so a .deb produced on a t64-transitioned system pins `libasound2t64` and refuses to install on Ubuntu 22.04 where only the un-suffixed name exists.

Post-process the generated .deb to rewrite each `<pkg>t64` entry in the Depends field as `<pkg>t64 | <pkg>`, satisfying the requirement on both old and new releases without overriding jpackage's auto-detected dependency list.

Fixes #7819



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Debian package compatibility by relaxing dependency requirements so packages will accept alternate library/package name variants (e.g., differing 32/64-bit naming), reducing installation failures on diverse Linux systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->