### PR TITLE
build: create separate Gradle task for each build target

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/DebJpackageTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/DebJpackageTask.kt
@@ -1,0 +1,15 @@
+package bisq.gradle.packaging
+
+import org.gradle.api.tasks.TaskAction
+
+abstract class DebJpackageTask : JPackageTask() {
+
+    @TaskAction
+    override fun run() {
+        val jPackagePath = jdkDirectory.asFile.get().toPath().resolve("bin").resolve("jpackage")
+        val jPackageConfig = createJPackageConfig()
+
+        DebPackager(jPackagePath, jPackageConfig)
+            .build(computePackageFormatConfigs())
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/DebPackager.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/DebPackager.kt
@@ -1,0 +1,124 @@
+package bisq.gradle.packaging
+
+import bisq.gradle.packaging.jpackage.JPackageConfig
+import bisq.gradle.packaging.jpackage.PackageFactory
+import bisq.gradle.packaging.jpackage.package_formats.JPackagePackageFormatConfigs
+import bisq.gradle.packaging.jpackage.package_formats.PackageFormat
+import org.gradle.api.GradleException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+class DebPackager(private val jPackagePath: Path, private val jPackageConfig: JPackageConfig) {
+    fun build(packageFormatConfigs: JPackagePackageFormatConfigs) {
+        val linuxPackager = LinuxPackager(jPackagePath, jPackageConfig, packageFormatConfigs)
+        linuxPackager.build(PackageFormat.DEB)
+        relaxDebT64Dependencies(jPackageConfig)
+    }
+
+    // Debian/Ubuntu 24.04 renamed many libraries during the 64-bit time_t transition,
+    // appending a `t64` suffix (e.g. libasound2 -> libasound2t64). jpackage inherits
+    // whatever names dpkg-shlibdeps picks up on the build host, so a .deb produced on
+    // a t64-transitioned system pins `libasound2t64` and refuses to install on Ubuntu
+    // 22.04 where only the un-suffixed name exists. Rewrite the Depends field so each
+    // `<pkg>t64` entry becomes `<pkg>t64 | <pkg>`, satisfying both old and new releases.
+    fun relaxDebT64Dependencies(jPackageConfig: JPackageConfig) {
+        val debPath = PackageFactory.findSinglePackageArtifact(PackageFormat.DEB, jPackageConfig)
+        val repackRoot = jPackageConfig.temporaryDirPath.resolve("deb-repack")
+        val repackRootFile = repackRoot.toFile()
+        if (repackRootFile.exists() && !repackRootFile.deleteRecursively()) {
+            throw GradleException("Couldn't delete DEB repack directory: ${repackRoot.toAbsolutePath()}")
+        }
+
+        val payloadRoot = repackRoot.resolve("payload")
+        Files.createDirectories(repackRoot)
+
+        PackageFactory.runProcess(
+            ProcessBuilder(
+                "dpkg-deb", "-R",
+                debPath.toAbsolutePath().toString(),
+                payloadRoot.toAbsolutePath().toString()
+            ),
+            "extract DEB payload"
+        )
+
+        val controlFile = payloadRoot.resolve("DEBIAN").resolve("control")
+        if (!Files.isRegularFile(controlFile)) {
+            throw GradleException("DEB control file not found after extraction: ${controlFile.toAbsolutePath()}")
+        }
+        val original = Files.readString(controlFile)
+        val updated = relaxT64Dependencies(original)
+        if (updated == original) {
+            return
+        }
+        Files.writeString(controlFile, updated)
+
+        val rebuiltDebPath = repackRoot.resolve(debPath.fileName)
+        PackageFactory.runProcess(
+            ProcessBuilder(
+                "dpkg-deb",
+                "--root-owner-group",
+                "--build",
+                payloadRoot.toAbsolutePath().toString(),
+                rebuiltDebPath.toAbsolutePath().toString()
+            ),
+            "rebuild DEB with relaxed dependencies"
+        )
+
+        Files.move(rebuiltDebPath, debPath, StandardCopyOption.REPLACE_EXISTING)
+        PackageFactory.normalizePathTimestamps(debPath)
+    }
+
+
+    private fun relaxT64Dependencies(controlFileContent: String): String {
+        val lines = controlFileContent.split("\n")
+        val result = StringBuilder()
+        var i = 0
+        while (i < lines.size) {
+            val line = lines[i]
+            if (line.startsWith("Depends:", ignoreCase = true)) {
+                val colonIdx = line.indexOf(':')
+                val deps = StringBuilder(line.substring(colonIdx + 1).trim())
+                var j = i + 1
+                while (j < lines.size && lines[j].isNotEmpty() && (lines[j][0] == ' ' || lines[j][0] == '\t')) {
+                    if (deps.isNotEmpty()) deps.append(' ')
+                    deps.append(lines[j].trim())
+                    j++
+                }
+                result.append(line.substring(0, colonIdx + 1))
+                    .append(' ')
+                    .append(relaxDepsList(deps.toString()))
+                i = j
+            } else {
+                result.append(line)
+                i++
+            }
+            if (i < lines.size) {
+                result.append('\n')
+            }
+        }
+        return result.toString()
+    }
+
+    private fun relaxDepsList(deps: String): String {
+        if (deps.isBlank()) return deps
+        return deps.split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .joinToString(", ") { relaxT64Dependency(it) }
+    }
+
+    private fun relaxT64Dependency(dep: String): String {
+        if (dep.contains("|")) {
+            return dep
+        }
+        val nameEndIdx = dep.indexOfAny(charArrayOf(' ', '\t', ':', '('))
+        val pkgName = if (nameEndIdx == -1) dep else dep.substring(0, nameEndIdx)
+        if (!pkgName.endsWith("t64") || pkgName.length <= 3) {
+            return dep
+        }
+        val baseName = pkgName.dropLast(3)
+        val suffix = dep.removePrefix(pkgName)
+        return "$dep | $baseName$suffix"
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
@@ -3,11 +3,7 @@ package bisq.gradle.packaging
 import bisq.gradle.packaging.jpackage.JPackageAppConfig
 import bisq.gradle.packaging.jpackage.JPackageConfig
 import bisq.gradle.packaging.jpackage.PackageFactory
-import bisq.gradle.packaging.jpackage.package_formats.JPackagePackageFormatConfigs
-import bisq.gradle.packaging.jpackage.package_formats.LinuxPackages
-import bisq.gradle.packaging.jpackage.package_formats.MacPackage
-import bisq.gradle.packaging.jpackage.package_formats.PackageFormat
-import bisq.gradle.packaging.jpackage.package_formats.WindowsPackage
+import bisq.gradle.packaging.jpackage.package_formats.*
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
@@ -44,12 +40,19 @@ abstract class JPackageTask : DefaultTask() {
     abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
-    fun run() {
+    open fun run() {
         val jPackagePath = jdkDirectory.asFile.get().toPath().resolve("bin").resolve("jpackage")
+        val jPackageConfig = createJPackageConfig()
+
+        val packageFactory = PackageFactory(jPackagePath, jPackageConfig)
+        packageFactory.createPackages()
+    }
+
+    fun createJPackageConfig(): JPackageConfig {
         val outputDirectoryFile = outputDirectory.asFile.get()
         deleteExistingInstallerArtifacts(outputDirectoryFile)
 
-        val jPackageConfig = JPackageConfig(
+        return JPackageConfig(
             inputDirPath = distDirFile.get().toPath().resolve("lib"),
             outputDirPath = outputDirectoryFile.toPath(),
             jPackageTempDirPath = outputDirectoryFile.toPath().resolve("jpackage_temp"),
@@ -62,28 +65,25 @@ abstract class JPackageTask : DefaultTask() {
                 jvmArgs = jvmArgs.get()
             ),
 
-            packageFormatConfigs = getPackageFormatConfigs()
+            packageFormatConfigs = computePackageFormatConfigs()
         )
-
-        val packageFactory = PackageFactory(jPackagePath, jPackageConfig)
-        packageFactory.createPackages()
     }
 
     private fun deleteExistingInstallerArtifacts(outputDirectoryFile: File) {
         outputDirectoryFile.mkdirs()
         val installerExtensions = PackageFormat.values()
-                .map { it.fileExtension }
-                .toSet()
+            .map { it.fileExtension }
+            .toSet()
         outputDirectoryFile.listFiles()
-                ?.filter { it.isFile && it.extension.lowercase() in installerExtensions }
-                ?.forEach { installerArtifact ->
-                    if (!installerArtifact.delete()) {
-                        throw GradleException("Failed to delete stale installer artifact: ${installerArtifact.absolutePath}")
-                    }
+            ?.filter { it.isFile && it.extension.lowercase() in installerExtensions }
+            ?.forEach { installerArtifact ->
+                if (!installerArtifact.delete()) {
+                    throw GradleException("Failed to delete stale installer artifact: ${installerArtifact.absolutePath}")
                 }
+            }
     }
 
-    private fun getPackageFormatConfigs(): JPackagePackageFormatConfigs {
+    fun computePackageFormatConfigs(): JPackagePackageFormatConfigs {
         val packagePath = packageResourcesDir.asFile.get().toPath()
         return when (getOS()) {
             OS.WINDOWS -> {

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/LinuxPackager.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/LinuxPackager.kt
@@ -1,0 +1,78 @@
+package bisq.gradle.packaging
+
+import bisq.gradle.packaging.jpackage.JPackageConfig
+import bisq.gradle.packaging.jpackage.PackageFactory
+import bisq.gradle.packaging.jpackage.package_formats.JPackagePackageFormatConfigs
+import bisq.gradle.packaging.jpackage.package_formats.PackageFormat
+import org.gradle.api.GradleException
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.collections.plus
+
+class LinuxPackager(
+    private val jPackagePath: Path,
+    private val jPackageConfig: JPackageConfig,
+    private val packageFormatConfigs: JPackagePackageFormatConfigs
+) {
+    fun build(packageFormat: PackageFormat) {
+        build(packageFormat, emptyMap())
+    }
+
+    fun build(packageFormat: PackageFormat, environment: Map<String, String>) {
+        val linuxPackager = LinuxPackager(jPackagePath, jPackageConfig, packageFormatConfigs)
+
+        val processBuilder: ProcessBuilder = linuxPackager.preparePackageProcess()
+        processBuilder.environment()
+            .putAll(environment)
+
+        val commands = linuxPackager.createCommandsForPackageFormat(packageFormat)
+        processBuilder.command()
+            .addAll(commands)
+
+        // jpackage fails if temp directory is not empty
+        val jPackageTempDir = jPackageConfig.jPackageTempDirPath.toFile()
+        if (jPackageTempDir.exists()) {
+            val isSuccess = jPackageTempDir.deleteRecursively()
+            if (!isSuccess) {
+                throw GradleException("Couldn't delete jpackage temp directory: ${jPackageTempDir.absolutePath}")
+            }
+        }
+
+        val process: Process = processBuilder.start()
+        val finished = process.waitFor(15, TimeUnit.MINUTES)
+        if (!finished) {
+            process.destroyForcibly()
+            throw GradleException("jpackage timed out after 15 minutes: ${commands.joinToString(" ")}")
+        }
+
+        val exitCode = process.exitValue()
+        if (exitCode != 0) {
+            throw GradleException("jpackage failed with exit code $exitCode: ${commands.joinToString(" ")}")
+        }
+    }
+
+    fun createCommandsForPackageFormat(
+        packageFormat: PackageFormat
+    ): List<String> {
+        val commonArgs: List<String> =
+            PackageFactory.createCommonArguments(jPackageConfig.appConfig, jPackageConfig)
+        val customCommands = createCustomCommandsForPackageFormat(packageFormatConfigs, packageFormat)
+        return commonArgs + customCommands
+    }
+
+    fun preparePackageProcess(): ProcessBuilder {
+        val processBuilder = ProcessBuilder(jPackagePath.toAbsolutePath().toString())
+            .inheritIO()
+        processBuilder.environment()[PackageFactory.SOURCE_DATE_EPOCH] = PackageFactory.DEFAULT_SOURCE_DATE_EPOCH
+        return processBuilder
+    }
+
+    private fun createCustomCommandsForPackageFormat(
+        packageFormatConfigs: JPackagePackageFormatConfigs,
+        packageFormat: PackageFormat
+    ): List<String> =
+        packageFormatConfigs.createArgumentsForJPackage(packageFormat) + listOf(
+            "--type",
+            packageFormat.fileExtension
+        )
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -29,20 +29,30 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
         val javaApplicationExtension = project.extensions.findByType<JavaApplication>()
         checkNotNull(javaApplicationExtension) { "Can't find JavaApplication extension." }
 
-        project.tasks.register<JPackageTask>("generateInstallers") {
-            jdkDirectory.set(getProjectJdkDirectory(project))
-            distDirFile.set(installDistTask.map { it.destinationDir })
-            mainJarFile.set(jarTask.flatMap { it.archiveFile })
+        val jPackageTaskConfiguration = jPackageTaskConfiguration(installDistTask, jarTask, javaApplicationExtension)
 
-            mainClassName.set(javaApplicationExtension.mainClass)
-            jvmArgs.set(javaApplicationExtension.applicationDefaultJvmArgs)
-            appVersion.set(APP_VERSION)
+        project.tasks.register<JPackageTask>("generateInstallers", jPackageTaskConfiguration)
+        project.tasks.register<DebJpackageTask>("deb", jPackageTaskConfiguration)
+        project.tasks.register<RpmJpackageTask>("rpm", jPackageTaskConfiguration)
+    }
 
-            val packageResourcesDirFile = File(project.projectDir, "package")
-            packageResourcesDir.set(packageResourcesDirFile)
+    private fun jPackageTaskConfiguration(
+        installDistTask: TaskProvider<Sync>,
+        jarTask: TaskProvider<Jar>,
+        javaApplicationExtension: JavaApplication
+    ): JPackageTask.() -> Unit = {
+        jdkDirectory.set(getProjectJdkDirectory(project))
+        distDirFile.set(installDistTask.map { it.destinationDir })
+        mainJarFile.set(jarTask.flatMap { it.archiveFile })
 
-            outputDirectory.set(project.layout.buildDirectory.dir("packaging"))
-        }
+        mainClassName.set(javaApplicationExtension.mainClass)
+        jvmArgs.set(javaApplicationExtension.applicationDefaultJvmArgs)
+        appVersion.set(APP_VERSION)
+
+        val packageResourcesDirFile = File(project.projectDir, "package")
+        packageResourcesDir.set(packageResourcesDirFile)
+
+        outputDirectory.set(project.layout.buildDirectory.dir("packaging"))
     }
 
     private fun getProjectJdkDirectory(project: Project): Provider<Directory> {

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/RpmJpackageTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/RpmJpackageTask.kt
@@ -1,0 +1,15 @@
+package bisq.gradle.packaging
+
+import org.gradle.api.tasks.TaskAction
+
+abstract class RpmJpackageTask : JPackageTask() {
+
+    @TaskAction
+    override fun run() {
+        val jPackagePath = jdkDirectory.asFile.get().toPath().resolve("bin").resolve("jpackage")
+        val jPackageConfig = createJPackageConfig()
+
+        RpmPackager(jPackagePath, jPackageConfig)
+            .build(computePackageFormatConfigs())
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/RpmPackager.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/RpmPackager.kt
@@ -1,0 +1,151 @@
+package bisq.gradle.packaging
+
+import bisq.gradle.packaging.jpackage.JPackageAppConfig
+import bisq.gradle.packaging.jpackage.JPackageConfig
+import bisq.gradle.packaging.jpackage.PackageFactory
+import bisq.gradle.packaging.jpackage.package_formats.JPackagePackageFormatConfigs
+import bisq.gradle.packaging.jpackage.package_formats.PackageFormat
+import org.gradle.api.GradleException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+class RpmPackager(private val jPackagePath: Path, private val jPackageConfig: JPackageConfig) {
+    fun build(packageFormatConfigs: JPackagePackageFormatConfigs) {
+        val linuxPackager = LinuxPackager(jPackagePath, jPackageConfig, packageFormatConfigs)
+        val environment = mutableMapOf(Pair("HOME", createRpmHome().toAbsolutePath().toString()))
+
+        linuxPackager.build(PackageFormat.RPM, environment)
+        normalizeRpmPackage()
+    }
+
+    private fun createRpmHome(): Path {
+        val rpmHomePath = jPackageConfig.temporaryDirPath.resolve("rpm-home")
+        Files.createDirectories(rpmHomePath)
+        Files.writeString(
+            rpmHomePath.resolve(".rpmmacros"),
+            """
+                    %use_source_date_epoch_as_buildtime 1
+                    %clamp_mtime_to_source_date_epoch 1
+                    %_buildhost bisq-release-builder
+                """.trimIndent() + "\n"
+        )
+        return rpmHomePath
+    }
+
+    fun normalizeRpmPackage() {
+        val rpmPath = PackageFactory.findSinglePackageArtifact(PackageFormat.RPM, jPackageConfig)
+        val repackRoot = jPackageConfig.temporaryDirPath.resolve("rpm-repack")
+        val repackRootFile = repackRoot.toFile()
+        if (repackRootFile.exists() && !repackRootFile.deleteRecursively()) {
+            throw GradleException("Couldn't delete RPM repack directory: ${repackRoot.toAbsolutePath()}")
+        }
+
+        val payloadRoot = repackRoot.resolve("payload")
+        val topDir = repackRoot.resolve("rpmbuild")
+        val specDir = topDir.resolve("SPECS")
+        val buildRoot = repackRoot.resolve("buildroot")
+        Files.createDirectories(payloadRoot)
+        Files.createDirectories(specDir)
+
+        PackageFactory.runProcess(
+            ProcessBuilder(
+                "sh",
+                "-c",
+                "cd ${PackageFactory.shellSingleQuote(payloadRoot.toAbsolutePath().toString())} && " +
+                        "rpm2cpio ${
+                            PackageFactory.shellSingleQuote(
+                                rpmPath.toAbsolutePath().toString()
+                            )
+                        } | cpio -idm --quiet"
+            ),
+            "extract RPM payload"
+        )
+
+        val specPath = specDir.resolve("bisq.spec")
+        Files.writeString(specPath, createNormalizedRpmSpec(jPackageConfig.appConfig, payloadRoot))
+
+        PackageFactory.runProcess(
+            ProcessBuilder(
+                "rpmbuild",
+                "-bb",
+                "--buildroot", buildRoot.toAbsolutePath().toString(),
+                "--define", "_topdir ${topDir.toAbsolutePath()}",
+                "--define", "_buildhost bisq-release-builder",
+                "--define", "use_source_date_epoch_as_buildtime 1",
+                "--define", "clamp_mtime_to_source_date_epoch 1",
+                "--define", "source_date_epoch_from_changelog 0",
+                "--define", "_binary_payload w9.gzdio",
+                "--define", "_build_id_links none",
+                "--define", "__os_install_post %{nil}",
+                specPath.toAbsolutePath().toString()
+            ),
+            "rebuild normalized RPM"
+        )
+
+        val rebuiltRpmPath = topDir
+            .resolve("RPMS")
+            .resolve("x86_64")
+            .resolve(rpmPath.fileName)
+        if (!Files.isRegularFile(rebuiltRpmPath)) {
+            throw GradleException("rpmbuild did not create expected RPM: ${rebuiltRpmPath.toAbsolutePath()}")
+        }
+
+        Files.move(rebuiltRpmPath, rpmPath, StandardCopyOption.REPLACE_EXISTING)
+        PackageFactory.normalizePathTimestamps(rpmPath)
+    }
+
+    private fun createNormalizedRpmSpec(appConfig: JPackageAppConfig, payloadRoot: Path): String {
+        val sourceDateEpoch = PackageFactory.sourceDateEpochSeconds()
+        val payloadRootPath = PackageFactory.shellSingleQuote(payloadRoot.toAbsolutePath().toString())
+
+        return """
+            Name: bisq
+            Version: ${appConfig.appVersion}
+            Release: 1
+            Summary: Bisq
+            License: AGPLv3
+            Group: Unspecified
+            Vendor: Bisq
+            Prefix: /opt
+            BuildArch: x86_64
+            AutoReqProv: no
+            Requires: xdg-utils
+            Provides: bisq
+
+            %description
+            A decentralized bitcoin exchange network.
+
+            %prep
+
+            %build
+
+            %install
+            rm -rf "%{buildroot}"
+            mkdir -p "%{buildroot}"
+            cp -a ${payloadRootPath}/. "%{buildroot}/"
+            find "%{buildroot}" -exec touch -h -d @${sourceDateEpoch} {} +
+
+            %pre
+            package_type=rpm
+
+            if [ "${'$'}1" = 2 ]; then
+              true;
+            fi
+
+            %post
+            package_type=rpm
+
+            xdg-desktop-menu install /opt/bisq/lib/bisq-Bisq.desktop
+
+            %preun
+            package_type=rpm
+
+            xdg-desktop-menu uninstall /opt/bisq/lib/bisq-Bisq.desktop
+
+            %files
+            %defattr(-,root,root,-)
+            /opt
+        """.trimIndent() + "\n"
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/PackageFactory.kt
@@ -11,30 +11,118 @@ import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.FileTime
 import java.time.Instant
 import java.time.Year
+import java.time.ZoneOffset
 import java.util.Comparator
 import java.util.concurrent.TimeUnit
 
 class PackageFactory(private val jPackagePath: Path, private val jPackageConfig: JPackageConfig) {
 
     companion object {
-        private const val SOURCE_DATE_EPOCH = "SOURCE_DATE_EPOCH"
-        private const val DEFAULT_SOURCE_DATE_EPOCH = "0"
+        const val SOURCE_DATE_EPOCH = "SOURCE_DATE_EPOCH"
+        const val DEFAULT_SOURCE_DATE_EPOCH = "0"
+
+        fun createCommonArguments(appConfig: JPackageAppConfig, jPackageConfig: JPackageConfig): List<String> {
+            val currentYear = Instant.ofEpochSecond(sourceDateEpochSeconds())
+                .atZone(ZoneOffset.UTC)
+                .year
+
+            return mutableListOf(
+                "--temp", jPackageConfig.jPackageTempDirPath.toAbsolutePath().toString(),
+                "--dest", jPackageConfig.outputDirPath.toAbsolutePath().toString(),
+
+                "--name", "Bisq",
+                "--description", "A decentralized bitcoin exchange network.",
+                "--copyright", "Copyright © 2013-$currentYear - The Bisq developers",
+                "--vendor", "Bisq",
+
+                "--app-version", appConfig.appVersion,
+
+                "--input", jPackageConfig.inputDirPath.toAbsolutePath().toString(),
+                "--main-jar", appConfig.mainJarFileName,
+
+                "--main-class", appConfig.mainClassName,
+                "--java-options", appConfig.jvmArgs.joinToString(separator = " "),
+            )
+        }
+
+        fun findSinglePackageArtifact(packageFormat: PackageFormat, jPackageConfig: JPackageConfig): Path {
+            val extension = ".${packageFormat.fileExtension}"
+            val matchingArtifacts = Files.list(jPackageConfig.outputDirPath).use { files ->
+                files.filter { path ->
+                    Files.isRegularFile(path) && path.fileName.toString().endsWith(extension)
+                }.toList()
+            }
+
+            if (matchingArtifacts.size != 1) {
+                throw GradleException(
+                    "Expected exactly one ${extension} package in ${jPackageConfig.outputDirPath}, " +
+                            "found ${matchingArtifacts.size}: ${matchingArtifacts.joinToString(", ")}"
+                )
+            }
+
+            return matchingArtifacts.single()
+        }
+
+        fun runProcess(processBuilder: ProcessBuilder, description: String) {
+            processBuilder.inheritIO()
+            processBuilder.environment().putIfAbsent(SOURCE_DATE_EPOCH, DEFAULT_SOURCE_DATE_EPOCH)
+
+            val allCommands = processBuilder.command()
+            val process = processBuilder.start()
+            val finished = process.waitFor(15, TimeUnit.MINUTES)
+            if (!finished) {
+                process.destroyForcibly()
+                throw GradleException("${description} timed out after 15 minutes: ${allCommands.joinToString(" ")}")
+            }
+
+            val exitCode = process.exitValue()
+            if (exitCode != 0) {
+                throw GradleException("${description} failed with exit code ${exitCode}: ${allCommands.joinToString(" ")}")
+            }
+        }
+
+        fun shellSingleQuote(value: String): String {
+            return "'${value.replace("'", "'\"'\"'")}'"
+        }
+
+        fun normalizePathTimestamps(path: Path) {
+            val timestamp = FileTime.from(Instant.ofEpochSecond(sourceDateEpochSeconds()))
+            Files.walk(path).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach { entry ->
+                    Files.setLastModifiedTime(entry, timestamp)
+                }
+            }
+        }
+
+        fun sourceDateEpochSeconds(): Long {
+            val sourceDateEpoch = System.getenv(SOURCE_DATE_EPOCH) ?: PackageFactory.DEFAULT_SOURCE_DATE_EPOCH
+            return sourceDateEpoch.toLongOrNull() ?: DEFAULT_SOURCE_DATE_EPOCH.toLong()
+        }
     }
 
     fun createPackages() {
-        val jPackageCommonArgs: List<String> = createCommonArguments(jPackageConfig.appConfig)
+        val jPackageCommonArgs: List<String> = createCommonArguments(jPackageConfig.appConfig, jPackageConfig)
 
         val packageFormatConfigs = jPackageConfig.packageFormatConfigs
         val perPackageCommand = packageFormatConfigs.packageFormats
-                .map { packageFormat ->
-                    packageFormat to packageFormatConfigs.createArgumentsForJPackage(packageFormat) + listOf("--type", packageFormat.fileExtension)
+            .map { packageFormat ->
+                if (packageFormat == PackageFormat.DEB || packageFormat == PackageFormat.RPM) {
+                    throw GradleException(
+                        "This Gradle task doesn't support the packaging formats " +
+                                "${PackageFormat.DEB} and ${PackageFormat.RPM}."
+                    )
                 }
+
+                packageFormat to packageFormatConfigs.createArgumentsForJPackage(packageFormat) + listOf(
+                    "--type",
+                    packageFormat.fileExtension
+                )
+            }
 
         perPackageCommand.forEach { (packageFormat, customCommands) ->
             val processBuilder = ProcessBuilder(jPackagePath.toAbsolutePath().toString())
-                    .inheritIO()
+                .inheritIO()
             processBuilder.environment().putIfAbsent(SOURCE_DATE_EPOCH, DEFAULT_SOURCE_DATE_EPOCH)
-            configureReproducibleRpmEnvironment(processBuilder, packageFormat)
 
             val allCommands = processBuilder.command()
             allCommands.addAll(jPackageCommonArgs)
@@ -61,166 +149,16 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
                 throw GradleException("jpackage failed with exit code $exitCode: ${allCommands.joinToString(" ")}")
             }
 
-            if (packageFormat == PackageFormat.RPM) {
-                normalizeRpmPackage(jPackageConfig.appConfig)
-            }
-            if (packageFormat == PackageFormat.DEB) {
-                relaxDebT64Dependencies()
-            }
             if (packageFormat == PackageFormat.DMG && getOS() == OS.MAC_OS) {
                 renameMacOsDmgPackage(jPackageConfig.appConfig)
             }
         }
     }
 
-    private fun createCommonArguments(appConfig: JPackageAppConfig): List<String> =
-        mutableListOf(
-            "--temp", jPackageConfig.jPackageTempDirPath.toAbsolutePath().toString(),
-            "--dest", jPackageConfig.outputDirPath.toAbsolutePath().toString(),
-
-            "--name", "Bisq",
-            "--description", "A decentralized bitcoin exchange network.",
-            "--copyright", "Copyright © 2013-${Year.now()} - The Bisq developers",
-            "--vendor", "Bisq",
-
-            "--app-version", appConfig.appVersion,
-
-            "--input", jPackageConfig.inputDirPath.toAbsolutePath().toString(),
-            "--main-jar", appConfig.mainJarFileName,
-
-            "--main-class", appConfig.mainClassName,
-            "--java-options", appConfig.jvmArgs.joinToString(separator = " "),
-        )
-
-    private fun configureReproducibleRpmEnvironment(processBuilder: ProcessBuilder, packageFormat: PackageFormat) {
-        if (packageFormat != PackageFormat.RPM) {
-            return
-        }
-
-        processBuilder.environment()["HOME"] = createRpmHome().toAbsolutePath().toString()
-    }
-
-    private fun createRpmHome(): Path {
-        val rpmHomePath = jPackageConfig.temporaryDirPath.resolve("rpm-home")
-        Files.createDirectories(rpmHomePath)
-        Files.writeString(
-                rpmHomePath.resolve(".rpmmacros"),
-                """
-                    %use_source_date_epoch_as_buildtime 1
-                    %clamp_mtime_to_source_date_epoch 1
-                    %_buildhost bisq-release-builder
-                """.trimIndent() + "\n"
-        )
-        return rpmHomePath
-    }
-
-    private fun normalizeRpmPackage(appConfig: JPackageAppConfig) {
-        val rpmPath = findSinglePackageArtifact(PackageFormat.RPM)
-        val repackRoot = jPackageConfig.temporaryDirPath.resolve("rpm-repack")
-        repackRoot.toFile().deleteRecursively()
-
-        val payloadRoot = repackRoot.resolve("payload")
-        val topDir = repackRoot.resolve("rpmbuild")
-        val specDir = topDir.resolve("SPECS")
-        val buildRoot = repackRoot.resolve("buildroot")
-        Files.createDirectories(payloadRoot)
-        Files.createDirectories(specDir)
-
-        runProcess(
-                ProcessBuilder(
-                        "sh",
-                        "-c",
-                        "cd ${shellSingleQuote(payloadRoot.toAbsolutePath().toString())} && " +
-                                "rpm2cpio ${shellSingleQuote(rpmPath.toAbsolutePath().toString())} | cpio -idm --quiet"
-                ),
-                "extract RPM payload"
-        )
-
-        val specPath = specDir.resolve("bisq.spec")
-        Files.writeString(specPath, createNormalizedRpmSpec(appConfig, payloadRoot))
-
-        runProcess(
-                ProcessBuilder(
-                        "rpmbuild",
-                        "-bb",
-                        "--buildroot", buildRoot.toAbsolutePath().toString(),
-                        "--define", "_topdir ${topDir.toAbsolutePath()}",
-                        "--define", "_buildhost bisq-release-builder",
-                        "--define", "use_source_date_epoch_as_buildtime 1",
-                        "--define", "clamp_mtime_to_source_date_epoch 1",
-                        "--define", "source_date_epoch_from_changelog 0",
-                        "--define", "_binary_payload w9.gzdio",
-                        "--define", "_build_id_links none",
-                        "--define", "__os_install_post %{nil}",
-                        specPath.toAbsolutePath().toString()
-                ),
-                "rebuild normalized RPM"
-        )
-
-        val rebuiltRpmPath = topDir
-                .resolve("RPMS")
-                .resolve("x86_64")
-                .resolve(rpmPath.fileName)
-        if (!Files.isRegularFile(rebuiltRpmPath)) {
-            throw GradleException("rpmbuild did not create expected RPM: ${rebuiltRpmPath.toAbsolutePath()}")
-        }
-
-        Files.move(rebuiltRpmPath, rpmPath, StandardCopyOption.REPLACE_EXISTING)
-        normalizePathTimestamps(rpmPath)
-    }
-
-    // Debian/Ubuntu 24.04 renamed many libraries during the 64-bit time_t transition,
-    // appending a `t64` suffix (e.g. libasound2 -> libasound2t64). jpackage inherits
-    // whatever names dpkg-shlibdeps picks up on the build host, so a .deb produced on
-    // a t64-transitioned system pins `libasound2t64` and refuses to install on Ubuntu
-    // 22.04 where only the un-suffixed name exists. Rewrite the Depends field so each
-    // `<pkg>t64` entry becomes `<pkg>t64 | <pkg>`, satisfying both old and new releases.
-    private fun relaxDebT64Dependencies() {
-        val debPath = findSinglePackageArtifact(PackageFormat.DEB)
-        val repackRoot = jPackageConfig.temporaryDirPath.resolve("deb-repack")
-        repackRoot.toFile().deleteRecursively()
-        val payloadRoot = repackRoot.resolve("payload")
-        Files.createDirectories(repackRoot)
-
-        runProcess(
-                ProcessBuilder(
-                        "dpkg-deb", "-R",
-                        debPath.toAbsolutePath().toString(),
-                        payloadRoot.toAbsolutePath().toString()
-                ),
-                "extract DEB payload"
-        )
-
-        val controlFile = payloadRoot.resolve("DEBIAN").resolve("control")
-        if (!Files.isRegularFile(controlFile)) {
-            throw GradleException("DEB control file not found after extraction: ${controlFile.toAbsolutePath()}")
-        }
-        val original = Files.readString(controlFile)
-        val updated = relaxT64Dependencies(original)
-        if (updated == original) {
-            return
-        }
-        Files.writeString(controlFile, updated)
-
-        val rebuiltDebPath = repackRoot.resolve(debPath.fileName)
-        runProcess(
-                ProcessBuilder(
-                        "dpkg-deb",
-                        "--root-owner-group",
-                        "--build",
-                        payloadRoot.toAbsolutePath().toString(),
-                        rebuiltDebPath.toAbsolutePath().toString()
-                ),
-                "rebuild DEB with relaxed dependencies"
-        )
-
-        Files.move(rebuiltDebPath, debPath, StandardCopyOption.REPLACE_EXISTING)
-        normalizePathTimestamps(debPath)
-    }
-
     private fun renameMacOsDmgPackage(appConfig: JPackageAppConfig) {
         val sourcePath = jPackageConfig.outputDirPath.resolve("Bisq-${appConfig.appVersion}.dmg")
-        val targetPath = jPackageConfig.outputDirPath.resolve("Bisq-${getArchitecture().installerClassifier}-${appConfig.appVersion}.dmg")
+        val targetPath =
+            jPackageConfig.outputDirPath.resolve("Bisq-${getArchitecture().installerClassifier}-${appConfig.appVersion}.dmg")
         if (!Files.exists(sourcePath) && Files.exists(targetPath)) {
             return
         }
@@ -230,166 +168,5 @@ class PackageFactory(private val jPackagePath: Path, private val jPackageConfig:
         }
 
         Files.move(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING)
-    }
-
-    private fun createNormalizedRpmSpec(appConfig: JPackageAppConfig, payloadRoot: Path): String {
-        val sourceDateEpoch = sourceDateEpochSeconds()
-        val payloadRootPath = shellSingleQuote(payloadRoot.toAbsolutePath().toString())
-
-        return """
-            Name: bisq
-            Version: ${appConfig.appVersion}
-            Release: 1
-            Summary: Bisq
-            License: AGPLv3
-            Group: Unspecified
-            Vendor: Bisq
-            Prefix: /opt
-            BuildArch: x86_64
-            AutoReqProv: no
-            Requires: xdg-utils
-            Provides: bisq
-
-            %description
-            A decentralized bitcoin exchange network.
-
-            %prep
-
-            %build
-
-            %install
-            rm -rf "%{buildroot}"
-            mkdir -p "%{buildroot}"
-            cp -a ${payloadRootPath}/. "%{buildroot}/"
-            find "%{buildroot}" -exec touch -h -d @${sourceDateEpoch} {} +
-
-            %pre
-            package_type=rpm
-
-            if [ "${'$'}1" = 2 ]; then
-              true;
-            fi
-
-            %post
-            package_type=rpm
-
-            xdg-desktop-menu install /opt/bisq/lib/bisq-Bisq.desktop
-
-            %preun
-            package_type=rpm
-
-            xdg-desktop-menu uninstall /opt/bisq/lib/bisq-Bisq.desktop
-
-            %files
-            %defattr(-,root,root,-)
-            /opt
-        """.trimIndent() + "\n"
-    }
-
-    private fun relaxT64Dependencies(controlFileContent: String): String {
-        val lines = controlFileContent.split("\n")
-        val result = StringBuilder()
-        var i = 0
-        while (i < lines.size) {
-            val line = lines[i]
-            if (line.startsWith("Depends:", ignoreCase = true)) {
-                val colonIdx = line.indexOf(':')
-                val deps = StringBuilder(line.substring(colonIdx + 1).trim())
-                var j = i + 1
-                while (j < lines.size && lines[j].isNotEmpty() && (lines[j][0] == ' ' || lines[j][0] == '\t')) {
-                    if (deps.isNotEmpty()) deps.append(' ')
-                    deps.append(lines[j].trim())
-                    j++
-                }
-                result.append(line.substring(0, colonIdx + 1))
-                        .append(' ')
-                        .append(relaxDepsList(deps.toString()))
-                i = j
-            } else {
-                result.append(line)
-                i++
-            }
-            if (i < lines.size) {
-                result.append('\n')
-            }
-        }
-        return result.toString()
-    }
-
-    private fun relaxDepsList(deps: String): String {
-        if (deps.isBlank()) return deps
-        return deps.split(",")
-                .map { it.trim() }
-                .filter { it.isNotEmpty() }
-                .joinToString(", ") { relaxT64Dependency(it) }
-    }
-
-    private fun relaxT64Dependency(dep: String): String {
-        if (dep.contains("|")) {
-            return dep
-        }
-        val nameEndIdx = dep.indexOfAny(charArrayOf(' ', '\t', ':', '('))
-        val pkgName = if (nameEndIdx == -1) dep else dep.substring(0, nameEndIdx)
-        if (!pkgName.endsWith("t64") || pkgName.length <= 3) {
-            return dep
-        }
-        val baseName = pkgName.dropLast(3)
-        val suffix = dep.removePrefix(pkgName)
-        return "$dep | $baseName$suffix"
-    }
-
-    private fun findSinglePackageArtifact(packageFormat: PackageFormat): Path {
-        val extension = ".${packageFormat.fileExtension}"
-        val matchingArtifacts = Files.list(jPackageConfig.outputDirPath).use { files ->
-            files.filter { path ->
-                Files.isRegularFile(path) && path.fileName.toString().endsWith(extension)
-            }.toList()
-        }
-
-        if (matchingArtifacts.size != 1) {
-            throw GradleException(
-                    "Expected exactly one ${extension} package in ${jPackageConfig.outputDirPath}, " +
-                            "found ${matchingArtifacts.size}: ${matchingArtifacts.joinToString(", ")}"
-            )
-        }
-
-        return matchingArtifacts.single()
-    }
-
-    private fun runProcess(processBuilder: ProcessBuilder, description: String) {
-        processBuilder.inheritIO()
-        processBuilder.environment().putIfAbsent(SOURCE_DATE_EPOCH, DEFAULT_SOURCE_DATE_EPOCH)
-        processBuilder.environment()["HOME"] = createRpmHome().toAbsolutePath().toString()
-
-        val allCommands = processBuilder.command()
-        val process = processBuilder.start()
-        val finished = process.waitFor(15, TimeUnit.MINUTES)
-        if (!finished) {
-            process.destroyForcibly()
-            throw GradleException("${description} timed out after 15 minutes: ${allCommands.joinToString(" ")}")
-        }
-
-        val exitCode = process.exitValue()
-        if (exitCode != 0) {
-            throw GradleException("${description} failed with exit code ${exitCode}: ${allCommands.joinToString(" ")}")
-        }
-    }
-
-    private fun normalizePathTimestamps(path: Path) {
-        val timestamp = FileTime.from(Instant.ofEpochSecond(sourceDateEpochSeconds()))
-        Files.walk(path).use { paths ->
-            paths.sorted(Comparator.reverseOrder()).forEach { entry ->
-                Files.setLastModifiedTime(entry, timestamp)
-            }
-        }
-    }
-
-    private fun sourceDateEpochSeconds(): Long {
-        val sourceDateEpoch = System.getenv(SOURCE_DATE_EPOCH) ?: DEFAULT_SOURCE_DATE_EPOCH
-        return sourceDateEpoch.toLongOrNull() ?: DEFAULT_SOURCE_DATE_EPOCH.toLong()
-    }
-
-    private fun shellSingleQuote(value: String): String {
-        return "'${value.replace("'", "'\"'\"'")}'"
     }
 }


### PR DESCRIPTION
Recent changes broke several build tasks. Previously, Linux release binaries for all supported distributions were built sequentially. If one target failed, the entire pipeline failed.

By separating the build targets into individual Gradle tasks, they are now decoupled. This prevents isolated failures from blocking the pipeline and resolves RPM build issues that previously failed when DEB builds encountered errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native packaging tasks to produce Debian and RPM installers.

* **Chores**
  * Improved Linux packaging pipeline for more deterministic, reproducible DEB and RPM artifacts.
  * Post-processing now relaxes certain DEB dependency declarations and normalizes RPM contents for consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->