### PR TITLE
Feature: Detect if multiple instances are running

### DIFF
--- a/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
+++ b/daemon/src/main/java/bisq/daemon/app/BisqDaemonMain.java
@@ -30,6 +30,12 @@ import java.util.concurrent.ExecutorService;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 
 
 import bisq.daemon.grpc.GrpcServer;
@@ -40,8 +46,69 @@ public class BisqDaemonMain extends BisqHeadlessAppMain implements BisqSetup.Bis
     private GrpcServer grpcServer;
 
     public static void main(String[] args) {
+        // Check for existing instance
+        if (!checkForExistingInstance()) {
+            System.exit(1);
+        }
+        
         new BisqDaemonMain().execute(args);
     }
+
+   private static boolean checkForExistingInstance() {
+    try {
+        String appDataDir = System.getProperty("user.dir");
+        String lockFileName = "bisq-daemon.lock";
+        File lockFile = new File(appDataDir, lockFileName);
+
+        // If lock file exists, check if that PID is still running
+        if (lockFile.exists()) {
+            String pidString = Files.readString(Paths.get(lockFile.getPath()));
+            long pid = -1; // default invalid PID
+            try {
+                pid = Long.parseLong(pidString);
+                boolean isRunning = ProcessHandle.of(pid)
+                        .map(ProcessHandle::isAlive)
+                        .orElse(false);
+
+                if (isRunning) {
+                    log.warn("Another instance of Bisq daemon is already running with PID: " + pid);
+                    return false;
+                } else {
+                    // Process not running, remove stale lock file
+                    log.info("Stale lock file found with PID: " + pid + ", removing it");
+                    lockFile.delete();
+                }
+            } catch (NumberFormatException e) {
+                log.info("Invalid PID in lock file, removing stale lock file");
+                lockFile.delete();
+            } catch (Exception e) {
+                log.info("Could not verify process with PID: " + pid + ", removing stale lock file");
+                lockFile.delete();
+            }
+        }
+
+        // Create new lock file with current PID
+        long currentPid = ProcessHandle.current().pid();
+        try (FileWriter writer = new FileWriter(lockFile)) {
+            writer.write(String.valueOf(currentPid));
+        }
+        log.info("Created lock file with PID: " + currentPid);
+
+        // Ensure lock file is deleted on exit
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (lockFile.exists()) {
+                lockFile.delete();
+                log.info("Removed lock file");
+            }
+        }));
+
+        return true;
+    } catch (IOException e) {
+        log.error("Failed to check for existing instance", e);
+        return false;
+    }
+}
+
 
     /////////////////////////////////////////////////////////////////////////////////////
     // First synchronous execution tasks

--- a/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
@@ -35,11 +35,18 @@ import bisq.core.user.User;
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
 import bisq.common.app.Version;
+import bisq.common.util.Utilities;
 
 import javafx.application.Application;
 import javafx.application.Platform;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Slf4j
 public class BisqAppMain extends BisqExecutable {
@@ -59,8 +66,64 @@ public class BisqAppMain extends BisqExecutable {
         // realMain method:
         Thread.currentThread().setContextClassLoader(BisqAppMain.class.getClassLoader());
 
+        // Check for existing instance
+        if (!checkForExistingInstance()) {
+            System.exit(1);
+        }
+
         new BisqAppMain().execute(args);
     }
+
+    private static boolean checkForExistingInstance() {
+    try {
+        String appDataDir = Utilities.getUserDataDir().getPath();
+        String lockFileName = "bisq-desktop.lock";
+        File lockFile = new File(appDataDir, lockFileName);
+
+        if (lockFile.exists()) {
+            String pidString = Files.readString(Paths.get(lockFile.getPath()));
+            long pid = -1; // declare PID before try/catch
+            try {
+                pid = Long.parseLong(pidString);
+                boolean isRunning = ProcessHandle.of(pid)
+                        .map(ProcessHandle::isAlive)
+                        .orElse(false);
+
+                if (isRunning) {
+                    log.warn("Another instance of Bisq desktop is already running with PID: " + pid);
+                    return false;
+                } else {
+                    log.info("Stale lock file found with PID: " + pid + ", removing it");
+                    lockFile.delete();
+                }
+            } catch (NumberFormatException e) {
+                log.info("Invalid PID in lock file, removing stale lock file");
+                lockFile.delete();
+            } catch (Exception e) {
+                log.info("Could not verify process with PID: " + pid + ", removing stale lock file");
+                lockFile.delete();
+            }
+        }
+
+        long currentPid = ProcessHandle.current().pid();
+        try (FileWriter writer = new FileWriter(lockFile)) {
+            writer.write(String.valueOf(currentPid));
+        }
+        log.info("Created lock file with PID: " + currentPid);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (lockFile.exists()) {
+                lockFile.delete();
+                log.info("Removed lock file");
+            }
+        }));
+
+        return true;
+    } catch (IOException e) {
+        log.error("Failed to check for existing instance", e);
+        return false;
+    }
+}
 
     @Override
     public void onSetupComplete() {


### PR DESCRIPTION
This PR makes both the desktop app and daemon detect if another instance is running and if so, it will not start. Previously, if another instance was to be started, the user would recieve a plain TOR error. This improves the Bisq UX.

I have only tested the desktop app, but the daemon should work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop and daemon applications now prevent multiple instances from running concurrently, ensuring data integrity and avoiding conflicts that could occur when multiple processes access the same resources simultaneously.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->