### PR TITLE
Add more sepa countries supporting EURO

### DIFF
--- a/core/src/main/java/bisq/core/locale/CountryUtil.java
+++ b/core/src/main/java/bisq/core/locale/CountryUtil.java
@@ -37,8 +37,34 @@ import lombok.extern.slf4j.Slf4j;
 public class CountryUtil {
     public static List<Country> getAllSepaEuroCountries() {
         List<Country> list = new ArrayList<>();
-        String[] codes = {"AT", "BE", "CY", "DE", "EE", "FI", "FR", "GR", "IE",
-                "IT", "LV", "LT", "LU", "MC", "MT", "NL", "PT", "SK", "SI", "ES", "AD", "SM", "VA"};
+        String[] codes = {
+                "AD", // Andorra
+                "AT", // Austria
+                "BE", // Belgium
+                "CY", // Cyprus
+                "DE", // Germany
+                "EE", // Estonia
+                "ES", // Spain
+                "FI", // Finland
+                "FR", // France
+                "GR", // Greece
+                "HR", // Croatia
+                "IE", // Ireland
+                "IT", // Italy
+                "LT", // Lithuania
+                "LU", // Luxembourg
+                "LV", // Latvia
+                "MC", // Monaco
+                "ME", // Montenegro
+                "MT", // Malta
+                "NL", // Netherlands
+                "PT", // Portugal
+                "SI", // Slovenia
+                "SK", // Slovakia
+                "SM", // San Marino
+                "VA", // Vatican City
+                "XK"  // Kosovo
+        };
         populateCountryListByCodes(list, codes);
         list.sort((a, b) -> a.name.compareTo(b.name));
 


### PR DESCRIPTION
Add more sepa countries supporting EURO

HR – Croatia (official euro area)
ME – Montenegro (uses EUR unilaterally, SEPA participant)
XK – Kosovo (uses EUR unilaterally, SEPA participant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Croatia, Montenegro, and Kosovo to the list of supported SEPA euro countries.
  * SEPA countries continue to be displayed in alphabetical order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->