### PR TITLE
Replace deprecated Charsets.UTF_8 with StandardCharsets.UTF_8

### DIFF
--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerOsUrlProvider.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerOsUrlProvider.kt
@@ -1,5 +1,6 @@
 package bisq.gradle.tasks
 
+import java.net.URI
 import java.net.URL
 
 interface PerOsUrlProvider {
@@ -10,7 +11,7 @@ interface PerOsUrlProvider {
     val windowsUrl: String
 
     val url: URL
-        get() = URL(urlPrefix + getUrlSuffix())
+        get() = URI(urlPrefix + getUrlSuffix()).toURL()
 
     private fun getUrlSuffix() =
         when (getOS()) {

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/download/SignedBinaryDownloader.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/download/SignedBinaryDownloader.kt
@@ -7,6 +7,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
+import java.net.URI
 import java.net.URL
 
 class SignedBinaryDownloader(
@@ -27,7 +28,7 @@ class SignedBinaryDownloader(
         val binaryDownloadTask =
             downloadTaskFactory.registerDownloadTask("download${binaryName}Binary", binaryDownloadUrl)
 
-        val signatureDownloadUrl: Provider<URL> = binaryDownloadUrl.map { URL("$it.asc") }
+        val signatureDownloadUrl: Provider<URL> = binaryDownloadUrl.map { URI("$it.asc").toURL() }
         val signatureDownloadTask =
             downloadTaskFactory.registerDownloadTask("download${binaryName}Signature", signatureDownloadUrl)
 

--- a/cli/src/main/java/bisq/cli/PasswordCallCredentials.java
+++ b/cli/src/main/java/bisq/cli/PasswordCallCredentials.java
@@ -55,8 +55,4 @@ class PasswordCallCredentials extends CallCredentials {
             }
         });
     }
-
-    @Override
-    public void thisUsesUnstableApi() {
-    }
 }

--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -17,7 +17,7 @@
 
 package bisq.common.app;
 
-import java.net.URL;
+import java.net.URI;
 
 import java.util.Arrays;
 import java.util.List;
@@ -147,7 +147,7 @@ public class Version {
         try {
             String pth = Objects.requireNonNull(Version.class.getResource(Version.class.getSimpleName() + ".class")).toString();
             String mnf = pth.substring(0, pth.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
-            Attributes attr = new Manifest(new URL(mnf).openStream()).getMainAttributes();
+            Attributes attr = new Manifest(new URI(mnf).toURL().openStream()).getMainAttributes();
             return Optional.of(attr.getValue("Implementation-Version"));
         } catch (Exception ignored) {
             return Optional.empty();

--- a/common/src/main/java/bisq/common/crypto/Hash.java
+++ b/common/src/main/java/bisq/common/crypto/Hash.java
@@ -19,14 +19,13 @@ package bisq.common.crypto;
 
 import org.bitcoinj.core.Utils;
 
-import com.google.common.base.Charsets;
-
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -53,7 +52,7 @@ public class Hash {
      * @return Hash of data
      */
     public static byte[] getSha256Hash(String message) {
-        return getSha256Hash(message.getBytes(Charsets.UTF_8));
+        return getSha256Hash(message.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/common/src/main/java/bisq/common/crypto/Sig.java
+++ b/common/src/main/java/bisq/common/crypto/Sig.java
@@ -20,8 +20,6 @@ package bisq.common.crypto;
 import bisq.common.util.Base64;
 import bisq.common.util.Utilities;
 
-import com.google.common.base.Charsets;
-
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -33,6 +31,8 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +90,7 @@ public class Sig {
      * @return Base64 encoded signature
      */
     public static String sign(PrivateKey privateKey, String message) throws CryptoException {
-        byte[] sigAsBytes = sign(privateKey, message.getBytes(Charsets.UTF_8));
+        byte[] sigAsBytes = sign(privateKey, message.getBytes(StandardCharsets.UTF_8));
         return Base64.encode(sigAsBytes);
     }
 
@@ -118,7 +118,7 @@ public class Sig {
      * @return
      */
     public static boolean verify(PublicKey publicKey, String message, String signature) throws CryptoException {
-        return verify(publicKey, message.getBytes(Charsets.UTF_8), Base64.decode(signature));
+        return verify(publicKey, message.getBytes(StandardCharsets.UTF_8), Base64.decode(signature));
     }
 
     /**


### PR DESCRIPTION
StandardCharsets is built into Java 7+, allowing us to rely on the
standard library instead of the deprecated Guava implementation.
This helps reduce our reliance on external dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling for downloads, detached signatures, and version metadata retrieval.
  * Enhanced compatibility when accessing remote resources.

* **Refactor**
  * Updated cryptographic operations to use standard Java UTF-8 handling without changing hashing, signing, or verification behavior.
  * Removed obsolete API-related code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->