### PR TITLE
Fix TradeStatistics3 hash validation test fixture

### DIFF
--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatistics3Test.java
@@ -58,6 +58,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TradeStatistics3Test {
+    private static final long POST_STRICT_HASH_CHECK_DATE = 1_700_000_000_000L;
+
     @Test
     public void isValidAcceptsHistoricalTradeAboveCurrentTradeLimit() {
         TradeStatistics3 tradeStatistics = new TradeStatistics3("USD",
@@ -258,7 +260,7 @@ public class TradeStatistics3Test {
                 50_000_000,
                 Coin.parseCoin("0.25").value,
                 "SEPA",
-                1,
+                POST_STRICT_HASH_CHECK_DATE,
                 "mediator",
                 "refundAgent",
                 extraDataMap);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated trade statistics test data to use a defined timestamp for strict hash validation scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->