### PR TITLE
Remove extra data maps if it was empty map

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
@@ -32,6 +32,8 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.concurrent.Immutable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Holds encryptedVotes, encryptedMeritList, txId of blindVote tx and stake.
  * A encryptedVotes for 1 proposal is 304 bytes
@@ -90,6 +92,11 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
     }
 
     public static BlindVote fromProto(protobuf.BlindVote proto) {
+        // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in BlindVote");
+
         return new BlindVote(proto.getEncryptedVotes().toByteArray(),
                 proto.getTxId(),
                 proto.getStake(),

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVote.java
@@ -21,14 +21,9 @@ import bisq.core.dao.governance.ConsensusCritical;
 
 import bisq.common.proto.network.NetworkPayload;
 import bisq.common.proto.persistable.PersistablePayload;
-import bisq.common.util.CollectionUtils;
-import bisq.common.util.ExtraDataMapValidator;
 import bisq.common.util.Utilities;
 
 import com.google.protobuf.ByteString;
-
-import java.util.Map;
-import java.util.Optional;
 
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -60,21 +55,16 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
     // an unused field.
     private final long date;
 
-    // This hash map allows addition of data in future versions without breaking consensus
-    private final Map<String, String> extraDataMap;
-
     public BlindVote(byte[] encryptedVotes,
                      String txId,
                      long stake,
                      byte[] encryptedMeritList,
-                     long date,
-                     Map<String, String> extraDataMap) {
+                     long date) {
         this.encryptedVotes = encryptedVotes;
         this.txId = txId;
         this.stake = stake;
         this.encryptedMeritList = encryptedMeritList;
         this.date = date;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
     }
 
 
@@ -96,7 +86,6 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 .setStake(stake)
                 .setEncryptedMeritList(ByteString.copyFrom(encryptedMeritList))
                 .setDate(date);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
         return builder;
     }
 
@@ -105,9 +94,7 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 proto.getTxId(),
                 proto.getStake(),
                 proto.getEncryptedMeritList().toByteArray(),
-                proto.getDate(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getDate());
     }
 
 
@@ -122,7 +109,6 @@ public final class BlindVote implements PersistablePayload, NetworkPayload, Cons
                 ",\n     stake=" + stake +
                 ",\n     encryptedMeritList=" + Utilities.bytesAsHexString(encryptedMeritList) +
                 ",\n     date=" + date +
-                ",\n     extraDataMap=" + extraDataMap +
                 "\n}";
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
@@ -73,8 +73,6 @@ public class BlindVoteValidator {
                     "getEncryptedMeritList must not be empty");
             checkArgument(blindVote.getEncryptedMeritList().length <= 100000,
                     "getEncryptedMeritList must not exceed 100kb");
-
-            ExtraDataMapValidator.validate(blindVote.getExtraDataMap());
         } catch (Throwable e) {
             log.warn(e.toString());
             throw new ProposalValidationException(e);

--- a/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/MyBlindVoteListService.java
@@ -214,8 +214,7 @@ public class MyBlindVoteListService implements PersistedDataHost, DaoStateListen
                     blindVoteTxId,
                     stake.value,
                     encryptedMeritList,
-                    new Date().getTime(),
-                    new HashMap<>());
+                    new Date().getTime());
             addBlindVoteToList(blindVote);
 
             addToP2PNetwork(blindVote, errorMessage -> {

--- a/core/src/main/java/bisq/core/dao/governance/proposal/confiscatebond/ConfiscateBondProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/confiscatebond/ConfiscateBondProposalFactory.java
@@ -30,8 +30,6 @@ import org.bitcoinj.core.InsufficientMoneyException;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -71,7 +69,6 @@ public class ConfiscateBondProposalFactory extends BaseProposalFactory<Confiscat
         return new ConfiscateBondProposal(
                 name,
                 link,
-                lockupTxId,
-                new HashMap<>());
+                lockupTxId);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/generic/GenericProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/generic/GenericProposalFactory.java
@@ -64,6 +64,6 @@ public class GenericProposalFactory extends BaseProposalFactory<GenericProposal>
 
     @Override
     protected GenericProposal createProposalWithoutTxId() {
-        return new GenericProposal(name, link, new HashMap<>());
+        return new GenericProposal(name, link);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/param/ChangeParamProposalFactory.java
@@ -31,8 +31,6 @@ import org.bitcoinj.core.InsufficientMoneyException;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -76,7 +74,6 @@ public class ChangeParamProposalFactory extends BaseProposalFactory<ChangeParamP
                 name,
                 link,
                 param,
-                paramValue,
-                new HashMap<>());
+                paramValue);
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/reimbursement/ReimbursementProposalFactory.java
@@ -39,8 +39,6 @@ import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -79,8 +77,7 @@ public class ReimbursementProposalFactory extends BaseProposalFactory<Reimbursem
                 name,
                 link,
                 requestedBsq,
-                bsqAddress,
-                new HashMap<>());
+                bsqAddress);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/governance/proposal/removeAsset/RemoveAssetProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/removeAsset/RemoveAssetProposalFactory.java
@@ -32,8 +32,6 @@ import org.bitcoinj.core.InsufficientMoneyException;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -73,7 +71,6 @@ public class RemoveAssetProposalFactory extends BaseProposalFactory<RemoveAssetP
         return new RemoveAssetProposal(
                 name,
                 link,
-                asset.getTickerSymbol(),
-                new HashMap<>());
+                asset.getTickerSymbol());
     }
 }

--- a/core/src/main/java/bisq/core/dao/governance/proposal/role/RoleProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/role/RoleProposalFactory.java
@@ -31,8 +31,6 @@ import org.bitcoinj.core.InsufficientMoneyException;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -67,6 +65,6 @@ public class RoleProposalFactory extends BaseProposalFactory<RoleProposal> {
 
     @Override
     protected RoleProposal createProposalWithoutTxId() {
-        return new RoleProposal(role, new HashMap<>());
+        return new RoleProposal(role);
     }
 }

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ChangeParamProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ChangeParamProposal.java
@@ -23,16 +23,16 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.util.CollectionUtils;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.Objects;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.Immutable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Immutable
 @Slf4j
@@ -44,16 +44,14 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
     public ChangeParamProposal(String name,
                                String link,
                                Param param,
-                               String paramValue,
-                               Map<String, String> extraDataMap) {
+                               String paramValue) {
         this(name,
                 link,
                 param,
                 paramValue,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -67,14 +65,13 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                                 String paramValue,
                                 byte version,
                                 long creationDate,
-                                String txId,
-                                Map<String, String> extraDataMap) {
+                                String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.param = param;
         this.paramValue = paramValue;
@@ -89,6 +86,10 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
     }
 
     public static ChangeParamProposal fromProto(protobuf.Proposal proto) {
+        // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in ChangeParamProposal");
         final protobuf.ChangeParamProposal proposalProto = proto.getChangeParamProposal();
         return new ChangeParamProposal(proto.getName(),
                 proto.getLink(),
@@ -96,9 +97,7 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                 proposalProto.getParamValue(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -134,8 +133,7 @@ public final class ChangeParamProposal extends Proposal implements ImmutableDaoS
                 getParamValue(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ConfiscateBondProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ConfiscateBondProposal.java
@@ -23,16 +23,16 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.util.CollectionUtils;
 
 import java.util.Date;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.Immutable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Immutable
 @Slf4j
@@ -43,15 +43,13 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
 
     public ConfiscateBondProposal(String name,
                                   String link,
-                                  String lockupTxId,
-                                  Map<String, String> extraDataMap) {
+                                  String lockupTxId) {
         this(name,
                 link,
                 lockupTxId,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -64,14 +62,13 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                                    String lockupTxId,
                                    byte version,
                                    long creationDate,
-                                   String txId,
-                                   Map<String, String> extraDataMap) {
+                                   String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
         this.lockupTxId = lockupTxId;
     }
 
@@ -83,15 +80,18 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
     }
 
     public static ConfiscateBondProposal fromProto(protobuf.Proposal proto) {
+        // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in ConfiscateBondProposal");
+
         final protobuf.ConfiscateBondProposal proposalProto = proto.getConfiscateBondProposal();
         return new ConfiscateBondProposal(proto.getName(),
                 proto.getLink(),
                 proposalProto.getLockupTxId(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -126,8 +126,7 @@ public final class ConfiscateBondProposal extends Proposal implements ImmutableD
                 getLockupTxId(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/GenericProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/GenericProposal.java
@@ -23,10 +23,8 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.util.CollectionUtils;
 
 import java.util.Date;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -34,21 +32,20 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.Immutable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Immutable
 @Slf4j
 @EqualsAndHashCode(callSuper = true)
 @Value
 public final class GenericProposal extends Proposal implements ImmutableDaoStateModel {
 
-    public GenericProposal(String name,
-                           String link,
-                           Map<String, String> extraDataMap) {
+    public GenericProposal(String name, String link) {
         this(name,
                 link,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -60,14 +57,13 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                             String link,
                             byte version,
                             long creationDate,
-                            String txId,
-                            Map<String, String> extraDataMap) {
+                            String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
     }
 
     @Override
@@ -77,13 +73,16 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
     }
 
     public static GenericProposal fromProto(protobuf.Proposal proto) {
+        // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in GenericProposal");
+
         return new GenericProposal(proto.getName(),
                 proto.getLink(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -117,8 +116,7 @@ public final class GenericProposal extends Proposal implements ImmutableDaoState
                 getLink(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
@@ -24,18 +24,18 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.util.CollectionUtils;
 
 import org.bitcoinj.core.Coin;
 
 import java.util.Date;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.Immutable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Immutable
 @Slf4j
@@ -48,16 +48,14 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
     public ReimbursementProposal(String name,
                                  String link,
                                  Coin requestedBsq,
-                                 String bsqAddress,
-                                 Map<String, String> extraDataMap) {
+                                 String bsqAddress) {
         this(name,
                 link,
                 bsqAddress,
                 requestedBsq.value,
                 Version.REIMBURSEMENT_REQUEST,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -71,14 +69,13 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                                   long requestedBsq,
                                   byte version,
                                   long creationDate,
-                                  String txId,
-                                  Map<String, String> extraDataMap) {
+                                  String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.requestedBsq = requestedBsq;
         this.bsqAddress = bsqAddress;
@@ -93,6 +90,11 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
     }
 
     public static ReimbursementProposal fromProto(protobuf.Proposal proto) {
+        // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in getReimbursementProposal");
+
         final protobuf.ReimbursementProposal proposalProto = proto.getReimbursementProposal();
         return new ReimbursementProposal(proto.getName(),
                 proto.getLink(),
@@ -100,9 +102,7 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                 proposalProto.getRequestedBsq(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -143,8 +143,7 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
                 getRequestedBsq().value,
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
@@ -23,16 +23,16 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.util.CollectionUtils;
 
 import java.util.Date;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.Immutable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Immutable
 @Slf4j
@@ -43,15 +43,13 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
 
     public RemoveAssetProposal(String name,
                                String link,
-                               String tickerSymbol,
-                               Map<String, String> extraDataMap) {
+                               String tickerSymbol) {
         this(name,
                 link,
                 tickerSymbol,
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -64,14 +62,13 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                                 String tickerSymbol,
                                 byte version,
                                 long creationDate,
-                                String txId,
-                                Map<String, String> extraDataMap) {
+                                String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.tickerSymbol = tickerSymbol;
     }
@@ -84,15 +81,18 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
     }
 
     public static RemoveAssetProposal fromProto(protobuf.Proposal proto) {
-        final protobuf.RemoveAssetProposal proposalProto = proto.getRemoveAssetProposal();
+        // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in getRemoveAssetProposal");
+
+        protobuf.RemoveAssetProposal proposalProto = proto.getRemoveAssetProposal();
         return new RemoveAssetProposal(proto.getName(),
                 proto.getLink(),
                 proposalProto.getTickerSymbol(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -127,8 +127,7 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
                 getTickerSymbol(),
                 getVersion(),
                 getCreationDate(),
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/RoleProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RoleProposal.java
@@ -23,16 +23,16 @@ import bisq.core.dao.state.model.ImmutableDaoStateModel;
 import bisq.core.dao.state.model.blockchain.TxType;
 
 import bisq.common.app.Version;
-import bisq.common.util.CollectionUtils;
 
 import java.util.Date;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.Immutable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Immutable
 @Slf4j
@@ -43,7 +43,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
     private final long requiredBondUnit;
     private final int unlockTime; // in blocks
 
-    public RoleProposal(Role role, Map<String, String> extraDataMap) {
+    public RoleProposal(Role role) {
         this(role.getName(),
                 role.getLink(),
                 role,
@@ -51,8 +51,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 role.getBondedRoleType().getUnlockTimeInBlocks(),
                 Version.PROPOSAL,
                 new Date().getTime(),
-                null,
-                extraDataMap);
+                null);
     }
 
 
@@ -67,14 +66,13 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                          int unlockTime,
                          byte version,
                          long creationDate,
-                         String txId,
-                         Map<String, String> extraDataMap) {
+                         String txId) {
         super(name,
                 link,
                 version,
                 creationDate,
                 txId,
-                extraDataMap);
+                null);
 
         this.role = role;
         this.requiredBondUnit = requiredBondUnit;
@@ -91,7 +89,12 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
     }
 
     public static RoleProposal fromProto(protobuf.Proposal proto) {
-        final protobuf.RoleProposal proposalProto = proto.getRoleProposal();
+        // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
+        // It is not expected that any historical data exist with a non-empty ExtraDataMap.
+        checkArgument(proto.getExtraDataMap().isEmpty(),
+                "ExtraDataMap is expected to be not set in RoleProposal");
+
+        protobuf.RoleProposal proposalProto = proto.getRoleProposal();
         return new RoleProposal(proto.getName(),
                 proto.getLink(),
                 Role.fromProto(proposalProto.getRole()),
@@ -99,9 +102,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 proposalProto.getUnlockTime(),
                 (byte) proto.getVersion(),
                 proto.getCreationDate(),
-                proto.getTxId(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                proto.getTxId());
     }
 
 
@@ -138,8 +139,7 @@ public final class RoleProposal extends Proposal implements ImmutableDaoStateMod
                 unlockTime,
                 version,
                 creationDate,
-                txId,
-                extraDataMap);
+                txId);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/filter/Filter.java
+++ b/core/src/main/java/bisq/core/filter/Filter.java
@@ -38,7 +38,6 @@ import java.security.PublicKey;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;

--- a/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/mediator/Mediator.java
@@ -23,13 +23,11 @@ import bisq.network.p2p.NodeAddress;
 
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.ProtoUtil;
-import bisq.common.util.CollectionUtils;
 
 import com.google.protobuf.ByteString;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/refundagent/RefundAgent.java
@@ -26,13 +26,11 @@ import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.ProtoUtil;
-import bisq.common.util.CollectionUtils;
 
 import com.google.protobuf.ByteString;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;

--- a/core/src/test/java/bisq/core/proto/DeprecatedExtraDataMapTest.java
+++ b/core/src/test/java/bisq/core/proto/DeprecatedExtraDataMapTest.java
@@ -18,8 +18,18 @@
 package bisq.core.proto;
 
 import bisq.core.alert.Alert;
+import bisq.core.dao.governance.blindvote.BlindVote;
+import bisq.core.dao.governance.param.Param;
 import bisq.core.dao.governance.proposal.storage.temp.TempProposalPayload;
+import bisq.core.dao.state.model.governance.BondedRoleType;
+import bisq.core.dao.state.model.governance.ChangeParamProposal;
+import bisq.core.dao.state.model.governance.ConfiscateBondProposal;
 import bisq.core.dao.state.model.governance.GenericProposal;
+import bisq.core.dao.state.model.governance.Proposal;
+import bisq.core.dao.state.model.governance.ReimbursementProposal;
+import bisq.core.dao.state.model.governance.RemoveAssetProposal;
+import bisq.core.dao.state.model.governance.Role;
+import bisq.core.dao.state.model.governance.RoleProposal;
 import bisq.core.filter.Filter;
 import bisq.core.filter.TestFilter;
 import bisq.core.offer.OfferDirection;
@@ -37,6 +47,7 @@ import bisq.common.crypto.Sig;
 
 import com.google.protobuf.Message;
 
+import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 
 import java.security.PublicKey;
@@ -132,6 +143,57 @@ public class DeprecatedExtraDataMapTest {
                 protobuf.BsqSwapOfferPayload::getExtraDataMap);
     }
 
+    @Test
+    public void blindVoteRejectsNonEmptyExtraDataMap() {
+        protobuf.BlindVote proto = blindVote().toProtoMessage();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                BlindVote::fromProto,
+                protobuf.BlindVote::getExtraDataMap);
+    }
+
+    @Test
+    public void reimbursementProposalRejectsNonEmptyExtraDataMap() {
+        assertProposalDeprecatedExtraDataMap(reimbursementProposal());
+    }
+
+    @Test
+    public void changeParamProposalRejectsNonEmptyExtraDataMap() {
+        assertProposalDeprecatedExtraDataMap(changeParamProposal());
+    }
+
+    @Test
+    public void roleProposalRejectsNonEmptyExtraDataMap() {
+        assertProposalDeprecatedExtraDataMap(roleProposal());
+    }
+
+    @Test
+    public void confiscateBondProposalRejectsNonEmptyExtraDataMap() {
+        assertProposalDeprecatedExtraDataMap(confiscateBondProposal());
+    }
+
+    @Test
+    public void genericProposalRejectsNonEmptyExtraDataMap() {
+        assertProposalDeprecatedExtraDataMap(genericProposal());
+    }
+
+    @Test
+    public void removeAssetProposalRejectsNonEmptyExtraDataMap() {
+        assertProposalDeprecatedExtraDataMap(removeAssetProposal());
+    }
+
+    private static void assertProposalDeprecatedExtraDataMap(Proposal proposal) {
+        protobuf.Proposal proto = proposal.toProtoMessage();
+
+        assertDeprecatedExtraDataMap(proto,
+                p -> p.toBuilder().putAllExtraData(Collections.emptyMap()).build(),
+                p -> p.toBuilder().putExtraData("key", "value").build(),
+                Proposal::fromProto,
+                protobuf.Proposal::getExtraDataMap);
+    }
+
     private static <T extends Message> void assertDeprecatedExtraDataMap(
             T proto,
             Function<T, T> addEmptyExtraDataMap,
@@ -199,7 +261,7 @@ public class DeprecatedExtraDataMapTest {
     }
 
     private static TempProposalPayload tempProposalPayload() {
-        return new TempProposalPayload(new GenericProposal("name", "link"), signaturePublicKey());
+        return new TempProposalPayload(genericProposal(), signaturePublicKey());
     }
 
     private static BsqSwapOfferPayload bsqSwapOfferPayload() {
@@ -214,6 +276,38 @@ public class DeprecatedExtraDataMapTest {
                 proofOfWork(),
                 "version",
                 1);
+    }
+
+    private static BlindVote blindVote() {
+        return new BlindVote(new byte[]{1},
+                "txId",
+                1L,
+                new byte[]{2},
+                3L);
+    }
+
+    private static ReimbursementProposal reimbursementProposal() {
+        return new ReimbursementProposal("name", "link", Coin.valueOf(1), "bsqAddress");
+    }
+
+    private static ChangeParamProposal changeParamProposal() {
+        return new ChangeParamProposal("name", "link", Param.PROPOSAL_FEE, "3");
+    }
+
+    private static RoleProposal roleProposal() {
+        return new RoleProposal(new Role("name", "link", BondedRoleType.BTC_NODE_OPERATOR));
+    }
+
+    private static ConfiscateBondProposal confiscateBondProposal() {
+        return new ConfiscateBondProposal("name", "link", "lockupTxId");
+    }
+
+    private static GenericProposal genericProposal() {
+        return new GenericProposal("name", "link");
+    }
+
+    private static RemoveAssetProposal removeAssetProposal() {
+        return new RemoveAssetProposal("name", "link", "BSQ");
     }
 
     private static ProofOfWork proofOfWork() {

--- a/core/src/test/java/bisq/core/proto/DeprecatedExtraDataMapTest.java
+++ b/core/src/test/java/bisq/core/proto/DeprecatedExtraDataMapTest.java
@@ -199,7 +199,7 @@ public class DeprecatedExtraDataMapTest {
     }
 
     private static TempProposalPayload tempProposalPayload() {
-        return new TempProposalPayload(new GenericProposal("name", "link", null), signaturePublicKey());
+        return new TempProposalPayload(new GenericProposal("name", "link"), signaturePublicKey());
     }
 
     private static BsqSwapOfferPayload bsqSwapOfferPayload() {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -2417,7 +2417,7 @@ message BlindVote {
     int64 stake = 3;
     bytes encrypted_merit_list = 4;
     int64 date = 5;
-    map<string, string> extra_data = 6;
+    map<string, string> extra_data = 6 [deprecated = true]; // Was always empty map and is not supported anymore since v1.10.2
 }
 
 message MyBlindVoteList {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -2283,6 +2283,7 @@ message Proposal {
         RemoveAssetProposal remove_asset_proposal = 12;
     }
     // We leave some index space here in case we add more subclasses.
+    // extra_data is only used in CompensationProposal, the other subclasses have set it to null
     map<string, string> extra_data = 20;
 }
 

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -871,7 +871,7 @@ message BsqSwapOfferPayload {
     int64 amount = 7;
     int64 min_amount = 8;
     ProofOfWork proof_of_work = 9;
-    map<string, string> extra_data = 10 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;;
+    map<string, string> extra_data = 10 [deprecated = true]; // Was always null and is not supported anymore since v1.10.2;
     string version_nr = 11;
     int32 protocol_version = 12;
 }


### PR DESCRIPTION
An empty map has the same wire format representation as a null value. We do not expect historical non-empty map values.

The empty map was added  in 2019 with commit 13ca802dd1a5c6465983d546c6dcbbdaf64a6c28 and has never been filled with entries for the affected classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal data handling by removing support for deprecated extra data fields across governance proposals and voting mechanisms. Enhanced validation to enforce stricter data constraints.

* **Tests**
  * Added validation tests to ensure deprecated data structures are properly rejected during deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->