### PR TITLE
Fix trade statistics validation after limit reductions

### DIFF
--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -23,7 +23,6 @@ import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
 import bisq.core.offer.bisq_v1.OfferPayload;
-import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
 import bisq.core.util.JsonUtil;
@@ -86,6 +85,9 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     private static final ZoneId ZONE_ID = ZoneId.systemDefault();
     @JsonExclude
     private static final long STRICT_FILTER_DATE = new GregorianCalendar(2021, Calendar.NOVEMBER, 1).getTime().getTime();
+    @JsonExclude
+    @VisibleForTesting
+    static final long HISTORICAL_MAX_TRADE_AMOUNT = Coin.COIN.multiply(2).value;
 
     public static TradeStatistics3 from(Trade trade,
                                         @Nullable String referralId,
@@ -450,30 +452,24 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
             return false;
         }
 
-        boolean validMaxTradeLimit = true;
+        boolean validHistoricalTradeAmount = true;
         boolean currencyFound = true;
         // We had historically higher trade limits and assets which are not in the currency list anymore, so we apply
         // the filter only for data after STRICT_FILTER_DATE.
         if (date > STRICT_FILTER_DATE) {
-            long maxTradeLimit = Coin.COIN.multiply(2).value;
-            try {
-                // We cover only active payment methods. Retired ones will not be found by getActivePaymentMethodById.
-                String paymentMethodId = getPaymentMethodId();
-                Optional<PaymentMethod> optionalPaymentMethod = PaymentMethod.getActivePaymentMethod(paymentMethodId);
-                if (optionalPaymentMethod.isPresent()) {
-                    maxTradeLimit = optionalPaymentMethod.get().getMaxTradeLimitAsCoin(currency).value;
-                }
-            } catch (Exception e) {
-                log.warn("Error at isValid().", e);
-            }
-            validMaxTradeLimit = amount <= maxTradeLimit;
+            // Trade statistics are historical facts. Do not validate them against the
+            // current payment-method or DAO trade limit: those limits can be lowered after
+            // a trade was executed, which would make old valid statistics disappear from
+            // storage, charts and republishing. Keep only a stable sanity cap based on the
+            // historical global trade limit.
+            validHistoricalTradeAmount = amount <= HISTORICAL_MAX_TRADE_AMOUNT;
 
             currencyFound = CurrencyUtil.getCryptoCurrency(currency).isPresent() ||
                     CurrencyUtil.getFiatCurrency(currency).isPresent();
         }
 
         return amount > 0 &&
-                validMaxTradeLimit &&
+                validHistoricalTradeAmount &&
                 price > 0 &&
                 date > 0 &&
                 paymentMethod != null &&

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -21,7 +21,10 @@ import bisq.core.payment.payload.PaymentMethod;
 
 import com.google.common.collect.Sets;
 
+import org.bitcoinj.core.Coin;
+
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,8 +32,38 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TradeStatistics3Test {
+    @Test
+    public void isValidAcceptsHistoricalTradeAboveCurrentTradeLimit() {
+        TradeStatistics3 tradeStatistics = new TradeStatistics3("USD",
+                50_000_000,
+                Coin.parseCoin("0.25").value,
+                "SEPA",
+                System.currentTimeMillis(),
+                null,
+                null,
+                (Map<String, String>) null);
+
+        assertTrue(tradeStatistics.isValid());
+    }
+
+    @Test
+    public void isValidRejectsTradeAboveHistoricalSanityLimit() {
+        TradeStatistics3 tradeStatistics = new TradeStatistics3("USD",
+                50_000_000,
+                TradeStatistics3.HISTORICAL_MAX_TRADE_AMOUNT + 1,
+                "SEPA",
+                System.currentTimeMillis(),
+                null,
+                null,
+                (Map<String, String>) null);
+
+        assertFalse(tradeStatistics.isValid());
+    }
+
     @Disabled("Not fixed yet")
     @Test
     public void allPaymentMethodsCoveredByWrapper() {


### PR DESCRIPTION
TradeStatistics3.isValid() was checking post-2021 trade amounts against the current payment-method trade limit. That limit is DAO-adjusted and can be reduced after a trade was executed, so valid historical trade statistics above the new limit could be rejected when loading persisted stats, receiving P2P stats, or republishing missing stats.

Keep trade statistics validation independent of mutable current limits by using a stable 2 BTC historical sanity cap. This preserves old valid statistics while still filtering implausibly large amounts.

Add regression coverage for a 0.25 BTC statistic, which is above the current 0.125 BTC cap but should remain valid historical data, and for rejecting amounts above the historical sanity cap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trade statistics validation has been enhanced to enforce a stable historical maximum trade amount limit, replacing previous payment method-based validation to ensure consistent validation of historical trade entries across the platform.

* **Tests**
  * Added comprehensive test coverage for historical trade validation, including scenarios that verify proper acceptance of valid historical amounts and rejection of amounts exceeding the new historical maximum limit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->