### PR TITLE
Remove JavaFX locale property from core settings

### DIFF
--- a/core/src/main/java/bisq/core/locale/GlobalSettings.java
+++ b/core/src/main/java/bisq/core/locale/GlobalSettings.java
@@ -17,19 +17,22 @@
 
 package bisq.core.locale;
 
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ReadOnlyObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class GlobalSettings {
+    public interface LocaleListener {
+        void onLocaleChanged(Locale oldLocale, Locale newLocale);
+    }
+
     private static boolean useAnimations = true;
     private static Locale locale;
-    private static final ObjectProperty<Locale> localeProperty = new SimpleObjectProperty<>(locale);
+    private static final List<LocaleListener> localeListeners = new CopyOnWriteArrayList<>();
     private static TradeCurrency defaultTradeCurrency;
     private static String btcDenomination;
 
@@ -43,8 +46,11 @@ public class GlobalSettings {
     }
 
     public static void setLocale(Locale locale) {
+        Locale oldLocale = GlobalSettings.locale;
         GlobalSettings.locale = locale;
-        localeProperty.set(locale);
+        if (!Objects.equals(oldLocale, locale)) {
+            localeListeners.forEach(listener -> listener.onLocaleChanged(oldLocale, locale));
+        }
     }
 
     public static void setUseAnimations(boolean useAnimations) {
@@ -68,8 +74,12 @@ public class GlobalSettings {
         return btcDenomination;
     }
 
-    public static ReadOnlyObjectProperty<Locale> localeProperty() {
-        return localeProperty;
+    public static void addLocaleListener(LocaleListener listener) {
+        localeListeners.add(listener);
+    }
+
+    public static void removeLocaleListener(LocaleListener listener) {
+        localeListeners.remove(listener);
     }
 
     public static boolean getUseAnimations() {

--- a/core/src/main/java/bisq/core/locale/Res.java
+++ b/core/src/main/java/bisq/core/locale/Res.java
@@ -59,7 +59,7 @@ public class Res {
     private static ResourceBundle resourceBundle = ResourceBundle.getBundle("i18n.displayStrings", GlobalSettings.getLocale(), new UTF8Control());
 
     static {
-        GlobalSettings.localeProperty().addListener((observable, oldValue, newValue) -> {
+        GlobalSettings.addLocaleListener((oldValue, newValue) -> {
             if ("en".equalsIgnoreCase(newValue.getLanguage()))
                 newValue = Locale.ROOT;
             resourceBundle = ResourceBundle.getBundle("i18n.displayStrings", newValue, new UTF8Control());

--- a/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
@@ -74,7 +74,7 @@ public class BsqFormatter implements CoinFormatter {
         this.monetaryFormat = new MonetaryFormat().shift(6).code(6, "BSQ").minDecimals(2);
         this.immutableCoinFormatter = new ImmutableCoinFormatter(monetaryFormat);
 
-        GlobalSettings.localeProperty().addListener((observable, oldValue, newValue) -> switchLocale(newValue));
+        GlobalSettings.addLocaleListener((oldValue, newValue) -> switchLocale(newValue));
         switchLocale(GlobalSettings.getLocale());
 
         amountFormat.setMinimumFractionDigits(2);


### PR DESCRIPTION
BridgeMain can initialize core locale resources before any JavaFX runtime dependency is present. Res loaded GlobalSettings during static initialization, and GlobalSettings exposed its locale state through javafx.beans.property.ObjectProperty, causing bridge startup to fail with NoClassDefFoundError for ReadOnlyObjectProperty.

Replace the JavaFX property with a small CopyOnWriteArrayList-backed LocaleListener API. Update Res and BsqFormatter to subscribe through that API so locale updates still refresh resource bundles and formatting without making headless core consumers depend on javafx.base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal locale change notification system to enhance code maintainability and overall application performance stability
  * Streamlined how the application processes language and regional setting updates across all components for greater efficiency and responsiveness
  * Optimized the underlying technical architecture for better long-term scalability while preserving all existing functionality and user experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->