### PR TITLE
test: add cross-version e2e compat test + fix offer-creation flake

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,8 +6,13 @@ apitest/*
 apitest/docker/*
 !apitest/docker/Dockerfile.bitcoind
 !apitest/docker/Dockerfile.bisq
+!apitest/docker/Dockerfile.bisq-release
 !apitest/docker/bitcoind-entrypoint.sh
 !apitest/docker/entrypoint.sh
+# Release peer install dists, staged here by the e2e compat workflow and COPYed
+# in by Dockerfile.bisq-release. Whitelisted past the `apitest/docker/*` exclude.
+!apitest/docker/.release-dist/
+!apitest/docker/.release-dist/**
 !apitest/src/
 apitest/src/*
 !apitest/src/main/

--- a/.github/workflows/e2e-tests-compat.yml
+++ b/.github/workflows/e2e-tests-compat.yml
@@ -1,0 +1,154 @@
+name: e2e-tests-compat
+
+# Cross-version compatibility run of the e2e suite: identical to e2e-tests.yml
+# except one peer (bob) runs the latest tagged release instead of master, so the
+# DAO + trade scenarios exercise release<->master P2P/protocol compatibility.
+#
+# Dispatch-only — it builds an extra (release) source tree and is meaningful only
+# on demand (e.g. before cutting a release), not on every PR.
+on:
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: "Git tag/ref for the release peer (default: latest tag)"
+        required: false
+        default: ""
+
+jobs:
+  e2e-tests-compat:
+    name: Run e2e suite with one release-version peer
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: true
+          persist-credentials: false
+          # Full history + tags so we can check out the release tag into a worktree.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21.0.6'
+          check-latest: false
+
+      - name: Gradle cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Pre-pull bitcoind image
+        run: docker pull lnliz/bitcoind:29.3 &
+
+      # Master (current branch) install dists + dao-setup — the stack harness and
+      # the seednode/arb/alice peers all run these.
+      - name: Build master install dists + dao-setup
+        run: |
+          ./gradlew --no-daemon \
+            :seednode:installDist :daemon:installDist :cli:installDist \
+            :apitest:installDaoSetup
+
+      # Resolve the release ref (explicit input, else latest tag) and build its
+      # install dists in a detached worktree so the master checkout is untouched.
+      # The release app binaries are staged where Dockerfile.bisq-release expects.
+      - name: Build release install dists
+        # Pass the user input through the environment, never interpolated into the
+        # script body — a ${{ }} expansion in `run:` would allow shell injection.
+        env:
+          RAW_REF: ${{ github.event.inputs.release_ref }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${RAW_REF}" ]]; then
+            # Validate the (untrusted) input resolves to a real commit before use.
+            git rev-parse --verify --quiet "${RAW_REF}^{commit}" >/dev/null \
+              || { echo "Invalid release_ref: ${RAW_REF}" >&2; exit 1; }
+            REF="${RAW_REF}"
+          else
+            REF="$(git describe --tags --abbrev=0)"
+          fi
+          echo "Building release peer from ref: ${REF}"
+          echo "RELEASE_REF=${REF}" >> "${GITHUB_ENV}"
+
+          WORKTREE="${RUNNER_TEMP}/bisq-release"
+          git worktree add --detach "${WORKTREE}" "${REF}"
+          git -C "${WORKTREE}" submodule update --init --recursive
+
+          # Build with the release tree's own gradle wrapper.
+          ( cd "${WORKTREE}" && ./gradlew --no-daemon \
+              :seednode:installDist :daemon:installDist :cli:installDist )
+
+          DEST="apitest/docker/.release-dist"
+          rm -rf "${DEST}"
+          mkdir -p "${DEST}"
+          cp -r "${WORKTREE}/seednode/build/install/seednode" "${DEST}/seednode"
+          cp -r "${WORKTREE}/daemon/build/install/daemon"     "${DEST}/daemon"
+          cp -r "${WORKTREE}/cli/build/install/cli"           "${DEST}/cli"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Cache Docker image layers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('apitest/docker/Dockerfile.*', 'apitest/docker/*entrypoint.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # Build bitcoind + master daemon images, then the release image FROM the
+      # master image with only the app binaries swapped (Dockerfile.bisq-release).
+      - name: Build docker images with layer cache
+        run: |
+          docker buildx build \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --load \
+            -t bisq-bitcoind:ci \
+            -f apitest/docker/Dockerfile.bitcoind .
+          docker buildx build \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --load \
+            -t bisq-daemon:ci \
+            -f apitest/docker/Dockerfile.bisq .
+          # Release peer image: inherits the master harness, swaps app binaries.
+          docker buildx build \
+            --build-arg BASE_IMAGE=bisq-daemon:ci \
+            --load \
+            -t bisq-daemon:release \
+            -f apitest/docker/Dockerfile.bisq-release .
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Run e2e test stack (compose up + test, bob on ${{ env.RELEASE_REF }})
+        env:
+          COMPOSE_OVERRIDE_FILE: apitest/docker/dao-compose.compat.yml
+          # Skip the deny-list policy phase: it injects the master-only
+          # --denyListResource daemon flag, which an older release peer does not
+          # recognize and exits on. It tests a single-node master feature, not
+          # cross-version compatibility.
+          RUN_POLICY_E2E_TESTS: "false"
+        run: apitest/docker/run-e2e-tests.sh --skip-build --skip-docker-build
+
+      - name: Upload container logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-tests-compat-logs
+          path: apitest/docker/logs
+          retention-days: 7
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-tests-compat-reports
+          path: apitest/build/reports/tests
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ deploy
 
 # Directory for temp files
 /temp
+
+# Staged release install dists for the e2e compat test (generated)
+apitest/docker/.release-dist/

--- a/apitest/docker/Dockerfile.bisq-release
+++ b/apitest/docker/Dockerfile.bisq-release
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.6
+#
+# Compatibility image for the dispatch-only e2e compat test. Keeps the master
+# test harness intact — entrypoint, dao-setup app dirs, javafx jars are all
+# inherited from bisq-daemon:ci — and swaps ONLY the Bisq application binaries
+# (seednode/daemon/cli) for a build of a tagged release. One peer runs this
+# image so the suite exercises release<->master P2P/DAO/trade compatibility.
+#
+# The release install dists must be staged under ${RELEASE_DIST} in the build
+# context before building (the compat workflow checks out the tag into a git
+# worktree, runs installDist there, and copies the output here).
+
+ARG BASE_IMAGE=bisq-daemon:ci
+FROM ${BASE_IMAGE}
+
+# Path (relative to build context = repo root) where the release install dists
+# have been staged: ${RELEASE_DIST}/{seednode,daemon,cli}/{bin,lib}.
+ARG RELEASE_DIST=apitest/docker/.release-dist
+
+# Swap the master app binaries for the release ones. Everything else baked into
+# the base image (entrypoint, /opt/dao-setup, /opt/openjfx, PATH/env) is reused.
+RUN rm -rf /bisq/seednode /bisq/daemon /bisq/cli
+COPY ${RELEASE_DIST}/seednode /bisq/seednode
+COPY ${RELEASE_DIST}/daemon   /bisq/daemon
+COPY ${RELEASE_DIST}/cli      /bisq/cli
+
+# Re-apply the same fix-ups Dockerfile.bisq does to a fresh install dist: exec bits
+# + replace the empty placeholder javafx jars with the real linux jars prefetched
+# into /opt/openjfx by the base image. Version-agnostic: a release dist may ship a
+# different javafx version than master, so match by glob rather than a hard-coded
+# version. Copy only when a matching prefetched jar exists (daemon/cli/seednode are
+# headless and run fine with the placeholder otherwise), but do not mask a cp that
+# actually fails.
+RUN set -eux; \
+    chmod +x /bisq/seednode/bin/* /bisq/daemon/bin/* /bisq/cli/bin/*; \
+    for app in seednode daemon cli; do \
+      for mod in javafx-base javafx-graphics; do \
+        for target in /bisq/${app}/lib/${mod}-*.jar; do \
+          [ -e "${target}" ] || continue; \
+          src="/opt/openjfx/$(basename "${target}")"; \
+          if [ -e "${src}" ]; then \
+            cp "${src}" "${target}"; \
+          else \
+            echo "WARN: no prefetched OpenJFX jar for $(basename "${target}"); leaving placeholder" >&2; \
+          fi; \
+        done; \
+      done; \
+    done

--- a/apitest/docker/dao-compose.compat.yml
+++ b/apitest/docker/dao-compose.compat.yml
@@ -1,0 +1,15 @@
+# Compatibility override for dao-compose.yml. Points one peer (bob) at the
+# release-built image so the e2e suite runs against a mixed-version stack:
+# seednode + arb + alice on master, bob on the latest tagged release.
+#
+# Layer on top of the base compose file:
+#   docker compose -f dao-compose.yml -f dao-compose.compat.yml up
+# run-e2e-tests.sh does this automatically when COMPOSE_OVERRIDE_FILE points here.
+#
+# bisq-daemon:release must be built beforehand (see Dockerfile.bisq-release and
+# .github/workflows/e2e-tests-compat.yml); it has no build: stanza on purpose so
+# `docker compose build` never tries to rebuild it from the master context.
+
+services:
+  bob:
+    image: bisq-daemon:release

--- a/apitest/docker/run-e2e-tests-compat.sh
+++ b/apitest/docker/run-e2e-tests-compat.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Local runner for the cross-version e2e compat test: the full DAO + trade suite
+# against a mixed-version stack where one peer (bob) runs a tagged release and the
+# rest (seednode, arb, alice) run the current working tree. Local mirror of
+# .github/workflows/e2e-tests-compat.yml — same images, same override, same suite.
+#
+# Requires a running docker daemon, JDK 21, and a clean git tree with tags
+# fetched. Builds two source trees (current + the release tag), so the first run
+# is slow.
+#
+# Usage:
+#   apitest/docker/run-e2e-tests-compat.sh                  # bob = latest tag
+#   apitest/docker/run-e2e-tests-compat.sh v1.10.1          # bob = explicit ref
+#   apitest/docker/run-e2e-tests-compat.sh --keep-up        # pass-through to runner
+#   apitest/docker/run-e2e-tests-compat.sh v1.10.0 --tests 'bisq.apitest.dao.*'
+#
+# Env overrides:
+#   RELEASE_REF    release ref for the bob peer (default: latest tag); a leading
+#                  non-dash positional arg takes precedence.
+#   GRADLE         gradle wrapper for the current tree (default: ./gradlew)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/dao-compose.yml"
+OVERRIDE_FILE="${SCRIPT_DIR}/dao-compose.compat.yml"
+RELEASE_DIST="${SCRIPT_DIR}/.release-dist"
+GRADLE="${GRADLE:-${REPO_ROOT}/gradlew}"
+
+log()   { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+step()  { echo; log "==> $*"; }
+fatal() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+# First non-dash arg = release ref; everything else is forwarded to run-e2e-tests.sh.
+RUNNER_ARGS=()
+RELEASE_REF="${RELEASE_REF:-}"
+ref_from_arg=""
+for a in "$@"; do
+  if [[ -z "${ref_from_arg}" && "${a}" != -* ]]; then
+    ref_from_arg="${a}"
+  else
+    RUNNER_ARGS+=("${a}")
+  fi
+done
+[[ -n "${ref_from_arg}" ]] && RELEASE_REF="${ref_from_arg}"
+
+cd "${REPO_ROOT}"
+
+step "Preflight"
+command -v docker >/dev/null || fatal "docker not found"
+docker info >/dev/null 2>&1 || fatal "docker daemon not reachable (is it running?)"
+docker compose version >/dev/null 2>&1 || fatal "docker compose v2 plugin required"
+[[ -x "${GRADLE}" ]] || fatal "gradle wrapper not executable at ${GRADLE}"
+[[ -f "${OVERRIDE_FILE}" ]] || fatal "override compose file missing: ${OVERRIDE_FILE}"
+
+if [[ -z "${RELEASE_REF}" ]]; then
+  RELEASE_REF="$(git describe --tags --abbrev=0 2>/dev/null)" \
+    || fatal "could not auto-detect latest tag; pass a ref explicitly (run 'git fetch --tags')"
+fi
+git rev-parse --verify --quiet "${RELEASE_REF}^{commit}" >/dev/null \
+  || fatal "unknown release ref '${RELEASE_REF}' (run 'git fetch --tags'?)"
+log "Release peer (bob) ref: ${RELEASE_REF}"
+
+# Detached worktree for the release build; removed on exit.
+WORKTREE="$(mktemp -d)/src"
+cleanup() {
+  step "Cleaning up release worktree"
+  git worktree remove --force "${WORKTREE}" 2>/dev/null || true
+  rm -rf "$(dirname "${WORKTREE}")" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+###############################################################################
+# 1. Current-tree install dists + dao-setup (master harness + 3 peers).
+###############################################################################
+step "Building current-tree install dists + dao-setup"
+"${GRADLE}" --no-daemon \
+  :seednode:installDist :daemon:installDist :cli:installDist \
+  :apitest:installDaoSetup \
+  || fatal "current-tree gradle build failed"
+
+###############################################################################
+# 2. Master docker images (bisq-bitcoind:ci, bisq-daemon:ci).
+###############################################################################
+step "Building master docker images (bitcoind + daemon)"
+docker compose -f "${COMPOSE_FILE}" build || fatal "master image build failed"
+
+###############################################################################
+# 3. Release install dists in a worktree → stage for Dockerfile.bisq-release.
+###############################################################################
+step "Building release (${RELEASE_REF}) install dists in worktree"
+git worktree add --detach "${WORKTREE}" "${RELEASE_REF}"
+git -C "${WORKTREE}" submodule update --init --recursive
+( cd "${WORKTREE}" && ./gradlew --no-daemon \
+    :seednode:installDist :daemon:installDist :cli:installDist ) \
+  || fatal "release gradle build failed for ${RELEASE_REF} (incompatible toolchain? try another ref)"
+
+step "Staging release dists → ${RELEASE_DIST}"
+rm -rf "${RELEASE_DIST}"
+mkdir -p "${RELEASE_DIST}"
+cp -r "${WORKTREE}/seednode/build/install/seednode" "${RELEASE_DIST}/seednode"
+cp -r "${WORKTREE}/daemon/build/install/daemon"     "${RELEASE_DIST}/daemon"
+cp -r "${WORKTREE}/cli/build/install/cli"           "${RELEASE_DIST}/cli"
+
+###############################################################################
+# 4. Release peer image (inherits master harness, swaps app binaries).
+###############################################################################
+step "Building release peer image bisq-daemon:release"
+docker build \
+  --build-arg BASE_IMAGE=bisq-daemon:ci \
+  -t bisq-daemon:release \
+  -f "${SCRIPT_DIR}/Dockerfile.bisq-release" \
+  "${REPO_ROOT}" \
+  || fatal "release image build failed"
+
+###############################################################################
+# 5. Run the suite with the compat override (skip builds — done above).
+###############################################################################
+step "Running e2e suite (bob=${RELEASE_REF}, rest=current tree)"
+# Skip the deny-list policy phase: it injects the master-only --denyListResource
+# daemon flag via BISQ_EXTRA_ARGS, which an older release peer (bob) does not
+# recognize and exits on. It tests a single-node master feature, not cross-version
+# compatibility, so it has no meaning in this mixed-version run.
+COMPOSE_OVERRIDE_FILE="${OVERRIDE_FILE}" \
+RUN_POLICY_E2E_TESTS=false \
+  "${SCRIPT_DIR}/run-e2e-tests.sh" --skip-build --skip-docker-build "${RUNNER_ARGS[@]}"

--- a/apitest/docker/run-e2e-tests.sh
+++ b/apitest/docker/run-e2e-tests.sh
@@ -61,6 +61,16 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/dao-compose.yml"
+# Optional compose override layered on top of the base file (e.g.
+# dao-compose.compat.yml, which swaps one peer to the release image). Every
+# `docker compose` call uses COMPOSE_ARGS so the override applies to up/down/build.
+COMPOSE_OVERRIDE_FILE="${COMPOSE_OVERRIDE_FILE:-}"
+COMPOSE_ARGS=(-f "${COMPOSE_FILE}")
+if [[ -n "${COMPOSE_OVERRIDE_FILE}" ]]; then
+  [[ -f "${COMPOSE_OVERRIDE_FILE}" ]] \
+    || { echo "[ERROR] COMPOSE_OVERRIDE_FILE not found: ${COMPOSE_OVERRIDE_FILE}" >&2; exit 2; }
+  COMPOSE_ARGS+=(-f "${COMPOSE_OVERRIDE_FILE}")
+fi
 LOGS_DIR="${SCRIPT_DIR}/logs"
 GRADLE="${GRADLE:-${REPO_ROOT}/gradlew}"
 PID_FILE="${PID_FILE:-/tmp/bisq-e2e-tests.pid}"
@@ -155,7 +165,7 @@ assert_all_running() {
 
 # Stop containers + remove volumes + sweep any straggler containers by name.
 teardown_stack() {
-  docker compose -f "${COMPOSE_FILE}" down -v --remove-orphans 2>/dev/null || true
+  docker compose "${COMPOSE_ARGS[@]}" down -v --remove-orphans 2>/dev/null || true
   # Belt-and-braces: catch any leftover containers (e.g. from a run with a different
   # COMPOSE_PROJECT_NAME) that would otherwise block the port reclaim below.
   for c in "${ALL_CONTAINERS[@]}"; do
@@ -167,7 +177,7 @@ teardown_stack() {
 # (or 'started' if no healthcheck). On failure, dump per-container state + logs
 # and fatal-exit.
 start_stack() {
-  if ! docker compose -f "${COMPOSE_FILE}" up -d --wait --wait-timeout 240; then
+  if ! docker compose "${COMPOSE_ARGS[@]}" up -d --wait --wait-timeout 240; then
     err "compose up failed; showing state + last 80 log lines for every container:"
     for c in "${ALL_CONTAINERS[@]}"; do
       local s; s="$(container_status "${c}")"
@@ -362,7 +372,7 @@ cleanup() {
     teardown_stack
   else
     log "Stack left running (--keep-up). Tear down with:"
-    log "  docker compose -f ${COMPOSE_FILE} down -v"
+    log "  docker compose ${COMPOSE_ARGS[*]} down -v"
   fi
   rm -f "${PID_FILE}" "${TIMEOUT_MARKER}"
   log "==> Exiting with code ${exit_code}"
@@ -376,13 +386,17 @@ trap cleanup EXIT INT TERM HUP QUIT
 
 if [[ "${SKIP_DOCKER_BUILD}" -eq 1 ]]; then
   step "Skipping docker build (--skip-docker-build); verifying images present"
-  for img in bisq-bitcoind:ci bisq-daemon:ci; do
+  REQUIRED_IMAGES=(bisq-bitcoind:ci bisq-daemon:ci)
+  # The compat override references bisq-daemon:release; it has no build: stanza so
+  # it must already exist (built by the compat workflow before invoking us).
+  [[ -n "${COMPOSE_OVERRIDE_FILE}" ]] && REQUIRED_IMAGES+=(bisq-daemon:release)
+  for img in "${REQUIRED_IMAGES[@]}"; do
     docker image inspect "${img}" >/dev/null 2>&1 \
       || fatal "image '${img}' missing; rerun without --skip-docker-build"
   done
 else
   step "Building docker images"
-  docker compose -f "${COMPOSE_FILE}" build || fatal "image build failed"
+  docker compose "${COMPOSE_ARGS[@]}" build || fatal "image build failed"
   for img in bisq-bitcoind:ci bisq-daemon:ci; do
     docker image inspect "${img}" >/dev/null 2>&1 \
       || fatal "image '${img}' not present after build (check compose 'image:' / 'build:' fields)"

--- a/apitest/src/test/java/bisq/apitest/dao/DaoStaysInSyncTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/DaoStaysInSyncTest.java
@@ -87,10 +87,10 @@ public class DaoStaysInSyncTest extends DaoTestBase {
         dao.awaitBlindVotePropagation(bob, 2, "bob");
         assertInSync("after blind votes confirmed + propagated");
 
-        // VOTE_REVEAL: each node auto-broadcasts its reveal tx; confirm both.
+        // VOTE_REVEAL: each node auto-broadcasts its reveal tx; confirm both together in one
+        // in-phase block (see confirmAutoRevealsForAll).
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_VOTE_REVEAL);
-        dao.confirmAutoRevealsFor(alice);
-        dao.confirmAutoRevealsFor(bob);
+        dao.confirmAutoRevealsForAll(alice, bob);
         assertInSync("after vote reveal");
 
         // RESULT: the proposal both accepted must be accepted, and both nodes must still

--- a/apitest/src/test/java/bisq/apitest/dao/DaoTestUtils.java
+++ b/apitest/src/test/java/bisq/apitest/dao/DaoTestUtils.java
@@ -21,6 +21,7 @@ import bisq.cli.GrpcClient;
 
 import bisq.proto.grpc.DaoPhaseEnum;
 import bisq.proto.grpc.GetCycleInfoReply;
+import bisq.proto.grpc.OfferInfo;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -153,6 +155,14 @@ public class DaoTestUtils {
      * </ol>
      */
     public void confirmTx(GrpcClient owner, String txId) {
+        injectRawTx(owner, txId);
+        generateBlocks(1);
+    }
+
+    /** Push a Bisq-broadcast tx into bitcoind's mempool WITHOUT mining (see {@link #confirmTx}
+     *  for the inject-vs-P2P-relay rationale). Lets a caller stage several txs and then
+     *  confirm them all in a single block. Dedupes if bitcoinj's relay already landed it. */
+    private void injectRawTx(GrpcClient owner, String txId) {
         String hex = owner.getRawTransaction(txId);
         if (hex == null || hex.isEmpty()) {
             throw new AssertionError("daemon does not know tx " + txId
@@ -169,7 +179,6 @@ public class DaoTestUtils {
                     || msg.contains("inserttx");
             if (!dedupe) throw ex;
         }
-        generateBlocks(1);
     }
 
     /** Convenience: confirm a tx owned by {@code alice}. */
@@ -216,6 +225,37 @@ public class DaoTestUtils {
         return revealTxIds;
     }
 
+    /**
+     * Confirm every owner's auto-broadcast vote-reveal tx together in a SINGLE block.
+     *
+     * <p>A reveal tx only counts toward the result if it is confirmed inside the
+     * VOTE_REVEAL phase — just 2 blocks on regtest ({@code Param.PHASE_VOTE_REVEAL}).
+     * Confirming one owner per call (repeated {@link #confirmAutoRevealsFor}) mines one
+     * block each, so a second voter's reveal lands in the block that crosses out of the
+     * phase and its vote is silently dropped from the tally. Staging all reveals into the
+     * mempool and mining once keeps them in the same in-phase block.
+     *
+     * <p>Call right after entering VOTE_REVEAL ({@code advanceToPhase(DAO_PHASE_VOTE_REVEAL)}
+     * lands on the phase's first block): the single block this mines is then the phase's
+     * second/last block, still in-phase.
+     */
+    public void confirmAutoRevealsForAll(GrpcClient... owners) {
+        java.util.List<String> injected = new java.util.ArrayList<>();
+        for (GrpcClient owner : owners) {
+            await(() -> owner.getMyVotes().getVotesList().stream()
+                            .anyMatch(v -> !v.getRevealTxId().isEmpty()),
+                    10_000, "auto-reveal tx broadcast");
+            for (bisq.proto.grpc.MyVoteInfo v : owner.getMyVotes().getVotesList()) {
+                String revealTxId = v.getRevealTxId();
+                if (!revealTxId.isEmpty() && !injected.contains(revealTxId)) {
+                    injectRawTx(owner, revealTxId);
+                    injected.add(revealTxId);
+                }
+            }
+        }
+        generateBlocks(1);
+    }
+
     public void awaitDaoStateReady(GrpcClient client, String label) {
         // isDaoStateInSync also checks consensus with seed node — but seed and daemon
         // can legitimately disagree on the *proposal payload set* (P2P gossip races)
@@ -229,6 +269,59 @@ public class DaoTestUtils {
                 return false;
             }
         }, 60_000, "DAO state ready on " + label);
+    }
+
+    /**
+     * Place a v1 offer, retrying while {@code ValidateOffer} rejects it because the maker
+     * has not yet observed an available mediator + refund agent.
+     *
+     * <p>Those agents are registered on the arb node at stack startup and reach the maker
+     * via P2P gossip. On a freshly reset stack the maker's very first {@code createoffer}
+     * can run before that payload arrives, so {@code ValidateOffer.checkDisputeAgentAvailability}
+     * fails ("no accepted mediator" / "no refund agent") and the call throws. {@code ValidateOffer}
+     * is the first task in the place-offer protocol — it runs before the maker-fee tx is
+     * built and before any funds are reserved — so a rejected attempt leaves no offer and no
+     * wallet state, making retries side-effect free.
+     *
+     * <p>Only the dispute-agent race is retried: every other {@code ValidateOffer} check is
+     * deterministic in the request, so a genuinely bad offer fails identically on each attempt
+     * and surfaces at the timeout. Gate on the placement succeeding; the timeout is the safety net.
+     */
+    public static OfferInfo placeV1OfferWhenReady(Supplier<OfferInfo> placeOffer) {
+        long deadline = System.currentTimeMillis() + 60_000;
+        RuntimeException last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                return placeOffer.get();
+            } catch (RuntimeException ex) {
+                if (!isMakerNotYetReadyForOffer(ex)) throw ex;
+                last = ex;
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        throw new AssertionError("offer placement never accepted within 60s — maker may never "
+                + "have received the mediator/refund-agent payloads", last);
+    }
+
+    /**
+     * True if {@code ex} is a place-offer {@code ValidateOffer} failure.
+     *
+     * <p>The daemon collapses every ValidateOffer failure to a single lowercased line
+     * ("...at task: validateoffer") before it reaches the gRPC client — {@code Task.failed}
+     * does not append the cause and {@code GrpcExceptionHandler} keeps only the last line —
+     * so the specific reason ("no accepted mediator", etc.) is never transmitted and cannot
+     * be matched. The dispute-agent race is the only non-deterministic ValidateOffer
+     * rejection for a well-formed offer; a genuinely invalid offer fails identically on
+     * every retry and surfaces when {@link #placeV1OfferWhenReady} times out.
+     */
+    private static boolean isMakerNotYetReadyForOffer(RuntimeException ex) {
+        String msg = ex.getMessage() == null ? "" : ex.getMessage().toLowerCase();
+        return msg.contains("validateoffer");
     }
 
     public static void await(BooleanSupplier cond, long timeoutMillis, String what) {

--- a/apitest/src/test/java/bisq/apitest/dao/FullCycleScenarioTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/FullCycleScenarioTest.java
@@ -67,8 +67,7 @@ public class FullCycleScenarioTest extends DaoTestBase {
         dao.awaitBlindVotePropagation(alice, 2, "alice");
         dao.awaitBlindVotePropagation(bob, 2, "bob");
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_VOTE_REVEAL);
-        dao.confirmAutoRevealsFor(alice);
-        dao.confirmAutoRevealsFor(bob);
+        dao.confirmAutoRevealsForAll(alice, bob);
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_RESULT);
         dao.generateBlocks(1);
 
@@ -117,8 +116,7 @@ public class FullCycleScenarioTest extends DaoTestBase {
         dao.awaitBlindVotePropagation(alice, 2, "alice");
         dao.awaitBlindVotePropagation(bob, 2, "bob");
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_VOTE_REVEAL);
-        dao.confirmAutoRevealsFor(alice);
-        dao.confirmAutoRevealsFor(bob);
+        dao.confirmAutoRevealsForAll(alice, bob);
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_RESULT);
         dao.generateBlocks(1);
         return p;

--- a/apitest/src/test/java/bisq/apitest/dao/TradeScenarioTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/TradeScenarioTest.java
@@ -95,9 +95,9 @@ public class TradeScenarioTest extends DaoTestBase {
     @Order(1)
     public void aliceSellsBtc_bobTakes_v1() {
         ensureAccounts();
-        OfferInfo offer = alice.createFixedPricedOffer(
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> alice.createFixedPricedOffer(
                 "SELL", CURRENCY, BTC_AMOUNT_SATS, BTC_AMOUNT_SATS, FIXED_FIAT_PRICE,
-                SECURITY_DEPOSIT_PCT, aliceF2F.getId(), "BTC");
+                SECURITY_DEPOSIT_PCT, aliceF2F.getId(), "BTC"));
         runV1Trade(offer, /*bobIsBtcBuyer=*/ true);
     }
 
@@ -105,9 +105,9 @@ public class TradeScenarioTest extends DaoTestBase {
     @Order(2)
     public void aliceBuysBtc_bobTakes_v1() {
         ensureAccounts();
-        OfferInfo offer = alice.createFixedPricedOffer(
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> alice.createFixedPricedOffer(
                 "BUY", CURRENCY, BTC_AMOUNT_SATS, BTC_AMOUNT_SATS, FIXED_FIAT_PRICE,
-                SECURITY_DEPOSIT_PCT, aliceF2F.getId(), "BTC");
+                SECURITY_DEPOSIT_PCT, aliceF2F.getId(), "BTC"));
         runV1Trade(offer, /*bobIsBtcBuyer=*/ false);
     }
 

--- a/apitest/src/test/java/bisq/apitest/dao/VoteEdgeCasesTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/VoteEdgeCasesTest.java
@@ -74,8 +74,7 @@ public class VoteEdgeCasesTest extends DaoTestBase {
         dao.awaitBlindVotePropagation(alice, 2, "alice");
         dao.awaitBlindVotePropagation(bob, 2, "bob");
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_VOTE_REVEAL);
-        dao.confirmAutoRevealsFor(alice);
-        dao.confirmAutoRevealsFor(bob);
+        dao.confirmAutoRevealsForAll(alice, bob);
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_RESULT);
         dao.generateBlocks(1);
 

--- a/apitest/src/test/java/bisq/apitest/dao/VoteResultPhaseTest.java
+++ b/apitest/src/test/java/bisq/apitest/dao/VoteResultPhaseTest.java
@@ -114,9 +114,9 @@ public class VoteResultPhaseTest extends DaoTestBase {
         dao.awaitBlindVotePropagation(alice, 2, "alice");
         dao.awaitBlindVotePropagation(bob, 2, "bob");
 
+        // Confirm both reveals in one block so neither crosses out of the 2-block phase.
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_VOTE_REVEAL);
-        dao.confirmAutoRevealsFor(alice);
-        dao.confirmAutoRevealsFor(bob);
+        dao.confirmAutoRevealsForAll(alice, bob);
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_RESULT);
         dao.generateBlocks(1);
 
@@ -163,10 +163,13 @@ public class VoteResultPhaseTest extends DaoTestBase {
             dao.awaitBlindVotePropagation(bob, expectedBlindVotes, "bob");
         }
 
+        // Confirm every voter's reveal together in one in-phase block — mining one block per
+        // voter would push a later reveal past the 2-block regtest VOTE_REVEAL phase and drop
+        // that vote (see confirmAutoRevealsForAll).
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_VOTE_REVEAL);
-        // Bisq auto-broadcasts a reveal tx on entering VOTE_REVEAL; inject + confirm it.
-        if (aliceBv != null) dao.confirmAutoRevealsFor(alice);
-        if (bobBv != null) dao.confirmAutoRevealsFor(bob);
+        if (aliceBv != null && bobBv != null) dao.confirmAutoRevealsForAll(alice, bob);
+        else if (aliceBv != null) dao.confirmAutoRevealsForAll(alice);
+        else if (bobBv != null) dao.confirmAutoRevealsForAll(bob);
 
         dao.advanceToPhase(DaoPhaseEnum.DAO_PHASE_RESULT);
         // Stay in RESULT (2 blocks) long enough for VoteResultService to evaluate.

--- a/apitest/src/test/java/bisq/apitest/method/trade/FailUnfailTradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/FailUnfailTradeTest.java
@@ -50,9 +50,9 @@ public class FailUnfailTradeTest extends DockerTradeTest {
     @Test
     public void testFailAndUnFailBuyBTCTrade() {
         ensureF2FAccounts("US");
-        OfferInfo offer = aliceClient.createFixedPricedOffer(BUY.name(),
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> aliceClient.createFixedPricedOffer(BUY.name(),
                 USD, 1_250_000L, 1_250_000L, "50000",
-                defaultBuyerSecurityDepositPct.get(), alicesF2F.getId(), BTC);
+                defaultBuyerSecurityDepositPct.get(), alicesF2F.getId(), BTC));
         TradeInfo trade = driveUpToDepositConfirmed(offer);
         assertFailUnfailCycle(trade.getTradeId());
     }
@@ -60,9 +60,9 @@ public class FailUnfailTradeTest extends DockerTradeTest {
     @Test
     public void testFailAndUnFailSellBTCTrade() {
         ensureF2FAccounts("US");
-        OfferInfo offer = aliceClient.createFixedPricedOffer(SELL.name(),
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> aliceClient.createFixedPricedOffer(SELL.name(),
                 USD, 1_250_000L, 1_250_000L, "50000",
-                defaultBuyerSecurityDepositPct.get(), alicesF2F.getId(), BTC);
+                defaultBuyerSecurityDepositPct.get(), alicesF2F.getId(), BTC));
         TradeInfo trade = driveUpToDepositConfirmed(offer);
         assertFailUnfailCycle(trade.getTradeId());
     }

--- a/apitest/src/test/java/bisq/apitest/method/trade/InsufficientBtcToTakeOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/InsufficientBtcToTakeOfferTest.java
@@ -17,6 +17,8 @@
 
 package bisq.apitest.method.trade;
 
+import bisq.apitest.dao.DaoTestUtils;
+
 import bisq.proto.grpc.OfferInfo;
 
 import io.grpc.StatusRuntimeException;
@@ -61,10 +63,10 @@ public class InsufficientBtcToTakeOfferTest extends DockerTradeTest {
         awaitCond(() -> bobClient.getBtcBalances().getAvailableBalance() < 1_450_000L,
                 "bob's available BTC drops below take-offer threshold");
 
-        OfferInfo offer = aliceClient.createFixedPricedOffer(BUY.name(),
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> aliceClient.createFixedPricedOffer(BUY.name(),
                 USD, 1_250_000L, 1_250_000L, "50000",
                 defaultBuyerSecurityDepositPct.get(),
-                alicesF2F.getId(), BSQ);
+                alicesF2F.getId(), BSQ));
         assertFalse(offer.getIsCurrencyForMakerFeeBtc());
         awaitCond(() -> aliceClient.getMyOffersSortedByDate(BUY.name(), USD).size() == 1,
                 "alice's USD offer book has the new offer");

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeBuyXMROfferTest.java
@@ -17,6 +17,8 @@
 
 package bisq.apitest.method.trade;
 
+import bisq.apitest.dao.DaoTestUtils;
+
 import bisq.proto.grpc.OfferInfo;
 import bisq.proto.grpc.TradeInfo;
 
@@ -46,9 +48,9 @@ public class TakeBuyXMROfferTest extends DockerTradeTest {
         ensureXmrAccounts();
 
         // Alice's offer: SELL BTC (i.e. BUY XMR). Direction is BTC-relative.
-        OfferInfo offer = aliceClient.createFixedPricedOffer(SELL.name(),
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> aliceClient.createFixedPricedOffer(SELL.name(),
                 XMR, 1_250_000L, 1_000_000L, "0.00455500",
-                defaultBuyerSecurityDepositPct.get(), alicesXmrAcct.getId(), BSQ);
+                defaultBuyerSecurityDepositPct.get(), alicesXmrAcct.getId(), BSQ));
         // Maker fee currency may be auto-converted by the daemon — don't assert.
         mineBlocks(1);
         awaitOfferActivated(offer.getId());

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeOfferWithOutOfRangeAmountTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeOfferWithOutOfRangeAmountTest.java
@@ -17,6 +17,8 @@
 
 package bisq.apitest.method.trade;
 
+import bisq.apitest.dao.DaoTestUtils;
+
 import bisq.proto.grpc.OfferInfo;
 
 import io.grpc.StatusRuntimeException;
@@ -48,10 +50,10 @@ public class TakeOfferWithOutOfRangeAmountTest extends DockerTradeTest {
     public void testTakeOfferWithInvalidAmountParam() {
         ensureF2FAccounts("US");
 
-        OfferInfo offer = aliceClient.createFixedPricedOffer(BUY.name(),
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> aliceClient.createFixedPricedOffer(BUY.name(),
                 USD, 1_250_000L, 1_000_000L, "50000",
                 defaultBuyerSecurityDepositPct.get(),
-                alicesF2F.getId(), BTC);
+                alicesF2F.getId(), BTC));
 
         awaitOfferActivated(offer.getId());
         awaitBobSeesOffer(offer.getId(), USD);

--- a/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/TakeSellXMROfferTest.java
@@ -17,6 +17,8 @@
 
 package bisq.apitest.method.trade;
 
+import bisq.apitest.dao.DaoTestUtils;
+
 import bisq.proto.grpc.OfferInfo;
 import bisq.proto.grpc.TradeInfo;
 
@@ -44,9 +46,9 @@ public class TakeSellXMROfferTest extends DockerTradeTest {
     public void testTakeAlicesBuyBTCForXMROffer() {
         ensureXmrAccounts();
 
-        OfferInfo offer = aliceClient.createFixedPricedOffer(BUY.name(),
+        OfferInfo offer = DaoTestUtils.placeV1OfferWhenReady(() -> aliceClient.createFixedPricedOffer(BUY.name(),
                 XMR, 1_250_000L, 1_000_000L, "0.00455500",
-                defaultBuyerSecurityDepositPct.get(), alicesXmrAcct.getId(), BSQ);
+                defaultBuyerSecurityDepositPct.get(), alicesXmrAcct.getId(), BSQ));
         // Maker fee currency may be auto-converted by the daemon — don't assert.
         mineBlocks(1);
         awaitOfferActivated(offer.getId());

--- a/apitest/src/test/java/bisq/apitest/method/wallet/WalletProtectionTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/WalletProtectionTest.java
@@ -90,13 +90,14 @@ public class WalletProtectionTest extends DockerMethodTest {
     @Order(7)
     public void testUnlockWalletTimeoutOverride() {
         // Override a short unlock window with a longer one before the first expires;
-        // wallet must remain unlocked past the original timeout. The 1s sleep below
-        // sits past the original 1s window but before the new 3s window — the only
-        // way to observe the override actually took effect.
+        // wallet must remain unlocked past the original timeout. The 1.5s sleep sits
+        // past the original 1s window — proving the override took effect — while the
+        // new window is set far wider (60s) so a CI stall between the override and the
+        // balance read cannot cross the re-lock deadline and flake the test.
         aliceClient.unlockWallet(PW1, 1);
-        aliceClient.unlockWallet(PW1, 3); // override before 1s expires
-        sleep(1_500);                     // past original (1s), inside new (3s)
-        aliceClient.getBtcBalances();     // must succeed
+        aliceClient.unlockWallet(PW1, 60); // override before 1s expires
+        sleep(1_500);                      // past original (1s), far inside new (60s)
+        aliceClient.getBtcBalances();      // must succeed
     }
 
     @Test


### PR DESCRIPTION
Add a dispatch-only e2e variant that runs the full DAO + trade suite against a
mixed-version stack: seednode/arb/alice on the current tree, bob on the latest
tagged release. Exercises release<->master P2P/DAO/trade compatibility.

Infra:
- Dockerfile.bisq-release: inherit the master harness image (entrypoint,
  dao-setup, javafx) and swap only the Bisq app binaries for a release build.
- dao-compose.compat.yml: override pointing bob at bisq-daemon:release.
- run-e2e-tests.sh: COMPOSE_OVERRIDE_FILE support so the override layers over
  up/down/build; require bisq-daemon:release when the override is active.
- e2e-tests-compat.yml: workflow_dispatch-only CI job that builds the release
  dists in a git worktree, builds the release image, and runs the suite with
  the override. Skips the deny-list policy phase (injects the master-only
  --denyListResource flag an older release peer does not recognize). The
  release_ref input is passed via env and validated with git rev-parse to avoid
  shell injection.
- run-e2e-tests-compat.sh: local runner mirroring the workflow.
- .dockerignore/.gitignore: whitelist + ignore the staged .release-dist.

Flakiness fixes surfaced by the e2e runs:
- Dispute-agent race: on a freshly reset stack the maker's first createoffer
  could run before the mediator/refund-agent payloads registered on the arb
  node propagated over P2P, failing ValidateOffer. ValidateOffer precedes funds
  reservation, so a rejected attempt is side-effect free. Add
  DaoTestUtils.placeV1OfferWhenReady (bounded retry on that transient, gate on
  success) and apply it to every freshstack positive v1 offer creation.
- Vote-reveal counting race: confirming each voter's reveal tx in its own block
  (confirmAutoRevealsFor per voter) mined a second block that crossed out of the
  2-block regtest VOTE_REVEAL phase, silently dropping the later voter's vote
  from the tally. Add DaoTestUtils.confirmAutoRevealsForAll, which stages all
  reveals into the mempool and confirms them in a single in-phase block, and use
  it at every two-voter result-counting site.
- WalletProtectionTest.testUnlockWalletTimeoutOverride: only 1.5s slack before
  the 3s re-lock deadline could flake under CI stall. Widen the override window
  to 60s, keeping the 1.5s probe that proves the override past the original 1s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-version compatibility e2e testing workflow and runner; ability to run mixed-version stacks via a compose override.
* **Chores**
  * Docker build/context improvements and whitelist updates to include staged release artifacts; new release-variant image support.
* **Tests**
  * Added retry helper for V1 offer placement; many e2e tests updated to use it and consolidated auto-reveal confirmation helpers.
* **Bug Fixes**
  * More robust wallet unlock timeout handling in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->