### PR TITLE
Add java fx base runtime to headless p2 p apps

### DIFF
--- a/core/src/main/java/bisq/core/locale/GlobalSettings.java
+++ b/core/src/main/java/bisq/core/locale/GlobalSettings.java
@@ -17,19 +17,22 @@
 
 package bisq.core.locale;
 
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ReadOnlyObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class GlobalSettings {
+    public interface LocaleListener {
+        void onLocaleChanged(Locale oldLocale, Locale newLocale);
+    }
+
     private static boolean useAnimations = true;
     private static Locale locale;
-    private static final ObjectProperty<Locale> localeProperty = new SimpleObjectProperty<>(locale);
+    private static final List<LocaleListener> localeListeners = new CopyOnWriteArrayList<>();
     private static TradeCurrency defaultTradeCurrency;
     private static String btcDenomination;
 
@@ -43,8 +46,11 @@ public class GlobalSettings {
     }
 
     public static void setLocale(Locale locale) {
+        Locale oldLocale = GlobalSettings.locale;
         GlobalSettings.locale = locale;
-        localeProperty.set(locale);
+        if (!Objects.equals(oldLocale, locale)) {
+            localeListeners.forEach(listener -> listener.onLocaleChanged(oldLocale, locale));
+        }
     }
 
     public static void setUseAnimations(boolean useAnimations) {
@@ -68,8 +74,12 @@ public class GlobalSettings {
         return btcDenomination;
     }
 
-    public static ReadOnlyObjectProperty<Locale> localeProperty() {
-        return localeProperty;
+    public static void addLocaleListener(LocaleListener listener) {
+        localeListeners.add(listener);
+    }
+
+    public static void removeLocaleListener(LocaleListener listener) {
+        localeListeners.remove(listener);
     }
 
     public static boolean getUseAnimations() {

--- a/core/src/main/java/bisq/core/locale/Res.java
+++ b/core/src/main/java/bisq/core/locale/Res.java
@@ -59,7 +59,7 @@ public class Res {
     private static ResourceBundle resourceBundle = ResourceBundle.getBundle("i18n.displayStrings", GlobalSettings.getLocale(), new UTF8Control());
 
     static {
-        GlobalSettings.localeProperty().addListener((observable, oldValue, newValue) -> {
+        GlobalSettings.addLocaleListener((oldValue, newValue) -> {
             if ("en".equalsIgnoreCase(newValue.getLanguage()))
                 newValue = Locale.ROOT;
             resourceBundle = ResourceBundle.getBundle("i18n.displayStrings", newValue, new UTF8Control());

--- a/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
+++ b/core/src/main/java/bisq/core/util/coin/BsqFormatter.java
@@ -74,7 +74,7 @@ public class BsqFormatter implements CoinFormatter {
         this.monetaryFormat = new MonetaryFormat().shift(6).code(6, "BSQ").minDecimals(2);
         this.immutableCoinFormatter = new ImmutableCoinFormatter(monetaryFormat);
 
-        GlobalSettings.localeProperty().addListener((observable, oldValue, newValue) -> switchLocale(newValue));
+        GlobalSettings.addLocaleListener((oldValue, newValue) -> switchLocale(newValue));
         switchLocale(GlobalSettings.getLocale());
 
         amountFormat.setMinimumFractionDigits(2);

--- a/daemon/build.gradle
+++ b/daemon/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'bisq.application'
+    id 'bisq.javafx'
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
@@ -7,6 +8,10 @@ distTar.enabled = true
 
 application {
     mainClass = 'bisq.daemon.app.BisqDaemonMain'
+}
+
+javafx {
+    modules = ['javafx.base']
 }
 
 dependencies {

--- a/inventory/build.gradle
+++ b/inventory/build.gradle
@@ -1,10 +1,15 @@
 plugins {
     id 'bisq.application'
+    id 'bisq.javafx'
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
 application {
     mainClass = 'bisq.inventory.InventoryMonitorMain'
+}
+
+javafx {
+    modules = ['javafx.base']
 }
 
 distTar.enabled = true

--- a/restapi/build.gradle
+++ b/restapi/build.gradle
@@ -1,10 +1,15 @@
 plugins {
     id 'bisq.application'
+    id 'bisq.javafx'
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
 application {
     mainClass = 'bisq.restapi.RestApiMain'
+}
+
+javafx {
+    modules = ['javafx.base']
 }
 
 distTar.enabled = false

--- a/statsnode/build.gradle
+++ b/statsnode/build.gradle
@@ -1,10 +1,15 @@
 plugins {
     id 'bisq.application'
+    id 'bisq.javafx'
     id 'bisq.gradle.app_start_plugin.AppStartPlugin'
 }
 
 application {
     mainClass = 'bisq.statistics.StatisticsMain'
+}
+
+javafx {
+    modules = ['javafx.base']
 }
 
 dependencies {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Replaced `localeProperty()` with a new listener-based locale change mechanism (`LocaleListener`, `addLocaleListener`, `removeLocaleListener`).

* **Chores**
  * Updated build configurations to apply JavaFX plugin and restrict JavaFX modules to `javafx.base` across daemon, inventory, restapi, and statsnode subprojects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq/pull/7858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->