### PR TITLE
Harden merit validation

### DIFF
--- a/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensus.java
@@ -19,6 +19,7 @@ package bisq.core.dao.governance.merit;
 
 import bisq.core.dao.governance.voteresult.VoteResultException;
 import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.governance.DaoArithmetics;
 import bisq.core.dao.state.model.governance.MeritList;
 
 import bisq.common.crypto.Encryption;

--- a/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensus.java
@@ -19,29 +19,17 @@ package bisq.core.dao.governance.merit;
 
 import bisq.core.dao.governance.voteresult.VoteResultException;
 import bisq.core.dao.state.DaoStateService;
-import bisq.core.dao.state.model.blockchain.Tx;
-import bisq.core.dao.state.model.governance.Issuance;
-import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.dao.state.model.governance.MeritList;
 
 import bisq.common.crypto.Encryption;
-import bisq.common.util.Utilities;
-
-import org.bitcoinj.core.ECKey;
-import org.bitcoinj.core.Sha256Hash;
-
-import com.google.common.annotations.VisibleForTesting;
 
 import javax.crypto.SecretKey;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 @Slf4j
 public class MeritConsensus {
-    // Value with 144 blocks a day and 365 days would be 52560. We take a close round number instead.
-    private static final int BLOCKS_PER_YEAR = 50_000;
+    public static final int MERIT_CONSENSUS_V2_ACTIVATION_HEIGHT = 954_200;
 
     public static MeritList decryptMeritList(byte[] encryptedMeritList, SecretKey secretKey)
             throws VoteResultException.DecryptionException {
@@ -54,117 +42,29 @@ public class MeritConsensus {
     }
 
     public static long getMeritStake(String blindVoteTxId, MeritList meritList, DaoStateService daoStateService) {
-        // We need to take the chain height when the blindVoteTx got published so we get the same merit for the vote even at
-        // later blocks (merit decreases with each block).
-        int blindVoteTxHeight = daoStateService.getTx(blindVoteTxId).map(Tx::getBlockHeight).orElse(0);
-        if (blindVoteTxHeight == 0) {
-            log.error("Error at getMeritStake: blindVoteTx not found in daoStateService. blindVoteTxId=" + blindVoteTxId);
-            return 0;
-        }
-
-        // We only use past issuance. In case we would calculate the merit after the vote result phase we have the
-        // issuance from the same cycle but we must not add that to the merit.
-        return meritList.getList().stream()
-                .filter(merit -> isSignatureValid(merit.getSignature(), merit.getIssuance().getPubKey(), blindVoteTxId))
-                .filter(merit -> merit.getIssuance().getChainHeight() <= blindVoteTxHeight)
-                .mapToLong(merit -> {
-                    try {
-                        Issuance issuance = merit.getIssuance();
-                        checkArgument(issuance.getIssuanceType() == IssuanceType.COMPENSATION,
-                                "issuance must be of type COMPENSATION");
-                        return getWeightedMeritAmount(issuance.getAmount(),
-                                issuance.getChainHeight(),
-                                blindVoteTxHeight,
-                                BLOCKS_PER_YEAR);
-                    } catch (Throwable t) {
-                        log.error("Error at getMeritStake: error={}, merit={}", t.toString(), merit);
-                        return 0;
-                    }
-                })
-                .sum();
+        return getMeritStake(blindVoteTxId, meritList, daoStateService, daoStateService.getChainHeight());
     }
 
-    @VisibleForTesting
-    private static boolean isSignatureValid(byte[] signatureFromMerit, String pubKeyAsHex, String blindVoteTxId) {
-        // We verify if signature of hash of blindVoteTxId is correct. EC key from first input for blind vote tx is
-        // used for signature.
-        if (pubKeyAsHex == null) {
-            log.error("Error at isSignatureValid: pubKeyAsHex is null");
-            return false;
+    public static long getMeritStake(String blindVoteTxId,
+                                     MeritList meritList,
+                                     DaoStateService daoStateService,
+                                     int evaluationBlockHeight) {
+        if (isMeritConsensusV2Activated(evaluationBlockHeight)) {
+            return MeritConsensusV2.getMeritStake(blindVoteTxId, meritList, daoStateService);
+        } else {
+            return MeritConsensusLegacy.getMeritStake(blindVoteTxId, meritList, daoStateService);
         }
-
-        boolean result = false;
-        try {
-            ECKey pubKey = ECKey.fromPublicOnly(Utilities.decodeFromHex(pubKeyAsHex));
-            ECKey.ECDSASignature signature = ECKey.ECDSASignature.decodeFromDER(signatureFromMerit).toCanonicalised();
-            Sha256Hash msg = Sha256Hash.wrap(blindVoteTxId);
-            result = pubKey.verify(msg, signature);
-        } catch (Throwable t) {
-            log.error("Signature verification of issuance failed: " + t.toString());
-        }
-        if (!result) {
-            log.error("Signature verification of issuance failed: blindVoteTxId={}, pubKeyAsHex={}",
-                    blindVoteTxId, pubKeyAsHex);
-        }
-        return result;
     }
 
-    public static long getWeightedMeritAmount(long amount, int issuanceHeight, int blockHeight, int blocksPerYear) {
-        if (issuanceHeight > blockHeight)
-            throw new IllegalArgumentException("issuanceHeight must not be larger than blockHeight. issuanceHeight=" + issuanceHeight + "; blockHeight=" + blockHeight);
-        if (blockHeight < 0)
-            throw new IllegalArgumentException("blockHeight must not be negative. blockHeight=" + blockHeight);
-        if (amount < 0)
-            throw new IllegalArgumentException("amount must not be negative. amount" + amount);
-        if (blocksPerYear < 0)
-            throw new IllegalArgumentException("blocksPerYear must not be negative. blocksPerYear=" + blocksPerYear);
-        if (issuanceHeight < 0)
-            throw new IllegalArgumentException("issuanceHeight must not be negative. issuanceHeight=" + issuanceHeight);
-
-        // We use a linear function to apply a factor for the issuance amount of 1 if the issuance was recent and 0
-        // if the issuance was 2 years old or older.
-        // To avoid rounding issues with double values we multiply initially with a large number and divide at the end
-        // by that number again. As we multiply the amount in satoshis we get a reasonable good precision even the long
-        // division is not using rounding. Sticking with long values makes that operation safer against consensus
-        // failures causes by rounding differences with double.
-
-        long maxAge = 2 * blocksPerYear; // maxAge=100 000 (MeritConsensus.BLOCKS_PER_YEAR is 50_000)
-        long age = Math.min(maxAge, blockHeight - issuanceHeight);
-        long inverseAge = maxAge - age;
-
-        // We want a resolution of 1 block so we use the inverseAge and divide by maxAge afterwards to get the
-        // weighted amount
-        // We need to multiply first before we divide!
-        long weightedAmount = (amount * inverseAge) / maxAge;
-
-        log.debug("getWeightedMeritAmount: age={}, inverseAge={}, weightedAmount={}, amount={}", age, inverseAge, weightedAmount, amount);
-        return weightedAmount;
+    public static boolean isMeritConsensusV2Activated(int blockHeight) {
+        return blockHeight >= MERIT_CONSENSUS_V2_ACTIVATION_HEIGHT;
     }
 
     public static long getCurrentlyAvailableMerit(MeritList meritList, int currentChainHeight) {
-        // We need to take the chain height when the blindVoteTx got published so we get the same merit for the vote even at
-        // later blocks (merit decreases with each block).
-        // We add 1 block to currentChainHeight so that the displayed merit would match the merit in case we get the
-        // blind vote tx into the next block.
-        int height = currentChainHeight + 1;
-        return meritList.getList().stream()
-                .mapToLong(merit -> {
-                    try {
-                        Issuance issuance = merit.getIssuance();
-                        checkArgument(issuance.getIssuanceType() == IssuanceType.COMPENSATION, "issuance must be of type COMPENSATION");
-                        int issuanceHeight = issuance.getChainHeight();
-                        checkArgument(issuanceHeight <= height,
-                                "issuanceHeight must not be larger as currentChainHeight");
-                        return getWeightedMeritAmount(issuance.getAmount(),
-                                issuanceHeight,
-                                height,
-                                BLOCKS_PER_YEAR);
-                    } catch (Throwable t) {
-                        log.error("Error at getCurrentlyAvailableMerit: " + t.toString());
-                        return 0;
-                    }
-                })
-                .sum();
+        if (isMeritConsensusV2Activated(currentChainHeight)) {
+            return MeritConsensusV2.getCurrentlyAvailableMerit(meritList, currentChainHeight);
+        } else {
+            return MeritConsensusLegacy.getCurrentlyAvailableMerit(meritList, currentChainHeight);
+        }
     }
-
 }

--- a/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusLegacy.java
+++ b/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusLegacy.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.governance.merit;
+
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.dao.state.model.governance.Issuance;
+import bisq.core.dao.state.model.governance.IssuanceType;
+import bisq.core.dao.state.model.governance.MeritList;
+
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+public class MeritConsensusLegacy {
+    // Value with 144 blocks a day and 365 days would be 52560. We take a close round number instead.
+    private static final int BLOCKS_PER_YEAR = 50_000;
+
+    public static long getMeritStake(String blindVoteTxId, MeritList meritList, DaoStateService daoStateService) {
+        // We need to take the chain height when the blindVoteTx got published so we get the same merit for the vote even at
+        // later blocks (merit decreases with each block).
+        int blindVoteTxHeight = daoStateService.getTx(blindVoteTxId).map(Tx::getBlockHeight).orElse(0);
+        if (blindVoteTxHeight == 0) {
+            log.error("Error at getMeritStake: blindVoteTx not found in daoStateService. blindVoteTxId=" + blindVoteTxId);
+            return 0;
+        }
+
+        // We only use past issuance. In case we would calculate the merit after the vote result phase we have the
+        // issuance from the same cycle but we must not add that to the merit.
+        return meritList.getList().stream()
+                .filter(merit -> isSignatureValid(merit.getSignature(), merit.getIssuance().getPubKey(), blindVoteTxId))
+                .filter(merit -> merit.getIssuance().getChainHeight() <= blindVoteTxHeight)
+                .mapToLong(merit -> {
+                    try {
+                        Issuance issuance = merit.getIssuance();
+                        checkArgument(issuance.getIssuanceType() == IssuanceType.COMPENSATION,
+                                "issuance must be of type COMPENSATION");
+                        return getWeightedMeritAmount(issuance.getAmount(),
+                                issuance.getChainHeight(),
+                                blindVoteTxHeight,
+                                BLOCKS_PER_YEAR);
+                    } catch (Throwable t) {
+                        log.error("Error at getMeritStake: error={}, merit={}", t.toString(), merit);
+                        return 0;
+                    }
+                })
+                .sum();
+    }
+
+    @VisibleForTesting
+    private static boolean isSignatureValid(byte[] signatureFromMerit, String pubKeyAsHex, String blindVoteTxId) {
+        // We verify if signature of hash of blindVoteTxId is correct. EC key from first input for blind vote tx is
+        // used for signature.
+        if (pubKeyAsHex == null) {
+            log.error("Error at isSignatureValid: pubKeyAsHex is null");
+            return false;
+        }
+
+        boolean result = false;
+        try {
+            ECKey pubKey = ECKey.fromPublicOnly(Utilities.decodeFromHex(pubKeyAsHex));
+            ECKey.ECDSASignature signature = ECKey.ECDSASignature.decodeFromDER(signatureFromMerit).toCanonicalised();
+            Sha256Hash msg = Sha256Hash.wrap(blindVoteTxId);
+            result = pubKey.verify(msg, signature);
+        } catch (Throwable t) {
+            log.error("Signature verification of issuance failed: " + t.toString());
+        }
+        if (!result) {
+            log.error("Signature verification of issuance failed: blindVoteTxId={}, pubKeyAsHex={}",
+                    blindVoteTxId, pubKeyAsHex);
+        }
+        return result;
+    }
+
+    public static long getWeightedMeritAmount(long amount, int issuanceHeight, int blockHeight, int blocksPerYear) {
+        if (issuanceHeight > blockHeight)
+            throw new IllegalArgumentException("issuanceHeight must not be larger than blockHeight. issuanceHeight=" + issuanceHeight + "; blockHeight=" + blockHeight);
+        if (blockHeight < 0)
+            throw new IllegalArgumentException("blockHeight must not be negative. blockHeight=" + blockHeight);
+        if (amount < 0)
+            throw new IllegalArgumentException("amount must not be negative. amount" + amount);
+        if (blocksPerYear < 0)
+            throw new IllegalArgumentException("blocksPerYear must not be negative. blocksPerYear=" + blocksPerYear);
+        if (issuanceHeight < 0)
+            throw new IllegalArgumentException("issuanceHeight must not be negative. issuanceHeight=" + issuanceHeight);
+
+        // We use a linear function to apply a factor for the issuance amount of 1 if the issuance was recent and 0
+        // if the issuance was 2 years old or older.
+        // To avoid rounding issues with double values we multiply initially with a large number and divide at the end
+        // by that number again. As we multiply the amount in satoshis we get a reasonable good precision even the long
+        // division is not using rounding. Sticking with long values makes that operation safer against consensus
+        // failures causes by rounding differences with double.
+
+        long maxAge = 2 * blocksPerYear; // maxAge=100 000 (MeritConsensus.BLOCKS_PER_YEAR is 50_000)
+        long age = Math.min(maxAge, blockHeight - issuanceHeight);
+        long inverseAge = maxAge - age;
+
+        // We want a resolution of 1 block so we use the inverseAge and divide by maxAge afterwards to get the
+        // weighted amount
+        // We need to multiply first before we divide!
+        long weightedAmount = (amount * inverseAge) / maxAge;
+
+        log.debug("getWeightedMeritAmount: age={}, inverseAge={}, weightedAmount={}, amount={}", age, inverseAge, weightedAmount, amount);
+        return weightedAmount;
+    }
+
+    public static long getCurrentlyAvailableMerit(MeritList meritList, int currentChainHeight) {
+        // We need to take the chain height when the blindVoteTx got published so we get the same merit for the vote even at
+        // later blocks (merit decreases with each block).
+        // We add 1 block to currentChainHeight so that the displayed merit would match the merit in case we get the
+        // blind vote tx into the next block.
+        int height = currentChainHeight + 1;
+        return meritList.getList().stream()
+                .mapToLong(merit -> {
+                    try {
+                        Issuance issuance = merit.getIssuance();
+                        checkArgument(issuance.getIssuanceType() == IssuanceType.COMPENSATION, "issuance must be of type COMPENSATION");
+                        int issuanceHeight = issuance.getChainHeight();
+                        checkArgument(issuanceHeight <= height,
+                                "issuanceHeight must not be larger as currentChainHeight");
+                        return getWeightedMeritAmount(issuance.getAmount(),
+                                issuanceHeight,
+                                height,
+                                BLOCKS_PER_YEAR);
+                    } catch (Throwable t) {
+                        log.error("Error at getCurrentlyAvailableMerit: " + t.toString());
+                        return 0;
+                    }
+                })
+                .sum();
+    }
+
+}

--- a/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusV2.java
+++ b/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusV2.java
@@ -76,7 +76,7 @@ public class MeritConsensusV2 {
                 }
                 Issuance issuance = optionalIssuance.get();
                 if (!issuance.isValueEqual(untrustedIssuance)) {
-                    log.warn("DAO state compensation issuance is not the same as the one from the unrusted merit. " +
+                    log.warn("DAO state compensation issuance is not the same as the one from the untrusted merit. " +
                             "DAO state compensation issuance={}, untrustedMerit={}", issuance, untrustedMerit);
                     continue;
                 }
@@ -107,6 +107,7 @@ public class MeritConsensusV2 {
             }
             return totalMeritAmount;
         } catch (ArithmeticException e) {
+            // Overflow in consensus merit arithmetic must fail the vote result instead of being treated as zero merit.
             throw e;
         } catch (RuntimeException e) {
             log.error("Error at getMeritStake. merit={}", untrustedMeritList, e);

--- a/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusV2.java
+++ b/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusV2.java
@@ -1,0 +1,217 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.governance.merit;
+
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.dao.state.model.governance.Issuance;
+import bisq.core.dao.state.model.governance.IssuanceType;
+import bisq.core.dao.state.model.governance.Merit;
+import bisq.core.dao.state.model.governance.MeritList;
+
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+public class MeritConsensusV2 {
+    // Value with 144 blocks a day and 365 days would be 52560. We take a close round number instead.
+    private static final int BLOCKS_PER_YEAR = 50_000;
+
+    public static long getMeritStake(String blindVoteTxId,
+                                     MeritList untrustedMeritList,
+                                     DaoStateService daoStateService) {
+        try {
+            // We need to take the chain height when the blindVoteTx got published so we get the same merit for the vote even at
+            // later blocks (merit decreases with each block).
+            int blindVoteTxHeight = daoStateService.getTx(blindVoteTxId).map(Tx::getBlockHeight).orElse(0);
+            if (blindVoteTxHeight <= 0) {
+                log.error("Error at getMeritStake: blindVoteTx not found in daoStateService. blindVoteTxId=" + blindVoteTxId);
+                return 0;
+            }
+
+            Set<String> alreadyUsedIssuanceTxIds = new HashSet<>();
+            long totalMeritAmount = 0;
+
+            for (Merit untrustedMerit : untrustedMeritList.getList()) {
+                Issuance untrustedIssuance = untrustedMerit.getIssuance();
+                String issuanceTxId = untrustedIssuance.getTxId();
+
+                if (untrustedMerit.getIssuance().getIssuanceType() != IssuanceType.COMPENSATION) {
+                    log.warn("Issuance type is not COMPENSATION. issuanceTxId={}, issuanceType={}",
+                            issuanceTxId, untrustedMerit.getIssuance().getIssuanceType());
+                    continue;
+                }
+                Optional<Issuance> optionalIssuance = daoStateService.getIssuance(issuanceTxId, IssuanceType.COMPENSATION);
+                if (optionalIssuance.isEmpty()) {
+                    log.warn("No DAO state compensation issuance found for merit. issuanceTxId={}", issuanceTxId);
+                    continue;
+                }
+                Issuance issuance = optionalIssuance.get();
+                if (!issuance.isValueEqual(untrustedIssuance)) {
+                    log.warn("DAO state compensation issuance is not the same as the one from the unrusted merit. " +
+                            "DAO state compensation issuance={}, untrustedMerit={}", issuance, untrustedMerit);
+                    continue;
+                }
+
+                int issuanceHeight = issuance.getChainHeight();
+                if (issuanceHeight > blindVoteTxHeight) {
+                    log.warn("Future merit ignored. issuanceTxId={}, issuanceHeight={}, blindVoteTxHeight={}",
+                            issuanceTxId, issuanceHeight, blindVoteTxHeight);
+                    continue;
+                }
+
+                if (!isSignatureValid(untrustedMerit.getSignature(), issuance.getPubKey(), blindVoteTxId)) {
+                    log.warn("Invalid signature in merit. merit={}", untrustedMerit);
+                    continue;
+                }
+
+                boolean didNotContain = alreadyUsedIssuanceTxIds.add(issuanceTxId);
+                if (!didNotContain) {
+                    log.warn("Issuance was already used. merit={}", untrustedMerit);
+                    continue;
+                }
+
+                long weightedMeritAmount = getWeightedMeritAmount(issuance.getAmount(),
+                        issuance.getChainHeight(),
+                        blindVoteTxHeight,
+                        BLOCKS_PER_YEAR);
+                totalMeritAmount = Math.addExact(totalMeritAmount, weightedMeritAmount);
+            }
+            return totalMeritAmount;
+        } catch (ArithmeticException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            log.error("Error at getMeritStake. merit={}", untrustedMeritList, e);
+            return 0;
+        }
+    }
+
+    @VisibleForTesting
+    private static boolean isSignatureValid(byte[] signatureFromMerit, String pubKeyAsHex, String blindVoteTxId) {
+        // We verify if signature of hash of blindVoteTxId is correct. EC key from first input for blind vote tx is
+        // used for signature.
+        if (pubKeyAsHex == null) {
+            log.error("Error at isSignatureValid: pubKeyAsHex is null");
+            return false;
+        }
+
+        boolean result = false;
+        try {
+            ECKey pubKey = ECKey.fromPublicOnly(Utilities.decodeFromHex(pubKeyAsHex));
+            ECKey.ECDSASignature signature = ECKey.ECDSASignature.decodeFromDER(signatureFromMerit).toCanonicalised();
+            Sha256Hash msg = Sha256Hash.wrap(blindVoteTxId);
+            result = pubKey.verify(msg, signature);
+        } catch (Throwable t) {
+            log.error("Signature verification of issuance failed: " + t.toString());
+        }
+        if (!result) {
+            log.error("Signature verification of issuance failed: blindVoteTxId={}, pubKeyAsHex={}",
+                    blindVoteTxId, pubKeyAsHex);
+        }
+        return result;
+    }
+
+    public static long getWeightedMeritAmount(long amount, int issuanceHeight, int blockHeight, int blocksPerYear) {
+        try {
+            if (issuanceHeight > blockHeight) {
+                throw new IllegalArgumentException("issuanceHeight must not be larger than blockHeight. issuanceHeight=" + issuanceHeight + "; blockHeight=" + blockHeight);
+            }
+            if (blockHeight <= 0) {
+                throw new IllegalArgumentException("blockHeight must be positive. blockHeight=" + blockHeight);
+            }
+            if (amount < 0) {
+                throw new IllegalArgumentException("amount must not be negative. amount" + amount);
+            }
+            if (amount == 0) {
+                return 0;
+            }
+            if (blocksPerYear <= 0) {
+                throw new IllegalArgumentException("blocksPerYear must be positive. blocksPerYear=" + blocksPerYear);
+            }
+            if (issuanceHeight <= 0) {
+                throw new IllegalArgumentException("issuanceHeight must be positive. issuanceHeight=" + issuanceHeight);
+            }
+            // We use a linear function to apply a factor for the issuance amount of 1 if the issuance was recent and 0
+            // if the issuance was 2 years old or older.
+            // To avoid rounding issues with double values we multiply initially with a large number and divide at the end
+            // by that number again. As we multiply the amount in satoshis we get a reasonable good precision even the long
+            // division is not using rounding. Sticking with long values makes that operation safer against consensus
+            // failures causes by rounding differences with double.
+
+            long maxAge = 2 * blocksPerYear; // maxAge=100 000 (MeritConsensus.BLOCKS_PER_YEAR is 50_000)
+            //noinspection ConstantValue
+            checkArgument(maxAge > 0, "maxAge must be positive. maxAge=" + maxAge);
+            long age = Math.min(maxAge, blockHeight - issuanceHeight);
+            long inverseAge = maxAge - age;
+
+            // We want a resolution of 1 block so we use the inverseAge and divide by maxAge afterwards to get the
+            // weighted amount
+            long weightedAmount = (amount * inverseAge) / maxAge;
+            checkArgument(weightedAmount >= 0, "weightedAmount must not be negative. " +
+                    "weightedAmount=" + weightedAmount);
+
+            log.debug("getWeightedMeritAmount: age={}, inverseAge={}, weightedAmount={}, amount={}", age, inverseAge, weightedAmount, amount);
+            return weightedAmount;
+        } catch (ArithmeticException e) {
+            log.error("ArithmeticException at getWeightedMeritAmount ", e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Exception at getWeightedMeritAmount ", e);
+            return 0;
+        }
+    }
+
+    public static long getCurrentlyAvailableMerit(MeritList meritList, int currentChainHeight) {
+        // We need to take the chain height when the blindVoteTx got published so we get the same merit for the vote even at
+        // later blocks (merit decreases with each block).
+        // We add 1 block to currentChainHeight so that the displayed merit would match the merit in case we get the
+        // blind vote tx into the next block.
+        int height = currentChainHeight + 1;
+        return meritList.getList().stream()
+                .mapToLong(merit -> {
+                    try {
+                        Issuance issuance = merit.getIssuance();
+                        checkArgument(issuance.getIssuanceType() == IssuanceType.COMPENSATION, "issuance must be of type COMPENSATION");
+                        int issuanceHeight = issuance.getChainHeight();
+                        checkArgument(issuanceHeight <= height,
+                                "issuanceHeight must not be larger as currentChainHeight");
+                        return getWeightedMeritAmount(issuance.getAmount(),
+                                issuanceHeight,
+                                height,
+                                BLOCKS_PER_YEAR);
+                    } catch (Throwable t) {
+                        log.error("Error at getCurrentlyAvailableMerit: " + t.toString());
+                        return 0;
+                    }
+                })
+                .sum();
+    }
+
+}

--- a/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusV2.java
+++ b/core/src/main/java/bisq/core/dao/governance/merit/MeritConsensusV2.java
@@ -19,6 +19,7 @@ package bisq.core.dao.governance.merit;
 
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.dao.state.model.governance.DaoArithmeticsV2;
 import bisq.core.dao.state.model.governance.Issuance;
 import bisq.core.dao.state.model.governance.IssuanceType;
 import bisq.core.dao.state.model.governance.Merit;
@@ -165,7 +166,7 @@ public class MeritConsensusV2 {
             // division is not using rounding. Sticking with long values makes that operation safer against consensus
             // failures causes by rounding differences with double.
 
-            long maxAge = 2 * blocksPerYear; // maxAge=100 000 (MeritConsensus.BLOCKS_PER_YEAR is 50_000)
+            long maxAge = DaoArithmeticsV2.multiplyLong(2, blocksPerYear); // maxAge=100 000 (MeritConsensus.BLOCKS_PER_YEAR is 50_000)
             //noinspection ConstantValue
             checkArgument(maxAge > 0, "maxAge must be positive. maxAge=" + maxAge);
             long age = Math.min(maxAge, blockHeight - issuanceHeight);
@@ -173,7 +174,7 @@ public class MeritConsensusV2 {
 
             // We want a resolution of 1 block so we use the inverseAge and divide by maxAge afterwards to get the
             // weighted amount
-            long weightedAmount = (amount * inverseAge) / maxAge;
+            long weightedAmount = DaoArithmeticsV2.multiplyAndDivide(amount, inverseAge, maxAge);
             checkArgument(weightedAmount >= 0, "weightedAmount must not be negative. " +
                     "weightedAmount=" + weightedAmount);
 

--- a/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultConsensus.java
@@ -85,6 +85,10 @@ public class VoteResultConsensus {
         if (hashWithStakeList.size() > 1) {
             long stakeOfAll = getStakeOfAll(hashWithStakeList, chainHeight);
             long stakeOfFirst = hashWithStakeList.get(0).getStake();
+            if (stakeOfAll == 0) {
+                log.warn("stakeOfAll must not be 0");
+                throw new VoteResultException.ConsensusException("stakeOfAll is 0.");
+            }
             if ((double) stakeOfFirst / (double) stakeOfAll < 0.8) {
                 log.warn("The winning data view has less then 80% of the " +
                         "total stake of all data views. We consider the voting cycle as invalid if the " +

--- a/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultConsensus.java
@@ -42,8 +42,6 @@ import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
-import javax.annotation.Nullable;
-
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -71,7 +69,6 @@ public class VoteResultConsensus {
     // hex encoded hashOfProposalList for comparison
     // Arithmetic overflow from DaoArithmetics is intentionally not converted here; vote-result processing records
     // it as a failed cycle through the surrounding VoteResultException boundary.
-    @Nullable
     public static byte[] getMajorityHash(List<VoteResultService.HashWithStake> hashWithStakeList, long chainHeight)
             throws VoteResultException.ValidationException, VoteResultException.ConsensusException {
         try {

--- a/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultConsensus.java
+++ b/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultConsensus.java
@@ -25,10 +25,13 @@ import bisq.core.dao.state.model.blockchain.TxInput;
 import bisq.core.dao.state.model.blockchain.TxOutput;
 import bisq.core.dao.state.model.blockchain.TxOutputType;
 import bisq.core.dao.state.model.blockchain.TxType;
+import bisq.core.dao.state.model.governance.DaoArithmetics;
 import bisq.core.dao.state.model.governance.DaoPhase;
 
 import bisq.common.crypto.Encryption;
 import bisq.common.util.Utilities;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.crypto.SecretKey;
 
@@ -66,8 +69,10 @@ public class VoteResultConsensus {
 
     // We compare first by stake and in case we have multiple entries with same stake we use the
     // hex encoded hashOfProposalList for comparison
+    // Arithmetic overflow from DaoArithmetics is intentionally not converted here; vote-result processing records
+    // it as a failed cycle through the surrounding VoteResultException boundary.
     @Nullable
-    public static byte[] getMajorityHash(List<VoteResultService.HashWithStake> hashWithStakeList)
+    public static byte[] getMajorityHash(List<VoteResultService.HashWithStake> hashWithStakeList, long chainHeight)
             throws VoteResultException.ValidationException, VoteResultException.ConsensusException {
         try {
             checkArgument(!hashWithStakeList.isEmpty(), "hashWithStakeList must not be empty");
@@ -81,7 +86,7 @@ public class VoteResultConsensus {
         // If there are conflicting data views (multiple hashes) we only consider the voting round as valid if
         // the majority is a super majority with > 80%.
         if (hashWithStakeList.size() > 1) {
-            long stakeOfAll = hashWithStakeList.stream().mapToLong(VoteResultService.HashWithStake::getStake).sum();
+            long stakeOfAll = getStakeOfAll(hashWithStakeList, chainHeight);
             long stakeOfFirst = hashWithStakeList.get(0).getStake();
             if ((double) stakeOfFirst / (double) stakeOfAll < 0.8) {
                 log.warn("The winning data view has less then 80% of the " +
@@ -93,6 +98,16 @@ public class VoteResultConsensus {
             }
         }
         return hashWithStakeList.get(0).getHash();
+    }
+
+    // chainHeight selects legacy primitive arithmetic before activation and exact arithmetic at/after activation.
+    @VisibleForTesting
+    static long getStakeOfAll(List<VoteResultService.HashWithStake> hashWithStakeList, long chainHeight) {
+        long stakeOfAll = 0;
+        for (VoteResultService.HashWithStake hashWithStake : hashWithStakeList) {
+            stakeOfAll = DaoArithmetics.addLong(stakeOfAll, hashWithStake.getStake(), chainHeight);
+        }
+        return stakeOfAll;
     }
 
     // Key is stored after version and type bytes and list of Blind votes. It has 16 bytes

--- a/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultService.java
+++ b/core/src/main/java/bisq/core/dao/governance/voteresult/VoteResultService.java
@@ -41,6 +41,7 @@ import bisq.core.dao.state.model.governance.BallotList;
 import bisq.core.dao.state.model.governance.ChangeParamProposal;
 import bisq.core.dao.state.model.governance.ConfiscateBondProposal;
 import bisq.core.dao.state.model.governance.Cycle;
+import bisq.core.dao.state.model.governance.DaoArithmetics;
 import bisq.core.dao.state.model.governance.DaoPhase;
 import bisq.core.dao.state.model.governance.DecryptedBallotsWithMerits;
 import bisq.core.dao.state.model.governance.EvaluatedProposal;
@@ -59,6 +60,8 @@ import bisq.network.p2p.storage.P2PDataStorage;
 import bisq.common.util.MathUtils;
 import bisq.common.util.PermutationUtil;
 import bisq.common.util.Utilities;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.inject.Inject;
 
@@ -184,11 +187,11 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
                 // A node which has a local blindVote list which does not match the winner data view will try
                 // permutations of his local list and if that does not succeed he need to recover it's
                 // local blindVote list by requesting the correct list from other peers.
-                Map<P2PDataStorage.ByteArray, Long> stakeByHashOfBlindVoteListMap = getStakeByHashOfBlindVoteListMap(decryptedBallotsWithMeritsSet);
-
                 try {
+                    Map<P2PDataStorage.ByteArray, Long> stakeByHashOfBlindVoteListMap = getStakeByHashOfBlindVoteListMap(decryptedBallotsWithMeritsSet, chainHeight);
+
                     // Get majority hash
-                    byte[] majorityBlindVoteListHash = calculateMajorityBlindVoteListHash(stakeByHashOfBlindVoteListMap);
+                    byte[] majorityBlindVoteListHash = calculateMajorityBlindVoteListHash(stakeByHashOfBlindVoteListMap, chainHeight);
 
                     // Is our local list matching the majority data view?
                     Optional<List<BlindVote>> optionalBlindVoteListMatchingMajorityHash = findBlindVoteListMatchingMajorityHash(majorityBlindVoteListHash);
@@ -428,7 +431,7 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
         return new BallotList(ballots);
     }
 
-    private Map<P2PDataStorage.ByteArray, Long> getStakeByHashOfBlindVoteListMap(Set<DecryptedBallotsWithMerits> decryptedBallotsWithMeritsSet) {
+    private Map<P2PDataStorage.ByteArray, Long> getStakeByHashOfBlindVoteListMap(Set<DecryptedBallotsWithMerits> decryptedBallotsWithMeritsSet, long chainHeight) {
         // Don't use byte[] as key as byte[] uses object identity for equals and hashCode
         Map<P2PDataStorage.ByteArray, Long> map = new HashMap<>();
         decryptedBallotsWithMeritsSet.forEach(decryptedBallotsWithMerits -> {
@@ -438,7 +441,7 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
             // have received it. We must rely only on blockchain data. The stake is from the vote reveal tx input.
             long aggregatedStake = map.get(hash);
             long stake = decryptedBallotsWithMerits.getStake();
-            aggregatedStake += stake;
+            aggregatedStake = addBlindVoteListStake(aggregatedStake, stake, chainHeight);
             map.put(hash, aggregatedStake);
 
             log.debug("blindVoteTxId={}, stake={}",
@@ -447,12 +450,12 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
         return map;
     }
 
-    private byte[] calculateMajorityBlindVoteListHash(Map<P2PDataStorage.ByteArray, Long> stakes)
+    private byte[] calculateMajorityBlindVoteListHash(Map<P2PDataStorage.ByteArray, Long> stakes, long chainHeight)
             throws VoteResultException.ValidationException, VoteResultException.ConsensusException {
         List<HashWithStake> stakeList = stakes.entrySet().stream()
                 .map(entry -> new HashWithStake(entry.getKey().bytes, entry.getValue()))
                 .collect(Collectors.toList());
-        return VoteResultConsensus.getMajorityHash(stakeList);
+        return VoteResultConsensus.getMajorityHash(stakeList, chainHeight);
     }
 
     // Deal with eventually consistency of P2P network
@@ -517,7 +520,8 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
     private Set<EvaluatedProposal> getEvaluatedProposals(Set<DecryptedBallotsWithMerits> decryptedBallotsWithMeritsSet,
                                                          int chainHeight) {
         // We reorganize the data structure to have a map of proposals with a list of VoteWithStake objects
-        Map<Proposal, List<VoteWithStake>> resultListByProposalMap = getVoteWithStakeListByProposalMap(decryptedBallotsWithMeritsSet);
+        Map<Proposal, List<VoteWithStake>> resultListByProposalMap = getVoteWithStakeListByProposalMap(decryptedBallotsWithMeritsSet,
+                chainHeight);
 
         Set<EvaluatedProposal> evaluatedProposals = new HashSet<>();
         resultListByProposalMap.forEach((proposal, voteWithStakeList) -> {
@@ -527,16 +531,16 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
                     "requiredVoteThreshold must be not be less then 50% otherwise we could have conflicting results.");
 
             // move to consensus class
-            ProposalVoteResult proposalVoteResult = getResultPerProposal(voteWithStakeList, proposal);
+            ProposalVoteResult proposalVoteResult = getResultPerProposal(voteWithStakeList, proposal, chainHeight);
             // Quorum is min. required BSQ stake to be considered valid
-            long reachedQuorum = proposalVoteResult.getQuorum();
+            long reachedQuorum = proposalVoteResult.getQuorum(chainHeight);
             log.debug("proposalTxId: {}, required requiredQuorum: {}, requiredVoteThreshold: {}",
                     proposal.getTxId(), requiredVoteThreshold / 100D, requiredQuorum);
             if (reachedQuorum >= requiredQuorum) {
                 // We multiply by 10000 as we use a long for reachedThreshold and we want precision of 2 with
                 // a % value. E.g. 50% is 5000.
                 // Threshold is percentage of accepted to total stake
-                long reachedThreshold = proposalVoteResult.getThreshold();
+                long reachedThreshold = proposalVoteResult.getThreshold(chainHeight);
 
                 log.debug("reached threshold: {} %, required threshold: {} %",
                         reachedThreshold / 100D,
@@ -574,13 +578,7 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
                 });
 
         // Check if our issuance sum is not exceeding the limit
-        long sumIssuance = evaluatedProposals.stream()
-                .filter(EvaluatedProposal::isAccepted)
-                .map(EvaluatedProposal::getProposal)
-                .filter(proposal -> proposal instanceof IssuanceProposal)
-                .map(proposal -> (IssuanceProposal) proposal)
-                .mapToLong(proposal -> proposal.getRequestedBsq().value)
-                .sum();
+        long sumIssuance = getSumIssuance(evaluatedProposals, chainHeight);
         long limit = daoStateService.getParamValueAsCoin(Param.ISSUANCE_LIMIT, chainHeight).value;
         if (sumIssuance > limit) {
             Set<EvaluatedProposal> evaluatedProposals2 = new HashSet<>();
@@ -605,7 +603,8 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
         return MathUtils.roundDoubleToLong(paramValueAsPercentDouble * 10000);
     }
 
-    private Map<Proposal, List<VoteWithStake>> getVoteWithStakeListByProposalMap(Set<DecryptedBallotsWithMerits> decryptedBallotsWithMeritsSet) {
+    private Map<Proposal, List<VoteWithStake>> getVoteWithStakeListByProposalMap(Set<DecryptedBallotsWithMerits> decryptedBallotsWithMeritsSet,
+                                                                                 int chainHeight) {
         Map<Proposal, List<VoteWithStake>> voteWithStakeByProposalMap = new HashMap<>();
         decryptedBallotsWithMeritsSet.forEach(decryptedBallotsWithMerits -> decryptedBallotsWithMerits.getBallotList()
                 .forEach(ballot -> {
@@ -613,7 +612,7 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
                     voteWithStakeByProposalMap.putIfAbsent(proposal, new ArrayList<>());
                     List<VoteWithStake> voteWithStakeList = voteWithStakeByProposalMap.get(proposal);
                     long sumOfAllMerits = MeritConsensus.getMeritStake(decryptedBallotsWithMerits.getBlindVoteTxId(),
-                            decryptedBallotsWithMerits.getMeritList(), daoStateService);
+                            decryptedBallotsWithMerits.getMeritList(), daoStateService, chainHeight);
                     VoteWithStake voteWithStake = new VoteWithStake(ballot.getVote(), decryptedBallotsWithMerits.getStake(), sumOfAllMerits);
                     voteWithStakeList.add(voteWithStake);
                     log.debug("Add entry to voteWithStakeListByProposalMap: proposalTxId={}, voteWithStake={} ", proposal.getTxId(), voteWithStake);
@@ -622,7 +621,7 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
     }
 
 
-    private ProposalVoteResult getResultPerProposal(List<VoteWithStake> voteWithStakeList, Proposal proposal) {
+    private ProposalVoteResult getResultPerProposal(List<VoteWithStake> voteWithStakeList, Proposal proposal, int chainHeight) {
         int numAcceptedVotes = 0;
         int numRejectedVotes = 0;
         int numIgnoredVotes = 0;
@@ -632,16 +631,16 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
         for (VoteWithStake voteWithStake : voteWithStakeList) {
             long sumOfAllMerits = voteWithStake.getSumOfAllMerits();
             long stake = voteWithStake.getStake();
-            long combinedStake = stake + sumOfAllMerits;
+            long combinedStake = getCombinedStake(stake, sumOfAllMerits, chainHeight);
             log.debug("proposalTxId={}, stake={}, sumOfAllMerits={}, combinedStake={}",
                     proposal.getTxId(), stake, sumOfAllMerits, combinedStake);
             Vote vote = voteWithStake.getVote();
             if (vote != null) {
                 if (vote.isAccepted()) {
-                    stakeOfAcceptedVotes += combinedStake;
+                    stakeOfAcceptedVotes = addVoteStake(stakeOfAcceptedVotes, combinedStake, chainHeight);
                     numAcceptedVotes++;
                 } else {
-                    stakeOfRejectedVotes += combinedStake;
+                    stakeOfRejectedVotes = addVoteStake(stakeOfRejectedVotes, combinedStake, chainHeight);
                     numRejectedVotes++;
                 }
             } else {
@@ -650,6 +649,32 @@ public class VoteResultService implements DaoStateListener, DaoSetupService {
             }
         }
         return new ProposalVoteResult(proposal, stakeOfAcceptedVotes, stakeOfRejectedVotes, numAcceptedVotes, numRejectedVotes, numIgnoredVotes);
+    }
+
+    @VisibleForTesting
+    static long addBlindVoteListStake(long aggregatedStake, long stake, long chainHeight) {
+        return DaoArithmetics.addLong(aggregatedStake, stake, chainHeight);
+    }
+
+    @VisibleForTesting
+    static long getCombinedStake(long stake, long sumOfAllMerits, long chainHeight) {
+        return DaoArithmetics.addLong(stake, sumOfAllMerits, chainHeight);
+    }
+
+    @VisibleForTesting
+    static long addVoteStake(long currentStake, long combinedStake, long chainHeight) {
+        return DaoArithmetics.addLong(currentStake, combinedStake, chainHeight);
+    }
+
+    @VisibleForTesting
+    static long getSumIssuance(Set<EvaluatedProposal> evaluatedProposals, long chainHeight) {
+        long sumIssuance = 0;
+        for (EvaluatedProposal evaluatedProposal : evaluatedProposals) {
+            if (evaluatedProposal.isAccepted() && evaluatedProposal.getProposal() instanceof IssuanceProposal issuanceProposal) {
+                sumIssuance = DaoArithmetics.addLong(sumIssuance, issuanceProposal.getRequestedBsq().value, chainHeight);
+            }
+        }
+        return sumIssuance;
     }
 
     private void applyAcceptedProposals(Set<EvaluatedProposal> acceptedEvaluatedProposals, int chainHeight) {

--- a/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmetics.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmetics.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model.governance;
+
+
+public class DaoArithmetics {
+    // Consensus activation height for DAO related arithmetic hardening. Historical heights must keep
+    // legacy primitive overflow behavior so replayed DAO state hashes remain deterministic.
+    private static final int USE_V2_ACTIVATION_HEIGHT = 954_200;
+
+    public static int addInteger(int a, int b, long chainHeight) {
+        if (isV2Activated(chainHeight)) {
+            return DaoArithmeticsV2.addInteger(a, b);
+        } else {
+            return DaoArithmeticsLegacy.addInteger(a, b);
+        }
+    }
+
+    public static long addLong(long a, long b, long chainHeight) {
+        if (isV2Activated(chainHeight)) {
+            return DaoArithmeticsV2.addLong(a, b);
+        } else {
+            return DaoArithmeticsLegacy.addLong(a, b);
+        }
+    }
+
+    public static long divideLong(long numerator, long denominator, long chainHeight) {
+        if (isV2Activated(chainHeight)) {
+            return DaoArithmeticsV2.divideLong(numerator, denominator);
+        } else {
+            return DaoArithmeticsLegacy.divideLong(numerator, denominator);
+        }
+    }
+
+    public static long multiplyLong(long a, long b, long chainHeight) {
+        if (isV2Activated(chainHeight)) {
+            return DaoArithmeticsV2.multiplyLong(a, b);
+        } else {
+            return DaoArithmeticsLegacy.multiplyLong(a, b);
+        }
+    }
+
+    public static long multiplyAndDivide(long a, long b, long denominator, long chainHeight) {
+        if (isV2Activated(chainHeight)) {
+            return DaoArithmeticsV2.multiplyAndDivide(a, b, denominator);
+        } else {
+            return DaoArithmeticsLegacy.multiplyAndDivide(a, b, denominator);
+        }
+    }
+
+    private static boolean isV2Activated(long chainHeight) {
+        return chainHeight >= USE_V2_ACTIVATION_HEIGHT;
+    }
+}

--- a/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmetics.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmetics.java
@@ -21,7 +21,7 @@ package bisq.core.dao.state.model.governance;
 public class DaoArithmetics {
     // Consensus activation height for DAO related arithmetic hardening. Historical heights must keep
     // legacy primitive overflow behavior so replayed DAO state hashes remain deterministic.
-    private static final int USE_V2_ACTIVATION_HEIGHT = 954_200;
+    public static final int DAO_CONSENSUS_V2_ACTIVATION_HEIGHT = 954_200;
 
     public static int addInteger(int a, int b, long chainHeight) {
         if (isV2Activated(chainHeight)) {
@@ -64,6 +64,6 @@ public class DaoArithmetics {
     }
 
     private static boolean isV2Activated(long chainHeight) {
-        return chainHeight >= USE_V2_ACTIVATION_HEIGHT;
+        return chainHeight >= DAO_CONSENSUS_V2_ACTIVATION_HEIGHT;
     }
 }

--- a/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmeticsLegacy.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmeticsLegacy.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model.governance;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DaoArithmeticsLegacy {
+    public static int addInteger(int a, int b) {
+        return a + b;
+    }
+
+    public static long addLong(long a, long b) {
+        return a + b;
+    }
+
+    public static long divideLong(long numerator, long denominator) {
+        if (denominator == 0) {
+            log.warn("denominator must not be zero. denominator={}", denominator);
+            return 0;
+        }
+        return numerator / denominator;
+    }
+
+    public static long multiplyLong(long a, long b) {
+        return a * b;
+    }
+
+    public static long multiplyAndDivide(long a, long b, long denominator) {
+        if (denominator == 0) {
+            log.warn("denominator must not be zero. denominator={}", denominator);
+            return 0;
+        }
+        return a * b / denominator;
+    }
+}

--- a/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmeticsV2.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/DaoArithmeticsV2.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model.governance;
+
+import java.math.BigInteger;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DaoArithmeticsV2 {
+    public static int addInteger(int a, int b) {
+        return BigInteger.valueOf(a)
+                .add(BigInteger.valueOf(b)).intValueExact();
+    }
+
+    public static long addLong(long a, long b) {
+        return BigInteger.valueOf(a)
+                .add(BigInteger.valueOf(b)).longValueExact();
+    }
+
+    public static long divideLong(long numerator, long denominator) {
+        if (denominator == 0) {
+            log.warn("denominator must not be zero. denominator={}", denominator);
+            return 0;
+        }
+        return BigInteger.valueOf(numerator)
+                .divide(BigInteger.valueOf(denominator))
+                .longValueExact();
+    }
+
+    public static long multiplyLong(long a, long b) {
+
+        return BigInteger.valueOf(a)
+                .multiply(BigInteger.valueOf(b))
+                .longValueExact();
+    }
+
+    public static long multiplyAndDivide(long a, long b, long denominator) {
+        if (denominator == 0) {
+            log.warn("denominator must not be zero. denominator={}", denominator);
+            return 0;
+        }
+        return BigInteger.valueOf(a)
+                .multiply(BigInteger.valueOf(b))
+                .divide(BigInteger.valueOf(denominator))
+                .longValueExact();
+    }
+}

--- a/core/src/main/java/bisq/core/dao/state/model/governance/Issuance.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/Issuance.java
@@ -92,6 +92,9 @@ public class Issuance implements PersistablePayload, NetworkPayload, ImmutableDa
 
     // Enums must not be used directly for hashCode or equals as it delivers the Object.hashCode (internal address)!
     // The equals and hashCode methods cannot be overwritten in Enums.
+
+    // equals use `super.equals` which makes it an identity equality check, not a value equality check. Use isValueEqual
+    // for value equality check.
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -109,4 +112,15 @@ public class Issuance implements PersistablePayload, NetworkPayload, ImmutableDa
     public int hashCode() {
         return Objects.hash(super.hashCode(), txId, chainHeight, amount, pubKey, issuanceType.name());
     }
+
+
+    public boolean isValueEqual(Object o) {
+        if (!(o instanceof Issuance issuance)) return false;
+        return chainHeight == issuance.chainHeight &&
+                amount == issuance.amount &&
+                Objects.equals(txId, issuance.txId) &&
+                Objects.equals(pubKey, issuance.pubKey) &&
+                issuanceType == issuance.issuanceType;
+    }
+
 }

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ProposalVoteResult.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ProposalVoteResult.java
@@ -112,7 +112,7 @@ public class ProposalVoteResult implements PersistablePayload, ImmutableDaoState
     public long getThreshold(long chainHeight) {
         checkArgument(stakeOfAcceptedVotes >= 0, "stakeOfAcceptedVotes must not be negative");
         checkArgument(stakeOfRejectedVotes >= 0, "stakeOfRejectedVotes must not be negative");
-        if (stakeOfAcceptedVotes == 0) {
+        if (stakeOfAcceptedVotes <= 0) {
             return 0;
         }
 

--- a/core/src/main/java/bisq/core/dao/state/model/governance/ProposalVoteResult.java
+++ b/core/src/main/java/bisq/core/dao/state/model/governance/ProposalVoteResult.java
@@ -80,23 +80,48 @@ public class ProposalVoteResult implements PersistablePayload, ImmutableDaoState
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public int getNumActiveVotes() {
-        return numAcceptedVotes + numRejectedVotes;
+        // For cases where we are not evaluating consensus relevant historical data we
+        // use the new version and set chainHeight to Long.MAX_VALUE.
+        return getNumActiveVotes(Long.MAX_VALUE);
+    }
+
+    public int getNumActiveVotes(long chainHeight) {
+        return DaoArithmetics.addInteger(numAcceptedVotes, numRejectedVotes, chainHeight);
     }
 
     public long getQuorum() {
+        // For cases where we are not evaluating consensus relevant historical data we
+        // use the new version and set chainHeight to Long.MAX_VALUE.
+        return getQuorum(Long.MAX_VALUE);
+    }
+
+    public long getQuorum(long chainHeight) {
         // Quorum is sum of all votes independent if accepted or rejected.
+        long totalStake = getTotalStake(chainHeight);
         log.debug("Quorum: proposalTxId: {}, totalStake: {}, stakeOfAcceptedVotes: {}, stakeOfRejectedVotes: {}",
-                proposal.getTxId(), getTotalStake(), stakeOfAcceptedVotes, stakeOfRejectedVotes);
-        return getTotalStake();
+                proposal.getTxId(), totalStake, stakeOfAcceptedVotes, stakeOfRejectedVotes);
+        return totalStake;
     }
 
     public long getThreshold() {
+        // For cases where we are not evaluating consensus relevant historical data we
+        // use the new version and set chainHeight to Long.MAX_VALUE.
+        return getThreshold(Long.MAX_VALUE);
+    }
+
+    public long getThreshold(long chainHeight) {
         checkArgument(stakeOfAcceptedVotes >= 0, "stakeOfAcceptedVotes must not be negative");
         checkArgument(stakeOfRejectedVotes >= 0, "stakeOfRejectedVotes must not be negative");
         if (stakeOfAcceptedVotes == 0) {
             return 0;
         }
-        return stakeOfAcceptedVotes * 10_000 / getTotalStake();
+
+        long totalStake = getTotalStake(chainHeight);
+        if (totalStake <= 0) {
+            log.warn("totalStake must be positive. totalStake={}", totalStake);
+            return 0;
+        }
+        return DaoArithmetics.multiplyAndDivide(stakeOfAcceptedVotes, 10_000, totalStake, chainHeight);
     }
 
     @Override
@@ -116,7 +141,7 @@ public class ProposalVoteResult implements PersistablePayload, ImmutableDaoState
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private long getTotalStake() {
-        return stakeOfAcceptedVotes + stakeOfRejectedVotes;
+    private long getTotalStake(long chainHeight) {
+        return DaoArithmetics.addLong(stakeOfAcceptedVotes, stakeOfRejectedVotes, chainHeight);
     }
 }

--- a/core/src/test/java/bisq/core/dao/governance/merit/MeritConsensusTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/merit/MeritConsensusTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.governance.merit;
+
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.dao.state.model.governance.Issuance;
+import bisq.core.dao.state.model.governance.IssuanceType;
+import bisq.core.dao.state.model.governance.Merit;
+import bisq.core.dao.state.model.governance.MeritList;
+
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MeritConsensusTest {
+    private static final int PRE_ACTIVATION_HEIGHT = MeritConsensus.MERIT_CONSENSUS_V2_ACTIVATION_HEIGHT - 1;
+    private static final int ACTIVATION_HEIGHT = MeritConsensus.MERIT_CONSENSUS_V2_ACTIVATION_HEIGHT;
+    private static final int BLIND_VOTE_HEIGHT = PRE_ACTIVATION_HEIGHT - 10;
+    private static final long ISSUANCE_AMOUNT = 100_000;
+    private static final long FORGED_ISSUANCE_AMOUNT = ISSUANCE_AMOUNT + 1;
+    private static final String BLIND_VOTE_TX_ID = txId("blind-vote-tx");
+
+    @Test
+    void getMeritStakeUsesEvaluationHeightForActivationBoundary() {
+        ECKey key = new ECKey();
+        Issuance daoStateIssuance = compensationIssuance("compensation-tx", BLIND_VOTE_HEIGHT, ISSUANCE_AMOUNT, key);
+        Issuance forgedEmbeddedIssuance = new Issuance(daoStateIssuance.getTxId(),
+                daoStateIssuance.getChainHeight(),
+                FORGED_ISSUANCE_AMOUNT,
+                daoStateIssuance.getPubKey(),
+                daoStateIssuance.getIssuanceType());
+        MeritList meritList = new MeritList(List.of(merit(forgedEmbeddedIssuance, key)));
+        DaoStateService daoStateService = daoStateService(ACTIVATION_HEIGHT, daoStateIssuance);
+
+        assertEquals(FORGED_ISSUANCE_AMOUNT, MeritConsensus.getMeritStake(BLIND_VOTE_TX_ID,
+                meritList,
+                daoStateService,
+                PRE_ACTIVATION_HEIGHT));
+        assertEquals(0, MeritConsensus.getMeritStake(BLIND_VOTE_TX_ID,
+                meritList,
+                daoStateService,
+                ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getMeritStakeDefaultUsesDaoStateChainHeight() {
+        ECKey key = new ECKey();
+        Issuance issuance = compensationIssuance("compensation-tx", BLIND_VOTE_HEIGHT, ISSUANCE_AMOUNT, key);
+        MeritList meritList = new MeritList(List.of(merit(issuance, key)));
+        DaoStateService daoStateService = daoStateService(ACTIVATION_HEIGHT, issuance);
+
+        assertEquals(ISSUANCE_AMOUNT, MeritConsensus.getMeritStake(BLIND_VOTE_TX_ID,
+                meritList,
+                daoStateService));
+    }
+
+    private static DaoStateService daoStateService(int chainHeight, Issuance issuance) {
+        DaoStateService daoStateService = mock(DaoStateService.class);
+        Tx blindVoteTx = mock(Tx.class);
+        when(blindVoteTx.getBlockHeight()).thenReturn(BLIND_VOTE_HEIGHT);
+        when(daoStateService.getChainHeight()).thenReturn(chainHeight);
+        when(daoStateService.getTx(BLIND_VOTE_TX_ID)).thenReturn(Optional.of(blindVoteTx));
+        when(daoStateService.getIssuance(issuance.getTxId(), IssuanceType.COMPENSATION))
+                .thenReturn(Optional.of(issuance));
+        return daoStateService;
+    }
+
+    private static Issuance compensationIssuance(String txIdSeed, int chainHeight, long amount, ECKey key) {
+        return new Issuance(txId(txIdSeed),
+                chainHeight,
+                amount,
+                Utilities.encodeToHex(key.getPubKey()),
+                IssuanceType.COMPENSATION);
+    }
+
+    private static Merit merit(Issuance issuance, ECKey key) {
+        byte[] signature = key.sign(Sha256Hash.wrap(BLIND_VOTE_TX_ID)).encodeToDER();
+        return new Merit(issuance, signature);
+    }
+
+    private static String txId(String seed) {
+        return Sha256Hash.of(seed.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+}

--- a/core/src/test/java/bisq/core/dao/governance/merit/MeritConsensusV2Test.java
+++ b/core/src/test/java/bisq/core/dao/governance/merit/MeritConsensusV2Test.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.governance.merit;
+
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Tx;
+import bisq.core.dao.state.model.governance.Issuance;
+import bisq.core.dao.state.model.governance.IssuanceType;
+import bisq.core.dao.state.model.governance.Merit;
+import bisq.core.dao.state.model.governance.MeritList;
+
+import bisq.common.util.Utilities;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Sha256Hash;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MeritConsensusV2Test {
+    private static final int BLIND_VOTE_HEIGHT = 954_210;
+    private static final long ISSUANCE_AMOUNT = 100_000;
+    private static final String BLIND_VOTE_TX_ID = txId("blind-vote-tx");
+
+    @Test
+    void getMeritStakeAcceptsDistinctIssuanceObjectWithSameValuesAsDaoState() {
+        ECKey key = new ECKey();
+        Issuance daoStateIssuance = compensationIssuance("compensation-tx", BLIND_VOTE_HEIGHT, ISSUANCE_AMOUNT, key);
+        Issuance embeddedIssuance = copy(daoStateIssuance);
+
+        assertNotSame(daoStateIssuance, embeddedIssuance);
+        assertTrue(daoStateIssuance.isValueEqual(embeddedIssuance));
+
+        MeritList meritList = new MeritList(List.of(merit(embeddedIssuance, key)));
+        DaoStateService daoStateService = daoStateService(daoStateIssuance);
+
+        assertEquals(ISSUANCE_AMOUNT, MeritConsensusV2.getMeritStake(BLIND_VOTE_TX_ID, meritList, daoStateService));
+    }
+
+    @Test
+    void getMeritStakeRejectsEmbeddedIssuanceWhenValuesDifferFromDaoState() {
+        ECKey key = new ECKey();
+        Issuance daoStateIssuance = compensationIssuance("compensation-tx", BLIND_VOTE_HEIGHT, ISSUANCE_AMOUNT, key);
+        Issuance forgedEmbeddedIssuance = new Issuance(daoStateIssuance.getTxId(),
+                daoStateIssuance.getChainHeight(),
+                daoStateIssuance.getAmount() + 1,
+                daoStateIssuance.getPubKey(),
+                daoStateIssuance.getIssuanceType());
+
+        MeritList meritList = new MeritList(List.of(merit(forgedEmbeddedIssuance, key)));
+        DaoStateService daoStateService = daoStateService(daoStateIssuance);
+
+        assertEquals(0, MeritConsensusV2.getMeritStake(BLIND_VOTE_TX_ID, meritList, daoStateService));
+    }
+
+    @Test
+    void getMeritStakeCountsDuplicateIssuanceTxIdOnlyOnce() {
+        ECKey key = new ECKey();
+        Issuance daoStateIssuance = compensationIssuance("compensation-tx", BLIND_VOTE_HEIGHT, ISSUANCE_AMOUNT, key);
+
+        MeritList meritList = new MeritList(List.of(
+                merit(copy(daoStateIssuance), key),
+                merit(copy(daoStateIssuance), key)));
+        DaoStateService daoStateService = daoStateService(daoStateIssuance);
+
+        assertEquals(ISSUANCE_AMOUNT, MeritConsensusV2.getMeritStake(BLIND_VOTE_TX_ID, meritList, daoStateService));
+    }
+
+    @Test
+    void getMeritStakeThrowsOnTotalMeritOverflow() {
+        ECKey firstKey = new ECKey();
+        ECKey secondKey = new ECKey();
+        Issuance firstIssuance = compensationIssuance("first-compensation-tx",
+                BLIND_VOTE_HEIGHT,
+                Long.MAX_VALUE,
+                firstKey);
+        Issuance secondIssuance = compensationIssuance("second-compensation-tx",
+                BLIND_VOTE_HEIGHT,
+                1,
+                secondKey);
+        MeritList meritList = new MeritList(List.of(
+                merit(firstIssuance, firstKey),
+                merit(secondIssuance, secondKey)));
+        DaoStateService daoStateService = daoStateService(firstIssuance, secondIssuance);
+
+        assertThrows(ArithmeticException.class,
+                () -> MeritConsensusV2.getMeritStake(BLIND_VOTE_TX_ID, meritList, daoStateService));
+    }
+
+    @Test
+    void getMeritStakeIgnoresInvalidAndExpiredMeritsWithoutAbortingValidMerits() {
+        ECKey validKey = new ECKey();
+        Issuance validIssuance = compensationIssuance("valid-compensation-tx",
+                BLIND_VOTE_HEIGHT,
+                ISSUANCE_AMOUNT,
+                validKey);
+
+        ECKey expiredKey = new ECKey();
+        Issuance expiredIssuance = compensationIssuance("expired-compensation-tx",
+                BLIND_VOTE_HEIGHT - 100_000,
+                ISSUANCE_AMOUNT,
+                expiredKey);
+
+        ECKey invalidTypeKey = new ECKey();
+        Issuance invalidTypeIssuance = new Issuance(txId("reimbursement-tx"),
+                BLIND_VOTE_HEIGHT,
+                ISSUANCE_AMOUNT,
+                Utilities.encodeToHex(invalidTypeKey.getPubKey()),
+                IssuanceType.REIMBURSEMENT);
+
+        MeritList meritList = new MeritList(List.of(
+                merit(invalidTypeIssuance, invalidTypeKey),
+                merit(copy(expiredIssuance), expiredKey),
+                merit(copy(validIssuance), validKey)));
+        DaoStateService daoStateService = daoStateService(validIssuance, expiredIssuance);
+
+        assertEquals(ISSUANCE_AMOUNT, MeritConsensusV2.getMeritStake(BLIND_VOTE_TX_ID, meritList, daoStateService));
+    }
+
+    private static DaoStateService daoStateService(Issuance... issuances) {
+        DaoStateService daoStateService = mock(DaoStateService.class);
+        Tx blindVoteTx = mock(Tx.class);
+        when(blindVoteTx.getBlockHeight()).thenReturn(BLIND_VOTE_HEIGHT);
+        when(daoStateService.getTx(BLIND_VOTE_TX_ID)).thenReturn(Optional.of(blindVoteTx));
+        for (Issuance issuance : issuances) {
+            when(daoStateService.getIssuance(issuance.getTxId(), IssuanceType.COMPENSATION))
+                    .thenReturn(Optional.of(issuance));
+        }
+        return daoStateService;
+    }
+
+    private static Issuance compensationIssuance(String txIdSeed, int chainHeight, long amount, ECKey key) {
+        return new Issuance(txId(txIdSeed),
+                chainHeight,
+                amount,
+                Utilities.encodeToHex(key.getPubKey()),
+                IssuanceType.COMPENSATION);
+    }
+
+    private static Issuance copy(Issuance issuance) {
+        return new Issuance(issuance.getTxId(),
+                issuance.getChainHeight(),
+                issuance.getAmount(),
+                issuance.getPubKey(),
+                issuance.getIssuanceType());
+    }
+
+    private static Merit merit(Issuance issuance, ECKey key) {
+        byte[] signature = key.sign(Sha256Hash.wrap(BLIND_VOTE_TX_ID)).encodeToDER();
+        return new Merit(issuance, signature);
+    }
+
+    private static String txId(String seed) {
+        return Sha256Hash.of(seed.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+}

--- a/core/src/test/java/bisq/core/dao/governance/voteresult/VoteResultConsensusTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/voteresult/VoteResultConsensusTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.governance.voteresult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class VoteResultConsensusTest {
+    private static final int PRE_ACTIVATION_HEIGHT = 954_199;
+    private static final int ACTIVATION_HEIGHT = 954_200;
+    private static final byte[] FIRST_HASH = new byte[]{1};
+    private static final byte[] SECOND_HASH = new byte[]{2};
+
+    @Test
+    void getStakeOfAllMatchesStreamSumBeforeActivationForNormalValues() {
+        List<VoteResultService.HashWithStake> hashWithStakeList = List.of(
+                new VoteResultService.HashWithStake(FIRST_HASH, 7),
+                new VoteResultService.HashWithStake(SECOND_HASH, 11),
+                new VoteResultService.HashWithStake(new byte[]{3}, 13));
+
+        long expected = hashWithStakeList.stream()
+                .mapToLong(VoteResultService.HashWithStake::getStake)
+                .sum();
+        assertEquals(expected, VoteResultConsensus.getStakeOfAll(hashWithStakeList, PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getStakeOfAllUsesLegacyOverflowBeforeActivation() {
+        List<VoteResultService.HashWithStake> hashWithStakeList = List.of(
+                new VoteResultService.HashWithStake(FIRST_HASH, Long.MAX_VALUE),
+                new VoteResultService.HashWithStake(SECOND_HASH, 1));
+
+        assertEquals(Long.MIN_VALUE, VoteResultConsensus.getStakeOfAll(hashWithStakeList, PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getMajorityHashThrowsOnTotalStakeOverflowAtActivation() {
+        List<VoteResultService.HashWithStake> hashWithStakeList = new ArrayList<>(List.of(
+                new VoteResultService.HashWithStake(FIRST_HASH, Long.MAX_VALUE),
+                new VoteResultService.HashWithStake(SECOND_HASH, 1)));
+
+        assertThrows(ArithmeticException.class,
+                () -> VoteResultConsensus.getMajorityHash(hashWithStakeList, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getMajorityHashThrowsConsensusExceptionWhenNoSuperMajority() {
+        List<VoteResultService.HashWithStake> hashWithStakeList = new ArrayList<>(List.of(
+                new VoteResultService.HashWithStake(FIRST_HASH, 50),
+                new VoteResultService.HashWithStake(SECOND_HASH, 50)));
+
+        assertThrows(VoteResultException.ConsensusException.class,
+                () -> VoteResultConsensus.getMajorityHash(hashWithStakeList, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getMajorityHashReturnsWinnerWhenSuperMajorityReached() throws Exception {
+        List<VoteResultService.HashWithStake> hashWithStakeList = new ArrayList<>(List.of(
+                new VoteResultService.HashWithStake(FIRST_HASH, 81),
+                new VoteResultService.HashWithStake(SECOND_HASH, 19)));
+
+        assertArrayEquals(FIRST_HASH, VoteResultConsensus.getMajorityHash(hashWithStakeList, ACTIVATION_HEIGHT));
+    }
+}

--- a/core/src/test/java/bisq/core/dao/governance/voteresult/VoteResultServiceTest.java
+++ b/core/src/test/java/bisq/core/dao/governance/voteresult/VoteResultServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.governance.voteresult;
+
+import bisq.core.dao.governance.proposal.IssuanceProposal;
+import bisq.core.dao.state.model.governance.EvaluatedProposal;
+import bisq.core.dao.state.model.governance.Proposal;
+import bisq.core.dao.state.model.governance.ProposalVoteResult;
+
+import org.bitcoinj.core.Coin;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+class VoteResultServiceTest {
+    private static final int PRE_ACTIVATION_HEIGHT = 954_199;
+    private static final int ACTIVATION_HEIGHT = 954_200;
+
+    @Test
+    void getCombinedStakeAddsStakeAndMerit() {
+        assertEquals(15, VoteResultService.getCombinedStake(10, 5, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getCombinedStakeUsesLegacyOverflowBeforeActivation() {
+        assertEquals(Long.MIN_VALUE, VoteResultService.getCombinedStake(Long.MAX_VALUE, 1, PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getCombinedStakeThrowsOnOverflowAtActivation() {
+        assertThrows(ArithmeticException.class,
+                () -> VoteResultService.getCombinedStake(Long.MAX_VALUE, 1, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void addVoteStakeUsesLegacyOverflowBeforeActivation() {
+        assertEquals(Long.MIN_VALUE, VoteResultService.addVoteStake(Long.MAX_VALUE, 1, PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void addVoteStakeThrowsOnOverflowAtActivation() {
+        assertThrows(ArithmeticException.class,
+                () -> VoteResultService.addVoteStake(Long.MAX_VALUE, 1, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void addBlindVoteListStakeUsesLegacyOverflowBeforeActivation() {
+        assertEquals(Long.MIN_VALUE, VoteResultService.addBlindVoteListStake(Long.MAX_VALUE,
+                1,
+                PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void addBlindVoteListStakeThrowsOnOverflowAtActivation() {
+        assertThrows(ArithmeticException.class,
+                () -> VoteResultService.addBlindVoteListStake(Long.MAX_VALUE, 1, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getSumIssuanceUsesLegacyOverflowBeforeActivation() {
+        Set<EvaluatedProposal> evaluatedProposals = Set.of(
+                acceptedIssuanceProposal(Long.MAX_VALUE),
+                acceptedIssuanceProposal(1));
+
+        assertEquals(Long.MIN_VALUE, VoteResultService.getSumIssuance(evaluatedProposals, PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getSumIssuanceThrowsOnOverflowAtActivation() {
+        Set<EvaluatedProposal> evaluatedProposals = Set.of(
+                acceptedIssuanceProposal(Long.MAX_VALUE),
+                acceptedIssuanceProposal(1));
+
+        assertThrows(ArithmeticException.class,
+                () -> VoteResultService.getSumIssuance(evaluatedProposals, ACTIVATION_HEIGHT));
+    }
+
+    private static EvaluatedProposal acceptedIssuanceProposal(long requestedBsq) {
+        Proposal proposal = mock(Proposal.class, withSettings().extraInterfaces(IssuanceProposal.class));
+        when(((IssuanceProposal) proposal).getRequestedBsq()).thenReturn(Coin.valueOf(requestedBsq));
+        return new EvaluatedProposal(true, new ProposalVoteResult(proposal, 0, 0, 0, 0, 0));
+    }
+}

--- a/core/src/test/java/bisq/core/dao/state/model/governance/DaoArithmeticsTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/governance/DaoArithmeticsTest.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model.governance;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DaoArithmeticsTest {
+    private static final int PRE_ACTIVATION_HEIGHT = 954_199;
+    private static final int ACTIVATION_HEIGHT = 954_200;
+
+    @Test
+    void addLongUsesLegacyOverflowBeforeActivation() {
+        assertEquals(Long.MIN_VALUE, DaoArithmetics.addLong(Long.MAX_VALUE, 1, PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void addLongThrowsOnOverflowAtActivation() {
+        assertThrows(ArithmeticException.class,
+                () -> DaoArithmetics.addLong(Long.MAX_VALUE, 1, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void addIntegerUsesLegacyOverflowBeforeActivation() {
+        assertEquals(Integer.MIN_VALUE, DaoArithmetics.addInteger(Integer.MAX_VALUE, 1, PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void addIntegerThrowsOnOverflowAtActivation() {
+        assertThrows(ArithmeticException.class,
+                () -> DaoArithmetics.addInteger(Integer.MAX_VALUE, 1, ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void multiplyAndDivideUsesLegacyIntermediateOverflowBeforeActivation() {
+        long acceptedStake = Long.MAX_VALUE / 10_000 + 1;
+
+        assertEquals(-9_999, DaoArithmetics.multiplyAndDivide(acceptedStake,
+                10_000,
+                acceptedStake + 1,
+                PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void multiplyAndDivideKeepsOverflowingIntermediateExactAtActivation() {
+        long acceptedStake = Long.MAX_VALUE / 10_000 + 1;
+
+        assertEquals(9_999, DaoArithmetics.multiplyAndDivide(acceptedStake,
+                10_000,
+                acceptedStake + 1,
+                ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void multiplyLongUsesLegacyOverflowBeforeActivation() {
+        assertEquals(Long.MIN_VALUE, DaoArithmetics.multiplyLong(Long.MAX_VALUE / 2 + 1,
+                2,
+                PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void multiplyLongThrowsOnOverflowAtActivation() {
+        assertThrows(ArithmeticException.class,
+                () -> DaoArithmetics.multiplyLong(Long.MAX_VALUE / 2 + 1, 2, ACTIVATION_HEIGHT));
+    }
+}

--- a/core/src/test/java/bisq/core/dao/state/model/governance/ProposalVoteResultTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/governance/ProposalVoteResultTest.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.state.model.governance;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProposalVoteResultTest {
+    private static final int PRE_ACTIVATION_HEIGHT = 954_199;
+    private static final int ACTIVATION_HEIGHT = 954_200;
+
+    @Test
+    void getThresholdReturnsAcceptedStakeRatio() {
+        ProposalVoteResult proposalVoteResult = new ProposalVoteResult(createProposal(), 70, 30, 1, 1, 0);
+
+        assertEquals(7_000, proposalVoteResult.getThreshold(ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getQuorumUsesLegacyOverflowBeforeActivation() {
+        ProposalVoteResult proposalVoteResult = new ProposalVoteResult(createProposal(), Long.MAX_VALUE, 1, 1, 1, 0);
+
+        assertEquals(Long.MIN_VALUE, proposalVoteResult.getQuorum(PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getQuorumThrowsOnOverflowAtActivation() {
+        ProposalVoteResult proposalVoteResult = new ProposalVoteResult(createProposal(), Long.MAX_VALUE, 1, 1, 1, 0);
+
+        assertThrows(ArithmeticException.class, () -> proposalVoteResult.getQuorum(ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getThresholdUsesLegacyIntermediateOverflowBeforeActivation() {
+        long acceptedStake = Long.MAX_VALUE / 10_000 + 1;
+        ProposalVoteResult proposalVoteResult = new ProposalVoteResult(createProposal(), acceptedStake, 1, 1, 1, 0);
+
+        assertEquals(-9_999, proposalVoteResult.getThreshold(PRE_ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getThresholdKeepsOverflowingIntermediateExactAtActivation() {
+        long acceptedStake = Long.MAX_VALUE / 10_000 + 1;
+        ProposalVoteResult proposalVoteResult = new ProposalVoteResult(createProposal(), acceptedStake, 1, 1, 1, 0);
+
+        assertEquals(9_999, proposalVoteResult.getThreshold(ACTIVATION_HEIGHT));
+    }
+
+    @Test
+    void getThresholdThrowsOnTotalStakeOverflowAtActivation() {
+        ProposalVoteResult proposalVoteResult = new ProposalVoteResult(createProposal(), Long.MAX_VALUE, 1, 1, 1, 0);
+
+        assertThrows(ArithmeticException.class, () -> proposalVoteResult.getThreshold(ACTIVATION_HEIGHT));
+    }
+
+    private static Proposal createProposal() {
+        Proposal proposal = mock(Proposal.class);
+        when(proposal.getTxId()).thenReturn("proposalTxId");
+        return proposal;
+    }
+}

--- a/core/src/test/java/bisq/core/dao/voting/voteresult/WeightedMeritAmountLegacyTest.java
+++ b/core/src/test/java/bisq/core/dao/voting/voteresult/WeightedMeritAmountLegacyTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.dao.voting.voteresult;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static bisq.core.dao.governance.merit.MeritConsensusLegacy.getWeightedMeritAmount;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Slf4j
+public class WeightedMeritAmountLegacyTest {
+    @BeforeEach
+    public void setup() {
+    }
+
+    @Test
+    public void testGetWeightedMeritAmount() {
+        int currentChainHeight;
+        int blocksPerYear = 50_000; // 144*365=51264;
+        currentChainHeight = 1_000_000;
+
+        assertEquals(100000, getWeightedMeritAmount(100_000, 1_000_000,
+                currentChainHeight, blocksPerYear), "fresh issuance");
+        assertEquals(75000, getWeightedMeritAmount(100_000, 975_000,
+                currentChainHeight, blocksPerYear), "0.5 year old issuance");
+        assertEquals(50000, getWeightedMeritAmount(100_000, 950_000,
+                currentChainHeight, blocksPerYear), "1 year old issuance");
+        assertEquals(25000, getWeightedMeritAmount(100_000, 925_000,
+                currentChainHeight, blocksPerYear), "1.5 year old issuance");
+        assertEquals(0, getWeightedMeritAmount(100_000, 900_000,
+                currentChainHeight, blocksPerYear), "2 year old issuance");
+        assertEquals(0, getWeightedMeritAmount(100_000, 850_000,
+                currentChainHeight, blocksPerYear), "3 year old issuance");
+
+
+        assertEquals(99999, getWeightedMeritAmount(100_000, 999_999,
+                currentChainHeight, blocksPerYear), "1 block old issuance");
+        assertEquals(99998, getWeightedMeritAmount(100_000, 999_998,
+                currentChainHeight, blocksPerYear), "2 block old issuance");
+        assertEquals(99990, getWeightedMeritAmount(100_000, 999_990,
+                currentChainHeight, blocksPerYear), "10 blocks old issuance");
+        assertEquals(99900, getWeightedMeritAmount(100_000, 999_900,
+                currentChainHeight, blocksPerYear), "100 blocks old issuance");
+        assertEquals(1, getWeightedMeritAmount(100_000, 900_001,
+                currentChainHeight, blocksPerYear), "99_999 blocks old issuance");
+        assertEquals(10, getWeightedMeritAmount(100_000, 900_010,
+                currentChainHeight, blocksPerYear), "99_990 blocks old issuance");
+        assertEquals(0, getWeightedMeritAmount(100_000, 899_999,
+                currentChainHeight, blocksPerYear), "100_001 blocks old issuance");
+        assertEquals(0, getWeightedMeritAmount(100_000, 0,
+                currentChainHeight, blocksPerYear), "1_000_000 blocks old issuance");
+    }
+
+    @Test
+    public void testInvalidChainHeight() {
+        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, 2_000_000, 1_000_000, 1_000_000));
+    }
+
+    @Test
+    public void testInvalidIssuanceHeight() {
+        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, -1, 1_000_000, 1_000_000));
+    }
+
+    @Test
+    public void testInvalidAmount() {
+        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(-100_000, 1, 1_000_000, 1_000_000));
+    }
+
+    @Test
+    public void testInvalidCurrentChainHeight() {
+        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, 1, -1, 1_000_000));
+    }
+
+    @Test
+    public void testInvalidBlockPerYear() {
+        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, 1, 11, -1));
+    }
+}

--- a/core/src/test/java/bisq/core/dao/voting/voteresult/WeightedMeritAmountV2Test.java
+++ b/core/src/test/java/bisq/core/dao/voting/voteresult/WeightedMeritAmountV2Test.java
@@ -22,12 +22,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static bisq.core.dao.governance.merit.MeritConsensus.getWeightedMeritAmount;
+import static bisq.core.dao.governance.merit.MeritConsensusV2.getWeightedMeritAmount;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Slf4j
-public class VoteResultConsensusTest {
+public class WeightedMeritAmountV2Test {
     @BeforeEach
     public void setup() {
     }
@@ -72,26 +72,26 @@ public class VoteResultConsensusTest {
 
     @Test
     public void testInvalidChainHeight() {
-        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, 2_000_000, 1_000_000, 1_000_000));
+        assertEquals(0, getWeightedMeritAmount(100_000, 2_000_000, 1_000_000, 1_000_000));
     }
 
     @Test
     public void testInvalidIssuanceHeight() {
-        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, -1, 1_000_000, 1_000_000));
+        assertEquals(0, getWeightedMeritAmount(100_000, -1, 1_000_000, 1_000_000));
     }
 
     @Test
     public void testInvalidAmount() {
-        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(-100_000, 1, 1_000_000, 1_000_000));
+        assertEquals(0, getWeightedMeritAmount(-100_000, 1, 1_000_000, 1_000_000));
     }
 
     @Test
     public void testInvalidCurrentChainHeight() {
-        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, 1, -1, 1_000_000));
+        assertEquals(0, getWeightedMeritAmount(100_000, 1, -1, 1_000_000));
     }
 
     @Test
     public void testInvalidBlockPerYear() {
-        assertThrows(IllegalArgumentException.class, () -> getWeightedMeritAmount(100_000, 1, 11, -1));
+        assertEquals(0, getWeightedMeritAmount(100_000, 1, 11, -1));
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ResultsOfCycle.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ResultsOfCycle.java
@@ -63,11 +63,13 @@ class ResultsOfCycle {
         this.evaluatedProposals = evaluatedProposals;
         this.decryptedVotesForCycle = decryptedVotesForCycle;
 
+        long chainHeight = cycle.getHeightOfFirstBlock();
+
         numVotes = evaluatedProposals.stream()
-                .mapToInt(e -> e.getProposalVoteResult().getNumActiveVotes())
+                .mapToInt(e -> e.getProposalVoteResult().getNumActiveVotes(chainHeight))
                 .sum();
         numAcceptedVotes = evaluatedProposals.stream()
-                .mapToInt(e -> e.getProposalVoteResult().getNumActiveVotes())
+                .mapToInt(e -> e.getProposalVoteResult().getNumActiveVotes(chainHeight))
                 .sum();
         numRejectedVotes = evaluatedProposals.stream()
                 .mapToInt(e -> e.getProposalVoteResult().getNumRejectedVotes())

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ResultsOfCycle.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ResultsOfCycle.java
@@ -70,7 +70,7 @@ class ResultsOfCycle {
                 .mapToInt(e -> e.getProposalVoteResult().getNumActiveVotes(chainHeight))
                 .sum();
         numAcceptedVotes = evaluatedProposals.stream()
-                .mapToInt(e -> e.getProposalVoteResult().getNumActiveVotes(chainHeight))
+                .mapToInt(e -> e.getProposalVoteResult().getNumAcceptedVotes())
                 .sum();
         numRejectedVotes = evaluatedProposals.stream()
                 .mapToInt(e -> e.getProposalVoteResult().getNumRejectedVotes())

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ResultsOfCycle.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/ResultsOfCycle.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.dao.governance.result;
 
 import bisq.core.dao.state.DaoStateService;
 import bisq.core.dao.state.model.governance.Cycle;
+import bisq.core.dao.state.model.governance.DaoPhase;
 import bisq.core.dao.state.model.governance.DecryptedBallotsWithMerits;
 import bisq.core.dao.state.model.governance.EvaluatedProposal;
 import bisq.core.dao.state.model.governance.Proposal;
@@ -63,7 +64,7 @@ class ResultsOfCycle {
         this.evaluatedProposals = evaluatedProposals;
         this.decryptedVotesForCycle = decryptedVotesForCycle;
 
-        long chainHeight = cycle.getHeightOfFirstBlock();
+        long chainHeight = cycle.getFirstBlockOfPhase(DaoPhase.Phase.RESULT);
 
         numVotes = evaluatedProposals.stream()
                 .mapToInt(e -> e.getProposalVoteResult().getNumActiveVotes(chainHeight))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Governance protocol upgrade activates at block **954,200**, enabling versioned merit and stake calculations.
  * Voting power, merit availability, and vote-result computations are now **chain-height aware**.

* **Bug Fixes**
  * Improved consensus majority/quorum checks with correct chain-height stake handling.
  * Arithmetic overflow handling now switches behavior at/after activation.
  * Governance results display vote counts using the proper evaluation height.

* **Tests**
  * Added/expanded unit tests for merit consensus v1/v2, weighted merit, arithmetic behavior, and activation-boundary vote-result logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->