### PR TITLE
Add Montenegro to SEPA countries

### DIFF
--- a/core/src/main/java/bisq/core/locale/CountryUtil.java
+++ b/core/src/main/java/bisq/core/locale/CountryUtil.java
@@ -38,7 +38,7 @@ public class CountryUtil {
     public static List<Country> getAllSepaEuroCountries() {
         List<Country> list = new ArrayList<>();
         String[] codes = {"AT", "BE", "CY", "DE", "EE", "FI", "FR", "GR", "IE",
-                "IT", "LV", "LT", "LU", "MC", "MT", "NL", "PT", "SK", "SI", "ES", "AD", "SM", "VA"};
+                "IT", "LV", "LT", "LU", "MC", "ME", "MT", "NL", "PT", "SK", "SI", "ES", "AD", "SM", "VA"};
         populateCountryListByCodes(list, codes);
         list.sort((a, b) -> a.name.compareTo(b.name));
 


### PR DESCRIPTION
## Summary

- Add Montenegro (`ME`) to the euro-denominated SEPA country list.
- Make Montenegro available when creating SEPA payment accounts.
- Allow Montenegrin IBANs through the existing SEPA validation flow.

Fixes #7588

## Testing

Not run (data-only country list update).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added Montenegro to the list of countries supported for SEPA euro transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->