### PR TITLE
Add coldStorageReminderThreshold to settings

### DIFF
--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -165,6 +165,15 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     public static final int CLEAR_DATA_AFTER_DAYS_INITIAL = 99999; // feature effectively disabled until user agrees to settings notification
     public static final int CLEAR_DATA_AFTER_DAYS_DEFAULT = 60; // used when user has agreed to settings notification
     public static final long INITIAL_TRADE_LIMIT = 10000000L;
+    public static final long INITIAL_COLD_STORAGE_REMINDER_THRESHOLD = 20000000L;
+    public static final long MAX_COLD_STORAGE_REMINDER_THRESHOLD = 200000000L;
+
+    public static long getClampedColdStorageReminderThreshold(long threshold) {
+        if (threshold <= 0) {
+            return INITIAL_COLD_STORAGE_REMINDER_THRESHOLD;
+        }
+        return Math.min(threshold, MAX_COLD_STORAGE_REMINDER_THRESHOLD);
+    }
 
     // payload is initialized so the default values are available for Property initialization.
     @Setter
@@ -378,6 +387,12 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
         if (prefPayload.getClearDataAfterDays() < 1) {
             setClearDataAfterDays(Preferences.CLEAR_DATA_AFTER_DAYS_INITIAL);
+        }
+
+        long coldStorageReminderThreshold = prefPayload.getColdStorageReminderThreshold();
+        long clampedColdStorageReminderThreshold = getClampedColdStorageReminderThreshold(coldStorageReminderThreshold);
+        if (coldStorageReminderThreshold != clampedColdStorageReminderThreshold) {
+            setColdStorageReminderThreshold(clampedColdStorageReminderThreshold);
         }
 
         // For users from old versions the 4 flags a false but we want to have it true by default
@@ -856,6 +871,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         requestPersistence();
     }
 
+    public void setColdStorageReminderThreshold(long value) {
+        prefPayload.setColdStorageReminderThreshold(getClampedColdStorageReminderThreshold(value));
+        requestPersistence();
+    }
+
     public void setProcessBurningManAccountingData(boolean processBurningManAccountingData) {
         prefPayload.setProcessBurningManAccountingData(processBurningManAccountingData);
         requestPersistence();
@@ -1213,6 +1233,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         void setUserDefinedTradeLimit(long userDefinedTradeLimit);
 
         void setUserHasRaisedTradeLimit(boolean userHasRaisedTradeLimit);
+
+        void setColdStorageReminderThreshold(long coldStorageReminderThreshold);
 
         void setProcessBurningManAccountingData(boolean processBurningManAccountingData);
 

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -153,6 +153,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
     //Added at 1.10.1
     private boolean tacAcceptedV1_10_1;
     private boolean tradeRulesAccepted;
+    private long coldStorageReminderThreshold = Preferences.INITIAL_COLD_STORAGE_REMINDER_THRESHOLD;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -228,7 +229,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .setIsFullBMAccountingNode(isFullBMAccountingNode)
                 .setUseBisqWalletFunding(useBisqWalletFunding)
                 .setTacAcceptedV1101(tacAcceptedV1_10_1)
-                .setTradeRulesAccepted(tradeRulesAccepted);
+                .setTradeRulesAccepted(tradeRulesAccepted)
+                .setColdStorageReminderThreshold(coldStorageReminderThreshold);
 
         Optional.ofNullable(backupDirectory).ifPresent(builder::setBackupDirectory);
         Optional.ofNullable(preferredTradeCurrency).ifPresent(e -> builder.setPreferredTradeCurrency((protobuf.TradeCurrency) e.toProtoMessage()));
@@ -343,7 +345,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.getIsFullBMAccountingNode(),
                 proto.getUseBisqWalletFunding(),
                 proto.getTacAcceptedV1101(),
-                proto.getTradeRulesAccepted()
+                proto.getTradeRulesAccepted(),
+                Preferences.getClampedColdStorageReminderThreshold(proto.getColdStorageReminderThreshold())
         );
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1427,6 +1427,7 @@ setting.preferences.txFeeTooLarge=Your input is above any reasonable value (>500
 setting.preferences.ignorePeers=Ignored peers [onion address:port]
 setting.preferences.ignoreDustThreshold=Min. non-dust output value
 setting.preferences.clearDataAfterDays=Clear sensitive data after (days)
+setting.preferences.coldStorageReminderThreshold=Cold storage reminder threshold (BTC)
 setting.preferences.useBitcoinUris=Use bitcoin URIs in QR codes
 setting.preferences.useBitcoinUris.tooltip=Bisq's QR codes can either store bitcoin URIs containing the address along\n\
   with some extra parameters (amount & label) or plain bitcoin addresses\n\
@@ -4734,8 +4735,7 @@ validation.invalidAddressList=Must be comma separated list of valid addresses
 validation.capitual.invalidFormat=Must be a valid CAP code of format: CAP-XXXXXX (6 alphanumeric characters)
 
 popup.warning.coldStorage.headline=Move idle funds to cold storage
-popup.warning.coldStorage.msg=Your Bisq wallet currently holds {0}, which is above the {1} threshold.\n\n\
-  Please treat your Bisq wallet as a hot wallet. It is connected to the internet and exposed to any future security flaw in Bisq or its dependencies. \
-  A single zero-day vulnerability could put all funds in this wallet at risk.\n\n\
-  Keep only the amount you need for active trading in Bisq. Move the rest to a cold wallet (hardware wallet or offline storage) you control.\n\n\
-  This reminder will keep appearing on every launch and during navigation until your Bisq wallet balance is below {1}.
+popup.warning.coldStorage.msg=Your Bisq wallet currently holds {0}, which exceeds your cold storage reminder threshold of {1}.\n\n\
+  The Bisq wallet is a hot wallet intended primarily for funds used in active trading. Because Bisq is a peer-to-peer application, it may be exposed to additional security risks compared to dedicated long-term storage.\n\n\
+  Keep only the amount needed for active trades in Bisq. Consider moving remaining funds to cold storage you control, such as a hardware wallet or offline wallet.\n\n\
+  This reminder will continue to appear while your wallet balance exceeds {1}. You can adjust the threshold in Settings.

--- a/desktop/src/main/java/bisq/desktop/main/overlays/popups/WalletColdStorageReminder.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/popups/WalletColdStorageReminder.java
@@ -21,6 +21,7 @@ import bisq.desktop.Navigation;
 
 import bisq.core.btc.Balances;
 import bisq.core.locale.Res;
+import bisq.core.user.Preferences;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
@@ -47,14 +48,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class WalletColdStorageReminder {
 
-    // Threshold above which the reminder fires. Tune by editing this constant.
-    private static final Coin THRESHOLD = Coin.parseCoin("0.5");
-
     // Re-show interval for the navigation trigger.
     private static final long COOLDOWN_MS = TimeUnit.HOURS.toMillis(6);
 
     private final Balances balances;
     private final Navigation navigation;
+    private final Preferences preferences;
     private final CoinFormatter btcFormatter;
 
     private long lastShownMs = 0L;
@@ -63,9 +62,11 @@ public class WalletColdStorageReminder {
     @Inject
     public WalletColdStorageReminder(Balances balances,
                                      Navigation navigation,
+                                     Preferences preferences,
                                      @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter) {
         this.balances = balances;
         this.navigation = navigation;
+        this.preferences = preferences;
         this.btcFormatter = btcFormatter;
     }
 
@@ -83,7 +84,8 @@ public class WalletColdStorageReminder {
 
     private void maybeShow(boolean ignoreCooldown) {
         Coin total = totalBalance();
-        if (!total.isGreaterThan(THRESHOLD)) return;
+        Coin threshold = Coin.valueOf(preferences.getColdStorageReminderThreshold());
+        if (!total.isGreaterThan(threshold)) return;
 
         if (DevEnv.isIgnorePopupsInDevMode()) {
             return;
@@ -97,7 +99,7 @@ public class WalletColdStorageReminder {
                 .headLine(Res.get("popup.warning.coldStorage.headline"))
                 .warning(Res.get("popup.warning.coldStorage.msg",
                         btcFormatter.formatCoinWithCode(total),
-                        btcFormatter.formatCoinWithCode(THRESHOLD)))
+                        btcFormatter.formatCoinWithCode(threshold)))
                 .show();
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/preferences/PreferencesView.java
@@ -139,7 +139,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     private int displayCurrenciesGridRowIndex = 0;
     private InputTextField transactionFeeInputTextField, ignoreTradersListInputTextField, ignoreDustThresholdInputTextField,
             autoConfRequiredConfirmationsTf, autoConfServiceAddressTf, autoConfTradeLimitTf, clearDataAfterDaysInputTextField,
-            rpcUserTextField, blockNotifyPortTextField, tradeLimitTf;
+            coldStorageReminderThresholdInputTextField, rpcUserTextField, blockNotifyPortTextField, tradeLimitTf;
     private PasswordTextField rpcPwTextField;
     private TitledGroupBg daoOptionsTitledGroupBg;
 
@@ -168,7 +168,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     private ObservableList<TradeCurrency> tradeCurrencies;
     private InputTextField deviationInputTextField, bsqAverageTrimThresholdTextField;
     private ChangeListener<String> deviationListener, bsqAverageTrimThresholdListener, ignoreTradersListListener, ignoreDustThresholdListener,
-            rpcUserListener, rpcPwListener, blockNotifyPortListener, clearDataAfterDaysListener,
+            rpcUserListener, rpcPwListener, blockNotifyPortListener, clearDataAfterDaysListener, coldStorageReminderThresholdListener,
             autoConfTradeLimitListener, autoConfServiceAddressListener, userDefinedTradeLimitListener;
     private ChangeListener<Boolean> deviationFocusedListener, bsqAverageTrimThresholdFocusedListener;
     private ChangeListener<Boolean> useCustomFeeCheckboxListener;
@@ -288,7 +288,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void initializeGeneralOptions() {
-        int titledGroupBgRowSpan = displayStandbyModeFeature ? 12 : 11;
+        int titledGroupBgRowSpan = displayStandbyModeFeature ? 13 : 12;
         TitledGroupBg titledGroupBg = addTitledGroupBg(root, gridRow, titledGroupBgRowSpan, Res.get("setting.preferences.general"));
         GridPane.setColumnSpan(titledGroupBg, 1);
 
@@ -433,6 +433,19 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
                     preferences.setClearDataAfterDays(value);
                 }
             } catch (Throwable ignore) {
+            }
+        };
+
+        coldStorageReminderThresholdInputTextField = addInputTextField(root, ++gridRow,
+                Res.get("setting.preferences.coldStorageReminderThreshold"));
+        BtcValidator coldStorageReminderThresholdValidator = new BtcValidator(formatter);
+        coldStorageReminderThresholdValidator.setMaxValue(Coin.valueOf(Preferences.MAX_COLD_STORAGE_REMINDER_THRESHOLD));
+        coldStorageReminderThresholdInputTextField.setValidator(coldStorageReminderThresholdValidator);
+        coldStorageReminderThresholdListener = (observable, oldValue, newValue) -> {
+            if (!newValue.equals(oldValue) &&
+                    coldStorageReminderThresholdInputTextField.getValidator().validate(newValue).isValid) {
+                Coin amountAsCoin = ParsingUtils.parseToCoin(newValue, formatter);
+                preferences.setColdStorageReminderThreshold(amountAsCoin.value);
             }
         };
 
@@ -951,6 +964,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         referralIdInputTextField.setPromptText(Res.get("setting.preferences.refererId.prompt"));*/
         ignoreDustThresholdInputTextField.setText(String.valueOf(preferences.getIgnoreDustThreshold()));
         clearDataAfterDaysInputTextField.setText(String.valueOf(preferences.getClearDataAfterDays()));
+        coldStorageReminderThresholdInputTextField.setText(formatter.formatCoin(
+                Coin.valueOf(preferences.getColdStorageReminderThreshold())));
         userLanguageComboBox.setItems(languageCodes);
         userLanguageComboBox.getSelectionModel().select(preferences.getUserLanguage());
         userLanguageComboBox.setConverter(new StringConverter<>() {
@@ -1024,6 +1039,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         //referralIdInputTextField.textProperty().addListener(referralIdListener);
         ignoreDustThresholdInputTextField.textProperty().addListener(ignoreDustThresholdListener);
         clearDataAfterDaysInputTextField.textProperty().addListener(clearDataAfterDaysListener);
+        coldStorageReminderThresholdInputTextField.textProperty().addListener(coldStorageReminderThresholdListener);
     }
 
     private Coin getTxFeeForWithdrawalPerVbyte() {
@@ -1401,6 +1417,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         //referralIdInputTextField.textProperty().removeListener(referralIdListener);
         ignoreDustThresholdInputTextField.textProperty().removeListener(ignoreDustThresholdListener);
         clearDataAfterDaysInputTextField.textProperty().removeListener(clearDataAfterDaysListener);
+        coldStorageReminderThresholdInputTextField.textProperty().removeListener(coldStorageReminderThresholdListener);
     }
 
     private void deactivateDisplayCurrencies() {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1997,6 +1997,7 @@ message PreferencesPayload {
     bool use_bisq_wallet_funding = 71;
     bool tac_accepted_v1_10_1 = 72;
     bool trade_rules_accepted = 73;
+    int64 cold_storage_reminder_threshold = 74;
 }
 
 message AutoConfirmSettings {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable cold storage reminder threshold setting accessible in Preferences, allowing users to customize when they receive reminders about maintaining adequate funds in cold storage.
  * Updated cold storage reminder messaging to reference the user's configured threshold and provide guidance on best practices for managing hot wallet balances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->