### PR TITLE
Fix bsq fee issues

### DIFF
--- a/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOffer.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOffer.java
@@ -83,6 +83,8 @@ class OpenBsqSwapOffer {
 
         Offer offer = openOffer.getOffer();
         isBuyOffer = offer.isBuyOffer();
+
+        // tradeFee is 0 for BSQ offers
         tradeFee = offer.getMakerFee().getValue();
 
         txFeePerVbyte = feeService.getTxFeePerVbyte().getValue();
@@ -184,10 +186,16 @@ class OpenBsqSwapOffer {
             hasMissingFunds = walletBalance.isLessThan(requiredBsqInput);
         } else {
             try {
+                // tradeFee is 0 at open BSQ offers. This should have been set at constructor to the min fee, but we
+                // don't want to touch that now, so we only apply a min fix to avoid down stream pollution with unreasonable values.
+                long fee = tradeFee;
+                if (tradeFee <= 0) {
+                    fee = FeeService.getMinMakerFee(false).value;
+                }
                 Coin requiredInput = BsqSwapCalculation.getSellersBtcInputValue(btcWalletService,
                         btcAmount,
                         txFeePerVbyte,
-                        tradeFee);
+                        fee);
                 hasMissingFunds = walletBalance.isLessThan(requiredInput);
             } catch (InsufficientMoneyException e) {
                 hasMissingFunds = true;

--- a/core/src/main/java/bisq/core/provider/fee/FeeService.java
+++ b/core/src/main/java/bisq/core/provider/fee/FeeService.java
@@ -153,7 +153,12 @@ public class FeeService {
         // when one side's BSQ trade fee exceeds its miner-portion (see BsqSwapCalculation),
         // and avoids multiply overflow in fee estimators if a bad feed returns absurd values.
         long networkMin = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
-        long clampedMinFee = Math.min(Math.max(minFeePerVByte, networkMin), BTC_MAX_TX_FEE);
+
+        // v1.10.0 does not clamp to networkMin, thus we can receive lower values (usually 10).
+        // To not break backward compatibility, we only clamp to BTC_MAX_TX_FEE.
+        // Once trade version has enforces > v1.10.0 we can use the networkMin as lower bound as well.
+        // long clampedMinFee = Math.min(Math.max(minFeePerVByte, networkMin), BTC_MAX_TX_FEE);
+        long clampedMinFee = Math.min(minFeePerVByte, BTC_MAX_TX_FEE);
         long clampedTxFee = Math.min(Math.max(txFeePerVbyte, clampedMinFee), BTC_MAX_TX_FEE);
         if (clampedTxFee != txFeePerVbyte || clampedMinFee != minFeePerVByte) {
             log.warn("Fee provider returned txFeePerVbyte={}, minFeePerVbyte={}, networkMin={}, maxFeePerVbyte={}; " +

--- a/core/src/main/java/bisq/core/provider/fee/FeeService.java
+++ b/core/src/main/java/bisq/core/provider/fee/FeeService.java
@@ -21,6 +21,7 @@ import bisq.core.dao.governance.param.Param;
 import bisq.core.dao.governance.period.PeriodService;
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.filter.FilterManager;
+import bisq.core.util.Validator;
 
 import bisq.common.config.Config;
 
@@ -144,6 +145,8 @@ public class FeeService {
     }
 
     public void updateFeeInfo(long txFeePerVbyte, long minFeePerVByte) {
+        Validator.checkIsPositive(txFeePerVbyte, "txFeePerVbyte");
+        Validator.checkIsPositive(minFeePerVByte, "minFeePerVByte");
         // Defense-in-depth: a misbehaving or malicious fee provider could push values outside
         // the realistic range downstream code assumes. Clamp both fields to the network
         // default min and cap them at the documented high-water mark so the invariant

--- a/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
+++ b/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
@@ -23,8 +23,9 @@ import bisq.core.btc.wallet.BsqWalletService;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.Restrictions;
 import bisq.core.monetary.Volume;
+import bisq.core.provider.fee.FeeService;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
-import bisq.core.trade.validation.MinerFeeValidation;
+import bisq.core.trade.validation.TradeFeeValidation;
 import bisq.core.util.Validator;
 
 import bisq.common.util.MathUtils;
@@ -37,6 +38,7 @@ import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -72,10 +74,18 @@ public class BsqSwapCalculation {
 
     // Buyer
     public static Coin getBuyersBsqInputValue(BsqSwapTrade trade, long buyersTradeFee) {
+        if (buyersTradeFee == 0) {
+            log.warn("We got a bsqTradeFee of 0. We ignore that and use the default value of 3 sat (0.03 BSQ)");
+            buyersTradeFee = FeeService.getMinMakerFee(false).value;
+        }
         return getBuyersBsqInputValue(trade.getBsqTradeAmount(), buyersTradeFee);
     }
 
     public static Coin getBuyersBsqInputValue(long bsqTradeAmount, long buyersTradeFee) {
+        if (buyersTradeFee == 0) {
+            log.warn("We got a bsqTradeFee of 0. We ignore that and use the default value of 3 sat (0.03 BSQ)");
+            buyersTradeFee = FeeService.getMinMakerFee(false).value;
+        }
         return Coin.valueOf(bsqTradeAmount).add(Coin.valueOf(buyersTradeFee));
     }
 
@@ -115,7 +125,7 @@ public class BsqSwapCalculation {
                                                         long buyerTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long buyersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
+        long buyersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
         return getBuyersBtcPayoutValue(btcTradeAmount.getValue(), buyersTxFee);
     }
 
@@ -154,7 +164,7 @@ public class BsqSwapCalculation {
                                                         long sellersTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long sellersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
+        long sellersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
         return getSellersBtcInputValue(btcTradeAmount.getValue(), sellersTxFee);
     }
 
@@ -229,46 +239,27 @@ public class BsqSwapCalculation {
         return size;
     }
 
-    public static long getAdjustedTxFee(BsqSwapTrade trade, int vBytes, long tradeFee) {
-        return getAdjustedTxFee(trade.getTxFeePerVbyte(), vBytes, tradeFee);
-    }
-
-    public static long getAdjustedTxFee(long txFeePerVbyte, int vBytes, long tradeFee) {
+    // We use the burned BSQ trade fee for funding the miner fee.
+    // In case the trade fee is higher than the miner fee, the effective fee is negative, which will lead
+    // to a reduction of the required BTC input.
+    public static long getAdjustedTxFee(long txFeePerVbyte, int vBytes, long bsqTradeFee) {
+        if (bsqTradeFee == 0) {
+            log.warn("We got a bsqTradeFee of 0. We ignore that and use the default value of 3 sat (0.03 BSQ)");
+            bsqTradeFee = FeeService.getMinMakerFee(false).value;
+        }
+        // txFeePerVbyte is currently min. 10
         Validator.checkIsPositive(txFeePerVbyte, "txFeePerVbyte");
-        Validator.checkIsPositive(vBytes, "vBytes");
-        Validator.checkIsNotNegative(tradeFee, "tradeFee");
-        // tradeFee must be strictly less than miner-fee portion; otherwise buyer payout inverts
-        // (or zeroes buyer fee contribution) and sum-of-outputs >= sum-of-inputs, producing
-        // an unbroadcastable tx. Coin.multiply/subtract use Math.*Exact internally, so overflow
-        // trips loudly if future callers relax current input bounds.
+
+        checkArgument(vBytes >= MIN_SELLERS_TX_SIZE,
+                "vBytes must be at least MIN_SELLERS_TX_SIZE (104)");
+
+        bsqTradeFee = TradeFeeValidation.checkBsqTradeFee(bsqTradeFee);
         Coin adjustedTxFee = Coin.valueOf(txFeePerVbyte)
                 .multiply(vBytes)
-                .subtract(Coin.valueOf(tradeFee));
-        Validator.checkIsPositive(adjustedTxFee, "adjustedTxFee");
-        return adjustedTxFee.value;
-    }
+                .subtract(Coin.valueOf(bsqTradeFee));
 
-    // Lenient variant for UI estimation paths where a precise value is not required and
-    // throwing would break display when wallet is underfunded. Saturates the output (not
-    // the inputs) at the documented trade-tx-fee upper bound on multiply overflow or
-    // absurd magnitudes, and clamps subtraction underflow to 0.
-    private static long getAdjustedTxFeeForEstimate(long txFeePerVbyte, int vBytes, long tradeFee) {
-        // Coin.multiply uses Math.multiplyExact internally; saturate on overflow at the
-        // documented trade-tx-fee upper bound rather than throwing.
-        Coin minerFeePortion;
-        try {
-            minerFeePortion = Coin.valueOf(txFeePerVbyte).multiply(vBytes);
-        } catch (ArithmeticException e) {
-            minerFeePortion = Coin.valueOf(MinerFeeValidation.MAX_TRADE_TX_FEE_SAT);
-        }
-        // tradeFee is expected to be non-negative; clamp defensively so a negative input
-        // cannot make the subtraction overflow upward. Coin.subtract throws on underflow,
-        // so guard before subtracting and clamp the result to zero.
-        Coin safeTradeFee = Coin.valueOf(Math.max(0L, tradeFee));
-        if (minerFeePortion.isLessThan(safeTradeFee)) {
-            return 0L;
-        }
-        return minerFeePortion.subtract(safeTradeFee).value;
+        // Negative value is possible
+        return adjustedTxFee.value;
     }
 
     // Convert BTC trade amount to BSQ amount

--- a/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
+++ b/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapCalculation.java
@@ -24,6 +24,7 @@ import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.Restrictions;
 import bisq.core.monetary.Volume;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
+import bisq.core.trade.validation.MinerFeeValidation;
 import bisq.core.util.Validator;
 
 import bisq.common.util.MathUtils;
@@ -114,7 +115,7 @@ public class BsqSwapCalculation {
                                                         long buyerTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long buyersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
+        long buyersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, buyerTradeFee);
         return getBuyersBtcPayoutValue(btcTradeAmount.getValue(), buyersTxFee);
     }
 
@@ -153,7 +154,7 @@ public class BsqSwapCalculation {
                                                         long sellersTradeFee) {
         // Use estimated size. This is used in case the wallet has not enough fund so we cannot calculate the exact
         // amount but we still want to provide some estimated value.
-        long sellersTxFee = getAdjustedTxFee(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
+        long sellersTxFee = getAdjustedTxFeeForEstimate(txFeePerVbyte, ESTIMATED_V_BYTES, sellersTradeFee);
         return getSellersBtcInputValue(btcTradeAmount.getValue(), sellersTxFee);
     }
 
@@ -236,31 +237,38 @@ public class BsqSwapCalculation {
         Validator.checkIsPositive(txFeePerVbyte, "txFeePerVbyte");
         Validator.checkIsPositive(vBytes, "vBytes");
         Validator.checkIsNotNegative(tradeFee, "tradeFee");
-        // BSQ trade fees burn into the miner-fee pool: BSQ-colored input sats that are not
-        // claimed by any BSQ output fall through into the tx fee. If this side's trade fee
-        // already covers its share of the miner cost, our BTC miner contribution is 0 and
-        // the excess BSQ simply makes the tx slightly overpay — still valid, still
-        // broadcastable. Clamping at 0 (rather than throwing on a negative result) is what
-        // keeps BSQ offers takable at low fee rates with small inputs, where the BSQ trade
-        // fee alone can exceed vBytes * txFeePerVbyte. The DAO still records the full trade
-        // fee as burnt regardless of whether the miner ends up overpaid. Coin.multiply uses
-        // Math.multiplyExact so an absurd txFeePerVbyte still trips loudly upstream.
-        //
-        // Min-relay viability: assuming Bisq's standing invariant txFeePerVbyte >=
-        // FeeService.getMinFeePerVByte(), clamping at 0 is provably equivalent to clamping
-        // at the per-side min-fee floor. Proof: the clamp branch fires only when
-        // tradeFee > vBytes * txFeePerVbyte, which under the invariant implies
-        // tradeFee > vBytes * minFeePerVbyte; the BSQ trade fee on its own already covers
-        // this side's share of the network minimum, so adding any positive BTC contribution
-        // would over-pay. A separate min-fee floor on the result would force a large BTC
-        // over-payment for no protocol benefit. The invariant on the input itself is
-        // out of scope for this calculator and is owned by FeeService / offer-create paths.
-        Coin minerFeePortion = Coin.valueOf(txFeePerVbyte).multiply(vBytes);
-        Coin tradeFeeCoin = Coin.valueOf(tradeFee);
-        if (minerFeePortion.isLessThan(tradeFeeCoin)) {
+        // tradeFee must be strictly less than miner-fee portion; otherwise buyer payout inverts
+        // (or zeroes buyer fee contribution) and sum-of-outputs >= sum-of-inputs, producing
+        // an unbroadcastable tx. Coin.multiply/subtract use Math.*Exact internally, so overflow
+        // trips loudly if future callers relax current input bounds.
+        Coin adjustedTxFee = Coin.valueOf(txFeePerVbyte)
+                .multiply(vBytes)
+                .subtract(Coin.valueOf(tradeFee));
+        Validator.checkIsPositive(adjustedTxFee, "adjustedTxFee");
+        return adjustedTxFee.value;
+    }
+
+    // Lenient variant for UI estimation paths where a precise value is not required and
+    // throwing would break display when wallet is underfunded. Saturates the output (not
+    // the inputs) at the documented trade-tx-fee upper bound on multiply overflow or
+    // absurd magnitudes, and clamps subtraction underflow to 0.
+    private static long getAdjustedTxFeeForEstimate(long txFeePerVbyte, int vBytes, long tradeFee) {
+        // Coin.multiply uses Math.multiplyExact internally; saturate on overflow at the
+        // documented trade-tx-fee upper bound rather than throwing.
+        Coin minerFeePortion;
+        try {
+            minerFeePortion = Coin.valueOf(txFeePerVbyte).multiply(vBytes);
+        } catch (ArithmeticException e) {
+            minerFeePortion = Coin.valueOf(MinerFeeValidation.MAX_TRADE_TX_FEE_SAT);
+        }
+        // tradeFee is expected to be non-negative; clamp defensively so a negative input
+        // cannot make the subtraction overflow upward. Coin.subtract throws on underflow,
+        // so guard before subtracting and clamp the result to zero.
+        Coin safeTradeFee = Coin.valueOf(Math.max(0L, tradeFee));
+        if (minerFeePortion.isLessThan(safeTradeFee)) {
             return 0L;
         }
-        return minerFeePortion.subtract(tradeFeeCoin).value;
+        return minerFeePortion.subtract(safeTradeFee).value;
     }
 
     // Convert BTC trade amount to BSQ amount

--- a/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerification.java
+++ b/core/src/main/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerification.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.trade.validation.TradeFeeValidation.checkBsqTradeFee;
 import static bisq.core.trade.validation.TradeFeeValidation.checkMakerFee;
 import static bisq.core.trade.validation.TradeFeeValidation.checkTakerFee;
 import static bisq.core.trade.validation.TradeValidation.checkTradeId;
@@ -80,14 +81,22 @@ public class BsqSwapTakeOfferRequestVerification {
 
             long peersMinerFeeRate = request.getTxFeePerVbyte();
             long expectedMinerFeeRate = feeService.getTxFeePerVbyte().getValue();
+
             long minMinerFeeRate = feeService.getMinFeePerVByte();
             Validator.checkIsPositive(minMinerFeeRate, "minMinerFeeRate");
-            checkArgument(peersMinerFeeRate >= minMinerFeeRate,
+
+            // To not break backward compatibility, we do not apply that strict check but rely on the tolerance only.
+            // Once trade version has enforces > v1.10.0 we can use the strict check again.
+            /* checkArgument(peersMinerFeeRate >= minMinerFeeRate,
                     "Peer miner fee rate is below minimum. peer=%s, min=%s", peersMinerFeeRate, minMinerFeeRate);
+            */
+
             MinerFeeValidation.checkMinerFeeRateIsInTolerance(peersMinerFeeRate, expectedMinerFeeRate);
 
             checkMakerFee(request.getMakerFee(), false, amountAsCoin);
             checkTakerFee(request.getTakerFee(), false, amountAsCoin);
+            checkBsqTradeFee(request.getMakerFee());
+            checkBsqTradeFee(request.getTakerFee());
         } catch (Exception e) {
             log.error("BsqSwapTakeOfferRequestVerification failed. Request={}, peer={}, error={}", request, peer, e.toString());
             return false;

--- a/core/src/main/java/bisq/core/trade/validation/TradeFeeValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeFeeValidation.java
@@ -31,7 +31,7 @@ public final class TradeFeeValidation {
     public static final double MAX_MAKER_FEE_DEVIATION_FACTOR = 2; // Max change by factor 2 (expected / 2 or expected * 2)
     public static final double MAX_TAKER_FEE_DEVIATION_FACTOR = 1.5; // Max change by factor 1.5 (expected / 1.5 or expected * 1.5)
 
-    // CBSQ trade fee is currently 274.4 BSQ/BTC for taker. With 0.25 BTC limit the fee would be 68.6 BSQ.
+    // BSQ trade fee is currently 274.4 BSQ/BTC for taker. With 0.25 BTC limit the fee would be 68.6 BSQ.
     // If we assume a very high fee of 2000 BSQ/BTC , we would get 500 BSQ as max trade fee.
     // This is only used for setting boundaries.
     public static final int MAX_BSQ_TRADE_FEE = 50000; // 500 BSQ

--- a/core/src/main/java/bisq/core/trade/validation/TradeFeeValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeFeeValidation.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade.validation;
 
+import bisq.core.provider.fee.FeeService;
 import bisq.core.trade.TradeFeeFactory;
 
 import org.bitcoinj.core.Coin;
@@ -24,10 +25,16 @@ import org.bitcoinj.core.Coin;
 import com.google.common.annotations.VisibleForTesting;
 
 import static bisq.core.util.Validator.checkIsPositive;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public final class TradeFeeValidation {
     public static final double MAX_MAKER_FEE_DEVIATION_FACTOR = 2; // Max change by factor 2 (expected / 2 or expected * 2)
     public static final double MAX_TAKER_FEE_DEVIATION_FACTOR = 1.5; // Max change by factor 1.5 (expected / 1.5 or expected * 1.5)
+
+    // CBSQ trade fee is currently 274.4 BSQ/BTC for taker. With 0.25 BTC limit the fee would be 68.6 BSQ.
+    // If we assume a very high fee of 2000 BSQ/BTC , we would get 500 BSQ as max trade fee.
+    // This is only used for setting boundaries.
+    public static final int MAX_BSQ_TRADE_FEE = 50000; // 500 BSQ
 
     private TradeFeeValidation() {
     }
@@ -99,5 +106,24 @@ public final class TradeFeeValidation {
     @VisibleForTesting
     static long checkMakerFeeInTolerance(long fee, long expectedFee) {
         return TradeValidation.checkValueInTolerance(fee, expectedFee, MAX_MAKER_FEE_DEVIATION_FACTOR);
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // BSQ trade fee
+    /* --------------------------------------------------------------------- */
+
+    public static long checkBsqTradeFee(long bsqTradeFee) {
+        // Min. BSQ trade fee is 0.03 BSQ -> 3 satoshi
+        long minMakerFee = FeeService.getMinMakerFee(false).value;
+        long minTakerFee = FeeService.getMinTakerFee(false).value;
+        long minTradeFee = Math.min(minMakerFee, minTakerFee);
+        checkArgument(bsqTradeFee >= minTradeFee,
+                "bsqTradeFee must not be less than minTradeFee");
+
+        // Set upper ceiling
+        checkArgument(bsqTradeFee <= TradeFeeValidation.MAX_BSQ_TRADE_FEE,
+                "bsqTradeFee must not be greater than TradeFeeValidation.MAX_BSQ_TRADE_FEE (50000 satoshi)");
+        return bsqTradeFee;
     }
 }

--- a/core/src/test/java/bisq/core/provider/fee/FeeServiceTest.java
+++ b/core/src/test/java/bisq/core/provider/fee/FeeServiceTest.java
@@ -24,6 +24,8 @@ import bisq.core.trade.bsq_swap.BsqSwapCalculation;
 
 import bisq.common.config.Config;
 
+import org.bitcoinj.core.Coin;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,7 +33,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class FeeServiceTest {
-    @Test
+
+    // For now, we do not clamp to networkMin because of backward compatibility issues
+    // @Test
     void updateFeeInfoClampsRatesToNetworkMin() {
         FeeService feeService = newFeeService();
         long networkMin = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
@@ -50,12 +54,11 @@ class FeeServiceTest {
 
         assertEquals(FeeService.BTC_MAX_TX_FEE, feeService.getTxFeePerVbyte().getValue());
         assertEquals(FeeService.BTC_MAX_TX_FEE, feeService.getMinFeePerVByte());
-        // Derived from the documented invariant so the assertion does not silently rot if
-        // either BTC_MAX_TX_FEE or ESTIMATED_V_BYTES is retuned.
-        assertEquals(FeeService.BTC_MAX_TX_FEE * BsqSwapCalculation.ESTIMATED_V_BYTES,
-                BsqSwapCalculation.getAdjustedTxFee(feeService.getTxFeePerVbyte().getValue(),
-                        BsqSwapCalculation.ESTIMATED_V_BYTES,
-                        0));
+        long expected = FeeService.BTC_MAX_TX_FEE * BsqSwapCalculation.ESTIMATED_V_BYTES - 3;
+        long adjustedTxFee = BsqSwapCalculation.getAdjustedTxFee(feeService.getTxFeePerVbyte().getValue(),
+                BsqSwapCalculation.ESTIMATED_V_BYTES,
+                3);
+        assertEquals(expected, adjustedTxFee);
     }
 
     @Test
@@ -81,6 +84,8 @@ class FeeServiceTest {
 
         FeeService feeService = new FeeService(daoStateService, periodService);
         feeService.onAllServicesInitialized(filterManager);
+        when(FeeService.getMinMakerFee(false)).thenReturn(Coin.valueOf(3));
+        when(FeeService.getMinTakerFee(false)).thenReturn(Coin.valueOf(3));
         return feeService;
     }
 }

--- a/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
+++ b/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
@@ -48,30 +48,4 @@ public class BsqSwapCalculationTest {
         assertThrows(IllegalArgumentException.class,
                 () -> BsqSwapCalculation.getAdjustedTxFee(Long.MAX_VALUE, 2, -1));
     }
-
-    @Test
-    void getAdjustedTxFeeClampsAtZeroWhenTradeFeeExceedsMinerPortion() {
-        // Real-world reproduction of the take-offer crash: low txFeePerVbyte + small vBytes
-        // (single segwit input) makes the miner-fee portion smaller than the BSQ trade fee.
-        // Returning 0 means this side contributes 0 BTC toward the miner fee; the BSQ trade
-        // fee burns directly into the miner-fee pool and the tx overpays slightly — still
-        // valid, still broadcastable. Pre-fix this threw IllegalArgumentException and killed
-        // the take-offer dialog. The boundary case (tradeFee == minerPortion) also returns 0
-        // since the BSQ fee alone covers the full miner cost.
-        assertEquals(0, BsqSwapCalculation.getAdjustedTxFee(1, 200, 500));
-        assertEquals(0, BsqSwapCalculation.getAdjustedTxFee(1, 200, 200));
-    }
-
-    @Test
-    void sellersAndBuyersFeeOverloadsClampAtZeroWhenTradeFeeExceedsMinerPortion() {
-        // Through the seller-path wrapper that BsqSwapOfferModel.calculateInputAndPayout calls:
-        // seller's BTC input collapses to just btcTradeAmount when their BSQ trade fee already
-        // covers the miner portion.
-        assertEquals(100_000_000L,
-                BsqSwapCalculation.getSellersBtcInputValue(100_000_000L, 1L, 100, 500L).value);
-        // Symmetric buyer-payout wrapper: buyer receives the full btcTradeAmount when their
-        // trade fee already covers the miner portion.
-        assertEquals(100_000_000L,
-                BsqSwapCalculation.getBuyersBtcPayoutValue(100_000_000L, 1L, 100, 500L).value);
-    }
 }

--- a/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
+++ b/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
@@ -17,14 +17,22 @@
 
 package bisq.core.trade.bsq_swap;
 
+import bisq.core.provider.fee.FeeService;
+
+import org.bitcoinj.core.Coin;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 public class BsqSwapCalculationTest {
     @Test
     void monetaryCalculationsReturnExpectedValues() {
+        when(FeeService.getMinMakerFee(false)).thenReturn(Coin.valueOf(3));
+        when(FeeService.getMinTakerFee(false)).thenReturn(Coin.valueOf(3));
+
         assertEquals(5_000_050, BsqSwapCalculation.getBuyersBsqInputValue(5_000_000, 50).value);
         assertEquals(99_998_050, BsqSwapCalculation.getBuyersBtcPayoutValue(100_000_000,
                 10,
@@ -34,7 +42,7 @@ public class BsqSwapCalculationTest {
         assertEquals(4_999_850, BsqSwapCalculation.getSellersBsqPayoutValue(5_000_000, 150).value);
         assertEquals(1_950, BsqSwapCalculation.getAdjustedTxFee(10, 200, 50));
         // 0 trade fee is allowed a seller has no trade fee
-        assertEquals(2_000, BsqSwapCalculation.getAdjustedTxFee(10, 200, 0));
+        assertEquals(1_997, BsqSwapCalculation.getAdjustedTxFee(10, 200, 3));
     }
 
     @Test

--- a/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerificationTest.java
+++ b/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapTakeOfferRequestVerificationTest.java
@@ -53,7 +53,7 @@ class BsqSwapTakeOfferRequestVerificationTest {
     private static final long MAKER_FEE = 50;
     private static final long TAKER_FEE = 150;
     // Derived from the network default so the assertions remain meaningful if the network
-    // minimum is retuned. FeeService.updateFeeInfo clamps stored rates up to NETWORK_MIN.
+    // minimum is retuned.
     private static final long NETWORK_MIN = Config.baseCurrencyNetwork().getDefaultMinFeePerVbyte();
     // Strictly above 2 * NETWORK_MIN so the tolerance check rejects it.
     private static final long OUTSIDE_TOLERANCE = 2 * NETWORK_MIN + 1;
@@ -70,20 +70,31 @@ class BsqSwapTakeOfferRequestVerificationTest {
     }
 
     @Test
-    void rejectsRequestBelowStoredMinimumFeeRateEvenWhenToleranceWouldAllowIt() {
+    void acceptsRequestBelowStoredMinimumFeeRateWhenToleranceAllowsIt() {
         // Force storedMin >= 2 so belowMin = storedMin - 1 is both strictly below the
-        // stored minimum and still within the 2x tolerance window. This keeps the test
-        // exercising the strict min-rate check (not the tolerance check) regardless of
-        // how the network minimum is tuned.
+        // stored minimum and still within the 2x tolerance window. This documents the
+        // backward-compatible behavior for peers running versions before strict min-rate
+        // enforcement.
         long storedMin = Math.max(2L, NETWORK_MIN);
         long belowMinWithinTolerance = storedMin - 1;
         Fixture fixture = new Fixture(storedMin);
+
+        assertTrue(BsqSwapTakeOfferRequestVerification.isValid(fixture.openOfferManager,
+                fixture.feeService,
+                fixture.keyRing,
+                PEER,
+                newRequest(belowMinWithinTolerance)));
+    }
+
+    @Test
+    void rejectsRequestWithBsqFeeBelowCurrentMinimumEvenWhenFeeToleranceWouldAllowIt() {
+        Fixture fixture = new Fixture(NETWORK_MIN);
 
         assertFalse(BsqSwapTakeOfferRequestVerification.isValid(fixture.openOfferManager,
                 fixture.feeService,
                 fixture.keyRing,
                 PEER,
-                newRequest(belowMinWithinTolerance)));
+                newRequest(NETWORK_MIN, MAKER_FEE - 1, TAKER_FEE)));
     }
 
     @Test
@@ -98,13 +109,17 @@ class BsqSwapTakeOfferRequestVerificationTest {
     }
 
     private static BsqSwapRequest newRequest(long txFeePerVbyte) {
+        return newRequest(txFeePerVbyte, MAKER_FEE, TAKER_FEE);
+    }
+
+    private static BsqSwapRequest newRequest(long txFeePerVbyte, long makerFee, long takerFee) {
         return new SellersBsqSwapRequest(TRADE_ID,
                 PEER,
                 mock(PubKeyRing.class),
                 TRADE_AMOUNT.value,
                 txFeePerVbyte,
-                MAKER_FEE,
-                TAKER_FEE,
+                makerFee,
+                takerFee,
                 System.currentTimeMillis());
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced minimum and maximum bounds for BSQ trade fees to prevent invalid values.
  * Seller-side funding now falls back to a configured minimum maker fee when trade fee is zero.
  * Miner-fee acceptance relaxed from a strict minimum to tolerance-based validation for better compatibility.
  * Transaction-fee adjustment logic updated (can produce negative adjusted miner-fee), affecting funding calculations.

* **Tests**
  * Updated unit tests to reflect new fee validation, fallback, and calculation behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->