### PR TITLE
packaging: use root packaging directory for build outputs

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -41,7 +41,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
             val packageResourcesDirFile = File(project.projectDir, "package")
             packageResourcesDir.set(packageResourcesDirFile)
 
-            outputDirectory.set(project.layout.buildDirectory.dir("packaging/jpackage/packages"))
+            outputDirectory.set(project.layout.buildDirectory.dir("packaging"))
         }
     }
 


### PR DESCRIPTION
The nested packaging/jpackage/packages directory structure is unnecessary. Flattening the output path to the root packaging directory simplifies the project structure and makes build artifact retrieval easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted build configuration for installer generation: the output location used during packaging has been changed, affecting where generated installers are placed in the build artifacts. No functional changes to installer contents or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->