### PR TITLE
build: remove obsolete macOS JDK overrides and runtime image setup

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
@@ -40,9 +40,6 @@ abstract class JPackageTask : DefaultTask() {
     @get:InputDirectory
     abstract val packageResourcesDir: DirectoryProperty
 
-    @get:InputDirectory
-    abstract val runtimeImageDirectory: DirectoryProperty
-
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
 
@@ -55,7 +52,6 @@ abstract class JPackageTask : DefaultTask() {
         val jPackageConfig = JPackageConfig(
                 inputDirPath = distDirFile.get().toPath().resolve("lib"),
                 outputDirPath = outputDirectoryFile.toPath(),
-                runtimeImageDirPath = runtimeImageDirectory.asFile.get().toPath(),
                 temporaryDirPath = temporaryDir.toPath(),
 
                 appConfig = JPackageAppConfig(

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -10,10 +10,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
-import org.gradle.jvm.toolchain.JvmImplementation
-import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.register
 import java.io.File
@@ -42,7 +39,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
         project.tasks.register<JPackageTask>("generateInstallers") {
             dependsOn(generateHashesTask)
 
-            jdkDirectory.set(getJPackageJdkDirectory())
+            jdkDirectory.set(getProjectJdkDirectory(project))
 
             distDirFile.set(installDistTask.map { it.destinationDir })
             mainJarFile.set(jarTask.flatMap { it.archiveFile })
@@ -54,11 +51,6 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
 
             val packageResourcesDirFile = File(project.projectDir, "package")
             packageResourcesDir.set(packageResourcesDirFile)
-
-            runtimeImageDirectory.set(
-                if (getOS() == OS.MAC_OS) getJPackageJdkDirectory()
-                else getProjectJdkDirectory(project)
-            )
 
             outputDirectory.set(project.layout.buildDirectory.dir("packaging/jpackage/packages"))
         }
@@ -81,14 +73,5 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
         val toolchain = javaExtension.toolchain
         val projectLauncherProvider = javaToolchainService.launcherFor(toolchain)
         return projectLauncherProvider.map { it.metadata.installationPath }
-    }
-
-    private fun getJPackageJdkDirectory(): Provider<Directory> {
-        val launcherProvider = javaToolchainService.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(21))
-            vendor.set(JvmVendorSpec.AZUL)
-            implementation.set(JvmImplementation.VENDOR_SPECIFIC)
-        }
-        return launcherProvider.map { it.metadata.installationPath }
     }
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/JPackageConfig.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/JPackageConfig.kt
@@ -6,7 +6,6 @@ import java.nio.file.Path
 data class JPackageConfig(
         val inputDirPath: Path,
         val outputDirPath: Path,
-        val runtimeImageDirPath: Path,
         val temporaryDirPath: Path,
         val appConfig: JPackageAppConfig,
         val packageFormatConfigs: JPackagePackageFormatConfigs

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
@@ -80,8 +80,6 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
 
                     "--main-class", appConfig.mainClassName,
                     "--java-options", appConfig.jvmArgs.joinToString(separator = " "),
-
-                    "--runtime-image", jPackageConfig.runtimeImageDirPath.toAbsolutePath().toString()
             )
 
     private fun configureReproducibleRpmEnvironment(processBuilder: ProcessBuilder, packageFormat: PackageFormat) {


### PR DESCRIPTION
Simplify the packaging configuration by removing legacy workarounds that are no longer required now that the project has upgraded to JDK 21.

1. Remove JDK 16 override for macOS: The previous JavaFX version was incompatible with JDK 11 on macOS and caused system crashes, triggering a workaround that forced JDK 16 on macOS while other operating systems used the default project JDK. This override is no longer necessary.

2. Remove custom JDK 11 runtime image creation: We previously used JDK 17's jpackage to build a runtime image for JDK 11 because JDK 11 lacked built-in jpackage support. Since the project is now on JDK 21, this custom pipeline is obsolete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Packaging workflow updated to use the project's configured Java toolchain for building installers, improving consistency across environments.
  * Installer output handling streamlined: installer artifacts are now produced to a designated output directory and stale artifacts are cleaned before packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->