### PR TITLE
Optimize encoding of spent info map

### DIFF
--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalEncoder.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalEncoder.java
@@ -133,11 +133,22 @@ public final class CanonicalEncoder {
         }
 
         CanonicalSchema.MapEncoding mapEncoding = Objects.requireNonNull(field.getMapEncoding());
-        List<Map.Entry<?, ?>> entries = mapEncoding.getEntries((Map) source);
         @Nullable
         CanonicalMapEntryByteCache cache = source instanceof CanonicalMapEntryByteCache ?
                 (CanonicalMapEntryByteCache) source :
                 null;
+        if (cache != null) {
+            byte[] encodedMap = cache.getEncodedMap(field);
+            if (encodedMap != null) {
+                writer.writeRawBytes(encodedMap);
+                return;
+            }
+        }
+
+        // At a cache hit we use a temporary mapWriter to contain only the map field bytes, not the parent message.
+        // At the end we write the mapWriter bytes to the parent writer.
+        CanonicalWriter mapWriter = cache == null ? writer : new CanonicalWriter();
+        List<Map.Entry<?, ?>> entries = mapEncoding.getEntries((Map) source);
         mapEncoding.iterate(entries).forEachRemaining(entry -> {
             Map.Entry<?, ?> mapEntry = (Map.Entry<?, ?>) entry;
             byte[] encodedEntry = cache == null ?
@@ -149,8 +160,13 @@ public final class CanonicalEncoder {
                     cache.putEncodedMapEntry(mapEntry.getKey(), mapEntry.getValue(), encodedEntry);
                 }
             }
-            writer.writeMapEntry(field.getNumber(), encodedEntry);
+            mapWriter.writeMapEntry(field.getNumber(), encodedEntry);
         });
+        if (cache != null) {
+            byte[] encodedMap = mapWriter.toByteArray();
+            cache.putEncodedMap(field, encodedMap);
+            writer.writeRawBytes(encodedMap);
+        }
     }
 
     private byte[] encodeMapEntry(Map.Entry<?, ?> entry, CanonicalSchema.MapEncoding<?, ?, ?, ?> mapEncoding) {

--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalEncoder.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalEncoder.java
@@ -145,8 +145,8 @@ public final class CanonicalEncoder {
             }
         }
 
-        // At a cache hit we use a temporary mapWriter to contain only the map field bytes, not the parent message.
-        // At the end we write the mapWriter bytes to the parent writer.
+        // After a full-map cache miss, cache-enabled maps use a temporary writer to contain only the map field bytes,
+        // not the parent message. At the end we write the mapWriter bytes to the parent writer.
         CanonicalWriter mapWriter = cache == null ? writer : new CanonicalWriter();
         List<Map.Entry<?, ?>> entries = mapEncoding.getEntries((Map) source);
         mapEncoding.iterate(entries).forEachRemaining(entry -> {

--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalEncoder.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalEncoder.java
@@ -134,8 +134,23 @@ public final class CanonicalEncoder {
 
         CanonicalSchema.MapEncoding mapEncoding = Objects.requireNonNull(field.getMapEncoding());
         List<Map.Entry<?, ?>> entries = mapEncoding.getEntries((Map) source);
-        mapEncoding.iterate(entries).forEachRemaining(entry ->
-                writer.writeMapEntry(field.getNumber(), encodeMapEntry((Map.Entry<?, ?>) entry, mapEncoding)));
+        @Nullable
+        CanonicalMapEntryByteCache cache = source instanceof CanonicalMapEntryByteCache ?
+                (CanonicalMapEntryByteCache) source :
+                null;
+        mapEncoding.iterate(entries).forEachRemaining(entry -> {
+            Map.Entry<?, ?> mapEntry = (Map.Entry<?, ?>) entry;
+            byte[] encodedEntry = cache == null ?
+                    null :
+                    cache.getEncodedMapEntry(mapEntry.getKey(), mapEntry.getValue());
+            if (encodedEntry == null) {
+                encodedEntry = encodeMapEntry(mapEntry, mapEncoding);
+                if (cache != null) {
+                    cache.putEncodedMapEntry(mapEntry.getKey(), mapEntry.getValue(), encodedEntry);
+                }
+            }
+            writer.writeMapEntry(field.getNumber(), encodedEntry);
+        });
     }
 
     private byte[] encodeMapEntry(Map.Entry<?, ?> entry, CanonicalSchema.MapEncoding<?, ?, ?, ?> mapEncoding) {

--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalMapEntryByteCache.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalMapEntryByteCache.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.encoding.canonical;
+
+import javax.annotation.Nullable;
+
+public interface CanonicalMapEntryByteCache<K, V> {
+    @Nullable
+    byte[] getEncodedMapEntry(K canonicalKey, V canonicalValue);
+
+    void putEncodedMapEntry(K canonicalKey, V canonicalValue, byte[] encodedMapEntry);
+}

--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalMapEntryByteCache.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalMapEntryByteCache.java
@@ -21,6 +21,14 @@ import javax.annotation.Nullable;
 
 public interface CanonicalMapEntryByteCache<K, V> {
     @Nullable
+    default byte[] getEncodedMap(Object cacheKey) {
+        return null;
+    }
+
+    default void putEncodedMap(Object cacheKey, byte[] encodedMap) {
+    }
+
+    @Nullable
     byte[] getEncodedMapEntry(K canonicalKey, V canonicalValue);
 
     void putEncodedMapEntry(K canonicalKey, V canonicalValue, byte[] encodedMapEntry);

--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalMapEntryByteCache.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalMapEntryByteCache.java
@@ -19,17 +19,48 @@ package bisq.common.encoding.canonical;
 
 import javax.annotation.Nullable;
 
+/**
+ * Optional two-tier cache for canonical map encoding.
+ * <p>
+ * {@link CanonicalEncoder} first asks a cache-enabled map for a complete encoded map field via
+ * {@link #getEncodedMap(Object)}. The {@code cacheKey} is the schema field instance used for the current encoding,
+ * so implementations that cache full-map bytes should key by field identity. A full-map hit must return bytes for
+ * exactly that map field, including its field tags, or {@code null} when unavailable.
+ * <p>
+ * If the full-map cache misses, {@link CanonicalEncoder} orders the map entries and then uses the per-entry cache
+ * methods. {@link #getEncodedMapEntry(Object, Object)} must return bytes only when {@code canonicalValue} is the
+ * same value instance that produced the cached entry bytes; otherwise it must return {@code null}. On a miss,
+ * {@link CanonicalEncoder} encodes the entry and calls {@link #putEncodedMapEntry(Object, Object, byte[])}. After
+ * all entries are written, it calls {@link #putEncodedMap(Object, byte[])} so implementations can cache the complete
+ * encoded map field for later unchanged encodes.
+ * <p>
+ * Encoding cache-enabled maps mutates the cache. Implementations should therefore be thread-confined with the source
+ * map or protected by external synchronization.
+ */
 public interface CanonicalMapEntryByteCache<K, V> {
+    /**
+     * @return encoded bytes for the complete canonical map field, or {@code null} when absent
+     */
     @Nullable
     default byte[] getEncodedMap(Object cacheKey) {
         return null;
     }
 
+    /**
+     * Stores encoded bytes for the complete canonical map field.
+     */
     default void putEncodedMap(Object cacheKey, byte[] encodedMap) {
     }
 
+    /**
+     * @return encoded bytes for one canonical map entry, or {@code null} when absent or when {@code canonicalValue}
+     *         is not the same value instance that produced the cached bytes
+     */
     @Nullable
     byte[] getEncodedMapEntry(K canonicalKey, V canonicalValue);
 
+    /**
+     * Stores encoded bytes for one canonical map entry.
+     */
     void putEncodedMapEntry(K canonicalKey, V canonicalValue, byte[] encodedMapEntry);
 }

--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalWriter.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalWriter.java
@@ -34,6 +34,10 @@ public final class CanonicalWriter {
         return out.toByteArray();
     }
 
+    public void writeRawBytes(byte[] bytes) {
+        out.write(bytes, 0, bytes.length);
+    }
+
     public void writeInt32(int fieldNumber, int value) {
         if (value != 0) {
             writeInt32Value(fieldNumber, value);

--- a/common/src/main/java/bisq/common/encoding/canonical/CanonicalWriter.java
+++ b/common/src/main/java/bisq/common/encoding/canonical/CanonicalWriter.java
@@ -20,6 +20,7 @@ package bisq.common.encoding.canonical;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -34,7 +35,12 @@ public final class CanonicalWriter {
         return out.toByteArray();
     }
 
+    /**
+     * Writes pre-encoded bytes directly to the output without adding field tags,
+     * wire types, lengths, or any other canonical encoding.
+     */
     public void writeRawBytes(byte[] bytes) {
+        Objects.requireNonNull(bytes, "Canonical raw bytes must not be null");
         out.write(bytes, 0, bytes.length);
     }
 

--- a/common/src/test/java/bisq/common/encoding/canonical/CanonicalEncoderTest.java
+++ b/common/src/test/java/bisq/common/encoding/canonical/CanonicalEncoderTest.java
@@ -66,6 +66,13 @@ public class CanonicalEncoderTest {
     }
 
     @Test
+    public void writeRawBytesRejectsNull() {
+        CanonicalWriter writer = new CanonicalWriter();
+
+        assertThrows(NullPointerException.class, () -> writer.writeRawBytes(null));
+    }
+
+    @Test
     public void rejectsNullTreeMapComparator() {
         assertThrows(IllegalArgumentException.class, () -> TreeMapIterator.comparing(null));
     }

--- a/common/src/test/java/bisq/common/encoding/canonical/CanonicalEncoderTest.java
+++ b/common/src/test/java/bisq/common/encoding/canonical/CanonicalEncoderTest.java
@@ -195,15 +195,22 @@ public class CanonicalEncoderTest {
                 .build();
 
         byte[] first = CanonicalEncoder.DEFAULT.encode(new Container(values), schema);
-        assertEquals(2, values.cacheWrites);
+        assertEquals(2, values.entryCacheReads);
+        assertEquals(2, values.entryCacheWrites);
+        assertEquals(1, values.mapCacheWrites);
 
         assertArrayEquals(first, CanonicalEncoder.DEFAULT.encode(new Container(values), schema));
-        assertEquals(2, values.cacheWrites);
+        assertEquals(1, values.mapCacheHits);
+        assertEquals(2, values.entryCacheReads);
+        assertEquals(2, values.entryCacheWrites);
+        assertEquals(1, values.mapCacheWrites);
 
         values.put("b", new Value(3));
 
         CanonicalEncoder.DEFAULT.encode(new Container(values), schema);
-        assertEquals(3, values.cacheWrites);
+        assertEquals(4, values.entryCacheReads);
+        assertEquals(3, values.entryCacheWrites);
+        assertEquals(2, values.mapCacheWrites);
     }
 
     @Test
@@ -402,10 +409,36 @@ public class CanonicalEncoderTest {
     private static final class CountingCacheMap extends LinkedHashMap<String, Value>
             implements CanonicalMapEntryByteCache<String, Value> {
         private final Map<String, CachedMapEntryBytes> encodedMapEntryBytesByKey = new HashMap<>();
-        private int cacheWrites;
+        private final Map<Object, byte[]> encodedMapBytesByCacheKey = new HashMap<>();
+        private int mapCacheHits;
+        private int mapCacheWrites;
+        private int entryCacheReads;
+        private int entryCacheWrites;
+
+        @Override
+        public Value put(String key, Value value) {
+            encodedMapBytesByCacheKey.clear();
+            return super.put(key, value);
+        }
+
+        @Override
+        public byte[] getEncodedMap(Object cacheKey) {
+            byte[] encodedMap = encodedMapBytesByCacheKey.get(cacheKey);
+            if (encodedMap != null) {
+                mapCacheHits++;
+            }
+            return encodedMap;
+        }
+
+        @Override
+        public void putEncodedMap(Object cacheKey, byte[] encodedMap) {
+            encodedMapBytesByCacheKey.put(cacheKey, encodedMap);
+            mapCacheWrites++;
+        }
 
         @Override
         public byte[] getEncodedMapEntry(String canonicalKey, Value canonicalValue) {
+            entryCacheReads++;
             CachedMapEntryBytes cached = encodedMapEntryBytesByKey.get(canonicalKey);
             return cached != null && cached.value == canonicalValue ? cached.encodedMapEntry : null;
         }
@@ -413,7 +446,7 @@ public class CanonicalEncoderTest {
         @Override
         public void putEncodedMapEntry(String canonicalKey, Value canonicalValue, byte[] encodedMapEntry) {
             encodedMapEntryBytesByKey.put(canonicalKey, new CachedMapEntryBytes(canonicalValue, encodedMapEntry));
-            cacheWrites++;
+            entryCacheWrites++;
         }
     }
 

--- a/common/src/test/java/bisq/common/encoding/canonical/CanonicalEncoderTest.java
+++ b/common/src/test/java/bisq/common/encoding/canonical/CanonicalEncoderTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,6 +179,31 @@ public class CanonicalEncoderTest {
 
         assertEquals(JAVA_11_HASH_MAP_ORDER,
                 readMapKeys(CanonicalEncoder.DEFAULT.encode(new Container(values), schema)));
+    }
+
+    @Test
+    public void mapStringToComposeUsesMapEntryCacheWhenSourceOptsIn() {
+        CountingCacheMap values = new CountingCacheMap();
+        values.put("b", new Value(2));
+        values.put("a", new Value(1));
+
+        CanonicalSchema<Container> schema = CanonicalSchema.<Container>newBuilder()
+                .mapStringToCompose(1,
+                        Container::getValues,
+                        VALUE_SCHEMA,
+                        TreeMapIterator.naturalOrder())
+                .build();
+
+        byte[] first = CanonicalEncoder.DEFAULT.encode(new Container(values), schema);
+        assertEquals(2, values.cacheWrites);
+
+        assertArrayEquals(first, CanonicalEncoder.DEFAULT.encode(new Container(values), schema));
+        assertEquals(2, values.cacheWrites);
+
+        values.put("b", new Value(3));
+
+        CanonicalEncoder.DEFAULT.encode(new Container(values), schema);
+        assertEquals(3, values.cacheWrites);
     }
 
     @Test
@@ -370,6 +396,34 @@ public class CanonicalEncoderTest {
 
         private List<Integer> getVersions() {
             return versions;
+        }
+    }
+
+    private static final class CountingCacheMap extends LinkedHashMap<String, Value>
+            implements CanonicalMapEntryByteCache<String, Value> {
+        private final Map<String, CachedMapEntryBytes> encodedMapEntryBytesByKey = new HashMap<>();
+        private int cacheWrites;
+
+        @Override
+        public byte[] getEncodedMapEntry(String canonicalKey, Value canonicalValue) {
+            CachedMapEntryBytes cached = encodedMapEntryBytesByKey.get(canonicalKey);
+            return cached != null && cached.value == canonicalValue ? cached.encodedMapEntry : null;
+        }
+
+        @Override
+        public void putEncodedMapEntry(String canonicalKey, Value canonicalValue, byte[] encodedMapEntry) {
+            encodedMapEntryBytesByKey.put(canonicalKey, new CachedMapEntryBytes(canonicalValue, encodedMapEntry));
+            cacheWrites++;
+        }
+    }
+
+    private static final class CachedMapEntryBytes {
+        private final Value value;
+        private final byte[] encodedMapEntry;
+
+        private CachedMapEntryBytes(Value value, byte[] encodedMapEntry) {
+            this.value = value;
+            this.encodedMapEntry = encodedMapEntry;
         }
     }
 

--- a/core/src/main/java/bisq/core/dao/node/full/RpcService.java
+++ b/core/src/main/java/bisq/core/dao/node/full/RpcService.java
@@ -413,7 +413,7 @@ public class RpcService {
                 @Override
                 public void onFailure(@NotNull Throwable throwable) {
                     if (!shutdownInProgress) {
-                        log.error("Error at requestRawDtoBlock: blockHeight={}", blockHeight);
+                        log.error("Error at requestRawDtoBlock: blockHeight={}", blockHeight, throwable);
                         UserThread.execute(() -> errorHandler.accept(throwable));
                     }
                 }

--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -69,7 +69,6 @@ public class DaoState implements PersistablePayload, Canonical {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Static
-
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static DaoState getClone(DaoState daoState) {
@@ -129,7 +128,6 @@ public class DaoState implements PersistablePayload, Canonical {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
-
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
@@ -150,7 +148,6 @@ public class DaoState implements PersistablePayload, Canonical {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
-
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private DaoState(int chainHeight,
@@ -291,7 +288,6 @@ public class DaoState implements PersistablePayload, Canonical {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
-
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void setChainHeight(int chainHeight) {
@@ -304,7 +300,15 @@ public class DaoState implements PersistablePayload, Canonical {
         // Reorgs are handled by rebuilding the hash chain from last snapshot.
         // Using the full blocks list becomes quite heavy. 7000 blocks are
         // about 1.4 MB and creating the hash takes 30 sec. By using just the last block we reduce the time to 7 sec.
-        return encodeCanonicalForStateHashChain(CanonicalEncoder.DEFAULT);
+
+        long ts = System.currentTimeMillis();
+        byte[] encodedState = encodeCanonicalForStateHashChain(CanonicalEncoder.DEFAULT);
+        log.info("encodeCanonicalForStateHashChain at chain height {} took \n" +
+                        "{} ms for canonical.\n" +
+                        "spentInfoMap size={}",
+                getChainHeight(), System.currentTimeMillis() - ts,
+                spentInfoMap.size());
+        return encodedState;
     }
 
     // Only present for verifying that legacy implementation results in same hash as

--- a/core/src/main/java/bisq/core/dao/state/model/DaoState.java
+++ b/core/src/main/java/bisq/core/dao/state/model/DaoState.java
@@ -19,6 +19,7 @@ package bisq.core.dao.state.model;
 
 import bisq.core.dao.state.model.blockchain.Block;
 import bisq.core.dao.state.model.blockchain.SpentInfo;
+import bisq.core.dao.state.model.blockchain.SpentInfoMap;
 import bisq.core.dao.state.model.blockchain.Tx;
 import bisq.core.dao.state.model.blockchain.TxOutput;
 import bisq.core.dao.state.model.blockchain.TxOutputKey;
@@ -136,7 +137,7 @@ public class DaoState implements PersistablePayload, Canonical {
                 new LinkedList<>(),
                 new LinkedList<>(),
                 new TreeMap<>(),
-                new TreeMap<>(),
+                new SpentInfoMap(),
                 new ArrayList<>(),
                 new TreeMap<>(),
                 new ArrayList<>(),
@@ -165,7 +166,9 @@ public class DaoState implements PersistablePayload, Canonical {
         this.cycles = cycles;
 
         this.unspentTxOutputMap = unspentTxOutputMap;
-        this.spentInfoMap = spentInfoMap;
+        this.spentInfoMap = spentInfoMap instanceof SpentInfoMap ?
+                spentInfoMap :
+                new SpentInfoMap(spentInfoMap);
 
         this.confiscatedLockupTxList = confiscatedLockupTxList;
         this.issuanceMap = issuanceMap;
@@ -303,7 +306,7 @@ public class DaoState implements PersistablePayload, Canonical {
 
         long ts = System.currentTimeMillis();
         byte[] encodedState = encodeCanonicalForStateHashChain(CanonicalEncoder.DEFAULT);
-        log.info("encodeCanonicalForStateHashChain at chain height {} took \n" +
+        log.trace("encodeCanonicalForStateHashChain at chain height {} took \n" +
                         "{} ms for canonical.\n" +
                         "spentInfoMap size={}",
                 getChainHeight(), System.currentTimeMillis() - ts,

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfo.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfo.java
@@ -24,17 +24,26 @@ import bisq.common.encoding.canonical.CanonicalSchema;
 
 import bisq.common.proto.persistable.PersistablePayload;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Value;
 
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-@Value
+@EqualsAndHashCode
+@Getter
 public final class SpentInfo implements PersistablePayload, ImmutableDaoStateModel, Canonical {
     private final long blockHeight;
     // Spending tx
     private final String txId;
     private final int inputIndex;
+
+    public SpentInfo(long blockHeight, String txId, int inputIndex) {
+        this.blockHeight = blockHeight;
+        this.txId = txId;
+        this.inputIndex = inputIndex;
+    }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfoMap.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfoMap.java
@@ -30,12 +30,21 @@ public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
         implements CanonicalMapEntryByteCache<String, SpentInfo> {
     private static final long serialVersionUID = 1L;
 
+    // These caches intentionally trade steady-state heap for avoiding repeated canonical encoding of the large
+    // spentInfoMap. The full-map snapshot is shallow: it duplicates TreeMap structure, but not TxOutputKey or
+    // SpentInfo instances.
     private final transient Map<String, CachedMapEntryBytes> encodedMapEntryBytesByKey = new HashMap<>();
 
     // The encoded-map cache stores the bytes for one complete canonical map field, including that field's tags.
     // It must therefore be keyed by the exact CanonicalSchema.Field instance, not by structural equality: the same
     // source map can be encoded differently by another schema field number or map encoding.
     private final transient Map<Object, byte[]> encodedMapBytesByCacheKey = new IdentityHashMap<>();
+
+    // TreeMap view removals do not call our overridden mutators, and TreeMap.modCount is not accessible here.
+    // Keep a shallow snapshot of the map content that produced the full-map cache and drop both cache tiers if
+    // current content no longer matches it.
+    @Nullable
+    private transient Map<TxOutputKey, SpentInfo> encodedMapSnapshot;
 
     public SpentInfoMap() {
     }
@@ -47,19 +56,30 @@ public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
     @Override
     @Nullable
     public byte[] getEncodedMap(Object cacheKey) {
-        return encodedMapBytesByCacheKey.get(cacheKey);
+        byte[] encodedMap = encodedMapBytesByCacheKey.get(cacheKey);
+        if (encodedMap == null) {
+            return null;
+        }
+
+        if (!matchesEncodedMapSnapshot()) {
+            invalidateAllEncodedCaches();
+            return null;
+        }
+
+        return encodedMap;
     }
 
     @Override
     public void putEncodedMap(Object cacheKey, byte[] encodedMap) {
         encodedMapBytesByCacheKey.put(cacheKey, encodedMap);
+        encodedMapSnapshot = new TreeMap<>(this);
     }
 
     @Override
     @Nullable
     public byte[] getEncodedMapEntry(String canonicalKey, SpentInfo canonicalValue) {
         CachedMapEntryBytes cached = encodedMapEntryBytesByKey.get(canonicalKey);
-        return cached != null && cached.spentInfo.equals(canonicalValue) ? cached.encodedMapEntry : null;
+        return cached != null && cached.spentInfo == canonicalValue ? cached.encodedMapEntry : null;
     }
 
     @Override
@@ -69,28 +89,31 @@ public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
 
     @Override
     public SpentInfo put(TxOutputKey key, SpentInfo value) {
-        encodedMapBytesByCacheKey.clear();
+        invalidateEncodedMapCache();
         return super.put(key, value);
     }
 
     @Override
     public void putAll(Map<? extends TxOutputKey, ? extends SpentInfo> map) {
         if (!map.isEmpty()) {
-            encodedMapBytesByCacheKey.clear();
+            invalidateEncodedMapCache();
         }
         super.putAll(map);
     }
 
     @Override
     public SpentInfo remove(Object key) {
-        encodedMapBytesByCacheKey.clear();
-        return super.remove(key);
+        SpentInfo removed = super.remove(key);
+        if (removed != null) {
+            invalidateEncodedMapCache();
+            encodedMapEntryBytesByKey.remove(key.toString());
+        }
+        return removed;
     }
 
     @Override
     public void clear() {
-        encodedMapBytesByCacheKey.clear();
-        encodedMapEntryBytesByKey.clear();
+        invalidateAllEncodedCaches();
         super.clear();
     }
 
@@ -98,7 +121,8 @@ public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
     public Map.Entry<TxOutputKey, SpentInfo> pollFirstEntry() {
         Map.Entry<TxOutputKey, SpentInfo> entry = super.pollFirstEntry();
         if (entry != null) {
-            encodedMapBytesByCacheKey.clear();
+            invalidateEncodedMapCache();
+            encodedMapEntryBytesByKey.remove(entry.getKey().toString());
         }
         return entry;
     }
@@ -107,9 +131,27 @@ public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
     public Map.Entry<TxOutputKey, SpentInfo> pollLastEntry() {
         Map.Entry<TxOutputKey, SpentInfo> entry = super.pollLastEntry();
         if (entry != null) {
-            encodedMapBytesByCacheKey.clear();
+            invalidateEncodedMapCache();
+            encodedMapEntryBytesByKey.remove(entry.getKey().toString());
         }
         return entry;
+    }
+
+    private boolean matchesEncodedMapSnapshot() {
+        return encodedMapSnapshot != null &&
+                size() == encodedMapSnapshot.size() &&
+                entrySet().equals(encodedMapSnapshot.entrySet());
+    }
+
+    private void invalidateEncodedMapCache() {
+        encodedMapBytesByCacheKey.clear();
+        encodedMapSnapshot = null;
+    }
+
+    private void invalidateAllEncodedCaches() {
+        encodedMapBytesByCacheKey.clear();
+        encodedMapEntryBytesByKey.clear();
+        encodedMapSnapshot = null;
     }
 
     private static final class CachedMapEntryBytes {

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfoMap.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfoMap.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model.blockchain;
+
+import bisq.common.encoding.canonical.CanonicalMapEntryByteCache;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.annotation.Nullable;
+
+public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
+        implements CanonicalMapEntryByteCache<String, SpentInfo> {
+    private static final long serialVersionUID = 1L;
+
+    private final transient Map<String, CachedMapEntryBytes> encodedMapEntryBytesByKey = new HashMap<>();
+
+    public SpentInfoMap() {
+    }
+
+    public SpentInfoMap(Map<TxOutputKey, SpentInfo> source) {
+        putAll(source);
+    }
+
+    @Override
+    @Nullable
+    public byte[] getEncodedMapEntry(String canonicalKey, SpentInfo canonicalValue) {
+        CachedMapEntryBytes cached = encodedMapEntryBytesByKey.get(canonicalKey);
+        return cached != null && cached.spentInfo.equals(canonicalValue) ? cached.encodedMapEntry : null;
+    }
+
+    @Override
+    public void putEncodedMapEntry(String canonicalKey, SpentInfo canonicalValue, byte[] encodedMapEntry) {
+        encodedMapEntryBytesByKey.put(canonicalKey, new CachedMapEntryBytes(canonicalValue, encodedMapEntry));
+    }
+
+    @Override
+    public void clear() {
+        encodedMapEntryBytesByKey.clear();
+        super.clear();
+    }
+
+    private static final class CachedMapEntryBytes {
+        private final SpentInfo spentInfo;
+        private final byte[] encodedMapEntry;
+
+        private CachedMapEntryBytes(SpentInfo spentInfo, byte[] encodedMapEntry) {
+            this.spentInfo = spentInfo;
+            this.encodedMapEntry = encodedMapEntry;
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfoMap.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/SpentInfoMap.java
@@ -20,6 +20,7 @@ package bisq.core.dao.state.model.blockchain;
 import bisq.common.encoding.canonical.CanonicalMapEntryByteCache;
 
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -31,11 +32,27 @@ public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
 
     private final transient Map<String, CachedMapEntryBytes> encodedMapEntryBytesByKey = new HashMap<>();
 
+    // The encoded-map cache stores the bytes for one complete canonical map field, including that field's tags.
+    // It must therefore be keyed by the exact CanonicalSchema.Field instance, not by structural equality: the same
+    // source map can be encoded differently by another schema field number or map encoding.
+    private final transient Map<Object, byte[]> encodedMapBytesByCacheKey = new IdentityHashMap<>();
+
     public SpentInfoMap() {
     }
 
     public SpentInfoMap(Map<TxOutputKey, SpentInfo> source) {
         putAll(source);
+    }
+
+    @Override
+    @Nullable
+    public byte[] getEncodedMap(Object cacheKey) {
+        return encodedMapBytesByCacheKey.get(cacheKey);
+    }
+
+    @Override
+    public void putEncodedMap(Object cacheKey, byte[] encodedMap) {
+        encodedMapBytesByCacheKey.put(cacheKey, encodedMap);
     }
 
     @Override
@@ -51,9 +68,48 @@ public final class SpentInfoMap extends TreeMap<TxOutputKey, SpentInfo>
     }
 
     @Override
+    public SpentInfo put(TxOutputKey key, SpentInfo value) {
+        encodedMapBytesByCacheKey.clear();
+        return super.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<? extends TxOutputKey, ? extends SpentInfo> map) {
+        if (!map.isEmpty()) {
+            encodedMapBytesByCacheKey.clear();
+        }
+        super.putAll(map);
+    }
+
+    @Override
+    public SpentInfo remove(Object key) {
+        encodedMapBytesByCacheKey.clear();
+        return super.remove(key);
+    }
+
+    @Override
     public void clear() {
+        encodedMapBytesByCacheKey.clear();
         encodedMapEntryBytesByKey.clear();
         super.clear();
+    }
+
+    @Override
+    public Map.Entry<TxOutputKey, SpentInfo> pollFirstEntry() {
+        Map.Entry<TxOutputKey, SpentInfo> entry = super.pollFirstEntry();
+        if (entry != null) {
+            encodedMapBytesByCacheKey.clear();
+        }
+        return entry;
+    }
+
+    @Override
+    public Map.Entry<TxOutputKey, SpentInfo> pollLastEntry() {
+        Map.Entry<TxOutputKey, SpentInfo> entry = super.pollLastEntry();
+        if (entry != null) {
+            encodedMapBytesByCacheKey.clear();
+        }
+        return entry;
     }
 
     private static final class CachedMapEntryBytes {

--- a/core/src/main/java/bisq/core/dao/state/model/blockchain/TxOutputKey.java
+++ b/core/src/main/java/bisq/core/dao/state/model/blockchain/TxOutputKey.java
@@ -19,7 +19,8 @@ package bisq.core.dao.state.model.blockchain;
 
 import bisq.core.dao.state.model.ImmutableDaoStateModel;
 
-import lombok.Value;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -30,19 +31,23 @@ import javax.annotation.concurrent.Immutable;
  * Used as key in maps in the daoState.
  */
 @Immutable
-@Value
+@EqualsAndHashCode
 public final class TxOutputKey implements ImmutableDaoStateModel, Comparable<Object> {
+    @Getter
     private final String txId;
+    @Getter
     private final int index;
+    private final transient String keyAsString;
 
     public TxOutputKey(String txId, int index) {
         this.txId = txId;
         this.index = index;
+        keyAsString = txId + ":" + index;
     }
 
     @Override
     public String toString() {
-        return txId + ":" + index;
+        return keyAsString;
     }
 
     public static TxOutputKey getKeyFromString(String keyAsString) {

--- a/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
@@ -24,6 +24,7 @@ import bisq.core.dao.state.model.blockchain.TxOutputKey;
 import bisq.core.dao.state.model.governance.Issuance;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.common.encoding.canonical.CanonicalEncoder;
+import bisq.common.encoding.canonical.CanonicalMapEntryByteCache;
 import bisq.common.encoding.canonical.CanonicalSchema;
 import bisq.common.encoding.canonical.LegacyCollectorsToMapIterator;
 
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DaoStateCanonicalEncoderTest {
     private static final int RANDOMIZED_TX_OUTPUT_KEY_COUNT = 50_000;
@@ -123,6 +125,15 @@ class DaoStateCanonicalEncoderTest {
                 new ArrayList<>(proto.getUnspentTxOutputMapMap().keySet()));
         assertEquals(TX_OUTPUT_KEY_TREE_MAP_ORDER,
                 new ArrayList<>(proto.getSpentInfoMapMap().keySet()));
+    }
+
+    @Test
+    void spentInfoMapOptsIntoCanonicalMapEntryCaching() {
+        DaoState daoState = getDaoStateWithMaps();
+        DaoState fromProto = DaoState.fromProto((protobuf.DaoState) daoState.toProtoMessage());
+
+        assertTrue(daoState.getSpentInfoMap() instanceof CanonicalMapEntryByteCache);
+        assertTrue(fromProto.getSpentInfoMap() instanceof CanonicalMapEntryByteCache);
     }
 
     @Test

--- a/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DaoStateCanonicalEncoderTest {
@@ -144,6 +146,28 @@ class DaoStateCanonicalEncoderTest {
 
         assertEquals(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), fieldNumbers(DaoState.SCHEMA));
         assertEquals(2, proto.getBlocksCount());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void spentInfoMapCachesAndInvalidatesEncodedMapField() {
+        DaoState daoState = getDaoStateWithMaps();
+        CanonicalMapEntryByteCache<String, SpentInfo> cache =
+                (CanonicalMapEntryByteCache<String, SpentInfo>) daoState.getSpentInfoMap();
+        CanonicalSchema.Field<DaoState> spentInfoMapField = DaoState.STATE_HASH_CHAIN_SCHEMA.getFields().stream()
+                .filter(field -> field.getNumber() == 7)
+                .findFirst()
+                .orElseThrow();
+
+        assertNull(cache.getEncodedMap(spentInfoMapField));
+
+        daoState.getSerializedStateForHashChain();
+
+        assertNotNull(cache.getEncodedMap(spentInfoMapField));
+
+        daoState.getSpentInfoMap().put(new TxOutputKey("changed", 0), new SpentInfo(101, "changed", 0));
+
+        assertNull(cache.getEncodedMap(spentInfoMapField));
     }
 
     @Test

--- a/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
@@ -152,6 +152,7 @@ class DaoStateCanonicalEncoderTest {
     @SuppressWarnings("unchecked")
     void spentInfoMapCachesAndInvalidatesEncodedMapField() {
         DaoState daoState = getDaoStateWithMaps();
+        // DaoState maps TxOutputKey to its canonical string form before the encoder uses the map-entry cache.
         CanonicalMapEntryByteCache<String, SpentInfo> cache =
                 (CanonicalMapEntryByteCache<String, SpentInfo>) daoState.getSpentInfoMap();
         CanonicalSchema.Field<DaoState> spentInfoMapField = DaoState.STATE_HASH_CHAIN_SCHEMA.getFields().stream()
@@ -168,6 +169,36 @@ class DaoStateCanonicalEncoderTest {
         daoState.getSpentInfoMap().put(new TxOutputKey("changed", 0), new SpentInfo(101, "changed", 0));
 
         assertNull(cache.getEncodedMap(spentInfoMapField));
+    }
+
+    @Test
+    void spentInfoMapInvalidatesEncodedMapFieldForEntrySetIteratorRemove() throws Exception {
+        DaoState daoState = getDaoStateWithMaps();
+        int initialCount = protobuf.DaoState.parseFrom(daoState.getSerializedStateForHashChain())
+                .getSpentInfoMapCount();
+
+        var iterator = daoState.getSpentInfoMap().entrySet().iterator();
+        iterator.next();
+        iterator.remove();
+
+        protobuf.DaoState proto = protobuf.DaoState.parseFrom(daoState.getSerializedStateForHashChain());
+
+        assertEquals(initialCount - 1, proto.getSpentInfoMapCount());
+    }
+
+    @Test
+    void spentInfoMapInvalidatesEncodedMapFieldForSubMapClear() throws Exception {
+        DaoState daoState = getDaoStateWithMaps();
+        int initialCount = protobuf.DaoState.parseFrom(daoState.getSerializedStateForHashChain())
+                .getSpentInfoMapCount();
+
+        daoState.getSpentInfoMap()
+                .subMap(new TxOutputKey("k00", 0), true, new TxOutputKey("k02", 0), true)
+                .clear();
+
+        protobuf.DaoState proto = protobuf.DaoState.parseFrom(daoState.getSerializedStateForHashChain());
+
+        assertEquals(initialCount - 3, proto.getSpentInfoMapCount());
     }
 
     @Test


### PR DESCRIPTION
The `spentInfoMap` currently contains around 300,000 entries and continues to grow over time. Encoding the entire map for every block as part of the DAO state hash introduces significant overhead.

To address this, this PR adds caching at two levels:

1. **Entry-level caching** for individual map entries.
2. **Map-level caching** for the fully encoded map when the `spentInfoMap` has not changed.

Since we use a custom iterator, rebuilding the same map from cached entries would still incur a considerable cost. Therefore, a second cache for the fully encoded map was introduced to avoid this additional work.

Before this optimization, block encoding for the DAO state hash computation took approximately **300 ms per block**.

With the new caching:

* When `spentInfoMap` has changed, computation takes about **130 ms per block**. In most cases only one or a few entries are added, so the majority of entries are served from the entry cache. Most of the remaining time is spent iterating over the map and encoding it.
* When `spentInfoMap` is unchanged, computation drops to approximately **19 ms per block canonicalization**, as the fully encoded map can be reused directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster state serialization via two-tier encoded-map/entry caching for map-backed state.
* **Bug Fixes**
  * Improved RPC error logging while preserving shutdown guard behavior.
  * Ensured map-encoding caches invalidate correctly on state mutations.
* **Tests**
  * Added tests for encoding cache behavior and raw-byte write validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->