### PR TITLE
Handle extra data maps with multiple entries

### DIFF
--- a/core/src/main/java/bisq/core/alert/Alert.java
+++ b/core/src/main/java/bisq/core/alert/Alert.java
@@ -64,11 +64,6 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
     @Nullable
     private PublicKey ownerPubKey;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    private Map<String, String> extraDataMap;
 
     public Alert(String message,
                  boolean isUpdateInfo,
@@ -91,15 +86,13 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
                  boolean isPreReleaseInfo,
                  String version,
                  byte[] ownerPubKeyBytes,
-                 String signatureAsBase64,
-                 Map<String, String> extraDataMap) {
+                 String signatureAsBase64) {
         this.message = message;
         this.isUpdateInfo = isUpdateInfo;
         this.isPreReleaseInfo = isPreReleaseInfo;
         this.version = version;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
         this.signatureAsBase64 = signatureAsBase64;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
 
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyBytes);
     }
@@ -131,9 +124,7 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
                 proto.getIsPreReleaseInfo(),
                 proto.getVersion(),
                 proto.getOwnerPubKeyBytes().toByteArray(),
-                proto.getSignatureAsBase64(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getSignatureAsBase64());
     }
 
 
@@ -181,5 +172,4 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
     public String showAgainKey() {
         return "Update_" + version;
     }
-
 }

--- a/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
+++ b/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
@@ -126,7 +126,6 @@ class CoreDisputeAgentsService {
                 ecKey.getPubKey(),
                 signature,
                 null,
-                null,
                 null
         );
         mediatorManager.addDisputeAgent(mediator, () -> {
@@ -146,7 +145,6 @@ class CoreDisputeAgentsService {
                 new Date().getTime(),
                 ecKey.getPubKey(),
                 signature,
-                null,
                 null,
                 null
         );

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -552,7 +552,7 @@ class CoreOffersService {
                 offer.getAcceptedCountryCodes(),
                 offer.getBankId(),
                 offer.getAcceptedBankIds(),
-                offer.getExtraDataMap());
+                offer.getOfferPayloadExtraDataMap());
         log.info("Merging OfferPayload with {}", mutableOfferPayloadFields);
         return offerUtil.getMergedOfferPayload(openOffer, mutableOfferPayloadFields);
     }

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
@@ -60,21 +60,16 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
     // an unused field.
     private final long date;
 
-    // This hash map allows addition of data in future versions without breaking consensus
-    private final Map<String, String> extraDataMap;
-
     public BlindVote(byte[] encryptedVotes,
                      String txId,
                      long stake,
                      byte[] encryptedMeritList,
-                     long date,
-                     Map<String, String> extraDataMap) {
+                     long date) {
         this.encryptedVotes = encryptedVotes;
         this.txId = txId;
         this.stake = stake;
         this.encryptedMeritList = encryptedMeritList;
         this.date = date;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
     }
 
 
@@ -96,7 +91,6 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 .setStake(stake)
                 .setEncryptedMeritList(ByteString.copyFrom(encryptedMeritList))
                 .setDate(date);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return builder;
     }
 
@@ -105,9 +99,7 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 proto.getTxId(),
                 proto.getStake(),
                 proto.getEncryptedMeritList().toByteArray(),
-                proto.getDate(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getDate());
     }
 
 
@@ -122,7 +114,6 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 ",\n     stake=" + stake +
                 ",\n     encryptedMeritList=" + Utilities.bytesAsHexString(encryptedMeritList) +
                 ",\n     date=" + date +
-                ",\n     extraDataMap=" + extraDataMap +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
@@ -73,8 +73,6 @@ public class BlindVoteValidator {
                     "getEncryptedMeritList must not be empty");
             checkArgument(blindVote.getEncryptedMeritList().length <= 100000,
                     "getEncryptedMeritList must not exceed 100kb");
-
-            ExtraDataMapValidator.validate(blindVote.getExtraDataMap());
         } catch (Throwable e) {
             log.warn(e.toString());
             throw new ProposalValidationException(e);

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
@@ -214,8 +214,7 @@ public class MyBlindVoteListService implements PersistedDataHost, DaoStateListen
                     blindVoteTxId,
                     stake.value,
                     encryptedMeritList,
-                    new Date().getTime(),
-                    new HashMap<>());
+                    new Date().getTime());
             addBlindVoteToList(blindVote);
 
             addToP2PNetwork(blindVote, errorMessage -> {

--- a/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
@@ -39,9 +39,8 @@ import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -79,9 +78,9 @@ public class CompensationProposalFactory extends BaseProposalFactory<Compensatio
 
     @Override
     protected CompensationProposal createProposalWithoutTxId() {
-        Map<String, String> extraDataMap = null;
+        TreeMap<String, String> extraDataMap = null;
         if (burningManReceiverAddress.isPresent()) {
-            extraDataMap = new HashMap<>();
+            extraDataMap = new TreeMap<>();
             extraDataMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, burningManReceiverAddress.get());
         }
         return new CompensationProposal(

--- a/core/src/main/java/bisq/core/dao/governance/proposal/confiscatebond/ConfiscateBondProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/confiscatebond/ConfiscateBondProposalFactory.java
@@ -71,7 +71,6 @@ public class ConfiscateBondProposalFactory extends BaseProposalFactory<Confiscat
         return new ConfiscateBondProposal(
                 name,
                 link,
-                lockupTxId,
-                new HashMap<>());
+                lockupTxId);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/generic/GenericProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/generic/GenericProposalFactory.java
@@ -64,6 +64,6 @@ public class GenericProposalFactory extends BaseProposalFactory<GenericProposal>
 
     @Override
     protected GenericProposal createProposalWithoutTxId() {
-        return new GenericProposal(name, link, new HashMap<>());
+        return new GenericProposal(name, link);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamProposalFactory.java
@@ -76,7 +76,6 @@ public class ChangeParamProposalFactory extends BaseProposalFactory<ChangeParamP
                 name,
                 link,
                 param,
-                paramValue,
-                new HashMap<>());
+                paramValue);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
@@ -79,8 +79,7 @@ public class ReimbursementProposalFactory extends BaseProposalFactory<Reimbursem
                 name,
                 link,
                 requestedBsq,
-                bsqAddress,
-                new HashMap<>());
+                bsqAddress);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/governance/proposal/removeAsset/RemoveAssetProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/removeAsset/RemoveAssetProposalFactory.java
@@ -73,7 +73,6 @@ public class RemoveAssetProposalFactory extends BaseProposalFactory<RemoveAssetP
         return new RemoveAssetProposal(
                 name,
                 link,
-                asset.getTickerSymbol(),
-                new HashMap<>());
+                asset.getTickerSymbol());
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/role/RoleProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/role/RoleProposalFactory.java
@@ -67,6 +67,6 @@ public class RoleProposalFactory extends BaseProposalFactory<RoleProposal> {
 
     @Override
     protected RoleProposal createProposalWithoutTxId() {
-        return new RoleProposal(role, new HashMap<>());
+        return new RoleProposal(role);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
@@ -110,12 +110,6 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
         return ownerPubKey;
     }
 
-    @Nullable
-    @Override
-    public Map<String, String> getExtraDataMap() {
-        return null;
-    }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // ExpirablePayload

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
@@ -63,18 +63,12 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     protected final Proposal proposal;
     protected final byte[] ownerPubKeyEncoded;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    protected final Map<String, String> extraDataMap;
-
     // Used just for caching. Don't persist.
     private final transient PublicKey ownerPubKey;
 
     public TempProposalPayload(Proposal proposal,
                                PublicKey ownerPublicKey) {
-        this(proposal, Sig.getPublicKeyBytes(ownerPublicKey), null);
+        this(proposal, Sig.getPublicKeyBytes(ownerPublicKey));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -82,11 +76,9 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private TempProposalPayload(Proposal proposal,
-                                byte[] ownerPubPubKeyEncoded,
-                                @Nullable Map<String, String> extraDataMap) {
+                                byte[] ownerPubPubKeyEncoded) {
         this.proposal = proposal;
         this.ownerPubKeyEncoded = ownerPubPubKeyEncoded;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
 
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyEncoded);
     }
@@ -95,7 +87,6 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
         final protobuf.TempProposalPayload.Builder builder = protobuf.TempProposalPayload.newBuilder()
                 .setProposal(proposal.getProposalBuilder())
                 .setOwnerPubKeyEncoded(ByteString.copyFrom(ownerPubKeyEncoded));
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return builder;
     }
 
@@ -106,8 +97,7 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
 
     public static TempProposalPayload fromProto(protobuf.TempProposalPayload proto) {
         return new TempProposalPayload(Proposal.fromProto(proto.getProposal()),
-                proto.getOwnerPubKeyEncoded().toByteArray(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                proto.getOwnerPubKeyEncoded().toByteArray());
     }
 
 
@@ -118,6 +108,12 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     @Override
     public PublicKey getOwnerPubKey() {
         return ownerPubKey;
+    }
+
+    @Nullable
+    @Override
+    public Map<String, String> getExtraDataMap() {
+        return null;
     }
 
 

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ChangeParamProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ChangeParamProposal.java
@@ -44,16 +44,14 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
     public ChangeParamProposal(String name,
                                String link,
                                Param param,
-                               String paramValue,
-                               Map<String, String> extraDataMap) {
+                               String paramValue) {
         this(name,
                 link,
                 param,
                 paramValue,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -67,14 +65,12 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                                 String paramValue,
                                 byte version,
                                 long creationDate,
-                                String txId,
-                                Map<String, String> extraDataMap) {
+                                String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
-                txId,
-                extraDataMap);
+                txId, null);
 
         this.param = param;
         this.paramValue = paramValue;
@@ -96,9 +92,7 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                 proposalProto.getParamValue(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -134,8 +128,7 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                 getParamValue(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
@@ -29,8 +29,8 @@ import bisq.common.util.CollectionUtils;
 import org.bitcoinj.core.Coin;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -54,7 +54,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                                 String link,
                                 Coin requestedBsq,
                                 String bsqAddress,
-                                @Nullable Map<String, String> extraDataMap) {
+                                @Nullable TreeMap<String, String> extraDataMap) {
         this(name,
                 link,
                 bsqAddress,
@@ -68,6 +68,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private CompensationProposal(String name,
@@ -77,7 +78,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                                  byte version,
                                  long creationDate,
                                  String txId,
-                                 @Nullable Map<String, String> extraDataMap) {
+                                 @Nullable TreeMap<String, String> extraDataMap) {
         super(name,
                 link,
                 version,
@@ -107,12 +108,13 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                 proto.getCreationDate(),
                 proto.getTxId(),
                 CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                        null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Getters
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
@@ -154,7 +156,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                 getVersion(),
                 getCreationDate(),
                 txId,
-                extraDataMap);
+                (TreeMap<String, String>) extraDataMap);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ConfiscateBondProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ConfiscateBondProposal.java
@@ -43,15 +43,13 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
 
     public ConfiscateBondProposal(String name,
                                   String link,
-                                  String lockupTxId,
-                                  Map<String, String> extraDataMap) {
+                                  String lockupTxId) {
         this(name,
                 link,
                 lockupTxId,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -64,14 +62,13 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                                    String lockupTxId,
                                    byte version,
                                    long creationDate,
-                                   String txId,
-                                   Map<String, String> extraDataMap) {
+                                   String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
         this.lockupTxId = lockupTxId;
     }
 
@@ -89,9 +86,7 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                 proposalProto.getLockupTxId(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -126,8 +121,7 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                 getLockupTxId(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/GenericProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/GenericProposal.java
@@ -41,14 +41,12 @@ import javax.annotation.concurrent.Immutable;
 public final class GenericProposal extends Proposal implements ImmutableDaoStateModel {
 
     public GenericProposal(String name,
-                           String link,
-                           Map<String, String> extraDataMap) {
+                           String link) {
         this(name,
                 link,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -60,14 +58,13 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                             String link,
                             byte version,
                             long creationDate,
-                            String txId,
-                            Map<String, String> extraDataMap) {
+                            String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
     }
 
     @Override
@@ -81,9 +78,7 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                 proto.getLink(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -117,8 +112,7 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                 getLink(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
@@ -31,6 +31,7 @@ import bisq.common.util.ExtraDataMapValidator;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -63,7 +64,7 @@ public abstract class Proposal implements PersistablePayload, NetworkPayload, Co
                        byte version,
                        long creationDate,
                        @Nullable String txId,
-                       @Nullable Map<String, String> extraDataMap) {
+                       @Nullable TreeMap<String, String> extraDataMap) {
         this.name = name;
         this.link = link;
         this.version = version;

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
@@ -48,16 +48,14 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
     public ReimbursementProposal(String name,
                                  String link,
                                  Coin requestedBsq,
-                                 String bsqAddress,
-                                 Map<String, String> extraDataMap) {
+                                 String bsqAddress) {
         this(name,
                 link,
                 bsqAddress,
                 requestedBsq.value,
                 Version.REIMBURSEMENT_REQUEST,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -71,14 +69,13 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                                   long requestedBsq,
                                   byte version,
                                   long creationDate,
-                                  String txId,
-                                  Map<String, String> extraDataMap) {
+                                  String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.requestedBsq = requestedBsq;
         this.bsqAddress = bsqAddress;
@@ -100,9 +97,7 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                 proposalProto.getRequestedBsq(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -143,8 +138,7 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                 getRequestedBsq().value,
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
@@ -43,15 +43,13 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
 
     public RemoveAssetProposal(String name,
                                String link,
-                               String tickerSymbol,
-                               Map<String, String> extraDataMap) {
+                               String tickerSymbol) {
         this(name,
                 link,
                 tickerSymbol,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -64,14 +62,13 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                                 String tickerSymbol,
                                 byte version,
                                 long creationDate,
-                                String txId,
-                                Map<String, String> extraDataMap) {
+                                String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.tickerSymbol = tickerSymbol;
     }
@@ -90,9 +87,7 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                 proposalProto.getTickerSymbol(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -127,8 +122,7 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                 getTickerSymbol(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/RoleProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RoleProposal.java
@@ -43,7 +43,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
     private final long requiredBondUnit;
     private final int unlockTime; // in blocks
 
-    public RoleProposal(Role role, Map<String, String> extraDataMap) {
+    public RoleProposal(Role role) {
         this(role.getName(),
                 role.getLink(),
                 role,
@@ -51,8 +51,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 role.getBondedRoleType().getUnlockTimeInBlocks(),
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -67,14 +66,13 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                          int unlockTime,
                          byte version,
                          long creationDate,
-                         String txId,
-                         Map<String, String> extraDataMap) {
+                         String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.role = role;
         this.requiredBondUnit = requiredBondUnit;
@@ -99,9 +97,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 proposalProto.getUnlockTime(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -138,8 +134,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 unlockTime,
                 version,
                 creationDate,
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -25,8 +25,6 @@ import bisq.common.ExcludeForHashAwareProto;
 import bisq.common.crypto.Sig;
 import bisq.common.proto.ProtoUtil;
 import bisq.common.proto.network.GetDataResponsePriority;
-import bisq.common.util.CollectionUtils;
-import bisq.common.util.ExtraDataMapValidator;
 import bisq.common.util.Hex;
 import bisq.common.util.Utilities;
 
@@ -91,12 +89,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
     private final long creationDate;
 
     private final List<String> bannedPrivilegedDevPubKeys;
-
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    private Map<String, String> extraDataMap;
 
     private transient PublicKey ownerPubKey;
 
@@ -163,7 +155,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getBtcFeeReceiverAddresses(),
                 filter.getOwnerPubKeyBytes(),
                 filter.getCreationDate(),
-                filter.getExtraDataMap(),
                 signatureAsBase64,
                 filter.getSignerPubKeyAsHex(),
                 filter.getBannedPrivilegedDevPubKeys(),
@@ -207,7 +198,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getBtcFeeReceiverAddresses(),
                 filter.getOwnerPubKeyBytes(),
                 filter.getCreationDate(),
-                filter.getExtraDataMap(),
                 null,
                 filter.getSignerPubKeyAsHex(),
                 filter.getBannedPrivilegedDevPubKeys(),
@@ -287,7 +277,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 Sig.getPublicKeyBytes(ownerPubKey),
                 System.currentTimeMillis(),
                 null,
-                null,
                 signerPubKeyAsHex,
                 bannedPrivilegedDevPubKeys,
                 disableAutoConf,
@@ -334,7 +323,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                   List<String> btcFeeReceiverAddresses,
                   byte[] ownerPubKeyBytes,
                   long creationDate,
-                  @Nullable Map<String, String> extraDataMap,
                   @Nullable String signatureAsBase64,
                   String signerPubKeyAsHex,
                   List<String> bannedPrivilegedDevPubKeys,
@@ -374,7 +362,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
         this.btcFeeReceiverAddresses = btcFeeReceiverAddresses;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
         this.creationDate = creationDate;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
         this.signatureAsBase64 = signatureAsBase64;
         this.signerPubKeyAsHex = signerPubKeyAsHex;
         this.bannedPrivilegedDevPubKeys = bannedPrivilegedDevPubKeys;
@@ -471,7 +458,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 .setDisableBsqSwap(disableBsqSwap);
 
         Optional.ofNullable(signatureAsBase64).ifPresent(builder::setSignatureAsBase64);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
 
         return builder;
     }
@@ -503,7 +489,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 ProtoUtil.protocolStringListToList(proto.getBtcFeeReceiverAddressesList()),
                 proto.getOwnerPubKeyBytes().toByteArray(),
                 proto.getCreationDate(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap(),
                 proto.getSignatureAsBase64(),
                 proto.getSignerPubKeyAsHex(),
                 ProtoUtil.protocolStringListToList(proto.getBannedPrivilegedDevPubKeysList()),
@@ -569,7 +554,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 ",\n     bannedAccountWitnessSignerPubKeys=" + bannedAccountWitnessSignerPubKeys +
                 ",\n     btcFeeReceiverAddresses=" + btcFeeReceiverAddresses +
                 ",\n     bannedPrivilegedDevPubKeys=" + bannedPrivilegedDevPubKeys +
-                ",\n     extraDataMap=" + extraDataMap +
                 ",\n     ownerPubKey=" + Hex.encode(ownerPubKeyBytes) +
                 ",\n     disableAutoConf=" + disableAutoConf +
                 ",\n     nodeAddressesBannedFromNetwork=" + nodeAddressesBannedFromNetwork +

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -26,6 +26,8 @@ import bisq.core.offer.availability.OfferAvailabilityModel;
 import bisq.core.offer.availability.OfferAvailabilityProtocol;
 import bisq.core.offer.bisq_v1.MarketPriceNotAvailableException;
 import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys;
 import bisq.core.offer.bsq_swap.BsqSwapOfferPayload;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.price.MarketPrice;
@@ -57,7 +59,6 @@ import java.security.PublicKey;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.Getter;
@@ -66,6 +67,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Values.*;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -382,25 +385,25 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     public Optional<String> getAccountAgeWitnessHashAsHex() {
-        Map<String, String> extraDataMap = getExtraDataMap();
-        if (extraDataMap != null && extraDataMap.containsKey(OfferPayload.ACCOUNT_AGE_WITNESS_HASH))
-            return Optional.of(extraDataMap.get(OfferPayload.ACCOUNT_AGE_WITNESS_HASH));
+        OfferPayloadExtraDataMap extraDataMap = getOfferPayloadExtraDataMap();
+        if (extraDataMap != null && extraDataMap.containsKey(ACCOUNT_AGE_WITNESS_HASH))
+            return Optional.of(extraDataMap.get(ACCOUNT_AGE_WITNESS_HASH));
         else
             return Optional.empty();
     }
 
     public String getF2FCity() {
-        if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.F2F_CITY))
-            return getExtraDataMap().get(OfferPayload.F2F_CITY);
+        if (getOfferPayloadExtraDataMap() != null && getOfferPayloadExtraDataMap().containsKey(F2F_CITY))
+            return getOfferPayloadExtraDataMap().get(F2F_CITY);
         else
             return "";
     }
 
     public String getExtraInfo() {
-        if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.F2F_EXTRA_INFO))
-            return getExtraDataMap().get(OfferPayload.F2F_EXTRA_INFO);
-        else if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.CASH_BY_MAIL_EXTRA_INFO))
-            return getExtraDataMap().get(OfferPayload.CASH_BY_MAIL_EXTRA_INFO);
+        if (getOfferPayloadExtraDataMap() != null && getOfferPayloadExtraDataMap().containsKey(F2F_EXTRA_INFO))
+            return getOfferPayloadExtraDataMap().get(F2F_EXTRA_INFO);
+        else if (getOfferPayloadExtraDataMap() != null && getOfferPayloadExtraDataMap().containsKey(CASH_BY_MAIL_EXTRA_INFO))
+            return getOfferPayloadExtraDataMap().get(CASH_BY_MAIL_EXTRA_INFO);
         else
             return "";
     }
@@ -529,8 +532,8 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     @Nullable
-    public Map<String, String> getExtraDataMap() {
-        return offerPayloadBase.getExtraDataMap();
+    public OfferPayloadExtraDataMap getOfferPayloadExtraDataMap() {
+        return offerPayloadBase.getOfferPayloadExtraDataMap();
     }
 
     public boolean isUseAutoClose() {
@@ -549,11 +552,11 @@ public class Offer implements NetworkPayload, PersistablePayload {
         if (!isXmr()) {
             return false;
         }
-        if (getExtraDataMap() == null || !getExtraDataMap().containsKey(OfferPayload.XMR_AUTO_CONF)) {
+        if (getOfferPayloadExtraDataMap() == null || !getOfferPayloadExtraDataMap().containsKey(XMR_AUTO_CONF)) {
             return false;
         }
 
-        return getExtraDataMap().get(OfferPayload.XMR_AUTO_CONF).equals(OfferPayload.XMR_AUTO_CONF_ENABLED_VALUE);
+        return getOfferPayloadExtraDataMap().get(XMR_AUTO_CONF).equals(XMR_AUTO_CONF_ENABLED_VALUE);
     }
 
     public boolean isXmr() {

--- a/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
@@ -17,6 +17,8 @@
 
 package bisq.core.offer;
 
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
+
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.storage.payload.ExpirablePayload;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
@@ -63,7 +65,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
     // cache
     protected transient byte[] hash;
     @Nullable
-    protected final Map<String, String> extraDataMap;
+    protected final OfferPayloadExtraDataMap offerPayloadExtraDataMap;
 
     public OfferPayloadBase(String id,
                             long date,
@@ -77,7 +79,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
                             long minAmount,
                             String paymentMethodId,
                             String makerPaymentAccountId,
-                            @Nullable Map<String, String> extraDataMap,
+                            @Nullable OfferPayloadExtraDataMap offerPayloadExtraDataMap,
                             String versionNr,
                             int protocolVersion) {
         this.id = id;
@@ -92,7 +94,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
         this.minAmount = minAmount;
         this.paymentMethodId = paymentMethodId;
         this.makerPaymentAccountId = makerPaymentAccountId;
-        this.extraDataMap = extraDataMap;
+        this.offerPayloadExtraDataMap = offerPayloadExtraDataMap;
         this.versionNr = versionNr;
         this.protocolVersion = protocolVersion;
     }
@@ -123,6 +125,11 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
         return TTL;
     }
 
+    @Nullable
+    public Map<String, String> getExtraDataMap() {
+        return offerPayloadExtraDataMap != null ? offerPayloadExtraDataMap.getMap() : null;
+    }
+
     @Override
     public String toString() {
         return "OfferPayloadBase{" +
@@ -141,7 +148,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
                 ",\r\n     protocolVersion=" + protocolVersion +
                 ",\r\n     pubKeyRing=" + pubKeyRing +
                 ",\r\n     hash=" + (hash != null ? Hex.encode(hash) : "null") +
-                ",\r\n     extraDataMap=" + extraDataMap +
+                ",\r\n     offerPayloadExtraDataMap=" + offerPayloadExtraDataMap +
                 "\r\n}";
     }
 }

--- a/core/src/main/java/bisq/core/offer/OfferRestrictions.java
+++ b/core/src/main/java/bisq/core/offer/OfferRestrictions.java
@@ -17,7 +17,7 @@
 
 package bisq.core.offer;
 
-import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 
 import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
@@ -28,7 +28,8 @@ import org.bitcoinj.core.Coin;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.Map;
+
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 
 public class OfferRestrictions {
     public static final Date TOLERATED_SMALL_TRADE_AMOUNT_CHANGE_ACTIVATION_DATE = Utilities.getUTCDate(2025, GregorianCalendar.FEBRUARY, 17);
@@ -46,9 +47,9 @@ public class OfferRestrictions {
             : Coin.parseCoin("0.01");
 
     static boolean hasOfferMandatoryCapability(Offer offer, Capability mandatoryCapability) {
-        Map<String, String> extraDataMap = offer.getExtraDataMap();
-        if (extraDataMap != null && extraDataMap.containsKey(OfferPayload.CAPABILITIES)) {
-            String commaSeparatedOrdinals = extraDataMap.get(OfferPayload.CAPABILITIES);
+        OfferPayloadExtraDataMap extraDataMap = offer.getOfferPayloadExtraDataMap();
+        if (extraDataMap != null && extraDataMap.containsKey(CAPABILITIES)) {
+            String commaSeparatedOrdinals = extraDataMap.get(CAPABILITIES);
             Capabilities capabilities = Capabilities.fromStringList(commaSeparatedOrdinals);
             return Capabilities.hasMandatoryCapability(capabilities, mandatoryCapability);
         }

--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -27,6 +27,7 @@ import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.bisq_v1.MutableOfferPayloadFields;
 import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.payment.CashByMailAccount;
 import bisq.core.payment.F2FAccount;
 import bisq.core.payment.PaymentAccount;
@@ -62,9 +63,7 @@ import org.bitcoinj.utils.Fiat;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -79,7 +78,8 @@ import static bisq.core.btc.wallet.Restrictions.getMaxBuyerSecurityDepositAsPerc
 import static bisq.core.btc.wallet.Restrictions.getMinBuyerSecurityDepositAsPercent;
 import static bisq.core.btc.wallet.Restrictions.getMinNonDustOutput;
 import static bisq.core.btc.wallet.Restrictions.isDust;
-import static bisq.core.offer.bisq_v1.OfferPayload.*;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Values.*;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -343,39 +343,40 @@ public class OfferUtil {
                 bsqFormatter);
     }
 
-    public Map<String, String> getExtraDataMap(PaymentAccount paymentAccount,
-                                               String currencyCode,
-                                               OfferDirection direction) {
-        Map<String, String> extraDataMap = new HashMap<>();
+    @Nullable
+    public OfferPayloadExtraDataMap getOfferPayloadExtraDataMap(PaymentAccount paymentAccount,
+                                                                String currencyCode,
+                                                                OfferDirection direction) {
+        OfferPayloadExtraDataMap offerPayloadExtraDataMap = new OfferPayloadExtraDataMap();
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String myWitnessHashAsHex = accountAgeWitnessService
                     .getMyWitnessHashAsHex(paymentAccount.getPaymentAccountPayload());
-            extraDataMap.put(ACCOUNT_AGE_WITNESS_HASH, myWitnessHashAsHex);
+            offerPayloadExtraDataMap.putCanonical(ACCOUNT_AGE_WITNESS_HASH, myWitnessHashAsHex);
         }
 
         if (referralIdService.getOptionalReferralId().isPresent()) {
-            extraDataMap.put(REFERRAL_ID, referralIdService.getOptionalReferralId().get());
+            offerPayloadExtraDataMap.putCanonical(REFERRAL_ID, referralIdService.getOptionalReferralId().get());
         }
 
         if (paymentAccount instanceof F2FAccount) {
-            extraDataMap.put(F2F_CITY, ((F2FAccount) paymentAccount).getCity());
-            extraDataMap.put(F2F_EXTRA_INFO, ((F2FAccount) paymentAccount).getExtraInfo());
+            offerPayloadExtraDataMap.putCanonical(F2F_CITY, ((F2FAccount) paymentAccount).getCity());
+            offerPayloadExtraDataMap.putCanonical(F2F_EXTRA_INFO, ((F2FAccount) paymentAccount).getExtraInfo());
         }
 
         if (paymentAccount instanceof CashByMailAccount) {
-            extraDataMap.put(CASH_BY_MAIL_EXTRA_INFO, ((CashByMailAccount) paymentAccount).getExtraInfo());
+            offerPayloadExtraDataMap.putCanonical(CASH_BY_MAIL_EXTRA_INFO, ((CashByMailAccount) paymentAccount).getExtraInfo());
         }
 
-        extraDataMap.put(CAPABILITIES, Capabilities.app.toStringList());
+        offerPayloadExtraDataMap.putCanonical(CAPABILITIES, Capabilities.app.toStringList());
 
         if (currencyCode.equals("XMR") && direction == OfferDirection.SELL) {
             preferences.getAutoConfirmSettingsList().stream()
                     .filter(e -> e.getCurrencyCode().equals("XMR"))
                     .filter(AutoConfirmSettings::isEnabled)
-                    .forEach(e -> extraDataMap.put(XMR_AUTO_CONF, XMR_AUTO_CONF_ENABLED_VALUE));
+                    .forEach(e -> offerPayloadExtraDataMap.putCanonical(XMR_AUTO_CONF, XMR_AUTO_CONF_ENABLED_VALUE));
         }
 
-        return extraDataMap.isEmpty() ? null : extraDataMap;
+        return offerPayloadExtraDataMap.isEmpty() ? null : offerPayloadExtraDataMap;
     }
 
     public void validateOfferData(double buyerSecurityDeposit,

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -37,6 +37,7 @@ import bisq.core.offer.availability.messages.OfferAvailabilityResponse;
 import bisq.core.offer.bisq_v1.CreateOfferService;
 import bisq.core.offer.bisq_v1.MarketPriceNotAvailableException;
 import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.offer.placeoffer.bisq_v1.PlaceOfferModel;
 import bisq.core.offer.placeoffer.bisq_v1.PlaceOfferProtocol;
 import bisq.core.provider.mempool.FeeValidationStatus;
@@ -105,6 +106,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 import static bisq.core.trade.validation.DelayedPayoutTxValidation.checkBurningManSelectionHeight;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -1038,21 +1040,21 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
                 // - Capabilities changed?
                 // We rewrite our offer with the additional capabilities entry
-                Map<String, String> updatedExtraDataMap = new HashMap<>();
+                OfferPayloadExtraDataMap updatedMap = new OfferPayloadExtraDataMap();
                 if (!OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.MEDIATION) ||
                         !OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.REFUND_AGENT)) {
-                    Map<String, String> originalExtraDataMap = original.getExtraDataMap();
+                    OfferPayloadExtraDataMap originalMap = original.getOfferPayloadExtraDataMap();
 
-                    if (originalExtraDataMap != null) {
-                        updatedExtraDataMap.putAll(originalExtraDataMap);
+                    if (originalMap != null) {
+                        updatedMap.putAll(originalMap.getMap());
                     }
 
                     // We overwrite any entry with our current capabilities
-                    updatedExtraDataMap.put(OfferPayload.CAPABILITIES, Capabilities.app.toStringList());
+                    updatedMap.putCanonical(CAPABILITIES, Capabilities.app.toStringList());
 
                     log.info("Converted offer to support new Capability.MEDIATION and Capability.REFUND_AGENT capability. id={}", originalOffer.getId());
                 } else {
-                    updatedExtraDataMap = original.getExtraDataMap();
+                    updatedMap = original.getOfferPayloadExtraDataMap();
                 }
 
                 // - Protocol version changed?
@@ -1106,7 +1108,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                         original.getUpperClosePrice(),
                         original.isPrivateOffer(),
                         original.getHashOfChallenge(),
-                        updatedExtraDataMap,
+                        updatedMap,
                         protocolVersion);
 
                 // Save states from original data to use for the updated

--- a/core/src/main/java/bisq/core/offer/bisq_v1/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/CreateOfferService.java
@@ -51,7 +51,6 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -169,7 +168,7 @@ public class CreateOfferService {
         long lowerClosePrice = 0;
         long upperClosePrice = 0;
         String hashOfChallenge = null;
-        Map<String, String> extraDataMap = offerUtil.getExtraDataMap(paymentAccount,
+        OfferPayloadExtraDataMap extraDataMap = offerUtil.getOfferPayloadExtraDataMap(paymentAccount,
                 currencyCode,
                 direction);
 

--- a/core/src/main/java/bisq/core/offer/bisq_v1/MutableOfferPayloadFields.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/MutableOfferPayloadFields.java
@@ -18,7 +18,6 @@
 package bisq.core.offer.bisq_v1;
 
 import java.util.List;
-import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -50,7 +49,7 @@ public final class MutableOfferPayloadFields {
     @Nullable
     private final List<String> acceptedBankIds;
     @Nullable
-    private final Map<String, String> extraDataMap;
+    private final OfferPayloadExtraDataMap extraDataMap;
 
     public MutableOfferPayloadFields(OfferPayload offerPayload) {
         this(offerPayload.getPrice(),
@@ -66,7 +65,7 @@ public final class MutableOfferPayloadFields {
                 offerPayload.getAcceptedCountryCodes(),
                 offerPayload.getBankId(),
                 offerPayload.getAcceptedBankIds(),
-                offerPayload.getExtraDataMap());
+                offerPayload.getOfferPayloadExtraDataMap());
     }
 
     public MutableOfferPayloadFields(long fixedPrice,
@@ -82,7 +81,7 @@ public final class MutableOfferPayloadFields {
                                      @Nullable List<String> acceptedCountryCodes,
                                      @Nullable String bankId,
                                      @Nullable List<String> acceptedBankIds,
-                                     @Nullable Map<String, String> extraDataMap) {
+                                     @Nullable OfferPayloadExtraDataMap extraDataMap) {
         this.fixedPrice = fixedPrice;
         this.marketPriceMargin = marketPriceMargin;
         this.useMarketBasedPrice = useMarketBasedPrice;

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
@@ -33,7 +33,6 @@ import com.google.gson.JsonSerializationContext;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -55,23 +54,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Getter
 @Slf4j
 public final class OfferPayload extends OfferPayloadBase {
-    // Keys for extra map
-    // Only set for fiat offers
-    public static final String ACCOUNT_AGE_WITNESS_HASH = "accountAgeWitnessHash";
-    public static final String REFERRAL_ID = "referralId";
-    // Only used in payment method F2F
-    public static final String F2F_CITY = "f2fCity";
-    public static final String F2F_EXTRA_INFO = "f2fExtraInfo";
-    public static final String CASH_BY_MAIL_EXTRA_INFO = "cashByMailExtraInfo";
-
-    // Comma separated list of ordinal of a bisq.common.app.Capability. E.g. ordinal of
-    // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker
-    // of the offer supports both capabilities we add "11, 12" to capabilities.
-    public static final String CAPABILITIES = "capabilities";
-    // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
-    public static final String XMR_AUTO_CONF = "xmrAutoConf";
-    public static final String XMR_AUTO_CONF_ENABLED_VALUE = "1";
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Instance fields
@@ -132,6 +114,7 @@ public final class OfferPayload extends OfferPayloadBase {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public OfferPayload(String id,
@@ -170,7 +153,7 @@ public final class OfferPayload extends OfferPayloadBase {
                         long upperClosePrice,
                         boolean isPrivateOffer,
                         @Nullable String hashOfChallenge,
-                        @Nullable Map<String, String> extraDataMap,
+                        @Nullable OfferPayloadExtraDataMap extraDataMap,
                         int protocolVersion) {
         super(id,
                 date,
@@ -226,6 +209,7 @@ public final class OfferPayload extends OfferPayloadBase {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @SuppressWarnings("deprecation")
@@ -276,7 +260,7 @@ public final class OfferPayload extends OfferPayloadBase {
         Optional.ofNullable(acceptedBankIds).ifPresent(builder::addAllAcceptedBankIds);
         Optional.ofNullable(acceptedCountryCodes).ifPresent(builder::addAllAcceptedCountryCodes);
         Optional.ofNullable(hashOfChallenge).ifPresent(builder::setHashOfChallenge);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
+        Optional.ofNullable(offerPayloadExtraDataMap).map(OfferPayloadExtraDataMap::getMap).ifPresent(builder::putAllExtraData);
 
         return protobuf.StoragePayload.newBuilder().setOfferPayload(builder).build();
     }
@@ -289,8 +273,8 @@ public final class OfferPayload extends OfferPayloadBase {
         List<String> acceptedCountryCodes = proto.getAcceptedCountryCodesList().isEmpty() ?
                 null : new ArrayList<>(proto.getAcceptedCountryCodesList());
         String hashOfChallenge = ProtoUtil.stringOrNullFromProto(proto.getHashOfChallenge());
-        Map<String, String> extraDataMapMap = CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                null : proto.getExtraDataMap();
+        OfferPayloadExtraDataMap extraDataMapMap = CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
+                null : new OfferPayloadExtraDataMap(proto.getExtraDataMap());
 
         return new OfferPayload(proto.getId(),
                 proto.getDate(),
@@ -402,7 +386,9 @@ public final class OfferPayload extends OfferPayloadBase {
             object.add("lowerClosePrice", context.serialize(offerPayload.getLowerClosePrice()));
             object.add("upperClosePrice", context.serialize(offerPayload.getUpperClosePrice()));
             object.add("isPrivateOffer", context.serialize(offerPayload.isPrivateOffer()));
-            object.add("extraDataMap", context.serialize(offerPayload.getExtraDataMap()));
+            object.add("extraDataMap", context.serialize(offerPayload.getOfferPayloadExtraDataMap() != null
+                    ? offerPayload.getOfferPayloadExtraDataMap().getMap()
+                    : null));
             object.add("protocolVersion", context.serialize(offerPayload.getProtocolVersion()));
             return object;
         }

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.offer.bisq_v1;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import lombok.Getter;
+
+public class OfferPayloadExtraDataMap {
+    // This mimics the order of the Java HashMap so it is backward compatible.
+    public static final List<String> LEGACY_HASHMAP_ORDER = List.of(
+            Keys.CAPABILITIES,
+            Keys.REFERRAL_ID,
+            Keys.XMR_AUTO_CONF,
+            Keys.ACCOUNT_AGE_WITNESS_HASH,
+            Keys.CASH_BY_MAIL_EXTRA_INFO,
+            Keys.F2F_EXTRA_INFO,
+            Keys.F2F_CITY
+    );
+
+    @Getter
+    private final Map<String, String> map;
+
+    // We use the LEGACY_HASHMAP_ORDER as comparator for the TreeMap
+    public OfferPayloadExtraDataMap() {
+        map = new TreeMap<>(Comparator.comparingInt(LEGACY_HASHMAP_ORDER::indexOf));
+    }
+
+    // If we get constructed from protobuf data we keep the order of the protobuf
+    // LinkedHashMap
+    public OfferPayloadExtraDataMap(Map<String, String> map) {
+        this.map = new LinkedHashMap<>(map);
+    }
+
+    public String putCanonical(String key, String value) {
+        return map.put(key, value);
+    }
+
+    public void putAll(Map<String, String> map) {
+        this.map.putAll(map);
+    }
+
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+
+    public String get(String key) {
+        return map.get(key);
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public static class Keys {
+        // Keys for extra map
+        // Only set for fiat offers
+        public static final String ACCOUNT_AGE_WITNESS_HASH = "accountAgeWitnessHash";
+        public static final String REFERRAL_ID = "referralId";
+        // Only used in payment method F2F
+        public static final String F2F_CITY = "f2fCity";
+        public static final String F2F_EXTRA_INFO = "f2fExtraInfo";
+        public static final String CASH_BY_MAIL_EXTRA_INFO = "cashByMailExtraInfo";
+        // Comma separated list of ordinal of a bisq.common.app.Capability. E.g. ordinal of
+        // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker
+        // of the offer supports both capabilities we add "11, 12" to capabilities.
+        public static final String CAPABILITIES = "capabilities";
+        // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
+        public static final String XMR_AUTO_CONF = "xmrAutoConf";
+    }
+
+    public static class Values {
+        // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
+        public static final String XMR_AUTO_CONF_ENABLED_VALUE = "1";
+    }
+}

--- a/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
@@ -31,16 +31,10 @@ import bisq.common.app.Capability;
 import bisq.common.crypto.ProofOfWork;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.ProtoUtil;
-import bisq.common.util.CollectionUtils;
-
-import java.util.Map;
-import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
-import org.jetbrains.annotations.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @Getter
@@ -60,7 +54,6 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 original.getAmount(),
                 original.getMinAmount(),
                 proofOfWork,
-                original.getExtraDataMap(),
                 original.getVersionNr(),
                 original.getProtocolVersion()
         );
@@ -77,7 +70,6 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                                long amount,
                                long minAmount,
                                ProofOfWork proofOfWork,
-                               @Nullable Map<String, String> extraDataMap,
                                String versionNr,
                                int protocolVersion) {
         super(id,
@@ -92,7 +84,7 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 minAmount,
                 PaymentMethod.BSQ_SWAP_ID,
                 BsqSwapAccount.ID,
-                extraDataMap,
+                null,
                 versionNr,
                 protocolVersion);
 
@@ -126,15 +118,10 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 .setProofOfWork(proofOfWork.toProtoMessage())
                 .setVersionNr(versionNr)
                 .setProtocolVersion(protocolVersion);
-
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
-
         return protobuf.StoragePayload.newBuilder().setBsqSwapOfferPayload(builder).build();
     }
 
     public static BsqSwapOfferPayload fromProto(protobuf.BsqSwapOfferPayload proto) {
-        Map<String, String> extraDataMapMap = CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                null : proto.getExtraDataMap();
         return new BsqSwapOfferPayload(proto.getId(),
                 proto.getDate(),
                 NodeAddress.fromProto(proto.getOwnerNodeAddress()),
@@ -144,7 +131,6 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 proto.getAmount(),
                 proto.getMinAmount(),
                 ProofOfWork.fromProto(proto.getProofOfWork()),
-                extraDataMapMap,
                 proto.getVersionNr(),
                 proto.getProtocolVersion()
         );

--- a/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
@@ -223,7 +223,6 @@ public class OpenBsqSwapOfferService {
                                 amount.getValue(),
                                 minAmount.getValue(),
                                 proofOfWork,
-                                null,
                                 Version.VERSION,
                                 Version.TRADE_PROTOCOL_VERSION);
                         resultHandler.accept(new Offer(bsqSwapOfferPayload));

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -93,12 +93,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         return pubKeyRing.getSignaturePubKey();
     }
 
-    @Nullable
-    @Override
-    public Map<String, String> getExtraDataMap() {
-        return null;
-    }
-
     @Override
     public String toString() {
         return "DisputeAgent{" +

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -55,12 +55,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
     @Nullable
     protected final String info;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    protected Map<String, String> extraDataMap;
-
     public DisputeAgent(NodeAddress nodeAddress,
                         PubKeyRing pubKeyRing,
                         List<String> languageCodes,
@@ -68,8 +62,7 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
                         byte[] registrationPubKey,
                         String registrationSignature,
                         @Nullable String emailAddress,
-                        @Nullable String info,
-                        @Nullable Map<String, String> extraDataMap) {
+                        @Nullable String info) {
         this.nodeAddress = nodeAddress;
         this.pubKeyRing = pubKeyRing;
         this.languageCodes = languageCodes;
@@ -78,7 +71,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         this.registrationSignature = registrationSignature;
         this.emailAddress = emailAddress;
         this.info = info;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
     }
 
 
@@ -101,6 +93,11 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         return pubKeyRing.getSignaturePubKey();
     }
 
+    @Nullable
+    @Override
+    public Map<String, String> getExtraDataMap() {
+        return null;
+    }
 
     @Override
     public String toString() {
@@ -113,7 +110,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
                 ",\n     registrationSignature='" + registrationSignature + '\'' +
                 ",\n     emailAddress='" + emailAddress + '\'' +
                 ",\n     info='" + info + '\'' +
-                ",\n     extraDataMap=" + extraDataMap +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
@@ -55,8 +55,7 @@ public final class Arbitrator extends DisputeAgent {
                       byte[] registrationPubKey,
                       String registrationSignature,
                       @Nullable String emailAddress,
-                      @Nullable String info,
-                      @Nullable Map<String, String> extraDataMap) {
+                      @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -65,8 +64,7 @@ public final class Arbitrator extends DisputeAgent {
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
 
         this.btcPubKey = btcPubKey;
         this.btcAddress = btcAddress;
@@ -89,7 +87,6 @@ public final class Arbitrator extends DisputeAgent {
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setArbitrator(builder).build();
     }
 
@@ -103,8 +100,7 @@ public final class Arbitrator extends DisputeAgent {
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
@@ -47,8 +47,7 @@ public final class Mediator extends DisputeAgent {
                     byte[] registrationPubKey,
                     String registrationSignature,
                     @Nullable String emailAddress,
-                    @Nullable String info,
-                    @Nullable Map<String, String> extraDataMap) {
+                    @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -57,8 +56,7 @@ public final class Mediator extends DisputeAgent {
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -76,7 +74,6 @@ public final class Mediator extends DisputeAgent {
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setMediator(builder).build();
     }
 
@@ -88,8 +85,7 @@ public final class Mediator extends DisputeAgent {
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
@@ -53,8 +53,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                        byte[] registrationPubKey,
                        String registrationSignature,
                        @Nullable String emailAddress,
-                       @Nullable String info,
-                       @Nullable Map<String, String> extraDataMap) {
+                       @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -63,8 +62,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -82,7 +80,6 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setRefundAgent(builder).build();
     }
 
@@ -94,8 +91,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -23,6 +23,7 @@ import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferDirection;
 import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.util.JsonUtil;
 import bisq.core.util.VolumeUtil;
@@ -48,7 +49,6 @@ import org.bitcoinj.core.Coin;
 import com.google.common.base.Charsets;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -61,6 +61,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -78,7 +79,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
                                         boolean isTorNetworkNode) {
         TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
-            extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
+            extraDataMap.put(REFERRAL_ID, referralId);
         }
 
         NodeAddress mediatorNodeAddress = trade.getMediatorNodeAddress();

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics2.java
@@ -51,6 +51,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -75,7 +76,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
     public static TradeStatistics2 from(Trade trade,
                                         @Nullable String referralId,
                                         boolean isTorNetworkNode) {
-        Map<String, String> extraDataMap = new HashMap<>();
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
             extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
         }
@@ -144,7 +145,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
                             Coin tradeAmount,
                             Date tradeDate,
                             String depositTxId,
-                            Map<String, String> extraDataMap) {
+                            TreeMap<String, String> extraDataMap) {
         this(offerPayload.getDirection(),
                 offerPayload.getBaseCurrencyCode(),
                 offerPayload.getCounterCurrencyCode(),
@@ -182,7 +183,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
                             long tradeDate,
                             @Nullable String depositTxId,
                             @Nullable byte[] hash,
-                            @Nullable Map<String, String> extraDataMap) {
+                            @Nullable TreeMap<String, String> extraDataMap) {
         this.direction = direction;
         this.baseCurrency = baseCurrency;
         this.counterCurrency = counterCurrency;
@@ -256,7 +257,7 @@ public final class TradeStatistics2 implements ProcessOncePersistableNetworkPayl
                 proto.getTradeDate(),
                 ProtoUtil.stringOrNullFromProto(proto.getDepositTxId()),
                 null,   // We want to clean up the hashes with the changed hash method in v.1.2.0 so we don't use the value from the proto
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -64,6 +64,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -93,7 +94,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     public static TradeStatistics3 from(Trade trade,
                                         @Nullable String referralId,
                                         boolean isTorNetworkNode) {
-        Map<String, String> extraDataMap = new HashMap<>();
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
             extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
         }
@@ -255,7 +256,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                             long date,
                             String mediator,
                             String refundAgent,
-                            @Nullable Map<String, String> extraDataMap) {
+                            @Nullable TreeMap<String, String> extraDataMap) {
         this(currency,
                 price,
                 amount,
@@ -299,7 +300,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                             long date,
                             @Nullable String mediator,
                             @Nullable String refundAgent,
-                            @Nullable Map<String, String> extraDataMap,
+                            @Nullable TreeMap<String, String> extraDataMap,
                             @Nullable byte[] hash) {
         this.currency = currency;
         this.price = price;
@@ -360,7 +361,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                 proto.getDate(),
                 ProtoUtil.stringOrNullFromProto(proto.getMediator()),
                 ProtoUtil.stringOrNullFromProto(proto.getRefundAgent()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap(),
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()),
                 proto.getHash().toByteArray());
     }
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -22,7 +22,7 @@ import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
-import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
 import bisq.core.util.JsonUtil;
@@ -60,7 +60,6 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -73,6 +72,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -96,7 +96,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                                         boolean isTorNetworkNode) {
         TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
-            extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
+            extraDataMap.put(REFERRAL_ID, referralId);
         }
 
         NodeAddress mediatorNodeAddress = checkNotNull(trade.getMediatorNodeAddress());

--- a/core/src/test/java/bisq/core/arbitration/ArbitratorManagerTest.java
+++ b/core/src/test/java/bisq/core/arbitration/ArbitratorManagerTest.java
@@ -58,11 +58,11 @@ public class ArbitratorManagerTest {
 
         Arbitrator one = new Arbitrator(new NodeAddress("arbitrator:1"), null, null, null,
                 languagesOne, 0L, null, "", null,
-                null, null);
+                null);
 
         Arbitrator two = new Arbitrator(new NodeAddress("arbitrator:2"), null, null, null,
                 languagesTwo, 0L, null, "", null,
-                null, null);
+                null);
 
         manager.addDisputeAgent(one, () -> {
         }, errorMessage -> {
@@ -94,11 +94,11 @@ public class ArbitratorManagerTest {
 
         Arbitrator one = new Arbitrator(new NodeAddress("arbitrator:1"), null, null, null,
                 languagesOne, 0L, null, "", null,
-                null, null);
+                null);
 
         Arbitrator two = new Arbitrator(new NodeAddress("arbitrator:2"), null, null, null,
                 languagesTwo, 0L, null, "", null,
-                null, null);
+                null);
 
         ArrayList<NodeAddress> nodeAddresses = new ArrayList<NodeAddress>() {{
             add(two.getNodeAddress());

--- a/core/src/test/java/bisq/core/arbitration/ArbitratorTest.java
+++ b/core/src/test/java/bisq/core/arbitration/ArbitratorTest.java
@@ -51,7 +51,7 @@ public class ArbitratorTest {
                 new Date().getTime(),
                 getBytes(100),
                 "registrationSignature",
-                null, null, null);
+                null, null);
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/test/java/bisq/core/arbitration/MediatorTest.java
+++ b/core/src/test/java/bisq/core/arbitration/MediatorTest.java
@@ -50,7 +50,6 @@ public class MediatorTest {
                 getBytes(100),
                 "registrationSignature",
                 "email",
-                "info",
-                null);
+                "info");
     }
 }

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -45,8 +45,8 @@ import javafx.collections.FXCollections;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -362,7 +362,8 @@ public class BurningManServiceTest {
                                                                                     long amount,
                                                                                     String receiverAddress) {
         var issuance = new Issuance(txId, chainHeight, amount, null, IssuanceType.COMPENSATION);
-        var extraDataMap = Map.of(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, receiverAddress);
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
+        extraDataMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, receiverAddress);
         var proposal = new CompensationProposal(name, "link", Coin.valueOf(amount), "bsqAddress", extraDataMap);
         return new Tuple2<>(issuance, new ProposalPayload(proposal.cloneProposalAndAddTxId(txId)));
     }

--- a/core/src/test/java/bisq/core/filter/TestFilter.java
+++ b/core/src/test/java/bisq/core/filter/TestFilter.java
@@ -90,7 +90,6 @@ public class TestFilter {
                 ownerPublicKey.getEncoded(),
                 creationDate,
                 null,
-                null,
                 signerPubKeyAsHex,
                 bannedDevKeys,
                 false,

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -26,6 +26,7 @@ import org.bitcoinj.core.Coin;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Disabled;
@@ -45,7 +46,7 @@ public class TradeStatistics3Test {
                 System.currentTimeMillis(),
                 null,
                 null,
-                (Map<String, String>) null);
+                (TreeMap<String, String>) null);
 
         assertTrue(tradeStatistics.isValid());
     }
@@ -59,7 +60,7 @@ public class TradeStatistics3Test {
                 System.currentTimeMillis(),
                 null,
                 null,
-                (Map<String, String>) null);
+                (TreeMap<String, String>) null);
 
         assertFalse(tradeStatistics.isValid());
     }

--- a/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
+++ b/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
@@ -238,7 +238,6 @@ class ValidationTestUtils {
                 new byte[]{1},
                 "registrationSignature",
                 null,
-                null,
                 null);
     }
 

--- a/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
+++ b/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
@@ -42,7 +42,7 @@ public class UserPayloadModelVOTest {
     public void testRoundtripFull() {
         UserPayload vo = new UserPayload();
         vo.setAccountId("accountId");
-        vo.setDisplayedAlert(new Alert("message", true, false, "version", new byte[]{12, -64, 12}, "string", null));
+        vo.setDisplayedAlert(new Alert("message", true, false, "version", new byte[]{12, -64, 12}, "string"));
         vo.setDevelopersFilter(new Filter(Lists.newArrayList(),
                 Lists.newArrayList(),
                 Lists.newArrayList(),
@@ -62,7 +62,6 @@ public class UserPayloadModelVOTest {
                 Lists.newArrayList(),
                 null,
                 0,
-                null,
                 null,
                 null,
                 null,

--- a/desktop/src/main/java/bisq/desktop/main/account/register/arbitrator/ArbitratorRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/arbitrator/ArbitratorRegistrationViewModel.java
@@ -59,7 +59,6 @@ public class ArbitratorRegistrationViewModel extends AgentRegistrationViewModel<
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/register/mediator/MediatorRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/mediator/MediatorRegistrationViewModel.java
@@ -55,7 +55,6 @@ class MediatorRegistrationViewModel extends AgentRegistrationViewModel<Mediator,
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/register/refundagent/RefundAgentRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/refundagent/RefundAgentRegistrationViewModel.java
@@ -56,7 +56,6 @@ public class RefundAgentRegistrationViewModel extends AgentRegistrationViewModel
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -35,7 +35,7 @@ import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
-import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.trade.statistics.TradeStatistics3StorageService;
 import bisq.core.util.FormattingUtils;
@@ -66,6 +66,8 @@ import javafx.event.EventHandler;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 
 @FxmlView
 public class MarketView extends ActivatableView<TabPane, Void> {
@@ -192,7 +194,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                 .filter(e -> e instanceof TradeStatistics3)
                 .map(e -> (TradeStatistics3) e)
                 .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap() != null)
-                .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap().get(OfferPayload.REFERRAL_ID) != null)
+                .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap().get(REFERRAL_ID) != null)
                 .map(tradeStatistics3 -> {
                     StringBuilder sb = new StringBuilder();
                     sb.append("Date: ").append(DisplayUtils.formatDateTime(tradeStatistics3.getDate())).append("\n")
@@ -201,7 +203,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                             .append("Amount: ").append(formatter.formatCoin(tradeStatistics3.getTradeAmount())).append("\n")
                             .append("Volume: ").append(VolumeUtil.formatVolume(tradeStatistics3.getTradeVolume())).append("\n")
                             .append("Payment method: ").append(Res.get(tradeStatistics3.getPaymentMethodId())).append("\n")
-                            .append("ReferralID: ").append(tradeStatistics3.getExtraDataMap().get(OfferPayload.REFERRAL_ID));
+                            .append("ReferralID: ").append(tradeStatistics3.getExtraDataMap().get(REFERRAL_ID));
                     return sb.toString();
                 })
                 .collect(Collectors.toList());
@@ -211,8 +213,8 @@ public class MarketView extends ActivatableView<TabPane, Void> {
     private String getAllOffersWithReferralId() {
         List<String> list = offerBook.getOfferBookListItems().stream()
                 .map(OfferBookListItem::getOffer)
-                .filter(offer -> offer.getExtraDataMap() != null)
-                .filter(offer -> offer.getExtraDataMap().get(OfferPayload.REFERRAL_ID) != null)
+                .filter(offer -> offer.getOfferPayloadExtraDataMap() != null)
+                .filter(offer -> offer.getOfferPayloadExtraDataMap().get(REFERRAL_ID) != null)
                 .map(offer -> {
                     StringBuilder sb = new StringBuilder();
                     sb.append("Offer ID: ").append(offer.getId()).append("\n")
@@ -221,7 +223,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                             .append("Price: ").append(FormattingUtils.formatPrice(offer.getPrice())).append("\n")
                             .append("Amount: ").append(DisplayUtils.formatAmount(offer, formatter)).append(" BTC\n")
                             .append("Payment method: ").append(Res.get(offer.getPaymentMethod().getId())).append("\n")
-                            .append("ReferralID: ").append(offer.getExtraDataMap().get(OfferPayload.REFERRAL_ID));
+                            .append("ReferralID: ").append(offer.getOfferPayloadExtraDataMap().get(REFERRAL_ID));
                     return sb.toString();
                 })
                 .collect(Collectors.toList());

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/cloneoffer/CloneOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/cloneoffer/CloneOfferDataModel.java
@@ -233,7 +233,7 @@ class CloneOfferDataModel extends MutableOfferDataModel {
                 sourceOfferPayload.getUpperClosePrice(),
                 sourceOfferPayload.isPrivateOffer(),
                 sourceOfferPayload.getHashOfChallenge(),
-                editedOfferPayload.getExtraDataMap(),
+                editedOfferPayload.getOfferPayloadExtraDataMap(),
                 sourceOfferPayload.getProtocolVersion());
         Offer clonedOffer = new Offer(clonedOfferPayload);
         clonedOffer.setPriceFeedService(priceFeedService);

--- a/desktop/src/test/java/bisq/desktop/main/settings/preferences/PreferencesViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/settings/preferences/PreferencesViewModelTest.java
@@ -59,10 +59,10 @@ public class PreferencesViewModelTest {
         }};
 
         RefundAgent one = new RefundAgent(new NodeAddress("refundAgent:1"), null, languagesOne, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         RefundAgent two = new RefundAgent(new NodeAddress("refundAgent:2"), null, languagesTwo, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         refundAgents.put(one.getNodeAddress(), one);
         refundAgents.put(two.getNodeAddress(), two);
@@ -94,10 +94,10 @@ public class PreferencesViewModelTest {
         }};
 
         Mediator one = new Mediator(new NodeAddress("refundAgent:1"), null, languagesOne, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         Mediator two = new Mediator(new NodeAddress("refundAgent:2"), null, languagesTwo, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         mnediators.put(one.getNodeAddress(), one);
         mnediators.put(two.getNodeAddress(), two);

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
@@ -28,9 +28,9 @@ import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import lombok.EqualsAndHashCode;
@@ -85,7 +85,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
 
         // We do not permit longer TTL as the default one
         if (ttl < TTL) {
-            extraDataMap = new HashMap<>();
+            extraDataMap = new TreeMap<>();
             extraDataMap.put(EXTRA_MAP_KEY_TTL, String.valueOf(ttl));
         }
     }
@@ -93,6 +93,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private MailboxStoragePayload(PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage,
@@ -123,12 +124,13 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
                 PrefixedSealedAndSignedMessage.fromPayloadProto(proto.getPrefixedSealedAndSignedMessage()),
                 proto.getSenderPubKeyForAddOperationBytes().toByteArray(),
                 proto.getOwnerPubKeyBytes().toByteArray(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStoragePayload.java
@@ -48,7 +48,9 @@ public interface ProtectedStoragePayload extends NetworkPayload {
     // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
     // field in a class would break that hash and therefore break the storage mechanism.
     @Nullable
-    Map<String, String> getExtraDataMap();
+    default Map<String, String> getExtraDataMap() {
+        return null;
+    }
 
     static ProtectedStoragePayload fromProto(protobuf.StoragePayload storagePayload, NetworkProtoResolver networkProtoResolver) {
         return (ProtectedStoragePayload) networkProtoResolver.fromProto(storagePayload);

--- a/p2p/src/test/java/bisq/network/p2p/storage/mocks/MockData.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/mocks/MockData.java
@@ -34,9 +34,6 @@ public class MockData implements ProtectedStoragePayload, ExpirablePayload {
     public final PublicKey publicKey;
     public long ttl;
 
-    @Nullable
-    private Map<String, String> extraDataMap;
-
     public MockData(String msg, PublicKey publicKey) {
         this.msg = msg;
         this.publicKey = publicKey;
@@ -63,12 +60,6 @@ public class MockData implements ProtectedStoragePayload, ExpirablePayload {
         return "MockData{" +
                 "msg='" + msg + '\'' +
                 '}';
-    }
-
-    @Nullable
-    @Override
-    public Map<String, String> getExtraDataMap() {
-        return extraDataMap;
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced typed `OfferPayloadExtraDataMap` to replace generic map handling for offer data; standardized extra data field usage across proposals, alerts, and dispute agents.
  * Removed extra data map support from Alert, BlindVote, Filter, and various Proposal types for simplified data models.
  * Updated dispute agent classes (Arbitrator, Mediator, RefundAgent) to use consistent info field handling.
  * Standardized data structures to use `TreeMap` for deterministic key ordering in trade statistics and storage payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->