### PR TITLE
Temporarily deactivate usage of btcFeeReceiverAddresses from filter.

### DIFF
--- a/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
+++ b/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
@@ -259,16 +259,21 @@ public class MempoolService {
     private List<String> getAllBtcFeeReceivers() {
         List<String> btcFeeReceivers = new ArrayList<>();
         // fee receivers from filter ref: bisq-network/bisq/pull/4294
-        List<String> feeReceivers = Optional.ofNullable(filterManager.getFilter())
+
+        // We deactivate the fee receivers from filter temporarily as not used currently.
+
+        /* List<String> feeReceivers = Optional.ofNullable(filterManager.getFilter())
                 .flatMap(f -> Optional.ofNullable(f.getBtcFeeReceiverAddresses()))
                 .orElse(List.of());
+
         feeReceivers.forEach(e -> {
             try {
                 btcFeeReceivers.add(e.split("#")[0]); // victim's receiver address
             } catch (RuntimeException ignore) {
                 // If input format is not as expected we ignore entry
             }
-        });
+        });*/
+
         btcFeeReceivers.addAll(daoFacade.getAllDonationAddresses());
 
         // We use all BM who had ever had burned BSQ to avoid if a BM just got "deactivated" due decayed burn amounts


### PR DESCRIPTION
It is not used at the moment and will be handled in a new filter implementation in master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted BTC fee receiver selection so it no longer includes addresses from the configured filter, while still using other supported address sources.
  * This helps ensure the displayed receiver list reflects the expected set of valid addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->