### PR TITLE
regtest-startRegtestAlice: Add dependency to startMediatorTask

### DIFF
--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest_plugin/RegtestPlugin.kt
@@ -160,6 +160,7 @@ class RegtestPlugin @Inject constructor(private val javaToolchainService: JavaTo
         val startAliceTask = project.tasks.register<StartBisqTask>("startRegtestAlice") {
             dependsOn(startFirstSeedNodeTask)
             dependsOn(startSecondSeedNodeTask)
+            dependsOn(startMediatorTask)
 
             workingDirectory.set(project.layout.projectDirectory)
             javaExecutable.set(getJavaExecutable())


### PR DESCRIPTION
Alice can't trade without any arbitrators or mediators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced regtest environment to support dual bitcoind instances alongside seednodes and application nodes for more comprehensive testing scenarios.
  * Restructured local network startup and shutdown task management for improved configuration and lifecycle control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->