### PR TITLE
Add sender signature pub key to dispute messages

### DIFF
--- a/core/src/main/java/bisq/core/support/SupportManager.java
+++ b/core/src/main/java/bisq/core/support/SupportManager.java
@@ -174,14 +174,18 @@ public abstract class SupportManager {
             Optional<ChatMessage> sourceMessage = allChatMessages.stream()
                     .filter(msg -> msg.getUid().equals(ackMessage.getSourceUid()))
                     .findFirst();
-            if (sourceMessage.isPresent()) {
-                PubKeyRing expectedSenderPubKeyRing = getPeerPubKeyRing(sourceMessage.get());
-                if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
-                        expectedSenderPubKeyRing,
-                        ackMessage.getClass().getSimpleName(),
-                        ackMessage.getSourceId())) {
-                    return;
-                }
+            if (sourceMessage.isEmpty()) {
+                log.warn("Ignoring AckMessage for {} with tradeId {} and uid {} because the source message was not found",
+                        ackMessage.getSourceMsgClassName(), ackMessage.getSourceId(), ackMessage.getSourceUid());
+                return;
+            }
+
+            PubKeyRing expectedSenderPubKeyRing = getPeerPubKeyRing(sourceMessage.get());
+            if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
+                    expectedSenderPubKeyRing,
+                    ackMessage.getClass().getSimpleName(),
+                    ackMessage.getSourceId())) {
+                return;
             }
 
             if (ackMessage.isSuccess()) {

--- a/core/src/main/java/bisq/core/support/SupportManager.java
+++ b/core/src/main/java/bisq/core/support/SupportManager.java
@@ -40,6 +40,7 @@ import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import lombok.extern.slf4j.Slf4j;
@@ -152,18 +153,37 @@ public abstract class SupportManager {
         }
 
         cleanupRetryMap(uid);
-        PubKeyRing receiverPubKeyRing = getPeerPubKeyRing(chatMessage);
+        PubKeyRing senderPubKeyRing = getPeerPubKeyRing(chatMessage);
+        if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
+                senderPubKeyRing,
+                chatMessage.getClass().getSimpleName(),
+                tradeId)) {
+            return;
+        }
 
         addAndPersistChatMessage(chatMessage);
 
         // We never get a errorMessage in that method (only if we cannot resolve the receiverPubKeyRing but then we
         // cannot send it anyway)
-        if (receiverPubKeyRing != null)
-            sendAckMessage(chatMessage, receiverPubKeyRing, true, null);
+        sendAckMessage(chatMessage, senderPubKeyRing, true, null);
     }
 
     private void onAckMessage(AckMessage ackMessage, PublicKey senderSignaturePubKey) {
         if (ackMessage.getSourceType() == getAckMessageSourceType()) {
+            List<ChatMessage> allChatMessages = getAllChatMessages(ackMessage.getSourceId());
+            Optional<ChatMessage> sourceMessage = allChatMessages.stream()
+                    .filter(msg -> msg.getUid().equals(ackMessage.getSourceUid()))
+                    .findFirst();
+            if (sourceMessage.isPresent()) {
+                PubKeyRing expectedSenderPubKeyRing = getPeerPubKeyRing(sourceMessage.get());
+                if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
+                        expectedSenderPubKeyRing,
+                        ackMessage.getClass().getSimpleName(),
+                        ackMessage.getSourceId())) {
+                    return;
+                }
+            }
+
             if (ackMessage.isSuccess()) {
                 log.info("Received AckMessage for {} with tradeId {} and uid {}",
                         ackMessage.getSourceMsgClassName(), ackMessage.getSourceId(), ackMessage.getSourceUid());
@@ -172,7 +192,7 @@ public abstract class SupportManager {
                         ackMessage.getSourceMsgClassName(), ackMessage.getSourceId(), ackMessage.getErrorMessage());
             }
 
-            getAllChatMessages(ackMessage.getSourceId()).stream()
+            allChatMessages.stream()
                     .filter(msg -> msg.getUid().equals(ackMessage.getSourceUid()))
                     .forEach(msg -> {
                         if (ackMessage.isSuccess())
@@ -282,6 +302,26 @@ public abstract class SupportManager {
 
     protected boolean canProcessMessage(SupportMessage message) {
         return message.getSupportType() == getSupportType();
+    }
+
+    protected boolean isSenderSignaturePubKeyExpected(PublicKey senderSignaturePubKey,
+                                                      @Nullable PubKeyRing expectedSenderPubKeyRing,
+                                                      String messageClassName,
+                                                      String tradeId) {
+        if (expectedSenderPubKeyRing == null) {
+            log.warn("Ignoring {} for trade {} because expected sender pubKeyRing is unknown",
+                    messageClassName, tradeId);
+            return false;
+        }
+
+        PublicKey expectedSenderSignaturePubKey = expectedSenderPubKeyRing.getSignaturePubKey();
+        if (!senderSignaturePubKey.equals(expectedSenderSignaturePubKey)) {
+            log.warn("Ignoring {} for trade {} because sender signature pubKey does not match the expected peer",
+                    messageClassName, tradeId);
+            return false;
+        }
+
+        return true;
     }
 
     protected void cleanupRetryMap(String uid) {

--- a/core/src/main/java/bisq/core/support/SupportManager.java
+++ b/core/src/main/java/bisq/core/support/SupportManager.java
@@ -35,6 +35,8 @@ import bisq.common.UserThread;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.proto.network.NetworkEnvelope;
 
+import java.security.PublicKey;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +87,7 @@ public abstract class SupportManager {
     // Abstract methods
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    protected abstract void onSupportMessage(SupportMessage networkEnvelope);
+    protected abstract void onSupportMessage(SupportMessage networkEnvelope, PublicKey senderSignaturePubKey);
 
     public abstract NodeAddress getPeerNodeAddress(ChatMessage message);
 
@@ -133,14 +135,14 @@ public abstract class SupportManager {
     // Message handler
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    protected void onChatMessage(ChatMessage chatMessage) {
+    protected void onChatMessage(ChatMessage chatMessage, PublicKey senderSignaturePubKey) {
         final String tradeId = chatMessage.getTradeId();
         final String uid = chatMessage.getUid();
         boolean channelOpen = channelOpen(chatMessage);
         if (!channelOpen) {
             log.debug("We got a chatMessage but we don't have a matching chat. TradeId = " + tradeId);
             if (!delayMsgMap.containsKey(uid)) {
-                Timer timer = UserThread.runAfter(() -> onChatMessage(chatMessage), 1);
+                Timer timer = UserThread.runAfter(() -> onChatMessage(chatMessage, senderSignaturePubKey), 1);
                 delayMsgMap.put(uid, timer);
             } else {
                 String msg = "We got a chatMessage after we already repeated to apply the message after a delay. That should never happen. TradeId = " + tradeId;
@@ -160,7 +162,7 @@ public abstract class SupportManager {
             sendAckMessage(chatMessage, receiverPubKeyRing, true, null);
     }
 
-    private void onAckMessage(AckMessage ackMessage) {
+    private void onAckMessage(AckMessage ackMessage, PublicKey senderSignaturePubKey) {
         if (ackMessage.getSourceType() == getAckMessageSourceType()) {
             if (ackMessage.isSuccess()) {
                 log.info("Received AckMessage for {} with tradeId {} and uid {}",
@@ -305,10 +307,10 @@ public abstract class SupportManager {
     private void applyMessages() {
         decryptedDirectMessageWithPubKeys.forEach(decryptedMessageWithPubKey -> {
             NetworkEnvelope networkEnvelope = decryptedMessageWithPubKey.getNetworkEnvelope();
-            if (networkEnvelope instanceof SupportMessage) {
-                onSupportMessage((SupportMessage) networkEnvelope);
-            } else if (networkEnvelope instanceof AckMessage) {
-                onAckMessage((AckMessage) networkEnvelope);
+            if (networkEnvelope instanceof SupportMessage supportMessage) {
+                onSupportMessage(supportMessage, decryptedMessageWithPubKey.getSignaturePubKey());
+            } else if (networkEnvelope instanceof AckMessage ackMessage) {
+                onAckMessage(ackMessage, decryptedMessageWithPubKey.getSignaturePubKey());
             }
         });
         decryptedDirectMessageWithPubKeys.clear();
@@ -316,13 +318,11 @@ public abstract class SupportManager {
         decryptedMailboxMessageWithPubKeys.forEach(decryptedMessageWithPubKey -> {
             NetworkEnvelope networkEnvelope = decryptedMessageWithPubKey.getNetworkEnvelope();
             log.trace("## decryptedMessageWithPubKey message={}", networkEnvelope.getClass().getSimpleName());
-            if (networkEnvelope instanceof SupportMessage) {
-                SupportMessage supportMessage = (SupportMessage) networkEnvelope;
-                onSupportMessage(supportMessage);
+            if (networkEnvelope instanceof SupportMessage supportMessage) {
+                onSupportMessage(supportMessage, decryptedMessageWithPubKey.getSignaturePubKey());
                 mailboxMessageService.removeMailboxMsg(supportMessage);
-            } else if (networkEnvelope instanceof AckMessage) {
-                AckMessage ackMessage = (AckMessage) networkEnvelope;
-                onAckMessage(ackMessage);
+            } else if (networkEnvelope instanceof AckMessage ackMessage) {
+                onAckMessage(ackMessage, decryptedMessageWithPubKey.getSignaturePubKey());
                 mailboxMessageService.removeMailboxMsg(ackMessage);
             }
         });

--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -891,7 +891,8 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
         DisputeResultMessage disputeResultMessage = new DisputeResultMessage(disputeResult,
                 p2PService.getAddress(),
                 UUID.randomUUID().toString(),
-                getSupportType());
+                getSupportType(),
+                pubKeyRing.getSignaturePubKey());
         log.info("Send {} to peer {}. tradeId={}, disputeResultMessage.uid={}, chatMessage.uid={}",
                 disputeResultMessage.getClass().getSimpleName(), peersNodeAddress, disputeResultMessage.getTradeId(),
                 disputeResultMessage.getUid(), chatMessage.getUid());

--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -67,6 +67,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import java.security.KeyPair;
+import java.security.PublicKey;
 
 import java.time.Instant;
 
@@ -207,7 +208,7 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     // We get that message at both peers. The dispute object is in context of the trader
-    public abstract void onDisputeResultMessage(DisputeResultMessage disputeResultMessage);
+    public abstract void onDisputeResultMessage(DisputeResultMessage disputeResultMessage, PublicKey senderSignaturePubKey);
 
     @Nullable
     public abstract NodeAddress getAgentNodeAddress(Dispute dispute);

--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -213,6 +213,9 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
     @Nullable
     public abstract NodeAddress getAgentNodeAddress(Dispute dispute);
 
+    @Nullable
+    protected abstract PubKeyRing getExpectedAgentPubKeyRing(Trade trade);
+
     protected abstract Trade.DisputeState getDisputeStateStartedByPeer();
 
     public abstract void cleanupDisputes();
@@ -387,7 +390,7 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
     }
 
     // dispute agent receives that from trader who opens dispute
-    protected void onOpenNewDisputeMessage(OpenNewDisputeMessage openNewDisputeMessage) {
+    protected void onOpenNewDisputeMessage(OpenNewDisputeMessage openNewDisputeMessage, PublicKey senderSignaturePubKey) {
         T disputeList = getDisputeList();
         if (disputeList == null) {
             log.warn("disputes is null");
@@ -402,6 +405,13 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
         dispute.setState(Dispute.State.NEW);    // this can be removed a few months after 1.6.0 release
 
         Contract contract = dispute.getContract();
+
+        if (!isDisputeOpenerSignaturePubKeyValid(dispute,
+                senderSignaturePubKey,
+                openNewDisputeMessage.getClass().getSimpleName())) {
+            return;
+        }
+
         addPriceInfoMessage(dispute, 0);
 
         PubKeyRing peersPubKeyRing = dispute.isDisputeOpenerIsBuyer() ? contract.getSellerPubKeyRing() : contract.getBuyerPubKeyRing();
@@ -451,35 +461,66 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
     }
 
     // Not-dispute-requester receives that msg from dispute agent
-    protected void onPeerOpenedDisputeMessage(PeerOpenedDisputeMessage peerOpenedDisputeMessage) {
+    protected void onPeerOpenedDisputeMessage(PeerOpenedDisputeMessage peerOpenedDisputeMessage, PublicKey senderSignaturePubKey) {
         Dispute dispute = peerOpenedDisputeMessage.getDispute();
         tradeManager.getTradeById(dispute.getTradeId()).ifPresentOrElse(
-            trade -> peerOpenedDisputeForTrade(peerOpenedDisputeMessage, dispute, trade),
+            trade -> peerOpenedDisputeForTrade(peerOpenedDisputeMessage, dispute, trade, senderSignaturePubKey, false),
             () -> closedTradableManager.getTradableById(dispute.getTradeId()).ifPresentOrElse(
-                closedTradable -> newDisputeRevertsClosedTrade(peerOpenedDisputeMessage, dispute, (Trade)closedTradable),
+                closedTradable -> newDisputeRevertsClosedTrade(peerOpenedDisputeMessage, dispute, (Trade)closedTradable, senderSignaturePubKey),
                 () -> failedTradesManager.getTradeById(dispute.getTradeId()).ifPresent(
-                    trade -> newDisputeRevertsFailedTrade(peerOpenedDisputeMessage, dispute, trade))));
+                    trade -> newDisputeRevertsFailedTrade(peerOpenedDisputeMessage, dispute, trade, senderSignaturePubKey))));
     }
 
-    private void newDisputeRevertsFailedTrade(PeerOpenedDisputeMessage peerOpenedDisputeMessage, Dispute dispute, Trade trade) {
+    private void newDisputeRevertsFailedTrade(PeerOpenedDisputeMessage peerOpenedDisputeMessage,
+                                              Dispute dispute,
+                                              Trade trade,
+                                              PublicKey senderSignaturePubKey) {
+        if (!isDisputeAgentSignaturePubKeyValid(dispute,
+                trade,
+                senderSignaturePubKey,
+                peerOpenedDisputeMessage.getClass().getSimpleName())) {
+            return;
+        }
+
         log.info("Peer dispute ticket received, reverting failed trade {} to pending", trade.getShortId());
         failedTradesManager.removeTrade(trade);
         tradeManager.addTradeToPendingTrades(trade);
-        peerOpenedDisputeForTrade(peerOpenedDisputeMessage, dispute, trade);
+        peerOpenedDisputeForTrade(peerOpenedDisputeMessage, dispute, trade, senderSignaturePubKey, true);
     }
 
-    private void newDisputeRevertsClosedTrade(PeerOpenedDisputeMessage peerOpenedDisputeMessage, Dispute dispute, Trade trade) {
+    private void newDisputeRevertsClosedTrade(PeerOpenedDisputeMessage peerOpenedDisputeMessage,
+                                              Dispute dispute,
+                                              Trade trade,
+                                              PublicKey senderSignaturePubKey) {
+        if (!isDisputeAgentSignaturePubKeyValid(dispute,
+                trade,
+                senderSignaturePubKey,
+                peerOpenedDisputeMessage.getClass().getSimpleName())) {
+            return;
+        }
+
         log.info("Peer dispute ticket received, reverting closed trade {} to pending", trade.getShortId());
         closedTradableManager.remove(trade);
         tradeManager.addTradeToPendingTrades(trade);
-        peerOpenedDisputeForTrade(peerOpenedDisputeMessage, dispute, trade);
+        peerOpenedDisputeForTrade(peerOpenedDisputeMessage, dispute, trade, senderSignaturePubKey, true);
     }
 
-    private void peerOpenedDisputeForTrade(PeerOpenedDisputeMessage peerOpenedDisputeMessage, Dispute dispute, Trade trade) {
+    private void peerOpenedDisputeForTrade(PeerOpenedDisputeMessage peerOpenedDisputeMessage,
+                                           Dispute dispute,
+                                           Trade trade,
+                                           PublicKey senderSignaturePubKey,
+                                           boolean agentSignatureAlreadyChecked) {
         String errorMessage = null;
         T disputeList = getDisputeList();
         if (disputeList == null) {
             log.warn("disputes is null");
+            return;
+        }
+
+        if (!agentSignatureAlreadyChecked && !isDisputeAgentSignaturePubKeyValid(dispute,
+                trade,
+                senderSignaturePubKey,
+                peerOpenedDisputeMessage.getClass().getSimpleName())) {
             return;
         }
 
@@ -927,6 +968,70 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
 
     public boolean isAgent(Dispute dispute) {
         return pubKeyRing.equals(dispute.getAgentPubKeyRing());
+    }
+
+    protected boolean isDisputeAgentSignaturePubKeyValid(Dispute dispute,
+                                                         PublicKey senderSignaturePubKey,
+                                                         String messageClassName) {
+        Optional<Trade> tradeOptional = findTrade(dispute);
+        if (tradeOptional.isPresent()) {
+            return isDisputeAgentSignaturePubKeyValid(dispute,
+                    tradeOptional.get(),
+                    senderSignaturePubKey,
+                    messageClassName);
+        }
+
+        log.warn("Cannot pin dispute agent for {} because trade {} was not found. Falling back to stored dispute agent key.",
+                messageClassName, dispute.getTradeId());
+        return isSenderSignaturePubKeyExpected(senderSignaturePubKey,
+                dispute.getAgentPubKeyRing(),
+                messageClassName,
+                dispute.getTradeId());
+    }
+
+    private boolean isDisputeAgentSignaturePubKeyValid(Dispute dispute,
+                                                       Trade trade,
+                                                       PublicKey senderSignaturePubKey,
+                                                       String messageClassName) {
+        PubKeyRing expectedAgentPubKeyRing = getExpectedAgentPubKeyRing(trade);
+        if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
+                expectedAgentPubKeyRing,
+                messageClassName,
+                dispute.getTradeId())) {
+            return false;
+        }
+
+        if (!expectedAgentPubKeyRing.equals(dispute.getAgentPubKeyRing())) {
+            log.warn("Ignoring {} for trade {} because dispute agent pubKeyRing does not match the trade's expected agent",
+                    messageClassName, dispute.getTradeId());
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isDisputeOpenerSignaturePubKeyValid(Dispute dispute,
+                                                        PublicKey senderSignaturePubKey,
+                                                        String messageClassName) {
+        Contract contract = dispute.getContract();
+        PubKeyRing expectedOpenerPubKeyRing = dispute.isDisputeOpenerIsBuyer() ?
+                contract.getBuyerPubKeyRing() :
+                contract.getSellerPubKeyRing();
+
+        if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
+                expectedOpenerPubKeyRing,
+                messageClassName,
+                dispute.getTradeId())) {
+            return false;
+        }
+
+        if (!expectedOpenerPubKeyRing.equals(dispute.getTraderPubKeyRing())) {
+            log.warn("Ignoring {} for trade {} because dispute trader pubKeyRing does not match the declared opener",
+                    messageClassName, dispute.getTradeId());
+            return false;
+        }
+
+        return true;
     }
 
     private Optional<Dispute> findDispute(Dispute dispute) {

--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -399,12 +399,15 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
 
         String errorMessage = null;
         Dispute dispute = openNewDisputeMessage.getDispute();
+        if (dispute == null) {
+            log.warn("Ignoring {} because dispute is null", openNewDisputeMessage.getClass().getSimpleName());
+            return;
+        }
+
         // Disputes from clients < 1.2.0 always have support type ARBITRATION in dispute as the field didn't exist before
         dispute.setSupportType(openNewDisputeMessage.getSupportType());
         // disputes from clients < 1.6.0 have state not set as the field didn't exist before
         dispute.setState(Dispute.State.NEW);    // this can be removed a few months after 1.6.0 release
-
-        Contract contract = dispute.getContract();
 
         if (!isDisputeOpenerSignaturePubKeyValid(dispute,
                 senderSignaturePubKey,
@@ -412,6 +415,21 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
             return;
         }
 
+        try {
+            DisputeValidation.validateDisputeData(dispute, btcWalletService);
+            DisputeValidation.validateNodeAddresses(dispute, config);
+            DisputeValidation.validateSenderNodeAddress(dispute, openNewDisputeMessage.getSenderNodeAddress());
+            DisputeValidation.testIfDisputeTriesReplay(dispute, disputeList.getList());
+            if (dispute.isUsingLegacyBurningMan()) {
+                DisputeValidation.validateDonationAddressMatchesAnyPastParamValues(dispute, dispute.getDonationAddressOfDelayedPayoutTx(), daoFacade);
+            }
+        } catch (DisputeValidation.ValidationException e) {
+            log.error(e.toString());
+            validationExceptions.add(e);
+            return;
+        }
+
+        Contract contract = dispute.getContract();
         addPriceInfoMessage(dispute, 0);
 
         PubKeyRing peersPubKeyRing = dispute.isDisputeOpenerIsBuyer() ? contract.getSellerPubKeyRing() : contract.getBuyerPubKeyRing();
@@ -444,19 +462,6 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
         }
 
         addMediationResultMessage(dispute);
-
-        try {
-            DisputeValidation.validateDisputeData(dispute, btcWalletService);
-            DisputeValidation.validateNodeAddresses(dispute, config);
-            DisputeValidation.validateSenderNodeAddress(dispute, openNewDisputeMessage.getSenderNodeAddress());
-            DisputeValidation.testIfDisputeTriesReplay(dispute, disputeList.getList());
-            if (dispute.isUsingLegacyBurningMan()) {
-                DisputeValidation.validateDonationAddressMatchesAnyPastParamValues(dispute, dispute.getDonationAddressOfDelayedPayoutTx(), daoFacade);
-            }
-        } catch (DisputeValidation.ValidationException e) {
-            log.error(e.toString());
-            validationExceptions.add(e);
-        }
         requestPersistence();
     }
 
@@ -467,8 +472,10 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
             trade -> peerOpenedDisputeForTrade(peerOpenedDisputeMessage, dispute, trade, senderSignaturePubKey, false),
             () -> closedTradableManager.getTradableById(dispute.getTradeId()).ifPresentOrElse(
                 closedTradable -> newDisputeRevertsClosedTrade(peerOpenedDisputeMessage, dispute, (Trade)closedTradable, senderSignaturePubKey),
-                () -> failedTradesManager.getTradeById(dispute.getTradeId()).ifPresent(
-                    trade -> newDisputeRevertsFailedTrade(peerOpenedDisputeMessage, dispute, trade, senderSignaturePubKey))));
+                () -> failedTradesManager.getTradeById(dispute.getTradeId()).ifPresentOrElse(
+                    trade -> newDisputeRevertsFailedTrade(peerOpenedDisputeMessage, dispute, trade, senderSignaturePubKey),
+                    () -> log.warn("Dropping {} for trade {}: no local trade, closed tradable, or failed trade found.",
+                            peerOpenedDisputeMessage.getClass().getSimpleName(), dispute.getTradeId()))));
     }
 
     private void newDisputeRevertsFailedTrade(PeerOpenedDisputeMessage peerOpenedDisputeMessage,
@@ -973,6 +980,11 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
     protected boolean isDisputeAgentSignaturePubKeyValid(Dispute dispute,
                                                          PublicKey senderSignaturePubKey,
                                                          String messageClassName) {
+        if (dispute == null) {
+            log.warn("Ignoring {} because dispute is missing", messageClassName);
+            return false;
+        }
+
         Optional<Trade> tradeOptional = findTrade(dispute);
         if (tradeOptional.isPresent()) {
             return isDisputeAgentSignaturePubKeyValid(dispute,
@@ -981,12 +993,9 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
                     messageClassName);
         }
 
-        log.warn("Cannot pin dispute agent for {} because trade {} was not found. Falling back to stored dispute agent key.",
+        log.warn("Ignoring {} for trade {} because no local trade record was found to authenticate the dispute agent",
                 messageClassName, dispute.getTradeId());
-        return isSenderSignaturePubKeyExpected(senderSignaturePubKey,
-                dispute.getAgentPubKeyRing(),
-                messageClassName,
-                dispute.getTradeId());
+        return false;
     }
 
     private boolean isDisputeAgentSignaturePubKeyValid(Dispute dispute,
@@ -1013,15 +1022,37 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
     private boolean isDisputeOpenerSignaturePubKeyValid(Dispute dispute,
                                                         PublicKey senderSignaturePubKey,
                                                         String messageClassName) {
+        if (dispute == null) {
+            log.warn("Ignoring {} because dispute is missing", messageClassName);
+            return false;
+        }
+
         Contract contract = dispute.getContract();
+        if (contract == null) {
+            log.warn("Ignoring {} for trade {} because dispute contract is missing",
+                    messageClassName, dispute.getTradeId());
+            return false;
+        }
+
         PubKeyRing expectedOpenerPubKeyRing = dispute.isDisputeOpenerIsBuyer() ?
                 contract.getBuyerPubKeyRing() :
                 contract.getSellerPubKeyRing();
+        if (expectedOpenerPubKeyRing == null) {
+            log.warn("Ignoring {} for trade {} because expected opener pubKeyRing is missing",
+                    messageClassName, dispute.getTradeId());
+            return false;
+        }
 
         if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
                 expectedOpenerPubKeyRing,
                 messageClassName,
                 dispute.getTradeId())) {
+            return false;
+        }
+
+        if (dispute.getTraderPubKeyRing() == null) {
+            log.warn("Ignoring {} for trade {} because dispute trader pubKeyRing is missing",
+                    messageClassName, dispute.getTradeId());
             return false;
         }
 
@@ -1071,11 +1102,12 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
     }
 
     public Optional<Trade> findTrade(Dispute dispute) {
-        Optional<Trade> retVal = tradeManager.getTradeById(dispute.getTradeId());
-        if (retVal.isEmpty()) {
-            retVal = closedTradableManager.getClosedTrades().stream().filter(e -> e.getId().equals(dispute.getTradeId())).findFirst();
-        }
-        return retVal;
+        String tradeId = dispute.getTradeId();
+        return tradeManager.getTradeById(tradeId)
+                .or(() -> closedTradableManager.getClosedTrades().stream()
+                        .filter(e -> e.getId().equals(tradeId))
+                        .findFirst())
+                .or(() -> failedTradesManager.getTradeById(tradeId));
     }
 
     private void addMediationResultMessage(Dispute dispute) {

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
@@ -60,6 +60,8 @@ import org.bitcoinj.core.Transaction;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import java.security.PublicKey;
+
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
@@ -108,21 +110,21 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
     }
 
     @Override
-    public void onSupportMessage(SupportMessage message) {
+    public void onSupportMessage(SupportMessage message, PublicKey senderSignaturePubKey) {
         if (canProcessMessage(message)) {
             log.info("Received {} with tradeId {} and uid {}",
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
 
-            if (message instanceof OpenNewDisputeMessage) {
-                onOpenNewDisputeMessage((OpenNewDisputeMessage) message);
-            } else if (message instanceof PeerOpenedDisputeMessage) {
-                onPeerOpenedDisputeMessage((PeerOpenedDisputeMessage) message);
-            } else if (message instanceof ChatMessage) {
-                onChatMessage((ChatMessage) message);
-            } else if (message instanceof DisputeResultMessage) {
-                onDisputeResultMessage((DisputeResultMessage) message);
-            } else if (message instanceof PeerPublishedDisputePayoutTxMessage) {
-                onDisputedPayoutTxMessage((PeerPublishedDisputePayoutTxMessage) message);
+            if (message instanceof OpenNewDisputeMessage openNewDisputeMessage) {
+                onOpenNewDisputeMessage(openNewDisputeMessage);
+            } else if (message instanceof PeerOpenedDisputeMessage peerOpenedDisputeMessage) {
+                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage);
+            } else if (message instanceof ChatMessage chatMessage) {
+                onChatMessage(chatMessage, senderSignaturePubKey);
+            } else if (message instanceof DisputeResultMessage disputeResultMessage) {
+                onDisputeResultMessage(disputeResultMessage, senderSignaturePubKey);
+            } else if (message instanceof PeerPublishedDisputePayoutTxMessage peerPublishedDisputePayoutTxMessage) {
+                onDisputedPayoutTxMessage(peerPublishedDisputePayoutTxMessage);
             } else {
                 log.warn("Unsupported message at dispatchMessage. message={}", message);
             }
@@ -178,7 +180,7 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
 
     @Override
     // We get that message at both peers. The dispute object is in context of the trader
-    public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage) {
+    public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage, PublicKey senderSignaturePubKey) {
         DisputeResult disputeResult = disputeResultMessage.getDisputeResult();
         ChatMessage chatMessage = disputeResult.getChatMessage();
         checkNotNull(chatMessage, "chatMessage must not be null");
@@ -197,7 +199,7 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
                     "We try again after 2 sec. to apply the disputeResultMessage. TradeId = " + tradeId);
             if (!delayMsgMap.containsKey(uid)) {
                 // We delay 2 sec. to be sure the comm. msg gets added first
-                Timer timer = UserThread.runAfter(() -> onDisputeResultMessage(disputeResultMessage), 2);
+                Timer timer = UserThread.runAfter(() -> onDisputeResultMessage(disputeResultMessage, senderSignaturePubKey), 2);
                 delayMsgMap.put(uid, timer);
             } else {
                 log.warn("We got a dispute result msg after we already repeated to apply the message after a delay. " +

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
@@ -75,6 +75,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Deprecated
 @Slf4j
 @Singleton
+// TODO: Remove active legacy arbitration handling in a dedicated cleanup PR.
+// Keep read-only access to persisted user arbitration cases until the UI has a replacement display path.
 public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeList> {
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -111,6 +113,7 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
 
     @Override
     public void onSupportMessage(SupportMessage message, PublicKey senderSignaturePubKey) {
+        // TODO: Ignore or remove inbound ARBITRATION support messages; old arbitration messages are no longer supported.
         if (canProcessMessage(message)) {
             log.info("Received {} with tradeId {} and uid {}",
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
@@ -134,32 +137,38 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
     @Nullable
     @Override
     public NodeAddress getAgentNodeAddress(Dispute dispute) {
+        // TODO: Remove active arbitrator-agent routing; persisted user cases should not need an agent address.
         return null;
     }
 
     @Nullable
     @Override
     protected PubKeyRing getExpectedAgentPubKeyRing(Trade trade) {
+        // TODO: Remove with inbound arbitration message authentication.
         return trade.getArbitratorPubKeyRing();
     }
 
     @Override
     protected Trade.DisputeState getDisputeStateStartedByPeer() {
+        // TODO: Remove active ARBITRATION dispute-state transitions; preserve persisted states for display only.
         return Trade.DisputeState.DISPUTE_STARTED_BY_PEER;
     }
 
     @Override
     protected AckMessageSourceType getAckMessageSourceType() {
+        // TODO: Remove ARBITRATION_MESSAGE ACK handling with inbound arbitration support.
         return AckMessageSourceType.ARBITRATION_MESSAGE;
     }
 
     @Override
     public void cleanupDisputes() {
+        // TODO: Do not drop persisted arbitration cases; replace active cleanup with read-only historical display support.
         disputeListService.cleanupDisputes(tradeId -> tradeManager.closeDisputedTrade(tradeId, Trade.DisputeState.DISPUTE_CLOSED));
     }
 
     @Override
     protected String getDisputeInfo(Dispute dispute) {
+        // TODO: Remove dispute-opening UI text; keep separate labels for persisted user arbitration case display.
         String role = Res.get("shared.arbitrator").toLowerCase();
         String link = "https://bisq.wiki/Arbitrator#Arbitrator_versus_Legacy_Arbitrator";
         return Res.get("support.initialInfo", role, "", role, link);        // Arbitration is not used anymore
@@ -167,16 +176,19 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
 
     @Override
     protected String getDisputeIntroForPeer(String disputeInfo) {
+        // TODO: Remove dispute-opening UI text; keep separate labels for persisted user arbitration case display.
         return Res.get("support.peerOpenedDispute", disputeInfo, Version.VERSION);
     }
 
     @Override
     protected String getDisputeIntroForDisputeCreator(String disputeInfo) {
+        // TODO: Remove dispute-opening UI text; keep separate labels for persisted user arbitration case display.
         return Res.get("support.youOpenedDispute", disputeInfo, Version.VERSION);
     }
 
     @Override
     protected void addPriceInfoMessage(Dispute dispute, int counter) {
+        // TODO: Remove this no-op override with ArbitrationManager.
         // Arbitrator is not used anymore.
     }
 
@@ -187,6 +199,7 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
     @Override
     // We get that message at both peers. The dispute object is in context of the trader
     public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage, PublicKey senderSignaturePubKey) {
+        // TODO: Remove legacy arbitration result processing; persisted results should be displayed, not updated by messages.
         DisputeResult disputeResult = disputeResultMessage.getDisputeResult();
         ChatMessage chatMessage = disputeResult.getChatMessage();
         checkNotNull(chatMessage, "chatMessage must not be null");
@@ -313,6 +326,7 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
     // Losing trader or in case of 50/50 the seller gets the tx sent from the winner or buyer
     private void onDisputedPayoutTxMessage(PeerPublishedDisputePayoutTxMessage peerPublishedDisputePayoutTxMessage,
                                            PublicKey senderSignaturePubKey) {
+        // TODO: Remove legacy peer-published arbitration payout transaction handling; old messages are not supported.
         String uid = peerPublishedDisputePayoutTxMessage.getUid();
         String tradeId = peerPublishedDisputePayoutTxMessage.getTradeId();
         Optional<Dispute> disputeOptional = findOwnDispute(tradeId);
@@ -360,6 +374,7 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
 
     // winner (or buyer in case of 50/50) sends tx to other peer
     private void sendPeerPublishedPayoutTxMessage(Transaction transaction, Dispute dispute, Contract contract) {
+        // TODO: Remove legacy arbitration payout transaction relay; no active arbitrator role remains.
         PubKeyRing peersPubKeyRing = dispute.isDisputeOpenerIsBuyer() ? contract.getSellerPubKeyRing() : contract.getBuyerPubKeyRing();
         NodeAddress peersNodeAddress = dispute.isDisputeOpenerIsBuyer() ? contract.getSellerNodeAddress() : contract.getBuyerNodeAddress();
         log.trace("sendPeerPublishedPayoutTxMessage to peerAddress {}", peersNodeAddress);
@@ -396,6 +411,7 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
     }
 
     private void updateTradeOrOpenOfferManager(String tradeId) {
+        // TODO: Remove active arbitration close helper; persisted closed cases should remain visible from storage.
         // set state after payout as we call swapTradeEntryToAvailableEntry
         if (tradeManager.getTradeById(tradeId).isPresent()) {
             tradeManager.closeDisputedTrade(tradeId, Trade.DisputeState.DISPUTE_CLOSED);

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/ArbitrationManager.java
@@ -116,15 +116,15 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
 
             if (message instanceof OpenNewDisputeMessage openNewDisputeMessage) {
-                onOpenNewDisputeMessage(openNewDisputeMessage);
+                onOpenNewDisputeMessage(openNewDisputeMessage, senderSignaturePubKey);
             } else if (message instanceof PeerOpenedDisputeMessage peerOpenedDisputeMessage) {
-                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage);
+                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage, senderSignaturePubKey);
             } else if (message instanceof ChatMessage chatMessage) {
                 onChatMessage(chatMessage, senderSignaturePubKey);
             } else if (message instanceof DisputeResultMessage disputeResultMessage) {
                 onDisputeResultMessage(disputeResultMessage, senderSignaturePubKey);
             } else if (message instanceof PeerPublishedDisputePayoutTxMessage peerPublishedDisputePayoutTxMessage) {
-                onDisputedPayoutTxMessage(peerPublishedDisputePayoutTxMessage);
+                onDisputedPayoutTxMessage(peerPublishedDisputePayoutTxMessage, senderSignaturePubKey);
             } else {
                 log.warn("Unsupported message at dispatchMessage. message={}", message);
             }
@@ -135,6 +135,12 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
     @Override
     public NodeAddress getAgentNodeAddress(Dispute dispute) {
         return null;
+    }
+
+    @Nullable
+    @Override
+    protected PubKeyRing getExpectedAgentPubKeyRing(Trade trade) {
+        return trade.getArbitratorPubKeyRing();
     }
 
     @Override
@@ -209,6 +215,12 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
         }
 
         Dispute dispute = disputeOptional.get();
+        if (!isDisputeAgentSignaturePubKeyValid(dispute,
+                senderSignaturePubKey,
+                disputeResultMessage.getClass().getSimpleName())) {
+            return;
+        }
+
         cleanupRetryMap(uid);
         if (!dispute.getChatMessages().contains(chatMessage)) {
             dispute.addAndPersistChatMessage(chatMessage);
@@ -299,7 +311,8 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
     }
 
     // Losing trader or in case of 50/50 the seller gets the tx sent from the winner or buyer
-    private void onDisputedPayoutTxMessage(PeerPublishedDisputePayoutTxMessage peerPublishedDisputePayoutTxMessage) {
+    private void onDisputedPayoutTxMessage(PeerPublishedDisputePayoutTxMessage peerPublishedDisputePayoutTxMessage,
+                                           PublicKey senderSignaturePubKey) {
         String uid = peerPublishedDisputePayoutTxMessage.getUid();
         String tradeId = peerPublishedDisputePayoutTxMessage.getTradeId();
         Optional<Dispute> disputeOptional = findOwnDispute(tradeId);
@@ -307,7 +320,8 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
             log.debug("We got a peerPublishedPayoutTxMessage but we don't have a matching dispute. TradeId = " + tradeId);
             if (!delayMsgMap.containsKey(uid)) {
                 // We delay 3 sec. to be sure the close msg gets added first
-                Timer timer = UserThread.runAfter(() -> onDisputedPayoutTxMessage(peerPublishedDisputePayoutTxMessage), 3);
+                Timer timer = UserThread.runAfter(() -> onDisputedPayoutTxMessage(peerPublishedDisputePayoutTxMessage,
+                        senderSignaturePubKey), 3);
                 delayMsgMap.put(uid, timer);
             } else {
                 log.warn("We got a peerPublishedPayoutTxMessage after we already repeated to apply the message after a delay. " +
@@ -320,6 +334,12 @@ public final class ArbitrationManager extends DisputeManager<ArbitrationDisputeL
         Contract contract = dispute.getContract();
         boolean isBuyer = pubKeyRing.equals(contract.getBuyerPubKeyRing());
         PubKeyRing peersPubKeyRing = isBuyer ? contract.getSellerPubKeyRing() : contract.getBuyerPubKeyRing();
+        if (!isSenderSignaturePubKeyExpected(senderSignaturePubKey,
+                peersPubKeyRing,
+                peerPublishedDisputePayoutTxMessage.getClass().getSimpleName(),
+                tradeId)) {
+            return;
+        }
 
         cleanupRetryMap(uid);
 

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -59,6 +59,8 @@ import org.bitcoinj.core.Coin;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import java.security.PublicKey;
+
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
@@ -105,19 +107,19 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
     }
 
     @Override
-    public void onSupportMessage(SupportMessage message) {
+    public void onSupportMessage(SupportMessage message, PublicKey senderSignaturePubKey) {
         if (canProcessMessage(message)) {
             log.info("Received {} with tradeId {} and uid {}",
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
 
-            if (message instanceof OpenNewDisputeMessage) {
-                onOpenNewDisputeMessage((OpenNewDisputeMessage) message);
-            } else if (message instanceof PeerOpenedDisputeMessage) {
-                onPeerOpenedDisputeMessage((PeerOpenedDisputeMessage) message);
-            } else if (message instanceof ChatMessage) {
-                onChatMessage((ChatMessage) message);
-            } else if (message instanceof DisputeResultMessage) {
-                onDisputeResultMessage((DisputeResultMessage) message);
+            if (message instanceof OpenNewDisputeMessage openNewDisputeMessage) {
+                onOpenNewDisputeMessage(openNewDisputeMessage);
+            } else if (message instanceof PeerOpenedDisputeMessage peerOpenedDisputeMessage) {
+                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage);
+            } else if (message instanceof ChatMessage chatMessage) {
+                onChatMessage(chatMessage, senderSignaturePubKey);
+            } else if (message instanceof DisputeResultMessage disputeResultMessage) {
+                onDisputeResultMessage(disputeResultMessage, senderSignaturePubKey);
             } else {
                 log.warn("Unsupported message at dispatchMessage. message={}", message);
             }
@@ -171,7 +173,7 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
 
     @Override
     // We get that message at both peers. The dispute object is in context of the trader
-    public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage) {
+    public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage, PublicKey senderSignaturePubKey) {
         DisputeResult disputeResult = disputeResultMessage.getDisputeResult();
         String tradeId = disputeResult.getTradeId();
         ChatMessage chatMessage = disputeResult.getChatMessage();
@@ -184,7 +186,7 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
                     "We try again after 2 sec. to apply the disputeResultMessage. TradeId = " + tradeId);
             if (!delayMsgMap.containsKey(uid)) {
                 // We delay 2 sec. to be sure the comm. msg gets added first
-                Timer timer = UserThread.runAfter(() -> onDisputeResultMessage(disputeResultMessage), 2);
+                Timer timer = UserThread.runAfter(() -> onDisputeResultMessage(disputeResultMessage, senderSignaturePubKey), 2);
                 delayMsgMap.put(uid, timer);
             } else {
                 log.warn("We got a dispute result msg after we already repeated to apply the message after a delay. " +

--- a/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/mediation/MediationManager.java
@@ -51,6 +51,7 @@ import bisq.common.UserThread;
 import bisq.common.app.Version;
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.PubKeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
 
@@ -113,9 +114,9 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
 
             if (message instanceof OpenNewDisputeMessage openNewDisputeMessage) {
-                onOpenNewDisputeMessage(openNewDisputeMessage);
+                onOpenNewDisputeMessage(openNewDisputeMessage, senderSignaturePubKey);
             } else if (message instanceof PeerOpenedDisputeMessage peerOpenedDisputeMessage) {
-                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage);
+                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage, senderSignaturePubKey);
             } else if (message instanceof ChatMessage chatMessage) {
                 onChatMessage(chatMessage, senderSignaturePubKey);
             } else if (message instanceof DisputeResultMessage disputeResultMessage) {
@@ -196,6 +197,12 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
         }
 
         Dispute dispute = disputeOptional.get();
+        if (!isDisputeAgentSignaturePubKeyValid(dispute,
+                senderSignaturePubKey,
+                disputeResultMessage.getClass().getSimpleName())) {
+            return;
+        }
+
         cleanupRetryMap(uid);
         if (!dispute.getChatMessages().contains(chatMessage)) {
             dispute.addAndPersistChatMessage(chatMessage);
@@ -238,6 +245,12 @@ public final class MediationManager extends DisputeManager<MediationDisputeList>
     @Override
     public NodeAddress getAgentNodeAddress(Dispute dispute) {
         return dispute.getContract().getMediatorNodeAddress();
+    }
+
+    @Nullable
+    @Override
+    protected PubKeyRing getExpectedAgentPubKeyRing(Trade trade) {
+        return trade.getMediatorPubKeyRing();
     }
 
     public void onAcceptMediationResult(Trade trade,

--- a/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
@@ -51,7 +51,19 @@ public abstract class DisputeMessage extends SupportMessage {
     }
 
     protected boolean isSenderSignaturePubKeyValidationRequired() {
-        return new Date().after(SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE);
+        return isSenderSignaturePubKeyValidationRequired(null);
+    }
+
+    protected boolean isSenderSignaturePubKeyValidationRequired(@Nullable Date tradeDate) {
+        return isSenderSignaturePubKeyValidationRequired(new Date(), tradeDate);
+    }
+
+    static boolean isSenderSignaturePubKeyValidationRequired(Date now, @Nullable Date tradeDate) {
+        if (!now.after(SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE)) {
+            return false;
+        }
+
+        return tradeDate == null || !tradeDate.before(SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE);
     }
 
     @Nullable

--- a/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
@@ -20,10 +20,26 @@ package bisq.core.support.dispute.messages;
 import bisq.core.support.SupportType;
 import bisq.core.support.messages.SupportMessage;
 
+import bisq.common.crypto.Sig;
+import bisq.common.proto.ProtoUtil;
+import bisq.common.util.Utilities;
+
+import com.google.protobuf.ByteString;
+
+import java.security.PublicKey;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
 
 public abstract class DisputeMessage extends SupportMessage {
     public static final long TTL = TimeUnit.DAYS.toMillis(15);
+    // Compatibility window for dispute messages sent by clients before sender_signature_pub_key existed.
+    // TODO: Once no old dispute messages are expected, remove the null handling/nullability annotations and enforce unconditionally.
+    public static final Date SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE =
+            Utilities.getUTCDate(2026, GregorianCalendar.SEPTEMBER, 1);
 
     public DisputeMessage(int messageVersion, String uid, SupportType supportType) {
         super(messageVersion, uid, supportType);
@@ -34,4 +50,17 @@ public abstract class DisputeMessage extends SupportMessage {
         return TTL;
     }
 
+    protected boolean isSenderSignaturePubKeyValidationRequired() {
+        return new Date().after(SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE);
+    }
+
+    @Nullable
+    protected static PublicKey senderSignaturePubKeyFromProto(ByteString proto) {
+        byte[] publicKeyBytes = ProtoUtil.byteArrayOrNullFromProto(proto);
+        return publicKeyBytes == null ? null : Sig.getPublicKeyFromBytes(publicKeyBytes);
+    }
+
+    protected static ByteString senderSignaturePubKeyToProto(PublicKey senderSignaturePubKey) {
+        return ByteString.copyFrom(Sig.getPublicKeyBytes(senderSignaturePubKey));
+    }
 }

--- a/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
@@ -50,11 +50,7 @@ public abstract class DisputeMessage extends SupportMessage {
         return TTL;
     }
 
-    protected boolean isSenderSignaturePubKeyValidationRequired() {
-        return isSenderSignaturePubKeyValidationRequired(null);
-    }
-
-    protected boolean isSenderSignaturePubKeyValidationRequired(@Nullable Date tradeDate) {
+    protected static boolean isSenderSignaturePubKeyValidationRequired(@Nullable Date tradeDate) {
         return isSenderSignaturePubKeyValidationRequired(new Date(), tradeDate);
     }
 
@@ -63,7 +59,12 @@ public abstract class DisputeMessage extends SupportMessage {
             return false;
         }
 
-        return tradeDate == null || !tradeDate.before(SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE);
+        // Proto3 uses 0 as the default for unset int64 fields, so treat epoch/non-positive dates as missing.
+        if (tradeDate == null || tradeDate.getTime() <= 0L) {
+            return true;
+        }
+
+        return !tradeDate.before(SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE);
     }
 
     @Nullable

--- a/core/src/main/java/bisq/core/support/dispute/messages/DisputeResultMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/DisputeResultMessage.java
@@ -21,19 +21,26 @@ import bisq.core.support.SupportType;
 import bisq.core.support.dispute.DisputeResult;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.SendersSignaturePubKeyProvidingPayload;
 
 import bisq.common.app.Version;
 
+import java.security.PublicKey;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
-public final class DisputeResultMessage extends DisputeMessage {
+public final class DisputeResultMessage extends DisputeMessage implements SendersSignaturePubKeyProvidingPayload {
     private final DisputeResult disputeResult;
     private final NodeAddress senderNodeAddress;
+    @Nullable
+    private final PublicKey senderSignaturePubKey;
 
     public DisputeResultMessage(DisputeResult disputeResult,
                                 NodeAddress senderNodeAddress,
@@ -42,8 +49,21 @@ public final class DisputeResultMessage extends DisputeMessage {
         this(disputeResult,
                 senderNodeAddress,
                 uid,
+                supportType,
+                null);
+    }
+
+    public DisputeResultMessage(DisputeResult disputeResult,
+                                NodeAddress senderNodeAddress,
+                                String uid,
+                                SupportType supportType,
+                                @Nullable PublicKey senderSignaturePubKey) {
+        this(disputeResult,
+                senderNodeAddress,
+                uid,
                 Version.getP2PMessageVersion(),
-                supportType);
+                supportType,
+                senderSignaturePubKey);
     }
 
 
@@ -55,20 +75,26 @@ public final class DisputeResultMessage extends DisputeMessage {
                                  NodeAddress senderNodeAddress,
                                  String uid,
                                  int messageVersion,
-                                 SupportType supportType) {
+                                 SupportType supportType,
+                                 @Nullable PublicKey senderSignaturePubKey) {
         super(messageVersion, uid, supportType);
         this.disputeResult = disputeResult;
         this.senderNodeAddress = senderNodeAddress;
+        this.senderSignaturePubKey = senderSignaturePubKey;
     }
 
     @Override
     public protobuf.NetworkEnvelope toProtoNetworkEnvelope() {
+        protobuf.DisputeResultMessage.Builder builder = protobuf.DisputeResultMessage.newBuilder()
+                .setDisputeResult(disputeResult.toProtoMessage())
+                .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
+                .setUid(uid)
+                .setType(SupportType.toProtoMessage(supportType));
+        if (senderSignaturePubKey != null) {
+            builder.setSenderSignaturePubKey(senderSignaturePubKeyToProto(senderSignaturePubKey));
+        }
         return getNetworkEnvelopeBuilder()
-                .setDisputeResultMessage(protobuf.DisputeResultMessage.newBuilder()
-                        .setDisputeResult(disputeResult.toProtoMessage())
-                        .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
-                        .setUid(uid)
-                        .setType(SupportType.toProtoMessage(supportType)))
+                .setDisputeResultMessage(builder)
                 .build();
     }
 
@@ -78,7 +104,8 @@ public final class DisputeResultMessage extends DisputeMessage {
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),
                 messageVersion,
-                SupportType.fromProto(proto.getType()));
+                SupportType.fromProto(proto.getType()),
+                senderSignaturePubKeyFromProto(proto.getSenderSignaturePubKey()));
     }
 
     @Override
@@ -87,10 +114,22 @@ public final class DisputeResultMessage extends DisputeMessage {
     }
 
     @Override
+    @Nullable
+    public PublicKey getSenderSignaturePubKey() {
+        return senderSignaturePubKey;
+    }
+
+    @Override
+    public boolean isSenderSignaturePubKeyRequired() {
+        return isSenderSignaturePubKeyValidationRequired();
+    }
+
+    @Override
     public String toString() {
         return "DisputeResultMessage{" +
                 "\n     disputeResult=" + disputeResult +
                 ",\n     senderNodeAddress=" + senderNodeAddress +
+                ",\n     senderSignaturePubKey=" + senderSignaturePubKey +
                 ",\n     DisputeResultMessage.uid='" + uid + '\'' +
                 ",\n     messageVersion=" + messageVersion +
                 ",\n     supportType=" + supportType +

--- a/core/src/main/java/bisq/core/support/dispute/messages/DisputeResultMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/DisputeResultMessage.java
@@ -45,17 +45,6 @@ public final class DisputeResultMessage extends DisputeMessage implements Sender
     public DisputeResultMessage(DisputeResult disputeResult,
                                 NodeAddress senderNodeAddress,
                                 String uid,
-                                SupportType supportType) {
-        this(disputeResult,
-                senderNodeAddress,
-                uid,
-                supportType,
-                null);
-    }
-
-    public DisputeResultMessage(DisputeResult disputeResult,
-                                NodeAddress senderNodeAddress,
-                                String uid,
                                 SupportType supportType,
                                 @Nullable PublicKey senderSignaturePubKey) {
         this(disputeResult,
@@ -121,7 +110,9 @@ public final class DisputeResultMessage extends DisputeMessage implements Sender
 
     @Override
     public boolean isSenderSignaturePubKeyRequired() {
-        return isSenderSignaturePubKeyValidationRequired();
+        // DisputeResultMessage has no reliable trade date before domain handling.
+        // The domain handlers authenticate the sender against the expected dispute agent key.
+        return false;
     }
 
     @Override

--- a/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
@@ -40,6 +40,8 @@ import javax.annotation.Nullable;
 public final class OpenNewDisputeMessage extends DisputeMessage implements SendersSignaturePubKeyProvidingPayload {
     private final Dispute dispute;
     private final NodeAddress senderNodeAddress;
+    @Nullable
+    private final PublicKey senderSignaturePubKey;
 
     public OpenNewDisputeMessage(Dispute dispute,
                                  NodeAddress senderNodeAddress,
@@ -49,7 +51,8 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
                 senderNodeAddress,
                 uid,
                 Version.getP2PMessageVersion(),
-                supportType);
+                supportType,
+                getDisputeOpenerSignaturePubKey(dispute));
     }
 
 
@@ -61,20 +64,26 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
                                   NodeAddress senderNodeAddress,
                                   String uid,
                                   int messageVersion,
-                                  SupportType supportType) {
+                                  SupportType supportType,
+                                  @Nullable PublicKey senderSignaturePubKey) {
         super(messageVersion, uid, supportType);
         this.dispute = dispute;
         this.senderNodeAddress = senderNodeAddress;
+        this.senderSignaturePubKey = senderSignaturePubKey;
     }
 
     @Override
     public protobuf.NetworkEnvelope toProtoNetworkEnvelope() {
+        protobuf.OpenNewDisputeMessage.Builder builder = protobuf.OpenNewDisputeMessage.newBuilder()
+                .setUid(uid)
+                .setDispute(dispute.toProtoMessage())
+                .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
+                .setType(SupportType.toProtoMessage(supportType));
+        if (senderSignaturePubKey != null) {
+            builder.setSenderSignaturePubKey(senderSignaturePubKeyToProto(senderSignaturePubKey));
+        }
         return getNetworkEnvelopeBuilder()
-                .setOpenNewDisputeMessage(protobuf.OpenNewDisputeMessage.newBuilder()
-                        .setUid(uid)
-                        .setDispute(dispute.toProtoMessage())
-                        .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
-                        .setType(SupportType.toProtoMessage(supportType)))
+                .setOpenNewDisputeMessage(builder)
                 .build();
     }
 
@@ -85,7 +94,8 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),
                 messageVersion,
-                SupportType.fromProto(proto.getType()));
+                SupportType.fromProto(proto.getType()),
+                senderSignaturePubKeyFromProto(proto.getSenderSignaturePubKey()));
     }
 
     @Override
@@ -96,6 +106,16 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
     @Override
     @Nullable
     public PublicKey getSenderSignaturePubKey() {
+        return senderSignaturePubKey;
+    }
+
+    @Override
+    public boolean isSenderSignaturePubKeyRequired() {
+        return isSenderSignaturePubKeyValidationRequired();
+    }
+
+    @Nullable
+    private static PublicKey getDisputeOpenerSignaturePubKey(@Nullable Dispute dispute) {
         Contract contract = dispute == null ? null : dispute.getContract();
         if (contract == null) {
             return null;
@@ -112,6 +132,7 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
         return "OpenNewDisputeMessage{" +
                 "\n     dispute=" + dispute +
                 ",\n     senderNodeAddress=" + senderNodeAddress +
+                ",\n     senderSignaturePubKey=" + senderSignaturePubKey +
                 ",\n     OpenNewDisputeMessage.uid='" + uid + '\'' +
                 ",\n     messageVersion=" + messageVersion +
                 ",\n     supportType=" + supportType +

--- a/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
@@ -22,15 +22,18 @@ import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.SendersSignaturePubKeyProvidingPayload;
 
 import bisq.common.app.Version;
+
+import java.security.PublicKey;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
-public final class OpenNewDisputeMessage extends DisputeMessage {
+public final class OpenNewDisputeMessage extends DisputeMessage implements SendersSignaturePubKeyProvidingPayload {
     private final Dispute dispute;
     private final NodeAddress senderNodeAddress;
 
@@ -84,6 +87,13 @@ public final class OpenNewDisputeMessage extends DisputeMessage {
     @Override
     public String getTradeId() {
         return dispute.getTradeId();
+    }
+
+    @Override
+    public PublicKey getSenderSignaturePubKey() {
+        return (dispute.isDisputeOpenerIsBuyer() ?
+                dispute.getContract().getBuyerPubKeyRing() :
+                dispute.getContract().getSellerPubKeyRing()).getSignaturePubKey();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
@@ -113,7 +113,7 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
 
     @Override
     public boolean isSenderSignaturePubKeyRequired() {
-        return isSenderSignaturePubKeyValidationRequired(getTradeDate(dispute));
+        return DisputeMessage.isSenderSignaturePubKeyValidationRequired(getTradeDate(dispute));
     }
 
     @Nullable

--- a/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
@@ -30,6 +30,8 @@ import bisq.common.crypto.PubKeyRing;
 
 import java.security.PublicKey;
 
+import java.util.Date;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
@@ -111,7 +113,7 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
 
     @Override
     public boolean isSenderSignaturePubKeyRequired() {
-        return isSenderSignaturePubKeyValidationRequired();
+        return isSenderSignaturePubKeyValidationRequired(getTradeDate(dispute));
     }
 
     @Nullable
@@ -125,6 +127,11 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
                 contract.getBuyerPubKeyRing() :
                 contract.getSellerPubKeyRing();
         return senderPubKeyRing == null ? null : senderPubKeyRing.getSignaturePubKey();
+    }
+
+    @Nullable
+    private static Date getTradeDate(@Nullable Dispute dispute) {
+        return dispute == null ? null : dispute.getTradeDate();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
@@ -20,16 +20,20 @@ package bisq.core.support.dispute.messages;
 import bisq.core.proto.CoreProtoResolver;
 import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
+import bisq.core.trade.model.bisq_v1.Contract;
 
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.SendersSignaturePubKeyProvidingPayload;
 
 import bisq.common.app.Version;
+import bisq.common.crypto.PubKeyRing;
 
 import java.security.PublicKey;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+
+import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
@@ -90,10 +94,17 @@ public final class OpenNewDisputeMessage extends DisputeMessage implements Sende
     }
 
     @Override
+    @Nullable
     public PublicKey getSenderSignaturePubKey() {
-        return (dispute.isDisputeOpenerIsBuyer() ?
-                dispute.getContract().getBuyerPubKeyRing() :
-                dispute.getContract().getSellerPubKeyRing()).getSignaturePubKey();
+        Contract contract = dispute == null ? null : dispute.getContract();
+        if (contract == null) {
+            return null;
+        }
+
+        PubKeyRing senderPubKeyRing = dispute.isDisputeOpenerIsBuyer() ?
+                contract.getBuyerPubKeyRing() :
+                contract.getSellerPubKeyRing();
+        return senderPubKeyRing == null ? null : senderPubKeyRing.getSignaturePubKey();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
@@ -25,11 +25,14 @@ import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.SendersSignaturePubKeyProvidingPayload;
 
 import bisq.common.app.Version;
+import bisq.common.crypto.PubKeyRing;
 
 import java.security.PublicKey;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+
+import javax.annotation.Nullable;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -90,8 +93,10 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
     }
 
     @Override
+    @Nullable
     public PublicKey getSenderSignaturePubKey() {
-        return dispute.getAgentPubKeyRing().getSignaturePubKey();
+        PubKeyRing agentPubKeyRing = dispute == null ? null : dispute.getAgentPubKeyRing();
+        return agentPubKeyRing == null ? null : agentPubKeyRing.getSignaturePubKey();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
@@ -112,7 +112,7 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
 
     @Override
     public boolean isSenderSignaturePubKeyRequired() {
-        return isSenderSignaturePubKeyValidationRequired(getTradeDate(dispute));
+        return DisputeMessage.isSenderSignaturePubKeyValidationRequired(getTradeDate(dispute));
     }
 
     @Nullable

--- a/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
@@ -22,15 +22,18 @@ import bisq.core.support.SupportType;
 import bisq.core.support.dispute.Dispute;
 
 import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.SendersSignaturePubKeyProvidingPayload;
 
 import bisq.common.app.Version;
+
+import java.security.PublicKey;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
-public final class PeerOpenedDisputeMessage extends DisputeMessage {
+public final class PeerOpenedDisputeMessage extends DisputeMessage implements SendersSignaturePubKeyProvidingPayload {
     private final Dispute dispute;
     private final NodeAddress senderNodeAddress;
 
@@ -84,6 +87,11 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage {
     @Override
     public String getTradeId() {
         return dispute.getTradeId();
+    }
+
+    @Override
+    public PublicKey getSenderSignaturePubKey() {
+        return dispute.getAgentPubKeyRing().getSignaturePubKey();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
@@ -29,6 +29,8 @@ import bisq.common.crypto.PubKeyRing;
 
 import java.security.PublicKey;
 
+import java.util.Date;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
@@ -110,13 +112,18 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
 
     @Override
     public boolean isSenderSignaturePubKeyRequired() {
-        return isSenderSignaturePubKeyValidationRequired();
+        return isSenderSignaturePubKeyValidationRequired(getTradeDate(dispute));
     }
 
     @Nullable
     private static PublicKey getDisputeAgentSignaturePubKey(@Nullable Dispute dispute) {
         PubKeyRing agentPubKeyRing = dispute == null ? null : dispute.getAgentPubKeyRing();
         return agentPubKeyRing == null ? null : agentPubKeyRing.getSignaturePubKey();
+    }
+
+    @Nullable
+    private static Date getTradeDate(@Nullable Dispute dispute) {
+        return dispute == null ? null : dispute.getTradeDate();
     }
 
     @Override

--- a/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
@@ -39,6 +39,8 @@ import javax.annotation.Nullable;
 public final class PeerOpenedDisputeMessage extends DisputeMessage implements SendersSignaturePubKeyProvidingPayload {
     private final Dispute dispute;
     private final NodeAddress senderNodeAddress;
+    @Nullable
+    private final PublicKey senderSignaturePubKey;
 
     public PeerOpenedDisputeMessage(Dispute dispute,
                                     NodeAddress senderNodeAddress,
@@ -48,7 +50,8 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
                 senderNodeAddress,
                 uid,
                 Version.getP2PMessageVersion(),
-                supportType);
+                supportType,
+                getDisputeAgentSignaturePubKey(dispute));
     }
 
 
@@ -60,20 +63,26 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
                                      NodeAddress senderNodeAddress,
                                      String uid,
                                      int messageVersion,
-                                     SupportType supportType) {
+                                     SupportType supportType,
+                                     @Nullable PublicKey senderSignaturePubKey) {
         super(messageVersion, uid, supportType);
         this.dispute = dispute;
         this.senderNodeAddress = senderNodeAddress;
+        this.senderSignaturePubKey = senderSignaturePubKey;
     }
 
     @Override
     public protobuf.NetworkEnvelope toProtoNetworkEnvelope() {
+        protobuf.PeerOpenedDisputeMessage.Builder builder = protobuf.PeerOpenedDisputeMessage.newBuilder()
+                .setUid(uid)
+                .setDispute(dispute.toProtoMessage())
+                .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
+                .setType(SupportType.toProtoMessage(supportType));
+        if (senderSignaturePubKey != null) {
+            builder.setSenderSignaturePubKey(senderSignaturePubKeyToProto(senderSignaturePubKey));
+        }
         return getNetworkEnvelopeBuilder()
-                .setPeerOpenedDisputeMessage(protobuf.PeerOpenedDisputeMessage.newBuilder()
-                        .setUid(uid)
-                        .setDispute(dispute.toProtoMessage())
-                        .setSenderNodeAddress(senderNodeAddress.toProtoMessage())
-                        .setType(SupportType.toProtoMessage(supportType)))
+                .setPeerOpenedDisputeMessage(builder)
                 .build();
     }
 
@@ -84,7 +93,8 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),
                 messageVersion,
-                SupportType.fromProto(proto.getType()));
+                SupportType.fromProto(proto.getType()),
+                senderSignaturePubKeyFromProto(proto.getSenderSignaturePubKey()));
     }
 
     @Override
@@ -95,6 +105,16 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
     @Override
     @Nullable
     public PublicKey getSenderSignaturePubKey() {
+        return senderSignaturePubKey;
+    }
+
+    @Override
+    public boolean isSenderSignaturePubKeyRequired() {
+        return isSenderSignaturePubKeyValidationRequired();
+    }
+
+    @Nullable
+    private static PublicKey getDisputeAgentSignaturePubKey(@Nullable Dispute dispute) {
         PubKeyRing agentPubKeyRing = dispute == null ? null : dispute.getAgentPubKeyRing();
         return agentPubKeyRing == null ? null : agentPubKeyRing.getSignaturePubKey();
     }
@@ -104,6 +124,7 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage implements Se
         return "PeerOpenedDisputeMessage{" +
                 "\n     dispute=" + dispute +
                 ",\n     senderNodeAddress=" + senderNodeAddress +
+                ",\n     senderSignaturePubKey=" + senderSignaturePubKey +
                 ",\n     PeerOpenedDisputeMessage.uid='" + uid + '\'' +
                 ",\n     messageVersion=" + messageVersion +
                 ",\n     supportType=" + supportType +

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -51,6 +51,7 @@ import bisq.common.UserThread;
 import bisq.common.app.Version;
 import bisq.common.config.Config;
 import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.PubKeyRing;
 import bisq.common.util.Hex;
 import bisq.common.util.Tuple2;
 
@@ -129,9 +130,9 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
 
             if (message instanceof OpenNewDisputeMessage openNewDisputeMessage) {
-                onOpenNewDisputeMessage(openNewDisputeMessage);
+                onOpenNewDisputeMessage(openNewDisputeMessage, senderSignaturePubKey);
             } else if (message instanceof PeerOpenedDisputeMessage peerOpenedDisputeMessage) {
-                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage);
+                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage, senderSignaturePubKey);
             } else if (message instanceof ChatMessage chatMessage) {
                 onChatMessage(chatMessage, senderSignaturePubKey);
             } else if (message instanceof DisputeResultMessage disputeResultMessage) {
@@ -213,6 +214,12 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
         }
 
         Dispute dispute = disputeOptional.get();
+        if (!isDisputeAgentSignaturePubKeyValid(dispute,
+                senderSignaturePubKey,
+                disputeResultMessage.getClass().getSimpleName())) {
+            return;
+        }
+
         cleanupRetryMap(uid);
         if (!dispute.getChatMessages().contains(chatMessage)) {
             dispute.addAndPersistChatMessage(chatMessage);
@@ -263,6 +270,12 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
     @Override
     public NodeAddress getAgentNodeAddress(Dispute dispute) {
         return dispute.getContract().getRefundAgentNodeAddress();
+    }
+
+    @Nullable
+    @Override
+    protected PubKeyRing getExpectedAgentPubKeyRing(Trade trade) {
+        return trade.getRefundAgentPubKeyRing();
     }
 
     public CompletableFuture<List<Transaction>> requestBlockchainTransactions(String makerFeeTxId,

--- a/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/refund/RefundManager.java
@@ -64,6 +64,8 @@ import org.bitcoinj.core.TransactionOutput;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import java.security.PublicKey;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -121,19 +123,19 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
     }
 
     @Override
-    public void onSupportMessage(SupportMessage message) {
+    public void onSupportMessage(SupportMessage message, PublicKey senderSignaturePubKey) {
         if (canProcessMessage(message)) {
             log.info("Received {} with tradeId {} and uid {}",
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
 
-            if (message instanceof OpenNewDisputeMessage) {
-                onOpenNewDisputeMessage((OpenNewDisputeMessage) message);
-            } else if (message instanceof PeerOpenedDisputeMessage) {
-                onPeerOpenedDisputeMessage((PeerOpenedDisputeMessage) message);
-            } else if (message instanceof ChatMessage) {
-                onChatMessage((ChatMessage) message);
-            } else if (message instanceof DisputeResultMessage) {
-                onDisputeResultMessage((DisputeResultMessage) message);
+            if (message instanceof OpenNewDisputeMessage openNewDisputeMessage) {
+                onOpenNewDisputeMessage(openNewDisputeMessage);
+            } else if (message instanceof PeerOpenedDisputeMessage peerOpenedDisputeMessage) {
+                onPeerOpenedDisputeMessage(peerOpenedDisputeMessage);
+            } else if (message instanceof ChatMessage chatMessage) {
+                onChatMessage(chatMessage, senderSignaturePubKey);
+            } else if (message instanceof DisputeResultMessage disputeResultMessage) {
+                onDisputeResultMessage(disputeResultMessage, senderSignaturePubKey);
             } else {
                 log.warn("Unsupported message at dispatchMessage. message={}", message);
             }
@@ -188,7 +190,7 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
 
     @Override
     // We get that message at both peers. The dispute object is in context of the trader
-    public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage) {
+    public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage, PublicKey senderSignaturePubKey) {
         DisputeResult disputeResult = disputeResultMessage.getDisputeResult();
         String tradeId = disputeResult.getTradeId();
         ChatMessage chatMessage = disputeResult.getChatMessage();
@@ -201,7 +203,7 @@ public final class RefundManager extends DisputeManager<RefundDisputeList> {
                     "We try again after 2 sec. to apply the disputeResultMessage. TradeId = " + tradeId);
             if (!delayMsgMap.containsKey(uid)) {
                 // We delay 2 sec. to be sure the comm. msg gets added first
-                Timer timer = UserThread.runAfter(() -> onDisputeResultMessage(disputeResultMessage), 2);
+                Timer timer = UserThread.runAfter(() -> onDisputeResultMessage(disputeResultMessage, senderSignaturePubKey), 2);
                 delayMsgMap.put(uid, timer);
             } else {
                 log.warn("We got a dispute result msg after we already repeated to apply the message after a delay. " +

--- a/core/src/main/java/bisq/core/support/traderchat/TraderChatManager.java
+++ b/core/src/main/java/bisq/core/support/traderchat/TraderChatManager.java
@@ -39,6 +39,8 @@ import javax.inject.Singleton;
 
 import javafx.collections.FXCollections;
 
+import java.security.PublicKey;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -151,12 +153,12 @@ public class TraderChatManager extends SupportManager {
         tryApplyMessages();
     }
 
-    public void onSupportMessage(SupportMessage message) {
+    public void onSupportMessage(SupportMessage message, PublicKey senderSignaturePubKey) {
         if (canProcessMessage(message)) {
             log.info("Received {} with tradeId {} and uid {}",
                     message.getClass().getSimpleName(), message.getTradeId(), message.getUid());
-            if (message instanceof ChatMessage) {
-                onChatMessage((ChatMessage) message);
+            if (message instanceof ChatMessage chatMessage) {
+                onChatMessage(chatMessage, senderSignaturePubKey);
             } else {
                 log.warn("Unsupported message at dispatchMessage. message={}", message);
             }

--- a/core/src/test/java/bisq/core/support/SupportManagerAckTest.java
+++ b/core/src/test/java/bisq/core/support/SupportManagerAckTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support;
+
+import bisq.core.btc.setup.WalletsSetup;
+import bisq.core.support.messages.ChatMessage;
+import bisq.core.support.messages.SupportMessage;
+
+import bisq.network.p2p.AckMessage;
+import bisq.network.p2p.AckMessageSourceType;
+import bisq.network.p2p.DecryptedDirectMessageListener;
+import bisq.network.p2p.DecryptedMessageWithPubKey;
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.mailbox.MailboxMessageService;
+
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.Sig;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.PublicKey;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SupportManagerAckTest {
+    private static final String TRADE_ID = "trade-id";
+    private static final String MISSING_UID = "missing-source-uid";
+    private static final NodeAddress PEER_NODE_ADDRESS = new NodeAddress("peer.onion", 9999);
+
+    @Test
+    void ackWithUnknownSourceMessageDoesNotPersistOrResolvePeerKey() {
+        P2PService p2PService = mock(P2PService.class);
+        WalletsSetup walletsSetup = mock(WalletsSetup.class);
+        when(p2PService.getMailboxMessageService()).thenReturn(mock(MailboxMessageService.class));
+        when(p2PService.isBootstrapped()).thenReturn(true);
+        when(walletsSetup.isDownloadComplete()).thenReturn(true);
+        when(walletsSetup.hasSufficientPeersForBroadcast()).thenReturn(true);
+
+        TestSupportManager manager = new TestSupportManager(p2PService, walletsSetup);
+        ArgumentCaptor<DecryptedDirectMessageListener> listenerCaptor =
+                ArgumentCaptor.forClass(DecryptedDirectMessageListener.class);
+        verify(p2PService).addDecryptedDirectMessageListener(listenerCaptor.capture());
+
+        manager.onAllServicesInitialized();
+        AckMessage ackMessage = new AckMessage(PEER_NODE_ADDRESS,
+                AckMessageSourceType.MEDIATION_MESSAGE,
+                ChatMessage.class.getSimpleName(),
+                MISSING_UID,
+                TRADE_ID,
+                true,
+                null);
+
+        listenerCaptor.getValue().onDirectMessage(
+                new DecryptedMessageWithPubKey(ackMessage, Sig.generateKeyPair().getPublic()),
+                PEER_NODE_ADDRESS);
+
+        assertEquals(0, manager.getPeerPubKeyRingCalls());
+        assertEquals(0, manager.getRequestPersistenceCalls());
+    }
+
+    private static final class TestSupportManager extends SupportManager {
+        private final AtomicInteger getPeerPubKeyRingCalls = new AtomicInteger();
+        private final AtomicInteger requestPersistenceCalls = new AtomicInteger();
+
+        private TestSupportManager(P2PService p2PService, WalletsSetup walletsSetup) {
+            super(p2PService, walletsSetup);
+        }
+
+        private int getPeerPubKeyRingCalls() {
+            return getPeerPubKeyRingCalls.get();
+        }
+
+        private int getRequestPersistenceCalls() {
+            return requestPersistenceCalls.get();
+        }
+
+        @Override
+        protected void onSupportMessage(SupportMessage networkEnvelope, PublicKey senderSignaturePubKey) {
+        }
+
+        @Override
+        public NodeAddress getPeerNodeAddress(ChatMessage message) {
+            return PEER_NODE_ADDRESS;
+        }
+
+        @Override
+        public PubKeyRing getPeerPubKeyRing(ChatMessage message) {
+            getPeerPubKeyRingCalls.incrementAndGet();
+            return null;
+        }
+
+        @Override
+        public SupportType getSupportType() {
+            return SupportType.MEDIATION;
+        }
+
+        @Override
+        public boolean channelOpen(ChatMessage message) {
+            return true;
+        }
+
+        @Override
+        public List<ChatMessage> getAllChatMessages(String tradeId) {
+            return List.of();
+        }
+
+        @Override
+        public void addAndPersistChatMessage(ChatMessage message) {
+        }
+
+        @Override
+        public void requestPersistence() {
+            requestPersistenceCalls.incrementAndGet();
+        }
+
+        @Override
+        protected AckMessageSourceType getAckMessageSourceType() {
+            return AckMessageSourceType.MEDIATION_MESSAGE;
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/support/dispute/DisputeManagerAuthTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/DisputeManagerAuthTest.java
@@ -1,0 +1,434 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support.dispute;
+
+import bisq.core.btc.setup.WalletsSetup;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.TradeWalletService;
+import bisq.core.dao.DaoFacade;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.provider.price.PriceFeedService;
+import bisq.core.support.SupportType;
+import bisq.core.support.dispute.messages.DisputeResultMessage;
+import bisq.core.support.dispute.messages.OpenNewDisputeMessage;
+import bisq.core.support.dispute.messages.PeerOpenedDisputeMessage;
+import bisq.core.support.messages.SupportMessage;
+import bisq.core.trade.ClosedTradableManager;
+import bisq.core.trade.TradeManager;
+import bisq.core.trade.bisq_v1.FailedTradesManager;
+import bisq.core.trade.model.bisq_v1.Contract;
+import bisq.core.trade.model.bisq_v1.Trade;
+
+import bisq.network.p2p.AckMessageSourceType;
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.mailbox.MailboxMessageService;
+
+import bisq.common.config.Config;
+import bisq.common.crypto.Encryption;
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.KeyStorage;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.Sig;
+
+import com.google.protobuf.Message;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import java.security.PublicKey;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DisputeManagerAuthTest {
+    private static final String TRADE_ID = "trade-id";
+    private static final String MESSAGE_CLASS_NAME = "TestDisputeMessage";
+    private static final NodeAddress PEER_NODE_ADDRESS = new NodeAddress("peer.onion", 9999);
+
+    @TempDir
+    private File keyStorageDir;
+
+    private TradeManager tradeManager;
+    private ClosedTradableManager closedTradableManager;
+    private FailedTradesManager failedTradesManager;
+    private TestDisputeManager manager;
+
+    @BeforeEach
+    void setUp() {
+        tradeManager = mock(TradeManager.class);
+        closedTradableManager = mock(ClosedTradableManager.class);
+        failedTradesManager = mock(FailedTradesManager.class);
+
+        when(tradeManager.getTradeById(anyString())).thenReturn(Optional.empty());
+        when(closedTradableManager.getClosedTrades()).thenReturn(List.of());
+        when(failedTradesManager.getTradeById(anyString())).thenReturn(Optional.empty());
+
+        P2PService p2PService = mock(P2PService.class);
+        when(p2PService.getMailboxMessageService()).thenReturn(mock(MailboxMessageService.class));
+
+        manager = new TestDisputeManager(p2PService,
+                tradeManager,
+                closedTradableManager,
+                failedTradesManager,
+                keyStorageDir);
+    }
+
+    @Test
+    void findTradeIncludesFailedTrades() {
+        PubKeyRing agentPubKeyRing = pubKeyRing();
+        Trade failedTrade = trade(TRADE_ID, agentPubKeyRing);
+        when(failedTradesManager.getTradeById(TRADE_ID)).thenReturn(Optional.of(failedTrade));
+
+        Dispute dispute = dispute(TRADE_ID, agentPubKeyRing);
+
+        assertSame(failedTrade, manager.findTrade(dispute).orElseThrow());
+    }
+
+    @Test
+    void agentSignatureAcceptsFailedTradeAgentKeyFromLocalTrade() {
+        PubKeyRing agentPubKeyRing = pubKeyRing();
+        Trade failedTrade = trade(TRADE_ID, agentPubKeyRing);
+        when(failedTradesManager.getTradeById(TRADE_ID)).thenReturn(Optional.of(failedTrade));
+
+        Dispute dispute = dispute(TRADE_ID, agentPubKeyRing);
+
+        assertTrue(manager.isAgentSignatureValid(dispute,
+                agentPubKeyRing.getSignaturePubKey(),
+                MESSAGE_CLASS_NAME));
+    }
+
+    @Test
+    void agentSignatureRejectsFailedTradeWhenDisputeAgentKeyDoesNotMatchLocalTrade() {
+        PubKeyRing localAgentPubKeyRing = pubKeyRing();
+        PubKeyRing payloadAgentPubKeyRing = pubKeyRing();
+        Trade failedTrade = trade(TRADE_ID, localAgentPubKeyRing);
+        when(failedTradesManager.getTradeById(TRADE_ID)).thenReturn(Optional.of(failedTrade));
+
+        Dispute dispute = dispute(TRADE_ID, payloadAgentPubKeyRing);
+
+        assertFalse(manager.isAgentSignatureValid(dispute,
+                localAgentPubKeyRing.getSignaturePubKey(),
+                MESSAGE_CLASS_NAME));
+    }
+
+    @Test
+    void agentSignatureRejectsUnknownTradeInsteadOfFallingBackToPayloadAgentKey() {
+        PubKeyRing payloadAgentPubKeyRing = pubKeyRing();
+        Dispute dispute = dispute(TRADE_ID, payloadAgentPubKeyRing);
+
+        assertFalse(manager.isAgentSignatureValid(dispute,
+                payloadAgentPubKeyRing.getSignaturePubKey(),
+                MESSAGE_CLASS_NAME));
+    }
+
+    @Test
+    void openNewDisputeWithInvalidOpenerSignatureDoesNotMutateDisputeList() {
+        TestDisputeList disputeList = new TestDisputeList();
+        DisputeListService<DisputeList<Dispute>> disputeListService = disputeListService(disputeList);
+        TestDisputeManager manager = new TestDisputeManager(mockP2PService(),
+                tradeManager,
+                closedTradableManager,
+                failedTradesManager,
+                keyStorageDir,
+                disputeListService);
+
+        PubKeyRing buyerPubKeyRing = pubKeyRing();
+        PubKeyRing sellerPubKeyRing = pubKeyRing();
+        PubKeyRing agentPubKeyRing = pubKeyRing();
+        Dispute dispute = dispute(TRADE_ID,
+                buyerPubKeyRing,
+                agentPubKeyRing,
+                contract(buyerPubKeyRing, sellerPubKeyRing));
+        OpenNewDisputeMessage message = new OpenNewDisputeMessage(dispute,
+                PEER_NODE_ADDRESS,
+                "open-dispute-uid",
+                SupportType.MEDIATION);
+
+        manager.onOpenNewDispute(message, pubKeyRing().getSignaturePubKey());
+
+        assertTrue(disputeList.isEmpty());
+        verify(disputeListService, never()).requestPersistence();
+    }
+
+    @Test
+    void openNewDisputeWithInvalidContractDataDoesNotMutateDisputeList() {
+        TestDisputeList disputeList = new TestDisputeList();
+        DisputeListService<DisputeList<Dispute>> disputeListService = disputeListService(disputeList);
+        TestDisputeManager manager = new TestDisputeManager(mockP2PService(),
+                tradeManager,
+                closedTradableManager,
+                failedTradesManager,
+                keyStorageDir,
+                disputeListService);
+
+        PubKeyRing buyerPubKeyRing = pubKeyRing();
+        PubKeyRing sellerPubKeyRing = pubKeyRing();
+        PubKeyRing agentPubKeyRing = pubKeyRing();
+        Dispute dispute = dispute(TRADE_ID,
+                buyerPubKeyRing,
+                agentPubKeyRing,
+                contract(buyerPubKeyRing, sellerPubKeyRing));
+        OpenNewDisputeMessage message = new OpenNewDisputeMessage(dispute,
+                PEER_NODE_ADDRESS,
+                "open-dispute-uid",
+                SupportType.MEDIATION);
+
+        manager.onOpenNewDispute(message, buyerPubKeyRing.getSignaturePubKey());
+
+        assertTrue(disputeList.isEmpty());
+        assertFalse(manager.getValidationExceptions().isEmpty());
+        verify(disputeListService, never()).requestPersistence();
+    }
+
+    @Test
+    void peerOpenedDisputeWithMismatchedAgentKeyDoesNotMutateDisputeList() {
+        TestDisputeList disputeList = new TestDisputeList();
+        DisputeListService<DisputeList<Dispute>> disputeListService = disputeListService(disputeList);
+        TestDisputeManager manager = new TestDisputeManager(mockP2PService(),
+                tradeManager,
+                closedTradableManager,
+                failedTradesManager,
+                keyStorageDir,
+                disputeListService);
+
+        PubKeyRing localAgentPubKeyRing = pubKeyRing();
+        PubKeyRing payloadAgentPubKeyRing = pubKeyRing();
+        Trade localTrade = trade(TRADE_ID, localAgentPubKeyRing);
+        when(tradeManager.getTradeById(TRADE_ID)).thenReturn(Optional.of(localTrade));
+
+        Dispute dispute = dispute(TRADE_ID, payloadAgentPubKeyRing);
+        PeerOpenedDisputeMessage message = new PeerOpenedDisputeMessage(dispute,
+                PEER_NODE_ADDRESS,
+                "peer-opened-dispute-uid",
+                SupportType.MEDIATION);
+
+        manager.onPeerOpenedDispute(message, localAgentPubKeyRing.getSignaturePubKey());
+
+        assertTrue(disputeList.isEmpty());
+        verify(disputeListService, never()).requestPersistence();
+    }
+
+    private static Trade trade(String tradeId, PubKeyRing mediatorPubKeyRing) {
+        Trade trade = mock(Trade.class);
+        when(trade.getId()).thenReturn(tradeId);
+        when(trade.getMediatorPubKeyRing()).thenReturn(mediatorPubKeyRing);
+        return trade;
+    }
+
+    private static Dispute dispute(String tradeId, PubKeyRing agentPubKeyRing) {
+        return dispute(tradeId, pubKeyRing(), agentPubKeyRing, null);
+    }
+
+    private static Dispute dispute(String tradeId,
+                                   PubKeyRing traderPubKeyRing,
+                                   PubKeyRing agentPubKeyRing,
+                                   Contract contract) {
+        return new Dispute(
+                0,
+                tradeId,
+                0,
+                true,
+                true,
+                traderPubKeyRing,
+                0,
+                0,
+                contract,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "",
+                null,
+                null,
+                agentPubKeyRing,
+                false,
+                SupportType.MEDIATION);
+    }
+
+    private static Contract contract(PubKeyRing buyerPubKeyRing, PubKeyRing sellerPubKeyRing) {
+        return new Contract(
+                null,
+                0,
+                0,
+                "takerFeeTxId",
+                new NodeAddress("buyer.onion", 9999),
+                new NodeAddress("seller.onion", 9999),
+                PEER_NODE_ADDRESS,
+                true,
+                "makerAccountId",
+                "takerAccountId",
+                null,
+                null,
+                buyerPubKeyRing,
+                sellerPubKeyRing,
+                "makerPayoutAddress",
+                "takerPayoutAddress",
+                new byte[33],
+                new byte[33],
+                0,
+                PEER_NODE_ADDRESS,
+                null,
+                null,
+                PaymentMethod.SEPA_ID,
+                PaymentMethod.SEPA_ID,
+                0);
+    }
+
+    private static PubKeyRing pubKeyRing() {
+        return new PubKeyRing(Sig.generateKeyPair().getPublic(),
+                Encryption.generateKeyPair().getPublic());
+    }
+
+    private static P2PService mockP2PService() {
+        P2PService p2PService = mock(P2PService.class);
+        when(p2PService.getMailboxMessageService()).thenReturn(mock(MailboxMessageService.class));
+        return p2PService;
+    }
+
+    private static DisputeListService<DisputeList<Dispute>> disputeListService() {
+        return disputeListService(new TestDisputeList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static DisputeListService<DisputeList<Dispute>> disputeListService(DisputeList<Dispute> disputeList) {
+        DisputeListService<DisputeList<Dispute>> disputeListService = mock(DisputeListService.class);
+        when(disputeListService.getDisputeList()).thenReturn(disputeList);
+        return disputeListService;
+    }
+
+    private static final class TestDisputeList extends DisputeList<Dispute> {
+        @Override
+        public Message toProtoMessage() {
+            return protobuf.PersistableEnvelope.newBuilder().build();
+        }
+    }
+
+    private static final class TestDisputeManager extends DisputeManager<DisputeList<Dispute>> {
+        private TestDisputeManager(P2PService p2PService,
+                                   TradeManager tradeManager,
+                                   ClosedTradableManager closedTradableManager,
+                                   FailedTradesManager failedTradesManager,
+                                   File keyStorageDir) {
+            this(p2PService, tradeManager, closedTradableManager, failedTradesManager, keyStorageDir, disputeListService());
+        }
+
+        private TestDisputeManager(P2PService p2PService,
+                                   TradeManager tradeManager,
+                                   ClosedTradableManager closedTradableManager,
+                                   FailedTradesManager failedTradesManager,
+                                   File keyStorageDir,
+                                   DisputeListService<DisputeList<Dispute>> disputeListService) {
+            super(p2PService,
+                    mock(TradeWalletService.class),
+                    mock(BtcWalletService.class),
+                    mock(WalletsSetup.class),
+                    tradeManager,
+                    closedTradableManager,
+                    failedTradesManager,
+                    mock(OpenOfferManager.class),
+                    mock(DaoFacade.class),
+                    new KeyRing(new KeyStorage(keyStorageDir)),
+                    disputeListService,
+                    mock(Config.class),
+                    mock(PriceFeedService.class));
+        }
+
+        private boolean isAgentSignatureValid(Dispute dispute,
+                                              PublicKey senderSignaturePubKey,
+                                              String messageClassName) {
+            return isDisputeAgentSignaturePubKeyValid(dispute, senderSignaturePubKey, messageClassName);
+        }
+
+        private void onOpenNewDispute(OpenNewDisputeMessage openNewDisputeMessage,
+                                      PublicKey senderSignaturePubKey) {
+            onOpenNewDisputeMessage(openNewDisputeMessage, senderSignaturePubKey);
+        }
+
+        private void onPeerOpenedDispute(PeerOpenedDisputeMessage peerOpenedDisputeMessage,
+                                         PublicKey senderSignaturePubKey) {
+            onPeerOpenedDisputeMessage(peerOpenedDisputeMessage, senderSignaturePubKey);
+        }
+
+        @Override
+        protected void onSupportMessage(SupportMessage networkEnvelope, PublicKey senderSignaturePubKey) {
+        }
+
+        @Override
+        public void onDisputeResultMessage(DisputeResultMessage disputeResultMessage, PublicKey senderSignaturePubKey) {
+        }
+
+        @Override
+        public NodeAddress getAgentNodeAddress(Dispute dispute) {
+            return null;
+        }
+
+        @Override
+        protected PubKeyRing getExpectedAgentPubKeyRing(Trade trade) {
+            return trade.getMediatorPubKeyRing();
+        }
+
+        @Override
+        protected Trade.DisputeState getDisputeStateStartedByPeer() {
+            return Trade.DisputeState.MEDIATION_STARTED_BY_PEER;
+        }
+
+        @Override
+        public void cleanupDisputes() {
+        }
+
+        @Override
+        protected String getDisputeInfo(Dispute dispute) {
+            return "";
+        }
+
+        @Override
+        protected String getDisputeIntroForPeer(String disputeInfo) {
+            return "";
+        }
+
+        @Override
+        protected String getDisputeIntroForDisputeCreator(String disputeInfo) {
+            return "";
+        }
+
+        @Override
+        public SupportType getSupportType() {
+            return SupportType.MEDIATION;
+        }
+
+        @Override
+        protected AckMessageSourceType getAckMessageSourceType() {
+            return AckMessageSourceType.MEDIATION_MESSAGE;
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/support/dispute/mediation/MediationManagerAuthTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/mediation/MediationManagerAuthTest.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support.dispute.mediation;
+
+import bisq.core.btc.setup.WalletsSetup;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.TradeWalletService;
+import bisq.core.dao.DaoFacade;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.provider.price.PriceFeedService;
+import bisq.core.support.SupportType;
+import bisq.core.support.dispute.Dispute;
+import bisq.core.support.dispute.DisputeResult;
+import bisq.core.support.dispute.messages.DisputeResultMessage;
+import bisq.core.support.messages.ChatMessage;
+import bisq.core.trade.ClosedTradableManager;
+import bisq.core.trade.TradeManager;
+import bisq.core.trade.bisq_v1.FailedTradesManager;
+import bisq.core.trade.model.bisq_v1.Trade;
+
+import bisq.network.p2p.NodeAddress;
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.mailbox.MailboxMessageService;
+
+import bisq.common.config.Config;
+import bisq.common.crypto.Encryption;
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.KeyStorage;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.Sig;
+import bisq.common.persistence.PersistenceManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MediationManagerAuthTest {
+    private static final String TRADE_ID = "trade-id";
+    private static final int TRADER_ID = 0;
+    private static final NodeAddress PEER_NODE_ADDRESS = new NodeAddress("peer.onion", 9999);
+
+    @TempDir
+    private File keyStorageDir;
+
+    @Test
+    void disputeResultSignedByNonAgentDoesNotMutateDispute() {
+        PersistenceManager<MediationDisputeList> persistenceManager = persistenceManager();
+        MediationDisputeListService disputeListService = new MediationDisputeListService(persistenceManager);
+
+        PubKeyRing expectedAgentPubKeyRing = pubKeyRing();
+        PubKeyRing nonAgentPubKeyRing = pubKeyRing();
+        Dispute dispute = dispute(expectedAgentPubKeyRing);
+        disputeListService.getDisputeList().add(dispute);
+
+        TradeManager tradeManager = tradeManager(expectedAgentPubKeyRing);
+        MediationManager manager = mediationManager(tradeManager, disputeListService);
+
+        ChatMessage chatMessage = new ChatMessage(SupportType.MEDIATION,
+                TRADE_ID,
+                TRADER_ID,
+                false,
+                "result",
+                PEER_NODE_ADDRESS);
+        DisputeResult disputeResult = new DisputeResult(TRADE_ID, TRADER_ID);
+        disputeResult.setChatMessage(chatMessage);
+        DisputeResultMessage message = new DisputeResultMessage(disputeResult,
+                PEER_NODE_ADDRESS,
+                "dispute-result-uid",
+                SupportType.MEDIATION);
+
+        manager.onDisputeResultMessage(message, nonAgentPubKeyRing.getSignaturePubKey());
+
+        assertFalse(dispute.getChatMessages().contains(chatMessage));
+        assertFalse(dispute.isResultProposed());
+        verify(persistenceManager, never()).requestPersistence();
+    }
+
+    private MediationManager mediationManager(TradeManager tradeManager,
+                                             MediationDisputeListService disputeListService) {
+        return new MediationManager(mockP2PService(),
+                mock(TradeWalletService.class),
+                mock(BtcWalletService.class),
+                mock(WalletsSetup.class),
+                tradeManager,
+                closedTradableManager(),
+                failedTradesManager(),
+                mock(OpenOfferManager.class),
+                mock(DaoFacade.class),
+                new KeyRing(new KeyStorage(keyStorageDir)),
+                disputeListService,
+                mock(Config.class),
+                mock(PriceFeedService.class));
+    }
+
+    private static TradeManager tradeManager(PubKeyRing expectedAgentPubKeyRing) {
+        Trade localTrade = mock(Trade.class);
+        when(localTrade.getMediatorPubKeyRing()).thenReturn(expectedAgentPubKeyRing);
+
+        TradeManager tradeManager = mock(TradeManager.class);
+        when(tradeManager.getTradeById(TRADE_ID)).thenReturn(Optional.of(localTrade));
+        return tradeManager;
+    }
+
+    private static ClosedTradableManager closedTradableManager() {
+        ClosedTradableManager closedTradableManager = mock(ClosedTradableManager.class);
+        when(closedTradableManager.getClosedTrades()).thenReturn(List.of());
+        return closedTradableManager;
+    }
+
+    private static FailedTradesManager failedTradesManager() {
+        FailedTradesManager failedTradesManager = mock(FailedTradesManager.class);
+        when(failedTradesManager.getTradeById(anyString())).thenReturn(Optional.empty());
+        return failedTradesManager;
+    }
+
+    private static P2PService mockP2PService() {
+        P2PService p2PService = mock(P2PService.class);
+        when(p2PService.getMailboxMessageService()).thenReturn(mock(MailboxMessageService.class));
+        return p2PService;
+    }
+
+    private static Dispute dispute(PubKeyRing agentPubKeyRing) {
+        return new Dispute(
+                0,
+                TRADE_ID,
+                TRADER_ID,
+                true,
+                true,
+                pubKeyRing(),
+                0,
+                0,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "",
+                null,
+                null,
+                agentPubKeyRing,
+                false,
+                SupportType.MEDIATION);
+    }
+
+    private static PubKeyRing pubKeyRing() {
+        return new PubKeyRing(Sig.generateKeyPair().getPublic(),
+                Encryption.generateKeyPair().getPublic());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static PersistenceManager<MediationDisputeList> persistenceManager() {
+        return mock(PersistenceManager.class);
+    }
+}

--- a/core/src/test/java/bisq/core/support/dispute/mediation/MediationManagerAuthTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/mediation/MediationManagerAuthTest.java
@@ -92,7 +92,8 @@ class MediationManagerAuthTest {
         DisputeResultMessage message = new DisputeResultMessage(disputeResult,
                 PEER_NODE_ADDRESS,
                 "dispute-result-uid",
-                SupportType.MEDIATION);
+                SupportType.MEDIATION,
+                null);
 
         manager.onDisputeResultMessage(message, nonAgentPubKeyRing.getSignaturePubKey());
 

--- a/core/src/test/java/bisq/core/support/dispute/messages/DisputeMessageTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/messages/DisputeMessageTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support.dispute.messages;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DisputeMessageTest {
+    @Test
+    public void senderSignaturePubKeyValidationIsNotRequiredBeforeActivation() {
+        Date beforeActivation = new Date(DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE.getTime() - 1);
+
+        assertFalse(DisputeMessage.isSenderSignaturePubKeyValidationRequired(beforeActivation, null));
+        assertFalse(DisputeMessage.isSenderSignaturePubKeyValidationRequired(beforeActivation, beforeActivation));
+    }
+
+    @Test
+    public void senderSignaturePubKeyValidationIsNotRequiredAfterActivationForPreActivationTrade() {
+        Date beforeActivation = new Date(DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE.getTime() - 1);
+        Date afterActivation = new Date(DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE.getTime() + 1);
+
+        assertFalse(DisputeMessage.isSenderSignaturePubKeyValidationRequired(afterActivation, beforeActivation));
+    }
+
+    @Test
+    public void senderSignaturePubKeyValidationIsRequiredAfterActivationWhenTradeDateIsMissing() {
+        Date afterActivation = new Date(DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE.getTime() + 1);
+
+        assertTrue(DisputeMessage.isSenderSignaturePubKeyValidationRequired(afterActivation, null));
+    }
+
+    @Test
+    public void senderSignaturePubKeyValidationIsRequiredAfterActivationForActivationOrLaterTrade() {
+        Date activation = DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE;
+        Date afterActivation = new Date(activation.getTime() + 1);
+
+        assertTrue(DisputeMessage.isSenderSignaturePubKeyValidationRequired(afterActivation, activation));
+        assertTrue(DisputeMessage.isSenderSignaturePubKeyValidationRequired(afterActivation, afterActivation));
+    }
+}

--- a/core/src/test/java/bisq/core/support/dispute/messages/DisputeMessageTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/messages/DisputeMessageTest.java
@@ -49,6 +49,21 @@ public class DisputeMessageTest {
     }
 
     @Test
+    public void senderSignaturePubKeyValidationIsRequiredAfterActivationWhenTradeDateIsUnsetProtoDefault() {
+        Date afterActivation = new Date(DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE.getTime() + 1);
+
+        assertTrue(DisputeMessage.isSenderSignaturePubKeyValidationRequired(afterActivation, new Date(0)));
+    }
+
+    @Test
+    public void senderSignaturePubKeyValidationIsNotRequiredAtActivationInstant() {
+        Date activation = DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE;
+
+        assertFalse(DisputeMessage.isSenderSignaturePubKeyValidationRequired(activation, null));
+        assertFalse(DisputeMessage.isSenderSignaturePubKeyValidationRequired(activation, activation));
+    }
+
+    @Test
     public void senderSignaturePubKeyValidationIsRequiredAfterActivationForActivationOrLaterTrade() {
         Date activation = DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE;
         Date afterActivation = new Date(activation.getTime() + 1);

--- a/core/src/test/java/bisq/core/support/dispute/messages/DisputeOpenMessageTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/messages/DisputeOpenMessageTest.java
@@ -1,0 +1,223 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support.dispute.messages;
+
+import bisq.core.offer.OfferDirection;
+import bisq.core.offer.bisq_v1.OfferPayload;
+import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.proto.CoreProtoResolver;
+import bisq.core.support.SupportType;
+import bisq.core.support.dispute.Dispute;
+import bisq.core.trade.model.bisq_v1.Contract;
+
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.crypto.Encryption;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.Sig;
+
+import java.security.PublicKey;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+public class DisputeOpenMessageTest {
+    private static final String TRADE_ID = "trade-id";
+    private static final int TRADER_ID = 0;
+    private static final NodeAddress SENDER_NODE_ADDRESS = new NodeAddress("sender.onion", 9999);
+    private static final NodeAddress BUYER_NODE_ADDRESS = new NodeAddress("buyer.onion", 9999);
+    private static final NodeAddress SELLER_NODE_ADDRESS = new NodeAddress("seller.onion", 9999);
+    private static final NodeAddress MEDIATOR_NODE_ADDRESS = new NodeAddress("mediator.onion", 9999);
+
+    @Test
+    public void openNewDisputeMessageRoundTripPreservesSenderSignaturePubKey() {
+        PubKeyRing buyerPubKeyRing = pubKeyRing();
+        OpenNewDisputeMessage message = new OpenNewDisputeMessage(dispute(buyerPubKeyRing, pubKeyRing(), pubKeyRing()),
+                SENDER_NODE_ADDRESS,
+                "uid",
+                SupportType.MEDIATION);
+
+        protobuf.OpenNewDisputeMessage proto = message.toProtoNetworkEnvelope().getOpenNewDisputeMessage();
+        OpenNewDisputeMessage fromProto = OpenNewDisputeMessage.fromProto(proto, mock(CoreProtoResolver.class), 1);
+
+        assertFalse(proto.getSenderSignaturePubKey().isEmpty());
+        assertPublicKeysEqual(buyerPubKeyRing.getSignaturePubKey(), fromProto.getSenderSignaturePubKey());
+    }
+
+    @Test
+    public void openNewDisputeMessageFromProtoKeepsMissingSenderSignaturePubKeyAsNull() {
+        OpenNewDisputeMessage message = new OpenNewDisputeMessage(dispute(pubKeyRing(), pubKeyRing(), pubKeyRing()),
+                SENDER_NODE_ADDRESS,
+                "uid",
+                SupportType.MEDIATION);
+        protobuf.OpenNewDisputeMessage proto = message.toProtoNetworkEnvelope()
+                .getOpenNewDisputeMessage()
+                .toBuilder()
+                .clearSenderSignaturePubKey()
+                .build();
+
+        OpenNewDisputeMessage fromProto = OpenNewDisputeMessage.fromProto(proto, mock(CoreProtoResolver.class), 1);
+
+        assertNull(fromProto.getSenderSignaturePubKey());
+    }
+
+    @Test
+    public void peerOpenedDisputeMessageRoundTripPreservesSenderSignaturePubKey() {
+        PubKeyRing agentPubKeyRing = pubKeyRing();
+        PeerOpenedDisputeMessage message = new PeerOpenedDisputeMessage(dispute(pubKeyRing(), pubKeyRing(), agentPubKeyRing),
+                SENDER_NODE_ADDRESS,
+                "uid",
+                SupportType.MEDIATION);
+
+        protobuf.PeerOpenedDisputeMessage proto = message.toProtoNetworkEnvelope().getPeerOpenedDisputeMessage();
+        PeerOpenedDisputeMessage fromProto = PeerOpenedDisputeMessage.fromProto(proto, mock(CoreProtoResolver.class), 1);
+
+        assertFalse(proto.getSenderSignaturePubKey().isEmpty());
+        assertPublicKeysEqual(agentPubKeyRing.getSignaturePubKey(), fromProto.getSenderSignaturePubKey());
+    }
+
+    @Test
+    public void peerOpenedDisputeMessageFromProtoKeepsMissingSenderSignaturePubKeyAsNull() {
+        PeerOpenedDisputeMessage message = new PeerOpenedDisputeMessage(dispute(pubKeyRing(), pubKeyRing(), pubKeyRing()),
+                SENDER_NODE_ADDRESS,
+                "uid",
+                SupportType.MEDIATION);
+        protobuf.PeerOpenedDisputeMessage proto = message.toProtoNetworkEnvelope()
+                .getPeerOpenedDisputeMessage()
+                .toBuilder()
+                .clearSenderSignaturePubKey()
+                .build();
+
+        PeerOpenedDisputeMessage fromProto = PeerOpenedDisputeMessage.fromProto(proto, mock(CoreProtoResolver.class), 1);
+
+        assertNull(fromProto.getSenderSignaturePubKey());
+    }
+
+    private static Dispute dispute(PubKeyRing buyerPubKeyRing,
+                                   PubKeyRing sellerPubKeyRing,
+                                   PubKeyRing agentPubKeyRing) {
+        return new Dispute(
+                0,
+                TRADE_ID,
+                TRADER_ID,
+                true,
+                true,
+                buyerPubKeyRing,
+                DisputeMessage.SENDER_SIGNATURE_PUB_KEY_VALIDATION_ACTIVATION_DATE.getTime() + 1,
+                0,
+                contract(buyerPubKeyRing, sellerPubKeyRing),
+                null,
+                null,
+                null,
+                null,
+                null,
+                "",
+                null,
+                null,
+                agentPubKeyRing,
+                false,
+                SupportType.MEDIATION);
+    }
+
+    private static Contract contract(PubKeyRing buyerPubKeyRing, PubKeyRing sellerPubKeyRing) {
+        return new Contract(
+                offerPayload(buyerPubKeyRing),
+                1_000_000L,
+                50_000_000L,
+                "takerFeeTxId",
+                BUYER_NODE_ADDRESS,
+                SELLER_NODE_ADDRESS,
+                MEDIATOR_NODE_ADDRESS,
+                true,
+                "makerAccountId",
+                "takerAccountId",
+                null,
+                null,
+                buyerPubKeyRing,
+                sellerPubKeyRing,
+                "makerPayoutAddress",
+                "takerPayoutAddress",
+                new byte[33],
+                new byte[33],
+                0,
+                MEDIATOR_NODE_ADDRESS,
+                null,
+                null,
+                PaymentMethod.SEPA_ID,
+                PaymentMethod.SEPA_ID,
+                0);
+    }
+
+    private static OfferPayload offerPayload(PubKeyRing makerPubKeyRing) {
+        return new OfferPayload("offer-id",
+                1_700_000_000_000L,
+                BUYER_NODE_ADDRESS,
+                makerPubKeyRing,
+                OfferDirection.SELL,
+                50_000_000L,
+                0,
+                false,
+                1_000_000L,
+                1_000_000L,
+                "BTC",
+                "EUR",
+                List.of(),
+                List.of(MEDIATOR_NODE_ADDRESS),
+                PaymentMethod.SEPA_ID,
+                "makerPaymentAccountId",
+                "offerFeePaymentTxId",
+                null,
+                null,
+                null,
+                null,
+                "1.9.9",
+                123_456L,
+                1_000L,
+                2_000L,
+                true,
+                3_000L,
+                4_000L,
+                5_000L,
+                6_000L,
+                false,
+                false,
+                0,
+                0,
+                false,
+                null,
+                null,
+                4);
+    }
+
+    private static PubKeyRing pubKeyRing() {
+        return new PubKeyRing(Sig.generateKeyPair().getPublic(),
+                Encryption.generateKeyPair().getPublic());
+    }
+
+    private static void assertPublicKeysEqual(PublicKey expected, PublicKey actual) {
+        assertNotNull(actual);
+        assertArrayEquals(Sig.getPublicKeyBytes(expected), Sig.getPublicKeyBytes(actual));
+    }
+}

--- a/core/src/test/java/bisq/core/support/dispute/messages/DisputeResultMessageTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/messages/DisputeResultMessageTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.support.dispute.messages;
+
+import bisq.core.support.SupportType;
+import bisq.core.support.dispute.DisputeResult;
+import bisq.core.support.messages.ChatMessage;
+
+import bisq.network.p2p.NodeAddress;
+
+import bisq.common.crypto.Sig;
+
+import java.security.PublicKey;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class DisputeResultMessageTest {
+    private static final String TRADE_ID = "trade-id";
+    private static final int TRADER_ID = 1;
+    private static final NodeAddress SENDER_NODE_ADDRESS = new NodeAddress("peer.onion", 9999);
+
+    @Test
+    public void toProtoAndFromProtoPreservesSenderSignaturePubKey() {
+        PublicKey senderSignaturePubKey = Sig.generateKeyPair().getPublic();
+        DisputeResultMessage message = new DisputeResultMessage(disputeResult(),
+                SENDER_NODE_ADDRESS,
+                "uid",
+                SupportType.MEDIATION,
+                senderSignaturePubKey);
+
+        protobuf.DisputeResultMessage proto = message.toProtoNetworkEnvelope().getDisputeResultMessage();
+        DisputeResultMessage fromProto = DisputeResultMessage.fromProto(proto, 1);
+        PublicKey parsedSenderSignaturePubKey = fromProto.getSenderSignaturePubKey();
+
+        assertFalse(proto.getSenderSignaturePubKey().isEmpty());
+        assertNotNull(parsedSenderSignaturePubKey);
+        assertArrayEquals(Sig.getPublicKeyBytes(senderSignaturePubKey),
+                Sig.getPublicKeyBytes(parsedSenderSignaturePubKey));
+    }
+
+    @Test
+    public void fromProtoKeepsMissingSenderSignaturePubKeyAsNull() {
+        protobuf.DisputeResultMessage proto = protobuf.DisputeResultMessage.newBuilder()
+                .setUid("uid")
+                .setDisputeResult(disputeResult().toProtoMessage())
+                .setSenderNodeAddress(SENDER_NODE_ADDRESS.toProtoMessage())
+                .setType(SupportType.toProtoMessage(SupportType.MEDIATION))
+                .build();
+
+        DisputeResultMessage fromProto = DisputeResultMessage.fromProto(proto, 1);
+
+        assertNull(fromProto.getSenderSignaturePubKey());
+    }
+
+    private static DisputeResult disputeResult() {
+        ChatMessage chatMessage = new ChatMessage(SupportType.MEDIATION,
+                TRADE_ID,
+                TRADER_ID,
+                false,
+                "result",
+                SENDER_NODE_ADDRESS);
+        DisputeResult disputeResult = new DisputeResult(TRADE_ID, TRADER_ID);
+        disputeResult.setChatMessage(chatMessage);
+        return disputeResult;
+    }
+}

--- a/core/src/test/java/bisq/core/support/dispute/messages/DisputeResultMessageTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/messages/DisputeResultMessageTest.java
@@ -72,6 +72,17 @@ public class DisputeResultMessageTest {
         assertNull(fromProto.getSenderSignaturePubKey());
     }
 
+    @Test
+    public void senderSignaturePubKeyIsAdvisoryForDisputeResultMessage() {
+        DisputeResultMessage message = new DisputeResultMessage(disputeResult(),
+                SENDER_NODE_ADDRESS,
+                "uid",
+                SupportType.MEDIATION,
+                null);
+
+        assertFalse(message.isSenderSignaturePubKeyRequired());
+    }
+
     private static DisputeResult disputeResult() {
         ChatMessage chatMessage = new ChatMessage(SupportType.MEDIATION,
                 TRADE_ID,

--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -416,7 +416,8 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
         PublicKey payloadSenderSignaturePubKey = signaturePubKeyProvidingPayload.getSenderSignaturePubKey();
         PublicKey signaturePubKey = decryptedMsg.getSignaturePubKey();
         if (!SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(payloadSenderSignaturePubKey,
-                signaturePubKey)) {
+                signaturePubKey,
+                signaturePubKeyProvidingPayload.isSenderSignaturePubKeyRequired())) {
             log.error("Sender signature pubkey of decrypted payload {} does not match signature pubkey " +
                             "of sealed payload {}",
                     payloadSenderSignaturePubKey, signaturePubKey);
@@ -519,7 +520,8 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
             PublicKey mySignaturePubKey = keyRing.getSignatureKeyPair().getPublic();
             PublicKey senderSignaturePubKey = signaturePubKeyProvidingPayload.getSenderSignaturePubKey();
             if (!SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(senderSignaturePubKey,
-                    mySignaturePubKey)) {
+                    mySignaturePubKey,
+                    signaturePubKeyProvidingPayload.isSenderSignaturePubKeyRequired())) {
                 log.error("Sender signature pubkey {} does not match my signature pubkey {}",
                         senderSignaturePubKey, mySignaturePubKey);
                 sendDirectMessageListener.onFault("Sender signature pubkey of payload is not matching our signature " +

--- a/p2p/src/main/java/bisq/network/p2p/SendersSignaturePubKeyProvidingPayload.java
+++ b/p2p/src/main/java/bisq/network/p2p/SendersSignaturePubKeyProvidingPayload.java
@@ -25,11 +25,21 @@ import javax.annotation.Nullable;
  * Interface for payloads that include the sender's signature public key.
  */
 public interface SendersSignaturePubKeyProvidingPayload {
+    @Nullable
     PublicKey getSenderSignaturePubKey();
 
+    default boolean isSenderSignaturePubKeyRequired() {
+        return true;
+    }
+
     static boolean isSenderSignaturePubKeyMatching(@Nullable PublicKey payloadSenderSignaturePubKey,
-                                                   @Nullable PublicKey expectedSenderSignaturePubKey) {
-        return payloadSenderSignaturePubKey != null &&
+                                                   @Nullable PublicKey expectedSenderSignaturePubKey,
+                                                   boolean senderSignaturePubKeyRequired) {
+        if (payloadSenderSignaturePubKey == null) {
+            return !senderSignaturePubKeyRequired;
+        }
+
+        return expectedSenderSignaturePubKey != null &&
                 payloadSenderSignaturePubKey.equals(expectedSenderSignaturePubKey);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxItem.java
+++ b/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxItem.java
@@ -117,7 +117,8 @@ public class MailboxItem implements PersistablePayload {
             PublicKey payloadSenderSignaturePubKey = signaturePubKeyProvidingPayload.getSenderSignaturePubKey();
             PublicKey signaturePubKey = decryptedMessageWithPubKey.getSignaturePubKey();
             if (!SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(payloadSenderSignaturePubKey,
-                    signaturePubKey)) {
+                    signaturePubKey,
+                    signaturePubKeyProvidingPayload.isSenderSignaturePubKeyRequired())) {
                 log.error("Decrypted mailbox item sender signature pubkey mismatch. " +
                                 "payloadSenderSignaturePubKey={}, sealedPayloadSignaturePubKey={}",
                         payloadSenderSignaturePubKey, signaturePubKey);

--- a/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxMessageService.java
+++ b/p2p/src/main/java/bisq/network/p2p/mailbox/MailboxMessageService.java
@@ -323,7 +323,8 @@ public class MailboxMessageService implements HashMapChangedListener, PersistedD
             PublicKey mySignaturePubKey = keyRing.getSignatureKeyPair().getPublic();
             PublicKey senderSignaturePubKey = signaturePubKeyProvidingPayload.getSenderSignaturePubKey();
             if (!SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(senderSignaturePubKey,
-                    mySignaturePubKey)) {
+                    mySignaturePubKey,
+                    signaturePubKeyProvidingPayload.isSenderSignaturePubKeyRequired())) {
                 log.error("Sender signature pubkey {} does not match my signature pubkey {}",
                         senderSignaturePubKey, mySignaturePubKey);
                 sendMailboxMessageListener.onFault("Sender signature pubkey of payload is not matching our signature " +

--- a/p2p/src/test/java/bisq/network/p2p/P2PServiceTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/P2PServiceTest.java
@@ -136,6 +136,23 @@ public class P2PServiceTest {
     }
 
     @Test
+    public void onMessageDispatchesDirectMessageWhenPayloadSenderSignaturePubKeyIsMissingButNotRequired()
+            throws Exception {
+        DirectReceiveFixture fixture = new DirectReceiveFixture(
+                new MockSignaturePubKeyProvidingMailboxPayload("msg", ENVELOPE_SENDER, null, false),
+                ENVELOPE_SENDER,
+                ENVELOPE_SENDER);
+        AtomicReference<NetworkEnvelope> receivedMessage = new AtomicReference<>();
+        fixture.p2PService.addDecryptedDirectMessageListener((decryptedMessageWithPubKey, senderNodeAddress) ->
+                receivedMessage.set(decryptedMessageWithPubKey.getNetworkEnvelope()));
+
+        fixture.p2PService.onMessage(fixture.sealedMessage, fixture.connection);
+
+        assertSame(fixture.payload, receivedMessage.get());
+        verify(fixture.connection).maybeHandleSupportedCapabilitiesMessage(same(fixture.payload));
+    }
+
+    @Test
     public void onMessageDispatchesDirectMessageWithoutPayloadSenderWhenOuterEnvelopeAndConnectionMatch()
             throws Exception {
         DirectReceiveFixture fixture = new DirectReceiveFixture(

--- a/p2p/src/test/java/bisq/network/p2p/SendersSignaturePubKeyProvidingPayloadTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/SendersSignaturePubKeyProvidingPayloadTest.java
@@ -28,6 +28,8 @@ import java.security.PublicKey;
 
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,7 +50,8 @@ public class SendersSignaturePubKeyProvidingPayloadTest {
         assertTrue(payload instanceof SendersSignaturePubKeyProvidingPayload);
         assertEquals(expectedSenderSignaturePubKey, payload.getSenderSignaturePubKey());
         assertTrue(SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(payload.getSenderSignaturePubKey(),
-                expectedSenderSignaturePubKey));
+                expectedSenderSignaturePubKey,
+                payload.isSenderSignaturePubKeyRequired()));
     }
 
     @Test
@@ -57,7 +60,8 @@ public class SendersSignaturePubKeyProvidingPayloadTest {
         PublicKey expectedSenderSignaturePubKey = TestUtils.generateKeyPair().getPublic();
 
         assertFalse(SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(payload.getSenderSignaturePubKey(),
-                expectedSenderSignaturePubKey));
+                expectedSenderSignaturePubKey,
+                payload.isSenderSignaturePubKeyRequired()));
     }
 
     @Test
@@ -65,21 +69,54 @@ public class SendersSignaturePubKeyProvidingPayloadTest {
         SignaturePubKeyProvidingPayload payload = new SignaturePubKeyProvidingPayload(TestUtils.generateKeyPair().getPublic());
 
         assertFalse(SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(payload.getSenderSignaturePubKey(),
-                null));
+                null,
+                payload.isSenderSignaturePubKeyRequired()));
+    }
+
+    @Test
+    public void senderProvidingPayloadRejectsMissingRequiredSenderSignaturePubKey() throws NoSuchAlgorithmException {
+        SignaturePubKeyProvidingPayload payload = new SignaturePubKeyProvidingPayload(null);
+
+        assertFalse(SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(payload.getSenderSignaturePubKey(),
+                TestUtils.generateKeyPair().getPublic(),
+                payload.isSenderSignaturePubKeyRequired()));
+    }
+
+    @Test
+    public void senderProvidingPayloadAcceptsMissingSenderSignaturePubKeyWhenNotRequired() throws NoSuchAlgorithmException {
+        SignaturePubKeyProvidingPayload payload = new SignaturePubKeyProvidingPayload(null, false);
+
+        assertTrue(SendersSignaturePubKeyProvidingPayload.isSenderSignaturePubKeyMatching(payload.getSenderSignaturePubKey(),
+                TestUtils.generateKeyPair().getPublic(),
+                payload.isSenderSignaturePubKeyRequired()));
     }
 
     private static class SignaturePubKeyProvidingPayload extends NetworkEnvelope
             implements SendersSignaturePubKeyProvidingPayload {
+        @Nullable
         private final PublicKey senderSignaturePubKey;
+        private final boolean senderSignaturePubKeyRequired;
 
-        private SignaturePubKeyProvidingPayload(PublicKey senderSignaturePubKey) {
+        private SignaturePubKeyProvidingPayload(@Nullable PublicKey senderSignaturePubKey) {
+            this(senderSignaturePubKey, true);
+        }
+
+        private SignaturePubKeyProvidingPayload(@Nullable PublicKey senderSignaturePubKey,
+                                                boolean senderSignaturePubKeyRequired) {
             super(0);
             this.senderSignaturePubKey = senderSignaturePubKey;
+            this.senderSignaturePubKeyRequired = senderSignaturePubKeyRequired;
         }
 
         @Override
+        @Nullable
         public PublicKey getSenderSignaturePubKey() {
             return senderSignaturePubKey;
+        }
+
+        @Override
+        public boolean isSenderSignaturePubKeyRequired() {
+            return senderSignaturePubKeyRequired;
         }
 
         @Override

--- a/p2p/src/test/java/bisq/network/p2p/mailbox/MailboxItemTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/mailbox/MailboxItemTest.java
@@ -98,6 +98,20 @@ public class MailboxItemTest {
     }
 
     @Test
+    public void constructorKeepsDecryptedMessageWhenSenderSignaturePubKeyIsMissingButNotRequired()
+            throws NoSuchAlgorithmException {
+        DecryptedMessageWithPubKey decryptedMessageWithPubKey = decryptedMessageWithPubKey(
+                new MockSignaturePubKeyProvidingMailboxPayload("msg", ENVELOPE_SENDER, null, false));
+
+        MailboxItem mailboxItem = new MailboxItem(protectedMailboxStorageEntry(ENVELOPE_SENDER),
+                decryptedMessageWithPubKey);
+
+        assertTrue(mailboxItem.isMine());
+        assertFalse(mailboxItem.isInvalidDecryptedMessage());
+        assertSame(decryptedMessageWithPubKey, mailboxItem.getDecryptedMessageWithPubKey());
+    }
+
+    @Test
     public void constructorDropsDecryptedMessageWhenSenderSignaturePubKeysMismatch() throws NoSuchAlgorithmException {
         DecryptedMessageWithPubKey decryptedMessageWithPubKey = decryptedMessageWithPubKey(
                 new MockSignaturePubKeyProvidingMailboxPayload("msg",

--- a/p2p/src/test/java/bisq/network/p2p/mocks/MockSignaturePubKeyProvidingMailboxPayload.java
+++ b/p2p/src/test/java/bisq/network/p2p/mocks/MockSignaturePubKeyProvidingMailboxPayload.java
@@ -30,6 +30,8 @@ import java.security.PublicKey;
 
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 import lombok.Getter;
 
 @Getter
@@ -37,17 +39,27 @@ public final class MockSignaturePubKeyProvidingMailboxPayload extends NetworkEnv
         implements MailboxMessage, ExpirablePayload, SendersSignaturePubKeyProvidingPayload {
     private final String msg;
     private final NodeAddress senderNodeAddress;
+    @Nullable
     private final PublicKey senderSignaturePubKey;
+    private final boolean senderSignaturePubKeyRequired;
     private final String uid;
     public long ttl = 0;
 
     public MockSignaturePubKeyProvidingMailboxPayload(String msg,
                                                       NodeAddress senderNodeAddress,
-                                                      PublicKey senderSignaturePubKey) {
+                                                      @Nullable PublicKey senderSignaturePubKey) {
+        this(msg, senderNodeAddress, senderSignaturePubKey, true);
+    }
+
+    public MockSignaturePubKeyProvidingMailboxPayload(String msg,
+                                                      NodeAddress senderNodeAddress,
+                                                      @Nullable PublicKey senderSignaturePubKey,
+                                                      boolean senderSignaturePubKeyRequired) {
         super(0);
         this.msg = msg;
         this.senderNodeAddress = senderNodeAddress;
         this.senderSignaturePubKey = senderSignaturePubKey;
+        this.senderSignaturePubKeyRequired = senderSignaturePubKeyRequired;
         uid = UUID.randomUUID().toString();
     }
 
@@ -59,5 +71,10 @@ public final class MockSignaturePubKeyProvidingMailboxPayload extends NetworkEnv
     @Override
     public long getTTL() {
         return ttl;
+    }
+
+    @Override
+    public boolean isSenderSignaturePubKeyRequired() {
+        return senderSignaturePubKeyRequired;
     }
 }

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -457,6 +457,7 @@ message OpenNewDisputeMessage {
     NodeAddress sender_node_address = 2;
     string uid = 3;
     SupportType type = 4;
+    bytes sender_signature_pub_key = 5;
 }
 
 message PeerOpenedDisputeMessage {
@@ -464,6 +465,7 @@ message PeerOpenedDisputeMessage {
     NodeAddress sender_node_address = 2;
     string uid = 3;
     SupportType type = 4;
+    bytes sender_signature_pub_key = 5;
 }
 
 message ChatMessage {
@@ -490,6 +492,7 @@ message DisputeResultMessage {
     DisputeResult dispute_result = 2;
     NodeAddress sender_node_address = 3;
     SupportType type = 4;
+    bytes sender_signature_pub_key = 5;
 }
 
 message PeerPublishedDisputePayoutTxMessage {


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq/pull/7918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sender signature verification for dispute and support messages to ensure messages originate from authorized senders.
  * Implemented gradual activation of signature validation (scheduled for September 2026) to maintain compatibility with legacy messages.

* **Security Improvements**
  * Messages failing sender authentication are now rejected before processing, preventing unauthorized modifications to disputes and support communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->