### PR TITLE
fix(apitest): de-flake TradeScenarioTest, fail CI on timeout

### DIFF
--- a/apitest/docker/run-e2e-tests.sh
+++ b/apitest/docker/run-e2e-tests.sh
@@ -31,7 +31,11 @@ SKIP_DOCKER_BUILD=0
 # `bisq.apitest.dao.*` covers DAO governance + v1 trade scenarios.
 TEST_PATTERN="${TEST_PATTERN:-bisq.apitest.method.* bisq.apitest.dao.*}"
 # Fresh-stack test discovery happens after SCRIPT_DIR/REPO_ROOT are set below.
-GLOBAL_TIMEOUT_SECS="${GLOBAL_TIMEOUT_SECS:-1800}"
+# 2-core CI runners run the 5-container stack ~3-4x slower than a dev box and do 9
+# fresh-stack resets on top of the shared phase, so a healthy run can approach 30min.
+# 1800s sat right on that edge → legit runs tripped the ceiling. 3600s gives headroom
+# while staying well under GitHub's 6h job cap. A trip now hard-fails (see TIMEOUT_MARKER).
+GLOBAL_TIMEOUT_SECS="${GLOBAL_TIMEOUT_SECS:-3600}"
 READY_TIMEOUT_SECS="${READY_TIMEOUT_SECS:-300}"
 
 while [[ $# -gt 0 ]]; do
@@ -54,6 +58,12 @@ COMPOSE_FILE="${SCRIPT_DIR}/dao-compose.yml"
 LOGS_DIR="${SCRIPT_DIR}/logs"
 GRADLE="${GRADLE:-${REPO_ROOT}/gradlew}"
 PID_FILE="${PID_FILE:-/tmp/bisq-e2e-tests.pid}"
+# Marker dropped by the global-timeout watchdog before it SIGTERMs us, so cleanup
+# can distinguish a timeout-abort (must fail CI) from a clean exit. Without it the
+# trap captures $? of whatever trivial command was mid-flight (often 0) and the
+# aborted run reports success.
+TIMEOUT_MARKER="${TIMEOUT_MARKER:-/tmp/bisq-e2e-tests.timedout}"
+rm -f "${TIMEOUT_MARKER}"
 
 # Auto-discover fresh-stack test classes from source: anything tagged
 # `@Tag("freshstack")` in apitest/src/test/java/bisq/apitest. Single source of truth
@@ -86,7 +96,7 @@ echo $$ > "${PID_FILE}"
 # but any fatal/exit before then would otherwise leave a stale PID file and an
 # orphan watchdog sleep. Replaced by the full trap at the bottom of the script.
 early_cleanup() {
-  rm -f "${PID_FILE}"
+  rm -f "${PID_FILE}" "${TIMEOUT_MARKER}"
   if [[ -n "${TIMEOUT_PID:-}" ]]; then
     pkill -P "${TIMEOUT_PID}" 2>/dev/null || true
     kill "${TIMEOUT_PID}" 2>/dev/null || true
@@ -205,7 +215,7 @@ reset_stack() {
 # Global timeout: send SIGTERM to ourselves (triggers cleanup trap below) if total
 # run exceeds GLOBAL_TIMEOUT_SECS. Using kill on $$ (not -$$) so trap fires before
 # child processes get reaped.
-( sleep "${GLOBAL_TIMEOUT_SECS}" && err "global timeout ${GLOBAL_TIMEOUT_SECS}s exceeded; aborting" && kill -TERM $$ ) &
+( sleep "${GLOBAL_TIMEOUT_SECS}" && err "global timeout ${GLOBAL_TIMEOUT_SECS}s exceeded; aborting" && touch "${TIMEOUT_MARKER}" && kill -TERM $$ ) &
 TIMEOUT_PID=$!
 
 ###############################################################################
@@ -317,6 +327,12 @@ fi
 
 cleanup() {
   local exit_code=$?
+  # A timeout-abort SIGTERMs us mid-command; $? is then whatever trivial command was
+  # running (often 0). Force a non-zero code so the aborted run fails CI.
+  if [[ -f "${TIMEOUT_MARKER}" ]]; then
+    exit_code=124
+    err "run aborted by global timeout — forcing exit ${exit_code}"
+  fi
   # Disable the trap so re-entrant signals (e.g. user hammers Ctrl-C) don't loop.
   trap - EXIT INT TERM HUP QUIT
   # Cancel the global-timeout watchdog so it doesn't fire mid-cleanup. Also kill its
@@ -342,7 +358,7 @@ cleanup() {
     log "Stack left running (--keep-up). Tear down with:"
     log "  docker compose -f ${COMPOSE_FILE} down -v"
   fi
-  rm -f "${PID_FILE}"
+  rm -f "${PID_FILE}" "${TIMEOUT_MARKER}"
   log "==> Exiting with code ${exit_code}"
   exit "${exit_code}"
 }
@@ -399,6 +415,18 @@ set +e
   "${JVM_PROPS[@]}"
 TEST_EXIT=$?
 set -e
+
+# Capture the shared-stack containers' logs NOW if the phase failed. The fresh-stack
+# loop below tears this stack down on its first reset_stack, and the final cleanup()
+# would otherwise only see the last reset's containers — losing the logs for the very
+# failure we care about. Saved aside so cleanup()'s top-level dump doesn't clobber them.
+if [[ ${TEST_EXIT} -ne 0 ]]; then
+  err "shared-stack phase failed (exit ${TEST_EXIT}); capturing its container logs before reset"
+  mkdir -p "${LOGS_DIR}/shared"
+  for c in "${ALL_CONTAINERS[@]}"; do
+    docker logs "$c" > "${LOGS_DIR}/shared/${c}.log" 2>&1 || true
+  done
+fi
 
 # Fresh-stack phase: one stack reset per test class. Any failure here flips TEST_EXIT
 # but lets the loop finish so we collect logs for every failing class, not just the first.

--- a/apitest/src/test/java/bisq/apitest/dao/DaoStaysInSyncTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/DaoStaysInSyncTest.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.apitest.dao;
+
+import bisq.cli.GrpcClient;
+
+import bisq.proto.grpc.DaoPhaseEnum;
+import bisq.proto.grpc.EvaluatedProposalInfo;
+import bisq.proto.grpc.GetVoteResultsReply;
+import bisq.proto.grpc.ProposalInfo;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for DAO-state consensus across a full governance cycle.
+ *
+ * <p>{@code getDaoStatus()} returns {@code daoFacade.isDaoStateReadyAndInSync()}, which is
+ * false while a daemon's {@code DaoStateMonitoringService} reports a block-hash conflict
+ * with the seed node. The seed node has no gRPC port, so a true result on Alice (and Bob)
+ * is exactly the assertion "this daemon's parsed DAO state agrees with the seed node".
+ *
+ * <p>Why this matters: a daemon whose DAO state diverges from the seed node fails that
+ * check, and {@code OpenOfferManager.handleOfferAvailabilityRequest} then answers a take
+ * with only a NACK (no OfferAvailabilityResponse) — the failure mode that flaked
+ * {@link TradeScenarioTest}. Several existing DAO tests' comments also note that polluting
+ * the DAO state "produces an isInConflictWithSeedNode state that breaks every subsequent
+ * test's awaitDaoStateReady". This test makes that property explicit: a correctly gated
+ * proposal + blind-vote + reveal + result cycle must leave every daemon in sync at each
+ * milestone, not just produce the right vote outcome.
+ *
+ * <p>Runs on a freshly reset stack (@Tag("freshstack")) so the assertion is about this one
+ * cycle, not state accumulated by the shared-stack governance suite.
+ */
+@Tag("freshstack")
+public class DaoStaysInSyncTest extends DaoTestBase {
+
+    // dao-setup seeds Alice with 1,000,000 BSQ. Wait for the parser to surface it before
+    // spending it on a proposal — on a freshly booted stack the BSQ parser and bitcoinj
+    // wallet are still catching up, and creating a governance tx too early races them.
+    private static final long ALICE_BSQ_BASELINE = 1_000_000L;
+
+    @Test
+    public void daoStaysInSyncThroughProposalAndVoteCycle() {
+        // Warm-up: both daemons in sync AND Alice's genesis BSQ confirmed/spendable before
+        // any governance tx, so proposal creation doesn't race cold-start wallet readiness.
+        assertInSync("baseline (fresh stack)");
+        DaoTestUtils.await(
+                () -> alice.getBalances().getBsq().getAvailableConfirmedBalance() >= ALICE_BSQ_BASELINE,
+                60_000, "alice's genesis BSQ confirmed and spendable");
+
+        // PROPOSAL: reserve >=3 blocks of headroom so creating + mining the proposal stays
+        // inside the phase (matches FullCycleScenarioTest); a proposal tx mined outside the
+        // PROPOSAL phase is discarded by the parser.
+        dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_PROPOSAL, 3);
+        ProposalInfo proposal = alice.createGenericProposal("sync-check", "https://x.test/sync");
+        dao.confirmTx(proposal.getTxId());
+
+        // BLIND_VOTE: gate on bob seeing the ballot — the deterministic signal that the
+        // proposal payload propagated to the peer (mirrors FullCycleScenarioTest).
+        dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_BLIND_VOTE);
+        DaoTestUtils.await(() -> hasBallot(bob, proposal.getTxId()), 60_000,
+                "bob sees ballot for proposal");
+        assertInSync("after proposal mined + propagated to peer");
+        String aliceBlindVoteTx = voteAndPublish(alice, proposal.getTxId(), "accept");
+        String bobBlindVoteTx = voteAndPublish(bob, proposal.getTxId(), "accept");
+        dao.confirmTx(alice, aliceBlindVoteTx);
+        dao.confirmTx(bob, bobBlindVoteTx);
+        dao.awaitBlindVotePropagation(alice, 2, "alice");
+        dao.awaitBlindVotePropagation(bob, 2, "bob");
+        assertInSync("after blind votes confirmed + propagated");
+
+        // VOTE_REVEAL: each node auto-broadcasts its reveal tx; confirm both.
+        dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_VOTE_REVEAL);
+        dao.confirmAutoRevealsFor(alice);
+        dao.confirmAutoRevealsFor(bob);
+        assertInSync("after vote reveal");
+
+        // RESULT: the proposal both accepted must be accepted, and both nodes must still
+        // agree with the seed node now that the cycle's result is parsed into DAO state.
+        dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_RESULT);
+        dao.generateBlocks(1);
+        EvaluatedProposalInfo evaluated = findEvaluated(alice.getVoteResults(-1), proposal.getTxId());
+        assertTrue(evaluated.getIsAccepted(),
+                "proposal both nodes voted accept on must be accepted");
+        assertInSync("after vote result parsed");
+    }
+
+    /** Block until both daemons report being in sync with the seed node, or fail. */
+    private void assertInSync(String stage) {
+        DaoTestUtils.await(alice::getDaoStatus, 30_000,
+                "alice DAO state in sync with seed node — " + stage);
+        DaoTestUtils.await(bob::getDaoStatus, 30_000,
+                "bob DAO state in sync with seed node — " + stage);
+    }
+
+    private static boolean hasBallot(GrpcClient c, String proposalTxId) {
+        return c.getBallots().getBallotsList().stream()
+                .anyMatch(b -> b.getProposal().getTxId().equals(proposalTxId));
+    }
+
+    private static String voteAndPublish(GrpcClient c, String proposalTxId, String vote) {
+        c.setVote(proposalTxId, vote);
+        return c.publishBlindVote(1_000_000L);
+    }
+
+    private static EvaluatedProposalInfo findEvaluated(GetVoteResultsReply reply, String txId) {
+        for (EvaluatedProposalInfo ep : reply.getEvaluatedProposalsList()) {
+            if (ep.getProposal().getTxId().equals(txId)) return ep;
+        }
+        throw new AssertionError("no evaluated proposal for tx " + txId);
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/dao/TradeScenarioTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/TradeScenarioTest.java
@@ -26,6 +26,7 @@ import protobuf.PaymentAccount;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * After the DAO suite runs, exercise the trade flow Alice→Bob across four offer kinds:
+ * Exercise the trade flow Alice→Bob across four offer kinds:
  *   - v1 BTC sell (Alice maker BTC seller / fiat buyer; Bob taker)
  *   - v1 BTC buy  (Alice maker BTC buyer  / fiat seller; Bob taker)
  *   - BSQ swap sell (Alice maker sells BTC for BSQ; Bob taker)
@@ -44,7 +45,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * Note: trade completion needs mediator + refund agent registered. The arb container's
  * entrypoint does this on startup; DisputeAgentBootstrapTest verifies it.
+ *
+ * Runs on a freshly reset stack (@Tag("freshstack")), like the sibling method.trade.*
+ * take-offer tests. The shared-stack DAO governance tests churn proposals/votes whose
+ * payloads propagate to the seed node and Alice on slightly different schedules, leaving
+ * Alice's DaoStateMonitoringService in a persistent block-hash conflict with the seed
+ * node (isInConflictWithSeedNode). A maker in that state fails isDaoStateReadyAndInSync,
+ * so OpenOfferManager.handleOfferAvailabilityRequest answers a take with only a NACK and
+ * no OfferAvailabilityResponse — the taker then hits the 90s "peer has not responded"
+ * timeout. A pristine stack has no such divergence, so the maker responds. The
+ * awaitMakerReadyToRespond gate below is a defensive fast-fail in case sync still lags.
  */
+@Tag("freshstack")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TradeScenarioTest extends DaoTestBase {
 
@@ -139,6 +151,7 @@ public class TradeScenarioTest extends DaoTestBase {
                         .anyMatch(o -> o.getId().equals(offer.getId())),
                 60_000, "bob sees offer " + offer.getId());
 
+        awaitMakerReadyToRespond(alice, offer);
         TradeInfo trade = bob.takeOffer(offer.getId(), bobF2F.getId(), "BTC", BTC_AMOUNT_SATS);
         assertNotNull(trade);
         // Confirm bob's taker-fee tx before the deposit tx, otherwise the deposit tx
@@ -195,6 +208,39 @@ public class TradeScenarioTest extends DaoTestBase {
         }
     }
 
+    /**
+     * Block until the maker is in the synced state its OfferAvailabilityRequest guard
+     * requires, before letting the taker request. {@code OpenOfferManager
+     * .handleOfferAvailabilityRequest} replies with ONLY a NACK AckMessage — and no
+     * {@code OfferAvailabilityResponse} — when the maker's DAO state or BTC wallet chain
+     * height is not yet synced. The taker's protocol only resolves on an
+     * OfferAvailabilityResponse, so a NACK leaves it to time out after 90s with
+     * "timeout reached: peer has not responded" (the flake this guards against).
+     *
+     * <p>{@link DaoTestUtils#generateBlocks(int)} already gates on the BSQ parser's chain
+     * height ({@code getCycleInfo}), but two other signals the guard reads are not covered:
+     * <ul>
+     *   <li>{@code isDaoStateReadyAndInSync()} additionally requires DAO-state-hash
+     *       consensus with the seed node, which races P2P gossip right after new blocks.</li>
+     *   <li>{@code isChainHeightSyncedWithinTolerance()} reads the maker's separate bitcoinj
+     *       wallet height, whose block relay can lag tens of seconds under load (see
+     *       {@link DaoTestUtils#confirmTx}).</li>
+     * </ul>
+     * Gate on both being observably true on the maker before the take.
+     */
+    private void awaitMakerReadyToRespond(GrpcClient maker, OfferInfo offer) {
+        DaoTestUtils.await(maker::getDaoStatus, 60_000, "maker DAO state ready and in sync");
+        // A broadcast maker-fee tx (v1 offers) lets us prove the maker's bitcoinj wallet
+        // reached the block that confirmed it: a non-pending tx ⇒ wallet at that height ⇒
+        // isChainHeightSyncedWithinTolerance holds. BSQ-swap offers have no such tx at
+        // creation, so the DAO-sync gate above is the available signal for them.
+        String makerFeeTxId = offer.getOfferFeePaymentTxId();
+        if (makerFeeTxId != null && !makerFeeTxId.isEmpty()) {
+            DaoTestUtils.await(() -> !maker.getTransaction(makerFeeTxId).getIsPending(),
+                    60_000, "maker BTC wallet confirmed maker-fee tx " + makerFeeTxId);
+        }
+    }
+
     /** Sum of available + reserved + locked BTC — the wallet's full BTC footprint. */
     private static long totalBtc(GrpcClient c) {
         var b = c.getBalances().getBtc();
@@ -217,6 +263,7 @@ public class TradeScenarioTest extends DaoTestBase {
                         .anyMatch(o -> o.getId().equals(offer.getId())),
                 60_000, "bob sees swap offer " + offer.getId());
 
+        awaitMakerReadyToRespond(alice, offer);
         TradeInfo trade = bob.takeBsqSwapOffer(offer.getId(), BTC_AMOUNT_SATS);
         assertNotNull(trade);
         // BSQ swap produces a single atomic tx; wait briefly for tx_id then inject.


### PR DESCRIPTION
Three related e2e fixes, found via repeated local runs (1 failure in 8):

1. TradeScenarioTest intermittently failed all four trades at takeOffer/takeBsqSwapOffer with gRPC "timeout reached: peer has not responded". Root cause: it ran in the shared-stack DAO phase, after the governance tests churn proposals/votes whose payloads reach the seed node and Alice on slightly different schedules. That leaves Alice's DaoStateMonitoringService in a persistent block-hash conflict with the seed node (isInConflictWithSeedNode), so isDaoStateReadyAndInSync stays false. OpenOfferManager.handleOfferAvailabilityRequest then answers a take with only a NACK AckMessage and no OfferAvailabilityResponse; the taker's protocol only resolves on the response, so it hits the 90s timeout.

   Fix: run TradeScenarioTest on a freshly reset stack (@Tag("freshstack")), like the sibling method.trade.* take-offer tests — a pristine stack has no governance-induced seed-node divergence. Confirmed by repeated fresh-stack runs passing where shared-stack runs flaked. Also add awaitMakerReadyToRespond before each take as a defensive fast-fail (getDaoStatus + non-pending maker-fee tx) so any residual maker-sync lag surfaces with a clear message instead of the opaque 90s gRPC timeout.

2. run-e2e-tests.sh could exit 0 on a global-timeout abort: the watchdog SIGTERMs the script mid-command and the cleanup trap captured $? of whatever trivial command was running (often 0), so an aborted run reported success and CI stayed green. The watchdog now drops a marker that cleanup turns into exit 124. Also raise GLOBAL_TIMEOUT_SECS 1800->3600 (a healthy run on a 2-core CI runner can approach 30min, so 1800 sat on the edge), and capture the shared-stack containers' logs on failure before the fresh-stack loop tears that stack down.

3. Add DaoStaysInSyncTest (freshstack): a regression guard asserting a correctly gated proposal + blind-vote + reveal + result cycle leaves every daemon in sync with the seed node (getDaoStatus() == true) at each milestone, not just producing the right vote outcome — pinning down the consensus property whose violation caused the flake above. Validated deterministic: 12/12 fresh-stack runs green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test infrastructure with improved timeout handling and failure detection.
  * Added regression test for DAO governance cycle to verify state consensus stability.
  * Improved trade scenario test reliability with enhanced readiness verification before offer execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->