### PR TITLE
Fix missing red badge styling after jfoenix removal

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -467,7 +467,10 @@ tree-table-view:focused {
 .jfx-badge .badge-pane .label {
     -fx-font-weight: bold;
     -fx-font-size: 0.692em;
-    -fx-text-fill: -bs-background-color;
+    /* Badge background is always red/orange in both themes, so keep the text
+       white for contrast. -bs-background-color is dark in the dark theme and
+       would make the count unreadable. */
+    -fx-text-fill: -bs-white;
 }
 
 .jfx-badge {

--- a/desktop/src/main/java/bisq/desktop/components/controls/BisqJfxBadge.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/BisqJfxBadge.java
@@ -5,6 +5,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Pos;
+import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
@@ -22,6 +23,8 @@ import javafx.scene.layout.StackPane;
  */
 public class BisqJfxBadge extends StackPane {
 
+    private final Group badge = new Group();
+    private final StackPane badgePane = new StackPane();
     private final Label badgeLabel = new Label();
     private final StringProperty text = new SimpleStringProperty("");
     private final BooleanProperty enabled = new SimpleBooleanProperty(true);
@@ -37,8 +40,16 @@ public class BisqJfxBadge extends StackPane {
         this.control = control;
         this.position = position;
         getStyleClass().add("jfx-badge");
-        badgeLabel.getStyleClass().add("jfx-badge-pane");
+        // Mirror the jfoenix JFXBadge node structure exactly:
+        //   jfx-badge (StackPane) > Group > badge-pane (StackPane) > Label
+        // The Group is essential: it is non-resizable, so the outer StackPane leaves
+        // the badge-pane at its content size and floats it at the corner. Without it
+        // the badge-pane is stretched to fill the cell (giant pill instead of a dot)
+        // and the ".jfx-badge .badge-pane" CSS no longer reads as intended.
+        badgePane.getStyleClass().add("badge-pane");
         badgeLabel.textProperty().bind(text);
+        badgePane.getChildren().add(badgeLabel);
+        badge.getChildren().add(badgePane);
         getChildren().addAll(control);
 
         text.addListener((o, oldV, newV) -> refreshBadge());
@@ -47,11 +58,11 @@ public class BisqJfxBadge extends StackPane {
     }
 
     public void refreshBadge() {
-        getChildren().remove(badgeLabel);
+        getChildren().remove(badge);
         String t = text.get();
         if (enabled.get() && t != null && !t.isEmpty()) {
-            StackPane.setAlignment(badgeLabel, position);
-            getChildren().add(badgeLabel);
+            StackPane.setAlignment(badge, position);
+            getChildren().add(badge);
         }
     }
 


### PR DESCRIPTION
BisqJfxBadge flattened the jfoenix JFXBadge node tree, applying a single
Label with style class "jfx-badge-pane". The existing badge CSS targets
".jfx-badge .badge-pane" and ".jfx-badge .badge-pane .label", so none of
the red-circle background, radius, or bold white text rules matched. New-
event badges rendered as plain, oversized white text.

Restore the jfoenix structure: wrap the label in an inner StackPane with
style class "badge-pane" so the existing CSS applies again. Covers all
consumers (mediation chat/new badges, nav badges, auto-conf badge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved badge label text contrast for better readability across light and dark themes.
  * Enhanced badge component layout for improved visual alignment and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->