### PR TITLE
Handle RejectedExecutionException at MemPoolSpaceTxBroadcaster

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/http/MemPoolSpaceTxBroadcaster.java
+++ b/core/src/main/java/bisq/core/btc/wallet/http/MemPoolSpaceTxBroadcaster.java
@@ -39,6 +39,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.RejectedExecutionException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -117,42 +118,49 @@ public class MemPoolSpaceTxBroadcaster {
         httpClient.setIgnoreSocks5Proxy(false);
 
         log.info("We broadcast rawTx {} to {}", rawTx, serviceAddress);
-        ListenableFuture<String> future = executorService.submit(() -> {
-            Thread.currentThread().setName("MemPoolSpaceTxBroadcaster @ " + serviceAddress);
-            return httpClient.post(rawTx, "User-Agent", "bisq/" + Version.VERSION);
-        });
+        try {
+            ListenableFuture<String> future = executorService.submit(() -> {
+                Thread.currentThread().setName("MemPoolSpaceTxBroadcaster @ " + serviceAddress);
+                return httpClient.post(rawTx, "User-Agent", "bisq/" + Version.VERSION);
+            });
 
-        Futures.addCallback(future, new FutureCallback<>() {
-            public void onSuccess(String txId) {
-                if (txId.equals(txIdToSend)) {
-                    log.info("Broadcast of raw tx with txId {} to {} was successful. rawTx={}",
-                            txId, serviceAddress, rawTx);
-                } else {
-                    log.error("The txId we got returned from the service does not match " +
-                                    "out tx of the sending tx. txId={}; txIdToSend={}",
-                            txId, txIdToSend);
-                }
-            }
-
-            public void onFailure(@NotNull Throwable throwable) {
-                Throwable cause = throwable.getCause();
-                if (cause instanceof HttpException) {
-                    int responseCode = ((HttpException) cause).getResponseCode();
-                    String message = cause.getMessage();
-                    // See all error codes at: https://github.com/bitcoin/bitcoin/blob/master/src/rpc/protocol.h
-                    if (responseCode == 400 && message.contains("code\":-27")) {
-                        log.info("Broadcast of raw tx to {} failed as transaction {} is already confirmed",
-                                serviceAddress, txIdToSend);
+            Futures.addCallback(future, new FutureCallback<>() {
+                public void onSuccess(String txId) {
+                    if (txId.equals(txIdToSend)) {
+                        log.info("Broadcast of raw tx with txId {} to {} was successful. rawTx={}",
+                                txId, serviceAddress, rawTx);
                     } else {
-                        log.info("Broadcast of raw tx to {} failed for transaction {}. responseCode={}, error={}",
-                                serviceAddress, txIdToSend, responseCode, message);
+                        log.error("The txId we got returned from the service does not match " +
+                                        "out tx of the sending tx. txId={}; txIdToSend={}",
+                                txId, txIdToSend);
                     }
-                } else {
-                    log.warn("Broadcast of raw tx with txId {} to {} failed. Error={}",
-                            txIdToSend, serviceAddress, throwable.toString());
                 }
-            }
-        }, MoreExecutors.directExecutor());
+
+                public void onFailure(@NotNull Throwable throwable) {
+                    Throwable cause = throwable.getCause();
+                    if (cause instanceof HttpException) {
+                        int responseCode = ((HttpException) cause).getResponseCode();
+                        String message = cause.getMessage();
+                        // See all error codes at: https://github.com/bitcoin/bitcoin/blob/master/src/rpc/protocol.h
+                        if (responseCode == 400 && message.contains("code\":-27")) {
+                            log.info("Broadcast of raw tx to {} failed as transaction {} is already confirmed",
+                                    serviceAddress, txIdToSend);
+                        } else {
+                            log.info("Broadcast of raw tx to {} failed for transaction {}. responseCode={}, error={}",
+                                    serviceAddress, txIdToSend, responseCode, message);
+                        }
+                    } else {
+                        log.warn("Broadcast of raw tx with txId {} to {} failed. Error={}",
+                                txIdToSend, serviceAddress, throwable.toString());
+                    }
+                }
+            }, MoreExecutors.directExecutor());
+        } catch (RejectedExecutionException exception) {
+            log.warn("Broadcast of raw tx with txId {} to {} was rejected as our executorService is " +
+                            "exhausted. As we use the mempool.space broadcast only for redundancy to the " +
+                            "BitcoinJ broadcast we ignore that error. Error={}",
+                    txIdToSend, serviceAddress, exception.toString());
+        }
     }
 
     @Nullable


### PR DESCRIPTION
Fixes #7577

The MemPoolSpaceTxBroadcaster executorService is limited to 5 threads
with a queue capacity of 5 (Utilities.getListeningExecutorService
defaults the queue capacity to maximumPoolSize). Each broadcast
submits up to 2 HTTP requests which can block for a long time over
Tor, so a few payouts in quick succession can exhaust the pool. This
matches the reported error (pool size = 5, active threads = 5,
queued tasks = 5).

In that case submit throws a RejectedExecutionException synchronously
into the calling trade task (SellerBroadcastPayoutTx in the report),
so the trade shows an error popup and can end up as failed even
though the BitcoinJ broadcast has already been performed and the
payout tx usually confirms fine.

As the mempool.space broadcast is only used for redundancy to the
BitcoinJ broadcast we catch the exception and log a warning instead,
following the same pattern as in NetworkNode.sendMessage (commit
c01ffaa8c3).

The pool sizing is left unchanged. When the pool is saturated the
redundant re-broadcast is skipped, which is harmless as the primary
BitcoinJ broadcast is not affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcasting stability by safely handling rejected broadcast requests.
  * Rejected broadcasts are logged without disrupting other broadcast operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->