### PR TITLE
Render buyer step 2 without seller payment account

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -833,6 +833,7 @@ portfolio.pending.step2_buyer.amountToTransfer=Amount to transfer
 portfolio.pending.step2_buyer.altcoin.address={0} Buyer''s address
 portfolio.pending.step2_buyer.buyerAccount=Your payment account to be used
 portfolio.pending.step2_buyer.paymentStarted=Payment started
+portfolio.pending.step2_buyer.paymentAccountPayloadMissing=The payment account details from the BTC seller are missing, so payment cannot be started here. This can happen if a trade message was lost. Please contact the seller in the trade chat; if the trade cannot be recovered before the trade period ends, open a mediation ticket.
 portfolio.pending.step2_buyer.fillInBsqWallet=Pay from BSQ wallet
 portfolio.pending.step2_buyer.warn=You still have not done your {0} payment!\nPlease note that the trade has to be completed by {1}.
 portfolio.pending.step2_buyer.openForDispute=You have not completed your payment!\nThe max. period for the trade has elapsed.\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -833,6 +833,7 @@ portfolio.pending.step2_buyer.amountToTransfer=Amount to transfer
 portfolio.pending.step2_buyer.altcoin.address={0} Buyer''s address
 portfolio.pending.step2_buyer.buyerAccount=Your payment account to be used
 portfolio.pending.step2_buyer.paymentStarted=Payment started
+portfolio.pending.step2_buyer.paymentAccountPayloadMissing=The payment account details from the BTC seller are missing, so payment cannot be started here. This can happen if a trade message was lost. Please contact the mediator to resolve the trade.
 portfolio.pending.step2_buyer.fillInBsqWallet=Pay from BSQ wallet
 portfolio.pending.step2_buyer.warn=You still have not done your {0} payment!\nPlease note that the trade has to be completed by {1}.
 portfolio.pending.step2_buyer.openForDispute=You have not completed your payment!\nThe max. period for the trade has elapsed.\

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -440,7 +440,9 @@ public class BuyerStep2View extends TradeStepView {
                 gridRow = SbpForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
                 break;
             default:
-                log.error("Not supported PaymentMethod: " + paymentMethodId);
+                if (paymentAccountPayload != null) {
+                    log.error("Not supported PaymentMethod: " + paymentMethodId);
+                }
         }
 
         Trade trade = model.getTrade();
@@ -461,7 +463,16 @@ public class BuyerStep2View extends TradeStepView {
             }
         }
 
-        if (paymentAccountPayload.showRefTextWarning()) {
+        if (paymentAccountPayload == null) {
+            // The seller's payment account payload never arrived (e.g. the mailbox
+            // DepositTxAndDelayedPayoutTxMessage was missed), so there are no payment
+            // details to show. Render a warning instead of dereferencing null here,
+            // which used to throw an NPE and leave the whole trade step pane blank.
+            SimpleMarkdownLabel missingLabel = addSimpleMarkdownLabel(gridPane, ++gridRow,
+                    Res.get("portfolio.pending.step2_buyer.paymentAccountPayloadMissing"), 10);
+            missingLabel.getStyleClass().add("medium-text");
+            GridPane.setColumnSpan(missingLabel, 2);
+        } else if (paymentAccountPayload.showRefTextWarning()) {
             SimpleMarkdownLabel footerLabel = addSimpleMarkdownLabel(gridPane, ++gridRow, Res.get("portfolio.pending.step2_buyer.refTextWarn"), 10);
             footerLabel.getStyleClass().add("medium-text");
             GridPane.setColumnSpan(footerLabel, 2);
@@ -476,6 +487,7 @@ public class BuyerStep2View extends TradeStepView {
         GridPane.setColumnSpan(hBox, 2);
         confirmButton = tuple3.first;
         confirmButton.setOnAction(e -> onPaymentStarted());
+        confirmButton.setDisable(paymentAccountPayload == null || !trade.confirmPermitted());
         busyAnimation = tuple3.second;
         statusLabel = tuple3.third;
 
@@ -484,7 +496,7 @@ public class BuyerStep2View extends TradeStepView {
             gridPane.setMinHeight(600); // make the scrollpane parent node activate its scrollbar
         }
 
-        if (trade.getOffer().getCurrencyCode().equals("BSQ")) {
+        if (paymentAccountPayload != null && trade.getOffer().getCurrencyCode().equals("BSQ")) {
             fillBsqButton = new AutoTooltipButton(Res.get("portfolio.pending.step2_buyer.fillInBsqWallet"));
             hBox.getChildren().add(1, fillBsqButton);
             fillBsqButton.setOnAction(e -> {
@@ -526,7 +538,8 @@ public class BuyerStep2View extends TradeStepView {
     protected void updateDisputeState(Trade.DisputeState disputeState) {
         super.updateDisputeState(disputeState);
 
-        confirmButton.setDisable(!trade.confirmPermitted());
+        confirmButton.setDisable(model.dataModel.getSellersPaymentAccountPayload() == null
+                || !trade.confirmPermitted());
     }
 
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -440,7 +440,9 @@ public class BuyerStep2View extends TradeStepView {
                 gridRow = SbpForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload);
                 break;
             default:
-                log.error("Not supported PaymentMethod: " + paymentMethodId);
+                if (!paymentMethodId.isEmpty()) {
+                    log.error("Not supported PaymentMethod: " + paymentMethodId);
+                }
         }
 
         Trade trade = model.getTrade();
@@ -461,7 +463,16 @@ public class BuyerStep2View extends TradeStepView {
             }
         }
 
-        if (paymentAccountPayload.showRefTextWarning()) {
+        if (paymentAccountPayload == null) {
+            // The seller's payment account payload never arrived (e.g. the mailbox
+            // DepositTxAndDelayedPayoutTxMessage was missed), so there are no payment
+            // details to show. Render a warning instead of dereferencing null here,
+            // which used to throw an NPE and leave the whole trade step pane blank.
+            SimpleMarkdownLabel missingLabel = addSimpleMarkdownLabel(gridPane, ++gridRow,
+                    Res.get("portfolio.pending.step2_buyer.paymentAccountPayloadMissing"), 10);
+            missingLabel.getStyleClass().add("medium-text");
+            GridPane.setColumnSpan(missingLabel, 2);
+        } else if (paymentAccountPayload.showRefTextWarning()) {
             SimpleMarkdownLabel footerLabel = addSimpleMarkdownLabel(gridPane, ++gridRow, Res.get("portfolio.pending.step2_buyer.refTextWarn"), 10);
             footerLabel.getStyleClass().add("medium-text");
             GridPane.setColumnSpan(footerLabel, 2);
@@ -484,7 +495,7 @@ public class BuyerStep2View extends TradeStepView {
             gridPane.setMinHeight(600); // make the scrollpane parent node activate its scrollbar
         }
 
-        if (trade.getOffer().getCurrencyCode().equals("BSQ")) {
+        if (paymentAccountPayload != null && trade.getOffer().getCurrencyCode().equals("BSQ")) {
             fillBsqButton = new AutoTooltipButton(Res.get("portfolio.pending.step2_buyer.fillInBsqWallet"));
             hBox.getChildren().add(1, fillBsqButton);
             fillBsqButton.setOnAction(e -> {


### PR DESCRIPTION
When the seller's PaymentAccountPayload never arrives (for example the mailbox DepositTxAndDelayedPayoutTxMessage is missed), BuyerStep2View dereferenced it in addContent() via
paymentAccountPayload.showRefTextWarning(), throwing an NPE inside the TradeStepView constructor. TradeSubView swallows that exception and leaves the whole trade step pane blank, so the buyer cannot reach the chat, the dispute button or the mediation-result popup and the trade cannot be resolved in the app.

Guard the null case: show a short warning that the seller's payment details are missing and to contact the mediator, and let addContent() finish so the pane and its controls render normally. The 'Pay from BSQ wallet' button is likewise skipped when the payload is null, since its click handler would otherwise dereference it.

Part of #7945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the buyer payment step to handle missing seller payment details safely.
  * Added a clear warning instructing buyers to contact the seller in trade chat and open mediation if the trade cannot be recovered.
  * Prevented payment confirmation and BSQ wallet actions when required payment information is unavailable.
  * Prevented errors when payment account data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->