### PR TITLE
Handle empty or single entry extra data maps

### DIFF
--- a/core/src/main/java/bisq/core/alert/Alert.java
+++ b/core/src/main/java/bisq/core/alert/Alert.java
@@ -64,11 +64,6 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
     @Nullable
     private PublicKey ownerPubKey;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    private Map<String, String> extraDataMap;
 
     public Alert(String message,
                  boolean isUpdateInfo,
@@ -91,15 +86,13 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
                  boolean isPreReleaseInfo,
                  String version,
                  byte[] ownerPubKeyBytes,
-                 String signatureAsBase64,
-                 Map<String, String> extraDataMap) {
+                 String signatureAsBase64) {
         this.message = message;
         this.isUpdateInfo = isUpdateInfo;
         this.isPreReleaseInfo = isPreReleaseInfo;
         this.version = version;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
         this.signatureAsBase64 = signatureAsBase64;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
 
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyBytes);
     }
@@ -131,9 +124,7 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
                 proto.getIsPreReleaseInfo(),
                 proto.getVersion(),
                 proto.getOwnerPubKeyBytes().toByteArray(),
-                proto.getSignatureAsBase64(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getSignatureAsBase64());
     }
 
 
@@ -181,5 +172,4 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
     public String showAgainKey() {
         return "Update_" + version;
     }
-
 }

--- a/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
+++ b/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
@@ -126,7 +126,6 @@ class CoreDisputeAgentsService {
                 ecKey.getPubKey(),
                 signature,
                 null,
-                null,
                 null
         );
         mediatorManager.addDisputeAgent(mediator, () -> {
@@ -146,7 +145,6 @@ class CoreDisputeAgentsService {
                 new Date().getTime(),
                 ecKey.getPubKey(),
                 signature,
-                null,
                 null,
                 null
         );

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
@@ -60,21 +60,16 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
     // an unused field.
     private final long date;
 
-    // This hash map allows addition of data in future versions without breaking consensus
-    private final Map<String, String> extraDataMap;
-
     public BlindVote(byte[] encryptedVotes,
                      String txId,
                      long stake,
                      byte[] encryptedMeritList,
-                     long date,
-                     Map<String, String> extraDataMap) {
+                     long date) {
         this.encryptedVotes = encryptedVotes;
         this.txId = txId;
         this.stake = stake;
         this.encryptedMeritList = encryptedMeritList;
         this.date = date;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
     }
 
 
@@ -96,7 +91,6 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 .setStake(stake)
                 .setEncryptedMeritList(ByteString.copyFrom(encryptedMeritList))
                 .setDate(date);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return builder;
     }
 
@@ -105,9 +99,7 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 proto.getTxId(),
                 proto.getStake(),
                 proto.getEncryptedMeritList().toByteArray(),
-                proto.getDate(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getDate());
     }
 
 
@@ -122,7 +114,6 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 ",\n     stake=" + stake +
                 ",\n     encryptedMeritList=" + Utilities.bytesAsHexString(encryptedMeritList) +
                 ",\n     date=" + date +
-                ",\n     extraDataMap=" + extraDataMap +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
@@ -73,8 +73,6 @@ public class BlindVoteValidator {
                     "getEncryptedMeritList must not be empty");
             checkArgument(blindVote.getEncryptedMeritList().length <= 100000,
                     "getEncryptedMeritList must not exceed 100kb");
-
-            ExtraDataMapValidator.validate(blindVote.getExtraDataMap());
         } catch (Throwable e) {
             log.warn(e.toString());
             throw new ProposalValidationException(e);

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
@@ -214,8 +214,7 @@ public class MyBlindVoteListService implements PersistedDataHost, DaoStateListen
                     blindVoteTxId,
                     stake.value,
                     encryptedMeritList,
-                    new Date().getTime(),
-                    new HashMap<>());
+                    new Date().getTime());
             addBlindVoteToList(blindVote);
 
             addToP2PNetwork(blindVote, errorMessage -> {

--- a/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
@@ -39,9 +39,8 @@ import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -79,9 +78,9 @@ public class CompensationProposalFactory extends BaseProposalFactory<Compensatio
 
     @Override
     protected CompensationProposal createProposalWithoutTxId() {
-        Map<String, String> extraDataMap = null;
+        TreeMap<String, String> extraDataMap = null;
         if (burningManReceiverAddress.isPresent()) {
-            extraDataMap = new HashMap<>();
+            extraDataMap = new TreeMap<>();
             extraDataMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, burningManReceiverAddress.get());
         }
         return new CompensationProposal(

--- a/core/src/main/java/bisq/core/dao/governance/proposal/confiscatebond/ConfiscateBondProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/confiscatebond/ConfiscateBondProposalFactory.java
@@ -71,7 +71,6 @@ public class ConfiscateBondProposalFactory extends BaseProposalFactory<Confiscat
         return new ConfiscateBondProposal(
                 name,
                 link,
-                lockupTxId,
-                new HashMap<>());
+                lockupTxId);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/generic/GenericProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/generic/GenericProposalFactory.java
@@ -64,6 +64,6 @@ public class GenericProposalFactory extends BaseProposalFactory<GenericProposal>
 
     @Override
     protected GenericProposal createProposalWithoutTxId() {
-        return new GenericProposal(name, link, new HashMap<>());
+        return new GenericProposal(name, link);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamProposalFactory.java
@@ -76,7 +76,6 @@ public class ChangeParamProposalFactory extends BaseProposalFactory<ChangeParamP
                 name,
                 link,
                 param,
-                paramValue,
-                new HashMap<>());
+                paramValue);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
@@ -79,8 +79,7 @@ public class ReimbursementProposalFactory extends BaseProposalFactory<Reimbursem
                 name,
                 link,
                 requestedBsq,
-                bsqAddress,
-                new HashMap<>());
+                bsqAddress);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/governance/proposal/removeAsset/RemoveAssetProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/removeAsset/RemoveAssetProposalFactory.java
@@ -73,7 +73,6 @@ public class RemoveAssetProposalFactory extends BaseProposalFactory<RemoveAssetP
         return new RemoveAssetProposal(
                 name,
                 link,
-                asset.getTickerSymbol(),
-                new HashMap<>());
+                asset.getTickerSymbol());
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/role/RoleProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/role/RoleProposalFactory.java
@@ -67,6 +67,6 @@ public class RoleProposalFactory extends BaseProposalFactory<RoleProposal> {
 
     @Override
     protected RoleProposal createProposalWithoutTxId() {
-        return new RoleProposal(role, new HashMap<>());
+        return new RoleProposal(role);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
@@ -110,12 +110,6 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
         return ownerPubKey;
     }
 
-    @Nullable
-    @Override
-    public Map<String, String> getExtraDataMap() {
-        return null;
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // ExpirablePayload

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
@@ -63,18 +63,12 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     protected final Proposal proposal;
     protected final byte[] ownerPubKeyEncoded;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    protected final Map<String, String> extraDataMap;
-
     // Used just for caching. Don't persist.
     private final transient PublicKey ownerPubKey;
 
     public TempProposalPayload(Proposal proposal,
                                PublicKey ownerPublicKey) {
-        this(proposal, Sig.getPublicKeyBytes(ownerPublicKey), null);
+        this(proposal, Sig.getPublicKeyBytes(ownerPublicKey));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -82,11 +76,9 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private TempProposalPayload(Proposal proposal,
-                                byte[] ownerPubPubKeyEncoded,
-                                @Nullable Map<String, String> extraDataMap) {
+                                byte[] ownerPubPubKeyEncoded) {
         this.proposal = proposal;
         this.ownerPubKeyEncoded = ownerPubPubKeyEncoded;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
 
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyEncoded);
     }
@@ -95,7 +87,6 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
         final protobuf.TempProposalPayload.Builder builder = protobuf.TempProposalPayload.newBuilder()
                 .setProposal(proposal.getProposalBuilder())
                 .setOwnerPubKeyEncoded(ByteString.copyFrom(ownerPubKeyEncoded));
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return builder;
     }
 
@@ -106,8 +97,7 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
 
     public static TempProposalPayload fromProto(protobuf.TempProposalPayload proto) {
         return new TempProposalPayload(Proposal.fromProto(proto.getProposal()),
-                proto.getOwnerPubKeyEncoded().toByteArray(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                proto.getOwnerPubKeyEncoded().toByteArray());
     }
 
 
@@ -118,6 +108,12 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     @Override
     public PublicKey getOwnerPubKey() {
         return ownerPubKey;
+    }
+
+    @Nullable
+    @Override
+    public Map<String, String> getExtraDataMap() {
+        return null;
     }
 
 

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ChangeParamProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ChangeParamProposal.java
@@ -44,16 +44,14 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
     public ChangeParamProposal(String name,
                                String link,
                                Param param,
-                               String paramValue,
-                               Map<String, String> extraDataMap) {
+                               String paramValue) {
         this(name,
                 link,
                 param,
                 paramValue,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -67,14 +65,12 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                                 String paramValue,
                                 byte version,
                                 long creationDate,
-                                String txId,
-                                Map<String, String> extraDataMap) {
+                                String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
-                txId,
-                extraDataMap);
+                txId, null);
 
         this.param = param;
         this.paramValue = paramValue;
@@ -96,9 +92,7 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                 proposalProto.getParamValue(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -134,8 +128,7 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                 getParamValue(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
@@ -29,8 +29,8 @@ import bisq.common.util.CollectionUtils;
 import org.bitcoinj.core.Coin;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -54,7 +54,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                                 String link,
                                 Coin requestedBsq,
                                 String bsqAddress,
-                                @Nullable Map<String, String> extraDataMap) {
+                                @Nullable TreeMap<String, String> extraDataMap) {
         this(name,
                 link,
                 bsqAddress,
@@ -68,6 +68,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private CompensationProposal(String name,
@@ -77,7 +78,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                                  byte version,
                                  long creationDate,
                                  String txId,
-                                 @Nullable Map<String, String> extraDataMap) {
+                                 @Nullable TreeMap<String, String> extraDataMap) {
         super(name,
                 link,
                 version,
@@ -107,12 +108,13 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                 proto.getCreationDate(),
                 proto.getTxId(),
                 CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                        null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Getters
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
@@ -154,7 +156,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                 getVersion(),
                 getCreationDate(),
                 txId,
-                extraDataMap);
+                (TreeMap<String, String>) extraDataMap);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ConfiscateBondProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ConfiscateBondProposal.java
@@ -43,15 +43,13 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
 
     public ConfiscateBondProposal(String name,
                                   String link,
-                                  String lockupTxId,
-                                  Map<String, String> extraDataMap) {
+                                  String lockupTxId) {
         this(name,
                 link,
                 lockupTxId,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -64,14 +62,13 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                                    String lockupTxId,
                                    byte version,
                                    long creationDate,
-                                   String txId,
-                                   Map<String, String> extraDataMap) {
+                                   String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
         this.lockupTxId = lockupTxId;
     }
 
@@ -89,9 +86,7 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                 proposalProto.getLockupTxId(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -126,8 +121,7 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                 getLockupTxId(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/GenericProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/GenericProposal.java
@@ -41,14 +41,12 @@ import javax.annotation.concurrent.Immutable;
 public final class GenericProposal extends Proposal implements ImmutableDaoStateModel {
 
     public GenericProposal(String name,
-                           String link,
-                           Map<String, String> extraDataMap) {
+                           String link) {
         this(name,
                 link,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -60,14 +58,13 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                             String link,
                             byte version,
                             long creationDate,
-                            String txId,
-                            Map<String, String> extraDataMap) {
+                            String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
     }
 
     @Override
@@ -81,9 +78,7 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                 proto.getLink(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -117,8 +112,7 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                 getLink(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
@@ -31,6 +31,7 @@ import bisq.common.util.ExtraDataMapValidator;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -63,7 +64,7 @@ public abstract class Proposal implements PersistablePayload, NetworkPayload, Co
                        byte version,
                        long creationDate,
                        @Nullable String txId,
-                       @Nullable Map<String, String> extraDataMap) {
+                       @Nullable TreeMap<String, String> extraDataMap) {
         this.name = name;
         this.link = link;
         this.version = version;

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
@@ -48,16 +48,14 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
     public ReimbursementProposal(String name,
                                  String link,
                                  Coin requestedBsq,
-                                 String bsqAddress,
-                                 Map<String, String> extraDataMap) {
+                                 String bsqAddress) {
         this(name,
                 link,
                 bsqAddress,
                 requestedBsq.value,
                 Version.REIMBURSEMENT_REQUEST,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -71,14 +69,13 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                                   long requestedBsq,
                                   byte version,
                                   long creationDate,
-                                  String txId,
-                                  Map<String, String> extraDataMap) {
+                                  String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.requestedBsq = requestedBsq;
         this.bsqAddress = bsqAddress;
@@ -100,9 +97,7 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                 proposalProto.getRequestedBsq(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -143,8 +138,7 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                 getRequestedBsq().value,
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
@@ -43,15 +43,13 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
 
     public RemoveAssetProposal(String name,
                                String link,
-                               String tickerSymbol,
-                               Map<String, String> extraDataMap) {
+                               String tickerSymbol) {
         this(name,
                 link,
                 tickerSymbol,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -64,14 +62,13 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                                 String tickerSymbol,
                                 byte version,
                                 long creationDate,
-                                String txId,
-                                Map<String, String> extraDataMap) {
+                                String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.tickerSymbol = tickerSymbol;
     }
@@ -90,9 +87,7 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                 proposalProto.getTickerSymbol(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -127,8 +122,7 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                 getTickerSymbol(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/RoleProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RoleProposal.java
@@ -43,7 +43,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
     private final long requiredBondUnit;
     private final int unlockTime; // in blocks
 
-    public RoleProposal(Role role, Map<String, String> extraDataMap) {
+    public RoleProposal(Role role) {
         this(role.getName(),
                 role.getLink(),
                 role,
@@ -51,8 +51,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 role.getBondedRoleType().getUnlockTimeInBlocks(),
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -67,14 +66,13 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                          int unlockTime,
                          byte version,
                          long creationDate,
-                         String txId,
-                         Map<String, String> extraDataMap) {
+                         String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.role = role;
         this.requiredBondUnit = requiredBondUnit;
@@ -99,9 +97,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 proposalProto.getUnlockTime(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -138,8 +134,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 unlockTime,
                 version,
                 creationDate,
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -25,8 +25,6 @@ import bisq.common.ExcludeForHashAwareProto;
 import bisq.common.crypto.Sig;
 import bisq.common.proto.ProtoUtil;
 import bisq.common.proto.network.GetDataResponsePriority;
-import bisq.common.util.CollectionUtils;
-import bisq.common.util.ExtraDataMapValidator;
 import bisq.common.util.Hex;
 import bisq.common.util.Utilities;
 
@@ -91,12 +89,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
     private final long creationDate;
 
     private final List<String> bannedPrivilegedDevPubKeys;
-
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    private Map<String, String> extraDataMap;
 
     private transient PublicKey ownerPubKey;
 
@@ -163,7 +155,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getBtcFeeReceiverAddresses(),
                 filter.getOwnerPubKeyBytes(),
                 filter.getCreationDate(),
-                filter.getExtraDataMap(),
                 signatureAsBase64,
                 filter.getSignerPubKeyAsHex(),
                 filter.getBannedPrivilegedDevPubKeys(),
@@ -207,7 +198,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getBtcFeeReceiverAddresses(),
                 filter.getOwnerPubKeyBytes(),
                 filter.getCreationDate(),
-                filter.getExtraDataMap(),
                 null,
                 filter.getSignerPubKeyAsHex(),
                 filter.getBannedPrivilegedDevPubKeys(),
@@ -287,7 +277,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 Sig.getPublicKeyBytes(ownerPubKey),
                 System.currentTimeMillis(),
                 null,
-                null,
                 signerPubKeyAsHex,
                 bannedPrivilegedDevPubKeys,
                 disableAutoConf,
@@ -334,7 +323,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                   List<String> btcFeeReceiverAddresses,
                   byte[] ownerPubKeyBytes,
                   long creationDate,
-                  @Nullable Map<String, String> extraDataMap,
                   @Nullable String signatureAsBase64,
                   String signerPubKeyAsHex,
                   List<String> bannedPrivilegedDevPubKeys,
@@ -374,7 +362,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
         this.btcFeeReceiverAddresses = btcFeeReceiverAddresses;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
         this.creationDate = creationDate;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
         this.signatureAsBase64 = signatureAsBase64;
         this.signerPubKeyAsHex = signerPubKeyAsHex;
         this.bannedPrivilegedDevPubKeys = bannedPrivilegedDevPubKeys;
@@ -471,7 +458,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 .setDisableBsqSwap(disableBsqSwap);
 
         Optional.ofNullable(signatureAsBase64).ifPresent(builder::setSignatureAsBase64);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
 
         return builder;
     }
@@ -503,7 +489,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 ProtoUtil.protocolStringListToList(proto.getBtcFeeReceiverAddressesList()),
                 proto.getOwnerPubKeyBytes().toByteArray(),
                 proto.getCreationDate(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap(),
                 proto.getSignatureAsBase64(),
                 proto.getSignerPubKeyAsHex(),
                 ProtoUtil.protocolStringListToList(proto.getBannedPrivilegedDevPubKeysList()),
@@ -569,7 +554,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 ",\n     bannedAccountWitnessSignerPubKeys=" + bannedAccountWitnessSignerPubKeys +
                 ",\n     btcFeeReceiverAddresses=" + btcFeeReceiverAddresses +
                 ",\n     bannedPrivilegedDevPubKeys=" + bannedPrivilegedDevPubKeys +
-                ",\n     extraDataMap=" + extraDataMap +
                 ",\n     ownerPubKey=" + Hex.encode(ownerPubKeyBytes) +
                 ",\n     disableAutoConf=" + disableAutoConf +
                 ",\n     nodeAddressesBannedFromNetwork=" + nodeAddressesBannedFromNetwork +

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -93,12 +93,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         return pubKeyRing.getSignaturePubKey();
     }
 
-    @Nullable
-    @Override
-    public Map<String, String> getExtraDataMap() {
-        return null;
-    }
-
     @Override
     public String toString() {
         return "DisputeAgent{" +

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -55,12 +55,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
     @Nullable
     protected final String info;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    protected Map<String, String> extraDataMap;
-
     public DisputeAgent(NodeAddress nodeAddress,
                         PubKeyRing pubKeyRing,
                         List<String> languageCodes,
@@ -68,8 +62,7 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
                         byte[] registrationPubKey,
                         String registrationSignature,
                         @Nullable String emailAddress,
-                        @Nullable String info,
-                        @Nullable Map<String, String> extraDataMap) {
+                        @Nullable String info) {
         this.nodeAddress = nodeAddress;
         this.pubKeyRing = pubKeyRing;
         this.languageCodes = languageCodes;
@@ -78,7 +71,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         this.registrationSignature = registrationSignature;
         this.emailAddress = emailAddress;
         this.info = info;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
     }
 
 
@@ -101,6 +93,11 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         return pubKeyRing.getSignaturePubKey();
     }
 
+    @Nullable
+    @Override
+    public Map<String, String> getExtraDataMap() {
+        return null;
+    }
 
     @Override
     public String toString() {
@@ -113,7 +110,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
                 ",\n     registrationSignature='" + registrationSignature + '\'' +
                 ",\n     emailAddress='" + emailAddress + '\'' +
                 ",\n     info='" + info + '\'' +
-                ",\n     extraDataMap=" + extraDataMap +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
@@ -55,8 +55,7 @@ public final class Arbitrator extends DisputeAgent {
                       byte[] registrationPubKey,
                       String registrationSignature,
                       @Nullable String emailAddress,
-                      @Nullable String info,
-                      @Nullable Map<String, String> extraDataMap) {
+                      @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -65,8 +64,7 @@ public final class Arbitrator extends DisputeAgent {
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
 
         this.btcPubKey = btcPubKey;
         this.btcAddress = btcAddress;
@@ -89,7 +87,6 @@ public final class Arbitrator extends DisputeAgent {
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setArbitrator(builder).build();
     }
 
@@ -103,8 +100,7 @@ public final class Arbitrator extends DisputeAgent {
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
@@ -47,8 +47,7 @@ public final class Mediator extends DisputeAgent {
                     byte[] registrationPubKey,
                     String registrationSignature,
                     @Nullable String emailAddress,
-                    @Nullable String info,
-                    @Nullable Map<String, String> extraDataMap) {
+                    @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -57,8 +56,7 @@ public final class Mediator extends DisputeAgent {
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -76,7 +74,6 @@ public final class Mediator extends DisputeAgent {
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setMediator(builder).build();
     }
 
@@ -88,8 +85,7 @@ public final class Mediator extends DisputeAgent {
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
@@ -53,8 +53,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                        byte[] registrationPubKey,
                        String registrationSignature,
                        @Nullable String emailAddress,
-                       @Nullable String info,
-                       @Nullable Map<String, String> extraDataMap) {
+                       @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -63,8 +62,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -82,7 +80,6 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setRefundAgent(builder).build();
     }
 
@@ -94,8 +91,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -51,6 +51,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -75,7 +76,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
     public static TradeStatistics2 from(Trade trade,
                                         @Nullable String referralId,
                                         boolean isTorNetworkNode) {
-        Map<String, String> extraDataMap = new HashMap<>();
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
             extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
         }
@@ -144,7 +145,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
                             Coin tradeAmount,
                             Date tradeDate,
                             String depositTxId,
-                            Map<String, String> extraDataMap) {
+                            TreeMap<String, String> extraDataMap) {
         this(offerPayload.getDirection(),
                 offerPayload.getBaseCurrencyCode(),
                 offerPayload.getCounterCurrencyCode(),
@@ -182,7 +183,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
                             long tradeDate,
                             @Nullable String depositTxId,
                             @Nullable byte[] hash,
-                            @Nullable Map<String, String> extraDataMap) {
+                            @Nullable TreeMap<String, String> extraDataMap) {
         this.direction = direction;
         this.baseCurrency = baseCurrency;
         this.counterCurrency = counterCurrency;
@@ -256,7 +257,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
                 proto.getTradeDate(),
                 ProtoUtil.stringOrNullFromProto(proto.getDepositTxId()),
                 null,   // We want to clean up the hashes with the changed hash method in v.1.2.0 so we don't use the value from the proto
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -64,6 +64,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -93,7 +94,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     public static TradeStatistics3 from(Trade trade,
                                         @Nullable String referralId,
                                         boolean isTorNetworkNode) {
-        Map<String, String> extraDataMap = new HashMap<>();
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
             extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
         }
@@ -255,7 +256,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                             long date,
                             String mediator,
                             String refundAgent,
-                            @Nullable Map<String, String> extraDataMap) {
+                            @Nullable TreeMap<String, String> extraDataMap) {
         this(currency,
                 price,
                 amount,
@@ -299,7 +300,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                             long date,
                             @Nullable String mediator,
                             @Nullable String refundAgent,
-                            @Nullable Map<String, String> extraDataMap,
+                            @Nullable TreeMap<String, String> extraDataMap,
                             @Nullable byte[] hash) {
         this.currency = currency;
         this.price = price;
@@ -360,7 +361,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                 proto.getDate(),
                 ProtoUtil.stringOrNullFromProto(proto.getMediator()),
                 ProtoUtil.stringOrNullFromProto(proto.getRefundAgent()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap(),
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()),
                 proto.getHash().toByteArray());
     }
 

--- a/core/src/test/java/bisq/core/arbitration/ArbitratorManagerTest.java
+++ b/core/src/test/java/bisq/core/arbitration/ArbitratorManagerTest.java
@@ -58,11 +58,11 @@ public class ArbitratorManagerTest {
 
         Arbitrator one = new Arbitrator(new NodeAddress("arbitrator:1"), null, null, null,
                 languagesOne, 0L, null, "", null,
-                null, null);
+                null);
 
         Arbitrator two = new Arbitrator(new NodeAddress("arbitrator:2"), null, null, null,
                 languagesTwo, 0L, null, "", null,
-                null, null);
+                null);
 
         manager.addDisputeAgent(one, () -> {
         }, errorMessage -> {
@@ -94,11 +94,11 @@ public class ArbitratorManagerTest {
 
         Arbitrator one = new Arbitrator(new NodeAddress("arbitrator:1"), null, null, null,
                 languagesOne, 0L, null, "", null,
-                null, null);
+                null);
 
         Arbitrator two = new Arbitrator(new NodeAddress("arbitrator:2"), null, null, null,
                 languagesTwo, 0L, null, "", null,
-                null, null);
+                null);
 
         ArrayList<NodeAddress> nodeAddresses = new ArrayList<NodeAddress>() {{
             add(two.getNodeAddress());

--- a/core/src/test/java/bisq/core/arbitration/ArbitratorTest.java
+++ b/core/src/test/java/bisq/core/arbitration/ArbitratorTest.java
@@ -51,7 +51,7 @@ public class ArbitratorTest {
                 new Date().getTime(),
                 getBytes(100),
                 "registrationSignature",
-                null, null, null);
+                null, null);
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/test/java/bisq/core/arbitration/MediatorTest.java
+++ b/core/src/test/java/bisq/core/arbitration/MediatorTest.java
@@ -50,7 +50,6 @@ public class MediatorTest {
                 getBytes(100),
                 "registrationSignature",
                 "email",
-                "info",
-                null);
+                "info");
     }
 }

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -45,8 +45,8 @@ import javafx.collections.FXCollections;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -362,7 +362,8 @@ public class BurningManServiceTest {
                                                                                     long amount,
                                                                                     String receiverAddress) {
         var issuance = new Issuance(txId, chainHeight, amount, null, IssuanceType.COMPENSATION);
-        var extraDataMap = Map.of(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, receiverAddress);
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
+        extraDataMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, receiverAddress);
         var proposal = new CompensationProposal(name, "link", Coin.valueOf(amount), "bsqAddress", extraDataMap);
         return new Tuple2<>(issuance, new ProposalPayload(proposal.cloneProposalAndAddTxId(txId)));
     }

--- a/core/src/test/java/bisq/core/filter/TestFilter.java
+++ b/core/src/test/java/bisq/core/filter/TestFilter.java
@@ -90,7 +90,6 @@ public class TestFilter {
                 ownerPublicKey.getEncoded(),
                 creationDate,
                 null,
-                null,
                 signerPubKeyAsHex,
                 bannedDevKeys,
                 false,

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -26,6 +26,7 @@ import org.bitcoinj.core.Coin;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Disabled;
@@ -45,7 +46,7 @@ public class TradeStatistics3Test {
                 System.currentTimeMillis(),
                 null,
                 null,
-                (Map<String, String>) null);
+                (TreeMap<String, String>) null);
 
         assertTrue(tradeStatistics.isValid());
     }
@@ -59,7 +60,7 @@ public class TradeStatistics3Test {
                 System.currentTimeMillis(),
                 null,
                 null,
-                (Map<String, String>) null);
+                (TreeMap<String, String>) null);
 
         assertFalse(tradeStatistics.isValid());
     }

--- a/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
+++ b/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
@@ -238,7 +238,6 @@ class ValidationTestUtils {
                 new byte[]{1},
                 "registrationSignature",
                 null,
-                null,
                 null);
     }
 

--- a/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
+++ b/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
@@ -42,7 +42,7 @@ public class UserPayloadModelVOTest {
     public void testRoundtripFull() {
         UserPayload vo = new UserPayload();
         vo.setAccountId("accountId");
-        vo.setDisplayedAlert(new Alert("message", true, false, "version", new byte[]{12, -64, 12}, "string", null));
+        vo.setDisplayedAlert(new Alert("message", true, false, "version", new byte[]{12, -64, 12}, "string"));
         vo.setDevelopersFilter(new Filter(Lists.newArrayList(),
                 Lists.newArrayList(),
                 Lists.newArrayList(),
@@ -62,7 +62,6 @@ public class UserPayloadModelVOTest {
                 Lists.newArrayList(),
                 null,
                 0,
-                null,
                 null,
                 null,
                 null,

--- a/desktop/src/main/java/bisq/desktop/main/account/register/arbitrator/ArbitratorRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/arbitrator/ArbitratorRegistrationViewModel.java
@@ -59,7 +59,6 @@ public class ArbitratorRegistrationViewModel extends AgentRegistrationViewModel<
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/register/mediator/MediatorRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/mediator/MediatorRegistrationViewModel.java
@@ -55,7 +55,6 @@ class MediatorRegistrationViewModel extends AgentRegistrationViewModel<Mediator,
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/register/refundagent/RefundAgentRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/refundagent/RefundAgentRegistrationViewModel.java
@@ -56,7 +56,6 @@ public class RefundAgentRegistrationViewModel extends AgentRegistrationViewModel
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/test/java/bisq/desktop/main/settings/preferences/PreferencesViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/settings/preferences/PreferencesViewModelTest.java
@@ -59,10 +59,10 @@ public class PreferencesViewModelTest {
         }};
 
         RefundAgent one = new RefundAgent(new NodeAddress("refundAgent:1"), null, languagesOne, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         RefundAgent two = new RefundAgent(new NodeAddress("refundAgent:2"), null, languagesTwo, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         refundAgents.put(one.getNodeAddress(), one);
         refundAgents.put(two.getNodeAddress(), two);
@@ -94,10 +94,10 @@ public class PreferencesViewModelTest {
         }};
 
         Mediator one = new Mediator(new NodeAddress("refundAgent:1"), null, languagesOne, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         Mediator two = new Mediator(new NodeAddress("refundAgent:2"), null, languagesTwo, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         mnediators.put(one.getNodeAddress(), one);
         mnediators.put(two.getNodeAddress(), two);

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
@@ -28,9 +28,9 @@ import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import lombok.EqualsAndHashCode;
@@ -85,7 +85,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
 
         // We do not permit longer TTL as the default one
         if (ttl < TTL) {
-            extraDataMap = new HashMap<>();
+            extraDataMap = new TreeMap<>();
             extraDataMap.put(EXTRA_MAP_KEY_TTL, String.valueOf(ttl));
         }
     }
@@ -93,6 +93,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private MailboxStoragePayload(PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage,
@@ -123,12 +124,13 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
                 PrefixedSealedAndSignedMessage.fromPayloadProto(proto.getPrefixedSealedAndSignedMessage()),
                 proto.getSenderPubKeyForAddOperationBytes().toByteArray(),
                 proto.getOwnerPubKeyBytes().toByteArray(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStoragePayload.java
@@ -48,7 +48,9 @@ public interface ProtectedStoragePayload extends NetworkPayload {
     // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
     // field in a class would break that hash and therefore break the storage mechanism.
     @Nullable
-    Map<String, String> getExtraDataMap();
+    default Map<String, String> getExtraDataMap() {
+        return null;
+    }
 
     static ProtectedStoragePayload fromProto(protobuf.StoragePayload storagePayload, NetworkProtoResolver networkProtoResolver) {
         return (ProtectedStoragePayload) networkProtoResolver.fromProto(storagePayload);

--- a/p2p/src/test/java/bisq/network/p2p/storage/mocks/MockData.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/mocks/MockData.java
@@ -34,9 +34,6 @@ public class MockData implements ProtectedStoragePayload, ExpirablePayload {
     public final PublicKey publicKey;
     public long ttl;
 
-    @Nullable
-    private Map<String, String> extraDataMap;
-
     public MockData(String msg, PublicKey publicKey) {
         this.msg = msg;
         this.publicKey = publicKey;
@@ -63,12 +60,6 @@ public class MockData implements ProtectedStoragePayload, ExpirablePayload {
         return "MockData{" +
                 "msg='" + msg + '\'' +
                 '}';
-    }
-
-    @Nullable
-    @Override
-    public Map<String, String> getExtraDataMap() {
-        return extraDataMap;
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed extra metadata storage from alerts, governance proposals, filters, dispute agents, and blind votes. Extra data will no longer be preserved when these objects are persisted or transmitted.
  * Updated extra metadata handling in trade statistics and mailbox storage to use sorted collections for improved consistency.
  * Simplified constructor signatures across multiple domain models by removing optional metadata parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->