### PR TITLE
Fix trader chat message ordering 

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/shared/ChatView.java
+++ b/desktop/src/main/java/bisq/desktop/main/shared/ChatView.java
@@ -74,7 +74,7 @@ import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
 
-import java.util.Comparator;
+//import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -177,7 +177,6 @@ public class ChatView extends AnchorPane {
 
         chatMessages = supportSession.getObservableChatMessageList();
         SortedList<ChatMessage> sortedList = new SortedList<>(chatMessages);
-        sortedList.setComparator(Comparator.comparingLong(ChatMessage::getDate));
         messageListView = new ListView<>(sortedList);
         messageListView.setId("message-list-view");
 


### PR DESCRIPTION
Fixes #3325

## Problem
Trader chat messages were sorted using `ChatMessage.getDate()`, which
is set once by the sender's local system clock at message creation
and is never corrected upon receipt. If a peer's system clock is
wrong, their messages display out of order in the chat.

## Fix
Removed the `SortedList` comparator in `ChatView.java`. The underlying
`chatMessages` list (from `Trade.getChatMessages()`) is already
populated in true arrival order — `TraderChatManager.addAndPersistChatMessage`
does a plain append and never resorts — so no comparator is needed;
messages now display in the order they were actually sent/received.

## Testing
Verified the project builds and runs cleanly with this change. Full
live reproduction requires two Bisq instances trading over regtest
with one instance's clock skewed, which is out of scope for this
fix's testing — the root cause was confirmed by tracing the message
flow through `ChatMessage`, `SupportManager`, and `TraderChatManager`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated chat message list ordering to use the list’s default ordering behavior instead of applying a date-based sort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->