### PR TITLE
Add program arguments for get date response limits

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -89,6 +89,9 @@ public class Config {
     public static final String NODE_PORT = "nodePort";
     public static final String USE_LOCALHOST_FOR_P2P = "useLocalhostForP2P";
     public static final String MAX_CONNECTIONS = "maxConnections";
+    public static final String GET_DATA_REQUEST_HANDLER_MAX_ENTRIES = "getDataRequestHandlerMaxEntries";
+    public static final String TRADE_STATISTICS_MAX_ITEMS = "tradeStatisticsMaxItems";
+    public static final String P2P_DATA_STORAGE_MAX_SIZE = "p2pDataStorageMaxSize";
     public static final String SOCKS_5_PROXY_BTC_ADDRESS = "socks5ProxyBtcAddress";
     public static final String SOCKS_5_PROXY_HTTP_ADDRESS = "socks5ProxyHttpAddress";
     public static final String USE_TOR_FOR_BTC = "useTorForBtc";
@@ -152,12 +155,15 @@ public class Config {
     public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC_PROVIDED = 7; // down from BitcoinJ default of 12
     public static final int DEFAULT_NUM_CONNECTIONS_FOR_BTC_PUBLIC = 9;
     public static final boolean DEFAULT_FULL_DAO_NODE = false;
+    public static final int DEFAULT_GET_DATA_REQUEST_HANDLER_MAX_ENTRIES = 20_000;
+    public static final int DEFAULT_TRADE_STATISTICS_MAX_ITEMS = 15_000;
     static final String DEFAULT_CONFIG_FILE_NAME = "bisq.properties";
 
     // Static fields that provide access to Config properties in locations where injecting
     // a Config instance is not feasible. See Javadoc for corresponding static accessors.
     private static File APP_DATA_DIR_VALUE;
     private static BaseCurrencyNetwork BASE_CURRENCY_NETWORK_VALUE = BaseCurrencyNetwork.BTC_MAINNET;
+    private static int TRADE_STATISTICS_MAX_ITEMS_VALUE = DEFAULT_TRADE_STATISTICS_MAX_ITEMS;
 
     // Default "data dir properties", i.e. properties that can determine the location of
     // Bisq's application data directory (appDataDir)
@@ -201,6 +207,10 @@ public class Config {
     public final List<String> banList;
     public final boolean useLocalhostForP2P;
     public final int maxConnections;
+    public final int getDataRequestHandlerMaxEntries;
+    public final int tradeStatistics3MaxItems;
+    public final double p2pDataStorageMaxSize;
+    public final boolean p2pDataStorageMaxSizeOptionSetExplicitly;
     public final String socks5ProxyBtcAddress;
     public final String socks5ProxyHttpAddress;
     public final File torrcFile;
@@ -492,6 +502,27 @@ public class Config {
                         .withRequiredArg()
                         .ofType(int.class)
                         .defaultsTo(12);
+
+        ArgumentAcceptingOptionSpec<Integer> getDataRequestHandlerMaxEntriesOpt =
+                parser.accepts(GET_DATA_REQUEST_HANDLER_MAX_ENTRIES,
+                                "Max. entries per payload type in a GetDataResponse")
+                        .withRequiredArg()
+                        .ofType(int.class)
+                        .defaultsTo(DEFAULT_GET_DATA_REQUEST_HANDLER_MAX_ENTRIES);
+
+        ArgumentAcceptingOptionSpec<Integer> tradeStatistics3MaxItemsOpt =
+                parser.accepts(TRADE_STATISTICS_MAX_ITEMS,
+                                "Max. TradeStatistics3 items included in a GetDataResponse")
+                        .withRequiredArg()
+                        .ofType(int.class)
+                        .defaultsTo(DEFAULT_TRADE_STATISTICS_MAX_ITEMS);
+
+        ArgumentAcceptingOptionSpec<Double> p2pDataStorageMaxSizeOpt =
+                parser.accepts(P2P_DATA_STORAGE_MAX_SIZE,
+                                "Max. P2PDataStorage GetDataResponse payload size in bytes")
+                        .withRequiredArg()
+                        .ofType(double.class)
+                        .defaultsTo(0D);
 
         ArgumentAcceptingOptionSpec<String> socks5ProxyBtcAddressOpt =
                 parser.accepts(SOCKS_5_PROXY_BTC_ADDRESS, "A proxy address to be used for Bitcoin network.")
@@ -899,6 +930,10 @@ public class Config {
             this.banList = options.valuesOf(banListOpt);
             this.useLocalhostForP2P = !this.baseCurrencyNetwork.isMainnet() && options.valueOf(useLocalhostForP2POpt);
             this.maxConnections = options.valueOf(maxConnectionsOpt);
+            this.getDataRequestHandlerMaxEntries = options.valueOf(getDataRequestHandlerMaxEntriesOpt);
+            this.tradeStatistics3MaxItems = options.valueOf(tradeStatistics3MaxItemsOpt);
+            this.p2pDataStorageMaxSize = options.valueOf(p2pDataStorageMaxSizeOpt);
+            this.p2pDataStorageMaxSizeOptionSetExplicitly = options.has(p2pDataStorageMaxSizeOpt);
             this.socks5ProxyBtcAddress = options.valueOf(socks5ProxyBtcAddressOpt);
             this.socks5ProxyHttpAddress = options.valueOf(socks5ProxyHttpAddressOpt);
             this.msgThrottlePerSec = options.valueOf(msgThrottlePerSecOpt);
@@ -961,6 +996,7 @@ public class Config {
         // Assign values to special-case static fields
         APP_DATA_DIR_VALUE = appDataDir;
         BASE_CURRENCY_NETWORK_VALUE = baseCurrencyNetwork;
+        TRADE_STATISTICS_MAX_ITEMS_VALUE = tradeStatistics3MaxItems;
     }
 
     private static File absoluteConfigFile(File parentDir, String relativeConfigFilePath) {
@@ -1096,5 +1132,9 @@ public class Config {
      */
     public static NetworkParameters baseCurrencyNetworkParameters() {
         return BASE_CURRENCY_NETWORK_VALUE.getParameters();
+    }
+
+    public static int tradeStatistics3MaxItems() {
+        return TRADE_STATISTICS_MAX_ITEMS_VALUE;
     }
 }

--- a/common/src/test/java/bisq/common/config/ConfigTests.java
+++ b/common/src/test/java/bisq/common/config/ConfigTests.java
@@ -211,6 +211,31 @@ public class ConfigTests {
     }
 
     @Test
+    public void whenP2PDataLimitOptionsAreUnset_thenDefaultValuesAreUsed() {
+        Config config = new Config();
+        assertThat(config.getDataRequestHandlerMaxEntries, equalTo(DEFAULT_GET_DATA_REQUEST_HANDLER_MAX_ENTRIES));
+        assertThat(config.tradeStatistics3MaxItems, equalTo(DEFAULT_TRADE_STATISTICS_MAX_ITEMS));
+        assertThat(config.p2pDataStorageMaxSize, equalTo(0D));
+        assertFalse(config.p2pDataStorageMaxSizeOptionSetExplicitly);
+    }
+
+    @Test
+    public void whenP2PDataLimitOptionsAreSet_thenPropertiesReflectTheirValues() {
+        try {
+            Config config = configWithOpts(
+                    opt(GET_DATA_REQUEST_HANDLER_MAX_ENTRIES, 1234),
+                    opt(TRADE_STATISTICS_MAX_ITEMS, 5678),
+                    opt(P2P_DATA_STORAGE_MAX_SIZE, 7_000_000D));
+            assertThat(config.getDataRequestHandlerMaxEntries, equalTo(1234));
+            assertThat(config.tradeStatistics3MaxItems, equalTo(5678));
+            assertThat(config.p2pDataStorageMaxSize, equalTo(7_000_000D));
+            assertTrue(config.p2pDataStorageMaxSizeOptionSetExplicitly);
+        } finally {
+            new Config();
+        }
+    }
+
+    @Test
     public void whenConfigIsConstructed_thenNoConsoleOutputSideEffectsShouldOccur() {
         PrintStream outOrig = System.out;
         PrintStream errOrig = System.err;

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -36,6 +36,7 @@ import bisq.network.p2p.storage.payload.ProcessOncePersistableNetworkPayload;
 
 import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
+import bisq.common.config.Config;
 import bisq.common.crypto.Hash;
 import bisq.common.proto.ProtoUtil;
 import bisq.common.util.CollectionUtils;
@@ -403,7 +404,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
 
     @Override
     public int maxItems() {
-        return 15000;
+        return Config.tradeStatistics3MaxItems();
     }
 
     public void pruneOptionalData() {
@@ -493,10 +494,10 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         TradeStatistics3 that = (TradeStatistics3) o;
         return date != that.date ? Long.compare(date, that.date)
                 : amount != that.amount ? Long.compare(amount, that.amount)
-                : !Objects.equals(currency, that.currency) ? nullsFirstCompare(currency, that.currency)
-                : price != that.price ? Long.compare(price, that.price)
-                : !Objects.equals(paymentMethod, that.paymentMethod) ? nullsFirstCompare(paymentMethod, that.paymentMethod)
-                : Arrays.compare(hash, that.hash);
+                  : !Objects.equals(currency, that.currency) ? nullsFirstCompare(currency, that.currency)
+                    : price != that.price ? Long.compare(price, that.price)
+                      : !Objects.equals(paymentMethod, that.paymentMethod) ? nullsFirstCompare(paymentMethod, that.paymentMethod)
+                        : Arrays.compare(hash, that.hash);
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/P2PModule.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PModule.java
@@ -82,6 +82,14 @@ public class P2PModule extends AppModule {
         bind(int.class).annotatedWith(named(NODE_PORT)).toInstance(config.nodePort);
 
         bindConstant().annotatedWith(named(MAX_CONNECTIONS)).to(config.maxConnections);
+        bindConstant().annotatedWith(named(GET_DATA_REQUEST_HANDLER_MAX_ENTRIES))
+                .to(config.getDataRequestHandlerMaxEntries);
+        bindConstant().annotatedWith(named(TRADE_STATISTICS_MAX_ITEMS))
+                .to(config.tradeStatistics3MaxItems);
+        bindConstant().annotatedWith(named(P2P_DATA_STORAGE_MAX_SIZE))
+                .to(config.p2pDataStorageMaxSizeOptionSetExplicitly ?
+                        config.p2pDataStorageMaxSize :
+                        P2PDataStorage.getDefaultMaxSize());
 
         bind(new TypeLiteral<List<String>>(){}).annotatedWith(named(BAN_LIST)).toInstance(config.banList);
         bindConstant().annotatedWith(named(SOCKS_5_PROXY_BTC_ADDRESS)).to(config.socks5ProxyBtcAddress);

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
@@ -26,6 +26,7 @@ import bisq.network.p2p.storage.P2PDataStorage;
 
 import bisq.common.Timer;
 import bisq.common.UserThread;
+import bisq.common.config.Config;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -43,7 +44,7 @@ import org.jetbrains.annotations.NotNull;
 public class GetDataRequestHandler {
     private static final long TIMEOUT = 240;
 
-    private static final int MAX_ENTRIES = 20_000; // Tradestatistics are about 20 000 in 2 months.
+    private static final int MAX_ENTRIES = Config.DEFAULT_GET_DATA_REQUEST_HANDLER_MAX_ENTRIES;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Listener
@@ -63,6 +64,7 @@ public class GetDataRequestHandler {
     private final NetworkNode networkNode;
     private final P2PDataStorage dataStorage;
     private final Listener listener;
+    private final int maxEntries;
     private Timer timeoutTimer;
     private boolean stopped;
 
@@ -72,9 +74,17 @@ public class GetDataRequestHandler {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public GetDataRequestHandler(NetworkNode networkNode, P2PDataStorage dataStorage, Listener listener) {
+        this(networkNode, dataStorage, listener, MAX_ENTRIES);
+    }
+
+    public GetDataRequestHandler(NetworkNode networkNode,
+                                 P2PDataStorage dataStorage,
+                                 Listener listener,
+                                 int maxEntries) {
         this.networkNode = networkNode;
         this.dataStorage = dataStorage;
         this.listener = listener;
+        this.maxEntries = maxEntries;
     }
 
 
@@ -92,7 +102,7 @@ public class GetDataRequestHandler {
         AtomicBoolean wasProtectedStorageEntriesTruncated = new AtomicBoolean(false);
         GetDataResponse getDataResponse = dataStorage.buildGetDataResponse(
                 getDataRequest,
-                MAX_ENTRIES,
+                maxEntries,
                 wasPersistableNetworkPayloadsTruncated,
                 wasProtectedStorageEntriesTruncated,
                 connection.getCapabilities());

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/RequestDataManager.java
@@ -32,7 +32,10 @@ import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.Version;
+import bisq.common.config.Config;
 import bisq.common.proto.network.NetworkEnvelope;
+
+import com.google.inject.name.Named;
 
 import javax.inject.Inject;
 
@@ -98,6 +101,7 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     private final NetworkNode networkNode;
     private final P2PDataStorage dataStorage;
     private final PeerManager peerManager;
+    private final int getDataRequestHandlerMaxEntries;
     private final List<NodeAddress> seedNodeAddresses;
     private final List<ResponseListener> responseListeners = new CopyOnWriteArrayList<>();
 
@@ -122,10 +126,12 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     public RequestDataManager(NetworkNode networkNode,
                               SeedNodeRepository seedNodeRepository,
                               P2PDataStorage dataStorage,
-                              PeerManager peerManager) {
+                              PeerManager peerManager,
+                              @Named(Config.GET_DATA_REQUEST_HANDLER_MAX_ENTRIES) int getDataRequestHandlerMaxEntries) {
         this.networkNode = networkNode;
         this.dataStorage = dataStorage;
         this.peerManager = peerManager;
+        this.getDataRequestHandlerMaxEntries = getDataRequestHandlerMaxEntries;
 
         this.networkNode.addMessageListener(this);
         this.networkNode.addConnectionListener(this);
@@ -308,7 +314,8 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                         log.warn("We have stopped already. We ignore that getDataRequestHandler.handle.onFault call.");
                                     }
                                 }
-                            });
+                            },
+                            getDataRequestHandlerMaxEntries);
                     getDataRequestHandlers.put(uid, getDataRequestHandler);
                     getDataRequestHandler.handle(getDataRequest, connection);
                 } else {

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -59,6 +59,7 @@ import bisq.common.ExcludeForHashAwareProto;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.Capabilities;
+import bisq.common.config.Config;
 import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.Hash;
 import bisq.common.crypto.Sig;
@@ -134,6 +135,10 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     @VisibleForTesting
     public static final int CHECK_TTL_INTERVAL_SEC = 60;
 
+    public static double getDefaultMaxSize() {
+        return Connection.getMaxPermittedMessageSize() * 0.6;
+    }
+
     private boolean initialRequestApplied = false;
 
     private final Broadcaster broadcaster;
@@ -159,6 +164,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     /// The maximum number of items that must exist in the SequenceNumberMap before it is scheduled for a purge
     /// which removes entries after PURGE_AGE_DAYS.
     private final int maxSequenceNumberMapSizeBeforePurge;
+    private final double maxGetDataResponseSize;
 
     // Don't convert to local variable as it might get GC'ed.
     private MonadicBinding<Boolean> readFromResourcesCompleteBinding;
@@ -180,7 +186,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
                           PersistenceManager<SequenceNumberMap> persistenceManager,
                           RemovedPayloadsService removedPayloadsService,
                           Clock clock,
-                          @Named("MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE") int maxSequenceNumberBeforePurge) {
+                          @Named("MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE") int maxSequenceNumberBeforePurge,
+                          @Named(Config.P2P_DATA_STORAGE_MAX_SIZE) double maxGetDataResponseSize) {
         this.broadcaster = broadcaster;
         this.appendOnlyDataStoreService = appendOnlyDataStoreService;
         this.protectedDataStoreService = protectedDataStoreService;
@@ -189,6 +196,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         this.removedPayloadsService = removedPayloadsService;
         this.clock = clock;
         this.maxSequenceNumberMapSizeBeforePurge = maxSequenceNumberBeforePurge;
+        this.maxGetDataResponseSize = maxGetDataResponseSize;
 
         networkNode.addMessageListener(this);
         networkNode.addConnectionListener(this);
@@ -316,8 +324,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         Map<ByteArray, PersistableNetworkPayload> mapForDataResponse = getMapForDataResponse(getDataRequest.getVersion());
 
         // Give a bit of tolerance for message overhead
-        double maxSize = Connection.getMaxPermittedMessageSize() * 0.6;
-
+        double maxSize = maxGetDataResponseSize;
         // 25% of space is allocated for PersistableNetworkPayloads
         long limit = Math.round(maxSize * 0.25);
         Set<PersistableNetworkPayload> filteredPersistableNetworkPayloads =

--- a/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/TestState.java
@@ -92,7 +92,8 @@ public class TestState {
                 this.mockSeqNrPersistenceManager,
                 removedPayloadsService,
                 this.clockFake,
-                MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE);
+                MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE,
+                P2PDataStorage.getDefaultMaxSize());
 
         this.appendOnlyDataStoreListener = mock(AppendOnlyDataStoreListener.class);
         this.hashMapChangedListener = mock(HashMapChangedListener.class);
@@ -149,7 +150,8 @@ public class TestState {
                 sequenceNrMapPersistenceManager,
                 removedPayloadsService,
                 clock,
-                MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE);
+                MAX_SEQUENCE_NUMBER_MAP_SIZE_BEFORE_PURGE,
+                P2PDataStorage.getDefaultMaxSize());
 
         // Currently TestState only supports reading ProtectedStorageEntries off disk.
         p2PDataStorage.readFromResourcesSync("unused");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three configurable limits for P2P network operations: data request handling capacity, trade statistics retention, and data storage size. These allow operators to customize system resource usage based on their deployment needs.

* **Tests**
  * Added configuration validation tests for the new P2P data limit options, including default behavior and explicit configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->