### PR TITLE
Fix jfoenix-removal component style regressions

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq-controls.css
+++ b/desktop/src/main/java/bisq/desktop/bisq-controls.css
@@ -94,7 +94,8 @@
  * is actually visible. */
 .jfx-text-field .error-label,
 .jfx-password-field .error-label,
-.jfx-text-area .error-label {
+.jfx-text-area .error-label,
+.jfx-combo-box .error-label {
     -fx-padding: 0;
 }
 
@@ -274,7 +275,9 @@
 .jfx-check-box:hover > .box {
     -fx-background-color: transparent;
     -fx-background-insets: 0;
-    -fx-border-color: -bs-color-gray-bbb;
+    /* -bs-color-gray-bbb (#d8d8d8 light) rendered too faint; use the shared input/line border
+       colour so the unchecked box reads clearly, matching jfoenix's darker default. */
+    -fx-border-color: -bs-color-gray-line;
 }
 
 .jfx-check-box:selected > .box,

--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -207,11 +207,6 @@
     -fx-underline: false;
 }
 
-.jfx-checkbox {
-    -jfx-checked-color: -bs-color-primary;
-    -fx-font-size: 0.692em;
-}
-
 .jfx-check-box .box,
 .jfx-check-box:indeterminate .box,
 .jfx-check-box:indeterminate:selected .box {
@@ -382,7 +377,8 @@ tree-table-view:focused {
     -jfx-unfocus-color: -bs-rd-error-red;
 }
 
-.jfx-text-field .error-label, .jfx-password-field .error-label, .jfx-text-area .error-label {
+.jfx-text-field .error-label, .jfx-password-field .error-label, .jfx-text-area .error-label,
+.jfx-combo-box .error-label {
     -fx-text-fill: -bs-rd-error-red;
     -fx-font-size: 0.692em;
     -fx-padding: -0.5em 0 0 0;

--- a/desktop/src/main/java/bisq/desktop/components/controls/BisqJfxComboBox.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/BisqJfxComboBox.java
@@ -1,7 +1,14 @@
 package bisq.desktop.components.controls;
 
+import bisq.desktop.components.controls.validation.Validator;
+
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.css.PseudoClass;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextInputControl;
 
 /**
  * Drop-in replacement for {@code com.jfoenix.controls.JFXComboBox}.
@@ -23,6 +30,50 @@ public class BisqJfxComboBox<T> extends ComboBox<T> implements LabelFloatable {
     @Override
     protected javafx.scene.control.Skin<?> createDefaultSkin() {
         return new bisq.desktop.components.controls.skin.BisqComboBoxSkin<>(this);
+    }
+
+    // ----- Validation (mirrors jfoenix JFXComboBox.getValidators()/validate()) ------------------
+    // ComboBox is not a TextInputControl, so validators run against the editor (present on
+    // editable combos). Controller-driven validators that set hasErrors externally still work for
+    // non-editable combos. validate() toggles the ":error" pseudo-class (styled in theme-*.css)
+    // and publishes the first failing message via errorMessageProperty() for the skin's error label.
+    private static final PseudoClass ERROR_PC = PseudoClass.getPseudoClass("error");
+    private final ObservableList<Validator> validators = FXCollections.observableArrayList();
+    private final ReadOnlyStringWrapper errorMessage = new ReadOnlyStringWrapper("");
+
+    public ObservableList<Validator> getValidators() {
+        return validators;
+    }
+
+    public void setValidators(Validator... vs) {
+        validators.setAll(vs);
+    }
+
+    public boolean validate() {
+        TextInputControl input = isEditable() ? getEditor() : null;
+        boolean anyError = false;
+        String msg = null;
+        for (Validator v : validators) {
+            if (input != null) {
+                v.validate(input);
+            }
+            if (v.getHasErrors()) {
+                anyError = true;
+                if (msg == null) {
+                    String m = v.getMessage();
+                    if (m != null && !m.isEmpty()) {
+                        msg = m;
+                    }
+                }
+            }
+        }
+        pseudoClassStateChanged(ERROR_PC, anyError);
+        errorMessage.set(msg);
+        return !anyError;
+    }
+
+    public ReadOnlyStringProperty errorMessageProperty() {
+        return errorMessage.getReadOnlyProperty();
     }
 
     // ----- jfoenix API surface bisq uses on its combo box --------------------------------------

--- a/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqCheckBoxSkin.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqCheckBoxSkin.java
@@ -50,7 +50,10 @@ public class BisqCheckBoxSkin extends CheckBoxSkin {
     private final DoubleProperty fillIntensity = new SimpleDoubleProperty(0);
     private Node mark;
     private Region box;
+    private final Region indeterminateMark = new Region();
     private Circle currentRipple;
+    private boolean applyingFill;
+    private final ChangeListener<Background> boxBackgroundListener;
     private final ChangeListener<Bounds> boxBoundsListener;
     private final javafx.event.EventHandler<MouseEvent> pressHandler;
     private final javafx.event.EventHandler<MouseEvent> releaseHandler;
@@ -66,7 +69,24 @@ public class BisqCheckBoxSkin extends CheckBoxSkin {
         rippleOverlay.setClip(clipShape);
         getChildren().add(rippleOverlay);
 
+        // Indeterminate state mark — a small filled square shown inside the box only while the
+        // checkbox is indeterminate. Styled via the ".jfx-check-box ... .indeterminate-mark" CSS.
+        // Installed into the box (a StackPane) in layoutChildren so it is centered automatically.
+        indeterminateMark.getStyleClass().add("indeterminate-mark");
+        indeterminateMark.setMouseTransparent(true);
+        indeterminateMark.visibleProperty().bind(control.indeterminateProperty());
+
         boxBoundsListener = (o, oldB, newB) -> syncOverlayToBox();
+
+        // CSS declares `-fx-background-color: transparent` on the box in every state, so any
+        // pseudo-class change (hover / armed / focused) re-runs CSS on the box and clobbers the
+        // inline green fill set in applyFillIntensity. Re-assert our fill whenever that happens.
+        // The applyingFill guard prevents the re-entrant set from looping.
+        boxBackgroundListener = (o, oldB, newB) -> {
+            if (!applyingFill) {
+                applyFillIntensity(fillIntensity.get());
+            }
+        };
 
         // Drive the box background from the fillIntensity property — single source of truth
         // for the green fill, animatable, no child overlay required.
@@ -105,7 +125,9 @@ public class BisqCheckBoxSkin extends CheckBoxSkin {
         }
         if (box != null) {
             box.boundsInParentProperty().removeListener(boxBoundsListener);
+            box.backgroundProperty().removeListener(boxBackgroundListener);
         }
+        indeterminateMark.visibleProperty().unbind();
         animation.stop();
         super.dispose();
     }
@@ -122,6 +144,10 @@ public class BisqCheckBoxSkin extends CheckBoxSkin {
             if (node instanceof Region rb) {
                 box = rb;
                 box.boundsInParentProperty().addListener(boxBoundsListener);
+                box.backgroundProperty().addListener(boxBackgroundListener);
+                if (box instanceof Pane bp && !bp.getChildren().contains(indeterminateMark)) {
+                    bp.getChildren().add(indeterminateMark);
+                }
                 applyFillIntensity(getSkinnable().isSelected() ? 1 : 0);
                 syncOverlayToBox();
             }
@@ -139,7 +165,9 @@ public class BisqCheckBoxSkin extends CheckBoxSkin {
         double clamped = Math.min(1, Math.max(0, a));
         Color fill = clamped <= 0 ? Color.TRANSPARENT
                 : Color.color(FILL_COLOR.getRed(), FILL_COLOR.getGreen(), FILL_COLOR.getBlue(), clamped);
+        applyingFill = true;
         box.setBackground(new Background(new BackgroundFill(fill, CornerRadii.EMPTY, Insets.EMPTY)));
+        applyingFill = false;
     }
 
     private void syncOverlayToBox() {

--- a/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqComboBoxSkin.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqComboBoxSkin.java
@@ -1,5 +1,6 @@
 package bisq.desktop.components.controls.skin;
 
+import bisq.desktop.components.controls.BisqJfxComboBox;
 import bisq.desktop.components.controls.LabelFloatable;
 
 import javafx.animation.Interpolator;
@@ -28,6 +29,7 @@ public class BisqComboBoxSkin<T> extends ComboBoxListViewSkin<T> {
     private final Region line = new Region();
     private final Region focusedLine = new Region();
     private final Label topLabel = new Label();
+    private final Label errorLabel = new Label();
     private final Timeline focusAnim = new Timeline();
     private final Timeline floatAnim = new Timeline();
     private final javafx.scene.transform.Scale promptScaleTransform =
@@ -66,7 +68,18 @@ public class BisqComboBoxSkin<T> extends ComboBoxListViewSkin<T> {
                         : combo.focusedProperty());
         topLabel.visibleProperty().bind(showTopLabel);
 
-        getChildren().addAll(line, focusedLine, topLabel);
+        // Error label below the combo, bound to BisqJfxComboBox.errorMessageProperty(). Unmanaged
+        // so it doesn't grow the combo's prefHeight (mirrors BisqTextFieldSkin).
+        errorLabel.getStyleClass().add("error-label");
+        errorLabel.setManaged(false);
+        errorLabel.setMouseTransparent(true);
+        errorLabel.setWrapText(true);
+        if (combo instanceof BisqJfxComboBox<?> bjcb) {
+            errorLabel.textProperty().bind(bjcb.errorMessageProperty());
+        }
+        errorLabel.visibleProperty().bind(errorLabel.textProperty().isNotEmpty());
+
+        getChildren().addAll(line, focusedLine, topLabel, errorLabel);
 
         focusListener = (o, ov, nv) -> { animateFocus(); updateFloatAnim(); };
         valueListener = (o, ov, nv) -> updateFloatAnim();
@@ -101,6 +114,8 @@ public class BisqComboBoxSkin<T> extends ComboBoxListViewSkin<T> {
         topLabel.textProperty().unbind();
         topLabel.translateYProperty().unbind();
         topLabel.visibleProperty().unbind();
+        errorLabel.textProperty().unbind();
+        errorLabel.visibleProperty().unbind();
         showTopLabel.dispose();
         focusAnim.stop();
         floatAnim.stop();
@@ -136,14 +151,18 @@ public class BisqComboBoxSkin<T> extends ComboBoxListViewSkin<T> {
         super.layoutChildren(x, y, w, h);
         double cw = getSkinnable().getWidth();
         double ch = getSkinnable().getHeight();
-        double lineY = ch - LINE_HEIGHT;
-        line.resizeRelocate(0, lineY, cw, LINE_HEIGHT);
-        double focusedY = ch - FOCUSED_LINE_HEIGHT;
-        focusedLine.resizeRelocate(0, focusedY, cw, FOCUSED_LINE_HEIGHT);
+        // Lines sit at the combo's bottom edge (y = ch), matching jfoenix's PromptLinesWrapper
+        // and BisqTextFieldSkin, so the underline rests on the box's bottom border.
+        line.resizeRelocate(0, ch, cw, LINE_HEIGHT);
+        focusedLine.resizeRelocate(0, ch, cw, FOCUSED_LINE_HEIGHT);
         if (topLabel.isVisible()) {
             double labelH = topLabel.prefHeight(-1);
             // Idle position: vertically centered inside the combo (prompt position).
             topLabel.resizeRelocate(x, y + (h - labelH) / 2, w, labelH);
+        }
+        if (errorLabel.isVisible()) {
+            double errH = errorLabel.prefHeight(cw);
+            errorLabel.resizeRelocate(0, ch + 3, cw, errH);
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqTabPaneSkin.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqTabPaneSkin.java
@@ -48,6 +48,7 @@ public class BisqTabPaneSkin extends SkinBase<TabPane> {
     private final StackPane contentArea = new StackPane();
     private final Region selectedLine = new Region();
     private final Timeline anim = new Timeline();
+    private final Rectangle paneClip = new Rectangle();
 
     private final ListChangeListener<Tab> tabsListener;
     private final ChangeListener<Tab> selectionListener;
@@ -70,6 +71,14 @@ public class BisqTabPaneSkin extends SkinBase<TabPane> {
 
         // Content first (below), then header (on top), then the slider line over the header.
         getChildren().addAll(contentArea, header, selectedLine);
+
+        // Clip the whole tab pane to its bounds (mirrors jfoenix's JFXTabPaneSkin). Combined with
+        // the computeMinHeight override below, this lets an ancestor shrink the pane: the content
+        // is clipped at the bottom instead of forcing the pane — and the surrounding chrome (main
+        // nav, sub-tabs) — taller than the window and scrolling it off-screen.
+        paneClip.widthProperty().bind(tabPane.widthProperty());
+        paneClip.heightProperty().bind(tabPane.heightProperty());
+        tabPane.setClip(paneClip);
 
         tabsListener = c -> {
             // (Un)wire content listeners on tabs added or removed.
@@ -268,6 +277,17 @@ public class BisqTabPaneSkin extends SkinBase<TabPane> {
     }
 
     @Override
+    protected double computeMinHeight(double width, double topInset, double rightInset,
+                                      double bottomInset, double leftInset) {
+        // Only the header is mandatory; the content is clipped (paneClip) when space is tight, so
+        // the pane can shrink to the header height. The default SkinBase implementation would add
+        // the content's (large) min height, making the pane unshrinkable and pushing surrounding
+        // chrome off-screen on resize.
+        double headerH = Math.max(header.prefHeight(width), 32);
+        return topInset + bottomInset + headerH;
+    }
+
+    @Override
     protected void layoutChildren(double x, double y, double w, double h) {
         double headerH = Math.max(header.prefHeight(w), 32);
         header.resizeRelocate(x, y, w, headerH);
@@ -286,6 +306,9 @@ public class BisqTabPaneSkin extends SkinBase<TabPane> {
     public void dispose() {
         TabPane tp = getSkinnable();
         if (tp != null) {
+            paneClip.widthProperty().unbind();
+            paneClip.heightProperty().unbind();
+            tp.setClip(null);
             tp.getTabs().removeListener(tabsListener);
             tp.getSelectionModel().selectedItemProperty().removeListener(selectionListener);
             tp.getSelectionModel().selectedItemProperty().removeListener(selectedClassListener);

--- a/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqTextFieldSkin.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/skin/BisqTextFieldSkin.java
@@ -190,12 +190,16 @@ public class BisqTextFieldSkin extends TextFieldSkin {
         super.layoutChildren(x, y, w, h);
         double cw = getSkinnable().getWidth();
         double ch = getSkinnable().getHeight();
-        double lineY = ch - LINE_HEIGHT;
-        line.resizeRelocate(-inputLineExtension, lineY,
-                cw + inputLineExtension * 2, LINE_HEIGHT);
-        double focusedY = ch - FOCUSED_LINE_HEIGHT;
-        focusedLine.resizeRelocate(-inputLineExtension, focusedY,
-                cw + inputLineExtension * 2, FOCUSED_LINE_HEIGHT);
+        // Underline spans the field plus inputLineExtension to the RIGHT only (to reach under an
+        // adjacent currency-code label sitting outside the field, e.g. offer amount/price rows).
+        // Matches the original JFXTextFieldSkinBisqStyle geometry (width = fieldWidth + extension,
+        // origin 0). The earlier "-extension .. cw + 2*extension" overhung both sides.
+        // Lines sit at the field's bottom edge (y = ch) extending downward, matching jfoenix's
+        // PromptLinesWrapper (line.resizeRelocate(x, controlHeight, ...)). Drawing them at
+        // ch - height instead floats them inside the field, above the box's bottom border.
+        double lineWidth = cw + inputLineExtension;
+        line.resizeRelocate(0, ch, lineWidth, LINE_HEIGHT);
+        focusedLine.resizeRelocate(0, ch, lineWidth, FOCUSED_LINE_HEIGHT);
         // Floating label baseline INSIDE the field. translateY (driven by promptOffsetY) lifts
         // it above when focused/filled.
         if (topLabel.isVisible()) {

--- a/desktop/src/main/java/bisq/desktop/theme-light.css
+++ b/desktop/src/main/java/bisq/desktop/theme-light.css
@@ -189,9 +189,11 @@
 .jfx-text-field:error > .input-line,
 .jfx-password-field:error > .input-line,
 .jfx-text-area:error > .input-line,
+.jfx-combo-box:error > .input-line,
 .jfx-text-field:error > .input-focused-line,
 .jfx-password-field:error > .input-focused-line,
-.jfx-text-area:error > .input-focused-line {
+.jfx-text-area:error > .input-focused-line,
+.jfx-combo-box:error > .input-focused-line {
     -fx-background-color: -bs-rd-error-red;
 }
 


### PR DESCRIPTION
Fix jfoenix-removal component style regressions
Several pure-JavaFX control replacements diverged from the CSS contract /
jfoenix node structure after the jfoenix removal. Fixes:

- Checkbox green fill vanished on hover: the inline box fill was clobbered
  whenever a pseudo-class change re-ran the box CSS (-fx-background-color:
  transparent). Re-assert the fill via a guarded backgroundProperty listener.

- Offer input underlines overflowed the field and floated above the box
  border. Restore jfoenix geometry in BisqTextFieldSkin/BisqComboBoxSkin:
  line width = fieldWidth + inputLineExtension (right-only, not both sides)
  and y = controlHeight so the line rests on the box's bottom border.

- Unchecked checkbox border was too faint (-bs-color-gray-bbb); use the
  shared -bs-color-gray-line so it reads clearly, matching jfoenix.

- Remove the dead `.jfx-checkbox` rule (typo for `.jfx-check-box`; carried a
  removed-jfoenix `-jfx-checked-color` property and never matched).

- Add the `.indeterminate-mark` node to BisqCheckBoxSkin so the indeterminate
  state renders per the existing CSS (jfoenix-faithful drop-in).

- Restore ComboBox validation: BisqJfxComboBox gets getValidators()/validate()/
  errorMessageProperty() and toggles the :error pseudo-class; BisqComboBoxSkin
  renders the .error-label; add the matching combo error CSS (error-label rules
  + light-theme :error underline).

- Tabs scrolled off-screen on window resize (e.g. open-trades): BisqTabPaneSkin
  let the content's min height propagate, making the pane and its ancestors
  unshrinkable. Clip the pane to its bounds and override computeMinHeight to the
  header height so content clips instead of pushing the chrome off-screen
  (mirrors jfoenix's clipped JFXTabPaneSkin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combo boxes now support built-in validation and show error messages beneath the field
  * Checkboxes display an indeterminate state mark

* **Style**
  * Expanded error-state styling to cover combo boxes and input underlines
  * Refined text-field underline positioning and subtle checkbox hover/focus color adjustment

* **Bug Fixes**
  * Tabbed views are now clipped to bounds to prevent layout overflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->