### PR TITLE
Use treemap for extra data maps if map had only 1 entry

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
+++ b/core/src/main/java/bisq/core/dao/governance/blindvote/BlindVoteValidator.java
@@ -24,8 +24,6 @@ import bisq.core.dao.state.DaoStateService;
 import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.dao.state.model.governance.DaoPhase;
 
-import bisq.common.util.ExtraDataMapValidator;
-
 import javax.inject.Inject;
 
 import java.util.Optional;

--- a/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
+++ b/core/src/main/java/bisq/core/dao/governance/proposal/compensation/CompensationProposalFactory.java
@@ -39,9 +39,8 @@ import org.bitcoinj.core.Transaction;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -79,9 +78,9 @@ public class CompensationProposalFactory extends BaseProposalFactory<Compensatio
 
     @Override
     protected CompensationProposal createProposalWithoutTxId() {
-        Map<String, String> extraDataMap = null;
+        TreeMap<String, String> extraDataMap = null;
         if (burningManReceiverAddress.isPresent()) {
-            extraDataMap = new HashMap<>();
+            extraDataMap = new TreeMap<>();
             extraDataMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, burningManReceiverAddress.get());
         }
         return new CompensationProposal(

--- a/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
@@ -31,6 +31,7 @@ import org.bitcoinj.core.Coin;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -54,7 +55,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                                 String link,
                                 Coin requestedBsq,
                                 String bsqAddress,
-                                @Nullable Map<String, String> extraDataMap) {
+                                @Nullable TreeMap<String, String> extraDataMap) {
         this(name,
                 link,
                 bsqAddress,
@@ -77,7 +78,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                                  byte version,
                                  long creationDate,
                                  String txId,
-                                 @Nullable Map<String, String> extraDataMap) {
+                                 @Nullable TreeMap<String, String> extraDataMap) {
         super(name,
                 link,
                 version,
@@ -98,7 +99,14 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
     }
 
     public static CompensationProposal fromProto(protobuf.Proposal proto) {
-        final protobuf.CompensationProposal proposalProto = proto.getCompensationProposal();
+        if (proto.getExtraDataMap().size() > 1) {
+            // We do not throw an exception as we might add more entries in the future.
+            // In that case, the size check can be removed, but we need to ensure that all users have updated
+            // to v1.10.2 or higher.
+            log.warn("ExtraDataMap in CompensationProposal had more then 1 map entries. " +
+                    "This is not expected.");
+        }
+        protobuf.CompensationProposal proposalProto = proto.getCompensationProposal();
         return new CompensationProposal(proto.getName(),
                 proto.getLink(),
                 proposalProto.getBsqAddress(),
@@ -107,7 +115,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                 proto.getCreationDate(),
                 proto.getTxId(),
                 CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                        null : proto.getExtraDataMap());
+                        null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 
@@ -154,7 +162,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
                 getVersion(),
                 getCreationDate(),
                 txId,
-                extraDataMap);
+                (TreeMap<String, String>) extraDataMap);
     }
 
     @Override

--- a/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/CompensationProposal.java
@@ -103,7 +103,7 @@ public final class CompensationProposal extends Proposal implements IssuanceProp
             // We do not throw an exception as we might add more entries in the future.
             // In that case, the size check can be removed, but we need to ensure that all users have updated
             // to v1.10.2 or higher.
-            log.warn("ExtraDataMap in CompensationProposal had more then 1 map entries. " +
+            log.warn("ExtraDataMap in CompensationProposal had more then 1 map entry. " +
                     "This is not expected.");
         }
         protobuf.CompensationProposal proposalProto = proto.getCompensationProposal();

--- a/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
@@ -70,7 +70,9 @@ public abstract class Proposal implements PersistablePayload, NetworkPayload, Co
         this.version = version;
         this.creationDate = creationDate;
         this.txId = txId;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
+
+        Map<String, String> validatedExtraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
+        this.extraDataMap = validatedExtraDataMap == null ? null : new TreeMap<>(validatedExtraDataMap);
     }
 
 

--- a/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/Proposal.java
@@ -31,6 +31,7 @@ import bisq.common.util.ExtraDataMapValidator;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -63,7 +64,7 @@ public abstract class Proposal implements PersistablePayload, NetworkPayload, Co
                        byte version,
                        long creationDate,
                        @Nullable String txId,
-                       @Nullable Map<String, String> extraDataMap) {
+                       @Nullable TreeMap<String, String> extraDataMap) {
         this.name = name;
         this.link = link;
         this.version = version;

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ReimbursementProposal.java
@@ -93,7 +93,7 @@ public final class ReimbursementProposal extends Proposal implements IssuancePro
         // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
         // It is not expected that any historical data exist with a non-empty ExtraDataMap.
         checkArgument(proto.getExtraDataMap().isEmpty(),
-                "ExtraDataMap is expected to be not set in getReimbursementProposal");
+                "ExtraDataMap is expected to be not set in ReimbursementProposal");
 
         final protobuf.ReimbursementProposal proposalProto = proto.getReimbursementProposal();
         return new ReimbursementProposal(proto.getName(),

--- a/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/RemoveAssetProposal.java
@@ -84,7 +84,7 @@ public final class RemoveAssetProposal extends Proposal implements ImmutableDaoS
         // ExtraDataMap was always empty and is not supported anymore since v1.10.2.
         // It is not expected that any historical data exist with a non-empty ExtraDataMap.
         checkArgument(proto.getExtraDataMap().isEmpty(),
-                "ExtraDataMap is expected to be not set in getRemoveAssetProposal");
+                "ExtraDataMap is expected to be not set in RemoveAssetProposal");
 
         protobuf.RemoveAssetProposal proposalProto = proto.getRemoveAssetProposal();
         return new RemoveAssetProposal(proto.getName(),

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -315,8 +315,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         this.date = date;
         this.mediator = mediator;
         this.refundAgent = refundAgent;
-        ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
-        this.extraDataMap = extraDataMap;
+        Map<String, String> validatedExtraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
+        this.extraDataMap = validatedExtraDataMap == null ? null : new TreeMap<>(validatedExtraDataMap);
         this.hash = hash == null ? createHash() : hash;
 
         dateObj = new Date(date);

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -60,10 +60,10 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -93,7 +93,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     public static TradeStatistics3 from(Trade trade,
                                         @Nullable String referralId,
                                         boolean isTorNetworkNode) {
-        Map<String, String> extraDataMap = new HashMap<>();
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
             extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
         }
@@ -231,13 +231,14 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
     // Hash get set in constructor from json of all the other data fields (with hash = null).
     @JsonExclude
     private final byte[] hash;
+
     // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
     // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
     // field in a class would break that hash and therefore break the storage mechanism.
     @Nullable
     @JsonExclude
     @Getter
-    private final Map<String, String> extraDataMap;
+    private final TreeMap<String, String> extraDataMap;
 
     // We cache the date object to avoid reconstructing a new Date at each getDate call.
     @JsonExclude
@@ -255,7 +256,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                             long date,
                             String mediator,
                             String refundAgent,
-                            @Nullable Map<String, String> extraDataMap) {
+                            @Nullable TreeMap<String, String> extraDataMap) {
         this(currency,
                 price,
                 amount,
@@ -299,7 +300,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                             long date,
                             @Nullable String mediator,
                             @Nullable String refundAgent,
-                            @Nullable Map<String, String> extraDataMap,
+                            @Nullable TreeMap<String, String> extraDataMap,
                             @Nullable byte[] hash) {
         this.currency = currency;
         this.price = price;
@@ -314,8 +315,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         this.date = date;
         this.mediator = mediator;
         this.refundAgent = refundAgent;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
-
+        ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
+        this.extraDataMap = extraDataMap;
         this.hash = hash == null ? createHash() : hash;
 
         dateObj = new Date(date);
@@ -360,7 +361,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                 proto.getDate(),
                 ProtoUtil.stringOrNullFromProto(proto.getMediator()),
                 ProtoUtil.stringOrNullFromProto(proto.getRefundAgent()),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap(),
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()),
                 proto.getHash().toByteArray());
     }
 

--- a/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/burningman/BurningManServiceTest.java
@@ -45,8 +45,8 @@ import javafx.collections.FXCollections;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -362,7 +362,8 @@ public class BurningManServiceTest {
                                                                                     long amount,
                                                                                     String receiverAddress) {
         var issuance = new Issuance(txId, chainHeight, amount, null, IssuanceType.COMPENSATION);
-        var extraDataMap = Map.of(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, receiverAddress);
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
+        extraDataMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, receiverAddress);
         var proposal = new CompensationProposal(name, "link", Coin.valueOf(amount), "bsqAddress", extraDataMap);
         return new Tuple2<>(issuance, new ProposalPayload(proposal.cloneProposalAndAddTxId(txId)));
     }

--- a/core/src/test/java/bisq/core/dao/state/model/governance/CompensationProposalTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/governance/CompensationProposalTest.java
@@ -17,6 +17,8 @@
 
 package bisq.core.dao.state.model.governance;
 
+import bisq.common.util.ExtraDataMapValidator;
+
 import org.bitcoinj.core.Coin;
 
 import java.util.HashMap;
@@ -26,6 +28,7 @@ import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CompensationProposalTest {
@@ -72,5 +75,32 @@ public class CompensationProposalTest {
 
         assertTrue(proposal.getExtraDataMap() instanceof TreeMap);
         assertArrayEquals(hashMapProto.toByteArray(), proposal.toProtoMessage().toByteArray());
+    }
+
+    @Test
+    public void fromProtoSanitizesInvalidExtraDataMap() {
+        Map<String, String> oversizedMap = new HashMap<>();
+        for (int i = 0; i <= ExtraDataMapValidator.MAX_SIZE; i++) {
+            oversizedMap.put("key" + i, "value");
+        }
+        protobuf.Proposal proto = protobuf.Proposal.newBuilder()
+                .setName("name")
+                .setLink("link")
+                .setVersion(1)
+                .setCreationDate(1)
+                .setTxId("txId")
+                .setCompensationProposal(protobuf.CompensationProposal.newBuilder()
+                        .setRequestedBsq(10_000)
+                        .setBsqAddress("bsqAddress"))
+                .putAllExtraData(oversizedMap)
+                .build();
+
+        CompensationProposal proposal = CompensationProposal.fromProto(proto);
+
+        Map<String, String> extraDataMap = proposal.getExtraDataMap();
+        assertNotNull(extraDataMap);
+        assertTrue(extraDataMap instanceof TreeMap);
+        assertTrue(extraDataMap.isEmpty());
+        assertTrue(proposal.toProtoMessage().getExtraDataMap().isEmpty());
     }
 }

--- a/core/src/test/java/bisq/core/dao/state/model/governance/CompensationProposalTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/governance/CompensationProposalTest.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model.governance;
+
+import org.bitcoinj.core.Coin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CompensationProposalTest {
+    @Test
+    public void singleEntryExtraDataMapSerializesLikeHashMap() {
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
+        extraDataMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, "receiverAddress");
+
+        CompensationProposal proposal = new CompensationProposal(
+                "name",
+                "link",
+                Coin.valueOf(10_000),
+                "bsqAddress",
+                extraDataMap);
+
+        protobuf.Proposal treeMapProto = proposal.toProtoMessage();
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, "receiverAddress");
+        protobuf.Proposal hashMapProto = treeMapProto.toBuilder()
+                .clearExtraData()
+                .putAllExtraData(hashMap)
+                .build();
+
+        assertArrayEquals(hashMapProto.toByteArray(), treeMapProto.toByteArray());
+    }
+
+    @Test
+    public void fromProtoConvertsExtraDataMapToTreeMapWithoutChangingSingleEntryBytes() {
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put(CompensationProposal.BURNING_MAN_RECEIVER_ADDRESS, "receiverAddress");
+        protobuf.Proposal hashMapProto = protobuf.Proposal.newBuilder()
+                .setName("name")
+                .setLink("link")
+                .setVersion(1)
+                .setCreationDate(1)
+                .setTxId("txId")
+                .setCompensationProposal(protobuf.CompensationProposal.newBuilder()
+                        .setRequestedBsq(10_000)
+                        .setBsqAddress("bsqAddress"))
+                .putAllExtraData(hashMap)
+                .build();
+
+        CompensationProposal proposal = CompensationProposal.fromProto(hashMapProto);
+
+        assertTrue(proposal.getExtraDataMap() instanceof TreeMap);
+        assertArrayEquals(hashMapProto.toByteArray(), proposal.toProtoMessage().toByteArray());
+    }
+}

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -20,6 +20,8 @@ package bisq.core.trade.statistics;
 import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.payment.payload.PaymentMethod;
 
+import bisq.common.util.ExtraDataMapValidator;
+
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 
@@ -38,6 +40,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TradeStatistics3Test {
@@ -114,6 +118,48 @@ public class TradeStatistics3Test {
 
         assertTrue(tradeStatistics.getExtraDataMap() instanceof TreeMap);
         assertArrayEquals(hashMapProto.toByteArray(), tradeStatistics.toProtoTradeStatistics3().toByteArray());
+    }
+
+    @Test
+    public void fromProtoPreservesNullExtraDataMap() {
+        protobuf.TradeStatistics3 proto = protobuf.TradeStatistics3.newBuilder()
+                .setCurrency("USD")
+                .setPrice(50_000_000)
+                .setAmount(Coin.parseCoin("0.25").value)
+                .setPaymentMethod(String.valueOf(TradeStatistics3.PaymentMethodMapper.SEPA.ordinal()))
+                .setDate(1)
+                .setHash(ByteString.copyFrom(new byte[20]))
+                .build();
+
+        TradeStatistics3 tradeStatistics = TradeStatistics3.fromProto(proto);
+
+        assertNull(tradeStatistics.getExtraDataMap());
+        assertTrue(tradeStatistics.toProtoTradeStatistics3().getExtraDataMap().isEmpty());
+    }
+
+    @Test
+    public void fromProtoSanitizesInvalidExtraDataMap() {
+        Map<String, String> oversizedMap = new HashMap<>();
+        for (int i = 0; i <= ExtraDataMapValidator.MAX_SIZE; i++) {
+            oversizedMap.put("key" + i, "value");
+        }
+        protobuf.TradeStatistics3 proto = protobuf.TradeStatistics3.newBuilder()
+                .setCurrency("USD")
+                .setPrice(50_000_000)
+                .setAmount(Coin.parseCoin("0.25").value)
+                .setPaymentMethod(String.valueOf(TradeStatistics3.PaymentMethodMapper.SEPA.ordinal()))
+                .setDate(1)
+                .setHash(ByteString.copyFrom(new byte[20]))
+                .putAllExtraData(oversizedMap)
+                .build();
+
+        TradeStatistics3 tradeStatistics = TradeStatistics3.fromProto(proto);
+
+        Map<String, String> extraDataMap = tradeStatistics.getExtraDataMap();
+        assertNotNull(extraDataMap);
+        assertTrue(extraDataMap instanceof TreeMap);
+        assertTrue(extraDataMap.isEmpty());
+        assertTrue(tradeStatistics.toProtoTradeStatistics3().getExtraDataMap().isEmpty());
     }
 
     @Disabled("Not fixed yet")

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -26,6 +26,7 @@ import org.bitcoinj.core.Coin;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Disabled;
@@ -45,7 +46,7 @@ public class TradeStatistics3Test {
                 System.currentTimeMillis(),
                 null,
                 null,
-                (Map<String, String>) null);
+                (TreeMap<String, String>) null);
 
         assertTrue(tradeStatistics.isValid());
     }
@@ -59,7 +60,7 @@ public class TradeStatistics3Test {
                 System.currentTimeMillis(),
                 null,
                 null,
-                (Map<String, String>) null);
+                (TreeMap<String, String>) null);
 
         assertFalse(tradeStatistics.isValid());
     }

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -17,13 +17,16 @@
 
 package bisq.core.trade.statistics;
 
+import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.payment.payload.PaymentMethod;
 
 import com.google.common.collect.Sets;
+import com.google.protobuf.ByteString;
 
 import org.bitcoinj.core.Coin;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -32,6 +35,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,6 +67,53 @@ public class TradeStatistics3Test {
                 (TreeMap<String, String>) null);
 
         assertFalse(tradeStatistics.isValid());
+    }
+
+    @Test
+    public void singleEntryExtraDataMapSerializesLikeHashMap() {
+        TreeMap<String, String> extraDataMap = new TreeMap<>();
+        extraDataMap.put(OfferPayload.REFERRAL_ID, "referralId");
+        TradeStatistics3 tradeStatistics = new TradeStatistics3("USD",
+                50_000_000,
+                Coin.parseCoin("0.25").value,
+                "SEPA",
+                1,
+                "mediator",
+                "refundAgent",
+                extraDataMap,
+                new byte[20]);
+
+        protobuf.TradeStatistics3 treeMapProto = tradeStatistics.toProtoTradeStatistics3();
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put(OfferPayload.REFERRAL_ID, "referralId");
+        protobuf.TradeStatistics3 hashMapProto = treeMapProto.toBuilder()
+                .clearExtraData()
+                .putAllExtraData(hashMap)
+                .build();
+
+        assertArrayEquals(hashMapProto.toByteArray(), treeMapProto.toByteArray());
+    }
+
+    @Test
+    public void fromProtoConvertsExtraDataMapToTreeMapWithoutChangingSingleEntryBytes() {
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put(OfferPayload.REFERRAL_ID, "referralId");
+        protobuf.TradeStatistics3 hashMapProto = protobuf.TradeStatistics3.newBuilder()
+                .setCurrency("USD")
+                .setPrice(50_000_000)
+                .setAmount(Coin.parseCoin("0.25").value)
+                .setPaymentMethod(String.valueOf(TradeStatistics3.PaymentMethodMapper.SEPA.ordinal()))
+                .setDate(1)
+                .setMediator("mediator")
+                .setRefundAgent("refundAgent")
+                .setHash(ByteString.copyFrom(new byte[20]))
+                .putAllExtraData(hashMap)
+                .build();
+
+        TradeStatistics3 tradeStatistics = TradeStatistics3.fromProto(hashMapProto);
+
+        assertTrue(tradeStatistics.getExtraDataMap() instanceof TreeMap);
+        assertArrayEquals(hashMapProto.toByteArray(), tradeStatistics.toProtoTradeStatistics3().toByteArray());
     }
 
     @Disabled("Not fixed yet")

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
@@ -28,9 +28,9 @@ import com.google.protobuf.ByteString;
 
 import java.security.PublicKey;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import lombok.EqualsAndHashCode;
@@ -70,7 +70,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
 
     // We add optional TTL entry in v 1.5.5 so we can support different TTL for trade messages and for AckMessages
     @Nullable
-    private Map<String, String> extraDataMap;
+    private TreeMap<String, String> extraDataMap;
 
     public MailboxStoragePayload(PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage,
                                  @NotNull PublicKey senderPubKeyForAddOperation,
@@ -85,7 +85,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
 
         // We do not permit longer TTL as the default one
         if (ttl < TTL) {
-            extraDataMap = new HashMap<>();
+            extraDataMap = new TreeMap<>();
             extraDataMap.put(EXTRA_MAP_KEY_TTL, String.valueOf(ttl));
         }
     }
@@ -98,12 +98,12 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
     private MailboxStoragePayload(PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage,
                                   byte[] senderPubKeyForAddOperationBytes,
                                   byte[] ownerPubKeyBytes,
-                                  @Nullable Map<String, String> extraDataMap) {
+                                  @Nullable TreeMap<String, String> extraDataMap) {
         this.prefixedSealedAndSignedMessage = prefixedSealedAndSignedMessage;
         this.senderPubKeyForAddOperationBytes = senderPubKeyForAddOperationBytes;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
-        this.extraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
-
+        ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
+        this.extraDataMap = extraDataMap;
         senderPubKeyForAddOperation = Sig.getPublicKeyFromBytes(senderPubKeyForAddOperationBytes);
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyBytes);
     }
@@ -119,11 +119,18 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
     }
 
     public static MailboxStoragePayload fromProto(protobuf.MailboxStoragePayload proto) {
+        if (proto.getExtraDataMap().size() > 1) {
+            // We do not throw an exception as we might add more entries in the future.
+            // In that case, the size check can be removed, but we need to ensure that all users have updated
+            // to v1.10.2 or higher.
+            log.warn("ExtraDataMap in MailboxStoragePayload had more then 1 map entries. " +
+                    "This is not expected.");
+        }
         return new MailboxStoragePayload(
                 PrefixedSealedAndSignedMessage.fromPayloadProto(proto.getPrefixedSealedAndSignedMessage()),
                 proto.getSenderPubKeyForAddOperationBytes().toByteArray(),
                 proto.getOwnerPubKeyBytes().toByteArray(),
-                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : proto.getExtraDataMap());
+                CollectionUtils.isEmpty(proto.getExtraDataMap()) ? null : new TreeMap<>(proto.getExtraDataMap()));
     }
 
 
@@ -144,5 +151,10 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
         }
         // If not set in extraDataMap or value is invalid or too large we return default TTL
         return TTL;
+    }
+
+    @Nullable
+    public Map<String, String> getExtraDataMap() {
+        return extraDataMap;
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
@@ -102,8 +102,8 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
         this.prefixedSealedAndSignedMessage = prefixedSealedAndSignedMessage;
         this.senderPubKeyForAddOperationBytes = senderPubKeyForAddOperationBytes;
         this.ownerPubKeyBytes = ownerPubKeyBytes;
-        ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
-        this.extraDataMap = extraDataMap;
+        Map<String, String> validatedExtraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(extraDataMap);
+        this.extraDataMap = validatedExtraDataMap == null ? null : new TreeMap<>(validatedExtraDataMap);
         senderPubKeyForAddOperation = Sig.getPublicKeyFromBytes(senderPubKeyForAddOperationBytes);
         ownerPubKey = Sig.getPublicKeyFromBytes(ownerPubKeyBytes);
     }

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
@@ -123,7 +123,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
             // We do not throw an exception as we might add more entries in the future.
             // In that case, the size check can be removed, but we need to ensure that all users have updated
             // to v1.10.2 or higher.
-            log.warn("ExtraDataMap in MailboxStoragePayload had more then 1 map entries. " +
+            log.warn("ExtraDataMap in MailboxStoragePayload had more then 1 map entry. " +
                     "This is not expected.");
         }
         return new MailboxStoragePayload(

--- a/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/payload/MailboxStoragePayload.java
@@ -154,6 +154,7 @@ public final class MailboxStoragePayload implements ProtectedStoragePayload, Exp
     }
 
     @Nullable
+    @Override
     public Map<String, String> getExtraDataMap() {
         return extraDataMap;
     }

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/MailboxStoragePayloadTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/MailboxStoragePayloadTest.java
@@ -22,6 +22,7 @@ import bisq.network.p2p.PrefixedSealedAndSignedMessage;
 import bisq.network.p2p.TestUtils;
 
 import bisq.common.crypto.SealedAndSigned;
+import bisq.common.util.ExtraDataMapValidator;
 
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
@@ -34,6 +35,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MailboxStoragePayloadTest {
@@ -66,6 +69,42 @@ public class MailboxStoragePayloadTest {
         assertTrue(payload.getExtraDataMap() instanceof TreeMap);
         assertEquals(CUSTOM_TTL, payload.getTTL());
         assertArrayEquals(hashMapProto.toByteArray(), payload.toProtoMessage().toByteArray());
+    }
+
+    @Test
+    public void fromProtoPreservesNullExtraDataMap() throws NoSuchAlgorithmException {
+        protobuf.MailboxStoragePayload proto = newMailboxStoragePayload(MailboxStoragePayload.TTL)
+                .toProtoMessage()
+                .getMailboxStoragePayload();
+
+        MailboxStoragePayload payload = MailboxStoragePayload.fromProto(proto);
+
+        assertNull(payload.getExtraDataMap());
+        assertEquals(MailboxStoragePayload.TTL, payload.getTTL());
+        assertTrue(payload.toProtoMessage().getMailboxStoragePayload().getExtraDataMap().isEmpty());
+    }
+
+    @Test
+    public void fromProtoSanitizesInvalidExtraDataMap() throws NoSuchAlgorithmException {
+        Map<String, String> oversizedMap = new HashMap<>();
+        for (int i = 0; i <= ExtraDataMapValidator.MAX_SIZE; i++) {
+            oversizedMap.put("key" + i, "value");
+        }
+        protobuf.MailboxStoragePayload proto = newMailboxStoragePayload(CUSTOM_TTL)
+                .toProtoMessage()
+                .getMailboxStoragePayload()
+                .toBuilder()
+                .clearExtraData()
+                .putAllExtraData(oversizedMap)
+                .build();
+
+        MailboxStoragePayload payload = MailboxStoragePayload.fromProto(proto);
+
+        Map<String, String> extraDataMap = payload.getExtraDataMap();
+        assertNotNull(extraDataMap);
+        assertTrue(extraDataMap instanceof TreeMap);
+        assertTrue(extraDataMap.isEmpty());
+        assertTrue(payload.toProtoMessage().getMailboxStoragePayload().getExtraDataMap().isEmpty());
     }
 
     private static protobuf.StoragePayload buildStoragePayloadWithHashMapExtraData() throws NoSuchAlgorithmException {

--- a/p2p/src/test/java/bisq/network/p2p/storage/payload/MailboxStoragePayloadTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/payload/MailboxStoragePayloadTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage.payload;
+
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.PrefixedSealedAndSignedMessage;
+import bisq.network.p2p.TestUtils;
+
+import bisq.common.crypto.SealedAndSigned;
+
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MailboxStoragePayloadTest {
+    private static final long CUSTOM_TTL = MailboxStoragePayload.TTL - 1;
+
+    @Test
+    public void singleEntryExtraDataMapSerializesLikeHashMap() throws NoSuchAlgorithmException {
+        MailboxStoragePayload payload = newMailboxStoragePayload(CUSTOM_TTL);
+
+        protobuf.StoragePayload treeMapProto = payload.toProtoMessage();
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put(MailboxStoragePayload.EXTRA_MAP_KEY_TTL, String.valueOf(CUSTOM_TTL));
+        protobuf.MailboxStoragePayload hashMapMailboxProto = treeMapProto.getMailboxStoragePayload().toBuilder()
+                .clearExtraData()
+                .putAllExtraData(hashMap)
+                .build();
+        protobuf.StoragePayload hashMapProto = protobuf.StoragePayload.newBuilder()
+                .setMailboxStoragePayload(hashMapMailboxProto)
+                .build();
+
+        assertArrayEquals(hashMapProto.toByteArray(), treeMapProto.toByteArray());
+    }
+
+    @Test
+    public void fromProtoConvertsExtraDataMapToTreeMapWithoutChangingSingleEntryBytes() throws NoSuchAlgorithmException {
+        protobuf.StoragePayload hashMapProto = buildStoragePayloadWithHashMapExtraData();
+
+        MailboxStoragePayload payload = MailboxStoragePayload.fromProto(hashMapProto.getMailboxStoragePayload());
+
+        assertTrue(payload.getExtraDataMap() instanceof TreeMap);
+        assertEquals(CUSTOM_TTL, payload.getTTL());
+        assertArrayEquals(hashMapProto.toByteArray(), payload.toProtoMessage().toByteArray());
+    }
+
+    private static protobuf.StoragePayload buildStoragePayloadWithHashMapExtraData() throws NoSuchAlgorithmException {
+        protobuf.StoragePayload treeMapProto = newMailboxStoragePayload(CUSTOM_TTL).toProtoMessage();
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put(MailboxStoragePayload.EXTRA_MAP_KEY_TTL, String.valueOf(CUSTOM_TTL));
+        return protobuf.StoragePayload.newBuilder()
+                .setMailboxStoragePayload(treeMapProto.getMailboxStoragePayload().toBuilder()
+                        .clearExtraData()
+                        .putAllExtraData(hashMap))
+                .build();
+    }
+
+    private static MailboxStoragePayload newMailboxStoragePayload(long ttl) throws NoSuchAlgorithmException {
+        KeyPair keyPair = TestUtils.generateKeyPair();
+        SealedAndSigned sealedAndSigned = new SealedAndSigned(
+                new byte[] { 1 },
+                new byte[] { 2 },
+                new byte[] { 3 },
+                keyPair.getPublic());
+        PrefixedSealedAndSignedMessage prefixedSealedAndSignedMessage =
+                new PrefixedSealedAndSignedMessage(new NodeAddress("host", 1000), sealedAndSigned);
+        return new MailboxStoragePayload(
+                prefixedSealedAndSignedMessage,
+                keyPair.getPublic(),
+                keyPair.getPublic(),
+                ttl);
+    }
+}


### PR DESCRIPTION
Replacing HashMap with TreeMap for maps which only contains 1 entry is safe as order is irrelevant in that case.

Those affected maps had never more then 1 entry in the past.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Extra-data maps now use a deterministic, ordered representation to ensure consistent serialization across components.

* **Bug Fixes**
  * Incoming oversized/invalid extra-data is sanitized and triggers warnings to prevent malformed payloads.

* **Tests**
  * Added comprehensive protobuf round-trip and edge-case tests for extra-data handling and serialization determinism.

* **Chores**
  * Removed an unused validator import and clarified related error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->