### PR TITLE
Fix broken regtest libs paths

### DIFF
--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
@@ -83,13 +83,20 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
             pidFile.set(startSecondSeedNodeTask.flatMap { it.pidFile })
         }
 
+        val desktopAppLibsDir: Provider<File> = project.provider {
+            val desktopProject: Project = project.project("desktop")
+            val installDistTask: TaskProvider<Sync> = desktopProject.tasks.named("installDist", Sync::class.java)
+            val libsDir = File(installDistTask.get().destinationDir, "lib")
+            libsDir
+        }
+
         val startMediatorTask = project.tasks.register<StartBisqTask>("startRegtestMediator") {
             dependsOn(startFirstSeedNodeTask)
             dependsOn(startSecondSeedNodeTask)
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("desktop/build/app/lib"))
+            libsDir.set(desktopAppLibsDir.get())
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
             arguments.set(
@@ -110,7 +117,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("desktop/build/app/lib"))
+            libsDir.set(desktopAppLibsDir.get())
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
 
@@ -141,7 +148,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("desktop/build/app/lib"))
+            libsDir.set(desktopAppLibsDir.get())
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
             arguments.set(

--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
@@ -4,11 +4,14 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Sync
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.jvm.toolchain.JvmImplementation
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.kotlin.dsl.register
+import java.io.File
 import javax.inject.Inject
 
 class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaToolchainService) : Plugin<Project> {
@@ -32,12 +35,19 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
             pidFile.set(startBitcoindTask.flatMap { it.pidFile })
         }
 
+        val seedNodeLibsDir: Provider<File> = project.provider {
+            val seedNodeProject: Project = project.project("seednode")
+            val installDistTask: TaskProvider<Sync> = seedNodeProject.tasks.named("installDist", Sync::class.java)
+            val libsDir = File(installDistTask.get().destinationDir, "lib")
+            libsDir
+        }
+
         val startFirstSeedNodeTask = project.tasks.register<StartBisqTask>("startRegtestFirstSeednode") {
             dependsOn(startBitcoindTask)
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("seednode/build/app/lib"))
+            libsDir.set(seedNodeLibsDir.get())
 
             mainClass.set("bisq.seednode.SeedNodeMain")
             arguments.set(
@@ -58,7 +68,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("seednode/build/app/lib"))
+            libsDir.set(seedNodeLibsDir.get())
 
             mainClass.set("bisq.seednode.SeedNodeMain")
             arguments.set(


### PR DESCRIPTION
- [regtest: Fix broken desktop app libs path](https://github.com/bisq-network/bisq/commit/e0c9cd1ef67976317eca87613b7e1af5a6d1affe)
  - The desktop app's libs path changed from "desktop/build/app/lib" to "desktop/build/install/seednode/lib". Now, we compute it dynamically instead of hardcoding it.
- [regtest: Fix broken seednode libs path](https://github.com/bisq-network/bisq/commit/26b0ab27abb0549914260fc7e7fcb301e9151bcb)
  - The seednode's libs path changed from "seednode/build/app/lib" to "seednode/build/install/seednode/lib". Now, we compute it dynamically instead of hardcoding it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Regtest build now resolves library directories dynamically via Gradle providers instead of hardcoded paths. Regtest tasks share common providers for seednode and desktop app libraries, and now obtain their libs from those shared providers, simplifying how library locations are determined in the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->