### PR TITLE
fix(filter): defer no-filter warning until seed data received

### DIFF
--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -114,6 +114,7 @@ public class FilterManager {
     private ECKey filterSigningKey;
     private final Set<Filter> invalidFilters = new HashSet<>();
     private Consumer<String> filterWarningHandler;
+    private boolean noFilterWarningShown;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -168,12 +169,6 @@ public class FilterManager {
                 .map(protectedStoragePayload -> (Filter) protectedStoragePayload)
                 .forEach(this::onFilterAddedFromNetwork);
 
-        // On mainNet we expect to have received a filter object, if not show a popup to the user to inform the
-        // Bisq devs.
-        if (Config.baseCurrencyNetwork().isMainnet() && getFilter() == null && filterWarningHandler != null) {
-            filterWarningHandler.accept(Res.get("popup.warning.noFilter"));
-        }
-
         p2PService.addHashSetChangedListener(new HashMapChangedListener() {
             @Override
             public void onAdded(Collection<ProtectedStorageEntry> protectedStorageEntries) {
@@ -204,6 +199,15 @@ public class FilterManager {
                 // remove message if we have not been online.
                 if (filterProperty.get() == null) {
                     clearBannedNodes();
+
+                    // On mainNet we expect to have received a filter object by the time the initial data request
+                    // from the seed nodes has completed. We check here (not at startup) so that a slow network,
+                    // where the filter has not arrived yet, does not trigger a false-positive warning. We only
+                    // warn once.
+                    if (Config.baseCurrencyNetwork().isMainnet() && filterWarningHandler != null && !noFilterWarningShown) {
+                        noFilterWarningShown = true;
+                        filterWarningHandler.accept(Res.get("popup.warning.noFilter"));
+                    }
                 }
             }
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3417,7 +3417,7 @@ popup.warning.mandatoryUpdate.dao=Please update to the latest Bisq version. \
   Please check out the Bisq Forum for more information.
 popup.warning.disable.dao=The Bisq DAO and BSQ are temporary disabled. \
   Please check out the Bisq Forum for more information.
-popup.warning.noFilter=We did not receive a filter object from the seed nodes. This is a not expected situation. Please inform the Bisq developers.
+popup.warning.noFilter=We did not receive a filter object from the seed nodes. This is an unexpected situation. Please inform the Bisq developers.
 popup.warning.burnBTC=This transaction is not possible, as the mining fees of {0} would exceed the amount to transfer of {1}. \
   Please wait until the mining fees are low again or until you''ve accumulated more BTC to transfer.
 

--- a/core/src/test/java/bisq/core/filter/FilterManagerInitializationTests.java
+++ b/core/src/test/java/bisq/core/filter/FilterManagerInitializationTests.java
@@ -24,6 +24,7 @@ import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
 import bisq.network.p2p.P2PService;
+import bisq.network.p2p.P2PServiceListener;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.network.BanFilter;
 import bisq.network.p2p.storage.P2PDataStorage;
@@ -45,6 +46,7 @@ import java.util.HashMap;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import org.junit.jupiter.api.Test;
@@ -55,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 
 public class FilterManagerInitializationTests {
 
@@ -85,15 +88,20 @@ public class FilterManagerInitializationTests {
     }
 
     @Test
-    void onAllServicesInitializedNoFilterMainnet() {
+    void onAllServicesInitializedNoFilterMainnet(@TempDir Path tmpDir) throws IOException {
         P2PService p2PService = mock(P2PService.class);
+        Config config = mock(Config.class);
+        Path configFilePath = tmpDir.resolve("configFile");
+        Files.writeString(configFilePath, "otherOption=keep\n");
+        doReturn(configFilePath.toFile()).when(config).getConfigFile();
+
         var filterManager = new FilterManager(
                 p2PService,
                 mock(KeyRing.class),
                 mock(User.class),
                 mock(Preferences.class),
                 DenyList.empty(),
-                mock(Config.class),
+                config,
                 mock(PriceFeedNodeAddressProvider.class),
                 mock(BanFilter.class),
                 mock(PriceFeedService.class),
@@ -119,6 +127,13 @@ public class FilterManagerInitializationTests {
             });
 
             filterManager.onAllServicesInitialized();
+
+            // The no-filter warning is deferred: it is raised only once the initial seed-node data
+            // request completes (onDataReceived), not synchronously at startup. Capture the listener
+            // and simulate the data handshake finishing with no filter received.
+            ArgumentCaptor<P2PServiceListener> listenerCaptor = ArgumentCaptor.forClass(P2PServiceListener.class);
+            verify(p2PService).addP2PServiceListener(listenerCaptor.capture());
+            listenerCaptor.getValue().onDataReceived();
         }
 
         assertTrue(warningHandlerTriggered.get());


### PR DESCRIPTION
  ### Problem
  The "no filter object received" warning fired synchronously in
  `onAllServicesInitialized()`, before the initial P2P data request to the seed
  nodes completed. On slow networks the filter simply hadn't arrived yet,
  producing a false-positive popup telling users to contact the Bisq developers.

  ### Change
  - Move the check into the `onDataReceived()` listener, which fires after the
    seed-node data handshake completes. By then any network filter has been
    applied via the `onAdded` listener. A one-shot guard (`noFilterWarningShown`)
    prevents repeat warnings.
  - When no seed node is reachable, `onDataReceived` never fires, so the existing
    "No seed nodes available" path covers that case.
  - Fix grammar typo in the warning string: "a not expected situation" →
    "an unexpected situation".

  ### Tests
  - Updated `onAllServicesInitializedNoFilterMainnet` to reflect the deferred
    behavior: capture the registered `P2PServiceListener` and invoke
    `onDataReceived()` to simulate the data handshake finishing with no filter.
  - Supplied a real temp config file so the `clearBannedNodes()` path (now hit on
    `onDataReceived`) runs without NPE.
  - All `FilterManagerInitializationTests` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing and behavior of the missing filter warning on mainnet so it’s emitted at the appropriate handshake point and shown only once per instance.
  * Fixed grammar in the warning message.

* **Tests**
  * Updated tests to reflect deferred warning behavior and the new one-time display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->