### PR TITLE
fix: broken mediation on master

### DIFF
--- a/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeManager.java
@@ -415,18 +415,33 @@ public abstract class DisputeManager<T extends DisputeList<Dispute>> extends Sup
             return;
         }
 
+        // Integrity checks: a mismatch here means the payload was tampered with or replayed. The opener
+        // is already authenticated, so a genuine dispute cannot fail these. Fail closed and drop silently
+        // (log only, no UI popup): the payload is attacker-controlled, so surfacing rejects as dialogs would be
+        // a popup-flood vector and would point at a case that was never stored.
         try {
             DisputeValidation.validateDisputeData(dispute, btcWalletService);
+            DisputeValidation.testIfDisputeTriesReplay(dispute, disputeList.getList());
+        } catch (DisputeValidation.ValidationException e) {
+            log.warn("Rejecting {} for trade {}: {}",
+                    openNewDisputeMessage.getClass().getSimpleName(), dispute.getTradeId(), e.toString());
+            return;
+        }
+
+        // Advisory checks: a legitimate dispute can trip these (e.g. donation-address param drift, node address
+        // formatting). We must NOT drop the case, or the trader is stuck with no way to get mediation. Instead we
+        // store and forward it as usual and alert the agent via validationExceptions (popup) so they can resolve
+        // it manually, matching pre-1.10.3 behavior and the sibling peerOpenedDisputeForTrade handler.
+        try {
             DisputeValidation.validateNodeAddresses(dispute, config);
             DisputeValidation.validateSenderNodeAddress(dispute, openNewDisputeMessage.getSenderNodeAddress());
-            DisputeValidation.testIfDisputeTriesReplay(dispute, disputeList.getList());
             if (dispute.isUsingLegacyBurningMan()) {
                 DisputeValidation.validateDonationAddressMatchesAnyPastParamValues(dispute, dispute.getDonationAddressOfDelayedPayoutTx(), daoFacade);
             }
         } catch (DisputeValidation.ValidationException e) {
-            log.error(e.toString());
+            log.warn("Advisory validation failed for {} on trade {}: {}",
+                    openNewDisputeMessage.getClass().getSimpleName(), dispute.getTradeId(), e.toString());
             validationExceptions.add(e);
-            return;
         }
 
         Contract contract = dispute.getContract();

--- a/core/src/main/java/bisq/core/support/dispute/DisputeValidation.java
+++ b/core/src/main/java/bisq/core/support/dispute/DisputeValidation.java
@@ -249,6 +249,14 @@ public class DisputeValidation {
         Map<String, Set<String>> disputesPerDelayedPayoutTxId = tuple.second;
         Map<String, Set<String>> disputesPerDepositTxId = tuple.third;
 
+        // Include the dispute under test in the counters. Callers may validate before the dispute has been added
+        // to the list (fail-closed ingest path); the counters are keyed by uid, so re-adding an already stored
+        // dispute is idempotent and the <= 2 disputes-per-trade limit holds regardless of call order.
+        String uid = dispute.getUid();
+        addUid(disputesPerTradeId, dispute.getTradeId(), uid);
+        addUid(disputesPerDelayedPayoutTxId, dispute.getDelayedPayoutTxId(), uid);
+        addUid(disputesPerDepositTxId, dispute.getDepositTxId(), uid);
+
         testIfDisputeTriesReplay(dispute,
                 disputesPerTradeId,
                 disputesPerDelayedPayoutTxId,
@@ -284,6 +292,13 @@ public class DisputeValidation {
         });
 
         return new Tuple3<>(disputesPerTradeId, disputesPerDelayedPayoutTxId, disputesPerDepositTxId);
+    }
+
+    private static void addUid(Map<String, Set<String>> disputesPerKey, @Nullable String key, String uid) {
+        if (key == null) {
+            return;
+        }
+        disputesPerKey.computeIfAbsent(key, k -> new HashSet<>()).add(uid);
     }
 
     private static void testIfDisputeTriesReplay(Dispute disputeToTest,

--- a/core/src/test/java/bisq/core/support/dispute/DisputeManagerAuthTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/DisputeManagerAuthTest.java
@@ -21,7 +21,10 @@ import bisq.core.btc.setup.WalletsSetup;
 import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.dao.DaoFacade;
+import bisq.core.locale.Res;
+import bisq.core.offer.OfferDirection;
 import bisq.core.offer.OpenOfferManager;
+import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.price.PriceFeedService;
 import bisq.core.support.SupportType;
@@ -40,8 +43,11 @@ import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.mailbox.MailboxMessageService;
 
+import bisq.core.util.JsonUtil;
+
 import bisq.common.config.Config;
 import bisq.common.crypto.Encryption;
+import bisq.common.crypto.Hash;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.KeyStorage;
 import bisq.common.crypto.PubKeyRing;
@@ -84,6 +90,8 @@ class DisputeManagerAuthTest {
 
     @BeforeEach
     void setUp() {
+        Res.setup();
+
         tradeManager = mock(TradeManager.class);
         closedTradableManager = mock(ClosedTradableManager.class);
         failedTradesManager = mock(FailedTradesManager.class);
@@ -180,7 +188,10 @@ class DisputeManagerAuthTest {
     }
 
     @Test
-    void openNewDisputeWithInvalidContractDataDoesNotMutateDisputeList() {
+    void openNewDisputeWithForgedContractDataIsDroppedSilently() {
+        // Integrity/forgery failure (invalid contractAsJson/hash): the payload was tampered with. Fail closed -
+        // do not store the dispute, and do NOT surface a UI popup (validationExceptions), since the payload is
+        // attacker-controlled and popups would be a flood vector pointing at a case that was never stored.
         TestDisputeList disputeList = new TestDisputeList();
         DisputeListService<DisputeList<Dispute>> disputeListService = disputeListService(disputeList);
         TestDisputeManager manager = new TestDisputeManager(mockP2PService(),
@@ -205,8 +216,38 @@ class DisputeManagerAuthTest {
         manager.onOpenNewDispute(message, buyerPubKeyRing.getSignaturePubKey());
 
         assertTrue(disputeList.isEmpty());
-        assertFalse(manager.getValidationExceptions().isEmpty());
+        assertTrue(manager.getValidationExceptions().isEmpty());
         verify(disputeListService, never()).requestPersistence();
+    }
+
+    @Test
+    void openNewDisputeWithAdvisoryValidationFailureIsStoredAndPopsUpForAgent() {
+        // Advisory failure on an otherwise valid, integrity-checked dispute (here: node addresses that are not
+        // valid onion addresses). A legitimate dispute can trip these, so we must NOT drop it: store and forward
+        // it as usual and alert the agent via validationExceptions (popup) so the case can be resolved manually.
+        TestDisputeList disputeList = new TestDisputeList();
+        DisputeListService<DisputeList<Dispute>> disputeListService = disputeListService(disputeList);
+        TestDisputeManager manager = new TestDisputeManager(mockP2PService(),
+                tradeManager,
+                closedTradableManager,
+                failedTradesManager,
+                keyStorageDir,
+                disputeListService);
+
+        PubKeyRing buyerPubKeyRing = pubKeyRing();
+        PubKeyRing sellerPubKeyRing = pubKeyRing();
+        // Local node is the dispute agent so the dispute is actually processed (added + forwarded).
+        Dispute dispute = validDispute(buyerPubKeyRing, sellerPubKeyRing, manager.agentPubKeyRing());
+        OpenNewDisputeMessage message = new OpenNewDisputeMessage(dispute,
+                PEER_NODE_ADDRESS,
+                "open-dispute-uid",
+                SupportType.MEDIATION);
+
+        manager.onOpenNewDispute(message, buyerPubKeyRing.getSignaturePubKey());
+
+        assertTrue(disputeList.getList().contains(dispute));
+        assertFalse(manager.getValidationExceptions().isEmpty());
+        verify(disputeListService).requestPersistence();
     }
 
     @Test
@@ -304,6 +345,110 @@ class DisputeManagerAuthTest {
                 0);
     }
 
+    // A dispute that passes integrity validation (contract json/hash, agent pubkey) but trips an advisory check:
+    // the trader node addresses are not valid onion addresses, so validateNodeAddresses fails softly.
+    private static Dispute validDispute(PubKeyRing buyerPubKeyRing,
+                                        PubKeyRing sellerPubKeyRing,
+                                        PubKeyRing agentPubKeyRing) {
+        Contract contract = validContract(buyerPubKeyRing, sellerPubKeyRing, agentPubKeyRing);
+        String contractAsJson = JsonUtil.objectToJson(contract);
+        return new Dispute(
+                0,
+                TRADE_ID,
+                0,
+                true,
+                true,
+                buyerPubKeyRing,
+                0,
+                0,
+                contract,
+                Hash.getSha256Hash(contractAsJson),
+                null,
+                null,
+                "depositTxId",
+                null,
+                contractAsJson,
+                null,
+                null,
+                agentPubKeyRing,
+                false,
+                SupportType.MEDIATION);
+    }
+
+    private static Contract validContract(PubKeyRing buyerPubKeyRing,
+                                          PubKeyRing sellerPubKeyRing,
+                                          PubKeyRing mediatorPubKeyRing) {
+        return new Contract(
+                offerPayload(buyerPubKeyRing),
+                50_000_000L,
+                1_000_000L,
+                "takerFeeTxId",
+                new NodeAddress("buyer.onion", 9999),
+                new NodeAddress("seller.onion", 9999),
+                PEER_NODE_ADDRESS,
+                true,
+                "makerAccountId",
+                "takerAccountId",
+                null,
+                null,
+                buyerPubKeyRing,
+                sellerPubKeyRing,
+                "makerPayoutAddress",
+                "takerPayoutAddress",
+                new byte[33],
+                new byte[33],
+                0,
+                PEER_NODE_ADDRESS,
+                null,
+                null,
+                PaymentMethod.SEPA_ID,
+                PaymentMethod.SEPA_ID,
+                0,
+                mediatorPubKeyRing,
+                pubKeyRing());
+    }
+
+    private static OfferPayload offerPayload(PubKeyRing makerPubKeyRing) {
+        return new OfferPayload(TRADE_ID,
+                1_700_000_000_000L,
+                PEER_NODE_ADDRESS,
+                makerPubKeyRing,
+                OfferDirection.SELL,
+                50_000_000L,
+                0,
+                false,
+                1_000_000L,
+                1_000_000L,
+                "BTC",
+                "EUR",
+                List.of(),
+                List.of(PEER_NODE_ADDRESS),
+                PaymentMethod.SEPA_ID,
+                "makerPaymentAccountId",
+                "offerFeePaymentTxId",
+                null,
+                null,
+                null,
+                null,
+                "1.9.9",
+                123_456L,
+                1_000L,
+                2_000L,
+                true,
+                3_000L,
+                4_000L,
+                5_000L,
+                6_000L,
+                false,
+                false,
+                0,
+                0,
+                false,
+                null,
+                null,
+                4);
+    }
+
     private static PubKeyRing pubKeyRing() {
         return new PubKeyRing(Sig.generateKeyPair().getPublic(),
                 Encryption.generateKeyPair().getPublic());
@@ -367,6 +512,10 @@ class DisputeManagerAuthTest {
                                               PublicKey senderSignaturePubKey,
                                               String messageClassName) {
             return isDisputeAgentSignaturePubKeyValid(dispute, senderSignaturePubKey, messageClassName);
+        }
+
+        private PubKeyRing agentPubKeyRing() {
+            return pubKeyRing;
         }
 
         private void onOpenNewDispute(OpenNewDisputeMessage openNewDisputeMessage,

--- a/core/src/test/java/bisq/core/support/dispute/DisputeValidationTest.java
+++ b/core/src/test/java/bisq/core/support/dispute/DisputeValidationTest.java
@@ -118,6 +118,65 @@ class DisputeValidationTest {
                 () -> DisputeValidation.validateDisputeData(dispute, mock(BtcWalletService.class), POST_ACTIVATION_NOW));
     }
 
+    @Test
+    void replayCheckAcceptsFirstDisputeNotYetInList() {
+        // Regression: the fail-closed ingest path validates before the dispute is added to the list. The replay
+        // check must still count the dispute under test, otherwise the first legitimate dispute for a trade is
+        // rejected with a misleading "more then 2 disputes" error, breaking mediation.
+        Dispute dispute = replayDispute("uid-1");
+
+        assertDoesNotThrow(() -> DisputeValidation.testIfDisputeTriesReplay(dispute, List.of()));
+    }
+
+    @Test
+    void replayCheckAcceptsSecondDisputeForSameTrade() {
+        Dispute stored = replayDispute("uid-1");
+        Dispute incoming = replayDispute("uid-2");
+
+        assertDoesNotThrow(() -> DisputeValidation.testIfDisputeTriesReplay(incoming, List.of(stored)));
+    }
+
+    @Test
+    void replayCheckRejectsThirdDisputeForSameTrade() {
+        Dispute stored1 = replayDispute("uid-1");
+        Dispute stored2 = replayDispute("uid-2");
+        Dispute incoming = replayDispute("uid-3");
+
+        assertThrows(DisputeValidation.DisputeReplayException.class,
+                () -> DisputeValidation.testIfDisputeTriesReplay(incoming, List.of(stored1, stored2)));
+    }
+
+    private static Dispute replayDispute(String uid) {
+        PubKeyRing buyerPubKeyRing = pubKeyRing();
+        PubKeyRing sellerPubKeyRing = pubKeyRing();
+        PubKeyRing mediatorPubKeyRing = pubKeyRing();
+        Contract contract = contract(buyerPubKeyRing, sellerPubKeyRing, mediatorPubKeyRing, pubKeyRing());
+        String contractAsJson = JsonUtil.objectToJson(contract);
+        Dispute dispute = new Dispute(
+                0,
+                TRADE_ID,
+                TRADER_ID,
+                true,
+                true,
+                buyerPubKeyRing,
+                POST_ACTIVATION_TRADE_DATE,
+                0,
+                contract,
+                Hash.getSha256Hash(contractAsJson),
+                null,
+                null,
+                "depositTxId",
+                null,
+                contractAsJson,
+                null,
+                null,
+                mediatorPubKeyRing,
+                false,
+                SupportType.MEDIATION);
+        dispute.setUid(uid);
+        return dispute;
+    }
+
     private static Dispute dispute(PubKeyRing traderPubKeyRing,
                                    PubKeyRing agentPubKeyRing,
                                    Contract contract,


### PR DESCRIPTION
Commit 8b432c6e94 moved DisputeValidation ahead of the side effects in onOpenNewDisputeMessage and made every failure fail-closed. Two problems:

1. testIfDisputeTriesReplay assumed the dispute under test was already in the list (pre-1.10.3 order validated after disputeList.add). Run before the add, the first legitimate dispute for a trade hit a null trade-id set and threw "more then 2 disputes", so the agent silently dropped it and mediation never progressed.

2. Fail-closing on advisory data checks (donation address, node address) silently discarded legitimate disputes and stopped surfacing the agent popup those cases rely on, while still exposing a popup-flood vector for forged payloads.

Fixes:
- testIfDisputeTriesReplay now counts the dispute under test via an idempotent uid injection, so the <= 2 limit holds regardless of whether the caller validates before or after adding to the list.
- Split ingest validation: integrity/forgery checks (contract data, replay) stay fail-closed and drop silently (log only, no popup); advisory checks (node/donation address) store and forward the dispute and alert the agent via validationExceptions, matching pre-1.10.3 behavior and the sibling peerOpenedDisputeForTrade handler.

Tests: DisputeValidationTest replay regressions; DisputeManagerAuthTest hard-drop vs advisory-store paths.