### PR TITLE
feat: implement single-instance lock to prevent concurrent runs

### DIFF
--- a/common/src/main/java/bisq/common/app/InstanceLock.java
+++ b/common/src/main/java/bisq/common/app/InstanceLock.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.app;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import java.io.IOException;
+
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Guards against running more than one instance of the application against the same
+ * application data directory, which would otherwise lead to data and wallet corruption.
+ *
+ * <p>It acquires an OS-level advisory lock (via {@link FileChannel#tryLock()}) on a lock
+ * file inside the data directory. The lock is held for the whole lifetime of the JVM and
+ * is released automatically by the OS when the process exits — including on crash or kill,
+ * which is why we deliberately do not rely on PID files alone.
+ *
+ * <p>Strong references to the {@link FileChannel} and {@link FileLock} are retained for the
+ * instance lifetime: if they were garbage collected the lock would be released silently.
+ */
+@Slf4j
+public class InstanceLock implements AutoCloseable {
+    private static final String LOCK_FILE_NAME = "instance.lock";
+
+    private final Path lockFilePath;
+
+    // Held for the whole JVM lifetime. Must not be GC'd or the lock is released.
+    private FileChannel channel;
+    private FileLock fileLock;
+
+    public InstanceLock(Path appDataDir) {
+        this.lockFilePath = appDataDir.resolve(LOCK_FILE_NAME);
+    }
+
+    /**
+     * Tries to acquire the exclusive single-instance lock.
+     *
+     * @return {@code true} if this process now holds the lock (it is the only instance),
+     *         {@code false} if another running instance already holds it.
+     * @throws IOException if the lock file or its directory cannot be created or accessed,
+     *                     i.e. the locking mechanism itself is unusable.
+     */
+    public synchronized boolean tryLock() throws IOException {
+        if (fileLock != null) {
+            return true;
+        }
+        Files.createDirectories(lockFilePath.getParent());
+        channel = FileChannel.open(lockFilePath,
+                StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        try {
+            // tryLock returns null when the region is already locked by another process.
+            fileLock = channel.tryLock();
+        } catch (OverlappingFileLockException e) {
+            // Region already locked by this same JVM. Treat as "another instance" defensively.
+            fileLock = null;
+        } catch (IOException e) {
+            // The lock mechanism itself failed; close the channel before propagating so we
+            // don't leak the file descriptor on the fail-open path.
+            closeChannel();
+            throw e;
+        }
+
+        if (fileLock == null) {
+            closeChannel();
+            return false;
+        }
+
+        writeOwnerMetadata();
+        return true;
+    }
+
+    private void writeOwnerMetadata() {
+        try {
+            String info = ProcessHandle.current().pid() + System.lineSeparator();
+            channel.truncate(0);
+            ByteBuffer buffer = ByteBuffer.wrap(info.getBytes(StandardCharsets.UTF_8));
+            channel.position(0);
+            while (buffer.hasRemaining()) {
+                channel.write(buffer);
+            }
+            // No fsync (channel.force): the PID is a diagnostic hint, not durable state worth
+            // surviving a crash. write() already makes it visible to other processes via the
+            // page cache, which is all readOwnerPid needs.
+        } catch (IOException e) {
+            // Metadata is purely informational; failure does not affect the lock itself.
+            log.warn("Could not write instance lock owner metadata to {}", lockFilePath, e);
+        }
+    }
+
+    /**
+     * @return the PID recorded by the instance currently holding the lock, if readable.
+     *         Best-effort, for diagnostics only.
+     */
+    public Optional<Long> readOwnerPid() {
+        try {
+            String content = Files.readString(lockFilePath, StandardCharsets.UTF_8).trim();
+            return content.isEmpty() ? Optional.empty() : Optional.of(Long.parseLong(content));
+        } catch (IOException | NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        try {
+            if (fileLock != null && fileLock.isValid()) {
+                fileLock.release();
+            }
+        } catch (IOException e) {
+            log.warn("Failed to release instance lock {}", lockFilePath, e);
+        } finally {
+            fileLock = null;
+            closeChannel();
+        }
+    }
+
+    private void closeChannel() {
+        try {
+            if (channel != null && channel.isOpen()) {
+                channel.close();
+            }
+        } catch (IOException e) {
+            log.warn("Failed to close instance lock channel {}", lockFilePath, e);
+        } finally {
+            channel = null;
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/core/src/main/java/bisq/core/app/BisqExecutable.java
@@ -29,6 +29,7 @@ import bisq.core.setup.CorePersistedDataHost;
 import bisq.core.setup.CoreSetup;
 import bisq.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 import bisq.core.trade.statistics.TradeStatisticsManager;
+import bisq.core.locale.Res;
 import bisq.core.trade.txproof.xmr.XmrTxProofService;
 
 import bisq.network.p2p.P2PService;
@@ -36,6 +37,7 @@ import bisq.network.p2p.P2PService;
 import bisq.common.ClockWatcher;
 import bisq.common.UserThread;
 import bisq.common.app.AppModule;
+import bisq.common.app.InstanceLock;
 import bisq.common.config.BisqHelpFormatter;
 import bisq.common.config.Config;
 import bisq.common.config.ConfigException;
@@ -49,6 +51,8 @@ import bisq.common.util.Utilities;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+
+import java.io.IOException;
 
 import java.util.List;
 import java.util.Timer;
@@ -74,6 +78,7 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
     protected Injector injector;
     protected AppModule module;
     protected Config config;
+    protected InstanceLock instanceLock;
     protected volatile boolean isShutdownInProgress;
     private boolean hasDowngraded;
 
@@ -109,6 +114,12 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     protected void doExecute() {
+        if (!acquireInstanceLock()) {
+            // Another instance is already running against this data directory. The handler
+            // has already informed the user and terminated the process; we stop here defensively.
+            return;
+        }
+
         CommonSetup.setup(config, this);
         CoreSetup.setup(config);
 
@@ -116,6 +127,44 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
 
         // If application is JavaFX application we need to wait until it is initialized
         launchApplication();
+    }
+
+    /**
+     * Acquires the single-instance lock on the application data directory.
+     *
+     * @return true if startup may proceed, false if another instance already runs (in which
+     *         case {@link #handleAnotherInstanceRunning} has terminated the process).
+     */
+    private boolean acquireInstanceLock() {
+        instanceLock = new InstanceLock(config.appDataDir.toPath());
+        try {
+            if (instanceLock.tryLock()) {
+                return true;
+            }
+        } catch (IOException e) {
+            // The lock mechanism itself is unusable (e.g. data dir not writable). We fail open
+            // rather than bricking startup: an unusable lock file must not prevent the app from
+            // running, and an unwritable data dir will surface its own error downstream.
+            log.warn("Could not acquire single-instance lock, continuing without it", e);
+            return true;
+        }
+        // Res is used by the conflict handlers but its currency substitution is only safe after
+        // setup(). This runs before CoreSetup, so initialize it here. Config is already built.
+        Res.setup();
+        handleAnotherInstanceRunning();
+        return false;
+    }
+
+    /**
+     * Called when another instance already holds the lock. Default implementation logs the
+     * reason and exits. Desktop overrides this to additionally show a user-facing dialog.
+     */
+    protected void handleAnotherInstanceRunning() {
+        String pidInfo = instanceLock.readOwnerPid().map(pid -> " (PID " + pid + ")").orElse("");
+        log.error("Another instance of {} is already running{} using data directory {}",
+                appName, pidInfo, config.appDataDir);
+        System.err.println("error: " + Res.get("popup.alreadyRunning.msg", appName, config.appDataDir));
+        System.exit(EXIT_FAILURE);
     }
 
     protected abstract void configUserThread();
@@ -283,6 +332,11 @@ public abstract class BisqExecutable implements GracefulShutDownHandler, BisqSet
     }
 
     protected void flushAndExit(ResultHandler resultHandler, int status) {
+        // The OS releases the lock on process exit; we release explicitly for a clean handover
+        // to a restarting instance.
+        if (instanceLock != null) {
+            instanceLock.close();
+        }
         if (!hasDowngraded) {
             // If user tried to downgrade we do not write the persistable data to avoid data corruption
             log.info("PersistenceManager flushAllDataToDiskAtShutdown started");

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3486,6 +3486,9 @@ popup.bitcoinLocalhostNode.msg=Bisq detected a Bitcoin Core node running on this
   - pruning is disabled ('prune=0' in bitcoin.conf)\n\
   - bloom filters are enabled ('peerbloomfilters=1' in bitcoin.conf)
 
+popup.alreadyRunning.headline={0} is already running
+popup.alreadyRunning.msg=Another instance of {0} is already running.\nOnly one instance can run at a time using the same data directory:\n{1}\n\nPlease close the other instance and try again.
+
 popup.shutDownInProgress.headline=Shut down in progress
 popup.shutDownInProgress.msg=Shutting down application can take a few seconds.\nPlease don't interrupt this process.
 

--- a/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
+++ b/desktop/src/main/java/bisq/desktop/app/BisqAppMain.java
@@ -26,6 +26,7 @@ import bisq.desktop.util.GUIUtil;
 import bisq.core.app.AvoidStandbyModeService;
 import bisq.core.app.BisqExecutable;
 import bisq.core.app.TorSetup;
+import bisq.core.locale.Res;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.user.Cookie;
@@ -38,6 +39,10 @@ import bisq.common.app.Version;
 
 import javafx.application.Application;
 import javafx.application.Platform;
+
+import java.awt.GraphicsEnvironment;
+
+import javax.swing.JOptionPane;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -65,6 +70,26 @@ public class BisqAppMain extends BisqExecutable {
     @Override
     public void onSetupComplete() {
         log.debug("onSetupComplete");
+    }
+
+    @Override
+    protected void handleAnotherInstanceRunning() {
+        // Runs before JavaFX is launched, so we cannot use the JavaFX Popup here. Show a
+        // lightweight AWT dialog when a display is available, then fall back to stderr + exit.
+        String pidInfo = instanceLock.readOwnerPid().map(pid -> " (PID " + pid + ")").orElse("");
+        log.error("Another instance of {} is already running{} using data directory {}",
+                DEFAULT_APP_NAME, pidInfo, config.appDataDir);
+        String headline = Res.get("popup.alreadyRunning.headline", DEFAULT_APP_NAME);
+        String message = Res.get("popup.alreadyRunning.msg", DEFAULT_APP_NAME, config.appDataDir);
+        if (!GraphicsEnvironment.isHeadless()) {
+            try {
+                JOptionPane.showMessageDialog(null, message, headline, JOptionPane.WARNING_MESSAGE);
+            } catch (Throwable t) {
+                log.warn("Could not show already-running dialog", t);
+            }
+        }
+        System.err.println("error: " + message);
+        System.exit(BisqExecutable.EXIT_FAILURE);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
follow up to #7833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Prevents multiple instances of the application from running simultaneously by enforcing a single-instance lock for the selected data directory.
- If another instance is already running, the app shows (or prints, if no UI is available) a localized “already running” message with helpful context to close the current instance first.

## Improvements
- Improves restart handover by releasing the instance lock during shutdown, enabling clean subsequent launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->