### PR TITLE
Add dust limit validation in WithdrawalView to prevent IllegalArgumentException

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -618,6 +618,12 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
             return false;
         }
 
+        if (!Restrictions.isAboveDust(sendersAmount)) {
+            new Popup().warning(Res.get("validation.amountBelowDust",
+                    formatter.formatCoinWithCode(Restrictions.getMinNonDustOutput()))).show();
+            return false;
+        }
+
         if (!btcAddressValidator.validate(withdrawToTextField.getText()).isValid) {
             new Popup().warning(Res.get("validation.btc.invalidAddress")).show();
             return false;


### PR DESCRIPTION
## Summary

Fixes #5532

When a user enters an amount below the dust limit in the withdrawal screen, the "Withdraw selected" button could still be clicked, resulting in an unhandled `IllegalArgumentException: The amount is too low (dust limit).` being shown to the user.

## Problem

In `BtcWalletService.sendFundsForMultipleAddresses()`, the dust check uses `Preconditions.checkArgument()` which throws `IllegalArgumentException`. However, `WithdrawalView.sendFunds()` only catches `Wallet.DustySendRequested`, not `IllegalArgumentException`, so the raw exception message is displayed to the user in a popup.

## Fix

Added a dust limit validation check in `WithdrawalView.areInputsValid()` using `Restrictions.isAboveDust()` to catch the invalid amount early and display a proper formatted error message using the existing `validation.amountBelowDust` i18n key.

This prevents the `IllegalArgumentException` from being thrown at all, since the validation now catches the dust violation before the transaction is attempted.

## Changes

- `desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java`: Added dust limit check in `areInputsValid()` method (+6 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Withdrawals now warn users when the sender amount is too small to meet the minimum non-dust output requirement.
  * Invalid low-value withdrawals are blocked before further address and balance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->