### PR TITLE
Keep historical BTC fees address as fee receiver

### DIFF
--- a/core/src/main/java/bisq/core/dao/burningman/BurningManPresentationService.java
+++ b/core/src/main/java/bisq/core/dao/burningman/BurningManPresentationService.java
@@ -67,7 +67,7 @@ public class BurningManPresentationService implements DaoStateListener {
     private static final long BURN_TARGET_BOOST_AMOUNT = 10000000;
     public static final String LEGACY_BURNING_MAN_DPT_NAME = "Legacy Burningman (DPT)";
     public static final String LEGACY_BURNING_MAN_BTC_FEES_NAME = "Legacy Burningman (BTC fees)";
-    static final String LEGACY_BURNING_MAN_BTC_FEES_ADDRESS = "38bZBj5peYS3Husdz7AH3gEUiUbYRD951t";
+    public static final String LEGACY_BURNING_MAN_BTC_FEES_ADDRESS = "38bZBj5peYS3Husdz7AH3gEUiUbYRD951t";
     // Those are the opReturn data used by legacy BM for burning BTC received from DPT.
     // For regtest testing burn bsq and use the pre-image `dpt` which has the hash 14af04ea7e34bd7378b034ddf90da53b7c27a277.
     // The opReturn data gets additionally prefixed with 1701

--- a/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
+++ b/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
@@ -267,6 +267,9 @@ public class MempoolService {
         List<String> btcFeeReceivers = new ArrayList<>();
         btcFeeReceivers.addAll(daoFacade.getAllDonationAddresses());
         addBurningManAddressListLegacyAddress(btcFeeReceivers);
+        // Keep the historical BTC fees address recognised so that fee txs which paid it
+        // while it was the network-designated receiver do not get invalidated later.
+        btcFeeReceivers.add(BurningManPresentationService.LEGACY_BURNING_MAN_BTC_FEES_ADDRESS);
         btcFeeReceivers.addAll(BtcFeeReceiverService.getConfiguredReceiverAddresses(
                 filterPolicyService.getBtcFeeReceiverAddresses()));
 

--- a/core/src/test/java/bisq/core/provider/mempool/MempoolServiceTest.java
+++ b/core/src/test/java/bisq/core/provider/mempool/MempoolServiceTest.java
@@ -66,6 +66,15 @@ class MempoolServiceTest {
         assertFalse(receivers.contains(LIST_LEGACY_ADDRESS));
     }
 
+    @Test
+    void getAllBtcFeeReceiversIncludesHistoricalBtcFeesLegacyAddress() {
+        MempoolService service = newService(addressList("OTHER_NETWORK"));
+
+        List<String> receivers = service.getAllBtcFeeReceivers();
+
+        assertTrue(receivers.contains(BurningManPresentationService.LEGACY_BURNING_MAN_BTC_FEES_ADDRESS));
+    }
+
     private static MempoolService newService(BurningManAddressList addressList) {
         FilterPolicyService filterPolicyService = mock(FilterPolicyService.class);
         when(filterPolicyService.getBtcFeeReceiverAddresses()).thenReturn(List.of());


### PR DESCRIPTION
Fixes #7987.

The mempool validation list is built from current network data only, so
the 2026-07-30 filter update retroactively invalidated fee txs which
had paid the legacy burning man BTC fees address while it was the
network-designated receiver. Affected offers get deactivated with "Fee
receiver not a recognised address" and takers are blocked from taking
them.

This adds the historical address permanently to getAllBtcFeeReceivers,
mirroring how getAllDonationAddresses keeps the past DPT addresses. The
fee receiver selector never emits it for new fee txs, so no new fees
route there; the address only stays valid for validation of existing
ones. Includes a test.

This fixes validation from the next release on. Already deactivated
offers can then simply be re-enabled by their makers (the fee
validation status is transient and resets on activation). A faster
remedy for currently affected users would be a filter update re-listing
the address, as described in #7987.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical Bitcoin fee payments are now consistently recognized, including when configured fee addresses target a different network.
  * Improved compatibility with transactions sent to the legacy Bitcoin fee address.

* **Tests**
  * Added coverage to verify recognition of the historical fee receiver address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->