### PR TITLE
Replace deprecated URL constructor with URI.toURL()

### DIFF
--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerOsUrlProvider.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerOsUrlProvider.kt
@@ -1,5 +1,6 @@
 package bisq.gradle.tasks
 
+import java.net.URI
 import java.net.URL
 
 interface PerOsUrlProvider {
@@ -10,7 +11,7 @@ interface PerOsUrlProvider {
     val windowsUrl: String
 
     val url: URL
-        get() = URL(urlPrefix + getUrlSuffix())
+        get() = URI(urlPrefix + getUrlSuffix()).toURL()
 
     private fun getUrlSuffix() =
         when (getOS()) {

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/download/SignedBinaryDownloader.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/download/SignedBinaryDownloader.kt
@@ -7,6 +7,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
+import java.net.URI
 import java.net.URL
 
 class SignedBinaryDownloader(
@@ -27,7 +28,7 @@ class SignedBinaryDownloader(
         val binaryDownloadTask =
             downloadTaskFactory.registerDownloadTask("download${binaryName}Binary", binaryDownloadUrl)
 
-        val signatureDownloadUrl: Provider<URL> = binaryDownloadUrl.map { URL("$it.asc") }
+        val signatureDownloadUrl: Provider<URL> = binaryDownloadUrl.map { URI("$it.asc").toURL() }
         val signatureDownloadTask =
             downloadTaskFactory.registerDownloadTask("download${binaryName}Signature", signatureDownloadUrl)
 

--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -17,7 +17,7 @@
 
 package bisq.common.app;
 
-import java.net.URL;
+import java.net.URI;
 
 import java.util.Arrays;
 import java.util.List;
@@ -147,7 +147,7 @@ public class Version {
         try {
             String pth = Objects.requireNonNull(Version.class.getResource(Version.class.getSimpleName() + ".class")).toString();
             String mnf = pth.substring(0, pth.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
-            Attributes attr = new Manifest(new URL(mnf).openStream()).getMainAttributes();
+            Attributes attr = new Manifest(new URI(mnf).toURL().openStream()).getMainAttributes();
             return Optional.of(attr.getValue("Implementation-Version"));
         } catch (Exception ignored) {
             return Optional.empty();


### PR DESCRIPTION
The java.net.URL constructors were deprecated in Java 20. This updates the code to use the recommended approach: parsing a URI string and converting it via URI.toURL(), which ensures better syntax validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling for application updates, downloads, and version checks.
  * Replaced outdated URL construction with standards-compliant URI conversion.
  * Preserved existing platform-specific download behavior and signature retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->