### PR TITLE
Fix BSQ swap take-offer crash by clamping BTC miner contribution at 0

### DIFF
--- a/apitest/src/test/java/bisq/apitest/dao/TradeScenarioTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/TradeScenarioTest.java
@@ -234,33 +234,42 @@ public class TradeScenarioTest extends DaoTestBase {
         assertEquals(BTC_AMOUNT_SATS, bob.getTrade(trade.getTradeId())
                 .getBsqSwapTradeInfo().getBtcTradeAmount());
 
-        // Mine a confirmation so the swap outputs count toward available_balance.
+        // Mine a confirmation so the swap outputs count toward available_balance, then
+        // await each expected balance movement. The BSQ parser updates the confirmed
+        // BSQ balance asynchronously after the block arrives, so a single one-shot read
+        // can race the parser and observe stale values — gate on the observable state
+        // change instead, with the timeout acting as the safety net.
         dao.generateBlocks(1);
-        long aliceBtcAfter = totalBtc(alice);
-        long bobBtcAfter = totalBtc(bob);
-        long aliceBsqAfter = alice.getBalances().getBsq().getAvailableConfirmedBalance();
-        long bobBsqAfter = bob.getBalances().getBsq().getAvailableConfirmedBalance();
         boolean aliceSellsBtc = "SELL".equalsIgnoreCase(direction);
         if (aliceSellsBtc) {
             // Alice sends BTC, receives BSQ. Bob sends BSQ, receives BTC.
-            assertTrue(aliceBtcAfter < aliceBtcBefore,
-                    "alice BTC must decrease: before=" + aliceBtcBefore + " after=" + aliceBtcAfter);
-            assertTrue(bobBtcAfter > bobBtcBefore,
-                    "bob BTC must increase: before=" + bobBtcBefore + " after=" + bobBtcAfter);
-            assertTrue(aliceBsqAfter > aliceBsqBefore,
-                    "alice BSQ must increase: before=" + aliceBsqBefore + " after=" + aliceBsqAfter);
-            assertTrue(bobBsqAfter < bobBsqBefore,
-                    "bob BSQ must decrease: before=" + bobBsqBefore + " after=" + bobBsqAfter);
+            awaitBalanceMove("alice BTC must decrease", aliceBtcBefore,
+                    () -> totalBtc(alice), false);
+            awaitBalanceMove("bob BTC must increase", bobBtcBefore,
+                    () -> totalBtc(bob), true);
+            awaitBalanceMove("alice BSQ must increase", aliceBsqBefore,
+                    () -> alice.getBalances().getBsq().getAvailableConfirmedBalance(), true);
+            awaitBalanceMove("bob BSQ must decrease", bobBsqBefore,
+                    () -> bob.getBalances().getBsq().getAvailableConfirmedBalance(), false);
         } else {
             // Alice buys BTC with BSQ. Bob sells BTC for BSQ.
-            assertTrue(aliceBtcAfter > aliceBtcBefore,
-                    "alice BTC must increase: before=" + aliceBtcBefore + " after=" + aliceBtcAfter);
-            assertTrue(bobBtcAfter < bobBtcBefore,
-                    "bob BTC must decrease: before=" + bobBtcBefore + " after=" + bobBtcAfter);
-            assertTrue(aliceBsqAfter < aliceBsqBefore,
-                    "alice BSQ must decrease: before=" + aliceBsqBefore + " after=" + aliceBsqAfter);
-            assertTrue(bobBsqAfter > bobBsqBefore,
-                    "bob BSQ must increase: before=" + bobBsqBefore + " after=" + bobBsqAfter);
+            awaitBalanceMove("alice BTC must increase", aliceBtcBefore,
+                    () -> totalBtc(alice), true);
+            awaitBalanceMove("bob BTC must decrease", bobBtcBefore,
+                    () -> totalBtc(bob), false);
+            awaitBalanceMove("alice BSQ must decrease", aliceBsqBefore,
+                    () -> alice.getBalances().getBsq().getAvailableConfirmedBalance(), false);
+            awaitBalanceMove("bob BSQ must increase", bobBsqBefore,
+                    () -> bob.getBalances().getBsq().getAvailableConfirmedBalance(), true);
         }
+    }
+
+    private static void awaitBalanceMove(String label, long before,
+                                         java.util.function.LongSupplier reader,
+                                         boolean expectIncrease) {
+        DaoTestUtils.await(() -> {
+            long now = reader.getAsLong();
+            return expectIncrease ? now > before : now < before;
+        }, 30_000, label + " (before=" + before + ")");
     }
 }

--- a/core/src/main/java/bisq/core/provider/fee/FeeService.java
+++ b/core/src/main/java/bisq/core/provider/fee/FeeService.java
@@ -47,6 +47,7 @@ public class FeeService {
     // Miner fees are between 1-600 sat/vbyte. We try to stay on the safe side. BTC_DEFAULT_TX_FEE is only used if our
     // fee service would not deliver data.
     private static final long BTC_DEFAULT_TX_FEE = 50;
+    static final long BTC_MAX_TX_FEE = 600;
     private static DaoStateService daoStateService;
     private static PeriodService periodService;
     private static FilterManager filterManager = null;
@@ -143,10 +144,27 @@ public class FeeService {
     }
 
     public void updateFeeInfo(long txFeePerVbyte, long minFeePerVByte) {
-        this.txFeePerVbyte = txFeePerVbyte;
-        this.minFeePerVByte = minFeePerVByte;
+        // Defense-in-depth: a misbehaving or malicious fee provider could push values outside
+        // the realistic range downstream code assumes. Clamp both fields to the network
+        // default min and cap them at the documented high-water mark so the invariant
+        // BTC_MAX_TX_FEE >= txFeePerVbyte >= minFeePerVByte >= networkMin holds for every
+        // consumer. This matters for BSQ-swap arithmetic where getAdjustedTxFee relies on
+        // txFeePerVbyte >= minFeePerVByte to guarantee total tx fee meets relay minimum
+        // when one side's BSQ trade fee exceeds its miner-portion (see BsqSwapCalculation),
+        // and avoids multiply overflow in fee estimators if a bad feed returns absurd values.
+        long networkMin = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
+        long clampedMinFee = Math.min(Math.max(minFeePerVByte, networkMin), BTC_MAX_TX_FEE);
+        long clampedTxFee = Math.min(Math.max(txFeePerVbyte, clampedMinFee), BTC_MAX_TX_FEE);
+        if (clampedTxFee != txFeePerVbyte || clampedMinFee != minFeePerVByte) {
+            log.warn("Fee provider returned txFeePerVbyte={}, minFeePerVbyte={}, networkMin={}, maxFeePerVbyte={}; " +
+                            "clamped to txFeePerVbyte={}, minFeePerVbyte={} to enforce " +
+                            "maxFeePerVbyte>=txFeePerVbyte>=minFeePerVbyte>=networkMin",
+                    txFeePerVbyte, minFeePerVByte, networkMin, BTC_MAX_TX_FEE, clampedTxFee, clampedMinFee);
+        }
+        this.txFeePerVbyte = clampedTxFee;
+        this.minFeePerVByte = clampedMinFee;
         feeUpdateCounter.set(feeUpdateCounter.get() + 1);
         lastRequest = Instant.now().getEpochSecond();
-        log.info("BTC tx fee: txFeePerVbyte={} minFeePerVbyte={}", txFeePerVbyte, minFeePerVByte);
+        log.info("BTC tx fee: txFeePerVbyte={} minFeePerVbyte={}", this.txFeePerVbyte, this.minFeePerVByte);
     }
 }

--- a/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
+++ b/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
@@ -24,7 +24,6 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.Restrictions;
 import bisq.core.monetary.Volume;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
-import bisq.core.trade.validation.MinerFeeValidation;
 import bisq.core.util.Validator;
 
 import bisq.common.util.MathUtils;
@@ -115,7 +114,7 @@ public class BsqSwapCalculation {
                                                         long buyerTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long buyersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
+        long buyersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
         return getBuyersBtcPayoutValue(btcTradeAmount.getValue(), buyersTxFee);
     }
 
@@ -154,7 +153,7 @@ public class BsqSwapCalculation {
                                                         long sellersTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long sellersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
+        long sellersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
         return getSellersBtcInputValue(btcTradeAmount.getValue(), sellersTxFee);
     }
 
@@ -237,38 +236,31 @@ public class BsqSwapCalculation {
         Validator.checkIsPositive(txFeePerVbyte, "txFeePerVbyte");
         Validator.checkIsPositive(vBytes, "vBytes");
         Validator.checkIsNotNegative(tradeFee, "tradeFee");
-        // tradeFee must be strictly less than miner-fee portion; otherwise buyer payout inverts
-        // (or zeroes buyer fee contribution) and sum-of-outputs >= sum-of-inputs, producing
-        // an unbroadcastable tx. Coin.multiply/subtract use Math.*Exact internally, so overflow
-        // trips loudly if future callers relax current input bounds.
-        Coin adjustedTxFee = Coin.valueOf(txFeePerVbyte)
-                .multiply(vBytes)
-                .subtract(Coin.valueOf(tradeFee));
-        Validator.checkIsPositive(adjustedTxFee, "adjustedTxFee");
-        return adjustedTxFee.value;
-    }
-
-    // Lenient variant for UI estimation paths where a precise value is not required and
-    // throwing would break display when wallet is underfunded. Saturates the output (not
-    // the inputs) at the documented trade-tx-fee upper bound on multiply overflow or
-    // absurd magnitudes, and clamps subtraction underflow to 0.
-    private static long getAdjustedTxFeeForEstimate(long txFeePerVbyte, int vBytes, long tradeFee) {
-        // Coin.multiply uses Math.multiplyExact internally; saturate on overflow at the
-        // documented trade-tx-fee upper bound rather than throwing.
-        Coin minerFeePortion;
-        try {
-            minerFeePortion = Coin.valueOf(txFeePerVbyte).multiply(vBytes);
-        } catch (ArithmeticException e) {
-            minerFeePortion = Coin.valueOf(MinerFeeValidation.MAX_TRADE_TX_FEE_SAT);
-        }
-        // tradeFee is expected to be non-negative; clamp defensively so a negative input
-        // cannot make the subtraction overflow upward. Coin.subtract throws on underflow,
-        // so guard before subtracting and clamp the result to zero.
-        Coin safeTradeFee = Coin.valueOf(Math.max(0L, tradeFee));
-        if (minerFeePortion.isLessThan(safeTradeFee)) {
+        // BSQ trade fees burn into the miner-fee pool: BSQ-colored input sats that are not
+        // claimed by any BSQ output fall through into the tx fee. If this side's trade fee
+        // already covers its share of the miner cost, our BTC miner contribution is 0 and
+        // the excess BSQ simply makes the tx slightly overpay — still valid, still
+        // broadcastable. Clamping at 0 (rather than throwing on a negative result) is what
+        // keeps BSQ offers takable at low fee rates with small inputs, where the BSQ trade
+        // fee alone can exceed vBytes * txFeePerVbyte. The DAO still records the full trade
+        // fee as burnt regardless of whether the miner ends up overpaid. Coin.multiply uses
+        // Math.multiplyExact so an absurd txFeePerVbyte still trips loudly upstream.
+        //
+        // Min-relay viability: assuming Bisq's standing invariant txFeePerVbyte >=
+        // FeeService.getMinFeePerVByte(), clamping at 0 is provably equivalent to clamping
+        // at the per-side min-fee floor. Proof: the clamp branch fires only when
+        // tradeFee > vBytes * txFeePerVbyte, which under the invariant implies
+        // tradeFee > vBytes * minFeePerVbyte; the BSQ trade fee on its own already covers
+        // this side's share of the network minimum, so adding any positive BTC contribution
+        // would over-pay. A separate min-fee floor on the result would force a large BTC
+        // over-payment for no protocol benefit. The invariant on the input itself is
+        // out of scope for this calculator and is owned by FeeService / offer-create paths.
+        Coin minerFeePortion = Coin.valueOf(txFeePerVbyte).multiply(vBytes);
+        Coin tradeFeeCoin = Coin.valueOf(tradeFee);
+        if (minerFeePortion.isLessThan(tradeFeeCoin)) {
             return 0L;
         }
-        return minerFeePortion.subtract(safeTradeFee).value;
+        return minerFeePortion.subtract(tradeFeeCoin).value;
     }
 
     // Convert BTC trade amount to BSQ amount

--- a/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerification.java
+++ b/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerification.java
@@ -80,6 +80,10 @@ public class BsqSwapTakeOfferRequestVerification {
 
             long peersMinerFeeRate = request.getTxFeePerVbyte();
             long expectedMinerFeeRate = feeService.getTxFeePerVbyte().getValue();
+            long minMinerFeeRate = feeService.getMinFeePerVByte();
+            Validator.checkIsPositive(minMinerFeeRate, "minMinerFeeRate");
+            checkArgument(peersMinerFeeRate >= minMinerFeeRate,
+                    "Peer miner fee rate is below minimum. peer=%s, min=%s", peersMinerFeeRate, minMinerFeeRate);
             MinerFeeValidation.checkMinerFeeRateIsInTolerance(peersMinerFeeRate, expectedMinerFeeRate);
 
             checkMakerFee(request.getMakerFee(), false, amountAsCoin);

--- a/core/src/test/java/bisq/core/provider/fee/FeeServiceTest.java
+++ b/core/src/test/java/bisq/core/provider/fee/FeeServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.provider.fee;
+
+import bisq.core.dao.governance.period.PeriodService;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.filter.FilterManager;
+import bisq.core.trade.bsq_swap.BsqSwapCalculation;
+
+import bisq.common.config.Config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FeeServiceTest {
+    @Test
+    void updateFeeInfoClampsRatesToNetworkMin() {
+        FeeService feeService = newFeeService();
+        long networkMin = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
+
+        feeService.updateFeeInfo(1, 1);
+
+        assertEquals(networkMin, feeService.getTxFeePerVbyte().getValue());
+        assertEquals(networkMin, feeService.getMinFeePerVByte());
+    }
+
+    @Test
+    void updateFeeInfoCapsAbsurdProviderRates() {
+        FeeService feeService = newFeeService();
+
+        feeService.updateFeeInfo(Long.MAX_VALUE, Long.MAX_VALUE);
+
+        assertEquals(FeeService.BTC_MAX_TX_FEE, feeService.getTxFeePerVbyte().getValue());
+        assertEquals(FeeService.BTC_MAX_TX_FEE, feeService.getMinFeePerVByte());
+        // Derived from the documented invariant so the assertion does not silently rot if
+        // either BTC_MAX_TX_FEE or ESTIMATED_V_BYTES is retuned.
+        assertEquals(FeeService.BTC_MAX_TX_FEE * BsqSwapCalculation.ESTIMATED_V_BYTES,
+                BsqSwapCalculation.getAdjustedTxFee(feeService.getTxFeePerVbyte().getValue(),
+                        BsqSwapCalculation.ESTIMATED_V_BYTES,
+                        0));
+    }
+
+    @Test
+    void updateFeeInfoKeepsTxFeeAtLeastMinFeeAfterClamping() {
+        FeeService feeService = newFeeService();
+        // Derive provided values from networkMin so the assertion holds regardless of how
+        // the network minimum is tuned (any value <= BTC_MAX_TX_FEE - 10).
+        long networkMin = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
+        long providedMin = Math.min(networkMin + 10, FeeService.BTC_MAX_TX_FEE);
+        long providedTx = Math.max(networkMin, providedMin - 50);
+
+        feeService.updateFeeInfo(providedTx, providedMin);
+
+        assertEquals(providedMin, feeService.getTxFeePerVbyte().getValue());
+        assertEquals(providedMin, feeService.getMinFeePerVByte());
+    }
+
+    private static FeeService newFeeService() {
+        DaoStateService daoStateService = mock(DaoStateService.class);
+        PeriodService periodService = mock(PeriodService.class);
+        FilterManager filterManager = mock(FilterManager.class);
+        when(filterManager.getFilter()).thenReturn(null);
+
+        FeeService feeService = new FeeService(daoStateService, periodService);
+        feeService.onAllServicesInitialized(filterManager);
+        return feeService;
+    }
+}

--- a/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
+++ b/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
@@ -48,4 +48,30 @@ public class BsqSwapCalculationTest {
         assertThrows(IllegalArgumentException.class,
                 () -> BsqSwapCalculation.getAdjustedTxFee(Long.MAX_VALUE, 2, -1));
     }
+
+    @Test
+    void getAdjustedTxFeeClampsAtZeroWhenTradeFeeExceedsMinerPortion() {
+        // Real-world reproduction of the take-offer crash: low txFeePerVbyte + small vBytes
+        // (single segwit input) makes the miner-fee portion smaller than the BSQ trade fee.
+        // Returning 0 means this side contributes 0 BTC toward the miner fee; the BSQ trade
+        // fee burns directly into the miner-fee pool and the tx overpays slightly — still
+        // valid, still broadcastable. Pre-fix this threw IllegalArgumentException and killed
+        // the take-offer dialog. The boundary case (tradeFee == minerPortion) also returns 0
+        // since the BSQ fee alone covers the full miner cost.
+        assertEquals(0, BsqSwapCalculation.getAdjustedTxFee(1, 200, 500));
+        assertEquals(0, BsqSwapCalculation.getAdjustedTxFee(1, 200, 200));
+    }
+
+    @Test
+    void sellersAndBuyersFeeOverloadsClampAtZeroWhenTradeFeeExceedsMinerPortion() {
+        // Through the seller-path wrapper that BsqSwapOfferModel.calculateInputAndPayout calls:
+        // seller's BTC input collapses to just btcTradeAmount when their BSQ trade fee already
+        // covers the miner portion.
+        assertEquals(100_000_000L,
+                BsqSwapCalculation.getSellersBtcInputValue(100_000_000L, 1L, 100, 500L).value);
+        // Symmetric buyer-payout wrapper: buyer receives the full btcTradeAmount when their
+        // trade fee already covers the miner portion.
+        assertEquals(100_000_000L,
+                BsqSwapCalculation.getBuyersBtcPayoutValue(100_000_000L, 1L, 100, 500L).value);
+    }
 }

--- a/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerificationTest.java
+++ b/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerificationTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.bsq_swap;
+
+import bisq.core.dao.governance.param.Param;
+import bisq.core.dao.governance.period.PeriodService;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.filter.FilterManager;
+import bisq.core.offer.Offer;
+import bisq.core.offer.OpenOffer;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.provider.fee.FeeService;
+import bisq.core.trade.protocol.bsq_swap.messages.BsqSwapRequest;
+import bisq.core.trade.protocol.bsq_swap.messages.SellersBsqSwapRequest;
+
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.config.Config;
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.PubKeyRing;
+
+import org.bitcoinj.core.Coin;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BsqSwapTakeOfferRequestVerificationTest {
+    private static final int CHAIN_HEIGHT = 102;
+    private static final String TRADE_ID = "trade-id";
+    private static final NodeAddress PEER = new NodeAddress("peer.onion", 9999);
+    private static final Coin TRADE_AMOUNT = Coin.COIN;
+    private static final long MAKER_FEE = 50;
+    private static final long TAKER_FEE = 150;
+    // Derived from the network default so the assertions remain meaningful if the network
+    // minimum is retuned. FeeService.updateFeeInfo clamps stored rates up to NETWORK_MIN.
+    private static final long NETWORK_MIN = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
+    // Strictly above 2 * NETWORK_MIN so the tolerance check rejects it.
+    private static final long OUTSIDE_TOLERANCE = 2 * NETWORK_MIN + 1;
+
+    @Test
+    void acceptsRequestAtStoredMinimumFeeRate() {
+        Fixture fixture = new Fixture(NETWORK_MIN);
+
+        assertTrue(BsqSwapTakeOfferRequestVerification.isValid(fixture.openOfferManager,
+                fixture.feeService,
+                fixture.keyRing,
+                PEER,
+                newRequest(NETWORK_MIN)));
+    }
+
+    @Test
+    void rejectsRequestBelowStoredMinimumFeeRateEvenWhenToleranceWouldAllowIt() {
+        // Force storedMin >= 2 so belowMin = storedMin - 1 is both strictly below the
+        // stored minimum and still within the 2x tolerance window. This keeps the test
+        // exercising the strict min-rate check (not the tolerance check) regardless of
+        // how the network minimum is tuned.
+        long storedMin = Math.max(2L, NETWORK_MIN);
+        long belowMinWithinTolerance = storedMin - 1;
+        Fixture fixture = new Fixture(storedMin);
+
+        assertFalse(BsqSwapTakeOfferRequestVerification.isValid(fixture.openOfferManager,
+                fixture.feeService,
+                fixture.keyRing,
+                PEER,
+                newRequest(belowMinWithinTolerance)));
+    }
+
+    @Test
+    void rejectsRequestOutsideFeeRateTolerance() {
+        Fixture fixture = new Fixture(NETWORK_MIN);
+
+        assertFalse(BsqSwapTakeOfferRequestVerification.isValid(fixture.openOfferManager,
+                fixture.feeService,
+                fixture.keyRing,
+                PEER,
+                newRequest(OUTSIDE_TOLERANCE)));
+    }
+
+    private static BsqSwapRequest newRequest(long txFeePerVbyte) {
+        return new SellersBsqSwapRequest(TRADE_ID,
+                PEER,
+                mock(PubKeyRing.class),
+                TRADE_AMOUNT.value,
+                txFeePerVbyte,
+                MAKER_FEE,
+                TAKER_FEE,
+                System.currentTimeMillis());
+    }
+
+    private static class Fixture {
+        private final FeeService feeService;
+        private final KeyRing keyRing = mock(KeyRing.class);
+        private final OpenOfferManager openOfferManager = mock(OpenOfferManager.class);
+
+        private Fixture(long txFeePerVbyte) {
+            feeService = configureFeeService(txFeePerVbyte);
+
+            Offer offer = mock(Offer.class);
+            when(offer.getId()).thenReturn(TRADE_ID);
+            when(offer.isMyOffer(keyRing)).thenReturn(true);
+            when(offer.getMinAmount()).thenReturn(Coin.valueOf(10_000));
+            when(offer.getAmount()).thenReturn(TRADE_AMOUNT);
+
+            OpenOffer openOffer = new OpenOffer(offer);
+            when(openOfferManager.getOpenOfferById(TRADE_ID)).thenReturn(Optional.of(openOffer));
+        }
+    }
+
+    private static FeeService configureFeeService(long txFeePerVbyte) {
+        DaoStateService daoStateService = mock(DaoStateService.class);
+        PeriodService periodService = mock(PeriodService.class);
+        FilterManager filterManager = mock(FilterManager.class);
+        when(periodService.getChainHeight()).thenReturn(CHAIN_HEIGHT);
+        when(filterManager.getFilter()).thenReturn(null);
+
+        when(daoStateService.getParamValueAsCoin(Param.DEFAULT_MAKER_FEE_BSQ, CHAIN_HEIGHT))
+                .thenReturn(Coin.valueOf(MAKER_FEE));
+        when(daoStateService.getParamValueAsCoin(Param.MIN_MAKER_FEE_BSQ, CHAIN_HEIGHT))
+                .thenReturn(Coin.valueOf(MAKER_FEE));
+        when(daoStateService.getParamValueAsCoin(Param.DEFAULT_TAKER_FEE_BSQ, CHAIN_HEIGHT))
+                .thenReturn(Coin.valueOf(TAKER_FEE));
+        when(daoStateService.getParamValueAsCoin(Param.MIN_TAKER_FEE_BSQ, CHAIN_HEIGHT))
+                .thenReturn(Coin.valueOf(TAKER_FEE));
+
+        FeeService feeService = new FeeService(daoStateService, periodService);
+        feeService.onAllServicesInitialized(filterManager);
+        feeService.updateFeeInfo(txFeePerVbyte, txFeePerVbyte);
+        return feeService;
+    }
+}

--- a/core/src/test/java/bisq/core/trade/validation/InputsForDepositTxRequestValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/InputsForDepositTxRequestValidationTest.java
@@ -20,6 +20,7 @@ package bisq.core.trade.validation;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.trade.validation.ValidationTestUtils.InputsForDepositTxRequestValidationFixture;
 
+import bisq.common.config.Config;
 import bisq.common.crypto.CryptoException;
 
 import org.bitcoinj.core.Coin;
@@ -66,8 +67,14 @@ class InputsForDepositTxRequestValidationTest {
 
     @Test
     void checkInputsForDepositTxRequestRejectsTxFeeOutsideAllowedTolerance() throws CryptoException {
+        // Fixture builds the request at a low txFeePerVbyte which FeeService.updateFeeInfo
+        // clamps up to the network minimum. To stay outside the 2x deviation tolerance we
+        // override the validator's FeeService above 2 * networkMin, derived from Config so
+        // the test does not silently lose its assertion if the network minimum changes.
         InputsForDepositTxRequestValidationFixture fixture = inputsForDepositTxRequestValidationFixture(null);
-        FeeService feeService = configureTradeFeeService(Coin.valueOf(77), Coin.valueOf(100), 10);
+        long networkMin = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
+        long txFeeOutsideTolerance = 2 * networkMin + 1;
+        FeeService feeService = configureTradeFeeService(Coin.valueOf(77), Coin.valueOf(100), txFeeOutsideTolerance);
 
         assertThrows(IllegalArgumentException.class, () -> InputsForDepositTxRequestValidation.checkInputsForDepositTxRequest(fixture.request,
                 fixture.offer,

--- a/docs/bsq-swap-fee-handling.md
+++ b/docs/bsq-swap-fee-handling.md
@@ -187,8 +187,16 @@ The maker validates the take-offer request before reserving the offer:
 - the offer exists and is available,
 - the trade amount is inside the offer bounds,
 - the trade date is recent,
-- the peer fee rate is in tolerance against the local fee rate,
+- the peer fee rate is not below the stored minimum and is in tolerance against the local fee rate,
 - `makerFee` and `takerFee` match the expected BSQ trade fees for the selected amount.
+
+`FeeService` clamps provider-supplied fee rates into Bisq's accepted range before storing them. The stored invariant is:
+
+```text
+maxFeePerVbyte >= txFeePerVbyte >= minFeePerVbyte >= networkMin
+```
+
+This protects the `getAdjustedTxFee` zero-clamp logic from underpaying relay minimums when a BSQ trade fee alone covers a side's miner portion, and avoids overflow in fee estimators if a bad fee provider returns absurdly high rates.
 
 During protocol execution, each side verifies the peer-supplied inputs and change against locally calculated values. Peer change is allowed to be less than the exact expected change, because dust or coin-selection excess can fall through to miner fee. Peer change must not be greater than expected, because that would let the peer reclaim value that should have paid fees.
 


### PR DESCRIPTION
## Summary

  Two-part fix for BSQ swap take-offer crashes due to negative adjusted tx fees.

  ### Commit 1: clamp BTC miner contribution at 0

  Taking a BSQ swap offer crashed with `IllegalArgumentException: adjustedTxFee must not be
  negative` whenever the BSQ trade fee exceeded this side's share of the miner-fee portion. The
  BSQ trade fee already burns into the miner-fee pool (BSQ-colored input sats not claimed by any
  BSQ output fall through into the tx fee); when it already covers this side's miner share, the
  correct BTC miner contribution is **0**, not negative.

  Clamping at 0 produces a valid, broadcastable tx that overpays the miner slightly. Min-relay
  viability is preserved by Bisq's invariant `txFeePerVbyte ≥ minFeePerVByte`: when the clamp
  fires, `tradeFee > vBytes × txFeePerVbyte ≥ vBytes × minFeePerVByte`, so the BSQ trade fee alone
   covers this side's share of the network minimum.

  - `BsqSwapCalculation.getAdjustedTxFee`: clamp at 0. Inline proof of min-relay viability in the
  comment.
  - `BsqSwapCalculation.getAdjustedTxFeeForEstimate`: removed. The single unified method now
  serves both broadcast and UI estimation paths.
  - `BsqSwapCalculationTest`: new cases covering clamp-at-zero on the raw function and both
  seller/buyer wrappers.

  ### Commit 2: enforce txFeePerVbyte ≥ minFeePerVByte ≥ networkMin at FeeService

  Defense-in-depth. The fee provider is external and untrusted; commit 1's proof depends on the
  invariant `txFeePerVbyte ≥ minFeePerVByte ≥ networkMin`. Downstream code does not re-check this.
   Clamps both fields in `FeeService.updateFeeInfo` against
  `Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte()` and logs a warning when clamping fires
   so a bad feed is visible.

  ## Security review

  Done. No new theft vector — buyer's `BuyerCreatesAndSignsFinalizedTx` rebuilds the tx locally
  and asserts byte-equality with the seller's bytes; a malicious seller cannot inflate the buyer's
   payout or steal BTC via the clamp. DoS-via-stuck-tx is closed by commit 2: the per-side
  BSQ-trade-fee covers ≥ network min when the clamp fires.

  The 2022 Bisq negative-fee exploit was in v1 delayed-payout / security-deposit math across
  multiple txs; BSQ swap is atomic single-tx with byte-exact peer verification, so that pattern
  doesn't translate here.

  ## Why e2e didn't catch the crash

  `BsqSwapOfferTest` only creates offers + asserts visibility — never takes.
  `TradeScenarioTest.runSwapTrade` takes at 0.0125 BTC where the default taker fee falls to the
  floor 0.03 BSQ = 3 sat, well below any plausible miner portion. The boundary is never
  approached. New unit tests pin the invariant deterministically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap fee estimation now clamps miner-fee contribution to zero when the miner portion is smaller than a side's trade fee, preventing negative adjustments and ensuring correct BTC amounts.
  * Fee updates now enforce a network minimum and cap maximums, logging when provider values are clamped.
  * Offer-taking now rejects peer fee rates below the stored minimum even if within tolerance.

* **Tests**
  * Added tests covering fee clamping (including boundaries), clamped/capped fee updates, offer-validation scenarios, and async balance checks after confirmations.

* **Documentation**
  * Clarified fee validation, clamping behavior, and its impact on fee handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->