### PR TITLE
regtest: Support custom bitcoind ports and re-org testing

### DIFF
--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
@@ -83,13 +83,20 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
             pidFile.set(startSecondSeedNodeTask.flatMap { it.pidFile })
         }
 
+        val desktopAppLibsDir: Provider<File> = project.provider {
+            val desktopProject: Project = project.project("desktop")
+            val installDistTask: TaskProvider<Sync> = desktopProject.tasks.named("installDist", Sync::class.java)
+            val libsDir = File(installDistTask.get().destinationDir, "lib")
+            libsDir
+        }
+
         val startMediatorTask = project.tasks.register<StartBisqTask>("startRegtestMediator") {
             dependsOn(startFirstSeedNodeTask)
             dependsOn(startSecondSeedNodeTask)
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("desktop/build/app/lib"))
+            libsDir.set(desktopAppLibsDir.get())
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
             arguments.set(
@@ -110,7 +117,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("desktop/build/app/lib"))
+            libsDir.set(desktopAppLibsDir.get())
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
 
@@ -141,7 +148,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("desktop/build/app/lib"))
+            libsDir.set(desktopAppLibsDir.get())
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
             arguments.set(

--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
@@ -4,11 +4,14 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Sync
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.jvm.toolchain.JvmImplementation
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.kotlin.dsl.register
+import java.io.File
 import javax.inject.Inject
 
 class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaToolchainService) : Plugin<Project> {
@@ -32,12 +35,19 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
             pidFile.set(startBitcoindTask.flatMap { it.pidFile })
         }
 
+        val seedNodeLibsDir: Provider<File> = project.provider {
+            val seedNodeProject: Project = project.project("seednode")
+            val installDistTask: TaskProvider<Sync> = seedNodeProject.tasks.named("installDist", Sync::class.java)
+            val libsDir = File(installDistTask.get().destinationDir, "lib")
+            libsDir
+        }
+
         val startFirstSeedNodeTask = project.tasks.register<StartBisqTask>("startRegtestFirstSeednode") {
             dependsOn(startBitcoindTask)
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("seednode/build/app/lib"))
+            libsDir.set(seedNodeLibsDir.get())
 
             mainClass.set("bisq.seednode.SeedNodeMain")
             arguments.set(
@@ -58,7 +68,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(project.layout.projectDirectory.dir("seednode/build/app/lib"))
+            libsDir.set(seedNodeLibsDir.get())
 
             mainClass.set("bisq.seednode.SeedNodeMain")
             arguments.set(

--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
@@ -14,6 +14,7 @@ import org.gradle.kotlin.dsl.register
 import java.io.File
 import javax.inject.Inject
 
+@Suppress("unused")
 class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaToolchainService) : Plugin<Project> {
 
     companion object {

--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
@@ -2,10 +2,12 @@ package bisq.gradle.regtest_plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Sync
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.jvm.toolchain.JvmImplementation
@@ -23,7 +25,33 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
     }
 
     override fun apply(project: Project) {
+        val initialDaoSetupTask = project.tasks.register<Copy>("initialDaoSetup") {
+            from(project.zipTree("docs/dao-setup.zip"))
+            into(project.layout.projectDirectory.dir(".localnet"))
+
+            exclude("dao-setup/Bitcoin-regtest/bitcoin.conf")
+
+            eachFile {
+                path = sourcePath.replace("dao-setup/Bitcoin-regtest", "bitcoind")
+                    .replace("dao-setup/bisq-BTC_REGTEST_Alice_dao", "alice")
+                    .replace("dao-setup/bisq-BTC_REGTEST_Bob_dao", "bob")
+            }
+
+            includeEmptyDirs = false
+            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+            doLast {
+                val blockNotifyFile = project.layout.projectDirectory
+                    .dir(".localnet")
+                    .dir("bitcoind")
+                    .file("blocknotify")
+                    .asFile
+                blockNotifyFile.appendText("echo exit 0")
+            }
+        }
+
         val startBitcoindTask = project.tasks.register<StartBitcoindTask>("startRegtestBitcoind") {
+            dependsOn(initialDaoSetupTask)
             pidFile.set(project.layout.projectDirectory.file(".localnet/bitcoind.pid"))
 
             dataDirectory.set(project.layout.projectDirectory.dir(".localnet/bitcoind"))
@@ -36,19 +64,14 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
             pidFile.set(startBitcoindTask.flatMap { it.pidFile })
         }
 
-        val seedNodeLibsDir: Provider<File> = project.provider {
-            val seedNodeProject: Project = project.project("seednode")
-            val installDistTask: TaskProvider<Sync> = seedNodeProject.tasks.named("installDist", Sync::class.java)
-            val libsDir = File(installDistTask.get().destinationDir, "lib")
-            libsDir
-        }
+        val seedNodeLibsDirProvider: Provider<Directory> = getBisqAppLibsDirProvider(project, "seednode")
 
         val startFirstSeedNodeTask = project.tasks.register<StartBisqTask>("startRegtestFirstSeednode") {
             dependsOn(startBitcoindTask)
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(seedNodeLibsDir.get())
+            libsDir.set(seedNodeLibsDirProvider)
 
             mainClass.set("bisq.seednode.SeedNodeMain")
             arguments.set(
@@ -69,7 +92,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(seedNodeLibsDir.get())
+            libsDir.set(seedNodeLibsDirProvider)
 
             mainClass.set("bisq.seednode.SeedNodeMain")
             arguments.set(
@@ -84,12 +107,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
             pidFile.set(startSecondSeedNodeTask.flatMap { it.pidFile })
         }
 
-        val desktopAppLibsDir: Provider<File> = project.provider {
-            val desktopProject: Project = project.project("desktop")
-            val installDistTask: TaskProvider<Sync> = desktopProject.tasks.named("installDist", Sync::class.java)
-            val libsDir = File(installDistTask.get().destinationDir, "lib")
-            libsDir
-        }
+        val desktopAppLibsDirProvider: Provider<Directory> = getBisqAppLibsDirProvider(project, "desktop")
 
         val startMediatorTask = project.tasks.register<StartBisqTask>("startRegtestMediator") {
             dependsOn(startFirstSeedNodeTask)
@@ -97,7 +115,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(desktopAppLibsDir.get())
+            libsDir.set(desktopAppLibsDirProvider)
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
             arguments.set(
@@ -118,7 +136,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(desktopAppLibsDir.get())
+            libsDir.set(desktopAppLibsDirProvider)
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
 
@@ -149,7 +167,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())
-            libsDir.set(desktopAppLibsDir.get())
+            libsDir.set(desktopAppLibsDirProvider)
 
             mainClass.set("bisq.desktop.app.BisqAppMain")
             arguments.set(
@@ -172,6 +190,17 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
             pidFile.set(startBobTask.flatMap { it.pidFile })
         }
     }
+
+    private fun getBisqAppLibsDirProvider(project: Project, moduleName: String): Provider<Directory> =
+        project.provider {
+            project.project(moduleName)
+        }.flatMap { seedNodeProject ->
+            seedNodeProject.tasks.named("installDist", Sync::class.java)
+        }.flatMap { installDistTask ->
+            project.layout.dir(project.provider {
+                File(installDistTask.destinationDir, "lib")
+            })
+        }
 
     private fun getJavaExecutable(): Provider<RegularFile> =
         javaToolchainService.launcherFor {

--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/StartBitcoindTask.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/StartBitcoindTask.kt
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
@@ -11,11 +12,23 @@ import org.gradle.api.tasks.TaskAction
 
 abstract class StartBitcoindTask : DefaultTask() {
 
-    @get:Internal
-    abstract val pidFile: RegularFileProperty
-
     @get:InputDirectory
     abstract val dataDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val port: Property<Int>
+
+    @get:Input
+    abstract val onionPort: Property<Int>
+
+    @get:Input
+    abstract val otherNodes: SetProperty<String>
+
+    @get:Input
+    abstract val rpcAllowIp: Property<String>
+
+    @get:Input
+    abstract val rpcBindPort: Property<Int>
 
     @get:Input
     abstract val rpcUser: Property<String>
@@ -26,24 +39,46 @@ abstract class StartBitcoindTask : DefaultTask() {
     @get:Input
     abstract val blockNotifyArg: Property<String>
 
+    @get:Internal
+    abstract val pidFile: RegularFileProperty
+
+    init {
+        port.convention(18444)
+        onionPort.convention(18445)
+        rpcAllowIp.convention("")
+        rpcBindPort.convention(18443)
+    }
+
     @TaskAction
     fun run() {
-        val processBuilder = ProcessBuilder(
-                "bitcoind",
-                "-datadir=${dataDirectory.asFile.get().absolutePath}",
-                "-regtest",
+        val command = mutableListOf(
+            "bitcoind",
+            "-datadir=${dataDirectory.asFile.get().absolutePath}",
+            "-regtest",
 
-                "-prune=0",
-                "-txindex=1",
-                "-peerbloomfilters=1",
-                "-server",
+            "-port=${port.get()}",
+            "-bind=127.0.0.1:${onionPort.get()}=onion",
 
-                "-rpcuser=${rpcUser.get()}",
-                "-rpcpassword=${rpcPassword.get()}",
+            "-prune=0",
+            "-txindex=1",
+            "-peerbloomfilters=1",
+            "-server",
 
-                "-blocknotify= ${blockNotifyArg.get()}"
+            "-rpcbind=127.0.0.1:${rpcBindPort.get()}",
+            "-rpcuser=${rpcUser.get()}",
+            "-rpcpassword=${rpcPassword.get()}",
+
+            "-blocknotify=${blockNotifyArg.get()}"
         )
 
+        otherNodes.get().forEach { node -> command.add("-addnode=$node") }
+
+        val allowIp = rpcAllowIp.get()
+        if (allowIp.isNotEmpty()) {
+            command.add("-rpcallowip=$allowIp")
+        }
+
+        val processBuilder = ProcessBuilder(command)
         processBuilder.redirectErrorStream(true)
         processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD)
 
@@ -51,7 +86,7 @@ abstract class StartBitcoindTask : DefaultTask() {
         val pid = process.pid()
 
         pidFile.asFile
-                .get()
-                .writeText(pid.toString())
+            .get()
+            .writeText(pid.toString())
     }
 }


### PR DESCRIPTION
Add support for:
- Custom p2p and rpc ports
- Connect to other bitcoin nodes for local re-org testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated local DAO setup extraction into the local test network, normalizing embedded paths and startup behavior.
  * Added configurable Bitcoin daemon networking (ports, RPC bind/allow, onion bind) and support for additional peer connections.
  * Switched runtime library resolution to dynamic providers for seednode and application components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->