### PR TITLE
common: Replace RegExUtils.replacePattern with CharSequence version

### DIFF
--- a/common/src/main/java/bisq/common/util/Utilities.java
+++ b/common/src/main/java/bisq/common/util/Utilities.java
@@ -570,18 +570,18 @@ public class Utilities {
 
         String duration = durationMillis > 0 ? DurationFormatUtils.formatDuration(durationMillis, format) : "";
 
-        duration = RegExUtils.replacePattern(duration, "^1 " + seconds + "|\\b1 " + seconds, "1 " + second);
-        duration = RegExUtils.replacePattern(duration, "^1 " + minutes + "|\\b1 " + minutes, "1 " + minute);
-        duration = RegExUtils.replacePattern(duration, "^1 " + hours + "|\\b1 " + hours, "1 " + hour);
-        duration = RegExUtils.replacePattern(duration, "^1 " + days + "|\\b1 " + days, "1 " + day);
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^1 " + seconds + "|\\b1 " + seconds, "1 " + second);
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^1 " + minutes + "|\\b1 " + minutes, "1 " + minute);
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^1 " + hours + "|\\b1 " + hours, "1 " + hour);
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^1 " + days + "|\\b1 " + days, "1 " + day);
 
         duration = duration.replace(", 0 seconds", "");
         duration = duration.replace(", 0 minutes", "");
         duration = duration.replace(", 0 hours", "");
-        duration = RegExUtils.replacePattern(duration, "^0 days, ", "");
-        duration = RegExUtils.replacePattern(duration, "^0 hours, ", "");
-        duration = RegExUtils.replacePattern(duration, "^0 minutes, ", "");
-        duration = RegExUtils.replacePattern(duration, "^0 seconds, ", "");
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^0 days, ", "");
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^0 hours, ", "");
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^0 minutes, ", "");
+        duration = RegExUtils.replacePattern((CharSequence) duration, "^0 seconds, ", "");
 
         String result = duration.trim();
         if (result.isEmpty()) {


### PR DESCRIPTION
The RegExUtils.replacePattern method taking a String source parameter has been deprecated. This commit updates our usage to the recommended migration path, which accepts a CharSequence instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when formatting durations as readable text.
  * Preserved existing duration formatting and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->