### PR TITLE
Use custom sorted maps for extra data maps if map have more then 1 entry

### DIFF
--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -552,7 +552,7 @@ class CoreOffersService {
                 offer.getAcceptedCountryCodes(),
                 offer.getBankId(),
                 offer.getAcceptedBankIds(),
-                offer.getExtraDataMap());
+                offer.getOfferPayloadExtraDataMap());
         log.info("Merging OfferPayload with {}", mutableOfferPayloadFields);
         return offerUtil.getMergedOfferPayload(openOffer, mutableOfferPayloadFields);
     }

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -26,6 +26,7 @@ import bisq.core.offer.availability.OfferAvailabilityModel;
 import bisq.core.offer.availability.OfferAvailabilityProtocol;
 import bisq.core.offer.bisq_v1.MarketPriceNotAvailableException;
 import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.offer.bsq_swap.BsqSwapOfferPayload;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.price.MarketPrice;
@@ -57,7 +58,6 @@ import java.security.PublicKey;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.Getter;
@@ -66,6 +66,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Values.*;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -382,25 +384,25 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     public Optional<String> getAccountAgeWitnessHashAsHex() {
-        Map<String, String> extraDataMap = getExtraDataMap();
-        if (extraDataMap != null && extraDataMap.containsKey(OfferPayload.ACCOUNT_AGE_WITNESS_HASH))
-            return Optional.of(extraDataMap.get(OfferPayload.ACCOUNT_AGE_WITNESS_HASH));
+        OfferPayloadExtraDataMap extraDataMap = getOfferPayloadExtraDataMap();
+        if (extraDataMap != null && extraDataMap.containsKey(ACCOUNT_AGE_WITNESS_HASH))
+            return Optional.of(extraDataMap.get(ACCOUNT_AGE_WITNESS_HASH));
         else
             return Optional.empty();
     }
 
     public String getF2FCity() {
-        if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.F2F_CITY))
-            return getExtraDataMap().get(OfferPayload.F2F_CITY);
+        if (getOfferPayloadExtraDataMap() != null && getOfferPayloadExtraDataMap().containsKey(F2F_CITY))
+            return getOfferPayloadExtraDataMap().get(F2F_CITY);
         else
             return "";
     }
 
     public String getExtraInfo() {
-        if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.F2F_EXTRA_INFO))
-            return getExtraDataMap().get(OfferPayload.F2F_EXTRA_INFO);
-        else if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.CASH_BY_MAIL_EXTRA_INFO))
-            return getExtraDataMap().get(OfferPayload.CASH_BY_MAIL_EXTRA_INFO);
+        if (getOfferPayloadExtraDataMap() != null && getOfferPayloadExtraDataMap().containsKey(F2F_EXTRA_INFO))
+            return getOfferPayloadExtraDataMap().get(F2F_EXTRA_INFO);
+        else if (getOfferPayloadExtraDataMap() != null && getOfferPayloadExtraDataMap().containsKey(CASH_BY_MAIL_EXTRA_INFO))
+            return getOfferPayloadExtraDataMap().get(CASH_BY_MAIL_EXTRA_INFO);
         else
             return "";
     }
@@ -529,8 +531,8 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     @Nullable
-    public Map<String, String> getExtraDataMap() {
-        return offerPayloadBase.getExtraDataMap();
+    public OfferPayloadExtraDataMap getOfferPayloadExtraDataMap() {
+        return offerPayloadBase.getOfferPayloadExtraDataMap();
     }
 
     public boolean isUseAutoClose() {
@@ -549,11 +551,11 @@ public class Offer implements NetworkPayload, PersistablePayload {
         if (!isXmr()) {
             return false;
         }
-        if (getExtraDataMap() == null || !getExtraDataMap().containsKey(OfferPayload.XMR_AUTO_CONF)) {
+        if (getOfferPayloadExtraDataMap() == null || !getOfferPayloadExtraDataMap().containsKey(XMR_AUTO_CONF)) {
             return false;
         }
 
-        return getExtraDataMap().get(OfferPayload.XMR_AUTO_CONF).equals(OfferPayload.XMR_AUTO_CONF_ENABLED_VALUE);
+        return getOfferPayloadExtraDataMap().get(XMR_AUTO_CONF).equals(XMR_AUTO_CONF_ENABLED_VALUE);
     }
 
     public boolean isXmr() {

--- a/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayloadBase.java
@@ -17,6 +17,8 @@
 
 package bisq.core.offer;
 
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
+
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.storage.payload.ExpirablePayload;
 import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
@@ -63,7 +65,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
     // cache
     protected transient byte[] hash;
     @Nullable
-    protected final Map<String, String> extraDataMap;
+    protected final OfferPayloadExtraDataMap offerPayloadExtraDataMap;
 
     public OfferPayloadBase(String id,
                             long date,
@@ -77,7 +79,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
                             long minAmount,
                             String paymentMethodId,
                             String makerPaymentAccountId,
-                            @Nullable Map<String, String> extraDataMap,
+                            @Nullable OfferPayloadExtraDataMap offerPayloadExtraDataMap,
                             String versionNr,
                             int protocolVersion) {
         this.id = id;
@@ -92,7 +94,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
         this.minAmount = minAmount;
         this.paymentMethodId = paymentMethodId;
         this.makerPaymentAccountId = makerPaymentAccountId;
-        this.extraDataMap = extraDataMap;
+        this.offerPayloadExtraDataMap = offerPayloadExtraDataMap;
         this.versionNr = versionNr;
         this.protocolVersion = protocolVersion;
     }
@@ -123,6 +125,11 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
         return TTL;
     }
 
+    @Nullable
+    public Map<String, String> getExtraDataMap() {
+        return offerPayloadExtraDataMap != null ? offerPayloadExtraDataMap.getMap() : null;
+    }
+
     @Override
     public String toString() {
         return "OfferPayloadBase{" +
@@ -141,7 +148,7 @@ public abstract class OfferPayloadBase implements ProtectedStoragePayload, Expir
                 ",\r\n     protocolVersion=" + protocolVersion +
                 ",\r\n     pubKeyRing=" + pubKeyRing +
                 ",\r\n     hash=" + (hash != null ? Hex.encode(hash) : "null") +
-                ",\r\n     extraDataMap=" + extraDataMap +
+                ",\r\n     offerPayloadExtraDataMap=" + offerPayloadExtraDataMap +
                 "\r\n}";
     }
 }

--- a/core/src/main/java/bisq/core/offer/OfferRestrictions.java
+++ b/core/src/main/java/bisq/core/offer/OfferRestrictions.java
@@ -17,7 +17,7 @@
 
 package bisq.core.offer;
 
-import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 
 import bisq.common.app.Capabilities;
 import bisq.common.app.Capability;
@@ -28,7 +28,8 @@ import org.bitcoinj.core.Coin;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.Map;
+
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 
 public class OfferRestrictions {
     public static final Date TOLERATED_SMALL_TRADE_AMOUNT_CHANGE_ACTIVATION_DATE = Utilities.getUTCDate(2025, GregorianCalendar.FEBRUARY, 17);
@@ -46,9 +47,9 @@ public class OfferRestrictions {
             : Coin.parseCoin("0.01");
 
     static boolean hasOfferMandatoryCapability(Offer offer, Capability mandatoryCapability) {
-        Map<String, String> extraDataMap = offer.getExtraDataMap();
-        if (extraDataMap != null && extraDataMap.containsKey(OfferPayload.CAPABILITIES)) {
-            String commaSeparatedOrdinals = extraDataMap.get(OfferPayload.CAPABILITIES);
+        OfferPayloadExtraDataMap extraDataMap = offer.getOfferPayloadExtraDataMap();
+        if (extraDataMap != null && extraDataMap.containsKey(CAPABILITIES)) {
+            String commaSeparatedOrdinals = extraDataMap.get(CAPABILITIES);
             Capabilities capabilities = Capabilities.fromStringList(commaSeparatedOrdinals);
             return Capabilities.hasMandatoryCapability(capabilities, mandatoryCapability);
         }

--- a/core/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/core/src/main/java/bisq/core/offer/OfferUtil.java
@@ -27,6 +27,7 @@ import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.bisq_v1.MutableOfferPayloadFields;
 import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.payment.CashByMailAccount;
 import bisq.core.payment.F2FAccount;
 import bisq.core.payment.PaymentAccount;
@@ -62,9 +63,7 @@ import org.bitcoinj.utils.Fiat;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -79,7 +78,8 @@ import static bisq.core.btc.wallet.Restrictions.getMaxBuyerSecurityDepositAsPerc
 import static bisq.core.btc.wallet.Restrictions.getMinBuyerSecurityDepositAsPercent;
 import static bisq.core.btc.wallet.Restrictions.getMinNonDustOutput;
 import static bisq.core.btc.wallet.Restrictions.isDust;
-import static bisq.core.offer.bisq_v1.OfferPayload.*;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Values.*;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -343,39 +343,40 @@ public class OfferUtil {
                 bsqFormatter);
     }
 
-    public Map<String, String> getExtraDataMap(PaymentAccount paymentAccount,
-                                               String currencyCode,
-                                               OfferDirection direction) {
-        Map<String, String> extraDataMap = new HashMap<>();
+    @Nullable
+    public OfferPayloadExtraDataMap getOfferPayloadExtraDataMap(PaymentAccount paymentAccount,
+                                                                String currencyCode,
+                                                                OfferDirection direction) {
+        OfferPayloadExtraDataMap offerPayloadExtraDataMap = new OfferPayloadExtraDataMap();
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             String myWitnessHashAsHex = accountAgeWitnessService
                     .getMyWitnessHashAsHex(paymentAccount.getPaymentAccountPayload());
-            extraDataMap.put(ACCOUNT_AGE_WITNESS_HASH, myWitnessHashAsHex);
+            offerPayloadExtraDataMap.put(ACCOUNT_AGE_WITNESS_HASH, myWitnessHashAsHex);
         }
 
         if (referralIdService.getOptionalReferralId().isPresent()) {
-            extraDataMap.put(REFERRAL_ID, referralIdService.getOptionalReferralId().get());
+            offerPayloadExtraDataMap.put(REFERRAL_ID, referralIdService.getOptionalReferralId().get());
         }
 
         if (paymentAccount instanceof F2FAccount) {
-            extraDataMap.put(F2F_CITY, ((F2FAccount) paymentAccount).getCity());
-            extraDataMap.put(F2F_EXTRA_INFO, ((F2FAccount) paymentAccount).getExtraInfo());
+            offerPayloadExtraDataMap.put(F2F_CITY, ((F2FAccount) paymentAccount).getCity());
+            offerPayloadExtraDataMap.put(F2F_EXTRA_INFO, ((F2FAccount) paymentAccount).getExtraInfo());
         }
 
         if (paymentAccount instanceof CashByMailAccount) {
-            extraDataMap.put(CASH_BY_MAIL_EXTRA_INFO, ((CashByMailAccount) paymentAccount).getExtraInfo());
+            offerPayloadExtraDataMap.put(CASH_BY_MAIL_EXTRA_INFO, ((CashByMailAccount) paymentAccount).getExtraInfo());
         }
 
-        extraDataMap.put(CAPABILITIES, Capabilities.app.toStringList());
+        offerPayloadExtraDataMap.put(CAPABILITIES, Capabilities.app.toStringList());
 
         if (currencyCode.equals("XMR") && direction == OfferDirection.SELL) {
             preferences.getAutoConfirmSettingsList().stream()
                     .filter(e -> e.getCurrencyCode().equals("XMR"))
                     .filter(AutoConfirmSettings::isEnabled)
-                    .forEach(e -> extraDataMap.put(XMR_AUTO_CONF, XMR_AUTO_CONF_ENABLED_VALUE));
+                    .forEach(e -> offerPayloadExtraDataMap.put(XMR_AUTO_CONF, XMR_AUTO_CONF_ENABLED_VALUE));
         }
 
-        return extraDataMap.isEmpty() ? null : extraDataMap;
+        return offerPayloadExtraDataMap.isEmpty() ? null : offerPayloadExtraDataMap;
     }
 
     public void validateOfferData(double buyerSecurityDeposit,

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -37,6 +37,7 @@ import bisq.core.offer.availability.messages.OfferAvailabilityResponse;
 import bisq.core.offer.bisq_v1.CreateOfferService;
 import bisq.core.offer.bisq_v1.MarketPriceNotAvailableException;
 import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
 import bisq.core.offer.placeoffer.bisq_v1.PlaceOfferModel;
 import bisq.core.offer.placeoffer.bisq_v1.PlaceOfferProtocol;
 import bisq.core.provider.mempool.FeeValidationStatus;
@@ -105,6 +106,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 import static bisq.core.trade.validation.DelayedPayoutTxValidation.checkBurningManSelectionHeight;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -1038,21 +1040,21 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
                 // - Capabilities changed?
                 // We rewrite our offer with the additional capabilities entry
-                Map<String, String> updatedExtraDataMap = new HashMap<>();
+                OfferPayloadExtraDataMap updatedMap = new OfferPayloadExtraDataMap();
                 if (!OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.MEDIATION) ||
                         !OfferRestrictions.hasOfferMandatoryCapability(originalOffer, Capability.REFUND_AGENT)) {
-                    Map<String, String> originalExtraDataMap = original.getExtraDataMap();
+                    OfferPayloadExtraDataMap originalMap = original.getOfferPayloadExtraDataMap();
 
-                    if (originalExtraDataMap != null) {
-                        updatedExtraDataMap.putAll(originalExtraDataMap);
+                    if (originalMap != null) {
+                        updatedMap.putAll(originalMap.getMap());
                     }
 
                     // We overwrite any entry with our current capabilities
-                    updatedExtraDataMap.put(OfferPayload.CAPABILITIES, Capabilities.app.toStringList());
+                    updatedMap.put(CAPABILITIES, Capabilities.app.toStringList());
 
                     log.info("Converted offer to support new Capability.MEDIATION and Capability.REFUND_AGENT capability. id={}", originalOffer.getId());
                 } else {
-                    updatedExtraDataMap = original.getExtraDataMap();
+                    updatedMap = original.getOfferPayloadExtraDataMap();
                 }
 
                 // - Protocol version changed?
@@ -1106,7 +1108,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                         original.getUpperClosePrice(),
                         original.isPrivateOffer(),
                         original.getHashOfChallenge(),
-                        updatedExtraDataMap,
+                        updatedMap,
                         protocolVersion);
 
                 // Save states from original data to use for the updated

--- a/core/src/main/java/bisq/core/offer/bisq_v1/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/CreateOfferService.java
@@ -51,7 +51,6 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -169,7 +168,7 @@ public class CreateOfferService {
         long lowerClosePrice = 0;
         long upperClosePrice = 0;
         String hashOfChallenge = null;
-        Map<String, String> extraDataMap = offerUtil.getExtraDataMap(paymentAccount,
+        OfferPayloadExtraDataMap extraDataMap = offerUtil.getOfferPayloadExtraDataMap(paymentAccount,
                 currencyCode,
                 direction);
 

--- a/core/src/main/java/bisq/core/offer/bisq_v1/MutableOfferPayloadFields.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/MutableOfferPayloadFields.java
@@ -18,7 +18,6 @@
 package bisq.core.offer.bisq_v1;
 
 import java.util.List;
-import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -50,7 +49,7 @@ public final class MutableOfferPayloadFields {
     @Nullable
     private final List<String> acceptedBankIds;
     @Nullable
-    private final Map<String, String> extraDataMap;
+    private final OfferPayloadExtraDataMap extraDataMap;
 
     public MutableOfferPayloadFields(OfferPayload offerPayload) {
         this(offerPayload.getPrice(),
@@ -66,7 +65,7 @@ public final class MutableOfferPayloadFields {
                 offerPayload.getAcceptedCountryCodes(),
                 offerPayload.getBankId(),
                 offerPayload.getAcceptedBankIds(),
-                offerPayload.getExtraDataMap());
+                offerPayload.getOfferPayloadExtraDataMap());
     }
 
     public MutableOfferPayloadFields(long fixedPrice,
@@ -82,7 +81,7 @@ public final class MutableOfferPayloadFields {
                                      @Nullable List<String> acceptedCountryCodes,
                                      @Nullable String bankId,
                                      @Nullable List<String> acceptedBankIds,
-                                     @Nullable Map<String, String> extraDataMap) {
+                                     @Nullable OfferPayloadExtraDataMap extraDataMap) {
         this.fixedPrice = fixedPrice;
         this.marketPriceMargin = marketPriceMargin;
         this.useMarketBasedPrice = useMarketBasedPrice;

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayload.java
@@ -33,7 +33,6 @@ import com.google.gson.JsonSerializationContext;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -55,23 +54,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Getter
 @Slf4j
 public final class OfferPayload extends OfferPayloadBase {
-    // Keys for extra map
-    // Only set for fiat offers
-    public static final String ACCOUNT_AGE_WITNESS_HASH = "accountAgeWitnessHash";
-    public static final String REFERRAL_ID = "referralId";
-    // Only used in payment method F2F
-    public static final String F2F_CITY = "f2fCity";
-    public static final String F2F_EXTRA_INFO = "f2fExtraInfo";
-    public static final String CASH_BY_MAIL_EXTRA_INFO = "cashByMailExtraInfo";
-
-    // Comma separated list of ordinal of a bisq.common.app.Capability. E.g. ordinal of
-    // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker
-    // of the offer supports both capabilities we add "11, 12" to capabilities.
-    public static final String CAPABILITIES = "capabilities";
-    // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
-    public static final String XMR_AUTO_CONF = "xmrAutoConf";
-    public static final String XMR_AUTO_CONF_ENABLED_VALUE = "1";
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Instance fields
@@ -170,7 +152,7 @@ public final class OfferPayload extends OfferPayloadBase {
                         long upperClosePrice,
                         boolean isPrivateOffer,
                         @Nullable String hashOfChallenge,
-                        @Nullable Map<String, String> extraDataMap,
+                        @Nullable OfferPayloadExtraDataMap extraDataMap,
                         int protocolVersion) {
         super(id,
                 date,
@@ -276,7 +258,7 @@ public final class OfferPayload extends OfferPayloadBase {
         Optional.ofNullable(acceptedBankIds).ifPresent(builder::addAllAcceptedBankIds);
         Optional.ofNullable(acceptedCountryCodes).ifPresent(builder::addAllAcceptedCountryCodes);
         Optional.ofNullable(hashOfChallenge).ifPresent(builder::setHashOfChallenge);
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
+        Optional.ofNullable(offerPayloadExtraDataMap).map(OfferPayloadExtraDataMap::getMap).ifPresent(builder::putAllExtraData);
 
         return protobuf.StoragePayload.newBuilder().setOfferPayload(builder).build();
     }
@@ -289,8 +271,8 @@ public final class OfferPayload extends OfferPayloadBase {
         List<String> acceptedCountryCodes = proto.getAcceptedCountryCodesList().isEmpty() ?
                 null : new ArrayList<>(proto.getAcceptedCountryCodesList());
         String hashOfChallenge = ProtoUtil.stringOrNullFromProto(proto.getHashOfChallenge());
-        Map<String, String> extraDataMapMap = CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                null : proto.getExtraDataMap();
+        OfferPayloadExtraDataMap extraDataMapMap = CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
+                null : new OfferPayloadExtraDataMap(proto.getExtraDataMap());
 
         return new OfferPayload(proto.getId(),
                 proto.getDate(),
@@ -402,7 +384,9 @@ public final class OfferPayload extends OfferPayloadBase {
             object.add("lowerClosePrice", context.serialize(offerPayload.getLowerClosePrice()));
             object.add("upperClosePrice", context.serialize(offerPayload.getUpperClosePrice()));
             object.add("isPrivateOffer", context.serialize(offerPayload.isPrivateOffer()));
-            object.add("extraDataMap", context.serialize(offerPayload.getExtraDataMap()));
+            object.add("extraDataMap", context.serialize(offerPayload.getOfferPayloadExtraDataMap() != null
+                    ? offerPayload.getOfferPayloadExtraDataMap().getMap()
+                    : null));
             object.add("protocolVersion", context.serialize(offerPayload.getProtocolVersion()));
             return object;
         }

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.offer.bisq_v1;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import lombok.Getter;
+
+public class OfferPayloadExtraDataMap {
+    // This replicates the order of the Java HashMap for the given keys to support backward compatibility.
+    private static final List<String> LEGACY_HASHMAP_ORDER = List.of(
+            Keys.CAPABILITIES,
+            Keys.REFERRAL_ID,
+            Keys.XMR_AUTO_CONF,
+            Keys.ACCOUNT_AGE_WITNESS_HASH,
+            Keys.CASH_BY_MAIL_EXTRA_INFO,
+            Keys.F2F_EXTRA_INFO,
+            Keys.F2F_CITY
+    );
+
+    public ImmutableMap<String, String> getMap() {
+        // ImmutableMap.copyOf preserves the order.
+        // From the ImmutableMap.copyOf Java doc: The returned map iterates over entries in the same order
+        // as the entrySet of the original map.
+        return ImmutableMap.copyOf(map);
+    }
+
+    private final Map<String, String> map;
+
+    // We use the LEGACY_HASHMAP_ORDER as comparator for the TreeMap
+    public OfferPayloadExtraDataMap() {
+        map = new TreeMap<>(Comparator.comparingInt(LEGACY_HASHMAP_ORDER::indexOf));
+    }
+
+    // If we get constructed from protobuf data we keep the order of the protobuf
+    // LinkedHashMap
+    public OfferPayloadExtraDataMap(Map<String, String> map) {
+        this.map = new LinkedHashMap<>(map);
+    }
+
+    public String put(String key, String value) {
+        return map.put(key, value);
+    }
+
+    public void putAll(Map<String, String> map) {
+        this.map.putAll(map);
+    }
+
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+
+    public String get(String key) {
+        return map.get(key);
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public static class Keys {
+        // Keys for extra map
+        // Only set for fiat offers
+        public static final String ACCOUNT_AGE_WITNESS_HASH = "accountAgeWitnessHash";
+        public static final String REFERRAL_ID = "referralId";
+        // Only used in payment method F2F
+        public static final String F2F_CITY = "f2fCity";
+        public static final String F2F_EXTRA_INFO = "f2fExtraInfo";
+        public static final String CASH_BY_MAIL_EXTRA_INFO = "cashByMailExtraInfo";
+        // Comma separated list of ordinal of a bisq.common.app.Capability. E.g. ordinal of
+        // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker
+        // of the offer supports both capabilities we add "11, 12" to capabilities.
+        public static final String CAPABILITIES = "capabilities";
+        // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
+        public static final String XMR_AUTO_CONF = "xmrAutoConf";
+    }
+
+    public static class Values {
+        // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
+        public static final String XMR_AUTO_CONF_ENABLED_VALUE = "1";
+    }
+}

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
@@ -19,17 +19,16 @@ package bisq.core.offer.bisq_v1;
 
 import com.google.common.collect.ImmutableMap;
 
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-
-import lombok.Getter;
+import java.util.Objects;
+import java.util.Set;
 
 public class OfferPayloadExtraDataMap {
-    // This replicates the order of the Java HashMap for the given keys to support backward compatibility.
-    private static final List<String> LEGACY_HASHMAP_ORDER = List.of(
+    // This replicates the order of the Java HashMap for the given keys, inserted by current offer producers,
+    // to support backward compatibility.
+    static final List<String> LEGACY_HASHMAP_ORDER = List.of(
             Keys.CAPABILITIES,
             Keys.REFERRAL_ID,
             Keys.XMR_AUTO_CONF,
@@ -38,33 +37,37 @@ public class OfferPayloadExtraDataMap {
             Keys.F2F_EXTRA_INFO,
             Keys.F2F_CITY
     );
+    private static final Set<String> SUPPORTED_KEYS = Set.copyOf(LEGACY_HASHMAP_ORDER);
 
-    public ImmutableMap<String, String> getMap() {
-        // ImmutableMap.copyOf preserves the order.
-        // From the ImmutableMap.copyOf Java doc: The returned map iterates over entries in the same order
-        // as the entrySet of the original map.
-        return ImmutableMap.copyOf(map);
-    }
+    private final LinkedHashMap<String, String> map;
+    private final boolean preserveInsertionOrder;
 
-    private final Map<String, String> map;
-
-    // We use the LEGACY_HASHMAP_ORDER as comparator for the TreeMap
+    // Locally created maps are always serialized in the legacy Java HashMap order.
     public OfferPayloadExtraDataMap() {
-        map = new TreeMap<>(Comparator.comparingInt(LEGACY_HASHMAP_ORDER::indexOf));
+        preserveInsertionOrder = false;
+        map = new LinkedHashMap<>();
     }
 
     // If we get constructed from protobuf data we keep the order of the protobuf
     // LinkedHashMap
     public OfferPayloadExtraDataMap(Map<String, String> map) {
-        this.map = new LinkedHashMap<>(map);
+        preserveInsertionOrder = true;
+        this.map = new LinkedHashMap<>();
+        putAll(map);
     }
 
     public String put(String key, String value) {
-        return map.put(key, value);
+        validateEntry(key, value);
+        String previousValue = map.put(key, value);
+        maybeApplyLegacyHashMapOrder();
+        return previousValue;
     }
 
     public void putAll(Map<String, String> map) {
+        Objects.requireNonNull(map, "map must not be null");
+        map.forEach(OfferPayloadExtraDataMap::validateEntry);
         this.map.putAll(map);
+        maybeApplyLegacyHashMapOrder();
     }
 
     public boolean containsKey(String key) {
@@ -77,6 +80,53 @@ public class OfferPayloadExtraDataMap {
 
     public boolean isEmpty() {
         return map.isEmpty();
+    }
+
+    public ImmutableMap<String, String> getMap() {
+        // ImmutableMap.copyOf preserves the order.
+        // From the ImmutableMap.copyOf Java doc: The returned map iterates over entries in the same order
+        // as the entrySet of the original map.
+        return ImmutableMap.copyOf(map);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof OfferPayloadExtraDataMap that)) return false;
+
+        return map.equals(that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "OfferPayloadExtraDataMap{" +
+                "map=" + map +
+                '}';
+    }
+
+    private void maybeApplyLegacyHashMapOrder() {
+        if (preserveInsertionOrder) {
+            return;
+        }
+
+        LinkedHashMap<String, String> orderedMap = new LinkedHashMap<>();
+        LEGACY_HASHMAP_ORDER.stream()
+                .filter(map::containsKey)
+                .forEach(key -> orderedMap.put(key, map.get(key)));
+        map.clear();
+        map.putAll(orderedMap);
+    }
+
+    private static void validateEntry(String key, String value) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        if (!SUPPORTED_KEYS.contains(key)) {
+            throw new IllegalArgumentException("Unsupported OfferPayload extraDataMap key: " + key);
+        }
     }
 
     public static class Keys {

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
@@ -35,7 +35,11 @@ public class OfferPayloadExtraDataMap {
             Keys.ACCOUNT_AGE_WITNESS_HASH,
             Keys.CASH_BY_MAIL_EXTRA_INFO,
             Keys.F2F_EXTRA_INFO,
-            Keys.F2F_CITY
+            Keys.F2F_CITY,
+            Keys.RESERVED_0,
+            Keys.RESERVED_1,
+            Keys.RESERVED_2,
+            Keys.RESERVED_3
     );
     private static final Set<String> SUPPORTED_KEYS = Set.copyOf(LEGACY_HASHMAP_ORDER);
 
@@ -144,6 +148,12 @@ public class OfferPayloadExtraDataMap {
         public static final String CAPABILITIES = "capabilities";
         // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
         public static final String XMR_AUTO_CONF = "xmrAutoConf";
+
+        // Reserved for future use.
+        public static final String RESERVED_0 = "reserved0";
+        public static final String RESERVED_1 = "reserved1";
+        public static final String RESERVED_2 = "reserved2";
+        public static final String RESERVED_3 = "reserved3";
     }
 
     public static class Values {

--- a/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMap.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.Set;
 
 public class OfferPayloadExtraDataMap {
-    // This replicates the order of the Java HashMap for the given keys, inserted by current offer producers,
+    // This replicates the order of the Java HashMap for the given keys, inserted by current producers,
     // to support backward compatibility.
     static final List<String> LEGACY_HASHMAP_ORDER = List.of(
             Keys.CAPABILITIES,

--- a/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/BsqSwapOfferPayload.java
@@ -122,8 +122,6 @@ public final class BsqSwapOfferPayload extends OfferPayloadBase
                 .setVersionNr(versionNr)
                 .setProtocolVersion(protocolVersion);
 
-        Optional.ofNullable(extraDataMap).ifPresent(builder::putAllExtraData);
-
         return protobuf.StoragePayload.newBuilder().setBsqSwapOfferPayload(builder).build();
     }
 

--- a/core/src/main/java/bisq/core/payment/payload/AchTransferAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AchTransferAccountPayload.java
@@ -21,8 +21,6 @@ import bisq.core.locale.Res;
 
 import com.google.protobuf.Message;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -57,7 +55,7 @@ public final class AchTransferAccountPayload extends BankAccountPayload {
                                        String accountType,
                                        String holderAddress,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -106,7 +104,7 @@ public final class AchTransferAccountPayload extends BankAccountPayload {
                 bankAccountPayloadPB.getAccountType().isEmpty() ? null : bankAccountPayloadPB.getAccountType(),
                 accountPayloadPB.getHolderAddress().isEmpty() ? null : accountPayloadPB.getHolderAddress(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AdvancedCashAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -53,7 +51,7 @@ public final class AdvancedCashAccountPayload extends PaymentAccountPayload {
                                        String id,
                                        String accountNr,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -76,7 +74,7 @@ public final class AdvancedCashAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getAdvancedCashAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/AliPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AliPayAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -51,7 +49,7 @@ public final class AliPayAccountPayload extends PaymentAccountPayload {
                                  String id,
                                  String accountNr,
                                  long maxTradePeriod,
-                                 Map<String, String> excludeFromJsonDataMap) {
+                                 PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -73,7 +71,7 @@ public final class AliPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getAliPayAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/AmazonGiftCardAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AmazonGiftCardAccountPayload.java
@@ -24,8 +24,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -59,7 +57,7 @@ public class AmazonGiftCardAccountPayload extends PaymentAccountPayload {
                                          String emailOrMobileNr,
                                          String countryCode,
                                          long maxTradePeriod,
-                                         Map<String, String> excludeFromJsonDataMap) {
+                                         PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 maxTradePeriod,
@@ -87,7 +85,7 @@ public class AmazonGiftCardAccountPayload extends PaymentAccountPayload {
                 amazonGiftCardAccountPayload.getEmailOrMobileNr(),
                 amazonGiftCardAccountPayload.getCountryCode(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/AssetsAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AssetsAccountPayload.java
@@ -21,7 +21,6 @@ import bisq.core.locale.Res;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,7 +49,7 @@ public abstract class AssetsAccountPayload extends PaymentAccountPayload {
                                    String id,
                                    String address,
                                    long maxTradePeriod,
-                                   Map<String, String> excludeFromJsonDataMap) {
+                                   PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,

--- a/core/src/main/java/bisq/core/payment/payload/AustraliaPayidAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/AustraliaPayidAccountPayload.java
@@ -25,8 +25,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -57,7 +55,7 @@ public final class AustraliaPayidAccountPayload extends PaymentAccountPayload {
                                          String payid,
                                          String bankAccountName,
                                          long maxTradePeriod,
-                                         Map<String, String> excludeFromJsonDataMap) {
+                                         PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -85,7 +83,7 @@ public final class AustraliaPayidAccountPayload extends PaymentAccountPayload {
                 AustraliaPayidPayload.getPayid(),
                 AustraliaPayidPayload.getBankAccountName(),
                 proto.getMaxTradePeriod(),
-                CollectionUtils.isEmpty(proto.getExcludeFromJsonDataMap()) ? null : new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/BankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/BankAccountPayload.java
@@ -23,7 +23,6 @@ import bisq.core.locale.Res;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
@@ -72,7 +71,7 @@ public abstract class BankAccountPayload extends CountryBasedPaymentAccountPaylo
                                  @Nullable String bankId,
                                  @Nullable String nationalAccountId,
                                  long maxTradePeriod,
-                                 Map<String, String> excludeFromJsonDataMap) {
+                                 PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,

--- a/core/src/main/java/bisq/core/payment/payload/BizumAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/BizumAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,7 +47,7 @@ public final class BizumAccountPayload extends CountryBasedPaymentAccountPayload
                                 String countryCode,
                                 String mobileNr,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -80,7 +78,7 @@ public final class BizumAccountPayload extends CountryBasedPaymentAccountPayload
                 countryBasedPaymentAccountPayload.getCountryCode(),
                 paytmAccountPayloadPB.getMobileNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/CapitualAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CapitualAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -53,7 +51,7 @@ public final class CapitualAccountPayload extends PaymentAccountPayload {
                                    String id,
                                    String accountNr,
                                    long maxTradePeriod,
-                                   Map<String, String> excludeFromJsonDataMap) {
+                                   PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -76,7 +74,7 @@ public final class CapitualAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getCapitualAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/payment/payload/CashAppAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CashAppAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -56,7 +54,7 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
                                   String id,
                                   String cashTag,
                                   long maxTradePeriod,
-                                  Map<String, String> excludeFromJsonDataMap) {
+                                  PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -78,7 +76,7 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getCashAppAccountPayload().getCashTag(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/CashByMailAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CashByMailAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -58,7 +56,7 @@ public final class CashByMailAccountPayload extends PaymentAccountPayload implem
                                              String contact,
                                              String extraInfo,
                                              long maxTradePeriod,
-                                             Map<String, String> excludeFromJsonDataMap) {
+                                             PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -86,7 +84,7 @@ public final class CashByMailAccountPayload extends PaymentAccountPayload implem
                 proto.getCashByMailAccountPayload().getContact(),
                 proto.getCashByMailAccountPayload().getExtraInfo(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/CashDepositAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CashDepositAccountPayload.java
@@ -23,8 +23,6 @@ import bisq.core.locale.Res;
 
 import com.google.protobuf.Message;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
@@ -69,7 +67,7 @@ public class CashDepositAccountPayload extends BankAccountPayload {
                                       @Nullable String bankId,
                                       @Nullable String nationalAccountId,
                                       long maxTradePeriod,
-                                      Map<String, String> excludeFromJsonDataMap) {
+                                      PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -129,7 +127,7 @@ public class CashDepositAccountPayload extends BankAccountPayload {
                 cashDepositAccountPayload.getBankId().isEmpty() ? null : cashDepositAccountPayload.getBankId(),
                 cashDepositAccountPayload.getNationalAccountId().isEmpty() ? null : cashDepositAccountPayload.getNationalAccountId(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/CelPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CelPayAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -48,7 +46,7 @@ public final class CelPayAccountPayload extends PaymentAccountPayload {
                                   String id,
                                   String email,
                                   long maxTradePeriod,
-                                  Map<String, String> excludeFromJsonDataMap) {
+                                  PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -70,7 +68,7 @@ public final class CelPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getCelPayAccountPayload().getEmail(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/ChaseQuickPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/ChaseQuickPayAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -58,7 +56,7 @@ public final class ChaseQuickPayAccountPayload extends PaymentAccountPayload imp
                                         String email,
                                         String holderName,
                                         long maxTradePeriod,
-                                        Map<String, String> excludeFromJsonDataMap) {
+                                        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -83,7 +81,7 @@ public final class ChaseQuickPayAccountPayload extends PaymentAccountPayload imp
                 proto.getChaseQuickPayAccountPayload().getEmail(),
                 proto.getChaseQuickPayAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/ClearXchangeAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/ClearXchangeAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,7 +53,7 @@ public final class ClearXchangeAccountPayload extends PaymentAccountPayload impl
                                        String emailOrMobileNr,
                                        String holderName,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -81,7 +79,7 @@ public final class ClearXchangeAccountPayload extends PaymentAccountPayload impl
                 proto.getClearXchangeAccountPayload().getEmailOrMobileNr(),
                 proto.getClearXchangeAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/CountryBasedPaymentAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CountryBasedPaymentAccountPayload.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -45,7 +44,7 @@ public abstract class CountryBasedPaymentAccountPayload extends PaymentAccountPa
                                                 String id,
                                                 String countryCode,
                                                 long maxTradePeriod,
-                                                Map<String, String> excludeFromJsonDataMap) {
+                                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 maxTradePeriod,

--- a/core/src/main/java/bisq/core/payment/payload/CryptoCurrencyAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/CryptoCurrencyAccountPayload.java
@@ -19,8 +19,6 @@ package bisq.core.payment.payload;
 
 import com.google.protobuf.Message;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -48,7 +46,7 @@ public final class CryptoCurrencyAccountPayload extends AssetsAccountPayload {
                                          String id,
                                          String address,
                                          long maxTradePeriod,
-                                         Map<String, String> excludeFromJsonDataMap) {
+                                         PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 address,
@@ -70,6 +68,6 @@ public final class CryptoCurrencyAccountPayload extends AssetsAccountPayload {
                 proto.getId(),
                 proto.getCryptoCurrencyAccountPayload().getAddress(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/DomesticWireTransferAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/DomesticWireTransferAccountPayload.java
@@ -22,8 +22,6 @@ import bisq.core.locale.Res;
 
 import com.google.protobuf.Message;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -57,7 +55,7 @@ public final class DomesticWireTransferAccountPayload extends BankAccountPayload
                                       String accountNr,
                                       String holderAddress,
                                       long maxTradePeriod,
-                                      Map<String, String> excludeFromJsonDataMap) {
+                                      PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -105,7 +103,7 @@ public final class DomesticWireTransferAccountPayload extends BankAccountPayload
                 bankAccountPayloadPB.getAccountNr().isEmpty() ? null : bankAccountPayloadPB.getAccountNr(),
                 accountPayloadPB.getHolderAddress().isEmpty() ? null : accountPayloadPB.getHolderAddress(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/F2FAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/F2FAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -60,7 +58,7 @@ public final class F2FAccountPayload extends CountryBasedPaymentAccountPayload {
                               String city,
                               String extraInfo,
                               long maxTradePeriod,
-                              Map<String, String> excludeFromJsonDataMap) {
+                              PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -96,7 +94,7 @@ public final class F2FAccountPayload extends CountryBasedPaymentAccountPayload {
                 f2fAccountPayloadPB.getCity(),
                 f2fAccountPayloadPB.getExtraInfo(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/FasterPaymentsAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/FasterPaymentsAccountPayload.java
@@ -27,14 +27,14 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.*;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString
@@ -62,7 +62,7 @@ public final class FasterPaymentsAccountPayload extends PaymentAccountPayload {
                                          String accountNr,
                                          String email,
                                          long maxTradePeriod,
-                                         Map<String, String> excludeFromJsonDataMap) {
+                                         PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -91,21 +91,13 @@ public final class FasterPaymentsAccountPayload extends PaymentAccountPayload {
                 proto.getFasterPaymentsAccountPayload().getAccountNr(),
                 proto.getFasterPaymentsAccountPayload().getEmail(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
-
-    public String getHolderName() {
-        return excludeFromJsonDataMap.getOrDefault(HOLDER_NAME, "");
-    }
-
-    public void setHolderName(String holderName) {
-        excludeFromJsonDataMap.compute(HOLDER_NAME, (k, v) -> Strings.emptyToNull(holderName));
-    }
 
     @Override
     public String getPaymentDetails() {

--- a/core/src/main/java/bisq/core/payment/payload/HalCashAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/HalCashAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -52,7 +50,7 @@ public final class HalCashAccountPayload extends PaymentAccountPayload {
     private HalCashAccountPayload(String paymentMethod, String id,
                                   String mobileNr,
                                   long maxTradePeriod,
-                                  Map<String, String> excludeFromJsonDataMap) {
+                                  PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -74,7 +72,7 @@ public final class HalCashAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getHalCashAccountPayload().getMobileNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/IfscBasedAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/IfscBasedAccountPayload.java
@@ -7,7 +7,6 @@ import bisq.core.locale.Res;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.Map;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
@@ -41,7 +40,7 @@ public abstract class IfscBasedAccountPayload extends CountryBasedPaymentAccount
                                  String accountNr,
                                  String ifsc,
                                  long maxTradePeriod,
-                                 Map<String, String> excludeFromJsonDataMap) {
+                                 PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,

--- a/core/src/main/java/bisq/core/payment/payload/ImpsAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/ImpsAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,7 +48,7 @@ public final class ImpsAccountPayload extends IfscBasedAccountPayload {
                                String accountNr,
                                String ifsc,
                                long maxTradePeriod,
-                               Map<String, String> excludeFromJsonDataMap) {
+                               PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -88,7 +86,7 @@ public final class ImpsAccountPayload extends IfscBasedAccountPayload {
                 ifscBasedAccountPayloadPB.getAccountNr(),
                 ifscBasedAccountPayloadPB.getIfsc(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/InstantCryptoCurrencyPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/InstantCryptoCurrencyPayload.java
@@ -19,8 +19,6 @@ package bisq.core.payment.payload;
 
 import com.google.protobuf.Message;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -48,7 +46,7 @@ public final class InstantCryptoCurrencyPayload extends AssetsAccountPayload {
                                          String id,
                                          String address,
                                          long maxTradePeriod,
-                                         Map<String, String> excludeFromJsonDataMap) {
+                                         PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 address,
@@ -70,6 +68,6 @@ public final class InstantCryptoCurrencyPayload extends AssetsAccountPayload {
                 proto.getId(),
                 proto.getInstantCryptoCurrencyAccountPayload().getAddress(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/InteracETransferAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/InteracETransferAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -61,7 +59,7 @@ public final class InteracETransferAccountPayload extends PaymentAccountPayload 
                                            String question,
                                            String answer,
                                            long maxTradePeriod,
-                                           Map<String, String> excludeFromJsonDataMap) {
+                                           PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -92,7 +90,7 @@ public final class InteracETransferAccountPayload extends PaymentAccountPayload 
                 proto.getInteracETransferAccountPayload().getQuestion(),
                 proto.getInteracETransferAccountPayload().getAnswer(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/JapanBankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/JapanBankAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -68,7 +66,7 @@ public final class JapanBankAccountPayload extends PaymentAccountPayload impleme
                                     String bankAccountName,
                                     String bankAccountNumber,
                                     long maxTradePeriod,
-                                    Map<String, String> excludeFromJsonDataMap) {
+                                    PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -111,7 +109,7 @@ public final class JapanBankAccountPayload extends PaymentAccountPayload impleme
                 japanBankAccountPayload.getBankAccountName(),
                 japanBankAccountPayload.getBankAccountNumber(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/MercadoPagoAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/MercadoPagoAccountPayload.java
@@ -20,8 +20,6 @@ package bisq.core.payment.payload;
 import bisq.core.locale.Res;
 import com.google.protobuf.Message;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -48,7 +46,7 @@ public final class MercadoPagoAccountPayload extends CountryBasedPaymentAccountP
                                          String accountHolderName,
                                          String accountHolderId,
                                          long maxTradePeriod,
-                                         Map<String, String> excludeFromJsonDataMap) {
+                                         PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -82,7 +80,7 @@ public final class MercadoPagoAccountPayload extends CountryBasedPaymentAccountP
                 mercadoPagoAccountPayloadPB.getHolderName(),
                 mercadoPagoAccountPayloadPB.getHolderId(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/MoneseAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/MoneseAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,7 +48,7 @@ public final class MoneseAccountPayload extends PaymentAccountPayload {
                                  String holderName,
                                  String mobileNr,
                                  long maxTradePeriod,
-                                 Map<String, String> excludeFromJsonDataMap) {
+                                 PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -76,7 +74,7 @@ public final class MoneseAccountPayload extends PaymentAccountPayload {
                 proto.getMoneseAccountPayload().getHolderName(),
                 proto.getMoneseAccountPayload().getMobileNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/MoneyBeamAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/MoneyBeamAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,7 +53,7 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
                                     String id,
                                     String accountId,
                                     long maxTradePeriod,
-                                    Map<String, String> excludeFromJsonDataMap) {
+                                    PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -78,7 +76,7 @@ public final class MoneyBeamAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getMoneyBeamAccountPayload().getAccountId(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/MoneyGramAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/MoneyGramAccountPayload.java
@@ -25,8 +25,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -61,7 +59,7 @@ public class MoneyGramAccountPayload extends PaymentAccountPayload implements Pa
                                     String state,
                                     String email,
                                     long maxTradePeriod,
-                                    Map<String, String> excludeFromJsonDataMap) {
+                                    PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 maxTradePeriod,
@@ -96,7 +94,7 @@ public class MoneyGramAccountPayload extends PaymentAccountPayload implements Pa
                 moneyGramAccountPayload.getState(),
                 moneyGramAccountPayload.getEmail(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/NationalBankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/NationalBankAccountPayload.java
@@ -21,8 +21,6 @@ import bisq.core.locale.Res;
 
 import com.google.protobuf.Message;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -54,7 +52,7 @@ public final class NationalBankAccountPayload extends BankAccountPayload {
                                        String bankId,
                                        String nationalAccountId,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -102,7 +100,7 @@ public final class NationalBankAccountPayload extends BankAccountPayload {
                 bankAccountPayloadPB.getBankId().isEmpty() ? null : bankAccountPayloadPB.getBankId(),
                 bankAccountPayloadPB.getNationalAccountId().isEmpty() ? null : bankAccountPayloadPB.getNationalAccountId(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/NeftAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/NeftAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,7 +48,7 @@ public final class NeftAccountPayload extends IfscBasedAccountPayload {
                               String accountNr,
                               String ifsc,
                               long maxTradePeriod,
-                              Map<String, String> excludeFromJsonDataMap) {
+                              PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -88,7 +86,7 @@ public final class NeftAccountPayload extends IfscBasedAccountPayload {
                 ifscBasedAccountPayloadPB.getAccountNr(),
                 ifscBasedAccountPayloadPB.getIfsc(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/NequiAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/NequiAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,7 +47,7 @@ public final class NequiAccountPayload extends CountryBasedPaymentAccountPayload
                                 String countryCode,
                                 String mobileNr,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -80,7 +78,7 @@ public final class NequiAccountPayload extends CountryBasedPaymentAccountPayload
                 countryBasedPaymentAccountPayload.getCountryCode(),
                 paytmAccountPayloadPB.getMobileNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/OKPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/OKPayAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,7 +53,7 @@ public final class OKPayAccountPayload extends PaymentAccountPayload {
                                 String id,
                                 String accountNr,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -77,7 +75,7 @@ public final class OKPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getOKPayAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/PaxumAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaxumAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -53,7 +51,7 @@ public final class PaxumAccountPayload extends PaymentAccountPayload {
                                        String id,
                                        String email,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -75,7 +73,7 @@ public final class PaxumAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getPaxumAccountPayload().getEmail(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayload.java
@@ -32,14 +32,13 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.*;
 import static com.google.common.base.Preconditions.checkArgument;
 
 // That class is used in the contract for creating the contract json. Any change will break the contract.
@@ -51,11 +50,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 @ToString
 @Slf4j
 public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTradeContractJson {
-
-    // Keys for excludeFromJsonDataMap
-    public static final String SALT = "salt";
-    public static final String HOLDER_NAME = "holderName";
-
     protected final String paymentMethodId;
     protected final String id;
 
@@ -69,7 +63,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
     // PaymentAccountPayload is used for the json contract and a trade with a user who has an older version would
     // fail the contract verification.
     @JsonExclude
-    protected final Map<String, String> excludeFromJsonDataMap;
+    protected final PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -80,7 +74,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
         this(paymentMethodId,
                 id,
                 -1,
-                new HashMap<>());
+                new PaymentAccountPayloadExcludeFromJsonMap());
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -90,7 +84,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
     protected PaymentAccountPayload(String paymentMethodId,
                                     String id,
                                     long maxTradePeriod,
-                                    Map<String, String> excludeFromJsonDataMapParam) {
+                                    PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMapParam) {
         this.paymentMethodId = paymentMethodId;
         this.id = id;
         this.maxTradePeriod = maxTradePeriod;
@@ -110,7 +104,7 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
                 .setMaxTradePeriod(maxTradePeriod)
                 .setId(id);
 
-        builder.putAllExcludeFromJsonData(excludeFromJsonDataMap);
+        builder.putAllExcludeFromJsonData(excludeFromJsonDataMap.getMap());
 
         return builder;
     }
@@ -147,7 +141,8 @@ public abstract class PaymentAccountPayload implements NetworkPayload, UsedForTr
 
     public void setHolderName(String holderName) {
         // an empty string must result in the mapping removing the entry.
-        excludeFromJsonDataMap.compute(HOLDER_NAME, (k, v) -> Strings.emptyToNull(holderName));
+        excludeFromJsonDataMap.compute(HOLDER_NAME,
+                (k, v) -> Strings.emptyToNull(holderName));
     }
 
     // Identifying data of payment account (e.g. IBAN).

--- a/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayloadExcludeFromJsonMap.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayloadExcludeFromJsonMap.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 public class PaymentAccountPayloadExcludeFromJsonMap {
-    // This replicates the order of the Java HashMap for the given keys, inserted by current offer producers,
+    // This replicates the order of the Java HashMap for the given keys, inserted by current producers,
     // to support backward compatibility.
     static final List<String> LEGACY_HASHMAP_ORDER = List.of(
             Keys.HOLDER_NAME,
@@ -161,10 +161,5 @@ public class PaymentAccountPayloadExcludeFromJsonMap {
         public static final String RESERVED_1 = "reserved1";
         public static final String RESERVED_2 = "reserved2";
         public static final String RESERVED_3 = "reserved3";
-    }
-
-    public static class Values {
-        // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
-        public static final String XMR_AUTO_CONF_ENABLED_VALUE = "1";
     }
 }

--- a/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayloadExcludeFromJsonMap.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentAccountPayloadExcludeFromJsonMap.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+public class PaymentAccountPayloadExcludeFromJsonMap {
+    // This replicates the order of the Java HashMap for the given keys, inserted by current offer producers,
+    // to support backward compatibility.
+    static final List<String> LEGACY_HASHMAP_ORDER = List.of(
+            Keys.HOLDER_NAME,
+            Keys.SALT,
+            Keys.RESERVED_0,
+            Keys.RESERVED_1,
+            Keys.RESERVED_2,
+            Keys.RESERVED_3
+    );
+    private static final Set<String> SUPPORTED_KEYS = Set.copyOf(LEGACY_HASHMAP_ORDER);
+
+    private final LinkedHashMap<String, String> map;
+    private final boolean preserveInsertionOrder;
+
+    // Locally created maps are always serialized in the legacy Java HashMap order.
+    public PaymentAccountPayloadExcludeFromJsonMap() {
+        preserveInsertionOrder = false;
+        map = new LinkedHashMap<>();
+    }
+
+    // If we get constructed from protobuf data we keep the order of the protobuf
+    // LinkedHashMap
+    public PaymentAccountPayloadExcludeFromJsonMap(Map<String, String> map) {
+        preserveInsertionOrder = true;
+        this.map = new LinkedHashMap<>();
+        putAll(map);
+    }
+
+    public String put(String key, String value) {
+        validateEntry(key, value);
+        String previousValue = map.put(key, value);
+        maybeApplyLegacyHashMapOrder();
+        return previousValue;
+    }
+
+    public void putAll(Map<String, String> map) {
+        Objects.requireNonNull(map, "map must not be null");
+        map.forEach(PaymentAccountPayloadExcludeFromJsonMap::validateEntry);
+        this.map.putAll(map);
+        maybeApplyLegacyHashMapOrder();
+    }
+
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+
+    public String get(String key) {
+        return map.get(key);
+    }
+
+    public String compute(String key, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(remappingFunction, "remappingFunction must not be null");
+        if (!SUPPORTED_KEYS.contains(key)) {
+            throw new IllegalArgumentException("Unsupported key: " + key);
+        }
+
+        String newValue = remappingFunction.apply(key, map.get(key));
+        if (newValue == null) {
+            map.remove(key);
+            maybeApplyLegacyHashMapOrder();
+            return null;
+        }
+
+        put(key, newValue);
+        return newValue;
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public ImmutableMap<String, String> getMap() {
+        // ImmutableMap.copyOf preserves the order.
+        // From the ImmutableMap.copyOf Java doc: The returned map iterates over entries in the same order
+        // as the entrySet of the original map.
+        return ImmutableMap.copyOf(map);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof PaymentAccountPayloadExcludeFromJsonMap that)) return false;
+
+        return map.equals(that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "PaymentAccountPayloadExcludeFromJsonMap{" +
+                "map=" + map +
+                '}';
+    }
+
+    private void maybeApplyLegacyHashMapOrder() {
+        if (preserveInsertionOrder) {
+            return;
+        }
+
+        LinkedHashMap<String, String> orderedMap = new LinkedHashMap<>();
+        LEGACY_HASHMAP_ORDER.stream()
+                .filter(map::containsKey)
+                .forEach(key -> orderedMap.put(key, map.get(key)));
+        map.clear();
+        map.putAll(orderedMap);
+    }
+
+    private static void validateEntry(String key, String value) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        if (!SUPPORTED_KEYS.contains(key)) {
+            throw new IllegalArgumentException("Unsupported key: " + key);
+        }
+    }
+
+    public String getOrDefault(String key, String defaultValue) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    public static class Keys {
+        public static final String SALT = "salt";
+        public static final String HOLDER_NAME = "holderName";
+
+
+        // Reserved for future use.
+        public static final String RESERVED_0 = "reserved0";
+        public static final String RESERVED_1 = "reserved1";
+        public static final String RESERVED_2 = "reserved2";
+        public static final String RESERVED_3 = "reserved3";
+    }
+
+    public static class Values {
+        // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
+        public static final String XMR_AUTO_CONF_ENABLED_VALUE = "1";
+    }
+}

--- a/core/src/main/java/bisq/core/payment/payload/PayseraAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PayseraAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -53,7 +51,7 @@ public final class PayseraAccountPayload extends PaymentAccountPayload {
                                        String id,
                                        String email,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -75,7 +73,7 @@ public final class PayseraAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getPayseraAccountPayload().getEmail(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/PaytmAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaytmAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,7 +47,7 @@ public final class PaytmAccountPayload extends CountryBasedPaymentAccountPayload
                                 String countryCode,
                                 String emailOrMobileNr,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -80,7 +78,7 @@ public final class PaytmAccountPayload extends CountryBasedPaymentAccountPayload
                 countryBasedPaymentAccountPayload.getCountryCode(),
                 paytmAccountPayloadPB.getEmailOrMobileNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/PerfectMoneyAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PerfectMoneyAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -53,7 +51,7 @@ public final class PerfectMoneyAccountPayload extends PaymentAccountPayload {
                                        String id,
                                        String accountNr,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -76,7 +74,7 @@ public final class PerfectMoneyAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getPerfectMoneyAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/PixAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PixAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -51,7 +49,7 @@ public final class PixAccountPayload extends CountryBasedPaymentAccountPayload {
                                 String countryCode,
                                 String pixKey,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -82,7 +80,7 @@ public final class PixAccountPayload extends CountryBasedPaymentAccountPayload {
                 countryBasedPaymentAccountPayload.getCountryCode(),
                 paytmAccountPayloadPB.getPixKey(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/PopmoneyAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PopmoneyAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,7 +53,7 @@ public final class PopmoneyAccountPayload extends PaymentAccountPayload implemen
                                    String accountId,
                                    String holderName,
                                    long maxTradePeriod,
-                                   Map<String, String> excludeFromJsonDataMap) {
+                                   PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -81,7 +79,7 @@ public final class PopmoneyAccountPayload extends PaymentAccountPayload implemen
                 proto.getPopmoneyAccountPayload().getAccountId(),
                 proto.getPopmoneyAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/PromptPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/PromptPayAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -52,7 +50,7 @@ public final class PromptPayAccountPayload extends PaymentAccountPayload {
     private PromptPayAccountPayload(String paymentMethod, String id,
                                     String promptPayId,
                                     long maxTradePeriod,
-                                    Map<String, String> excludeFromJsonDataMap) {
+                                    PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -75,7 +73,7 @@ public final class PromptPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getPromptPayAccountPayload().getPromptPayId(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/RevolutAccountPayload.java
@@ -26,8 +26,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -74,7 +72,7 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
                                   String accountId,
                                   @Nullable String userName,
                                   long maxTradePeriod,
-                                  Map<String, String> excludeFromJsonDataMap) {
+                                  PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -100,7 +98,7 @@ public final class RevolutAccountPayload extends PaymentAccountPayload {
                 revolutAccountPayload.getAccountId(),
                 revolutAccountPayload.getUserName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/RtgsAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/RtgsAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,7 +48,7 @@ public final class RtgsAccountPayload extends IfscBasedAccountPayload {
                                String accountNr,
                                String ifsc,
                                long maxTradePeriod,
-                               Map<String, String> excludeFromJsonDataMap) {
+                               PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -88,7 +86,7 @@ public final class RtgsAccountPayload extends IfscBasedAccountPayload {
                 ifscBasedAccountPayloadPB.getAccountNr(),
                 ifscBasedAccountPayloadPB.getIfsc(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/SameBankAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SameBankAccountPayload.java
@@ -21,8 +21,6 @@ import bisq.core.locale.Res;
 
 import com.google.protobuf.Message;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -54,7 +52,7 @@ public final class SameBankAccountPayload extends BankAccountPayload {
                                    String bankId,
                                    String nationalAccountId,
                                    long maxTradePeriod,
-                                   Map<String, String> excludeFromJsonDataMap) {
+                                   PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -102,7 +100,7 @@ public final class SameBankAccountPayload extends BankAccountPayload {
                 bankAccountPayload.getBankId().isEmpty() ? null : bankAccountPayload.getBankId(),
                 bankAccountPayload.getNationalAccountId().isEmpty() ? null : bankAccountPayload.getNationalAccountId(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/payment/payload/SatispayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SatispayAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -51,7 +49,7 @@ public final class SatispayAccountPayload extends CountryBasedPaymentAccountPayl
                                    String holderName,
                                    String mobileNr,
                                    long maxTradePeriod,
-                                   Map<String, String> excludeFromJsonDataMap) {
+                                   PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -85,7 +83,7 @@ public final class SatispayAccountPayload extends CountryBasedPaymentAccountPayl
                 accountPayloadPB.getHolderName(),
                 accountPayloadPB.getMobileNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/SbpAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SbpAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -59,7 +57,7 @@ public final class SbpAccountPayload extends PaymentAccountPayload implements Pa
                                        String mobileNumber,
                                        String bankName,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -88,7 +86,7 @@ public final class SbpAccountPayload extends PaymentAccountPayload implements Pa
                 proto.getSbpAccountPayload().getMobileNumber(),
                 proto.getSbpAccountPayload().getBankName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/SepaAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SepaAccountPayload.java
@@ -28,9 +28,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
@@ -79,7 +77,7 @@ public final class SepaAccountPayload extends CountryBasedPaymentAccountPayload 
                                String email,
                                List<String> acceptedCountryCodes,
                                long maxTradePeriod,
-                               Map<String, String> excludeFromJsonDataMap) {
+                               PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -125,7 +123,7 @@ public final class SepaAccountPayload extends CountryBasedPaymentAccountPayload 
                 sepaAccountPayloadPB.getEmail(),
                 new ArrayList<>(sepaAccountPayloadPB.getAcceptedCountryCodesList()),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/SepaInstantAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SepaInstantAccountPayload.java
@@ -28,9 +28,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
@@ -77,7 +75,7 @@ public final class SepaInstantAccountPayload extends CountryBasedPaymentAccountP
                                       String bic,
                                       List<String> acceptedCountryCodes,
                                       long maxTradePeriod,
-                                      Map<String, String> excludeFromJsonDataMap) {
+                                      PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -119,7 +117,7 @@ public final class SepaInstantAccountPayload extends CountryBasedPaymentAccountP
                 sepaInstantAccountPayloadPB.getBic(),
                 new ArrayList<>(sepaInstantAccountPayloadPB.getAcceptedCountryCodesList()),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/SpecificBanksAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SpecificBanksAccountPayload.java
@@ -24,8 +24,6 @@ import com.google.protobuf.Message;
 import com.google.common.base.Joiner;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -62,7 +60,7 @@ public final class SpecificBanksAccountPayload extends BankAccountPayload {
                                         String nationalAccountId,
                                         ArrayList<String> acceptedBanks,
                                         long maxTradePeriod,
-                                        Map<String, String> excludeFromJsonDataMap) {
+                                        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -117,7 +115,7 @@ public final class SpecificBanksAccountPayload extends BankAccountPayload {
                 bankAccountPayload.getNationalAccountId().isEmpty() ? null : bankAccountPayload.getNationalAccountId(),
                 new ArrayList<>(specificBanksAccountPayload.getAcceptedBanksList()),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/StrikeAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/StrikeAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,7 +47,7 @@ public final class StrikeAccountPayload extends CountryBasedPaymentAccountPayloa
                                    String countryCode,
                                    String holderName,
                                    long maxTradePeriod,
-                                   Map<String, String> excludeFromJsonDataMap) {
+                                   PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -80,7 +78,7 @@ public final class StrikeAccountPayload extends CountryBasedPaymentAccountPayloa
                 countryBasedPaymentAccountPayload.getCountryCode(),
                 accountPayloadPB.getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/SwiftAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SwiftAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -91,7 +89,7 @@ public final class SwiftAccountPayload extends PaymentAccountPayload {
                                 String intermediaryBranch,
                                 String intermediaryAddress,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -161,7 +159,7 @@ public final class SwiftAccountPayload extends PaymentAccountPayload {
                 x.getIntermediaryBranch(),
                 x.getIntermediaryAddress(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/SwishAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/SwishAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -54,7 +52,7 @@ public final class SwishAccountPayload extends PaymentAccountPayload implements 
                                 String mobileNr,
                                 String holderName,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -79,7 +77,7 @@ public final class SwishAccountPayload extends PaymentAccountPayload implements 
                 proto.getSwishAccountPayload().getMobileNr(),
                 proto.getSwishAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/TikkieAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/TikkieAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,7 +47,7 @@ public final class TikkieAccountPayload extends CountryBasedPaymentAccountPayloa
                                    String countryCode,
                                    String iban,
                                    long maxTradePeriod,
-                                   Map<String, String> excludeFromJsonDataMap) {
+                                   PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -80,7 +78,7 @@ public final class TikkieAccountPayload extends CountryBasedPaymentAccountPayloa
                 countryBasedPaymentAccountPayload.getCountryCode(),
                 accountPayloadPB.getIban(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/TransferwiseAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/TransferwiseAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -55,7 +53,7 @@ public final class TransferwiseAccountPayload extends PaymentAccountPayload {
                                        String id,
                                        String email,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -77,7 +75,7 @@ public final class TransferwiseAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getTransferwiseAccountPayload().getEmail(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/TransferwiseUsdAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/TransferwiseUsdAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -53,7 +51,7 @@ public final class TransferwiseUsdAccountPayload extends CountryBasedPaymentAcco
                                  String holderName,
                                  String beneficiaryAddress,
                                  long maxTradePeriod,
-                                 Map<String, String> excludeFromJsonDataMap) {
+                                 PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -90,7 +88,7 @@ public final class TransferwiseUsdAccountPayload extends CountryBasedPaymentAcco
                 accountPayloadPB.getHolderName(),
                 accountPayloadPB.getBeneficiaryAddress(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/USPostalMoneyOrderAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/USPostalMoneyOrderAccountPayload.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -56,7 +54,7 @@ public final class USPostalMoneyOrderAccountPayload extends PaymentAccountPayloa
                                              String postalAddress,
                                              String holderName,
                                              long maxTradePeriod,
-                                             Map<String, String> excludeFromJsonDataMap) {
+                                             PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -81,7 +79,7 @@ public final class USPostalMoneyOrderAccountPayload extends PaymentAccountPayloa
                 proto.getUSPostalMoneyOrderAccountPayload().getPostalAddress(),
                 proto.getUSPostalMoneyOrderAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/UpholdAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/UpholdAccountPayload.java
@@ -25,8 +25,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -60,7 +58,7 @@ public final class UpholdAccountPayload extends PaymentAccountPayload {
                                  String accountId,
                                  String accountOwner,
                                  long maxTradePeriod,
-                                 Map<String, String> excludeFromJsonDataMap) {
+                                 PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -86,7 +84,7 @@ public final class UpholdAccountPayload extends PaymentAccountPayload {
                 proto.getUpholdAccountPayload().getAccountId(),
                 proto.getUpholdAccountPayload().getAccountOwner(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/UpiAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/UpiAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,7 +47,7 @@ public final class UpiAccountPayload extends CountryBasedPaymentAccountPayload {
                                 String countryCode,
                                 String virtualPaymentAddress,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 countryCode,
@@ -80,7 +78,7 @@ public final class UpiAccountPayload extends CountryBasedPaymentAccountPayload {
                 countryBasedPaymentAccountPayload.getCountryCode(),
                 upiAccountPayloadPB.getVirtualPaymentAddress(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/VenmoAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/VenmoAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -58,7 +56,7 @@ public final class VenmoAccountPayload extends PaymentAccountPayload {
                                 String venmoUserName,
                                 String holderName,
                                 long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+                                PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -83,7 +81,7 @@ public final class VenmoAccountPayload extends PaymentAccountPayload {
                 proto.getVenmoAccountPayload().getVenmoUserName(),
                 proto.getVenmoAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/VerseAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/VerseAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,7 +48,7 @@ public final class VerseAccountPayload extends PaymentAccountPayload {
                                  String id,
                                  String holderName,
                                  long maxTradePeriod,
-                                 Map<String, String> excludeFromJsonDataMap) {
+                                 PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -72,7 +70,7 @@ public final class VerseAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getVerseAccountPayload().getHolderName(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
     @Override

--- a/core/src/main/java/bisq/core/payment/payload/WeChatPayAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/WeChatPayAccountPayload.java
@@ -23,8 +23,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -51,7 +49,7 @@ public final class WeChatPayAccountPayload extends PaymentAccountPayload {
                                     String id,
                                     String accountNr,
                                     long maxTradePeriod,
-                                    Map<String, String> excludeFromJsonDataMap) {
+                                    PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -73,7 +71,7 @@ public final class WeChatPayAccountPayload extends PaymentAccountPayload {
                 proto.getId(),
                 proto.getWeChatPayAccountPayload().getAccountNr(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/payment/payload/WesternUnionAccountPayload.java
+++ b/core/src/main/java/bisq/core/payment/payload/WesternUnionAccountPayload.java
@@ -25,8 +25,6 @@ import com.google.protobuf.Message;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -62,7 +60,7 @@ public class WesternUnionAccountPayload extends CountryBasedPaymentAccountPayloa
                                        String state,
                                        String email,
                                        long maxTradePeriod,
-                                       Map<String, String> excludeFromJsonDataMap) {
+                                       PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonDataMap) {
         super(paymentMethodName,
                 id,
                 countryCode,
@@ -103,7 +101,7 @@ public class WesternUnionAccountPayload extends CountryBasedPaymentAccountPayloa
                 westernUnionAccountPayload.getState(),
                 westernUnionAccountPayload.getEmail(),
                 proto.getMaxTradePeriod(),
-                new HashMap<>(proto.getExcludeFromJsonDataMap()));
+                new PaymentAccountPayloadExcludeFromJsonMap(proto.getExcludeFromJsonDataMap()));
     }
 
 

--- a/core/src/main/java/bisq/core/support/dispute/Dispute.java
+++ b/core/src/main/java/bisq/core/support/dispute/Dispute.java
@@ -50,7 +50,6 @@ import javafx.collections.ObservableList;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -143,13 +142,11 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
     @Setter
     private long tradeTxFee;
 
-
     // Should be only used in emergency case if we need to add data but do not want to break backward compatibility
     // at the P2P network storage checks. The hash of the object will be used to verify if the data is valid. Any new
     // field in a class would break that hash and therefore break the storage mechanism.
     @Nullable
-    @Setter
-    private Map<String, String> extraDataMap;
+    private DisputeExtraDataMap extraDataMap;
 
     // We do not persist uid, it is only used by dispute agents to guarantee an uid.
     @Setter
@@ -168,6 +165,7 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public Dispute(long openingDate,
@@ -220,6 +218,7 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
@@ -261,7 +260,7 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
         Optional.ofNullable(mediatorsDisputeResult).ifPresent(result -> builder.setMediatorsDisputeResult(mediatorsDisputeResult));
         Optional.ofNullable(delayedPayoutTxId).ifPresent(result -> builder.setDelayedPayoutTxId(delayedPayoutTxId));
         Optional.ofNullable(donationAddressOfDelayedPayoutTx).ifPresent(result -> builder.setDonationAddressOfDelayedPayoutTx(donationAddressOfDelayedPayoutTx));
-        Optional.ofNullable(getExtraDataMap()).ifPresent(builder::putAllExtraData);
+        Optional.ofNullable(getExtraDataMap()).map(DisputeExtraDataMap::getMap).ifPresent(builder::putAllExtraData);
         return builder.build();
     }
 
@@ -287,9 +286,10 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
                 proto.getIsSupportTicket(),
                 SupportType.fromProto(proto.getSupportType()));
 
-        dispute.setExtraDataMap(CollectionUtils.isEmpty(proto.getExtraDataMap()) ?
-                null : ExtraDataMapValidator.getValidatedExtraDataMap(proto.getExtraDataMap()));
-
+        if (!CollectionUtils.isEmpty(proto.getExtraDataMap())) {
+            Map<String, String> validatedExtraDataMap = ExtraDataMapValidator.getValidatedExtraDataMap(proto.getExtraDataMap());
+            dispute.setExtraDataMap(new DisputeExtraDataMap(validatedExtraDataMap));
+        }
         dispute.chatMessages.addAll(proto.getChatMessageList().stream()
                 .map(ChatMessage::fromPayloadProto)
                 .collect(Collectors.toList()));
@@ -336,6 +336,7 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void addAndPersistChatMessage(ChatMessage chatMessage) {
@@ -376,7 +377,13 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Setters
+
     ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public void setExtraDataMap(@Nullable DisputeExtraDataMap extraDataMap) {
+        this.extraDataMap = extraDataMap;
+    }
+
 
     public void setIsClosed() {
         setState(State.CLOSED);
@@ -400,13 +407,14 @@ public final class Dispute implements NetworkPayload, PersistablePayload {
             return;
         }
         if (extraDataMap == null) {
-            extraDataMap = new HashMap<>();
+            extraDataMap = new DisputeExtraDataMap();
         }
         extraDataMap.put(key, value);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Getters
+
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public String getShortTradeId() {

--- a/core/src/main/java/bisq/core/support/dispute/DisputeExtraDataMap.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeExtraDataMap.java
@@ -17,8 +17,6 @@
 
 package bisq.core.support.dispute;
 
-import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -29,7 +27,7 @@ import java.util.Objects;
 import java.util.Set;
 
 public class DisputeExtraDataMap {
-    // This replicates the order of the Java HashMap for the given keys, inserted by current offer producers,
+    // This replicates the order of the Java HashMap for the given keys, inserted by current producers,
     // to support backward compatibility.
     static final List<String> LEGACY_HASHMAP_ORDER = List.of(
             Keys.COUNTER_CURRENCY_TX_ID,

--- a/core/src/main/java/bisq/core/support/dispute/DisputeExtraDataMap.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeExtraDataMap.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support.dispute;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class DisputeExtraDataMap {
+    // This replicates the order of the Java HashMap for the given keys, inserted by current offer producers,
+    // to support backward compatibility.
+    static final List<String> LEGACY_HASHMAP_ORDER = List.of(
+            Keys.COUNTER_CURRENCY_TX_ID,
+            Keys.COUNTER_CURRENCY_EXTRA_DATA
+    );
+    private static final Set<String> SUPPORTED_KEYS = Set.copyOf(LEGACY_HASHMAP_ORDER);
+
+    private final LinkedHashMap<String, String> map;
+    private final boolean preserveInsertionOrder;
+
+    // Locally created maps are always serialized in the legacy Java HashMap order.
+    public DisputeExtraDataMap() {
+        preserveInsertionOrder = false;
+        map = new LinkedHashMap<>();
+    }
+
+    // If we get constructed from protobuf data we keep the order of the protobuf
+    // LinkedHashMap
+    public DisputeExtraDataMap(Map<String, String> map) {
+        preserveInsertionOrder = true;
+        this.map = new LinkedHashMap<>();
+        putAll(map);
+    }
+
+    public String put(String key, String value) {
+        validateEntry(key, value);
+        String previousValue = map.put(key, value);
+        maybeApplyLegacyHashMapOrder();
+        return previousValue;
+    }
+
+    public void putAll(Map<String, String> map) {
+        Objects.requireNonNull(map, "map must not be null");
+        map.forEach(DisputeExtraDataMap::validateEntry);
+        this.map.putAll(map);
+        maybeApplyLegacyHashMapOrder();
+    }
+
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+
+    public String get(String key) {
+        return map.get(key);
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public ImmutableSet<Map.Entry<String, String>> entrySet() {
+        return ImmutableSet.copyOf(map.entrySet());
+    }
+
+    public ImmutableMap<String, String> getMap() {
+        // ImmutableMap.copyOf preserves the order.
+        // From the ImmutableMap.copyOf Java doc: The returned map iterates over entries in the same order
+        // as the entrySet of the original map.
+        return ImmutableMap.copyOf(map);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof DisputeExtraDataMap that)) return false;
+
+        return map.equals(that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "DisputeExtraDataMap{" +
+                "map=" + map +
+                '}';
+    }
+
+    private void maybeApplyLegacyHashMapOrder() {
+        if (preserveInsertionOrder) {
+            return;
+        }
+
+        LinkedHashMap<String, String> orderedMap = new LinkedHashMap<>();
+        LEGACY_HASHMAP_ORDER.stream()
+                .filter(map::containsKey)
+                .forEach(key -> orderedMap.put(key, map.get(key)));
+        map.clear();
+        map.putAll(orderedMap);
+    }
+
+    private static void validateEntry(String key, String value) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        if (!SUPPORTED_KEYS.contains(key)) {
+            throw new IllegalArgumentException("Unsupported Dispute extraDataMap key: " + key);
+        }
+    }
+
+    public static class Keys {
+        public static final String COUNTER_CURRENCY_TX_ID = "counterCurrencyTxId";
+        public static final String COUNTER_CURRENCY_EXTRA_DATA = "counterCurrencyExtraData";
+    }
+}

--- a/core/src/main/java/bisq/core/support/dispute/DisputeExtraDataMap.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeExtraDataMap.java
@@ -17,6 +17,8 @@
 
 package bisq.core.support.dispute;
 
+import bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -31,7 +33,11 @@ public class DisputeExtraDataMap {
     // to support backward compatibility.
     static final List<String> LEGACY_HASHMAP_ORDER = List.of(
             Keys.COUNTER_CURRENCY_TX_ID,
-            Keys.COUNTER_CURRENCY_EXTRA_DATA
+            Keys.COUNTER_CURRENCY_EXTRA_DATA,
+            Keys.RESERVED_0,
+            Keys.RESERVED_1,
+            Keys.RESERVED_2,
+            Keys.RESERVED_3
     );
     private static final Set<String> SUPPORTED_KEYS = Set.copyOf(LEGACY_HASHMAP_ORDER);
 
@@ -136,5 +142,11 @@ public class DisputeExtraDataMap {
     public static class Keys {
         public static final String COUNTER_CURRENCY_TX_ID = "counterCurrencyTxId";
         public static final String COUNTER_CURRENCY_EXTRA_DATA = "counterCurrencyExtraData";
+
+        // Reserved for future use.
+        public static final String RESERVED_0 = "reserved0";
+        public static final String RESERVED_1 = "reserved1";
+        public static final String RESERVED_2 = "reserved2";
+        public static final String RESERVED_3 = "reserved3";
     }
 }

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -22,7 +22,6 @@ import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
-import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
 import bisq.core.util.JsonUtil;
@@ -72,6 +71,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -95,7 +95,7 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
                                         boolean isTorNetworkNode) {
         TreeMap<String, String> extraDataMap = new TreeMap<>();
         if (referralId != null) {
-            extraDataMap.put(OfferPayload.REFERRAL_ID, referralId);
+            extraDataMap.put(REFERRAL_ID, referralId);
         }
 
         NodeAddress mediatorNodeAddress = checkNotNull(trade.getMediatorNodeAddress());

--- a/core/src/test/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMapTest.java
+++ b/core/src/test/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMapTest.java
@@ -1,0 +1,180 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.offer.bisq_v1;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.ACCOUNT_AGE_WITNESS_HASH;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.CAPABILITIES;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.CASH_BY_MAIL_EXTRA_INFO;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.F2F_CITY;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.F2F_EXTRA_INFO;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.REFERRAL_ID;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.XMR_AUTO_CONF;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OfferPayloadExtraDataMapTest {
+    private static final List<String> OFFER_UTIL_INSERTION_ORDER = List.of(
+            ACCOUNT_AGE_WITNESS_HASH,
+            REFERRAL_ID,
+            F2F_CITY,
+            F2F_EXTRA_INFO,
+            CASH_BY_MAIL_EXTRA_INFO,
+            CAPABILITIES,
+            XMR_AUTO_CONF
+    );
+    private static final String UNKNOWN_KEY = "unknownOfferPayloadExtraDataKey";
+
+    @Test
+    public void allEntrySetsSerializeLikeLegacyHashMapForOfferUtilInsertionOrder() {
+        for (int mask = 1; mask < (1 << OFFER_UTIL_INSERTION_ORDER.size()); mask++) {
+            Map<String, String> legacyHashMap = new HashMap<>();
+            OfferPayloadExtraDataMap extraDataMap = new OfferPayloadExtraDataMap();
+
+            for (String key : OFFER_UTIL_INSERTION_ORDER) {
+                if (isSelected(mask, key)) {
+                    legacyHashMap.put(key, valueFor(key));
+                    extraDataMap.put(key, valueFor(key));
+                }
+            }
+
+            assertEquals(keys(legacyHashMap),
+                    keys(extraDataMap.getMap()),
+                    "Unexpected key order for mask " + mask);
+            assertArrayEquals(serialize(legacyHashMap),
+                    serialize(extraDataMap.getMap()),
+                    "Unexpected protobuf bytes for mask " + mask);
+        }
+    }
+
+    @Test
+    public void locallyCreatedMapUsesLegacyOrderRegardlessOfCallerInsertionOrder() {
+        List<String> reverseInsertionOrder = new ArrayList<>(OFFER_UTIL_INSERTION_ORDER);
+        Collections.reverse(reverseInsertionOrder);
+
+        for (int mask = 1; mask < (1 << OFFER_UTIL_INSERTION_ORDER.size()); mask++) {
+            OfferPayloadExtraDataMap offerUtilOrderMap = createLocalMap(OFFER_UTIL_INSERTION_ORDER, mask);
+            OfferPayloadExtraDataMap reverseOrderMap = createLocalMap(reverseInsertionOrder, mask);
+
+            assertEquals(expectedLegacyOrder(mask),
+                    keys(reverseOrderMap.getMap()),
+                    "Unexpected legacy key order for mask " + mask);
+            assertEquals(keys(offerUtilOrderMap.getMap()),
+                    keys(reverseOrderMap.getMap()),
+                    "Caller insertion order changed key order for mask " + mask);
+            assertArrayEquals(serialize(offerUtilOrderMap.getMap()),
+                    serialize(reverseOrderMap.getMap()),
+                    "Caller insertion order changed protobuf bytes for mask " + mask);
+        }
+    }
+
+    @Test
+    public void locallyCreatedMapCanonicalizesPutAllInput() {
+        Map<String, String> nonCanonicalInput = new LinkedHashMap<>();
+        nonCanonicalInput.put(CASH_BY_MAIL_EXTRA_INFO, valueFor(CASH_BY_MAIL_EXTRA_INFO));
+        nonCanonicalInput.put(ACCOUNT_AGE_WITNESS_HASH, valueFor(ACCOUNT_AGE_WITNESS_HASH));
+        nonCanonicalInput.put(XMR_AUTO_CONF, valueFor(XMR_AUTO_CONF));
+        nonCanonicalInput.put(REFERRAL_ID, valueFor(REFERRAL_ID));
+
+        OfferPayloadExtraDataMap extraDataMap = new OfferPayloadExtraDataMap();
+        extraDataMap.putAll(nonCanonicalInput);
+
+        assertEquals(List.of(REFERRAL_ID, XMR_AUTO_CONF, ACCOUNT_AGE_WITNESS_HASH, CASH_BY_MAIL_EXTRA_INFO),
+                keys(extraDataMap.getMap()));
+    }
+
+    @Test
+    public void protobufConstructedMapPreservesInsertionOrder() {
+        Map<String, String> protobufOrder = new LinkedHashMap<>();
+        protobufOrder.put(CASH_BY_MAIL_EXTRA_INFO, valueFor(CASH_BY_MAIL_EXTRA_INFO));
+        protobufOrder.put(ACCOUNT_AGE_WITNESS_HASH, valueFor(ACCOUNT_AGE_WITNESS_HASH));
+        protobufOrder.put(XMR_AUTO_CONF, valueFor(XMR_AUTO_CONF));
+        protobufOrder.put(REFERRAL_ID, valueFor(REFERRAL_ID));
+
+        OfferPayloadExtraDataMap extraDataMap = new OfferPayloadExtraDataMap(protobufOrder);
+
+        assertEquals(keys(protobufOrder), keys(extraDataMap.getMap()));
+        assertArrayEquals(serialize(protobufOrder), serialize(extraDataMap.getMap()));
+    }
+
+    @Test
+    public void rejectsUnknownKeys() {
+        OfferPayloadExtraDataMap extraDataMap = new OfferPayloadExtraDataMap();
+        IllegalArgumentException putException = assertThrows(IllegalArgumentException.class,
+                () -> extraDataMap.put(UNKNOWN_KEY, "value"));
+        assertTrue(putException.getMessage().contains(UNKNOWN_KEY));
+
+        Map<String, String> mapWithUnknownKey = new LinkedHashMap<>();
+        mapWithUnknownKey.put(CAPABILITIES, valueFor(CAPABILITIES));
+        mapWithUnknownKey.put(UNKNOWN_KEY, "value");
+
+        OfferPayloadExtraDataMap putAllMap = new OfferPayloadExtraDataMap();
+        IllegalArgumentException putAllException = assertThrows(IllegalArgumentException.class,
+                () -> putAllMap.putAll(mapWithUnknownKey));
+        assertTrue(putAllException.getMessage().contains(UNKNOWN_KEY));
+        assertTrue(putAllMap.isEmpty());
+
+        IllegalArgumentException constructorException = assertThrows(IllegalArgumentException.class,
+                () -> new OfferPayloadExtraDataMap(mapWithUnknownKey));
+        assertTrue(constructorException.getMessage().contains(UNKNOWN_KEY));
+    }
+
+    private static OfferPayloadExtraDataMap createLocalMap(List<String> insertionOrder, int mask) {
+        OfferPayloadExtraDataMap extraDataMap = new OfferPayloadExtraDataMap();
+        insertionOrder.stream()
+                .filter(key -> isSelected(mask, key))
+                .forEach(key -> extraDataMap.put(key, valueFor(key)));
+        return extraDataMap;
+    }
+
+    private static List<String> expectedLegacyOrder(int mask) {
+        return OfferPayloadExtraDataMap.LEGACY_HASHMAP_ORDER.stream()
+                .filter(key -> isSelected(mask, key))
+                .toList();
+    }
+
+    private static boolean isSelected(int mask, String key) {
+        int index = OFFER_UTIL_INSERTION_ORDER.indexOf(key);
+        return (mask & (1 << index)) != 0;
+    }
+
+    private static String valueFor(String key) {
+        return "value-for-" + key;
+    }
+
+    private static List<String> keys(Map<String, String> map) {
+        return new ArrayList<>(map.keySet());
+    }
+
+    private static byte[] serialize(Map<String, String> map) {
+        return protobuf.OfferPayload.newBuilder()
+                .putAllExtraData(map)
+                .build()
+                .toByteArray();
+    }
+}

--- a/core/src/test/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMapTest.java
+++ b/core/src/test/java/bisq/core/offer/bisq_v1/OfferPayloadExtraDataMapTest.java
@@ -32,6 +32,10 @@ import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.CASH_BY_MAIL
 import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.F2F_CITY;
 import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.F2F_EXTRA_INFO;
 import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.REFERRAL_ID;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.RESERVED_0;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.RESERVED_1;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.RESERVED_2;
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.RESERVED_3;
 import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.XMR_AUTO_CONF;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,6 +51,19 @@ public class OfferPayloadExtraDataMapTest {
             CASH_BY_MAIL_EXTRA_INFO,
             CAPABILITIES,
             XMR_AUTO_CONF
+    );
+    private static final List<String> CANONICAL_ORDER = List.of(
+            CAPABILITIES,
+            REFERRAL_ID,
+            XMR_AUTO_CONF,
+            ACCOUNT_AGE_WITNESS_HASH,
+            CASH_BY_MAIL_EXTRA_INFO,
+            F2F_EXTRA_INFO,
+            F2F_CITY,
+            RESERVED_0,
+            RESERVED_1,
+            RESERVED_2,
+            RESERVED_3
     );
     private static final String UNKNOWN_KEY = "unknownOfferPayloadExtraDataKey";
 
@@ -106,6 +123,21 @@ public class OfferPayloadExtraDataMapTest {
 
         assertEquals(List.of(REFERRAL_ID, XMR_AUTO_CONF, ACCOUNT_AGE_WITNESS_HASH, CASH_BY_MAIL_EXTRA_INFO),
                 keys(extraDataMap.getMap()));
+    }
+
+    @Test
+    public void reservedKeysUseFutureCanonicalOrderAfterLegacyKeys() {
+        assertEquals(CANONICAL_ORDER, OfferPayloadExtraDataMap.LEGACY_HASHMAP_ORDER);
+
+        Map<String, String> reverseCanonicalInput = new LinkedHashMap<>();
+        List<String> reverseCanonicalOrder = new ArrayList<>(CANONICAL_ORDER);
+        Collections.reverse(reverseCanonicalOrder);
+        reverseCanonicalOrder.forEach(key -> reverseCanonicalInput.put(key, valueFor(key)));
+
+        OfferPayloadExtraDataMap extraDataMap = new OfferPayloadExtraDataMap();
+        extraDataMap.putAll(reverseCanonicalInput);
+
+        assertEquals(CANONICAL_ORDER, keys(extraDataMap.getMap()));
     }
 
     @Test

--- a/core/src/test/java/bisq/core/payment/payload/PaymentAccountPayloadExcludeFromJsonMapTest.java
+++ b/core/src/test/java/bisq/core/payment/payload/PaymentAccountPayloadExcludeFromJsonMapTest.java
@@ -1,0 +1,208 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.payment.payload;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.HOLDER_NAME;
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.RESERVED_0;
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.RESERVED_1;
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.RESERVED_2;
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.RESERVED_3;
+import static bisq.core.payment.payload.PaymentAccountPayloadExcludeFromJsonMap.Keys.SALT;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PaymentAccountPayloadExcludeFromJsonMapTest {
+    private static final List<String> PAYMENT_ACCOUNT_INSERTION_ORDER = List.of(
+            SALT,
+            HOLDER_NAME
+    );
+    private static final List<String> CANONICAL_ORDER = List.of(
+            HOLDER_NAME,
+            SALT,
+            RESERVED_0,
+            RESERVED_1,
+            RESERVED_2,
+            RESERVED_3
+    );
+    private static final String UNKNOWN_KEY = "unknownPaymentAccountPayloadExcludeFromJsonKey";
+
+    @Test
+    public void allEntrySetsSerializeLikeLegacyHashMapForPaymentAccountInsertionOrder() {
+        for (int mask = 1; mask < (1 << PAYMENT_ACCOUNT_INSERTION_ORDER.size()); mask++) {
+            Map<String, String> legacyHashMap = new HashMap<>();
+            PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonMap = new PaymentAccountPayloadExcludeFromJsonMap();
+
+            for (String key : PAYMENT_ACCOUNT_INSERTION_ORDER) {
+                if (isSelected(mask, key)) {
+                    legacyHashMap.put(key, valueFor(key));
+                    excludeFromJsonMap.put(key, valueFor(key));
+                }
+            }
+
+            assertEquals(keys(legacyHashMap),
+                    keys(excludeFromJsonMap.getMap()),
+                    "Unexpected key order for mask " + mask);
+            assertArrayEquals(serialize(legacyHashMap),
+                    serialize(excludeFromJsonMap.getMap()),
+                    "Unexpected protobuf bytes for mask " + mask);
+        }
+    }
+
+    @Test
+    public void locallyCreatedMapUsesLegacyOrderRegardlessOfCallerInsertionOrder() {
+        List<String> reverseInsertionOrder = new ArrayList<>(PAYMENT_ACCOUNT_INSERTION_ORDER);
+        Collections.reverse(reverseInsertionOrder);
+
+        for (int mask = 1; mask < (1 << PAYMENT_ACCOUNT_INSERTION_ORDER.size()); mask++) {
+            PaymentAccountPayloadExcludeFromJsonMap paymentAccountOrderMap =
+                    createLocalMap(PAYMENT_ACCOUNT_INSERTION_ORDER, mask);
+            PaymentAccountPayloadExcludeFromJsonMap reverseOrderMap =
+                    createLocalMap(reverseInsertionOrder, mask);
+
+            assertEquals(expectedLegacyOrder(mask),
+                    keys(reverseOrderMap.getMap()),
+                    "Unexpected legacy key order for mask " + mask);
+            assertEquals(keys(paymentAccountOrderMap.getMap()),
+                    keys(reverseOrderMap.getMap()),
+                    "Caller insertion order changed key order for mask " + mask);
+            assertArrayEquals(serialize(paymentAccountOrderMap.getMap()),
+                    serialize(reverseOrderMap.getMap()),
+                    "Caller insertion order changed protobuf bytes for mask " + mask);
+        }
+    }
+
+    @Test
+    public void locallyCreatedMapCanonicalizesPutAllInput() {
+        Map<String, String> nonCanonicalInput = new LinkedHashMap<>();
+        nonCanonicalInput.put(SALT, valueFor(SALT));
+        nonCanonicalInput.put(HOLDER_NAME, valueFor(HOLDER_NAME));
+
+        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonMap = new PaymentAccountPayloadExcludeFromJsonMap();
+        excludeFromJsonMap.putAll(nonCanonicalInput);
+
+        assertEquals(List.of(HOLDER_NAME, SALT), keys(excludeFromJsonMap.getMap()));
+    }
+
+    @Test
+    public void reservedKeysUseFutureCanonicalOrderAfterLegacyKeys() {
+        assertEquals(CANONICAL_ORDER, PaymentAccountPayloadExcludeFromJsonMap.LEGACY_HASHMAP_ORDER);
+
+        Map<String, String> reverseCanonicalInput = new LinkedHashMap<>();
+        List<String> reverseCanonicalOrder = new ArrayList<>(CANONICAL_ORDER);
+        Collections.reverse(reverseCanonicalOrder);
+        reverseCanonicalOrder.forEach(key -> reverseCanonicalInput.put(key, valueFor(key)));
+
+        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonMap = new PaymentAccountPayloadExcludeFromJsonMap();
+        excludeFromJsonMap.putAll(reverseCanonicalInput);
+
+        assertEquals(CANONICAL_ORDER, keys(excludeFromJsonMap.getMap()));
+    }
+
+    @Test
+    public void protobufConstructedMapPreservesInsertionOrder() {
+        Map<String, String> protobufOrder = new LinkedHashMap<>();
+        protobufOrder.put(SALT, valueFor(SALT));
+        protobufOrder.put(HOLDER_NAME, valueFor(HOLDER_NAME));
+
+        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonMap =
+                new PaymentAccountPayloadExcludeFromJsonMap(protobufOrder);
+
+        assertEquals(keys(protobufOrder), keys(excludeFromJsonMap.getMap()));
+        assertArrayEquals(serialize(protobufOrder), serialize(excludeFromJsonMap.getMap()));
+    }
+
+    @Test
+    public void computeUsesCanonicalOrderAndRemovesNullValues() {
+        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonMap = new PaymentAccountPayloadExcludeFromJsonMap();
+        excludeFromJsonMap.put(SALT, valueFor(SALT));
+        excludeFromJsonMap.compute(HOLDER_NAME, (key, value) -> valueFor(key));
+
+        assertEquals(List.of(HOLDER_NAME, SALT), keys(excludeFromJsonMap.getMap()));
+
+        excludeFromJsonMap.compute(HOLDER_NAME, (key, value) -> null);
+
+        assertEquals(List.of(SALT), keys(excludeFromJsonMap.getMap()));
+    }
+
+    @Test
+    public void rejectsUnknownKeys() {
+        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonMap = new PaymentAccountPayloadExcludeFromJsonMap();
+        IllegalArgumentException putException = assertThrows(IllegalArgumentException.class,
+                () -> excludeFromJsonMap.put(UNKNOWN_KEY, "value"));
+        assertTrue(putException.getMessage().contains(UNKNOWN_KEY));
+
+        Map<String, String> mapWithUnknownKey = new LinkedHashMap<>();
+        mapWithUnknownKey.put(SALT, valueFor(SALT));
+        mapWithUnknownKey.put(UNKNOWN_KEY, "value");
+
+        PaymentAccountPayloadExcludeFromJsonMap putAllMap = new PaymentAccountPayloadExcludeFromJsonMap();
+        IllegalArgumentException putAllException = assertThrows(IllegalArgumentException.class,
+                () -> putAllMap.putAll(mapWithUnknownKey));
+        assertTrue(putAllException.getMessage().contains(UNKNOWN_KEY));
+        assertTrue(putAllMap.isEmpty());
+
+        IllegalArgumentException constructorException = assertThrows(IllegalArgumentException.class,
+                () -> new PaymentAccountPayloadExcludeFromJsonMap(mapWithUnknownKey));
+        assertTrue(constructorException.getMessage().contains(UNKNOWN_KEY));
+    }
+
+    private static PaymentAccountPayloadExcludeFromJsonMap createLocalMap(List<String> insertionOrder, int mask) {
+        PaymentAccountPayloadExcludeFromJsonMap excludeFromJsonMap = new PaymentAccountPayloadExcludeFromJsonMap();
+        insertionOrder.stream()
+                .filter(key -> isSelected(mask, key))
+                .forEach(key -> excludeFromJsonMap.put(key, valueFor(key)));
+        return excludeFromJsonMap;
+    }
+
+    private static List<String> expectedLegacyOrder(int mask) {
+        return PaymentAccountPayloadExcludeFromJsonMap.LEGACY_HASHMAP_ORDER.stream()
+                .filter(key -> isSelected(mask, key))
+                .toList();
+    }
+
+    private static boolean isSelected(int mask, String key) {
+        int index = PAYMENT_ACCOUNT_INSERTION_ORDER.indexOf(key);
+        return (mask & (1 << index)) != 0;
+    }
+
+    private static String valueFor(String key) {
+        return "value-for-" + key;
+    }
+
+    private static List<String> keys(Map<String, String> map) {
+        return new ArrayList<>(map.keySet());
+    }
+
+    private static byte[] serialize(Map<String, String> map) {
+        return protobuf.PaymentAccountPayload.newBuilder()
+                .putAllExcludeFromJsonData(map)
+                .build()
+                .toByteArray();
+    }
+}

--- a/core/src/test/java/bisq/core/support/dispute/DisputeExtraDataMapTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/DisputeExtraDataMapTest.java
@@ -28,6 +28,10 @@ import org.junit.jupiter.api.Test;
 
 import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.COUNTER_CURRENCY_EXTRA_DATA;
 import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.COUNTER_CURRENCY_TX_ID;
+import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.RESERVED_0;
+import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.RESERVED_1;
+import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.RESERVED_2;
+import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.RESERVED_3;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,6 +41,14 @@ public class DisputeExtraDataMapTest {
     private static final List<String> PENDING_TRADES_INSERTION_ORDER = List.of(
             COUNTER_CURRENCY_TX_ID,
             COUNTER_CURRENCY_EXTRA_DATA
+    );
+    private static final List<String> CANONICAL_ORDER = List.of(
+            COUNTER_CURRENCY_TX_ID,
+            COUNTER_CURRENCY_EXTRA_DATA,
+            RESERVED_0,
+            RESERVED_1,
+            RESERVED_2,
+            RESERVED_3
     );
     private static final String UNKNOWN_KEY = "unknownDisputeExtraDataKey";
 
@@ -97,6 +109,21 @@ public class DisputeExtraDataMapTest {
     }
 
     @Test
+    public void reservedKeysUseFutureCanonicalOrderAfterLegacyKeys() {
+        assertEquals(CANONICAL_ORDER, DisputeExtraDataMap.LEGACY_HASHMAP_ORDER);
+
+        Map<String, String> reverseCanonicalInput = new LinkedHashMap<>();
+        List<String> reverseCanonicalOrder = new ArrayList<>(CANONICAL_ORDER);
+        Collections.reverse(reverseCanonicalOrder);
+        reverseCanonicalOrder.forEach(key -> reverseCanonicalInput.put(key, valueFor(key)));
+
+        DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap();
+        extraDataMap.putAll(reverseCanonicalInput);
+
+        assertEquals(CANONICAL_ORDER, keys(extraDataMap.getMap()));
+    }
+
+    @Test
     public void protobufConstructedMapPreservesInsertionOrder() {
         Map<String, String> protobufOrder = new LinkedHashMap<>();
         protobufOrder.put(COUNTER_CURRENCY_EXTRA_DATA, valueFor(COUNTER_CURRENCY_EXTRA_DATA));
@@ -109,15 +136,13 @@ public class DisputeExtraDataMapTest {
     }
 
     @Test
-    public void entrySetUsesCanonicalOrder() {
+    public void getMapUsesCanonicalOrder() {
         DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap();
         extraDataMap.put(COUNTER_CURRENCY_EXTRA_DATA, valueFor(COUNTER_CURRENCY_EXTRA_DATA));
         extraDataMap.put(COUNTER_CURRENCY_TX_ID, valueFor(COUNTER_CURRENCY_TX_ID));
 
         assertEquals(List.of(COUNTER_CURRENCY_TX_ID, COUNTER_CURRENCY_EXTRA_DATA),
-                extraDataMap.entrySet().stream()
-                        .map(Map.Entry::getKey)
-                        .toList());
+                keys(extraDataMap.getMap()));
     }
 
     @Test

--- a/core/src/test/java/bisq/core/support/dispute/DisputeExtraDataMapTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/DisputeExtraDataMapTest.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support.dispute;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.COUNTER_CURRENCY_EXTRA_DATA;
+import static bisq.core.support.dispute.DisputeExtraDataMap.Keys.COUNTER_CURRENCY_TX_ID;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DisputeExtraDataMapTest {
+    private static final List<String> PENDING_TRADES_INSERTION_ORDER = List.of(
+            COUNTER_CURRENCY_TX_ID,
+            COUNTER_CURRENCY_EXTRA_DATA
+    );
+    private static final String UNKNOWN_KEY = "unknownDisputeExtraDataKey";
+
+    @Test
+    public void allEntrySetsSerializeLikeLegacyHashMapForPendingTradesInsertionOrder() {
+        for (int mask = 1; mask < (1 << PENDING_TRADES_INSERTION_ORDER.size()); mask++) {
+            Map<String, String> legacyHashMap = new HashMap<>();
+            DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap();
+
+            for (String key : PENDING_TRADES_INSERTION_ORDER) {
+                if (isSelected(mask, key)) {
+                    legacyHashMap.put(key, valueFor(key));
+                    extraDataMap.put(key, valueFor(key));
+                }
+            }
+
+            assertEquals(keys(legacyHashMap),
+                    keys(extraDataMap.getMap()),
+                    "Unexpected key order for mask " + mask);
+            assertArrayEquals(serialize(legacyHashMap),
+                    serialize(extraDataMap.getMap()),
+                    "Unexpected protobuf bytes for mask " + mask);
+        }
+    }
+
+    @Test
+    public void locallyCreatedMapUsesLegacyOrderRegardlessOfCallerInsertionOrder() {
+        List<String> reverseInsertionOrder = new ArrayList<>(PENDING_TRADES_INSERTION_ORDER);
+        Collections.reverse(reverseInsertionOrder);
+
+        for (int mask = 1; mask < (1 << PENDING_TRADES_INSERTION_ORDER.size()); mask++) {
+            DisputeExtraDataMap pendingTradesOrderMap = createLocalMap(PENDING_TRADES_INSERTION_ORDER, mask);
+            DisputeExtraDataMap reverseOrderMap = createLocalMap(reverseInsertionOrder, mask);
+
+            assertEquals(expectedLegacyOrder(mask),
+                    keys(reverseOrderMap.getMap()),
+                    "Unexpected legacy key order for mask " + mask);
+            assertEquals(keys(pendingTradesOrderMap.getMap()),
+                    keys(reverseOrderMap.getMap()),
+                    "Caller insertion order changed key order for mask " + mask);
+            assertArrayEquals(serialize(pendingTradesOrderMap.getMap()),
+                    serialize(reverseOrderMap.getMap()),
+                    "Caller insertion order changed protobuf bytes for mask " + mask);
+        }
+    }
+
+    @Test
+    public void locallyCreatedMapCanonicalizesPutAllInput() {
+        Map<String, String> nonCanonicalInput = new LinkedHashMap<>();
+        nonCanonicalInput.put(COUNTER_CURRENCY_EXTRA_DATA, valueFor(COUNTER_CURRENCY_EXTRA_DATA));
+        nonCanonicalInput.put(COUNTER_CURRENCY_TX_ID, valueFor(COUNTER_CURRENCY_TX_ID));
+
+        DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap();
+        extraDataMap.putAll(nonCanonicalInput);
+
+        assertEquals(List.of(COUNTER_CURRENCY_TX_ID, COUNTER_CURRENCY_EXTRA_DATA),
+                keys(extraDataMap.getMap()));
+    }
+
+    @Test
+    public void protobufConstructedMapPreservesInsertionOrder() {
+        Map<String, String> protobufOrder = new LinkedHashMap<>();
+        protobufOrder.put(COUNTER_CURRENCY_EXTRA_DATA, valueFor(COUNTER_CURRENCY_EXTRA_DATA));
+        protobufOrder.put(COUNTER_CURRENCY_TX_ID, valueFor(COUNTER_CURRENCY_TX_ID));
+
+        DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap(protobufOrder);
+
+        assertEquals(keys(protobufOrder), keys(extraDataMap.getMap()));
+        assertArrayEquals(serialize(protobufOrder), serialize(extraDataMap.getMap()));
+    }
+
+    @Test
+    public void entrySetUsesCanonicalOrder() {
+        DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap();
+        extraDataMap.put(COUNTER_CURRENCY_EXTRA_DATA, valueFor(COUNTER_CURRENCY_EXTRA_DATA));
+        extraDataMap.put(COUNTER_CURRENCY_TX_ID, valueFor(COUNTER_CURRENCY_TX_ID));
+
+        assertEquals(List.of(COUNTER_CURRENCY_TX_ID, COUNTER_CURRENCY_EXTRA_DATA),
+                extraDataMap.entrySet().stream()
+                        .map(Map.Entry::getKey)
+                        .toList());
+    }
+
+    @Test
+    public void rejectsUnknownKeys() {
+        DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap();
+        IllegalArgumentException putException = assertThrows(IllegalArgumentException.class,
+                () -> extraDataMap.put(UNKNOWN_KEY, "value"));
+        assertTrue(putException.getMessage().contains("Dispute"));
+        assertTrue(putException.getMessage().contains(UNKNOWN_KEY));
+
+        Map<String, String> mapWithUnknownKey = new LinkedHashMap<>();
+        mapWithUnknownKey.put(COUNTER_CURRENCY_TX_ID, valueFor(COUNTER_CURRENCY_TX_ID));
+        mapWithUnknownKey.put(UNKNOWN_KEY, "value");
+
+        DisputeExtraDataMap putAllMap = new DisputeExtraDataMap();
+        IllegalArgumentException putAllException = assertThrows(IllegalArgumentException.class,
+                () -> putAllMap.putAll(mapWithUnknownKey));
+        assertTrue(putAllException.getMessage().contains("Dispute"));
+        assertTrue(putAllException.getMessage().contains(UNKNOWN_KEY));
+        assertTrue(putAllMap.isEmpty());
+
+        IllegalArgumentException constructorException = assertThrows(IllegalArgumentException.class,
+                () -> new DisputeExtraDataMap(mapWithUnknownKey));
+        assertTrue(constructorException.getMessage().contains("Dispute"));
+        assertTrue(constructorException.getMessage().contains(UNKNOWN_KEY));
+    }
+
+    private static DisputeExtraDataMap createLocalMap(List<String> insertionOrder, int mask) {
+        DisputeExtraDataMap extraDataMap = new DisputeExtraDataMap();
+        insertionOrder.stream()
+                .filter(key -> isSelected(mask, key))
+                .forEach(key -> extraDataMap.put(key, valueFor(key)));
+        return extraDataMap;
+    }
+
+    private static List<String> expectedLegacyOrder(int mask) {
+        return DisputeExtraDataMap.LEGACY_HASHMAP_ORDER.stream()
+                .filter(key -> isSelected(mask, key))
+                .toList();
+    }
+
+    private static boolean isSelected(int mask, String key) {
+        int index = PENDING_TRADES_INSERTION_ORDER.indexOf(key);
+        return (mask & (1 << index)) != 0;
+    }
+
+    private static String valueFor(String key) {
+        return "value-for-" + key;
+    }
+
+    private static List<String> keys(Map<String, String> map) {
+        return new ArrayList<>(map.keySet());
+    }
+
+    private static byte[] serialize(Map<String, String> map) {
+        return protobuf.Dispute.newBuilder()
+                .putAllExtraData(map)
+                .build()
+                .toByteArray();
+    }
+}

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -17,7 +17,6 @@
 
 package bisq.core.trade.statistics;
 
-import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.payment.payload.PaymentMethod;
 
 import bisq.common.util.ExtraDataMapValidator;
@@ -37,6 +36,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -76,7 +76,7 @@ public class TradeStatistics3Test {
     @Test
     public void singleEntryExtraDataMapSerializesLikeHashMap() {
         TreeMap<String, String> extraDataMap = new TreeMap<>();
-        extraDataMap.put(OfferPayload.REFERRAL_ID, "referralId");
+        extraDataMap.put(REFERRAL_ID, "referralId");
         TradeStatistics3 tradeStatistics = new TradeStatistics3("USD",
                 50_000_000,
                 Coin.parseCoin("0.25").value,
@@ -89,7 +89,7 @@ public class TradeStatistics3Test {
 
         protobuf.TradeStatistics3 treeMapProto = tradeStatistics.toProtoTradeStatistics3();
         Map<String, String> hashMap = new HashMap<>();
-        hashMap.put(OfferPayload.REFERRAL_ID, "referralId");
+        hashMap.put(REFERRAL_ID, "referralId");
         protobuf.TradeStatistics3 hashMapProto = treeMapProto.toBuilder()
                 .clearExtraData()
                 .putAllExtraData(hashMap)
@@ -101,7 +101,7 @@ public class TradeStatistics3Test {
     @Test
     public void fromProtoConvertsExtraDataMapToTreeMapWithoutChangingSingleEntryBytes() {
         Map<String, String> hashMap = new HashMap<>();
-        hashMap.put(OfferPayload.REFERRAL_ID, "referralId");
+        hashMap.put(REFERRAL_ID, "referralId");
         protobuf.TradeStatistics3 hashMapProto = protobuf.TradeStatistics3.newBuilder()
                 .setCurrency("USD")
                 .setPrice(50_000_000)

--- a/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/MarketView.java
@@ -35,7 +35,6 @@ import bisq.desktop.util.DisplayUtils;
 
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.Res;
-import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.trade.statistics.TradeStatistics3StorageService;
 import bisq.core.util.FormattingUtils;
@@ -66,6 +65,8 @@ import javafx.event.EventHandler;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static bisq.core.offer.bisq_v1.OfferPayloadExtraDataMap.Keys.*;
 
 @FxmlView
 public class MarketView extends ActivatableView<TabPane, Void> {
@@ -192,7 +193,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                 .filter(e -> e instanceof TradeStatistics3)
                 .map(e -> (TradeStatistics3) e)
                 .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap() != null)
-                .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap().get(OfferPayload.REFERRAL_ID) != null)
+                .filter(tradeStatistics3 -> tradeStatistics3.getExtraDataMap().get(REFERRAL_ID) != null)
                 .map(tradeStatistics3 -> {
                     StringBuilder sb = new StringBuilder();
                     sb.append("Date: ").append(DisplayUtils.formatDateTime(tradeStatistics3.getDate())).append("\n")
@@ -201,7 +202,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                             .append("Amount: ").append(formatter.formatCoin(tradeStatistics3.getTradeAmount())).append("\n")
                             .append("Volume: ").append(VolumeUtil.formatVolume(tradeStatistics3.getTradeVolume())).append("\n")
                             .append("Payment method: ").append(Res.get(tradeStatistics3.getPaymentMethodId())).append("\n")
-                            .append("ReferralID: ").append(tradeStatistics3.getExtraDataMap().get(OfferPayload.REFERRAL_ID));
+                            .append("ReferralID: ").append(tradeStatistics3.getExtraDataMap().get(REFERRAL_ID));
                     return sb.toString();
                 })
                 .collect(Collectors.toList());
@@ -211,8 +212,8 @@ public class MarketView extends ActivatableView<TabPane, Void> {
     private String getAllOffersWithReferralId() {
         List<String> list = offerBook.getOfferBookListItems().stream()
                 .map(OfferBookListItem::getOffer)
-                .filter(offer -> offer.getExtraDataMap() != null)
-                .filter(offer -> offer.getExtraDataMap().get(OfferPayload.REFERRAL_ID) != null)
+                .filter(offer -> offer.getOfferPayloadExtraDataMap() != null)
+                .filter(offer -> offer.getOfferPayloadExtraDataMap().get(REFERRAL_ID) != null)
                 .map(offer -> {
                     StringBuilder sb = new StringBuilder();
                     sb.append("Offer ID: ").append(offer.getId()).append("\n")
@@ -221,7 +222,7 @@ public class MarketView extends ActivatableView<TabPane, Void> {
                             .append("Price: ").append(FormattingUtils.formatPrice(offer.getPrice())).append("\n")
                             .append("Amount: ").append(DisplayUtils.formatAmount(offer, formatter)).append(" BTC\n")
                             .append("Payment method: ").append(Res.get(offer.getPaymentMethod().getId())).append("\n")
-                            .append("ReferralID: ").append(offer.getExtraDataMap().get(OfferPayload.REFERRAL_ID));
+                            .append("ReferralID: ").append(offer.getOfferPayloadExtraDataMap().get(REFERRAL_ID));
                     return sb.toString();
                 })
                 .collect(Collectors.toList());

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/DisputeSummaryWindow.java
@@ -323,7 +323,7 @@ public class DisputeSummaryWindow extends Overlay<DisputeSummaryWindow> {
                     tradePeriodEnd.getStyleClass().add("alert"); // highlight field when the trade period is still active
                 }
             }
-            if (dispute.getExtraDataMap() != null && dispute.getExtraDataMap().size() > 0) {
+            if (dispute.getExtraDataMap() != null && !dispute.getExtraDataMap().isEmpty()) {
                 String extraDataSummary = "";
                 for (Map.Entry<String, String> entry : dispute.getExtraDataMap().entrySet()) {
                     extraDataSummary += "[" + entry.getKey() + ":" + entry.getValue() + "] ";

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/cloneoffer/CloneOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/cloneoffer/CloneOfferDataModel.java
@@ -233,7 +233,7 @@ class CloneOfferDataModel extends MutableOfferDataModel {
                 sourceOfferPayload.getUpperClosePrice(),
                 sourceOfferPayload.isPrivateOffer(),
                 sourceOfferPayload.getHashOfChallenge(),
-                editedOfferPayload.getExtraDataMap(),
+                editedOfferPayload.getOfferPayloadExtraDataMap(),
                 sourceOfferPayload.getProtocolVersion());
         Offer clonedOffer = new Offer(clonedOfferPayload);
         clonedOffer.setPriceFeedService(priceFeedService);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -41,6 +41,7 @@ import bisq.core.payment.payload.PaymentAccountPayload;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 import bisq.core.support.dispute.DisputeAlreadyOpenException;
+import bisq.core.support.dispute.DisputeExtraDataMap;
 import bisq.core.support.dispute.DisputeList;
 import bisq.core.support.dispute.DisputeManager;
 import bisq.core.support.dispute.DisputeResult;
@@ -566,8 +567,9 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                     mediatorPubKeyRing,
                     isSupportTicket,
                     SupportType.MEDIATION);
-            dispute.setExtraData("counterCurrencyTxId", trade.getCounterCurrencyTxId());
-            dispute.setExtraData("counterCurrencyExtraData", trade.getCounterCurrencyExtraData());
+
+            dispute.setExtraData(DisputeExtraDataMap.Keys.COUNTER_CURRENCY_TX_ID, trade.getCounterCurrencyTxId());
+            dispute.setExtraData(DisputeExtraDataMap.Keys.COUNTER_CURRENCY_EXTRA_DATA, trade.getCounterCurrencyExtraData());
 
             dispute.setDonationAddressOfDelayedPayoutTx(donationAddressString.get());
             if (delayedPayoutTx != null) {
@@ -630,8 +632,9 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                     refundAgentPubKeyRing,
                     isSupportTicket,
                     SupportType.REFUND);
-            dispute.setExtraData("counterCurrencyTxId", trade.getCounterCurrencyTxId());
-            dispute.setExtraData("counterCurrencyExtraData", trade.getCounterCurrencyExtraData());
+
+            dispute.setExtraData(DisputeExtraDataMap.Keys.COUNTER_CURRENCY_TX_ID, trade.getCounterCurrencyTxId());
+            dispute.setExtraData(DisputeExtraDataMap.Keys.COUNTER_CURRENCY_EXTRA_DATA, trade.getCounterCurrencyExtraData());
 
             String tradeId = dispute.getTradeId();
             mediationManager.findDispute(tradeId)

--- a/docs/canonical-encoding/offer-payload-extra-data-map.md
+++ b/docs/canonical-encoding/offer-payload-extra-data-map.md
@@ -1,0 +1,75 @@
+# OfferPayload ExtraDataMap Ordering
+
+## Purpose
+
+`OfferPayload.extraDataMap` is part of the protobuf bytes used for offer payloads. Historical clients populated that map with `java.util.HashMap`. Protobuf Java serializes map fields in the iteration order of its internal map when normal, non-deterministic serialization is used, so changing the Java map iteration order can change the serialized bytes.
+
+`OfferPayloadExtraDataMap` exists to make the order explicit and stable while preserving byte compatibility for the finite set of offer extra-data keys used by existing producer code.
+
+## Supported Keys
+
+Only the following keys are supported:
+
+- `capabilities`
+- `referralId`
+- `xmrAutoConf`
+- `accountAgeWitnessHash`
+- `cashByMailExtraInfo`
+- `f2fExtraInfo`
+- `f2fCity`
+
+Any attempt to add another key must fail immediately. This is intentional. Supporting a new key requires updating `OfferPayloadExtraDataMap`, this document, and the ordering tests.
+
+Values must be non-null. Protobuf map fields cannot serialize null values.
+
+## Legacy Order
+
+The canonical order is:
+
+1. `capabilities`
+2. `referralId`
+3. `xmrAutoConf`
+4. `accountAgeWitnessHash`
+5. `cashByMailExtraInfo`
+6. `f2fExtraInfo`
+7. `f2fCity`
+
+This order matches Java 21 `HashMap` iteration for all non-empty subsets of the supported keys when the keys are inserted by the current offer producer order:
+
+1. `accountAgeWitnessHash`
+2. `referralId`
+3. `f2fCity`
+4. `f2fExtraInfo`
+5. `cashByMailExtraInfo`
+6. `capabilities`
+7. `xmrAutoConf`
+
+The same behavior is expected for Java 11 for this finite set because these keys stay in the default small-table `HashMap` bucket layout and do not trigger resizing or treeification.
+
+## Construction Modes
+
+`OfferPayloadExtraDataMap` has two ordering modes:
+
+- Local construction: `new OfferPayloadExtraDataMap()` stores entries in a `LinkedHashMap` and reorders the map into the canonical legacy order after every `put` or `putAll`. Caller insertion order does not affect serialized bytes.
+- Protobuf construction: `new OfferPayloadExtraDataMap(proto.getExtraDataMap())` validates the finite key set but preserves the protobuf map iteration order. This allows already serialized payloads to be read and written again without changing their extra-data entry order.
+
+If protobuf-loaded data is locally modified, the code must decide whether it is preserving existing bytes or intentionally rewriting the payload. Current capability-update code copies entries into a locally constructed `OfferPayloadExtraDataMap`, then writes the updated value, so the result uses canonical legacy order.
+
+## Constraints
+
+- Do not use raw `HashMap`, `TreeMap`, or `Map.of` as the final map passed to `protobuf.OfferPayload.Builder.putAllExtraData`.
+- Do not add a supported key without updating the canonical order and adding tests that compare against the legacy `HashMap` producer behavior.
+- Do not assume arbitrary insertion orders can be reproduced from a single canonical order. Java `HashMap` keeps insertion order inside colliding buckets. The compatibility guarantee is for current producer paths and for preserving already-loaded protobuf order.
+- Do not use deterministic protobuf serialization for byte compatibility with historical offer payloads. Deterministic serialization sorts string map keys lexicographically, which differs from the legacy order.
+- Keep `OfferPayloadExtraDataMapTest` focused on byte equality. The tests must cover every non-empty supported-key subset and must compare protobuf bytes against a real Java `HashMap` built in the current producer insertion order.
+
+## Adding A New Key
+
+Before adding a new key:
+
+1. Identify the producer path and exact insertion point.
+2. Re-evaluate Java 11 and Java 21 `HashMap` iteration order for every supported subset that can be produced.
+3. Update the canonical order in `OfferPayloadExtraDataMap`.
+4. Update the supported-key list in this document.
+5. Extend `OfferPayloadExtraDataMapTest` so it compares the new finite key set against the legacy producer behavior.
+6. Confirm normal protobuf serialization still emits the expected bytes.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of offer, payment-account and dispute extra-data to enforce valid keys, deterministic ordering and safer serialization for more reliable data round-trips.
* **Documentation**
  * Added canonical encoding guidance for extra-data maps to ensure compatibility.
* **Tests**
  * Added unit tests covering canonical ordering, validation, and protobuf serialization.
* **Bug Fix**
  * Minor UI rendering check refined for dispute extra-info display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->