### PR TITLE
Fix Mockito static stubbing in fee tests

### DIFF
--- a/core/src/test/java/bisq/core/provider/fee/FeeServiceTest.java
+++ b/core/src/test/java/bisq/core/provider/fee/FeeServiceTest.java
@@ -28,8 +28,11 @@ import org.bitcoinj.core.Coin;
 
 import org.junit.jupiter.api.Test;
 
+import org.mockito.MockedStatic;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class FeeServiceTest {
@@ -55,9 +58,14 @@ class FeeServiceTest {
         assertEquals(FeeService.BTC_MAX_TX_FEE, feeService.getTxFeePerVbyte().getValue());
         assertEquals(FeeService.BTC_MAX_TX_FEE, feeService.getMinFeePerVByte());
         long expected = FeeService.BTC_MAX_TX_FEE * BsqSwapCalculation.ESTIMATED_V_BYTES - 3;
-        long adjustedTxFee = BsqSwapCalculation.getAdjustedTxFee(feeService.getTxFeePerVbyte().getValue(),
-                BsqSwapCalculation.ESTIMATED_V_BYTES,
-                3);
+        long adjustedTxFee;
+        try (MockedStatic<FeeService> mockedFeeService = mockStatic(FeeService.class)) {
+            mockedFeeService.when(() -> FeeService.getMinMakerFee(false)).thenReturn(Coin.valueOf(3));
+            mockedFeeService.when(() -> FeeService.getMinTakerFee(false)).thenReturn(Coin.valueOf(3));
+            adjustedTxFee = BsqSwapCalculation.getAdjustedTxFee(feeService.getTxFeePerVbyte().getValue(),
+                    BsqSwapCalculation.ESTIMATED_V_BYTES,
+                    3);
+        }
         assertEquals(expected, adjustedTxFee);
     }
 
@@ -84,8 +92,6 @@ class FeeServiceTest {
 
         FeeService feeService = new FeeService(daoStateService, periodService);
         feeService.onAllServicesInitialized(filterManager);
-        when(FeeService.getMinMakerFee(false)).thenReturn(Coin.valueOf(3));
-        when(FeeService.getMinTakerFee(false)).thenReturn(Coin.valueOf(3));
         return feeService;
     }
 }

--- a/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
+++ b/core/src/test/java/bisq/core/trade/bsq_swap/BsqSwapCalculationTest.java
@@ -23,26 +23,30 @@ import org.bitcoinj.core.Coin;
 
 import org.junit.jupiter.api.Test;
 
+import org.mockito.MockedStatic;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 public class BsqSwapCalculationTest {
     @Test
     void monetaryCalculationsReturnExpectedValues() {
-        when(FeeService.getMinMakerFee(false)).thenReturn(Coin.valueOf(3));
-        when(FeeService.getMinTakerFee(false)).thenReturn(Coin.valueOf(3));
+        try (MockedStatic<FeeService> feeService = mockStatic(FeeService.class)) {
+            feeService.when(() -> FeeService.getMinMakerFee(false)).thenReturn(Coin.valueOf(3));
+            feeService.when(() -> FeeService.getMinTakerFee(false)).thenReturn(Coin.valueOf(3));
 
-        assertEquals(5_000_050, BsqSwapCalculation.getBuyersBsqInputValue(5_000_000, 50).value);
-        assertEquals(99_998_050, BsqSwapCalculation.getBuyersBtcPayoutValue(100_000_000,
-                10,
-                200,
-                50).value);
-        assertEquals(100_001_850, BsqSwapCalculation.getSellersBtcInputValue(100_000_000, 1_850).value);
-        assertEquals(4_999_850, BsqSwapCalculation.getSellersBsqPayoutValue(5_000_000, 150).value);
-        assertEquals(1_950, BsqSwapCalculation.getAdjustedTxFee(10, 200, 50));
-        // 0 trade fee is allowed a seller has no trade fee
-        assertEquals(1_997, BsqSwapCalculation.getAdjustedTxFee(10, 200, 3));
+            assertEquals(5_000_050, BsqSwapCalculation.getBuyersBsqInputValue(5_000_000, 50).value);
+            assertEquals(99_998_050, BsqSwapCalculation.getBuyersBtcPayoutValue(100_000_000,
+                    10,
+                    200,
+                    50).value);
+            assertEquals(100_001_850, BsqSwapCalculation.getSellersBtcInputValue(100_000_000, 1_850).value);
+            assertEquals(4_999_850, BsqSwapCalculation.getSellersBsqPayoutValue(5_000_000, 150).value);
+            assertEquals(1_950, BsqSwapCalculation.getAdjustedTxFee(10, 200, 50));
+            // 0 trade fee is allowed a seller has no trade fee
+            assertEquals(1_997, BsqSwapCalculation.getAdjustedTxFee(10, 200, 3));
+        }
     }
 
     @Test


### PR DESCRIPTION
Wrap FeeService.getMinMakerFee and getMinTakerFee stubbing in scoped MockedStatic blocks so Mockito receives static invocations through the supported API instead of plain when(...) calls.

Remove the invalid static stubbing from FeeServiceTest.newFeeService(), where the returned FeeService does not need it. Scope the static fee stubs only around the BsqSwapCalculation path that validates BSQ trade fees.

Update BsqSwapCalculationTest to keep all fee-dependent assertions inside a MockedStatic<FeeService> try-with-resources block, preventing static mock leakage between tests.

Verified with: ./gradlew :core:test --tests bisq.core.provider.fee.FeeServiceTest --tests bisq.core.trade.bsq_swap.BsqSwapCalculationTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure by updating static method mocking patterns in fee service and BSQ swap calculation tests for better test reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->