### PR TITLE
Make Legal Terms text selectable and copyable

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TacWindow.java
@@ -30,6 +30,7 @@ import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
@@ -497,11 +498,15 @@ public class TacWindow extends Overlay<TacWindow> {
         titleLabel.setMinWidth(0);
         titleLabel.setMaxWidth(Double.MAX_VALUE);
 
-        Label bodyLabel = new Label(body);
-        bodyLabel.getStyleClass().add("tac-agreement-legal-section-body");
+        TextArea bodyLabel = new TextArea(body);
+        bodyLabel.setEditable(false);
         bodyLabel.setWrapText(true);
+        bodyLabel.setFocusTraversable(false);
+        bodyLabel.getStyleClass().add("tac-agreement-legal-section-body");
         bodyLabel.setMinWidth(0);
         bodyLabel.setMaxWidth(Double.MAX_VALUE);
+        bodyLabel.setMinHeight(Region.USE_PREF_SIZE);
+        bodyLabel.setPrefRowCount(6);
 
         textBox.getChildren().addAll(titleLabel, bodyLabel);
         section.getChildren().addAll(numberLabel, textBox);


### PR DESCRIPTION
Fixes #7907

## Problem
The Legal Terms text in the User Agreement window (`TacWindow`) was
rendered using JavaFX `Label`, which does not support text selection.
Users could not copy the agreement text.

## Fix
Replaced the `Label` used for each legal section's body text with a
non-editable, non-focus-traversable `TextArea`, which supports
click-drag selection, Ctrl+A, and Ctrl+C.

## Testing
Ran locally via `./gradlew :desktop:run --args="--appName=BisqTacTest"`
and confirmed all 7 legal sections' text can be selected and copied.

<img width="900" height="558" alt="Screenshot 2026-07-16 145918" src="https://github.com/user-attachments/assets/9ca15085-42c9-4d32-8354-d504d0e585b7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of legal section text for better readability and consistent wrapping.
  * Legal text is now selectable and copyable, while remaining non-editable for clearer, safer viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->