### PR TITLE
Accept deposit-tx message in DEPOSIT_CONFIRMED

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/BuyerProtocol.java
@@ -69,6 +69,22 @@ public abstract class BuyerProtocol extends DisputeProtocol {
             Trade.State.BUYER_SEND_FAILED_FIAT_PAYMENT_INITIATED_MSG
     };
 
+    // Phases in which the buyer accepts the DepositTxAndDelayedPayoutTxMessage.
+    // DEPOSIT_CONFIRMED is included because the deposit can confirm through the
+    // wallet listener before the (mailbox) message is processed. A message
+    // arriving after the first confirmation must still be accepted, otherwise the
+    // seller's payment account payload is never stored, the contract stays
+    // hash-only and the trade is permanently stuck. The symmetric seller handler
+    // for ShareBuyerPaymentAccountMessage accepts the same set.
+    // Shared with BuyerDepositTxMessagePhaseTest so the regression test exercises
+    // the same phase list production uses.
+    @VisibleForTesting
+    public static final Trade.Phase[] DEPOSIT_TX_AND_DELAYED_PAYOUT_TX_MSG_PHASES = {
+            Trade.Phase.TAKER_FEE_PUBLISHED,
+            Trade.Phase.DEPOSIT_PUBLISHED,
+            Trade.Phase.DEPOSIT_CONFIRMED
+    };
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -122,7 +138,7 @@ public abstract class BuyerProtocol extends DisputeProtocol {
     // mailbox message but the stored in mailbox case is not expected and the seller would try to send the message again
     // in the hope to reach the buyer directly in case of network issues.
     protected void handle(DepositTxAndDelayedPayoutTxMessage message, NodeAddress peer) {
-        expect(anyPhase(Trade.Phase.TAKER_FEE_PUBLISHED, Trade.Phase.DEPOSIT_PUBLISHED)
+        expect(anyPhase(DEPOSIT_TX_AND_DELAYED_PAYOUT_TX_MSG_PHASES)
                 .with(message)
                 .from(peer)
                 .preCondition(trade.getDepositTx() == null || processModel.getTradePeer().getPaymentAccountPayload() == null,

--- a/core/src/test/java/bisq/core/trade/protocol/BuyerDepositTxMessagePhaseTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/BuyerDepositTxMessagePhaseTest.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.protocol;
+
+import bisq.core.trade.model.bisq_v1.Trade;
+import bisq.core.trade.protocol.bisq_v1.BuyerProtocol;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins down the phases in which the buyer accepts the
+ * DepositTxAndDelayedPayoutTxMessage (see BuyerProtocol#handle). The condition is
+ * built from the production phase list
+ * (BuyerProtocol#DEPOSIT_TX_AND_DELAYED_PAYOUT_TX_MSG_PHASES), so a change there is
+ * exercised by this test.
+ *
+ * DEPOSIT_CONFIRMED must be included: the deposit can confirm through the wallet
+ * listener before the (mailbox) message is processed, so a message arriving after
+ * the first confirmation must still be accepted. Otherwise the seller's payment
+ * account payload is never stored and the trade is permanently stuck.
+ */
+public class BuyerDepositTxMessagePhaseTest {
+
+    private enum TestEvent implements FluentProtocol.Event {
+        MESSAGE_RECEIVED
+    }
+
+    private static FluentProtocol.Condition depositTxMessageCondition(Trade trade) {
+        // phases mirror BuyerProtocol#handle; the phase list is the production
+        // constant itself
+        return new FluentProtocol.Condition(trade)
+                .anyPhase(BuyerProtocol.DEPOSIT_TX_AND_DELAYED_PAYOUT_TX_MSG_PHASES)
+                .with(TestEvent.MESSAGE_RECEIVED);
+    }
+
+    private static Trade tradeAt(Trade.Phase phase) {
+        Trade trade = mock(Trade.class);
+        when(trade.getTradePhase()).thenReturn(phase);
+        when(trade.getId()).thenReturn("test-trade-id");
+        return trade;
+    }
+
+    @Test
+    public void messageAcceptedAfterDepositConfirmed() {
+        // the fixed case: the deposit confirmed before the message was processed
+        assertTrue(depositTxMessageCondition(
+                tradeAt(Trade.Phase.DEPOSIT_CONFIRMED))
+                .getResult().isValid());
+    }
+
+    @Test
+    public void messageAcceptedWhileTakerFeeOrDepositPublished() {
+        assertTrue(depositTxMessageCondition(
+                tradeAt(Trade.Phase.TAKER_FEE_PUBLISHED))
+                .getResult().isValid());
+        assertTrue(depositTxMessageCondition(
+                tradeAt(Trade.Phase.DEPOSIT_PUBLISHED))
+                .getResult().isValid());
+    }
+
+    @Test
+    public void messageRejectedInLaterPhases() {
+        assertFalse(depositTxMessageCondition(
+                tradeAt(Trade.Phase.FIAT_SENT))
+                .getResult().isValid());
+        assertFalse(depositTxMessageCondition(
+                tradeAt(Trade.Phase.PAYOUT_PUBLISHED))
+                .getResult().isValid());
+    }
+
+    @Test
+    public void messageRejectedBeforeTakerFeePublished() {
+        assertFalse(depositTxMessageCondition(
+                tradeAt(Trade.Phase.INIT))
+                .getResult().isValid());
+    }
+}


### PR DESCRIPTION
The buyer's handler for DepositTxAndDelayedPayoutTxMessage accepts the message only in the TAKER_FEE_PUBLISHED and DEPOSIT_PUBLISHED phases. The deposit can confirm independently through the wallet listener, moving the trade to DEPOSIT_CONFIRMED before the (mailbox) message is processed. The phase gate then rejects it: no ACK is sent and the mailbox entry is not removed, so it is redelivered and re-rejected on every restart until its TTL. As a result the seller's payment account payload is never stored, both sides keep a hash-only contract, and the trade is permanently stuck.

The symmetric seller handler for ShareBuyerPaymentAccountMessage already accepts DEPOSIT_CONFIRMED. Add the same phase to the buyer gate. The existing preCondition still prevents reprocessing: it proceeds only while the payment account payload is missing and otherwise just resends the ACK.

The accepted phases move to a @VisibleForTesting constant, and a regression test pins the list (including DEPOSIT_CONFIRMED), mirroring STARTUP_RESEND_PAYMENT_STARTED_STATES.

Part of #7945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Buyers can now continue the trade flow after the deposit is confirmed, not just during earlier deposit-related steps.
  * Trade messages are handled consistently across all supported stages, reducing unexpected rejections.
  * Added coverage to verify message acceptance and rejection at the correct points in the trade process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->