### PR TITLE
Remove extra data maps if it was null

### DIFF
--- a/core/src/main/java/bisq/core/alert/Alert.java
+++ b/core/src/main/java/bisq/core/alert/Alert.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode
@@ -113,6 +114,11 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
 
     @Nullable
     public static Alert fromProto(protobuf.Alert proto) {
+        // ExtraDataMap was always null and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in Alert");
+
         // We got in dev testing sometimes an empty protobuf Alert. Not clear why that happened but as it causes an
         // exception and corrupted user db file we prefer to set it to null.
         if (proto.getSignatureAsBase64().isEmpty())

--- a/core/src/main/java/bisq/core/alert/Alert.java
+++ b/core/src/main/java/bisq/core/alert/Alert.java
@@ -25,21 +25,19 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 import bisq.common.app.Version;
 import bisq.common.crypto.Sig;
 import bisq.common.proto.network.GetDataResponsePriority;
-import bisq.common.util.CollectionUtils;
-import bisq.common.util.ExtraDataMapValidator;
 
 import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+
+import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.annotation.Nullable;
 
@@ -64,11 +62,6 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
     @Nullable
     private PublicKey ownerPubKey;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    private Map<String, String> extraDataMap;
 
     public Alert(String message,
                  boolean isUpdateInfo,
@@ -83,23 +76,23 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @SuppressWarnings("NullableProblems")
+    @VisibleForTesting
     public Alert(String message,
                  boolean isUpdateInfo,
                  boolean isPreReleaseInfo,
                  String version,
                  byte[] ownerPubKeyBytes,
-                 String signatureAsBase64,
-                 Map<String, String> extraDataMap) {
+                 String signatureAsBase64) {
         this.message = message;
         this.isUpdateInfo = isUpdateInfo;
         this.isPreReleaseInfo = isPreReleaseInfo;
         this.version = version;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
         this.signatureAsBase64 = signatureAsBase64;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
 
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyBytes);
     }
@@ -115,7 +108,6 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
                 .setVersion(version)
                 .setOwnerPubKeyBytes(ByteString.copyFrom(ownerPubKeyBytes))
                 .setSignatureAsBase64(signatureAsBase64);
-        Optional.ofNullable(getExtraDataMap()).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setAlert(builder).build();
     }
 
@@ -131,14 +123,13 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
                 proto.getIsPreReleaseInfo(),
                 proto.getVersion(),
                 proto.getOwnerPubKeyBytes().toByteArray(),
-                proto.getSignatureAsBase64(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getSignatureAsBase64());
     }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
@@ -181,5 +172,4 @@ public final class Alert implements ProtectedStoragePayload, ExpirablePayload {
     public String showAgainKey() {
         return "Update_" + version;
     }
-
 }

--- a/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
+++ b/core/src/main/java/bisq/core/api/CoreDisputeAgentsService.java
@@ -126,7 +126,6 @@ class CoreDisputeAgentsService {
                 ecKey.getPubKey(),
                 signature,
                 null,
-                null,
                 null
         );
         mediatorManager.addDisputeAgent(mediator, () -> {
@@ -146,7 +145,6 @@ class CoreDisputeAgentsService {
                 new Date().getTime(),
                 ecKey.getPubKey(),
                 signature,
-                null,
                 null,
                 null
         );

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
@@ -25,15 +25,11 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.crypto.Sig;
 import bisq.common.proto.persistable.PersistablePayload;
-import bisq.common.util.CollectionUtils;
-import bisq.common.util.ExtraDataMapValidator;
 
 import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import lombok.AccessLevel;
@@ -42,7 +38,6 @@ import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/storage/temp/TempProposalPayload.java
@@ -45,6 +45,8 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * TempProposalPayload is wrapper for proposal sent over wire as well as it gets persisted.
  * Data size: about 1.245 bytes (pubKey makes it big)
@@ -63,18 +65,12 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     protected final Proposal proposal;
     protected final byte[] ownerPubKeyEncoded;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    protected final Map<String, String> extraDataMap;
-
     // Used just for caching. Don't persist.
     private final transient PublicKey ownerPubKey;
 
     public TempProposalPayload(Proposal proposal,
                                PublicKey ownerPublicKey) {
-        this(proposal, Sig.getPublicKeyBytes(ownerPublicKey), null);
+        this(proposal, Sig.getPublicKeyBytes(ownerPublicKey));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -82,11 +78,9 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private TempProposalPayload(Proposal proposal,
-                                byte[] ownerPubPubKeyEncoded,
-                                @Nullable Map<String, String> extraDataMap) {
+                                byte[] ownerPubPubKeyEncoded) {
         this.proposal = proposal;
         this.ownerPubKeyEncoded = ownerPubPubKeyEncoded;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
 
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyEncoded);
     }
@@ -95,7 +89,6 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
         final protobuf.TempProposalPayload.Builder builder = protobuf.TempProposalPayload.newBuilder()
                 .setProposal(proposal.getProposalBuilder())
                 .setOwnerPubKeyEncoded(ByteString.copyFrom(ownerPubKeyEncoded));
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return builder;
     }
 
@@ -105,9 +98,13 @@ public class TempProposalPayload implements ProcessOncePersistableNetworkPayload
     }
 
     public static TempProposalPayload fromProto(protobuf.TempProposalPayload proto) {
+        // ExtraDataMap was always null and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in TempProposalPayload");
+
         return new TempProposalPayload(Proposal.fromProto(proto.getProposal()),
-                proto.getOwnerPubKeyEncoded().toByteArray(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                proto.getOwnerPubKeyEncoded().toByteArray());
     }
 
 

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -25,8 +25,6 @@ import bisq.common.ExcludeForHashAwareProto;
 import bisq.common.crypto.Sig;
 import bisq.common.proto.ProtoUtil;
 import bisq.common.proto.network.GetDataResponsePriority;
-import bisq.common.util.CollectionUtils;
-import bisq.common.util.ExtraDataMapValidator;
 import bisq.common.util.Hex;
 import bisq.common.util.Utilities;
 
@@ -91,12 +89,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
     private final long creationDate;
 
     private final List<String> bannedPrivilegedDevPubKeys;
-
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    private Map<String, String> extraDataMap;
 
     private transient PublicKey ownerPubKey;
 
@@ -163,7 +155,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getBtcFeeReceiverAddresses(),
                 filter.getOwnerPubKeyBytes(),
                 filter.getCreationDate(),
-                filter.getExtraDataMap(),
                 signatureAsBase64,
                 filter.getSignerPubKeyAsHex(),
                 filter.getBannedPrivilegedDevPubKeys(),
@@ -207,7 +198,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 filter.getBtcFeeReceiverAddresses(),
                 filter.getOwnerPubKeyBytes(),
                 filter.getCreationDate(),
-                filter.getExtraDataMap(),
                 null,
                 filter.getSignerPubKeyAsHex(),
                 filter.getBannedPrivilegedDevPubKeys(),
@@ -287,7 +277,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 Sig.getPublicKeyBytes(ownerPubKey),
                 System.currentTimeMillis(),
                 null,
-                null,
                 signerPubKeyAsHex,
                 bannedPrivilegedDevPubKeys,
                 disableAutoConf,
@@ -334,7 +323,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                   List<String> btcFeeReceiverAddresses,
                   byte[] ownerPubKeyBytes,
                   long creationDate,
-                  @Nullable Map<String, String> extraDataMap,
                   @Nullable String signatureAsBase64,
                   String signerPubKeyAsHex,
                   List<String> bannedPrivilegedDevPubKeys,
@@ -374,7 +362,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
         this.btcFeeReceiverAddresses = btcFeeReceiverAddresses;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
         this.creationDate = creationDate;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
         this.signatureAsBase64 = signatureAsBase64;
         this.signerPubKeyAsHex = signerPubKeyAsHex;
         this.bannedPrivilegedDevPubKeys = bannedPrivilegedDevPubKeys;
@@ -471,7 +458,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 .setDisableBsqSwap(disableBsqSwap);
 
         Optional.ofNullable(signatureAsBase64).ifPresent(builder::setSignatureAsBase64);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
 
         return builder;
     }
@@ -503,7 +489,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 ProtoUtil.protocolStringListToList(proto.getBtcFeeReceiverAddressesList()),
                 proto.getOwnerPubKeyBytes().toByteArray(),
                 proto.getCreationDate(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap(),
                 proto.getSignatureAsBase64(),
                 proto.getSignerPubKeyAsHex(),
                 ProtoUtil.protocolStringListToList(proto.getBannedPrivilegedDevPubKeysList()),
@@ -569,7 +554,6 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
                 ",\n     bannedAccountWitnessSignerPubKeys=" + bannedAccountWitnessSignerPubKeys +
                 ",\n     btcFeeReceiverAddresses=" + btcFeeReceiverAddresses +
                 ",\n     bannedPrivilegedDevPubKeys=" + bannedPrivilegedDevPubKeys +
-                ",\n     extraDataMap=" + extraDataMap +
                 ",\n     ownerPubKey=" + Hex.encode(ownerPubKeyBytes) +
                 ",\n     disableAutoConf=" + disableAutoConf +
                 ",\n     nodeAddressesBannedFromNetwork=" + nodeAddressesBannedFromNetwork +

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -50,6 +50,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Slf4j
 @Getter
 @EqualsAndHashCode
@@ -463,6 +465,11 @@ public final class Filter implements ProtectedStoragePayload, ExpirablePayload, 
     }
 
     public static Filter fromProto(protobuf.Filter proto) {
+        // ExtraDataMap was always null and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in Filter");
+
         List<PaymentAccountFilter> bannedPaymentAccountsList = proto.getBannedPaymentAccountsList().stream()
                 .map(PaymentAccountFilter::fromProto)
                 .collect(Collectors.toList());

--- a/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
@@ -31,16 +31,13 @@ import bisq.common.app.Capability;
 import bisq.common.crypto.ProofOfWork;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.ProtoUtil;
-import bisq.common.util.CollectionUtils;
-
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import org.jetbrains.annotations.Nullable;
+import static com.google.common.base.Preconditions.checkArgument;
 
 @EqualsAndHashCode(callSuper = true)
 @Getter
@@ -60,7 +57,6 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 original.getAmount(),
                 original.getMinAmount(),
                 proofOfWork,
-                original.getExtraDataMap(),
                 original.getVersionNr(),
                 original.getProtocolVersion()
         );
@@ -77,7 +73,6 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                                long amount,
                                long minAmount,
                                ProofOfWork proofOfWork,
-                               @Nullable Map<String, String> extraDataMap,
                                String versionNr,
                                int protocolVersion) {
         super(id,
@@ -92,7 +87,7 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 minAmount,
                 PaymentMethod.BSQ_SWAP_ID,
                 BsqSwapAccount.ID,
-                extraDataMap,
+                null,
                 versionNr,
                 protocolVersion);
 
@@ -133,8 +128,11 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
     }
 
     public static BsqSwapOfferPayload fromProto(protobuf.BsqSwapOfferPayload proto) {
-        Map<String, String> extraDataMapMap = CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                null : proto.getExtraDataMap();
+        // ExtraDataMap was always null and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in BsqSwapOfferPayload");
+
         return new BsqSwapOfferPayload(proto.getId(),
                 proto.getDate(),
                 NodeAddress.fromProto(proto.getOwnerNodeAddress()),
@@ -144,7 +142,6 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 proto.getAmount(),
                 proto.getMinAmount(),
                 ProofOfWork.fromProto(proto.getProofOfWork()),
-                extraDataMapMap,
                 proto.getVersionNr(),
                 proto.getProtocolVersion()
         );

--- a/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
@@ -223,7 +223,6 @@ public class OpenBsqSwapOfferService {
                                 amount.getValue(),
                                 minAmount.getValue(),
                                 proofOfWork,
-                                null,
                                 Version.VERSION,
                                 Version.TRADE_PROTOCOL_VERSION);
                         resultHandler.accept(new Offer(bsqSwapOfferPayload));

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -55,12 +55,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
     @Nullable
     protected final String info;
 
-    // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
-    // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
-    // field in a class would break that hash and therefore break the storage mechanism.
-    @Nullable
-    protected Map<String, String> extraDataMap;
-
     public DisputeAgent(NodeAddress nodeAddress,
                         PubKeyRing pubKeyRing,
                         List<String> languageCodes,
@@ -68,8 +62,7 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
                         byte[] registrationPubKey,
                         String registrationSignature,
                         @Nullable String emailAddress,
-                        @Nullable String info,
-                        @Nullable Map<String, String> extraDataMap) {
+                        @Nullable String info) {
         this.nodeAddress = nodeAddress;
         this.pubKeyRing = pubKeyRing;
         this.languageCodes = languageCodes;
@@ -78,7 +71,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         this.registrationSignature = registrationSignature;
         this.emailAddress = emailAddress;
         this.info = info;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
     }
 
 
@@ -101,7 +93,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
         return pubKeyRing.getSignaturePubKey();
     }
 
-
     @Override
     public String toString() {
         return "DisputeAgent{" +
@@ -113,7 +104,6 @@ public abstract class DisputeAgent implements ProtectedStoragePayload, Expirable
                 ",\n     registrationSignature='" + registrationSignature + '\'' +
                 ",\n     emailAddress='" + emailAddress + '\'' +
                 ",\n     info='" + info + '\'' +
-                ",\n     extraDataMap=" + extraDataMap +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/agent/DisputeAgent.java
@@ -23,13 +23,11 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.network.GetDataResponsePriority;
-import bisq.common.util.ExtraDataMapValidator;
 import bisq.common.util.Utilities;
 
 import java.security.PublicKey;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
@@ -55,8 +55,7 @@ public final class Arbitrator extends DisputeAgent {
                       byte[] registrationPubKey,
                       String registrationSignature,
                       @Nullable String emailAddress,
-                      @Nullable String info,
-                      @Nullable Map<String, String> extraDataMap) {
+                      @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -65,8 +64,7 @@ public final class Arbitrator extends DisputeAgent {
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
 
         this.btcPubKey = btcPubKey;
         this.btcAddress = btcAddress;
@@ -89,7 +87,6 @@ public final class Arbitrator extends DisputeAgent {
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setArbitrator(builder).build();
     }
 
@@ -103,8 +100,7 @@ public final class Arbitrator extends DisputeAgent {
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
@@ -23,14 +23,12 @@ import bisq.network.p2p.NodeAddress;
 
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.ProtoUtil;
-import bisq.common.util.CollectionUtils;
 import bisq.common.util.Utilities;
 
 import com.google.protobuf.ByteString;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/arbitrator/Arbitrator.java
@@ -39,6 +39,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @EqualsAndHashCode(callSuper = true)
 @Slf4j
 @Getter
@@ -91,6 +93,11 @@ public final class Arbitrator extends DisputeAgent {
     }
 
     public static Arbitrator fromProto(protobuf.Arbitrator proto) {
+        // ExtraDataMap was always null and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in Arbitrator");
+
         return new Arbitrator(NodeAddress.fromProto(proto.getNodeAddress()),
                 proto.getBtcPubKey().toByteArray(),
                 proto.getBtcAddress(),

--- a/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
@@ -47,8 +47,7 @@ public final class Mediator extends DisputeAgent {
                     byte[] registrationPubKey,
                     String registrationSignature,
                     @Nullable String emailAddress,
-                    @Nullable String info,
-                    @Nullable Map<String, String> extraDataMap) {
+                    @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -57,8 +56,7 @@ public final class Mediator extends DisputeAgent {
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -76,7 +74,6 @@ public final class Mediator extends DisputeAgent {
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setMediator(builder).build();
     }
 
@@ -88,8 +85,7 @@ public final class Mediator extends DisputeAgent {
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
@@ -37,6 +37,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @EqualsAndHashCode(callSuper = true)
 @Slf4j
 public final class Mediator extends DisputeAgent {
@@ -78,6 +80,11 @@ public final class Mediator extends DisputeAgent {
     }
 
     public static Mediator fromProto(protobuf.Mediator proto) {
+        // ExtraDataMap was always null and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in Mediator");
+
         return new Mediator(NodeAddress.fromProto(proto.getNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),
                 new ArrayList<>(proto.getLanguageCodesList()),

--- a/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
@@ -53,8 +53,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                        byte[] registrationPubKey,
                        String registrationSignature,
                        @Nullable String emailAddress,
-                       @Nullable String info,
-                       @Nullable Map<String, String> extraDataMap) {
+                       @Nullable String info) {
 
         super(nodeAddress,
                 pubKeyRing,
@@ -63,8 +62,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 registrationPubKey,
                 registrationSignature,
                 emailAddress,
-                info,
-                extraDataMap);
+                info);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -82,7 +80,6 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 .setRegistrationSignature(registrationSignature);
         Optional.ofNullable(emailAddress).ifPresent(builder::setEmailAddress);
         Optional.ofNullable(info).ifPresent(builder::setInfo);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return protobuf.StoragePayload.newBuilder().setRefundAgent(builder).build();
     }
 
@@ -94,8 +91,7 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
                 proto.getRegistrationPubKey().toByteArray(),
                 proto.getRegistrationSignature(),
                 ProtoUtil.stringOrNullFromProto(proto.getEmailAddress()),
-                ProtoUtil.stringOrNullFromProto(proto.getInfo()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                ProtoUtil.stringOrNullFromProto(proto.getInfo()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
@@ -41,6 +41,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @EqualsAndHashCode(callSuper = true)
 @Slf4j
 @Getter
@@ -84,6 +86,11 @@ public final class RefundAgent extends DisputeAgent implements CapabilityRequiri
     }
 
     public static RefundAgent fromProto(protobuf.RefundAgent proto) {
+        // ExtraDataMap was always null and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in RefundAgent");
+
         return new RefundAgent(NodeAddress.fromProto(proto.getNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),
                 new ArrayList<>(proto.getLanguageCodesList()),

--- a/core/src/test/java/bisq/core/arbitration/ArbitratorManagerTest.java
+++ b/core/src/test/java/bisq/core/arbitration/ArbitratorManagerTest.java
@@ -57,12 +57,10 @@ public class ArbitratorManagerTest {
         }};
 
         Arbitrator one = new Arbitrator(new NodeAddress("arbitrator:1"), null, null, null,
-                languagesOne, 0L, null, "", null,
-                null, null);
+                languagesOne, 0L, null, "", null, null);
 
         Arbitrator two = new Arbitrator(new NodeAddress("arbitrator:2"), null, null, null,
-                languagesTwo, 0L, null, "", null,
-                null, null);
+                languagesTwo, 0L, null, "", null, null);
 
         manager.addDisputeAgent(one, () -> {
         }, errorMessage -> {
@@ -93,12 +91,10 @@ public class ArbitratorManagerTest {
         }};
 
         Arbitrator one = new Arbitrator(new NodeAddress("arbitrator:1"), null, null, null,
-                languagesOne, 0L, null, "", null,
-                null, null);
+                languagesOne, 0L, null, "", null, null);
 
         Arbitrator two = new Arbitrator(new NodeAddress("arbitrator:2"), null, null, null,
-                languagesTwo, 0L, null, "", null,
-                null, null);
+                languagesTwo, 0L, null, "", null, null);
 
         ArrayList<NodeAddress> nodeAddresses = new ArrayList<NodeAddress>() {{
             add(two.getNodeAddress());

--- a/core/src/test/java/bisq/core/arbitration/ArbitratorTest.java
+++ b/core/src/test/java/bisq/core/arbitration/ArbitratorTest.java
@@ -51,7 +51,7 @@ public class ArbitratorTest {
                 new Date().getTime(),
                 getBytes(100),
                 "registrationSignature",
-                null, null, null);
+                null, null);
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/test/java/bisq/core/arbitration/MediatorTest.java
+++ b/core/src/test/java/bisq/core/arbitration/MediatorTest.java
@@ -50,7 +50,6 @@ public class MediatorTest {
                 getBytes(100),
                 "registrationSignature",
                 "email",
-                "info",
-                null);
+                "info");
     }
 }

--- a/core/src/test/java/bisq/core/filter/TestFilter.java
+++ b/core/src/test/java/bisq/core/filter/TestFilter.java
@@ -90,7 +90,6 @@ public class TestFilter {
                 ownerPublicKey.getEncoded(),
                 creationDate,
                 null,
-                null,
                 signerPubKeyAsHex,
                 bannedDevKeys,
                 false,

--- a/core/src/test/java/bisq/core/proto/DeprecatedExtraDataMapTest.java
+++ b/core/src/test/java/bisq/core/proto/DeprecatedExtraDataMapTest.java
@@ -1,0 +1,236 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.proto;
+
+import bisq.core.alert.Alert;
+import bisq.core.dao.governance.proposal.storage.temp.TempProposalPayload;
+import bisq.core.dao.state.model.governance.GenericProposal;
+import bisq.core.filter.Filter;
+import bisq.core.filter.TestFilter;
+import bisq.core.offer.OfferDirection;
+import bisq.core.offer.bsq_swap.BsqSwapOfferPayload;
+import bisq.core.support.dispute.arbitration.arbitrator.Arbitrator;
+import bisq.core.support.dispute.mediation.mediator.Mediator;
+import bisq.core.support.dispute.refund.refundagent.RefundAgent;
+
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.crypto.Encryption;
+import bisq.common.crypto.ProofOfWork;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.Sig;
+
+import com.google.protobuf.Message;
+
+import org.bitcoinj.core.ECKey;
+
+import java.security.PublicKey;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import static org.bitcoinj.core.Utils.HEX;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DeprecatedExtraDataMapTest {
+    @Test
+    public void alertRejectsNonEmptyExtraDataMap() {
+        protobuf.Alert proto = alert().toProtoMessage().getAlert();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                Alert::fromProto,
+                protobuf.Alert::getExtraDataMap);
+    }
+
+    @Test
+    public void filterRejectsNonEmptyExtraDataMap() {
+        protobuf.Filter proto = filter().toProtoMessage().getFilter();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                Filter::fromProto,
+                protobuf.Filter::getExtraDataMap);
+    }
+
+    @Test
+    public void arbitratorRejectsNonEmptyExtraDataMap() {
+        protobuf.Arbitrator proto = arbitrator().toProtoMessage().getArbitrator();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                Arbitrator::fromProto,
+                protobuf.Arbitrator::getExtraDataMap);
+    }
+
+    @Test
+    public void mediatorRejectsNonEmptyExtraDataMap() {
+        protobuf.Mediator proto = mediator().toProtoMessage().getMediator();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                Mediator::fromProto,
+                protobuf.Mediator::getExtraDataMap);
+    }
+
+    @Test
+    public void refundAgentRejectsNonEmptyExtraDataMap() {
+        protobuf.RefundAgent proto = refundAgent().toProtoMessage().getRefundAgent();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                RefundAgent::fromProto,
+                protobuf.RefundAgent::getExtraDataMap);
+    }
+
+    @Test
+    public void tempProposalPayloadRejectsNonEmptyExtraDataMap() {
+        protobuf.TempProposalPayload proto = tempProposalPayload().toProtoMessage().getTempProposalPayload();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                TempProposalPayload::fromProto,
+                protobuf.TempProposalPayload::getExtraDataMap);
+    }
+
+    @Test
+    public void bsqSwapOfferPayloadRejectsNonEmptyExtraDataMap() {
+        protobuf.BsqSwapOfferPayload proto = bsqSwapOfferPayload().toProtoMessage().getBsqSwapOfferPayload();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                BsqSwapOfferPayload::fromProto,
+                protobuf.BsqSwapOfferPayload::getExtraDataMap);
+    }
+
+    private static <T extends Message> void assertDeprecatedExtraDataMap(
+            T proto,
+            Function<T, T> addEmptyExtraDataMap,
+            Function<T, T> addNonEmptyExtraDataMap,
+            Function<T, ?> fromProto,
+            Function<T, ? extends java.util.Map<String, String>> extraDataMap) {
+        assertTrue(extraDataMap.apply(proto).isEmpty());
+        assertNotNull(fromProto.apply(proto));
+
+        T protoWithEmptyExtraDataMap = addEmptyExtraDataMap.apply(proto);
+        assertTrue(extraDataMap.apply(protoWithEmptyExtraDataMap).isEmpty());
+        assertArrayEquals(proto.toByteArray(), protoWithEmptyExtraDataMap.toByteArray());
+        assertNotNull(fromProto.apply(protoWithEmptyExtraDataMap));
+
+        T protoWithNonEmptyExtraDataMap = addNonEmptyExtraDataMap.apply(proto);
+        assertThrows(IllegalArgumentException.class, () -> fromProto.apply(protoWithNonEmptyExtraDataMap));
+    }
+
+    private static Alert alert() {
+        return new Alert("message",
+                true,
+                false,
+                "version",
+                Sig.getPublicKeyBytes(signaturePublicKey()),
+                "signature");
+    }
+
+    private static Filter filter() {
+        return TestFilter.createFilter(signaturePublicKey(), HEX.encode(new ECKey().getPubKey()), 1L);
+    }
+
+    private static Arbitrator arbitrator() {
+        return new Arbitrator(new NodeAddress("host", 1000),
+                new ECKey().getPubKey(),
+                "btcAddress",
+                pubKeyRing(),
+                List.of("en"),
+                1L,
+                new ECKey().getPubKey(),
+                "registrationSignature",
+                "email",
+                "info");
+    }
+
+    private static Mediator mediator() {
+        return new Mediator(new NodeAddress("host", 1000),
+                pubKeyRing(),
+                List.of("en"),
+                1L,
+                new ECKey().getPubKey(),
+                "registrationSignature",
+                "email",
+                "info");
+    }
+
+    private static RefundAgent refundAgent() {
+        return new RefundAgent(new NodeAddress("host", 1000),
+                pubKeyRing(),
+                List.of("en"),
+                1L,
+                new ECKey().getPubKey(),
+                "registrationSignature",
+                "email",
+                "info");
+    }
+
+    private static TempProposalPayload tempProposalPayload() {
+        return new TempProposalPayload(new GenericProposal("name", "link", null), signaturePublicKey());
+    }
+
+    private static BsqSwapOfferPayload bsqSwapOfferPayload() {
+        return new BsqSwapOfferPayload("id",
+                1L,
+                new NodeAddress("host", 1000),
+                pubKeyRing(),
+                OfferDirection.BUY,
+                1L,
+                2L,
+                1L,
+                proofOfWork(),
+                "version",
+                1);
+    }
+
+    private static ProofOfWork proofOfWork() {
+        return new ProofOfWork(new byte[]{1},
+                1L,
+                new byte[]{2},
+                1.0,
+                1L,
+                new byte[]{3},
+                1);
+    }
+
+    private static PubKeyRing pubKeyRing() {
+        return new PubKeyRing(signaturePublicKey(), Encryption.generateKeyPair().getPublic());
+    }
+
+    private static PublicKey signaturePublicKey() {
+        return Sig.generateKeyPair().getPublic();
+    }
+}

--- a/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
+++ b/core/src/test/java/bisq/core/trade/validation/ValidationTestUtils.java
@@ -238,7 +238,6 @@ class ValidationTestUtils {
                 new byte[]{1},
                 "registrationSignature",
                 null,
-                null,
                 null);
     }
 

--- a/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
+++ b/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
@@ -42,7 +42,7 @@ public class UserPayloadModelVOTest {
     public void testRoundtripFull() {
         UserPayload vo = new UserPayload();
         vo.setAccountId("accountId");
-        vo.setDisplayedAlert(new Alert("message", true, false, "version", new byte[]{12, -64, 12}, "string", null));
+        vo.setDisplayedAlert(new Alert("message", true, false, "version", new byte[]{12, -64, 12}, "string"));
         vo.setDevelopersFilter(new Filter(Lists.newArrayList(),
                 Lists.newArrayList(),
                 Lists.newArrayList(),

--- a/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
+++ b/core/src/test/java/bisq/core/user/UserPayloadModelVOTest.java
@@ -65,7 +65,6 @@ public class UserPayloadModelVOTest {
                 null,
                 null,
                 null,
-                null,
                 false,
                 Lists.newArrayList(),
                 new HashSet<>(),

--- a/desktop/src/main/java/bisq/desktop/main/account/register/arbitrator/ArbitratorRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/arbitrator/ArbitratorRegistrationViewModel.java
@@ -59,7 +59,6 @@ public class ArbitratorRegistrationViewModel extends AgentRegistrationViewModel<
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/register/mediator/MediatorRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/mediator/MediatorRegistrationViewModel.java
@@ -55,7 +55,6 @@ class MediatorRegistrationViewModel extends AgentRegistrationViewModel<Mediator,
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/register/refundagent/RefundAgentRegistrationViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/register/refundagent/RefundAgentRegistrationViewModel.java
@@ -56,7 +56,6 @@ public class RefundAgentRegistrationViewModel extends AgentRegistrationViewModel
                 registrationKey.getPubKey(),
                 registrationSignature,
                 emailAddress,
-                null,
                 null
         );
     }

--- a/desktop/src/test/java/bisq/desktop/main/settings/preferences/PreferencesViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/settings/preferences/PreferencesViewModelTest.java
@@ -59,10 +59,10 @@ public class PreferencesViewModelTest {
         }};
 
         RefundAgent one = new RefundAgent(new NodeAddress("refundAgent:1"), null, languagesOne, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         RefundAgent two = new RefundAgent(new NodeAddress("refundAgent:2"), null, languagesTwo, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         refundAgents.put(one.getNodeAddress(), one);
         refundAgents.put(two.getNodeAddress(), two);
@@ -94,10 +94,10 @@ public class PreferencesViewModelTest {
         }};
 
         Mediator one = new Mediator(new NodeAddress("refundAgent:1"), null, languagesOne, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         Mediator two = new Mediator(new NodeAddress("refundAgent:2"), null, languagesTwo, 0L,
-                null, null, null, null, null);
+                null, null, null, null);
 
         mnediators.put(one.getNodeAddress(), one);
         mnediators.put(two.getNodeAddress(), two);

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/ProtectedStoragePayload.java
@@ -48,7 +48,9 @@ public interface ProtectedStoragePayload extends NetworkPayload {
     // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
     // field in a class would break that hash and therefore break the storage mechanism.
     @Nullable
-    Map<String, String> getExtraDataMap();
+    default Map<String, String> getExtraDataMap() {
+        return null;
+    }
 
     static ProtectedStoragePayload fromProto(protobuf.StoragePayload storagePayload, NetworkProtoResolver networkProtoResolver) {
         return (ProtectedStoragePayload) networkProtoResolver.fromProto(storagePayload);

--- a/p2p/src/test/java/bisq/network/p2p/storage/mocks/MockData.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/mocks/MockData.java
@@ -24,18 +24,11 @@ import org.apache.commons.lang3.NotImplementedException;
 
 import java.security.PublicKey;
 
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 @SuppressWarnings("ALL")
 public class MockData implements ProtectedStoragePayload, ExpirablePayload {
     public final String msg;
     public final PublicKey publicKey;
     public long ttl;
-
-    @Nullable
-    private Map<String, String> extraDataMap;
 
     public MockData(String msg, PublicKey publicKey) {
         this.msg = msg;
@@ -63,12 +56,6 @@ public class MockData implements ProtectedStoragePayload, ExpirablePayload {
         return "MockData{" +
                 "msg='" + msg + '\'' +
                 '}';
-    }
-
-    @Nullable
-    @Override
-    public Map<String, String> getExtraDataMap() {
-        return extraDataMap;
     }
 
     @Override

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -688,7 +688,7 @@ message Alert {
     bool is_update_info = 3;
     string signature_as_base64 = 4;
     bytes owner_pub_key_bytes = 5;
-    map<string, string> extra_data = 6;
+    map<string, string> extra_data = 6 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2
     bool is_pre_release_info = 7;
 }
 
@@ -703,7 +703,7 @@ message Arbitrator {
     string btc_address = 8;
     string email_address = 9;
     string info = 10;
-    map<string, string> extra_data = 11;
+    map<string, string> extra_data = 11 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;
 }
 
 message Mediator {
@@ -715,7 +715,7 @@ message Mediator {
     PubKeyRing pub_key_ring = 6;
     string email_address = 7;
     string info = 8;
-    map<string, string> extra_data = 9;
+    map<string, string> extra_data = 9 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;
 }
 
 message RefundAgent {
@@ -727,7 +727,7 @@ message RefundAgent {
     PubKeyRing pub_key_ring = 6;
     string email_address = 7;
     string info = 8;
-    map<string, string> extra_data = 9;
+    map<string, string> extra_data = 9 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;
 }
 
 message Filter {
@@ -736,7 +736,7 @@ message Filter {
     repeated PaymentAccountFilter banned_payment_accounts = 3;
     string signature_as_base64 = 4;
     bytes owner_pub_key_bytes = 5;
-    map<string, string> extra_data = 6;
+    map<string, string> extra_data = 6 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;
     repeated string banned_currencies = 7;
     repeated string banned_payment_methods = 8;
     repeated string arbitrators = 9;

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -871,7 +871,7 @@ message BsqSwapOfferPayload {
     int64 amount = 7;
     int64 min_amount = 8;
     ProofOfWork proof_of_work = 9;
-    map<string, string> extra_data = 10;
+    map<string, string> extra_data = 10 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;;
     string version_nr = 11;
     int32 protocol_version = 12;
 }

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -2350,7 +2350,7 @@ message UnconfirmedBsqChangeOutputList {
 message TempProposalPayload {
     Proposal proposal = 1;
     bytes owner_pub_key_encoded = 2;
-    map<string, string> extra_data = 3;
+    map<string, string> extra_data = 3 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;
 }
 
 message ProposalPayload {


### PR DESCRIPTION
This PR contains only zero risk changes for cases when we have explicitly set `extraDataMap` to null or it was never set and therefor has been null as well. We do not check the `fromProto` values for extraDataMap as historical data always have been null for those cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed legacy per-item extra metadata across alerts, filters, dispute agents and payloads; constructors and serialization now omit extra-data.

* **Chores**
  * Marked legacy extra-data maps in protobuf as deprecated and added compatibility defaults to storage payloads.

* **Tests**
  * Added tests ensuring deprecated extra-data maps are empty and that non-empty maps are rejected; updated tests/mocks to match simplified constructors and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->