### PR TITLE
Temporarily deactivate addSeedNode in Filter

### DIFF
--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -29,6 +30,7 @@ import java.util.Optional;
 import ch.qos.logback.classic.Level;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -55,6 +57,8 @@ import static java.util.stream.Collectors.toList;
  * @see #Config(String...)
  * @see #Config(String, File, String...)
  */
+
+@Slf4j
 public class Config {
 
     // Option name constants
@@ -900,10 +904,18 @@ public class Config {
             this.maxMemory = options.valueOf(maxMemoryOpt);
             this.logLevel = options.valueOf(logLevelOpt);
             this.bannedBtcNodes = options.valuesOf(bannedBtcNodesOpt);
-            this.filterProvidedBtcNodes = options.valuesOf(filterProvidedBtcNodesOpt);
+
+            // this.filterProvidedBtcNodes = options.valuesOf(filterProvidedBtcNodesOpt);
+            // filterProvidedBtcNodes from filter is currently unsafe and therefore ignored.
+            filterProvidedBtcNodes = new ArrayList<>();
+
             this.bannedPriceRelayNodes = options.valuesOf(bannedPriceRelayNodesOpt);
             this.bannedSeedNodes = options.valuesOf(bannedSeedNodesOpt);
-            this.filterProvidedSeedNodes = options.valuesOf(filterProvidedSeedNodesOpt);
+
+            // this.filterProvidedSeedNodes = options.valuesOf(filterProvidedSeedNodesOpt);
+            // filterProvidedSeedNodes from filter is currently unsafe and therefore ignored.
+            filterProvidedSeedNodes = new ArrayList<>();
+
             this.baseCurrencyNetwork = (BaseCurrencyNetwork) options.valueOf(baseCurrencyNetworkOpt);
             this.networkParameters = baseCurrencyNetwork.getParameters();
             this.ignoreLocalBtcNode = options.valueOf(ignoreLocalBtcNodeOpt);

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -591,8 +591,13 @@ public class FilterManager {
         // We persist it to the property file which is read before any other initialisation.
         saveBannedNodes(BANNED_SEED_NODES, filterFromNetwork.getSeedNodes());
         saveBannedNodes(BANNED_BTC_NODES, filterFromNetwork.getBtcNodes());
-        saveBannedNodes(FILTER_PROVIDED_BTC_NODES, filterFromNetwork.getAddedBtcNodes());
-        saveBannedNodes(FILTER_PROVIDED_SEED_NODES, filterFromNetwork.getAddedSeedNodes());
+
+        // We deactivate the data from fields which are not included in the signature.
+        // The new filter implementation in master will fix that.
+        saveBannedNodes(FILTER_PROVIDED_BTC_NODES, null);
+        //saveBannedNodes(FILTER_PROVIDED_BTC_NODES, filterFromNetwork.getAddedBtcNodes());
+        saveBannedNodes(FILTER_PROVIDED_SEED_NODES, null);
+        //saveBannedNodes(FILTER_PROVIDED_SEED_NODES, filterFromNetwork.getAddedSeedNodes());
 
         // Banned price relay nodes we can apply at runtime
         List<String> priceRelayNodes = filterFromNetwork.getPriceRelayNodes();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how network-provided node filters are applied: previously stored “filter provided” node lists are now cleared instead of being retained.
  * As a result, stale or unwanted node entries no longer persist after new filter information is received.
* **Configuration**
  * Command-line/config options for “filter provided” BTC/seed nodes are now ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->