### PR TITLE
packaging: pass --temp argument to jpackage

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
@@ -50,18 +50,19 @@ abstract class JPackageTask : DefaultTask() {
         deleteExistingInstallerArtifacts(outputDirectoryFile)
 
         val jPackageConfig = JPackageConfig(
-                inputDirPath = distDirFile.get().toPath().resolve("lib"),
-                outputDirPath = outputDirectoryFile.toPath(),
-                temporaryDirPath = temporaryDir.toPath(),
+            inputDirPath = distDirFile.get().toPath().resolve("lib"),
+            outputDirPath = outputDirectoryFile.toPath(),
+            jPackageTempDirPath = outputDirectoryFile.toPath().resolve("jpackage_temp"),
+            temporaryDirPath = temporaryDir.toPath(),
 
-                appConfig = JPackageAppConfig(
-                        appVersion = appVersion.get(),
-                        mainJarFileName = mainJarFile.asFile.get().name,
-                        mainClassName = mainClassName.get(),
-                        jvmArgs = jvmArgs.get()
-                ),
+            appConfig = JPackageAppConfig(
+                appVersion = appVersion.get(),
+                mainJarFileName = mainJarFile.asFile.get().name,
+                mainClassName = mainClassName.get(),
+                jvmArgs = jvmArgs.get()
+            ),
 
-                packageFormatConfigs = getPackageFormatConfigs()
+            packageFormatConfigs = getPackageFormatConfigs()
         )
 
         val packageFactory = PackageFactory(jPackagePath, jPackageConfig)

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/JPackageConfig.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/JPackageConfig.kt
@@ -6,6 +6,7 @@ import java.nio.file.Path
 data class JPackageConfig(
         val inputDirPath: Path,
         val outputDirPath: Path,
+        val jPackageTempDirPath: Path,
         val temporaryDirPath: Path,
         val appConfig: JPackageAppConfig,
         val packageFormatConfigs: JPackagePackageFormatConfigs

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
@@ -40,6 +40,15 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
             allCommands.addAll(jPackageCommonArgs)
             allCommands.addAll(customCommands)
 
+            // jpackage fails if temp directory is not empty
+            val jPackageTempDir = jPackageConfig.jPackageTempDirPath.toFile()
+            if (jPackageTempDir.exists()) {
+                val isSuccess = jPackageTempDir.deleteRecursively()
+                if (!isSuccess) {
+                    throw GradleException("Couldn't delete jpackage temp directory: ${jPackageTempDir.absolutePath}")
+                }
+            }
+
             val process: Process = processBuilder.start()
             val finished = process.waitFor(15, TimeUnit.MINUTES)
             if (!finished) {
@@ -65,22 +74,23 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
     }
 
     private fun createCommonArguments(appConfig: JPackageAppConfig): List<String> =
-            mutableListOf(
-                    "--dest", jPackageConfig.outputDirPath.toAbsolutePath().toString(),
+        mutableListOf(
+            "--temp", jPackageConfig.jPackageTempDirPath.toAbsolutePath().toString(),
+            "--dest", jPackageConfig.outputDirPath.toAbsolutePath().toString(),
 
-                    "--name", "Bisq",
-                    "--description", "A decentralized bitcoin exchange network.",
-                    "--copyright", "Copyright © 2013-${Year.now()} - The Bisq developers",
-                    "--vendor", "Bisq",
+            "--name", "Bisq",
+            "--description", "A decentralized bitcoin exchange network.",
+            "--copyright", "Copyright © 2013-${Year.now()} - The Bisq developers",
+            "--vendor", "Bisq",
 
-                    "--app-version", appConfig.appVersion,
+            "--app-version", appConfig.appVersion,
 
-                    "--input", jPackageConfig.inputDirPath.toAbsolutePath().toString(),
-                    "--main-jar", appConfig.mainJarFileName,
+            "--input", jPackageConfig.inputDirPath.toAbsolutePath().toString(),
+            "--main-jar", appConfig.mainJarFileName,
 
-                    "--main-class", appConfig.mainClassName,
-                    "--java-options", appConfig.jvmArgs.joinToString(separator = " "),
-            )
+            "--main-class", appConfig.mainClassName,
+            "--java-options", appConfig.jvmArgs.joinToString(separator = " "),
+        )
 
     private fun configureReproducibleRpmEnvironment(processBuilder: ProcessBuilder, packageFormat: PackageFormat) {
         if (packageFormat != PackageFormat.RPM) {


### PR DESCRIPTION
The build fails without the --temp argument on Fedora 43+. Providing an explicit temporary directory ensures the packaging process completes successfully on newer Fedora systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the packaging temporary directory is cleared before packaging to avoid failures when leftovers remain.

* **Refactor**
  * Simplified packaging output location and introduced a dedicated jpackage temp directory for more reliable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->