### PR TITLE
Re-send payment started message at startup when it was never ACKed

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerProtocol.java
@@ -42,6 +42,8 @@ import bisq.network.p2p.NodeAddress;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -50,6 +52,22 @@ public abstract class BuyerProtocol extends DisputeProtocol {
         STARTUP,
         PAYMENT_SENT
     }
+
+    // States at which STARTUP re-runs BuyerSendCounterCurrencyTransferStartedMessage.
+    // BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG is included because it means we have not
+    // received the seller's AckMessage yet. The in-memory resend timer of
+    // BuyerSendCounterCurrencyTransferStartedMessage does not survive a restart, so
+    // without re-running the task here a restart before the ACK arrives would leave
+    // the trade without any resend attempts (buyer stuck at "Please send confirmation
+    // again", seller never learns the payment was started).
+    // Shared with BuyerStartupResendConditionTest so the regression test exercises
+    // the same state list production uses.
+    @VisibleForTesting
+    public static final Trade.State[] STARTUP_RESEND_PAYMENT_STARTED_STATES = {
+            Trade.State.BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG,
+            Trade.State.BUYER_STORED_IN_MAILBOX_FIAT_PAYMENT_INITIATED_MSG,
+            Trade.State.BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG
+    };
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -75,8 +93,7 @@ public abstract class BuyerProtocol extends DisputeProtocol {
                 .executeTasks();
 
         given(anyPhase(Trade.Phase.FIAT_SENT, Trade.Phase.FIAT_RECEIVED)
-                .anyState(Trade.State.BUYER_STORED_IN_MAILBOX_FIAT_PAYMENT_INITIATED_MSG,
-                        Trade.State.BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG)
+                .anyState(STARTUP_RESEND_PAYMENT_STARTED_STATES)
                 .with(BuyerEvent.STARTUP))
                 .setup(tasks(BuyerSendCounterCurrencyTransferStartedMessage.class))
                 .executeTasks();

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessage.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessage.java
@@ -135,6 +135,15 @@ public class BuyerSendCounterCurrencyTransferStartedMessage extends SendMailboxM
         try {
             runInterceptHook();
 
+            // The peer's ACK can be processed while no task instance is listening (e.g. it
+            // arrived after a restart, before this task got re-created at startup). In that
+            // case the persisted message state is already ACKNOWLEDGED and we only apply the
+            // state transition the ACK would have triggered instead of sending again.
+            if (processModel.getPaymentStartedMessageStateProperty().get() == MessageState.ACKNOWLEDGED) {
+                onMessageStateChange(MessageState.ACKNOWLEDGED);
+                return;
+            }
+
             super.run();
         } catch (Throwable t) {
             failed(t);

--- a/core/src/test/java/bisq/core/trade/model/bisq_v1/TradeStateTransitionTest.java
+++ b/core/src/test/java/bisq/core/trade/model/bisq_v1/TradeStateTransitionTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.model.bisq_v1;
+
+import org.junit.jupiter.api.Test;
+
+import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED;
+import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG;
+import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG;
+import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG;
+import static bisq.core.trade.model.bisq_v1.Trade.State.BUYER_STORED_IN_MAILBOX_FIAT_PAYMENT_INITIATED_MSG;
+import static bisq.core.trade.model.bisq_v1.Trade.State.DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * State transitions the startup re-send of the CounterCurrencyTransferStartedMessage
+ * relies on (see BuyerProtocol#onInitialized and
+ * BuyerSendCounterCurrencyTransferStartedMessage): all FIAT_SENT sub-states must be
+ * able to move to BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG once the seller's ACK
+ * arrives, regardless of which delivery attempt got stuck before.
+ */
+public class TradeStateTransitionTest {
+
+    @Test
+    public void ackAfterAnyStuckDeliveryStateIsAValidTransition() {
+        // sent but never ACKed (e.g. app restarted before the ACK arrived)
+        assertTrue(BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG
+                .isValidTransitionTo(BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG));
+
+        // stored in the peer's mailbox, ACK arrives after they came back online
+        assertTrue(BUYER_STORED_IN_MAILBOX_FIAT_PAYMENT_INITIATED_MSG
+                .isValidTransitionTo(BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG));
+
+        // send failed, a later re-send attempt got ACKed
+        assertTrue(BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG
+                .isValidTransitionTo(BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG));
+    }
+
+    @Test
+    public void deliveryStatesCanMoveBetweenEachOther() {
+        // same-phase moves between the delivery sub-states are permitted, so a
+        // re-send attempt may downgrade/upgrade the delivery marker freely
+        assertTrue(BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG
+                .isValidTransitionTo(BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG));
+        assertTrue(BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG
+                .isValidTransitionTo(BUYER_STORED_IN_MAILBOX_FIAT_PAYMENT_INITIATED_MSG));
+        assertTrue(BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED
+                .isValidTransitionTo(BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG));
+    }
+
+    @Test
+    public void movingBackToAnEarlierPhaseIsInvalid() {
+        assertFalse(BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG
+                .isValidTransitionTo(DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN));
+        assertFalse(BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG
+                .isValidTransitionTo(DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN));
+    }
+}

--- a/core/src/test/java/bisq/core/trade/protocol/BuyerStartupResendConditionTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/BuyerStartupResendConditionTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol;
+
+import bisq.core.trade.model.bisq_v1.Trade;
+import bisq.core.trade.protocol.bisq_v1.BuyerProtocol;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins down which trade states re-run BuyerSendCounterCurrencyTransferStartedMessage
+ * at STARTUP (see BuyerProtocol#onInitialized). The condition is built from the
+ * production state list (BuyerProtocol#STARTUP_RESEND_PAYMENT_STARTED_STATES), so a
+ * change there is exercised by this test.
+ *
+ * BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG must be included: it is the state of a
+ * buyer who sent the message but has not received the seller's ACK yet. The
+ * in-memory re-send timer does not survive a restart, so without matching this
+ * state at startup such a trade would never re-send and the seller might never
+ * learn the payment was started.
+ */
+public class BuyerStartupResendConditionTest {
+
+    private enum TestEvent implements FluentProtocol.Event {
+        STARTUP
+    }
+
+    private static FluentProtocol.Condition startupResendCondition(Trade trade) {
+        // phases and event mirror BuyerProtocol#onInitialized; the state list is
+        // the production constant itself
+        return new FluentProtocol.Condition(trade)
+                .anyPhase(Trade.Phase.FIAT_SENT, Trade.Phase.FIAT_RECEIVED)
+                .anyState(BuyerProtocol.STARTUP_RESEND_PAYMENT_STARTED_STATES)
+                .with(TestEvent.STARTUP);
+    }
+
+    private static Trade tradeAt(Trade.State state) {
+        Trade trade = mock(Trade.class);
+        when(trade.getTradeState()).thenReturn(state);
+        when(trade.getTradePhase()).thenReturn(state.getTradePhase());
+        when(trade.getId()).thenReturn("test-trade-id");
+        return trade;
+    }
+
+    @Test
+    public void resendFiresWhenMessageWasSentButNotAcked() {
+        // the fixed case: restart happened after sending, before the seller's ACK
+        assertTrue(startupResendCondition(
+                tradeAt(Trade.State.BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG))
+                .getResult().isValid());
+    }
+
+    @Test
+    public void resendFiresForMailboxAndFailedStates() {
+        assertTrue(startupResendCondition(
+                tradeAt(Trade.State.BUYER_STORED_IN_MAILBOX_FIAT_PAYMENT_INITIATED_MSG))
+                .getResult().isValid());
+        assertTrue(startupResendCondition(
+                tradeAt(Trade.State.BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG))
+                .getResult().isValid());
+    }
+
+    @Test
+    public void resendDoesNotFireOnceAckArrived() {
+        assertFalse(startupResendCondition(
+                tradeAt(Trade.State.BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG))
+                .getResult().isValid());
+    }
+
+    @Test
+    public void resendDoesNotFireBeforePaymentStarted() {
+        assertFalse(startupResendCondition(
+                tradeAt(Trade.State.DEPOSIT_CONFIRMED_IN_BLOCK_CHAIN))
+                .getResult().isValid());
+        assertFalse(startupResendCondition(
+                tradeAt(Trade.State.BUYER_CONFIRMED_IN_UI_FIAT_PAYMENT_INITIATED))
+                .getResult().isValid());
+    }
+}

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessageTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/buyer/BuyerSendCounterCurrencyTransferStartedMessageTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol.bisq_v1.tasks.buyer;
+
+import bisq.core.network.MessageState;
+import bisq.core.trade.TradeManager;
+import bisq.core.trade.model.TradeModel;
+import bisq.core.trade.model.bisq_v1.Trade;
+import bisq.core.trade.protocol.bisq_v1.model.ProcessModel;
+
+import bisq.common.taskrunner.TaskRunner;
+
+import javafx.beans.property.SimpleObjectProperty;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the short-circuit in BuyerSendCounterCurrencyTransferStartedMessage#run:
+ * when the seller's ACK was already processed while no task instance was listening
+ * (it can arrive after a restart, before the task is re-created at startup), the
+ * task must not send again but only apply the BUYER_SAW_ARRIVED state transition
+ * the ACK would have triggered.
+ */
+public class BuyerSendCounterCurrencyTransferStartedMessageTest {
+
+    private Trade trade;
+    private ProcessModel processModel;
+    private SimpleObjectProperty<MessageState> paymentStartedMessageState;
+    private final AtomicBoolean completed = new AtomicBoolean();
+    private final AtomicReference<String> errorMessage = new AtomicReference<>();
+
+    @BeforeEach
+    public void setUp() {
+        trade = mock(Trade.class);
+        processModel = mock(ProcessModel.class);
+        paymentStartedMessageState = new SimpleObjectProperty<>(MessageState.UNDEFINED);
+
+        when(trade.getProcessModel()).thenReturn(processModel);
+        when(processModel.getPaymentStartedMessageStateProperty()).thenReturn(paymentStartedMessageState);
+        when(processModel.getTradeManager()).thenReturn(mock(TradeManager.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void runTask() {
+        // same unchecked narrowing as TradeTaskRunner: tasks declare (TaskRunner, Trade)
+        // constructors, so the runner must look them up with Trade.class
+        TaskRunner<TradeModel> taskRunner = new TaskRunner<>(trade,
+                (Class<TradeModel>) (Class<?>) Trade.class,
+                () -> completed.set(true),
+                errorMessage::set);
+        taskRunner.addTasks(BuyerSendCounterCurrencyTransferStartedMessage.class);
+        taskRunner.run();
+    }
+
+    @Test
+    public void alreadyAcknowledgedMessageIsNotSentAgainButStateIsApplied() {
+        paymentStartedMessageState.set(MessageState.ACKNOWLEDGED);
+
+        runTask();
+
+        verify(trade).setStateIfValidTransitionTo(Trade.State.BUYER_SAW_ARRIVED_FIAT_PAYMENT_INITIATED_MSG);
+        // no send attempt: the wallet (payout address lookup for the message) is never touched
+        verify(processModel, never()).getBtcWalletService();
+        assertTrue(completed.get());
+        assertNull(errorMessage.get());
+    }
+
+    @Test
+    public void withoutAckTheSendPathIsTaken() {
+        paymentStartedMessageState.set(MessageState.SENT);
+
+        runTask();
+
+        // the send path is attempted (and fails in this stripped-down environment,
+        // proving the task did not short-circuit) and no ACK state transition happens
+        verify(trade, never()).setStateIfValidTransitionTo(any());
+        verify(processModel).getBtcWalletService();
+        assertFalse(completed.get());
+        assertNotNull(errorMessage.get());
+    }
+}


### PR DESCRIPTION
The buyer re-sends CounterCurrencyTransferStartedMessage on a timer until the seller ACKs it. The timer only lives in memory, so a restart kills it. The STARTUP rule in BuyerProtocol#onInitialized re-ran the send task only for the STORED_IN_MAILBOX and SEND_FAILED states. It skipped BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG (sent, but no ACK yet). Such a trade never re-sent the message. The buyer stayed stuck at "Please send confirmation again". The seller never learned the payment was started. This often ended in needless mediation.

Fix: include BUYER_SENT_FIAT_PAYMENT_INITIATED_MSG in the STARTUP re-send condition. Re-sending is safe: the message has a deterministic uid, so re-sends deduplicate, and the seller side tolerates repeated delivery.

Also skip the send when the persisted message state is already ACKNOWLEDGED. That happens when the ACK arrives while no task is listening (right after a restart). In that case only apply the BUYER_SAW_ARRIVED state transition.

Fixes the buyer side of #7243. Also reported in #6715 and #3372.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buyer recovery after restart for counter-currency “payment started” messages, ensuring resend eligibility remains active until the seller acknowledgment is received.
  * Avoided duplicate handling when the “payment started” message was already acknowledged before task execution.
  * Tightened trade state transition rules to support valid resumption paths while blocking invalid regressions.
* **Tests**
  * Added unit tests covering startup resend conditions, acknowledgment behavior after restarts, and allowed/blocked trade-state transitions for the buyer flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->