### PR TITLE
Round altcoin trade amounts to coin precision

### DIFF
--- a/assets/src/main/java/bisq/asset/AbstractAsset.java
+++ b/assets/src/main/java/bisq/asset/AbstractAsset.java
@@ -33,11 +33,20 @@ public abstract class AbstractAsset implements Asset {
 
     private final String name;
     private final String tickerSymbol;
+    private final int precision;
     private final AddressValidator addressValidator;
 
     public AbstractAsset(String name, String tickerSymbol, AddressValidator addressValidator) {
+        this(name, tickerSymbol, DEFAULT_PRECISION, addressValidator);
+    }
+
+    public AbstractAsset(String name, String tickerSymbol, int precision, AddressValidator addressValidator) {
         this.name = notBlank(name);
         this.tickerSymbol = notBlank(tickerSymbol);
+        if (precision < 0) {
+            throw new IllegalArgumentException("precision must be non-negative: " + precision);
+        }
+        this.precision = precision;
         this.addressValidator = Objects.requireNonNull(addressValidator);
     }
 
@@ -49,6 +58,11 @@ public abstract class AbstractAsset implements Asset {
     @Override
     public final String getTickerSymbol() {
         return tickerSymbol;
+    }
+
+    @Override
+    public final int getPrecision() {
+        return precision;
     }
 
     @Override

--- a/assets/src/main/java/bisq/asset/Asset.java
+++ b/assets/src/main/java/bisq/asset/Asset.java
@@ -38,9 +38,28 @@ package bisq.asset;
  */
 public interface Asset {
 
+    /**
+     * Default number of decimal places for an asset. This is also Bisq's internal
+     * maximum precision for altcoin amounts, so assets whose chain supports more
+     * decimals are still handled at this precision, while assets supporting fewer
+     * should report their real value (see {@link #getPrecision()}).
+     */
+    int DEFAULT_PRECISION = 8;
+
     String getName();
 
     String getTickerSymbol();
+
+    /**
+     * The number of decimal places this asset supports on its own chain, i.e. the
+     * number of digits after the decimal point in its smallest transferable unit.
+     * Defaults to {@value #DEFAULT_PRECISION}. Assets whose chain supports fewer
+     * decimals (e.g. USD Coin with 6) should report their real value so that trade
+     * amounts are rounded to a figure the sender can actually transfer.
+     */
+    default int getPrecision() {
+        return DEFAULT_PRECISION;
+    }
 
     AddressValidationResult validateAddress(String address);
 }

--- a/assets/src/main/java/bisq/asset/Coin.java
+++ b/assets/src/main/java/bisq/asset/Coin.java
@@ -44,8 +44,17 @@ public abstract class Coin extends AbstractAsset {
         this(name, tickerSymbol, addressValidator, Network.MAINNET);
     }
 
+    public Coin(String name, String tickerSymbol, int precision, AddressValidator addressValidator) {
+        this(name, tickerSymbol, precision, addressValidator, Network.MAINNET);
+    }
+
     public Coin(String name, String tickerSymbol, AddressValidator addressValidator, Network network) {
         super(name, tickerSymbol, addressValidator);
+        this.network = network;
+    }
+
+    public Coin(String name, String tickerSymbol, int precision, AddressValidator addressValidator, Network network) {
+        super(name, tickerSymbol, precision, addressValidator);
         this.network = network;
     }
 

--- a/assets/src/main/java/bisq/asset/Erc20Token.java
+++ b/assets/src/main/java/bisq/asset/Erc20Token.java
@@ -30,4 +30,8 @@ public abstract class Erc20Token extends Token {
     public Erc20Token(String name, String tickerSymbol) {
         super(name, tickerSymbol, new EtherAddressValidator());
     }
+
+    public Erc20Token(String name, String tickerSymbol, int precision) {
+        super(name, tickerSymbol, precision, new EtherAddressValidator());
+    }
 }

--- a/assets/src/main/java/bisq/asset/Token.java
+++ b/assets/src/main/java/bisq/asset/Token.java
@@ -34,4 +34,8 @@ public abstract class Token extends AbstractAsset {
     public Token(String name, String tickerSymbol, AddressValidator addressValidator) {
         super(name, tickerSymbol, addressValidator);
     }
+
+    public Token(String name, String tickerSymbol, int precision, AddressValidator addressValidator) {
+        super(name, tickerSymbol, precision, addressValidator);
+    }
 }

--- a/assets/src/main/java/bisq/asset/coins/Animecoin.java
+++ b/assets/src/main/java/bisq/asset/coins/Animecoin.java
@@ -23,7 +23,7 @@ import bisq.asset.NetworkParametersAdapter;
 
 public class Animecoin extends Coin {
     public Animecoin() {
-        super("Animecoin", "ANI", new Base58AddressValidator(new AnimecoinMainNetParams()));
+        super("Animecoin", "ANI", 5, new Base58AddressValidator(new AnimecoinMainNetParams()));
     }
 
     public static class AnimecoinMainNetParams extends NetworkParametersAdapter {

--- a/assets/src/main/java/bisq/asset/coins/CloakCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/CloakCoin.java
@@ -23,6 +23,6 @@ import bisq.asset.RegexAddressValidator;
 public class CloakCoin extends Coin {
 
     public CloakCoin() {
-        super("CloakCoin", "CLOAK", new RegexAddressValidator("^[B|C][a-km-zA-HJ-NP-Z1-9]{33}|^smY[a-km-zA-HJ-NP-Z1-9]{99}$"));
+        super("CloakCoin", "CLOAK", 6, new RegexAddressValidator("^[B|C][a-km-zA-HJ-NP-Z1-9]{33}|^smY[a-km-zA-HJ-NP-Z1-9]{99}$"));
     }
 }

--- a/assets/src/main/java/bisq/asset/coins/Dragonglass.java
+++ b/assets/src/main/java/bisq/asset/coins/Dragonglass.java
@@ -25,6 +25,6 @@ import bisq.asset.RegexAddressValidator;
 public class Dragonglass extends Coin {
 
     public Dragonglass() {
-        super("Dragonglass", "DRGL", new RegexAddressValidator("^(dRGL)[1-9A-HJ-NP-Za-km-z]{94}$"));
+        super("Dragonglass", "DRGL", 7, new RegexAddressValidator("^(dRGL)[1-9A-HJ-NP-Za-km-z]{94}$"));
     }
 }

--- a/assets/src/main/java/bisq/asset/coins/Emercoin.java
+++ b/assets/src/main/java/bisq/asset/coins/Emercoin.java
@@ -24,7 +24,7 @@ import bisq.asset.NetworkParametersAdapter;
 public class Emercoin extends Coin {
 
     public Emercoin() {
-        super("Emercoin", "EMC", new Base58AddressValidator(new EmercoinMainNetParams()), Network.MAINNET);
+        super("Emercoin", "EMC", 6, new Base58AddressValidator(new EmercoinMainNetParams()), Network.MAINNET);
     }
 
     public static class EmercoinMainNetParams extends NetworkParametersAdapter {

--- a/assets/src/main/java/bisq/asset/coins/LitecoinPlus.java
+++ b/assets/src/main/java/bisq/asset/coins/LitecoinPlus.java
@@ -24,7 +24,7 @@ import bisq.asset.NetworkParametersAdapter;
 public class LitecoinPlus extends Coin {
 
     public LitecoinPlus() {
-        super("LitecoinPlus", "LCP", new Base58AddressValidator(new LitecoinPlusMainNetParams()));
+        super("LitecoinPlus", "LCP", 6, new Base58AddressValidator(new LitecoinPlusMainNetParams()));
     }
 
     public static class LitecoinPlusMainNetParams extends NetworkParametersAdapter {

--- a/assets/src/main/java/bisq/asset/coins/Mile.java
+++ b/assets/src/main/java/bisq/asset/coins/Mile.java
@@ -31,7 +31,7 @@ import java.util.zip.Checksum;
 public class Mile extends Coin {
 
     public Mile() {
-        super("Mile", "MILE", new MileAddressValidator());
+        super("Mile", "MILE", 5, new MileAddressValidator());
     }
 
 

--- a/assets/src/main/java/bisq/asset/coins/TurtleCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/TurtleCoin.java
@@ -23,6 +23,6 @@ import bisq.asset.RegexAddressValidator;
 public class TurtleCoin extends Coin {
 
     public TurtleCoin() {
-        super("TurtleCoin", "TRTL", new RegexAddressValidator("^TRTL[1-9A-Za-z^OIl]{95}"));
+        super("TurtleCoin", "TRTL", 2, new RegexAddressValidator("^TRTL[1-9A-Za-z^OIl]{95}"));
     }
 }

--- a/assets/src/main/java/bisq/asset/coins/WrkzCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/WrkzCoin.java
@@ -23,6 +23,6 @@ import bisq.asset.RegexAddressValidator;
 public class WrkzCoin extends Coin {
 
     public WrkzCoin() {
-        super("WrkzCoin", "WRKZ", new RegexAddressValidator("^Wrkz[1-9A-Za-z^OIl]{94}"));
+        super("WrkzCoin", "WRKZ", 2, new RegexAddressValidator("^Wrkz[1-9A-Za-z^OIl]{94}"));
     }
 }

--- a/assets/src/main/java/bisq/asset/coins/uPlexa.java
+++ b/assets/src/main/java/bisq/asset/coins/uPlexa.java
@@ -25,6 +25,6 @@ import bisq.asset.RegexAddressValidator;
 public class uPlexa extends Coin {
 
     public uPlexa() {
-        super("uPlexa", "UPX", new RegexAddressValidator("^((UPX)[1-9A-Za-z^OIl]{95}|(UPi)[1-9A-Za-z^OIl]{106}|(UmV|UmW)[1-9A-Za-z^OIl]{94})$"));
+        super("uPlexa", "UPX", 2, new RegexAddressValidator("^((UPX)[1-9A-Za-z^OIl]{95}|(UPi)[1-9A-Za-z^OIl]{106}|(UmV|UmW)[1-9A-Za-z^OIl]{94})$"));
     }
 }

--- a/assets/src/main/java/bisq/asset/tokens/AugmintEuro.java
+++ b/assets/src/main/java/bisq/asset/tokens/AugmintEuro.java
@@ -22,6 +22,6 @@ import bisq.asset.Erc20Token;
 public class AugmintEuro extends Erc20Token {
 
     public AugmintEuro() {
-        super("Augmint Euro", "AEUR");
+        super("Augmint Euro", "AEUR", 2);
     }
 }

--- a/assets/src/main/java/bisq/asset/tokens/TetherUSDERC20.java
+++ b/assets/src/main/java/bisq/asset/tokens/TetherUSDERC20.java
@@ -6,6 +6,6 @@ public class TetherUSDERC20 extends Erc20Token {
     public TetherUSDERC20() {
         // If you add a new USDT variant or want to change this ticker symbol you should also look here:
         // core/src/main/java/bisq/core/provider/price/PriceProvider.java:getAll()
-        super("Tether USD (ERC20)", "USDT-E");
+        super("Tether USD (ERC20)", "USDT-E", 6);
     }
 }

--- a/assets/src/main/java/bisq/asset/tokens/USDCoin.java
+++ b/assets/src/main/java/bisq/asset/tokens/USDCoin.java
@@ -22,6 +22,6 @@ import bisq.asset.Erc20Token;
 public class USDCoin extends Erc20Token {
 
     public USDCoin() {
-        super("USD Coin", "USDC");
+        super("USD Coin", "USDC", 6);
     }
 }

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -70,6 +70,7 @@ public class CurrencyUtil {
     // See: https://github.com/bisq-network/bisq/pull/4955#issuecomment-745302802
     private static final Map<String, Boolean> isFiatCurrencyMap = new ConcurrentHashMap<>();
     private static final Map<String, Boolean> isCryptoCurrencyMap = new ConcurrentHashMap<>();
+    private static final Map<String, Integer> cryptoPrecisionMap = new ConcurrentHashMap<>();
 
     private static final Supplier<Map<String, FiatCurrency>> fiatCurrencyMapSupplier = Suppliers.memoize(
             CurrencyUtil::createFiatCurrencyMap);
@@ -427,6 +428,18 @@ public class CurrencyUtil {
         return assetRegistry.stream()
                 .filter(asset -> asset.getTickerSymbol().equals(tickerSymbol))
                 .findAny();
+    }
+
+    // Number of decimal places the given altcoin supports on its own chain. Falls back to
+    // the default precision for BTC, fiat or any unknown/removed asset (none in registry).
+    // findAsset is a linear scan over the asset registry and this gets called per offer row
+    // on UI recalculations, so the result is cached like isCryptoCurrency above.
+    public static int getCryptoPrecision(String currencyCode) {
+        if (currencyCode == null) {
+            return Asset.DEFAULT_PRECISION;
+        }
+        return cryptoPrecisionMap.computeIfAbsent(currencyCode,
+                code -> findAsset(code).map(Asset::getPrecision).orElse(Asset.DEFAULT_PRECISION));
     }
 
     public static Optional<Asset> findAsset(String tickerSymbol, BaseCurrencyNetwork baseCurrencyNetwork) {

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -429,6 +429,12 @@ public class CurrencyUtil {
                 .findAny();
     }
 
+    // Number of decimal places the given altcoin supports on its own chain. Falls back to
+    // the default precision for BTC, fiat or any unknown/removed asset (none in registry).
+    public static int getCryptoPrecision(String currencyCode) {
+        return findAsset(currencyCode).map(Asset::getPrecision).orElse(Asset.DEFAULT_PRECISION);
+    }
+
     public static Optional<Asset> findAsset(String tickerSymbol, BaseCurrencyNetwork baseCurrencyNetwork) {
         return assetRegistry.stream()
                 .filter(asset -> asset.getTickerSymbol().equals(tickerSymbol))

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -273,6 +273,11 @@ public class Offer implements NetworkPayload, PersistablePayload {
             volumeByAmount = VolumeUtil.getAdjustedVolumeForHalCash(volumeByAmount);
         else if (isFiatOffer())
             volumeByAmount = VolumeUtil.getRoundedFiatVolume(volumeByAmount);
+        else if (CurrencyUtil.isCryptoCurrency(getCurrencyCode()))
+            // Round to the coin's own precision so the stated amount can actually be sent
+            // (coins with fewer than 8 decimals cannot receive Bisq's 8-decimal volume).
+            volumeByAmount = VolumeUtil.getAdjustedAltcoinVolume(volumeByAmount,
+                    CurrencyUtil.getCryptoPrecision(getCurrencyCode()));
 
         return volumeByAmount;
     }

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -276,6 +276,11 @@ public class Offer implements NetworkPayload, PersistablePayload {
             volumeByAmount = VolumeUtil.getAdjustedVolumeForHalCash(volumeByAmount);
         else if (isFiatOffer())
             volumeByAmount = VolumeUtil.getRoundedFiatVolume(volumeByAmount);
+        else if (CurrencyUtil.isCryptoCurrency(getCurrencyCode()))
+            // Round to the coin's own precision so the stated amount can actually be sent
+            // (coins with fewer than 8 decimals cannot receive Bisq's 8-decimal volume).
+            volumeByAmount = VolumeUtil.getAdjustedAltcoinVolume(volumeByAmount,
+                    CurrencyUtil.getCryptoPrecision(getCurrencyCode()));
 
         return volumeByAmount;
     }

--- a/core/src/main/java/bisq/core/offer/bisq_v1/TakeOfferModel.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/TakeOfferModel.java
@@ -29,6 +29,7 @@ import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.fee.FeeService;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.validation.TradeAmountValidation;
 
 import bisq.common.taskrunner.Model;
 
@@ -198,7 +199,7 @@ public class TakeOfferModel implements Model {
             volumeByAmount = getAdjustedAltcoinVolume(volumeByAmount,
                     CurrencyUtil.getCryptoPrecision(offer.getCurrencyCode()));
 
-        volume = volumeByAmount;
+        volume = TradeAmountValidation.checkTradeVolume(volumeByAmount);
 
         updateBalance();
     }

--- a/core/src/main/java/bisq/core/offer/bisq_v1/TakeOfferModel.java
+++ b/core/src/main/java/bisq/core/offer/bisq_v1/TakeOfferModel.java
@@ -20,6 +20,7 @@ package bisq.core.offer.bisq_v1;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.btc.model.AddressEntry;
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.locale.CurrencyUtil;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
@@ -46,6 +47,7 @@ import org.jetbrains.annotations.NotNull;
 
 import static bisq.core.btc.model.AddressEntry.Context.OFFER_FUNDING;
 import static bisq.core.offer.OfferDirection.SELL;
+import static bisq.core.util.VolumeUtil.getAdjustedAltcoinVolume;
 import static bisq.core.util.VolumeUtil.getAdjustedVolumeForHalCash;
 import static bisq.core.util.VolumeUtil.getRoundedFiatVolume;
 import static bisq.core.util.coin.CoinUtil.minCoin;
@@ -192,6 +194,9 @@ public class TakeOfferModel implements Model {
             volumeByAmount = getAdjustedVolumeForHalCash(volumeByAmount);
         else if (offer.isFiatOffer())
             volumeByAmount = getRoundedFiatVolume(volumeByAmount);
+        else if (CurrencyUtil.isCryptoCurrency(offer.getCurrencyCode()))
+            volumeByAmount = getAdjustedAltcoinVolume(volumeByAmount,
+                    CurrencyUtil.getCryptoPrecision(offer.getCurrencyCode()));
 
         volume = volumeByAmount;
 

--- a/core/src/main/java/bisq/core/offer/placeoffer/bisq_v1/tasks/ValidateOffer.java
+++ b/core/src/main/java/bisq/core/offer/placeoffer/bisq_v1/tasks/ValidateOffer.java
@@ -18,6 +18,7 @@
 package bisq.core.offer.placeoffer.bisq_v1.tasks;
 
 import bisq.core.locale.Res;
+import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
 import bisq.core.offer.availability.DisputeAgentSelection;
 import bisq.core.offer.bisq_v1.OfferPayload;
@@ -77,6 +78,12 @@ public class ValidateOffer extends Task<PlaceOfferModel> {
             checkArgument(offer.getPrice().isPositive(),
                     "Price must be positive. price=" + offer.getPrice().toFriendlyString());
 
+            // An altcoin volume below half of one on-chain unit rounds to zero
+            // (see VolumeUtil.getAdjustedAltcoinVolume), which would create an offer
+            // with no payment obligation.
+            checkVolumeNotNullOrZero(offer.getVolume(), "Volume");
+            checkVolumeNotNullOrZero(offer.getMinVolume(), "MinVolume");
+
             checkArgument(offer.getDate().getTime() > 0,
                     "Date must not be 0. date=" + offer.getDate().toString());
 
@@ -119,6 +126,12 @@ public class ValidateOffer extends Task<PlaceOfferModel> {
         checkNotNull(value, name + " is null");
         checkArgument(value.isPositive(),
                 name + " must be positive. " + name + "=" + value.toFriendlyString());
+    }
+
+    public static void checkVolumeNotNullOrZero(Volume value, String name) {
+        checkNotNull(value, name + " is null");
+        checkArgument(value.getValue() > 0,
+                name + " must be positive. " + name + "=" + value.toPlainString());
     }
 
     public static String nonEmptyStringOf(String value) {

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
@@ -472,6 +472,9 @@ public final class Contract implements NetworkPayload {
             volumeByAmount = VolumeUtil.getAdjustedVolumeForHalCash(volumeByAmount);
         else if (CurrencyUtil.isFiatCurrency(getOfferPayload().getCurrencyCode()))
             volumeByAmount = VolumeUtil.getRoundedFiatVolume(volumeByAmount);
+        else if (CurrencyUtil.isCryptoCurrency(getOfferPayload().getCurrencyCode()))
+            volumeByAmount = VolumeUtil.getAdjustedAltcoinVolume(volumeByAmount,
+                    CurrencyUtil.getCryptoPrecision(getOfferPayload().getCurrencyCode()));
 
         return volumeByAmount;
     }

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/Contract.java
@@ -474,6 +474,9 @@ public final class Contract implements NetworkPayload {
             volumeByAmount = VolumeUtil.getAdjustedVolumeForHalCash(volumeByAmount);
         else if (CurrencyUtil.isFiatCurrency(getOfferPayload().getCurrencyCode()))
             volumeByAmount = VolumeUtil.getRoundedFiatVolume(volumeByAmount);
+        else if (CurrencyUtil.isCryptoCurrency(getOfferPayload().getCurrencyCode()))
+            volumeByAmount = VolumeUtil.getAdjustedAltcoinVolume(volumeByAmount,
+                    CurrencyUtil.getCryptoPrecision(getOfferPayload().getCurrencyCode()));
 
         return volumeByAmount;
     }

--- a/core/src/main/java/bisq/core/trade/model/bisq_v1/Trade.java
+++ b/core/src/main/java/bisq/core/trade/model/bisq_v1/Trade.java
@@ -18,6 +18,7 @@
 package bisq.core.trade.model.bisq_v1;
 
 import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.locale.CurrencyUtil;
 import bisq.core.monetary.Price;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.Offer;
@@ -772,6 +773,9 @@ public abstract class Trade extends TradeModel {
                         volumeByAmount = VolumeUtil.getAdjustedVolumeForHalCash(volumeByAmount);
                     else if (offer.isFiatOffer())
                         volumeByAmount = VolumeUtil.getRoundedFiatVolume(volumeByAmount);
+                    else if (CurrencyUtil.isCryptoCurrency(offer.getCurrencyCode()))
+                        volumeByAmount = VolumeUtil.getAdjustedAltcoinVolume(volumeByAmount,
+                                CurrencyUtil.getCryptoPrecision(offer.getCurrencyCode()));
                 }
                 return volumeByAmount;
             } else {

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -157,6 +157,9 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
 
             long takersTradePrice = TradePriceValidation.checkTakersTradePrice(request.getTradePrice(), priceFeedService, offer);
             trade.setPriceAsLong(takersTradePrice);
+            // The maker trade has no price until the taker's price is applied, so the
+            // volume can only be derived and validated from here on.
+            TradeAmountValidation.checkTradeVolume(trade.getVolume());
 
             trade.setTradingPeerNodeAddress(processModel.getTempTradingPeerNodeAddress());
 

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatistics3.java
@@ -433,7 +433,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         if (volume == null) {
             Price price = getTradePrice();
             this.volume = volume = price.getMonetary() instanceof Altcoin
-                    ? price.getVolumeByAmount(getTradeAmount())
+                    ? VolumeUtil.getAdjustedAltcoinVolume(price.getVolumeByAmount(getTradeAmount()),
+                            CurrencyUtil.getCryptoPrecision(price.getCurrencyCode()))
                     : VolumeUtil.getRoundedFiatVolume(price.getVolumeByAmount(getTradeAmount()));
         }
         return volume;

--- a/core/src/main/java/bisq/core/trade/validation/TradeAmountValidation.java
+++ b/core/src/main/java/bisq/core/trade/validation/TradeAmountValidation.java
@@ -17,12 +17,16 @@
 
 package bisq.core.trade.validation;
 
+import bisq.core.monetary.Volume;
 import bisq.core.payment.TradeLimits;
 
 import org.bitcoinj.core.Coin;
 
+import javax.annotation.Nullable;
+
 import static bisq.core.util.Validator.checkIsPositive;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class TradeAmountValidation {
     private TradeAmountValidation() {
@@ -55,5 +59,22 @@ public final class TradeAmountValidation {
                 "Trade amount must not exceed the network max trade amount. tradeAmount=%s, max=%s",
                 tradeAmount.toFriendlyString(), TradeLimits.MAX_TRADE_AMOUNT.toFriendlyString());
         return tradeAmount;
+    }
+
+    /* --------------------------------------------------------------------- */
+    // Trade volume
+    /* --------------------------------------------------------------------- */
+
+    // An altcoin volume below half of one on-chain unit rounds to zero (see
+    // VolumeUtil.getAdjustedAltcoinVolume), which would settle the trade with no
+    // payment obligation. Reachable through offers that bypassed the volume
+    // validation at placement, e.g. crafted or pre-existing ones, and through
+    // market-priced offers whose price has risen far enough since placement.
+    // Expects a volume already rounded to the asset's chain precision.
+    public static Volume checkTradeVolume(@Nullable Volume tradeVolume) {
+        checkNotNull(tradeVolume, "tradeVolume must not be null");
+        checkArgument(tradeVolume.getValue() > 0,
+                "Trade volume must not be zero. currencyCode=%s", tradeVolume.getCurrencyCode());
+        return tradeVolume;
     }
 }

--- a/core/src/main/java/bisq/core/util/VolumeUtil.java
+++ b/core/src/main/java/bisq/core/util/VolumeUtil.java
@@ -26,6 +26,8 @@ import org.bitcoinj.core.Monetary;
 import org.bitcoinj.utils.Fiat;
 import org.bitcoinj.utils.MonetaryFormat;
 
+import com.google.common.math.LongMath;
+
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
@@ -60,6 +62,31 @@ public class VolumeUtil {
         // Smallest allowed volume is factor (e.g. 10 EUR or 1 EUR,...)
         roundedVolume = Math.max(factor, roundedVolume);
         return Volume.parse(String.valueOf(roundedVolume), volumeByAmount.getCurrencyCode());
+    }
+
+    /**
+     * Round an altcoin volume to the coin's own precision so the resulting amount can
+     * actually be transferred on that coin's chain. Altcoin volumes are stored at
+     * 10^-8 precision, but the coin may support fewer decimals; one on-chain unit is
+     * 10^(8 - precision) internal units. Unlike {@link #getAdjustedFiatVolume} this does
+     * NOT coarsen to whole coins - it rounds to the finest unit the coin can represent.
+     *
+     * @param volumeByAmount    The volume generated from an amount.
+     * @param precision         The number of decimals the coin supports on its chain.
+     * @return The adjusted altcoin volume.
+     */
+    public static Volume getAdjustedAltcoinVolume(Volume volumeByAmount, int precision) {
+        int cappedPrecision = Math.min(precision, Altcoin.SMALLEST_UNIT_EXPONENT);
+        long step = LongMath.pow(10, Altcoin.SMALLEST_UNIT_EXPONENT - cappedPrecision);
+        long value = volumeByAmount.getValue();
+        // Round to the nearest multiple of step (half up) using exact integer arithmetic. We
+        // avoid floating point so large volumes stay bit-exact and precision 8 is a true no-op
+        // (a long -> double cast would lose precision above 2^53).
+        long roundedVolume = ((value + step / 2) / step) * step;
+        // Never round down to zero: a volume below one on-chain unit (e.g. a fraction of a
+        // whole coin on a 0-decimal coin) is raised to exactly one unit, so it stays sendable.
+        roundedVolume = Math.max(step, roundedVolume);
+        return new Volume(Altcoin.valueOf(volumeByAmount.getCurrencyCode(), roundedVolume));
     }
 
 

--- a/core/src/main/java/bisq/core/util/VolumeUtil.java
+++ b/core/src/main/java/bisq/core/util/VolumeUtil.java
@@ -26,6 +26,8 @@ import org.bitcoinj.core.Monetary;
 import org.bitcoinj.utils.Fiat;
 import org.bitcoinj.utils.MonetaryFormat;
 
+import com.google.common.math.LongMath;
+
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
@@ -60,6 +62,32 @@ public class VolumeUtil {
         // Smallest allowed volume is factor (e.g. 10 EUR or 1 EUR,...)
         roundedVolume = Math.max(factor, roundedVolume);
         return Volume.parse(String.valueOf(roundedVolume), volumeByAmount.getCurrencyCode());
+    }
+
+    /**
+     * Round an altcoin volume to the coin's own precision so the resulting amount can
+     * actually be transferred on that coin's chain. Altcoin volumes are stored at
+     * 10^-8 precision, but the coin may support fewer decimals; one on-chain unit is
+     * 10^(8 - precision) internal units. Unlike {@link #getAdjustedFiatVolume} this does
+     * NOT coarsen to whole coins - it rounds to the finest unit the coin can represent.
+     *
+     * @param volumeByAmount    The volume generated from an amount.
+     * @param precision         The number of decimals the coin supports on its chain.
+     * @return The adjusted altcoin volume; zero when the volume is below half of one on-chain
+     *         unit, which callers must reject as an amount below the coin's minimum.
+     */
+    public static Volume getAdjustedAltcoinVolume(Volume volumeByAmount, int precision) {
+        int cappedPrecision = Math.min(precision, Altcoin.SMALLEST_UNIT_EXPONENT);
+        long step = LongMath.pow(10, Altcoin.SMALLEST_UNIT_EXPONENT - cappedPrecision);
+        long value = volumeByAmount.getValue();
+        // Round to the nearest multiple of step (half up) using exact integer arithmetic. We
+        // avoid floating point so large volumes stay bit-exact and precision 8 is a true no-op
+        // (a long -> double cast would lose precision above 2^53). checkedAdd guards the one
+        // overflow-capable step, failing loudly instead of producing a silently wrong volume.
+        // A volume below half of one on-chain unit rounds to zero; inflating it to one unit
+        // here would silently change the agreed rate, so rejection is left to the callers.
+        long roundedVolume = (LongMath.checkedAdd(value, step / 2) / step) * step;
+        return new Volume(Altcoin.valueOf(volumeByAmount.getCurrencyCode(), roundedVolume));
     }
 
 

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -622,6 +622,7 @@ takeOffer.amountPriceBox.warning.invalidBtcDecimalPlaces=The amount you have ent
 takeOffer.validation.amountSmallerThanMinAmount=Amount cannot be smaller than minimum amount defined in the offer.
 takeOffer.validation.amountLargerThanOfferAmount=Input amount cannot be higher than the amount defined in the offer.
 takeOffer.validation.amountLargerThanOfferAmountMinusFee=That input amount would create dust change for the BTC seller.
+takeOffer.validation.amountRoundsToZeroVolume=The resulting {0} amount rounds to zero and cannot be transferred on the {0} network.
 takeOffer.fundsBox.title=Fund your trade
 takeOffer.fundsBox.isOfferAvailable=Checking if the offer is still available ...
 takeOffer.fundsBox.tradeAmount=Amount to sell

--- a/core/src/test/java/bisq/core/locale/CurrencyUtilTest.java
+++ b/core/src/test/java/bisq/core/locale/CurrencyUtilTest.java
@@ -27,8 +27,10 @@ import bisq.common.config.BaseCurrencyNetwork;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -133,6 +135,34 @@ public class CurrencyUtilTest {
     public void testGetNameAndCodeOfRemovedAsset() {
         assertEquals("Bitcoin Cash (BCH)", CurrencyUtil.getNameAndCode("BCH"));
         assertEquals("N/A (XYZ)", CurrencyUtil.getNameAndCode("XYZ"));
+    }
+
+    @Test
+    public void testGetCryptoPrecisionOfSub8DecimalAssets() {
+        // Derived from the registry so that adding, removing or changing a sub-8
+        // asset shows up as an explicit test change; a precision metadata omission
+        // would silently disable volume rounding for the affected asset.
+        Map<String, Integer> expected = Map.ofEntries(
+                Map.entry("AEUR", 2), Map.entry("TRTL", 2), Map.entry("UPX", 2), Map.entry("WRKZ", 2),
+                Map.entry("ANI", 5), Map.entry("MILE", 5),
+                Map.entry("CLOAK", 6), Map.entry("EMC", 6), Map.entry("LCP", 6),
+                Map.entry("USDC", 6), Map.entry("USDT-E", 6),
+                Map.entry("DRGL", 7));
+        Map<String, Integer> actual = new AssetRegistry().stream()
+                .filter(asset -> asset.getPrecision() < Asset.DEFAULT_PRECISION)
+                .collect(Collectors.toMap(Asset::getTickerSymbol, Asset::getPrecision, (a, b) -> a));
+        assertEquals(expected, actual);
+
+        // The precision lookup resolves from the registry.
+        assertEquals(2, CurrencyUtil.getCryptoPrecision("TRTL"));
+        assertEquals(6, CurrencyUtil.getCryptoPrecision("USDC"));
+
+        // Indivisible assets deliberately keep the default precision: half of one
+        // on-chain unit is a whole coin there, so half-up rounding would silently
+        // move real value. Asserted via the registry, because getCryptoPrecision
+        // would also return the default for an asset that is not registered at all.
+        assertEquals(Asset.DEFAULT_PRECISION, CurrencyUtil.findAsset("SF").orElseThrow().getPrecision());
+        assertEquals(Asset.DEFAULT_PRECISION, CurrencyUtil.findAsset("ASK").orElseThrow().getPrecision());
     }
 
     class MockAssetRegistry extends AssetRegistry {

--- a/core/src/test/java/bisq/core/offer/placeoffer/bisq_v1/tasks/ValidateOfferTest.java
+++ b/core/src/test/java/bisq/core/offer/placeoffer/bisq_v1/tasks/ValidateOfferTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.offer.placeoffer.bisq_v1.tasks;
+
+import bisq.core.monetary.Altcoin;
+import bisq.core.monetary.Volume;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ValidateOfferTest {
+
+    @Test
+    void checkVolumeNotNullOrZeroAcceptsPositiveVolume() {
+        // One on-chain unit of the 6-decimal coin, the smallest volume the
+        // rounding can produce.
+        assertDoesNotThrow(() ->
+                ValidateOffer.checkVolumeNotNullOrZero(new Volume(Altcoin.valueOf("USDC", 100L)), "Volume"));
+    }
+
+    @Test
+    void checkVolumeNotNullOrZeroRejectsNullAndZeroVolume() {
+        assertThrows(NullPointerException.class,
+                () -> ValidateOffer.checkVolumeNotNullOrZero(null, "Volume"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> ValidateOffer.checkVolumeNotNullOrZero(new Volume(Altcoin.valueOf("USDC", 0L)), "MinVolume"));
+
+        assertEquals("MinVolume must be positive. MinVolume=0", exception.getMessage());
+    }
+}

--- a/core/src/test/java/bisq/core/trade/model/bisq_v1/MakerTradeVolumeTest.java
+++ b/core/src/test/java/bisq/core/trade/model/bisq_v1/MakerTradeVolumeTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.model.bisq_v1;
+
+import bisq.core.offer.Offer;
+import bisq.core.offer.OfferDirection;
+import bisq.core.offer.OfferMaker;
+import bisq.core.trade.validation.TradeAmountValidation;
+
+import org.bitcoinj.core.Coin;
+
+import org.junit.jupiter.api.Test;
+
+import static com.natpryce.makeiteasy.MakeItEasy.a;
+import static com.natpryce.makeiteasy.MakeItEasy.make;
+import static com.natpryce.makeiteasy.MakeItEasy.with;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MakerTradeVolumeTest {
+
+    // 0.0001 BTC, the minimum trade amount.
+    private static final Coin TRADE_AMOUNT = Coin.valueOf(10_000);
+
+    private static SellerAsMakerTrade makerTrade() {
+        Offer offer = make(a(OfferMaker.Offer,
+                with(OfferMaker.baseCurrencyCode, "USDC"),
+                with(OfferMaker.counterCurrencyCode, "BTC"),
+                with(OfferMaker.direction, OfferDirection.SELL)));
+        return new SellerAsMakerTrade(offer,
+                Coin.valueOf(1_000) /* txFee */,
+                Coin.valueOf(100) /* takerFee */,
+                true,
+                null /* arbitratorNodeAddress */,
+                null /* mediatorNodeAddress */,
+                null /* refundAgentNodeAddress */,
+                null /* btcWalletService, unused by getVolume */,
+                null /* processModel, unused by getVolume */,
+                "uid");
+    }
+
+    @Test
+    void makerTradeHasNoVolumeUntilTakersPriceIsApplied() {
+        SellerAsMakerTrade trade = makerTrade();
+        trade.setAmount(TRADE_AMOUNT);
+
+        // The maker constructor does not set a price; it is applied from the take
+        // request, so the trade volume can only be validated after that point.
+        assertNull(trade.getVolume());
+        assertThrows(NullPointerException.class,
+                () -> TradeAmountValidation.checkTradeVolume(trade.getVolume()));
+
+        // 0.01 BTC per USDC: 0.0001 BTC buys 0.01 USDC, exactly on the 6-decimal grid.
+        trade.setPriceAsLong(1_000_000);
+        assertEquals(1_000_000,
+                TradeAmountValidation.checkTradeVolume(trade.getVolume()).getValue());
+    }
+
+    @Test
+    void makerRejectsTradeAmountThatRoundsToZeroVolume() {
+        SellerAsMakerTrade trade = makerTrade();
+        trade.setAmount(TRADE_AMOUNT);
+
+        // 250 BTC per USDC: 0.0001 BTC buys 0.0000004 USDC, below half of one
+        // on-chain unit of the 6-decimal coin, so the volume rounds to zero.
+        trade.setPriceAsLong(25_000_000_000L);
+        assertEquals("Trade volume must not be zero. currencyCode=USDC",
+                assertThrows(IllegalArgumentException.class,
+                        () -> TradeAmountValidation.checkTradeVolume(trade.getVolume())).getMessage());
+    }
+}

--- a/core/src/test/java/bisq/core/trade/validation/TradeAmountValidationTest.java
+++ b/core/src/test/java/bisq/core/trade/validation/TradeAmountValidationTest.java
@@ -17,6 +17,8 @@
 
 package bisq.core.trade.validation;
 
+import bisq.core.monetary.Altcoin;
+import bisq.core.monetary.Volume;
 import bisq.core.payment.TradeLimits;
 
 import org.bitcoinj.core.Coin;
@@ -145,6 +147,26 @@ class TradeAmountValidationTest {
                 () -> TradeAmountValidation.checkTradeAmount(Coin.valueOf(3_000), Coin.ZERO, OFFER_MAX_AMOUNT));
         assertThrows(IllegalArgumentException.class,
                 () -> TradeAmountValidation.checkTradeAmount(Coin.valueOf(3_000), OFFER_MIN_AMOUNT, Coin.ZERO));
+    }
+
+    @Test
+    void checkTradeVolumeAcceptsPositiveVolume() {
+        // One on-chain unit of the 6-decimal coin, the smallest volume the
+        // rounding can produce.
+        Volume volume = new Volume(Altcoin.valueOf("USDC", 100L));
+
+        assertSame(volume, TradeAmountValidation.checkTradeVolume(volume));
+    }
+
+    @Test
+    void checkTradeVolumeRejectsNullAndZeroVolume() {
+        assertThrows(NullPointerException.class,
+                () -> TradeAmountValidation.checkTradeVolume(null));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> TradeAmountValidation.checkTradeVolume(new Volume(Altcoin.valueOf("USDC", 0L))));
+
+        assertEquals("Trade volume must not be zero. currencyCode=USDC", exception.getMessage());
     }
 
 }

--- a/core/src/test/java/bisq/core/util/VolumeUtilTest.java
+++ b/core/src/test/java/bisq/core/util/VolumeUtilTest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.util;
+
+import bisq.core.monetary.Altcoin;
+import bisq.core.monetary.Volume;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VolumeUtilTest {
+
+    // Altcoin volumes are stored at 10^-8 precision; the value passed here is in those units.
+    private static Volume altcoin(String code, long internalValue) {
+        return new Volume(Altcoin.valueOf(code, internalValue));
+    }
+
+    @Test
+    public void testGetAdjustedAltcoinVolume() {
+        // 0.12345678 rounded to a 6-decimal coin (e.g. USD Coin) -> 0.123457 (step 10^(8-6) = 100).
+        assertEquals(12_345_700L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 12_345_678L), 6).getValue(),
+                "6-decimal volume should round to the coin's 6th decimal.");
+
+        // 0.12345678 rounded to a 2-decimal coin (e.g. TurtleCoin) -> 0.12 (step 10^6).
+        assertEquals(12_000_000L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("TRTL", 12_345_678L), 2).getValue(),
+                "2-decimal volume should round to the coin's 2nd decimal.");
+
+        // A coin using the full 8 decimals is left untouched (step 1).
+        assertEquals(12_345_678L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("XMR", 12_345_678L), 8).getValue(),
+                "8-decimal precision should not round.");
+
+        // Precision 8 must stay bit-exact even above 2^53, where a long -> double cast would drift.
+        assertEquals(12_345_678_901_234_567L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("XMR", 12_345_678_901_234_567L), 8).getValue(),
+                "8-decimal precision must be an exact no-op even above 2^53.");
+
+        // Currency code is preserved.
+        assertEquals("USDC",
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 12_345_678L), 6).getCurrencyCode());
+    }
+
+    @Test
+    public void testGetAdjustedAltcoinVolumeNeverZero() {
+        // A 0-decimal coin (whole units only, step 10^8): 0.4 of a coin must NOT collapse to zero;
+        // it is raised to exactly one whole coin so it stays sendable.
+        assertEquals(100_000_000L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("SF", 40_000_000L), 0).getValue(),
+                "A sub-unit volume on a 0-decimal coin must round up to one whole unit, not zero.");
+
+        // A tiny volume below one on-chain unit of a 6-decimal coin (0.0000004, step 100) -> 0.000001.
+        assertEquals(100L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 40L), 6).getValue(),
+                "A volume below one on-chain unit must round up to one unit, not zero.");
+
+        // Guard: the result is never zero, whatever the precision.
+        for (int precision = 0; precision <= 8; precision++) {
+            assertTrue(VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 1L), precision).getValue() > 0,
+                    "Rounded volume must stay positive for precision " + precision);
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/util/VolumeUtilTest.java
+++ b/core/src/test/java/bisq/core/util/VolumeUtilTest.java
@@ -63,9 +63,10 @@ public class VolumeUtilTest {
     public void testGetAdjustedAltcoinVolumeRoundsToZeroBelowHalfUnit() {
         // A volume below half of one on-chain unit rounds to ZERO instead of being inflated:
         // raising 0.4 of a 0-decimal coin to a whole coin would change the agreed rate by 150%.
-        // Callers must reject such an amount as below the coin's minimum.
+        // Callers must reject such an amount as below the coin's minimum. XYZ is synthetic:
+        // no registered asset declares 0 decimals (indivisible ones keep the default).
         assertEquals(0L,
-                VolumeUtil.getAdjustedAltcoinVolume(altcoin("SF", 40_000_000L), 0).getValue(),
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("XYZ", 40_000_000L), 0).getValue(),
                 "A volume below half of one on-chain unit must round to zero, not be inflated.");
         assertEquals(0L,
                 VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 40L), 6).getValue(),
@@ -73,7 +74,7 @@ public class VolumeUtilTest {
 
         // From half of one unit upwards normal half-up rounding applies.
         assertEquals(100_000_000L,
-                VolumeUtil.getAdjustedAltcoinVolume(altcoin("SF", 50_000_000L), 0).getValue(),
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("XYZ", 50_000_000L), 0).getValue(),
                 "Half of one on-chain unit must round up to one unit.");
 
         // Same boundary at precision 2, the coarsest precision among the sub-8 assets

--- a/core/src/test/java/bisq/core/util/VolumeUtilTest.java
+++ b/core/src/test/java/bisq/core/util/VolumeUtilTest.java
@@ -76,6 +76,15 @@ public class VolumeUtilTest {
                 VolumeUtil.getAdjustedAltcoinVolume(altcoin("SF", 50_000_000L), 0).getValue(),
                 "Half of one on-chain unit must round up to one unit.");
 
+        // Same boundary at precision 2, the coarsest precision among the sub-8 assets
+        // (step 10^6): 0.00499999 -> zero, 0.005 -> 0.01.
+        assertEquals(0L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("TRTL", 499_999L), 2).getValue(),
+                "A volume below half of one on-chain unit must round to zero, not be inflated.");
+        assertEquals(1_000_000L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("TRTL", 500_000L), 2).getValue(),
+                "Half of one on-chain unit must round up to one unit.");
+
         // Zero stays zero at every precision, also at 8 where step == 1. A floor clamp here
         // would turn zero into one atom and silently break the no-op invariant for
         // default-precision coins, BSQ included.

--- a/core/src/test/java/bisq/core/util/VolumeUtilTest.java
+++ b/core/src/test/java/bisq/core/util/VolumeUtilTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.util;
+
+import bisq.core.monetary.Altcoin;
+import bisq.core.monetary.Volume;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class VolumeUtilTest {
+
+    // Altcoin volumes are stored at 10^-8 precision; the value passed here is in those units.
+    private static Volume altcoin(String code, long internalValue) {
+        return new Volume(Altcoin.valueOf(code, internalValue));
+    }
+
+    @Test
+    public void testGetAdjustedAltcoinVolume() {
+        // 0.12345678 rounded to a 6-decimal coin (e.g. USD Coin) -> 0.123457 (step 10^(8-6) = 100).
+        assertEquals(12_345_700L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 12_345_678L), 6).getValue(),
+                "6-decimal volume should round to the coin's 6th decimal.");
+
+        // 0.12345678 rounded to a 2-decimal coin (e.g. TurtleCoin) -> 0.12 (step 10^6).
+        assertEquals(12_000_000L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("TRTL", 12_345_678L), 2).getValue(),
+                "2-decimal volume should round to the coin's 2nd decimal.");
+
+        // A coin using the full 8 decimals is left untouched (step 1).
+        assertEquals(12_345_678L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("XMR", 12_345_678L), 8).getValue(),
+                "8-decimal precision should not round.");
+
+        // Precision 8 must stay bit-exact even above 2^53, where a long -> double cast would drift.
+        assertEquals(12_345_678_901_234_567L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("XMR", 12_345_678_901_234_567L), 8).getValue(),
+                "8-decimal precision must be an exact no-op even above 2^53.");
+
+        // Currency code is preserved.
+        assertEquals("USDC",
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 12_345_678L), 6).getCurrencyCode());
+    }
+
+    @Test
+    public void testGetAdjustedAltcoinVolumeRoundsToZeroBelowHalfUnit() {
+        // A volume below half of one on-chain unit rounds to ZERO instead of being inflated:
+        // raising 0.4 of a 0-decimal coin to a whole coin would change the agreed rate by 150%.
+        // Callers must reject such an amount as below the coin's minimum.
+        assertEquals(0L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("SF", 40_000_000L), 0).getValue(),
+                "A volume below half of one on-chain unit must round to zero, not be inflated.");
+        assertEquals(0L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 40L), 6).getValue(),
+                "A volume below half of one on-chain unit must round to zero, not be inflated.");
+
+        // From half of one unit upwards normal half-up rounding applies.
+        assertEquals(100_000_000L,
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("SF", 50_000_000L), 0).getValue(),
+                "Half of one on-chain unit must round up to one unit.");
+
+        // Zero stays zero at every precision, also at 8 where step == 1. A floor clamp here
+        // would turn zero into one atom and silently break the no-op invariant for
+        // default-precision coins, BSQ included.
+        for (int precision = 0; precision <= 8; precision++) {
+            assertEquals(0L,
+                    VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", 0L), precision).getValue(),
+                    "Zero volume must stay zero for precision " + precision);
+        }
+    }
+
+    @Test
+    public void testGetAdjustedAltcoinVolumeOverflowFailsLoudly() {
+        // The half-up rounding add is the one overflow-capable step. A crafted value near
+        // Long.MAX_VALUE must fail loudly instead of silently producing a wrong volume.
+        assertThrows(ArithmeticException.class, () ->
+                VolumeUtil.getAdjustedAltcoinVolume(altcoin("USDC", Long.MAX_VALUE - 10), 6));
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferDataModel.java
@@ -580,6 +580,9 @@ public abstract class MutableOfferDataModel extends OfferDataModel implements Bs
             volumeByAmount = VolumeUtil.getAdjustedVolumeForHalCash(volumeByAmount);
         else if (CurrencyUtil.isFiatCurrency(tradeCurrencyCode.get()))
             volumeByAmount = VolumeUtil.getRoundedFiatVolume(volumeByAmount);
+        else if (CurrencyUtil.isCryptoCurrency(tradeCurrencyCode.get()))
+            volumeByAmount = VolumeUtil.getAdjustedAltcoinVolume(volumeByAmount,
+                    CurrencyUtil.getCryptoPrecision(tradeCurrencyCode.get()));
         return volumeByAmount;
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
@@ -485,6 +485,9 @@ class TakeOfferDataModel extends OfferDataModel {
                 volumeByAmount = VolumeUtil.getAdjustedVolumeForHalCash(volumeByAmount);
             else if (offer.isFiatOffer())
                 volumeByAmount = VolumeUtil.getRoundedFiatVolume(volumeByAmount);
+            else if (CurrencyUtil.isCryptoCurrency(offer.getCurrencyCode()))
+                volumeByAmount = VolumeUtil.getAdjustedAltcoinVolume(volumeByAmount,
+                        CurrencyUtil.getCryptoPrecision(offer.getCurrencyCode()));
 
             volume.set(volumeByAmount);
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferDataModel.java
@@ -586,6 +586,14 @@ class TakeOfferDataModel extends OfferDataModel {
         return true;
     }
 
+    boolean isRoundedVolumeZero() {
+        // An altcoin volume below half of one on-chain unit rounds to zero, so there
+        // would be nothing to pay. See docs/specifications/trade/altcoin-volume-precision.md
+        // for the offers that can reach this.
+        Volume volume = this.volume.get();
+        return volume != null && volume.isZero();
+    }
+
     boolean wouldCreateDustForMaker() {
         boolean result;
         if (amount.get() != null && offer != null) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/takeoffer/TakeOfferViewModel.java
@@ -192,7 +192,18 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
 
         updateButtonDisableState();
 
+        // The default amount can already produce a zero volume; explain the
+        // disabled button before the user ever edits the amount field.
+        applyRoundedVolumeZeroValidation();
+
         updateSpinnerInfo();
+    }
+
+    private void applyRoundedVolumeZeroValidation() {
+        if (dataModel.isRoundedVolumeZero())
+            amountValidationResult.set(new InputValidator.ValidationResult(false,
+                    Res.get("takeOffer.validation.amountRoundsToZeroVolume",
+                            dataModel.getCurrencyCode())));
     }
 
     @Override
@@ -365,6 +376,8 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
                 if (dataModel.wouldCreateDustForMaker())
                     amountValidationResult.set(new InputValidator.ValidationResult(false,
                             Res.get("takeOffer.validation.amountLargerThanOfferAmountMinusFee")));
+
+                applyRoundedVolumeZeroValidation();
             } else if (btcValidator.getMaxTradeLimit() != null && btcValidator.getMaxTradeLimit().value == OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.value) {
                 if (dataModel.getDirection() == OfferDirection.BUY) {
                     new Popup().information(Res.get("popup.warning.tradeLimitDueAccountAgeRestriction.seller",
@@ -484,7 +497,8 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
                 && !dataModel.isAmountLargerThanOfferAmount()
                 && dataModel.feeValidationStatus.get() != FeeValidationStatus.NOT_CHECKED_YET
                 && isOfferAvailable.get()
-                && !dataModel.wouldCreateDustForMaker();
+                && !dataModel.wouldCreateDustForMaker()
+                && !dataModel.isRoundedVolumeZero();
         isNextButtonDisabled.set(!inputDataValid);
         isTakeOfferButtonDisabled.set(takeOfferRequested || !inputDataValid || !dataModel.getIsBtcWalletFunded().get());
     }

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -51,5 +51,6 @@ specification says so explicitly instead of describing the implementation as if 
 
 | Specification | Covers |
 |---|---|
+| [`trade/altcoin-volume-precision.md`](trade/altcoin-volume-precision.md) | Rounding of altcoin trade volumes to the asset's chain precision, and the rejection of volumes that round to zero. |
 | [`trade/fiat-buyer-payment-account-validation.md`](trade/fiat-buyer-payment-account-validation.md) | Contract-bound buyer payment-account validation and the fiat deposit/settlement gates that depend on it. |
 | [`trade/xmr-payment-proof-timestamp.md`](trade/xmr-payment-proof-timestamp.md) | The timestamp rule of the XMR payment proof used for automatic confirmation, and why it is one-sided. |

--- a/docs/specifications/trade/altcoin-volume-precision.md
+++ b/docs/specifications/trade/altcoin-volume-precision.md
@@ -1,0 +1,65 @@
+# Altcoin volume precision
+
+## Scope
+
+This specification defines how the altcoin volume of a trade is derived from the signed trade
+amount and price, and when a derived volume must be rejected. It applies to offers, take-offer
+models, contracts and trades of altcoin markets. Fiat volume rounding
+(whole currency units, HalCash multiples) is unchanged and out of scope.
+
+## Rule
+
+The altcoin volume is the trade amount multiplied by the price, rounded half up to the number of
+decimals the asset supports on its own chain, at most 8. Volumes are stored at 10^-8 precision,
+so one on-chain unit corresponds to 10^(8 - precision) internal units.
+
+The asset precision is metadata declared by the asset. An asset without a declared precision uses
+the default of 8 decimals, which makes the rounding an exact no-op. The declared precision must
+not exceed the real number of decimals the chain supports, otherwise the stated volume can be
+impossible to transfer.
+
+The rounding must use exact integer arithmetic. The rounded value must be bit-identical for both
+peers, and precision 8 must reproduce the input exactly; floating point drifts above 2^53.
+
+## Zero volume
+
+A volume below half of one on-chain unit rounds to zero. It must not be inflated to one unit,
+because that would silently change the agreed exchange rate.
+
+A zero volume describes a trade with no payment obligation and must be rejected:
+
+- at offer placement, for both the volume and the minimum volume;
+- at take time, for the volume derived from the selected trade amount;
+- on the maker, for the trade amount received in the take request.
+
+Rounding is monotonic in the amount, so an offer whose minimum volume is positive at a given
+price yields a positive volume for every allowed trade amount at that price. Placement validates
+a market-priced offer at the market price of that moment; a price that has risen far enough since
+placement can push the derived volume of such an offer to zero. Editing an open offer republishes
+it without re-running placement validation. The take-time and maker checks therefore cover stale
+market-priced offers, edited offers and offers that bypassed placement validation, such as
+crafted offers or offers created before this rule.
+
+## Derivation, not negotiation
+
+The volume is not part of the signed contract; the contract carries the trade amount and the price,
+and each peer derives the volume locally. Clients without this rule derive a volume that differs by
+at most half of one on-chain unit; one on-chain unit is by construction the smallest amount the
+asset can transfer. This bounded divergence is accepted and does not require a trade protocol
+version change.
+
+Trade statistics and the market data JSON exports deliberately keep the unrounded volume
+representation they had before this rule.
+
+## Indivisible assets
+
+An asset whose whole on-chain unit is not a negligible value (Siafund, Askcoin) must not simply
+declare precision 0: half of one unit is then a whole coin, and half-up rounding would move real
+value. Such assets keep the default precision until they get their own treatment, for example
+rejecting them or adjusting the BTC amount so the volume lands on a whole unit.
+
+BSQ is a further deliberate exception. Its on-chain unit is 100 satoshi, i.e. 2 decimals, but BSQ
+trading uses the dedicated BSQ swap protocol, which is out of scope here, and BSQ amounts carry
+their own 2-decimal handling throughout the application. BSQ keeps the default precision so the
+rounding stays an exact no-op for it; declaring precision 2 would need its own analysis of the
+swap and DAO interactions.

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -230,10 +230,10 @@ message OfferInfo {
     // The offer's minimum BTC amount in satoshis.  One million satoshis is represented as 1000000.
     uint64 min_amount = 7;
     // The rounded volume of currency to be traded for BTC.
-    // Fiat volume is rounded to whole currency units (no cents).  Altcoin volume is rounded to 2 decimal places.
+    // Fiat volume is rounded to whole currency units (no cents).  Altcoin volume is rounded to the number of decimals the coin supports on its own chain, at most 8.
     string volume = 8;
     // The rounded, minimum volume of currency to be traded for BTC.
-    // Fiat volume is rounded to whole currency units (no cents).  Altcoin volume is rounded to 2 decimal places.
+    // Fiat volume is rounded to whole currency units (no cents).  Altcoin volume is rounded to the number of decimals the coin supports on its own chain, at most 8.
     string min_volume = 9;
     // A long representing the BTC buyer's security deposit in satoshis.
     uint64 buyer_security_deposit = 10;


### PR DESCRIPTION
## Problem
Bisq represents every altcoin amount at 8 decimals
(`Altcoin.SMALLEST_UNIT_EXPONENT`), regardless of how many decimals the
coin actually supports on its own chain. For a coin with fewer than 8
decimals (for example USDC, which has 6), the volume shown as the amount
to send carries digits the sender cannot transfer, so the exact amount
stated in the trade can never be paid.

This is the opposite of #1118 (a coin with more than 8 decimals, where
capping at 8 is fine because 8 decimals are still sendable). Here the
coin has fewer than 8 decimals, so the extra digits are unsendable.

## Change
- Add a per-asset precision to the asset model (`Asset.getPrecision()`,
  default 8), overridden on the coins that use fewer than 8 decimals,
  exposed via `CurrencyUtil.getCryptoPrecision(code)` (cached next to
  the existing `isCryptoCurrency` cache, since the registry lookup is a
  linear scan called per offer row).
- Round the altcoin trade volume to that precision on the payment path:
  `Offer`, `Trade`, `Contract` and the create/take amount models.

The internal 8-decimal storage exponent is unchanged; only the volume
the sender is asked to transfer is rounded, and precision 8 is an exact
no-op. Rounding is half up in exact integer arithmetic with an overflow
guard. A volume below half of one on-chain unit rounds to zero and is
to be rejected by callers as an amount below the coin's minimum, never
inflated to a whole unit, which would silently change the agreed rate;
the create path already validates the rounded volume and min volume as
non-zero before an offer can be placed.

## Notes
- Volume is not part of the signed contract (only `tradeAmount` and
  `tradePrice` are), so the wire format is unaffected. Rollout is not
  behaviour-identical though: both peers compute the trade volume
  locally, so an old and a new client can display send amounts
  differing by up to half a chain unit until both sides are upgraded.
- Fiat is unaffected. Fiat volumes are already rounded to whole currency
  units (`getRoundedFiatVolume`), which is payable for every currency,
  so this PR does not touch the fiat path.
- Derived analytics stay raw: `TradeStatistics3` and the market-data
  JSON exports (`OfferForJson`, `TradeStatisticsForJson`) are untouched.
  The rule is: the payment instruction is rounded to chain precision,
  derived analytics are not.
- A few obscure listed coins stay at the default 8 for now: four whose
  exact precision needs confirming (XDR0 - XDR, ZOD - Krypton, AMIT -
  Amitycoin, DONU - Donu) and two indivisible whole-unit coins (ASK -
  Askcoin, SF - Siafund).

## Tests
`VolumeUtilTest` covers rounding a volume to a coin's precision, that
precision 8 stays bit-exact above 2^53, that a volume below half of one
on-chain unit rounds to zero (and zero stays zero at every precision),
and that the rounding arithmetic fails loudly on overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added asset-specific cryptocurrency precision, with a default of 8 decimal places.
- Added precision-aware volume calculations and exact half-up rounding to valid on-chain units.
- Added explicit precision support for coins and ERC-20 tokens.
- Added validation to reject trade volumes that round to zero.

## Bug Fixes
- Improved cryptocurrency volume accuracy across varying decimal places.
- Prevented invalid fractional amounts and standardized rounding behavior.
- Take-off controls now flag and prevent amounts that cannot produce a transferable volume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->