### PR TITLE
Add DAO hash JDK comparison tooling

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -85,3 +85,9 @@ dependencies {
 test {
     systemProperty 'jdk.attach.allowAttachSelf', true
 }
+
+tasks.register('daoHashToolClasspath') {
+    doLast {
+        println sourceSets.test.runtimeClasspath.asPath
+    }
+}

--- a/core/src/test/java/bisq/core/dao/tools/DaoHashJdkComparisonTool.java
+++ b/core/src/test/java/bisq/core/dao/tools/DaoHashJdkComparisonTool.java
@@ -139,8 +139,8 @@ public class DaoHashJdkComparisonTool {
     }
 
     private static List<Path> findBucketFiles(Path blocksDir, int fromHeight, int toHeight) throws IOException {
-        int fromBucket = fromHeight / BSQ_BLOCK_BUCKET_SIZE + 1;
-        int toBucket = toHeight / BSQ_BLOCK_BUCKET_SIZE + 1;
+        int fromBucket = fromHeight <= 0 ? 0 : (fromHeight - 1) / BSQ_BLOCK_BUCKET_SIZE + 1;
+        int toBucket = toHeight <= 0 ? 0 : (toHeight - 1) / BSQ_BLOCK_BUCKET_SIZE + 1;
         List<Path> bucketFiles = new ArrayList<>();
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(blocksDir)) {
             for (Path path : stream) {

--- a/core/src/test/java/bisq/core/dao/tools/DaoHashJdkComparisonTool.java
+++ b/core/src/test/java/bisq/core/dao/tools/DaoHashJdkComparisonTool.java
@@ -1,0 +1,271 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.tools;
+
+import protobuf.BaseTxOutput;
+import protobuf.PersistableEnvelope;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class DaoHashJdkComparisonTool {
+    private static final Pattern BLOCK_BUCKET_FILE = Pattern.compile("BsqBlocks_(\\d+)-(\\d+)");
+    private static final int BSQ_BLOCK_BUCKET_SIZE = 1000;
+
+    public static void main(String[] args) throws Exception {
+        Options options = Options.parse(args);
+        if (options.help) {
+            printUsage();
+            return;
+        }
+
+        protobuf.DaoState daoStateProto = readDaoState(options.daoStateStore);
+        int snapshotHeight = daoStateProto.getChainHeight();
+        int fromHeight = options.fromHeight == null ? snapshotHeight : options.fromHeight;
+        int toHeight = options.toHeight == null ? snapshotHeight : options.toHeight;
+        if (fromHeight > toHeight) {
+            throw new IllegalArgumentException("--from-height must be <= --to-height");
+        }
+
+        List<protobuf.BaseBlock> selectedBlocks = readBlocks(options.blocksDir, fromHeight, toHeight);
+        if (selectedBlocks.isEmpty()) {
+            throw new IllegalArgumentException("No BSQ blocks found for range " + fromHeight + "-" + toHeight +
+                    " in " + options.blocksDir);
+        }
+
+        HashMap<String, BaseTxOutput> unspentTxOutputMap = collectLikeDaoBuilder(daoStateProto.getUnspentTxOutputMapMap());
+        HashMap<String, protobuf.SpentInfo> spentInfoMap = collectLikeDaoBuilder(daoStateProto.getSpentInfoMapMap());
+        HashMap<String, protobuf.Issuance> issuanceMap = collectLikeDaoBuilder(daoStateProto.getIssuanceMapMap());
+        protobuf.DaoState baseStateExcludingBlocks = buildStateExcludingBlocks(daoStateProto,
+                unspentTxOutputMap,
+                spentInfoMap,
+                issuanceMap);
+
+        if (!options.comparableOnly) {
+            System.out.println("runtime.java.version=" + System.getProperty("java.version"));
+            System.out.println("runtime.java.home=" + System.getProperty("java.home"));
+            System.out.println("input.daoStateStore=" + options.daoStateStore.toAbsolutePath());
+            System.out.println("input.blocksDir=" + options.blocksDir.toAbsolutePath());
+        }
+
+        printConstants();
+        System.out.println("snapshot.chainHeight=" + snapshotHeight);
+        System.out.println("range.fromHeight=" + fromHeight);
+        System.out.println("range.toHeight=" + toHeight);
+        System.out.println("range.selectedBlockCount=" + selectedBlocks.size());
+
+        printMapStats("unspentTxOutputMap", unspentTxOutputMap, options.sampleKeys);
+        printMapStats("spentInfoMap", spentInfoMap, options.sampleKeys);
+        printMapStats("issuanceMap", issuanceMap, options.sampleKeys);
+
+        for (protobuf.BaseBlock block : selectedBlocks) {
+            protobuf.DaoState stateForHash = baseStateExcludingBlocks.toBuilder()
+                    .setChainHeight(block.getHeight())
+                    .clearBlocks()
+                    .addBlocks(block)
+                    .build();
+            byte[] stateBytes = stateForHash.toByteArray();
+            System.out.println("hash." + block.getHeight() + ".serializedBytes=" + stateBytes.length);
+            System.out.println("hash." + block.getHeight() + ".stateBytesSha256=" +
+                    HashMapIntrospection.toHex(HashMapIntrospection.sha256(stateBytes)));
+        }
+    }
+
+    private static void printConstants() {
+        System.out.println("hashMap.defaultInitialCapacity=" + HashMapIntrospection.DEFAULT_INITIAL_CAPACITY);
+        System.out.println("hashMap.defaultLoadFactor=" + HashMapIntrospection.DEFAULT_LOAD_FACTOR);
+        System.out.println("hashMap.defaultResizeThreshold=" + HashMapIntrospection.DEFAULT_RESIZE_THRESHOLD);
+        System.out.println("hashMap.firstDefaultResizeInsertion=" + HashMapIntrospection.FIRST_DEFAULT_RESIZE_INSERTION);
+        System.out.println("hashMap.treeifyThreshold=" + HashMapIntrospection.TREEIFY_THRESHOLD);
+        System.out.println("hashMap.untreeifyThreshold=" + HashMapIntrospection.UNTREEIFY_THRESHOLD);
+        System.out.println("hashMap.minTreeifyCapacity=" + HashMapIntrospection.MIN_TREEIFY_CAPACITY);
+    }
+
+    private static protobuf.DaoState readDaoState(Path daoStateStore) throws IOException {
+        try (FileInputStream in = new FileInputStream(daoStateStore.toFile())) {
+            PersistableEnvelope envelope = PersistableEnvelope.parseDelimitedFrom(in);
+            if (envelope == null || !envelope.hasDaoStateStore()) {
+                throw new IllegalArgumentException("File is not a DaoStateStore PersistableEnvelope: " + daoStateStore);
+            }
+            return envelope.getDaoStateStore().getDaoState();
+        }
+    }
+
+    private static List<protobuf.BaseBlock> readBlocks(Path blocksDir, int fromHeight, int toHeight) throws IOException {
+        List<Path> bucketFiles = findBucketFiles(blocksDir, fromHeight, toHeight);
+        List<protobuf.BaseBlock> blocks = new ArrayList<>();
+        for (Path bucketFile : bucketFiles) {
+            try (FileInputStream in = new FileInputStream(bucketFile.toFile())) {
+                PersistableEnvelope envelope = PersistableEnvelope.parseDelimitedFrom(in);
+                if (envelope == null || !envelope.hasBsqBlockStore()) {
+                    throw new IllegalArgumentException("File is not a BsqBlockStore PersistableEnvelope: " + bucketFile);
+                }
+                envelope.getBsqBlockStore().getBlocksList().stream()
+                        .filter(block -> block.getHeight() >= fromHeight && block.getHeight() <= toHeight)
+                        .forEach(blocks::add);
+            }
+        }
+        Collections.sort(blocks, Comparator.comparingInt(protobuf.BaseBlock::getHeight));
+        return blocks;
+    }
+
+    private static List<Path> findBucketFiles(Path blocksDir, int fromHeight, int toHeight) throws IOException {
+        int fromBucket = fromHeight / BSQ_BLOCK_BUCKET_SIZE + 1;
+        int toBucket = toHeight / BSQ_BLOCK_BUCKET_SIZE + 1;
+        List<Path> bucketFiles = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(blocksDir)) {
+            for (Path path : stream) {
+                Matcher matcher = BLOCK_BUCKET_FILE.matcher(path.getFileName().toString());
+                if (!matcher.matches()) {
+                    continue;
+                }
+                int first = Integer.parseInt(matcher.group(1));
+                int bucket = first / BSQ_BLOCK_BUCKET_SIZE + 1;
+                if (bucket >= fromBucket && bucket <= toBucket) {
+                    bucketFiles.add(path);
+                }
+            }
+        }
+        Collections.sort(bucketFiles);
+        return bucketFiles;
+    }
+
+    private static protobuf.DaoState buildStateExcludingBlocks(protobuf.DaoState source,
+                                                               Map<String, BaseTxOutput> unspentTxOutputMap,
+                                                               Map<String, protobuf.SpentInfo> spentInfoMap,
+                                                               Map<String, protobuf.Issuance> issuanceMap) {
+        return protobuf.DaoState.newBuilder()
+                .setChainHeight(source.getChainHeight())
+                .addAllCycles(source.getCyclesList())
+                .putAllUnspentTxOutputMap(unspentTxOutputMap)
+                .putAllSpentInfoMap(spentInfoMap)
+                .addAllConfiscatedLockupTxList(source.getConfiscatedLockupTxListList())
+                .putAllIssuanceMap(issuanceMap)
+                .addAllParamChangeList(source.getParamChangeListList())
+                .addAllEvaluatedProposalList(source.getEvaluatedProposalListList())
+                .addAllDecryptedBallotsWithMeritsList(source.getDecryptedBallotsWithMeritsListList())
+                .build();
+    }
+
+    private static <V> HashMap<String, V> collectLikeDaoBuilder(Map<String, V> source) {
+        TreeMap<String, V> sortedLikeDaoStateTreeMap = new TreeMap<>(source);
+        Map<String, V> map = sortedLikeDaoStateTreeMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return requireHashMap(map);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <V> HashMap<String, V> requireHashMap(Map<String, V> map) {
+        if (!(map instanceof HashMap)) {
+            throw new IllegalStateException("Collectors.toMap produced " + map.getClass().getName() +
+                    ", not java.util.HashMap");
+        }
+        return (HashMap<String, V>) map;
+    }
+
+    private static void printMapStats(String name, HashMap<String, ?> map, int sampleKeys) {
+        HashMapIntrospection.Stats stats = HashMapIntrospection.inspect(map);
+        System.out.println("map." + name + ".size=" + stats.size);
+        System.out.println("map." + name + ".tableLength=" + stats.tableLength);
+        System.out.println("map." + name + ".threshold=" + stats.threshold);
+        System.out.println("map." + name + ".loadFactor=" + stats.loadFactor);
+        System.out.println("map." + name + ".nonEmptyBins=" + stats.nonEmptyBins);
+        System.out.println("map." + name + ".maxBinLength=" + stats.maxBinLength);
+        System.out.println("map." + name + ".treeBins=" + stats.treeBins);
+        System.out.println("map." + name + ".iterationSha256=" + HashMapIntrospection.keyIterationFingerprint(map));
+        if (sampleKeys > 0) {
+            System.out.println("map." + name + ".firstKeys=" + HashMapIntrospection.keySample(map, sampleKeys));
+        }
+    }
+
+    private static void printUsage() {
+        System.out.println("Usage: DaoHashJdkComparisonTool [options]");
+        System.out.println();
+        System.out.println("Options:");
+        System.out.println("  --dao-state-store <file>   DaoStateStore file. Default: p2p/src/main/resources/DaoStateStore_BTC_MAINNET");
+        System.out.println("  --blocks-dir <dir>         BsqBlocks directory. Default: p2p/src/main/resources/BsqBlocks_BTC_MAINNET");
+        System.out.println("  --from-height <height>     First block height to use as the last block in diagnostic serialization.");
+        System.out.println("  --to-height <height>       Last block height. Default: same as --from-height, or snapshot chain height.");
+        System.out.println("  --sample-keys <count>      Number of first HashMap iteration keys to print. Default: 3");
+        System.out.println("  --comparable-only          Omit runtime and absolute path lines for JDK-to-JDK diffing.");
+        System.out.println("  --help                     Show this text.");
+    }
+
+    private static final class Options {
+        Path daoStateStore = Paths.get("p2p/src/main/resources/DaoStateStore_BTC_MAINNET");
+        Path blocksDir = Paths.get("p2p/src/main/resources/BsqBlocks_BTC_MAINNET");
+        Integer fromHeight;
+        Integer toHeight;
+        int sampleKeys = 3;
+        boolean comparableOnly;
+        boolean help;
+
+        static Options parse(String[] args) {
+            Options options = new Options();
+            for (int i = 0; i < args.length; i++) {
+                String arg = args[i];
+                if ("--dao-state-store".equals(arg)) {
+                    options.daoStateStore = Paths.get(nextValue(args, ++i, arg));
+                } else if ("--blocks-dir".equals(arg)) {
+                    options.blocksDir = Paths.get(nextValue(args, ++i, arg));
+                } else if ("--from-height".equals(arg)) {
+                    options.fromHeight = Integer.parseInt(nextValue(args, ++i, arg));
+                } else if ("--to-height".equals(arg)) {
+                    options.toHeight = Integer.parseInt(nextValue(args, ++i, arg));
+                } else if ("--sample-keys".equals(arg)) {
+                    options.sampleKeys = Integer.parseInt(nextValue(args, ++i, arg));
+                } else if ("--comparable-only".equals(arg)) {
+                    options.comparableOnly = true;
+                } else if ("--help".equals(arg) || "-h".equals(arg)) {
+                    options.help = true;
+                } else {
+                    throw new IllegalArgumentException("Unknown option: " + arg);
+                }
+            }
+
+            if (options.fromHeight == null && options.toHeight != null) {
+                options.fromHeight = options.toHeight;
+            }
+            if (options.fromHeight != null && options.toHeight == null) {
+                options.toHeight = options.fromHeight;
+            }
+            return options;
+        }
+
+        private static String nextValue(String[] args, int index, String option) {
+            if (index >= args.length) {
+                throw new IllegalArgumentException(option + " requires a value");
+            }
+            return args[index];
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/dao/tools/HashMapIntrospection.java
+++ b/core/src/test/java/bisq/core/dao/tools/HashMapIntrospection.java
@@ -1,0 +1,183 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.tools;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+final class HashMapIntrospection {
+    static final int DEFAULT_INITIAL_CAPACITY = 16;
+    static final float DEFAULT_LOAD_FACTOR = 0.75f;
+    static final int DEFAULT_RESIZE_THRESHOLD = 12;
+    static final int FIRST_DEFAULT_RESIZE_INSERTION = 13;
+    static final int TREEIFY_THRESHOLD = 8;
+    static final int UNTREEIFY_THRESHOLD = 6;
+    static final int MIN_TREEIFY_CAPACITY = 64;
+
+    private HashMapIntrospection() {
+    }
+
+    static Stats inspect(HashMap<?, ?> map) {
+        try {
+            Object[] table = getTable(map);
+            Stats stats = new Stats();
+            stats.size = map.size();
+            stats.tableLength = table == null ? 0 : table.length;
+            stats.threshold = getIntField(HashMap.class, map, "threshold");
+            stats.loadFactor = getFloatField(HashMap.class, map, "loadFactor");
+
+            if (table != null) {
+                for (Object bin : table) {
+                    if (bin == null) {
+                        continue;
+                    }
+
+                    stats.nonEmptyBins++;
+                    if (isTreeNode(bin)) {
+                        stats.treeBins++;
+                    }
+
+                    int binLength = 0;
+                    Object node = bin;
+                    while (node != null) {
+                        binLength++;
+                        Field nextField = findField(node.getClass(), "next");
+                        node = nextField.get(node);
+                    }
+                    stats.maxBinLength = Math.max(stats.maxBinLength, binLength);
+                }
+            }
+            return stats;
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            throw new IllegalStateException("Cannot inspect java.util.HashMap internals. Run the tool with " +
+                    "'--add-opens java.base/java.util=ALL-UNNAMED'.", e);
+        }
+    }
+
+    static String keyIterationFingerprint(Map<String, ?> map) {
+        MessageDigest digest = sha256();
+        for (String key : map.keySet()) {
+            byte[] bytes = key.getBytes(StandardCharsets.UTF_8);
+            digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+            digest.update(bytes);
+        }
+        return toHex(digest.digest());
+    }
+
+    static String keySample(Map<String, ?> map, int sampleKeys) {
+        List<String> keys = new ArrayList<>();
+        int count = 0;
+        for (String key : map.keySet()) {
+            keys.add(key);
+            count++;
+            if (count >= sampleKeys) {
+                break;
+            }
+        }
+        return keys.toString();
+    }
+
+    static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(Character.forDigit((b >>> 4) & 0x0f, 16));
+            sb.append(Character.forDigit(b & 0x0f, 16));
+        }
+        return sb.toString();
+    }
+
+    static byte[] fromHex(String hex) {
+        if ((hex.length() & 1) != 0) {
+            throw new IllegalArgumentException("Hex string must have an even number of characters");
+        }
+
+        byte[] bytes = new byte[hex.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int high = Character.digit(hex.charAt(i * 2), 16);
+            int low = Character.digit(hex.charAt(i * 2 + 1), 16);
+            if (high < 0 || low < 0) {
+                throw new IllegalArgumentException("Invalid hex character in: " + hex);
+            }
+            bytes[i] = (byte) ((high << 4) + low);
+        }
+        return bytes;
+    }
+
+    static byte[] sha256(byte[] bytes) {
+        MessageDigest digest = sha256();
+        return digest.digest(bytes);
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Object[] getTable(HashMap<?, ?> map) throws ReflectiveOperationException {
+        Field tableField = findField(HashMap.class, "table");
+        return (Object[]) tableField.get(map);
+    }
+
+    private static int getIntField(Class<?> type, Object instance, String name) throws ReflectiveOperationException {
+        Field field = findField(type, name);
+        return field.getInt(instance);
+    }
+
+    private static float getFloatField(Class<?> type, Object instance, String name) throws ReflectiveOperationException {
+        Field field = findField(type, name);
+        return field.getFloat(instance);
+    }
+
+    private static Field findField(Class<?> type, String name) throws ReflectiveOperationException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                Field field = current.getDeclaredField(name);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+
+    private static boolean isTreeNode(Object node) {
+        return node.getClass().getName().equals("java.util.HashMap$TreeNode");
+    }
+
+    static final class Stats {
+        int size;
+        int tableLength;
+        int threshold;
+        float loadFactor;
+        int nonEmptyBins;
+        int maxBinLength;
+        int treeBins;
+    }
+}

--- a/core/src/test/java/bisq/core/dao/tools/HashMapOrderPathProbe.java
+++ b/core/src/test/java/bisq/core/dao/tools/HashMapOrderPathProbe.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.tools;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class HashMapOrderPathProbe {
+    private static final String[] KEYS = {
+            "31zf35rkuu6yf",
+            "1dbjp2a6kyqox",
+            "3b4553177plvg",
+            "bnvj3t0lpa79",
+            "3hr4261uk5i8i",
+            "2r912h4yyjucd",
+            "3m5w96199x87i",
+            "2uent5s0widco",
+            "gx5ryb218zq7",
+            "1ctcw65e5psnx",
+            "2hx74lb7768rt",
+            "2wzuozo92awxl"
+    };
+
+    public static void main(String[] args) {
+        boolean comparableOnly = args.length == 1 && "--comparable-only".equals(args[0]);
+        if (!comparableOnly) {
+            System.out.println("runtime.java.version=" + System.getProperty("java.version"));
+            System.out.println("runtime.java.home=" + System.getProperty("java.home"));
+        }
+
+        printConstants();
+
+        LinkedHashMap<String, Integer> source = new LinkedHashMap<>();
+        for (int i = 0; i < KEYS.length; i++) {
+            source.put(KEYS[i], i);
+        }
+
+        HashMap<String, Integer> viaConstructor = new HashMap<>(source);
+        HashMap<String, Integer> viaPutAll = new HashMap<>();
+        viaPutAll.putAll(source);
+        Map<String, Integer> collectorMap = source.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        if (!(collectorMap instanceof HashMap)) {
+            throw new IllegalStateException("Collectors.toMap produced " + collectorMap.getClass().getName());
+        }
+        @SuppressWarnings("unchecked")
+        HashMap<String, Integer> viaCollector = (HashMap<String, Integer>) collectorMap;
+
+        System.out.println("source.size=" + source.size());
+        print("constructor", viaConstructor);
+        print("putAll", viaPutAll);
+        print("collector", viaCollector);
+    }
+
+    private static void printConstants() {
+        System.out.println("hashMap.defaultInitialCapacity=" + HashMapIntrospection.DEFAULT_INITIAL_CAPACITY);
+        System.out.println("hashMap.defaultLoadFactor=" + HashMapIntrospection.DEFAULT_LOAD_FACTOR);
+        System.out.println("hashMap.defaultResizeThreshold=" + HashMapIntrospection.DEFAULT_RESIZE_THRESHOLD);
+        System.out.println("hashMap.firstDefaultResizeInsertion=" + HashMapIntrospection.FIRST_DEFAULT_RESIZE_INSERTION);
+        System.out.println("hashMap.treeifyThreshold=" + HashMapIntrospection.TREEIFY_THRESHOLD);
+        System.out.println("hashMap.untreeifyThreshold=" + HashMapIntrospection.UNTREEIFY_THRESHOLD);
+        System.out.println("hashMap.minTreeifyCapacity=" + HashMapIntrospection.MIN_TREEIFY_CAPACITY);
+    }
+
+    private static void print(String label, HashMap<String, Integer> map) {
+        HashMapIntrospection.Stats stats = HashMapIntrospection.inspect(map);
+        System.out.println(label + ".size=" + stats.size);
+        System.out.println(label + ".tableLength=" + stats.tableLength);
+        System.out.println(label + ".threshold=" + stats.threshold);
+        System.out.println(label + ".maxBinLength=" + stats.maxBinLength);
+        System.out.println(label + ".treeBins=" + stats.treeBins);
+        System.out.println(label + ".iterationSha256=" + HashMapIntrospection.keyIterationFingerprint(map));
+        System.out.println(label + ".keys=" + map.keySet());
+    }
+}

--- a/core/src/test/java/bisq/core/dao/tools/README.md
+++ b/core/src/test/java/bisq/core/dao/tools/README.md
@@ -1,0 +1,141 @@
+# DAO Hash JDK Comparison Tools
+
+These tools compare the DAO-state protobuf serialization path under two JDKs.
+They are diagnostic tools, not production code.
+
+## Files
+
+- `DaoHashJdkComparisonTool.java` loads a `DaoStateStore` and BSQ block bucket files, rebuilds the hash-relevant protobuf bytes, prints byte hashes, and prints the intermediate `HashMap` layout used by `getBsqStateBuilderExcludingBlocks()`. It deliberately uses only protobuf classes and JDK APIs so the script can compile it as Java 11 bytecode and run the same classes under both JDKs.
+- `HashMapOrderPathProbe.java` demonstrates the JDK 11 -> 21 `HashMap` path difference: `HashMap(Map)` / `putAll` can differ, while the collector path used by the DAO should remain stable.
+- `HashMapIntrospection.java` contains the reflection code that reads `HashMap.table`, `threshold`, `loadFactor`, bucket chain lengths, and tree-bin counts.
+- `compare-dao-hash-jdks.sh` runs the tools under Java 11 and Java 21 and fails if the comparable DAO output differs.
+
+## Run
+
+Set both JDK homes:
+
+```bash
+export JAVA11_HOME=/path/to/jdk-11
+export JAVA21_HOME=/path/to/jdk-21
+```
+
+Run the default mainnet resource snapshot:
+
+```bash
+core/src/test/java/bisq/core/dao/tools/compare-dao-hash-jdks.sh
+```
+
+Run a specific block height:
+
+```bash
+core/src/test/java/bisq/core/dao/tools/compare-dao-hash-jdks.sh \
+  --from-height 949481 \
+  --to-height 949481
+```
+
+Run a range of block heights:
+
+```bash
+core/src/test/java/bisq/core/dao/tools/compare-dao-hash-jdks.sh \
+  --from-height 949001 \
+  --to-height 949481
+```
+
+Use custom files:
+
+```bash
+core/src/test/java/bisq/core/dao/tools/compare-dao-hash-jdks.sh \
+  --dao-state-store /path/to/DaoStateStore_BTC_MAINNET \
+  --blocks-dir /path/to/BsqBlocks_BTC_MAINNET \
+  --from-height 949481
+```
+
+The script writes full outputs and diffs below `temp/dao-hash-jdk-compare-*`.
+Exit code `0` means the comparable DAO outputs matched. Exit code `2` means
+Java 11 and Java 21 produced different comparable DAO output.
+
+The `hash.<height>.stateBytesSha256` lines are SHA-256 fingerprints of the
+serialized bytes used for JDK-to-JDK byte identity checks. They are not the DAO
+network hash-chain link, which is `RIPEMD160(SHA256(previousHash || stateBytes))`.
+
+The script compiles the tool classes and generated protobuf sources into a
+temporary Java-11-compatible class directory under the output directory. This is
+necessary because the normal project test classes may be Java 21 bytecode and
+cannot be loaded by a Java 11 runtime.
+
+## What the Height Range Means
+
+The tool loads one DAO state snapshot from `DaoStateStore`, sorts map entries by
+string key to mirror the DAO `TreeMap` order, collects them through
+`Collectors.toMap(...)`, and then serializes that same snapshot with each
+selected block as the single `blocks` entry. This matches the map-order behavior
+and output shape of `DaoState.getSerializedStateForHashChain()` without loading
+the Java-21-compiled production classes into the Java 11 runtime.
+
+For the default resource files this is the correct current snapshot check at the
+snapshot chain height. A wider range is useful for detecting JDK-dependent map
+ordering while varying the last-block bytes, but it is not a historical DAO
+replay. To validate historical state at multiple heights, provide snapshots for
+those heights or replay the parser separately.
+
+## HashMap Internals Reported
+
+`treeBins` and `maxBinLength` are read reflectively from `java.util.HashMap`:
+
+```java
+Field tableField = HashMap.class.getDeclaredField("table");
+Object[] table = (Object[]) tableField.get(map);
+```
+
+For each non-null bucket, the tool walks the private `next` field on each node.
+It counts the bucket length, tracks the maximum as `maxBinLength`, and counts a
+bucket as a tree bin when the first node class is `java.util.HashMap$TreeNode`.
+
+Because these are JDK internals, the Java command must include:
+
+```bash
+--add-opens java.base/java.util=ALL-UNNAMED
+```
+
+The script adds this automatically.
+
+## What Would Cause Different Order
+
+The serialized DAO bytes can differ if the intermediate `HashMap` iteration
+order differs. Concrete causes are:
+
+- different table length/capacity, because bucket index is `(tableLength - 1) & hash`;
+- changed `HashMap.hash(Object)` spreading;
+- changed `putVal` or `resize` behavior;
+- different source encounter order for keys that collide into the same bucket;
+- tree-bin behavior for heavily collided buckets;
+- using `new HashMap<>(source)`, `putAll(source)`, or `clone()` instead of the current collector path, because those call `putMapEntries(...)`;
+- protobuf changing away from insertion-order-preserving map storage, or enabling deterministic serialization on only some nodes.
+
+The important JDK 11 -> 21 difference is the bulk `putMapEntries(...)` sizing
+path. `Collectors.toMap(...)` uses `new HashMap<>()` and per-entry insertion,
+so it avoids that changed path.
+
+## Default Bucket Size and Rearrangement Thresholds
+
+For `new HashMap<>()`:
+
+- default table length after the first insertion: `16` buckets;
+- default load factor: `0.75`;
+- resize threshold at table length `16`: `12` entries;
+- the 13th insertion resizes/rearranges the table to `32` buckets;
+- later thresholds are `24`, `48`, `96`, and so on as capacity doubles.
+
+For treeification:
+
+- `TREEIFY_THRESHOLD = 8`;
+- `MIN_TREEIFY_CAPACITY = 64`;
+- when a bucket gets too deep before table length reaches `64`, `HashMap`
+  resizes instead of treeifying;
+- at table length `64` or greater, adding another entry to a bucket that has
+  reached the treeification threshold can convert that bucket to a tree bin.
+
+For the bulk constructor path, the JDK 11 -> 21 sizing fix is enough to change
+order. With a 12-entry source map, JDK 11 pre-sizes to `32` buckets while JDK 21
+pre-sizes to `16` buckets. That changes bucket scan order even though the key
+set is identical.

--- a/core/src/test/java/bisq/core/dao/tools/compare-dao-hash-jdks.sh
+++ b/core/src/test/java/bisq/core/dao/tools/compare-dao-hash-jdks.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR"
+while [[ ! -x "$ROOT_DIR/gradlew" && "$ROOT_DIR" != "/" ]]; do
+  ROOT_DIR="$(dirname "$ROOT_DIR")"
+done
+
+if [[ ! -x "$ROOT_DIR/gradlew" ]]; then
+  echo "Cannot find project root with gradlew" >&2
+  exit 1
+fi
+
+JAVA11_HOME="${JAVA11_HOME:-${JDK11_HOME:-}}"
+JAVA21_HOME="${JAVA21_HOME:-${JDK21_HOME:-}}"
+
+if [[ -z "$JAVA11_HOME" || ! -x "$JAVA11_HOME/bin/java" ]]; then
+  echo "Set JAVA11_HOME or JDK11_HOME to a Java 11 installation" >&2
+  exit 1
+fi
+
+if [[ -z "$JAVA21_HOME" || ! -x "$JAVA21_HOME/bin/java" ]]; then
+  echo "Set JAVA21_HOME or JDK21_HOME to a Java 21 installation" >&2
+  exit 1
+fi
+
+OUT_DIR="${DAO_HASH_COMPARE_OUT_DIR:-$ROOT_DIR/temp/dao-hash-jdk-compare-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$OUT_DIR"
+
+cd "$ROOT_DIR"
+
+"$ROOT_DIR/gradlew" -q :proto:generateProto >/dev/null
+CLASSPATH="$("$ROOT_DIR/gradlew" -q :core:daoHashToolClasspath)"
+TOOL_CLASSES="$OUT_DIR/classes"
+TOOL_SOURCES="$OUT_DIR/sources.txt"
+mkdir -p "$TOOL_CLASSES"
+
+find "$ROOT_DIR/proto/build/generated/sources/proto/main/java/protobuf" -name '*.java' > "$TOOL_SOURCES"
+find "$ROOT_DIR/core/src/test/java/bisq/core/dao/tools" -name '*.java' >> "$TOOL_SOURCES"
+
+"$JAVA11_HOME/bin/javac" --release 11 -cp "$CLASSPATH" -d "$TOOL_CLASSES" @"$TOOL_SOURCES"
+
+JAVA_ARGS=(--add-opens java.base/java.util=ALL-UNNAMED -cp "$TOOL_CLASSES:$CLASSPATH")
+TOOL_CLASS="bisq.core.dao.tools.DaoHashJdkComparisonTool"
+PROBE_CLASS="bisq.core.dao.tools.HashMapOrderPathProbe"
+
+"$JAVA11_HOME/bin/java" "${JAVA_ARGS[@]}" "$TOOL_CLASS" --comparable-only "$@" > "$OUT_DIR/dao-java11.comparable.txt"
+"$JAVA21_HOME/bin/java" "${JAVA_ARGS[@]}" "$TOOL_CLASS" --comparable-only "$@" > "$OUT_DIR/dao-java21.comparable.txt"
+
+"$JAVA11_HOME/bin/java" "${JAVA_ARGS[@]}" "$TOOL_CLASS" "$@" > "$OUT_DIR/dao-java11.full.txt"
+"$JAVA21_HOME/bin/java" "${JAVA_ARGS[@]}" "$TOOL_CLASS" "$@" > "$OUT_DIR/dao-java21.full.txt"
+
+"$JAVA11_HOME/bin/java" "${JAVA_ARGS[@]}" "$PROBE_CLASS" --comparable-only > "$OUT_DIR/hashmap-path-java11.comparable.txt"
+"$JAVA21_HOME/bin/java" "${JAVA_ARGS[@]}" "$PROBE_CLASS" --comparable-only > "$OUT_DIR/hashmap-path-java21.comparable.txt"
+
+grep '^collector\.' "$OUT_DIR/hashmap-path-java11.comparable.txt" > "$OUT_DIR/hashmap-path-java11.collector.txt"
+grep '^collector\.' "$OUT_DIR/hashmap-path-java21.comparable.txt" > "$OUT_DIR/hashmap-path-java21.collector.txt"
+
+DAO_DIFF="$OUT_DIR/dao-java11-vs-java21.diff"
+COLLECTOR_DIFF="$OUT_DIR/hashmap-collector-java11-vs-java21.diff"
+PATH_DIFF="$OUT_DIR/hashmap-path-java11-vs-java21.diff"
+
+set +e
+diff -u "$OUT_DIR/dao-java11.comparable.txt" "$OUT_DIR/dao-java21.comparable.txt" > "$DAO_DIFF"
+DAO_STATUS=$?
+diff -u "$OUT_DIR/hashmap-path-java11.collector.txt" "$OUT_DIR/hashmap-path-java21.collector.txt" > "$COLLECTOR_DIFF"
+COLLECTOR_STATUS=$?
+diff -u "$OUT_DIR/hashmap-path-java11.comparable.txt" "$OUT_DIR/hashmap-path-java21.comparable.txt" > "$PATH_DIFF"
+PATH_STATUS=$?
+set -e
+
+echo "Output directory: $OUT_DIR"
+
+if [[ $PATH_STATUS -ne 0 ]]; then
+  echo "HashMap bulk-path probe differs across JDKs; this is expected for constructor/putAll and documented in $PATH_DIFF"
+else
+  echo "HashMap path probe did not differ across JDKs."
+fi
+
+if [[ $DAO_STATUS -ne 0 ]]; then
+  echo "DAO comparable output differs across Java 11 and Java 21. See $DAO_DIFF" >&2
+  exit 2
+fi
+
+if [[ $COLLECTOR_STATUS -ne 0 ]]; then
+  echo "Collectors.toMap HashMap path differs across Java 11 and Java 21. See $COLLECTOR_DIFF" >&2
+  exit 2
+fi
+
+echo "DAO comparable output matches across Java 11 and Java 21."
+echo "Collectors.toMap HashMap path matches across Java 11 and Java 21."


### PR DESCRIPTION
Add diagnostic tools under core/src/test/java/bisq/core/dao/tools for comparing DAO state serialization under Java 11 and Java 21. The main tool reads DaoStateStore and BsqBlocks resources, rebuilds the hash-relevant protobuf bytes for a configurable block height or range, and reports serialized-byte fingerprints plus intermediate HashMap layout details.

Add HashMap introspection helpers and a path probe to expose table length, threshold, load factor, max bucket length, and tree-bin counts. The probe demonstrates that HashMap(Map) and putAll can diverge across JDKs while the Collectors.toMap path used by the DAO remains stable.

Add a compare-dao-hash-jdks.sh runner that accepts JAVA11_HOME and JAVA21_HOME, compiles the tool and generated protobuf sources as Java 11 bytecode, runs both JDKs with the required --add-opens flag, and fails if comparable DAO or collector output differs. Add README usage notes and a Gradle classpath helper for the script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added diagnostic tools to compare DAO state serialization across Java 11 and Java 21.
  * Included utilities to inspect internal map behavior and construction-path differences.
  * Added an automated verification script to run cross-JDK consistency checks.

* **Documentation**
  * Added a guide describing the diagnostic tools, expected outputs, and usage notes.

* **Chores**
  * Added a build task to emit the test runtime classpath for tooling and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->