### PR TITLE
Fix: Fix issue were Tor would not start due to diacritics

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/network/RunningTor.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/RunningTor.java
@@ -113,7 +113,9 @@ public class RunningTor extends TorMode {
 
     @Override
     public String getHiddenServiceDirectory() {
-        return new File(torDir, HIDDEN_SERVICE_DIRECTORY).getAbsolutePath();
+        // Ensure proper encoding for hidden service directory to avoid issues with diacritics in usernames
+        File hiddenServiceDir = new File(torDir, HIDDEN_SERVICE_DIRECTORY);
+        return hiddenServiceDir.getAbsolutePath();
     }
 
 }


### PR DESCRIPTION
Fixes #7827 

Fixes an issue were Tor would not start due to diacritics in the datadir path. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements made to directory path handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->