### PR TITLE
docs: fix build/run instructions for current scripts layout

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,8 @@
    ```sh
    git clone https://github.com/bisq-network/bisq
    # if you intend to do testing on the latest release, you can clone the respective branch selectively, without downloading the whole repository
-   # for the 1.9.18 release, you would do it like this:
-   git clone --recurse-submodules --branch release/v1.9.19 https://github.com/bisq-network/bisq
+   # for the 1.10.2 release, you would do it like this:
+   git clone --recurse-submodules --branch release/v1.10.2 https://github.com/bisq-network/bisq
    cd bisq
    ```
 
@@ -50,7 +50,7 @@
    and if the version number on the JVM line is not a supported one, you can pick the correct JDK at runtime with this syntax (verify your system path):
 
    ```sh
-   ./gradlew build -Dorg.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64/
+   JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH ./gradlew clean build
    ```
 
 If you do not have JDK 21 installed, check out scripts in the [scripts](../scripts) directory or download it manually
@@ -58,20 +58,20 @@ from https://jdk.java.net/archive/.
 
 ## Running Bisq
 
-Once Bisq is installed, its executables will be available in the root project directory. Run **Bisq Desktop** as follows:
+Once Bisq is installed, its executables will be available in the `scripts` folder under the root project directory. Run **Bisq Desktop** as follows:
 
 On macOS and Linux:
 ```sh
-./bisq-desktop
+./scripts/desktop
 ```
 or, to select a specific version of Java:
 ```sh
-env JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./bisq-desktop
+env JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./scripts/desktop
 ```
 
 On Windows:
 ```cmd
-bisq-desktop.bat
+scripts\desktop.bat
 ```
 
 ## See also


### PR DESCRIPTION
updated PR from https://github.com/bisq-network/bisq/pull/7571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions to use the current Bisq release branch when cloning.
  * Simplified the JDK 21 build example to use an inline environment setup with `./gradlew clean build`.
  * Clarified how to start the app by running the desktop launch scripts from the `scripts` directory, with updated examples for both Unix-like systems and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->