### PR TITLE
Complete trade once withdraw tx is committed to the wallet

### DIFF
--- a/core/src/main/java/bisq/core/api/CoreTradesService.java
+++ b/core/src/main/java/bisq/core/api/CoreTradesService.java
@@ -299,7 +299,10 @@ class CoreTradesService {
                 (errorMessage, throwable) -> {
                     log.error(errorMessage, throwable);
                     throw new IllegalStateException(errorMessage, throwable);
-                });
+                },
+                (errorMessage, throwable) ->
+                        log.warn("Withdraw tx broadcast failed after trade {} was completed: {}",
+                                tradeId, errorMessage, throwable));
     }
 
     TradeModel getTradeModel(String tradeId) {

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -1169,23 +1169,16 @@ public class BtcWalletService extends WalletService {
             AddressEntryException, InsufficientMoneyException {
         SendRequest sendRequest = getSendRequest(fromAddress, toAddress, receiverAmount, fee, aesKey, context);
         Wallet.SendResult sendResult = wallet.sendCoins(sendRequest);
-        // The wallet has committed the tx at this point; the remaining steps are best-effort
-        // and must not throw the committed state at the caller as a failure. The callback is
-        // attached last, so an already failed future whose handler throws synchronously cannot
-        // suppress the mempool publish.
-        try {
-            if (memo != null) {
-                sendResult.tx.setMemo(memo);
-            }
-
-            // For better redundancy in case the broadcast via BitcoinJ fails we also
-            // publish the tx via mempool nodes.
-            MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx);
-
-            Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor());
-        } catch (RuntimeException e) {
-            log.error("Post-commit step failed for tx {}", sendResult.tx.getTxId(), e);
+        // The wallet has committed the tx at this point; the remaining steps are best-effort.
+        if (memo != null) {
+            runPostCommitStep("Setting the memo", sendResult.tx, () -> sendResult.tx.setMemo(memo));
         }
+        // For better redundancy in case the broadcast via BitcoinJ fails we also
+        // publish the tx via mempool nodes.
+        runPostCommitStep("The mempool publish", sendResult.tx,
+                () -> MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx));
+        runPostCommitStep("Attaching the broadcast callback", sendResult.tx,
+                () -> Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor()));
         return sendResult.tx.getTxId().toString();
     }
 
@@ -1201,25 +1194,30 @@ public class BtcWalletService extends WalletService {
 
         SendRequest request = getSendRequestForMultipleAddresses(fromAddresses, toAddress, receiverAmount, fee, changeAddress, aesKey);
         Wallet.SendResult sendResult = wallet.sendCoins(request);
-        // The wallet has committed the tx at this point; the remaining steps are best-effort
-        // and must not throw the committed state at the caller as a failure. The callback is
-        // attached last, so an already failed future whose handler throws synchronously cannot
-        // suppress the mempool publish.
-        try {
-            if (memo != null) {
-                sendResult.tx.setMemo(memo);
-            }
-            printTx("sendFunds", sendResult.tx);
-
-            // For better redundancy in case the broadcast via BitcoinJ fails we also
-            // publish the tx via mempool nodes.
-            MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx);
-
-            Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor());
-        } catch (RuntimeException e) {
-            log.error("Post-commit step failed for tx {}", sendResult.tx.getTxId(), e);
+        // The wallet has committed the tx at this point; the remaining steps are best-effort.
+        if (memo != null) {
+            runPostCommitStep("Setting the memo", sendResult.tx, () -> sendResult.tx.setMemo(memo));
         }
+        printTx("sendFunds", sendResult.tx);
+
+        // For better redundancy in case the broadcast via BitcoinJ fails we also
+        // publish the tx via mempool nodes.
+        runPostCommitStep("The mempool publish", sendResult.tx,
+                () -> MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx));
+        runPostCommitStep("Attaching the broadcast callback", sendResult.tx,
+                () -> Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor()));
         return sendResult.tx;
+    }
+
+    // Best-effort follow-up of an already committed send. The steps are independent: a failure
+    // must neither surface the committed state at the caller as a failure nor suppress another
+    // step, in particular not the registration of the broadcast callback.
+    private void runPostCommitStep(String description, Transaction tx, Runnable step) {
+        try {
+            step.run();
+        } catch (RuntimeException e) {
+            log.error("{} failed for tx {}", description, tx.getTxId(), e);
+        }
     }
 
     private SendRequest getSendRequest(String fromAddress,

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -1169,15 +1169,23 @@ public class BtcWalletService extends WalletService {
             AddressEntryException, InsufficientMoneyException {
         SendRequest sendRequest = getSendRequest(fromAddress, toAddress, receiverAmount, fee, aesKey, context);
         Wallet.SendResult sendResult = wallet.sendCoins(sendRequest);
-        Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor());
-        if (memo != null) {
-            sendResult.tx.setMemo(memo);
+        // The wallet has committed the tx at this point; the remaining steps are best-effort
+        // and must not throw the committed state at the caller as a failure. The callback is
+        // attached last, so an already failed future whose handler throws synchronously cannot
+        // suppress the mempool publish.
+        try {
+            if (memo != null) {
+                sendResult.tx.setMemo(memo);
+            }
+
+            // For better redundancy in case the broadcast via BitcoinJ fails we also
+            // publish the tx via mempool nodes.
+            MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx);
+
+            Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor());
+        } catch (RuntimeException e) {
+            log.error("Post-commit step failed for tx {}", sendResult.tx.getTxId(), e);
         }
-
-        // For better redundancy in case the broadcast via BitcoinJ fails we also
-        // publish the tx via mempool nodes.
-        MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx);
-
         return sendResult.tx.getTxId().toString();
     }
 
@@ -1193,16 +1201,24 @@ public class BtcWalletService extends WalletService {
 
         SendRequest request = getSendRequestForMultipleAddresses(fromAddresses, toAddress, receiverAmount, fee, changeAddress, aesKey);
         Wallet.SendResult sendResult = wallet.sendCoins(request);
-        Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor());
-        if (memo != null) {
-            sendResult.tx.setMemo(memo);
+        // The wallet has committed the tx at this point; the remaining steps are best-effort
+        // and must not throw the committed state at the caller as a failure. The callback is
+        // attached last, so an already failed future whose handler throws synchronously cannot
+        // suppress the mempool publish.
+        try {
+            if (memo != null) {
+                sendResult.tx.setMemo(memo);
+            }
+            printTx("sendFunds", sendResult.tx);
+
+            // For better redundancy in case the broadcast via BitcoinJ fails we also
+            // publish the tx via mempool nodes.
+            MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx);
+
+            Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor());
+        } catch (RuntimeException e) {
+            log.error("Post-commit step failed for tx {}", sendResult.tx.getTxId(), e);
         }
-        printTx("sendFunds", sendResult.tx);
-
-        // For better redundancy in case the broadcast via BitcoinJ fails we also
-        // publish the tx via mempool nodes.
-        MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx);
-
         return sendResult.tx;
     }
 

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -1170,6 +1170,11 @@ public class BtcWalletService extends WalletService {
         SendRequest sendRequest = getSendRequest(fromAddress, toAddress, receiverAmount, fee, aesKey, context);
         Wallet.SendResult sendResult = wallet.sendCoins(sendRequest);
         // The wallet has committed the tx at this point; the remaining steps are best-effort.
+        // The callback is attached before the memo is set: an already completed broadcast
+        // future invokes it synchronously at attach time, and a reply built there must see
+        // the tx without the memo, which is only persisted with the confirmed tx.
+        runPostCommitStep("Attaching the broadcast callback", sendResult.tx,
+                () -> Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor()));
         if (memo != null) {
             runPostCommitStep("Setting the memo", sendResult.tx, () -> sendResult.tx.setMemo(memo));
         }
@@ -1177,8 +1182,6 @@ public class BtcWalletService extends WalletService {
         // publish the tx via mempool nodes.
         runPostCommitStep("The mempool publish", sendResult.tx,
                 () -> MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx));
-        runPostCommitStep("Attaching the broadcast callback", sendResult.tx,
-                () -> Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor()));
         return sendResult.tx.getTxId().toString();
     }
 
@@ -1195,6 +1198,11 @@ public class BtcWalletService extends WalletService {
         SendRequest request = getSendRequestForMultipleAddresses(fromAddresses, toAddress, receiverAmount, fee, changeAddress, aesKey);
         Wallet.SendResult sendResult = wallet.sendCoins(request);
         // The wallet has committed the tx at this point; the remaining steps are best-effort.
+        // The callback is attached before the memo is set: an already completed broadcast
+        // future invokes it synchronously at attach time, and a reply built there must see
+        // the tx without the memo, which is only persisted with the confirmed tx.
+        runPostCommitStep("Attaching the broadcast callback", sendResult.tx,
+                () -> Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor()));
         if (memo != null) {
             runPostCommitStep("Setting the memo", sendResult.tx, () -> sendResult.tx.setMemo(memo));
         }
@@ -1205,8 +1213,6 @@ public class BtcWalletService extends WalletService {
         // publish the tx via mempool nodes.
         runPostCommitStep("The mempool publish", sendResult.tx,
                 () -> MemPoolSpaceTxBroadcaster.broadcastTx(sendResult.tx));
-        runPostCommitStep("Attaching the broadcast callback", sendResult.tx,
-                () -> Futures.addCallback(sendResult.broadcastComplete, callback, MoreExecutors.directExecutor()));
         return sendResult.tx;
     }
 

--- a/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/BtcWalletService.java
@@ -1198,7 +1198,8 @@ public class BtcWalletService extends WalletService {
         if (memo != null) {
             runPostCommitStep("Setting the memo", sendResult.tx, () -> sendResult.tx.setMemo(memo));
         }
-        printTx("sendFunds", sendResult.tx);
+        runPostCommitStep("Printing the transaction", sendResult.tx,
+                () -> printTx("sendFunds", sendResult.tx));
 
         // For better redundancy in case the broadcast via BitcoinJ fails we also
         // publish the tx via mempool nodes.

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -731,12 +731,9 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
             @Override
             public void onSuccess(@javax.annotation.Nullable Transaction transaction) {
                 if (transaction != null) {
-                    log.debug("onWithdraw onSuccess tx ID:" + transaction.getTxId().toString());
-                    onTradeCompleted(trade);
-                    trade.setState(Trade.State.WITHDRAW_COMPLETED);
-                    getTradeProtocol(trade).onWithdrawCompleted();
-                    requestPersistence();
-                    resultHandler.handleResult();
+                    log.debug("onWithdraw onSuccess tx ID: {}", transaction.getTxId().toString());
+                } else {
+                    log.error("onWithdraw transaction is null");
                 }
             }
 
@@ -744,7 +741,8 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
             public void onFailure(@NotNull Throwable t) {
                 t.printStackTrace();
                 log.error(t.getMessage());
-                faultHandler.handleFault("An exception occurred at requestWithdraw (onFailure).", t);
+                faultHandler.handleFault("The withdraw tx could not be broadcast. The trade was " +
+                        "completed and the tx remains in the wallet as pending.", t);
             }
         };
         try {
@@ -754,7 +752,21 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
             e.printStackTrace();
             log.error(e.getMessage());
             faultHandler.handleFault("An exception occurred at requestWithdraw.", e);
+            return;
         }
+
+        // sendFunds has committed the tx to the wallet at this point, so we do
+        // not gate the trade completion on the broadcastComplete future. That
+        // future only completes once connected peers announce the tx back to
+        // us, which over Tor can take a long time or never happen, leaving the
+        // trade in open trades although the funds were sent. A still pending
+        // tx is handed to the broadcaster again at startup and sendFunds also
+        // publishes it via mempool nodes.
+        trade.setState(Trade.State.WITHDRAW_COMPLETED);
+        onTradeCompleted(trade);
+        getTradeProtocol(trade).onWithdrawCompleted();
+        requestPersistence();
+        resultHandler.handleResult();
     }
 
     // If trade was completed (closed without fault but might be closed by a dispute) we move it to the closed trades

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -717,14 +717,21 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
 
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    // At most one of resultHandler and faultHandler is invoked, resultHandler once the withdraw
+    // tx is committed to the wallet, faultHandler when that commit failed with one of the checked
+    // exceptions; an unchecked failure before the commit propagates to the caller as the single
+    // outcome. A broadcast failure reported after the commit is a notification about an already
+    // completed withdrawal and goes to broadcastFailureHandler; the tx remains in the wallet as
+    // pending and is handed to the broadcaster again at startup.
     public void onWithdrawRequest(String toAddress,
                                   Coin amount,
                                   Coin fee,
-                                  KeyParameter aesKey,
+                                  @Nullable KeyParameter aesKey,
                                   Trade trade,
                                   @Nullable String memo,
                                   ResultHandler resultHandler,
-                                  FaultHandler faultHandler) {
+                                  FaultHandler faultHandler,
+                                  FaultHandler broadcastFailureHandler) {
         String fromAddress = btcWalletService.getOrCreateAddressEntry(trade.getId(),
                 AddressEntry.Context.TRADE_PAYOUT).getAddressString();
         FutureCallback<Transaction> callback = new FutureCallback<>() {
@@ -739,9 +746,8 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
 
             @Override
             public void onFailure(@NotNull Throwable t) {
-                t.printStackTrace();
-                log.error(t.getMessage());
-                faultHandler.handleFault("The withdraw tx could not be broadcast. The trade was " +
+                log.error("Withdraw tx broadcast failed for trade {}", trade.getShortId(), t);
+                broadcastFailureHandler.handleFault("The withdraw tx could not be broadcast. The trade was " +
                         "completed and the tx remains in the wallet as pending.", t);
             }
         };
@@ -749,8 +755,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
             btcWalletService.sendFunds(fromAddress, toAddress, amount, fee, aesKey,
                     AddressEntry.Context.TRADE_PAYOUT, memo, callback);
         } catch (AddressFormatException | InsufficientMoneyException | AddressEntryException e) {
-            e.printStackTrace();
-            log.error(e.getMessage());
+            log.error("An exception occurred at requestWithdraw.", e);
             faultHandler.handleFault("An exception occurred at requestWithdraw.", e);
             return;
         }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1050,6 +1050,9 @@ portfolio.pending.communicateWithMediator=Please communicate with the mediator o
 portfolio.pending.disputeOpenedMyUser=You have already opened a dispute.\n{0}
 portfolio.pending.disputeOpenedByPeer=Your trading peer opened a dispute\n{0}
 portfolio.pending.noReceiverAddressDefined=No receiver address defined
+portfolio.pending.withdrawBroadcastFailed=The withdrawal transaction could not be broadcast to the network. \
+  The trade was completed and the transaction remains in your wallet as pending; it will be broadcast again \
+  on the next startup.
 
 portfolio.pending.mediationResult.headline=Suggested payout from mediation
 portfolio.pending.mediationResult.info.noneAccepted=Complete the trade by accepting the mediator's suggestion for the trade payout.

--- a/core/src/test/java/bisq/core/trade/TradeManagerWithdrawTest.java
+++ b/core/src/test/java/bisq/core/trade/TradeManagerWithdrawTest.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade;
+
+import bisq.core.btc.model.AddressEntry;
+import bisq.core.btc.wallet.BsqWalletService;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.proto.persistable.CorePersistenceProtoResolver;
+import bisq.core.provider.price.PriceFeedService;
+import bisq.core.support.dispute.mediation.mediator.MediatorManager;
+import bisq.core.trade.bisq_v1.DumpDelayedPayoutTx;
+import bisq.core.trade.bisq_v1.FailedTradesManager;
+import bisq.core.trade.bisq_v1.TradeUtil;
+import bisq.core.trade.bsq_swap.BsqSwapTradeManager;
+import bisq.core.trade.model.bisq_v1.Trade;
+import bisq.core.trade.protocol.Provider;
+import bisq.core.trade.protocol.TradeProtocol;
+import bisq.core.trade.statistics.ReferralIdService;
+import bisq.core.trade.statistics.TradeStatisticsManager;
+import bisq.core.user.User;
+
+import bisq.network.p2p.P2PService;
+
+import bisq.common.ClockWatcher;
+import bisq.common.crypto.KeyRing;
+import bisq.common.handlers.FaultHandler;
+import bisq.common.handlers.ResultHandler;
+import bisq.common.persistence.PersistenceManager;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
+
+import com.google.common.util.concurrent.FutureCallback;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class TradeManagerWithdrawTest {
+    private static final String TRADE_ID = "tradeId";
+    private static final Coin AMOUNT = Coin.valueOf(2_000);
+    private static final Coin FEE = Coin.valueOf(1_000);
+
+    private TradeManager tradeManager;
+    private BtcWalletService btcWalletService;
+    private Trade trade;
+    private TradeProtocol tradeProtocol;
+    private ResultHandler resultHandler;
+    private FaultHandler faultHandler;
+    private FaultHandler broadcastFailureHandler;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        btcWalletService = mock(BtcWalletService.class);
+        AddressEntry addressEntry = mock(AddressEntry.class);
+        when(addressEntry.getAddressString()).thenReturn("fromAddress");
+        when(btcWalletService.getOrCreateAddressEntry(TRADE_ID, AddressEntry.Context.TRADE_PAYOUT))
+                .thenReturn(addressEntry);
+
+        tradeManager = spy(new TradeManager(mock(User.class), mock(KeyRing.class), btcWalletService,
+                mock(BsqWalletService.class), mock(OpenOfferManager.class), mock(ClosedTradableManager.class),
+                mock(BsqSwapTradeManager.class), mock(FailedTradesManager.class), mock(P2PService.class),
+                mock(PriceFeedService.class), mock(DelayedPayoutTxReceiverService.class),
+                mock(TradeStatisticsManager.class), mock(TradeUtil.class), mock(MediatorManager.class),
+                mock(Provider.class), mock(ClockWatcher.class), mock(PersistenceManager.class),
+                mock(ReferralIdService.class), mock(CorePersistenceProtoResolver.class),
+                mock(DumpDelayedPayoutTx.class), false));
+
+        trade = mock(Trade.class);
+        when(trade.getId()).thenReturn(TRADE_ID);
+        tradeProtocol = mock(TradeProtocol.class);
+        doReturn(tradeProtocol).when(tradeManager).getTradeProtocol(trade);
+
+        resultHandler = mock(ResultHandler.class);
+        faultHandler = mock(FaultHandler.class);
+        broadcastFailureHandler = mock(FaultHandler.class);
+    }
+
+    @Test
+    void committedSendCompletesTheTradeExactlyOnce() throws Exception {
+        withdraw();
+
+        verify(resultHandler, times(1)).handleResult();
+        verify(trade).setState(Trade.State.WITHDRAW_COMPLETED);
+        verify(tradeManager).onTradeCompleted(trade);
+        verify(tradeProtocol).onWithdrawCompleted();
+        verify(tradeManager, atLeastOnce()).requestPersistence();
+        verifyNoInteractions(faultHandler);
+        verifyNoInteractions(broadcastFailureHandler);
+    }
+
+    @Test
+    void laterBroadcastFailureIsANotificationNotASecondOutcome() throws Exception {
+        FutureCallback<Transaction> callback = withdraw();
+
+        callback.onFailure(new RuntimeException("rejected by peers"));
+
+        verify(resultHandler, times(1)).handleResult();
+        verify(broadcastFailureHandler, times(1)).handleFault(anyString(), any());
+        verifyNoInteractions(faultHandler);
+    }
+
+    @Test
+    void preCommitFailureFaultsWithoutCompletingTheTrade() throws Exception {
+        doThrow(new InsufficientMoneyException(Coin.valueOf(1)))
+                .when(btcWalletService).sendFunds(any(), any(), any(), any(), any(), any(), any(), any());
+
+        tradeManager.onWithdrawRequest("toAddress", AMOUNT, FEE, null, trade,
+                null, resultHandler, faultHandler, broadcastFailureHandler);
+
+        verify(faultHandler, times(1)).handleFault(anyString(), any());
+        verify(trade, never()).setState(any());
+        verify(tradeManager, never()).onTradeCompleted(any());
+        verifyNoInteractions(resultHandler);
+        verifyNoInteractions(broadcastFailureHandler);
+    }
+
+    @SuppressWarnings("unchecked")
+    private FutureCallback<Transaction> withdraw() throws Exception {
+        ArgumentCaptor<FutureCallback<Transaction>> captor = ArgumentCaptor.forClass(FutureCallback.class);
+        tradeManager.onWithdrawRequest("toAddress", AMOUNT, FEE, null, trade,
+                null, resultHandler, faultHandler, broadcastFailureHandler);
+        verify(btcWalletService).sendFunds(eq("fromAddress"), eq("toAddress"), any(), any(), isNull(),
+                eq(AddressEntry.Context.TRADE_PAYOUT), isNull(), captor.capture());
+        return captor.getValue();
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -66,6 +66,7 @@ import bisq.network.p2p.P2PService;
 import bisq.common.app.DevEnv;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.handlers.ErrorMessageHandler;
+import bisq.common.UserThread;
 import bisq.common.handlers.FaultHandler;
 import bisq.common.handlers.ResultHandler;
 
@@ -243,6 +244,13 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                     (errorMessage, throwable) -> {
                         log.error(errorMessage);
                         faultHandler.handleFault(errorMessage, throwable);
+                    },
+                    (errorMessage, throwable) -> {
+                        log.warn("Withdraw tx broadcast failed after the trade was completed: {}",
+                                errorMessage, throwable);
+                        // The broadcast callback can fire on a bitcoinj thread.
+                        UserThread.execute(() ->
+                                new Popup().warning(Res.get("portfolio.pending.withdrawBroadcastFailed")).show());
                     });
         } else {
             faultHandler.handleFault(Res.get("portfolio.pending.noReceiverAddressDefined"), null);

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -52,4 +52,5 @@ specification says so explicitly instead of describing the implementation as if 
 | Specification | Covers |
 |---|---|
 | [`trade/fiat-buyer-payment-account-validation.md`](trade/fiat-buyer-payment-account-validation.md) | Contract-bound buyer payment-account validation and the fiat deposit/settlement gates that depend on it. |
+| [`trade/withdrawal-completion.md`](trade/withdrawal-completion.md) | The completion invariant of a trade payout withdrawal: local wallet commit, one terminal outcome per request, and broadcast failure as a notification. |
 | [`trade/xmr-payment-proof-timestamp.md`](trade/xmr-payment-proof-timestamp.md) | The timestamp rule of the XMR payment proof used for automatic confirmation, and why it is one-sided. |

--- a/docs/specifications/trade/withdrawal-completion.md
+++ b/docs/specifications/trade/withdrawal-completion.md
@@ -1,0 +1,46 @@
+# Withdrawal completion
+
+## Scope
+
+This specification defines when the withdrawal of a trade payout to an external address completes
+the trade, and how failures before and after that point are reported. It covers the withdrawal
+started from the trade API; the equivalent desktop code path exists but is currently not wired to
+the user interface.
+
+## Completion invariant
+
+The withdrawal is complete once the withdraw transaction is committed to the wallet. The trade
+then leaves open trades, is stored with the closed trades and the requester is notified of the
+success, exactly once.
+
+Completion must not wait for the network to accept the transaction. The broadcast future used by
+the wallet only completes once connected peers announce the transaction back, which over Tor can
+take a long time or never happen; gating the completion on it left trades in open trades although
+the funds were sent. A committed transaction is re-broadcast at every start while it is pending,
+and it is additionally published via the mempool nodes right away.
+
+## One terminal outcome per request
+
+A withdrawal request has at most one terminal outcome: success once the transaction is committed,
+or failure when the commit itself failed, for example for an invalid address or insufficient
+funds; an unchecked failure before the commit propagates to the caller as the single outcome. A
+failed commit leaves the trade in open trades and can be retried.
+
+A broadcast failure reported after the commit is not a second outcome. It is a notification about
+an already completed withdrawal: the trade stays closed and the transaction remains in the wallet
+as pending. The desktop shows the notification to the user; the API logs it, since the request has
+already been answered.
+
+## Commit boundary
+
+The send must not fail after the wallet has committed the transaction. The steps following the
+commit inside the send, such as attaching the broadcast callback, setting the memo and handing the
+transaction to the mempool broadcaster, are best-effort; a failure there is logged and must not be
+reported to the caller as a failed send, because that would describe a committed withdrawal as not
+having happened.
+
+## Recovery
+
+A transaction which the network rejects permanently stays pending in the wallet. The trade is not
+reopened; recovery goes through the wallet, for example an SPV resync, which removes the pending
+transaction and returns its reserved inputs.


### PR DESCRIPTION
Fixes #5523

TradeManager.onWithdrawRequest completes the trade (move to closed
trades, WITHDRAW_COMPLETED, result handler) only inside the
onSuccess callback of the BitcoinJ broadcastComplete future. That
future only completes once enough connected peers have announced
the tx back to us, which over Tor can take a long time or never
happen. The trade then stays in open trades although the withdraw
tx was committed to the wallet and usually confirms on-chain, which
matches the report.

The desktop UI from the report was removed with the trade complete
summary redesign (1162060e28, v1.8.1), but the code path is still
live: the api daemon's withdrawfunds call goes through
TradeManager.onWithdrawRequest, and api daemons typically run over
Tor.

This change completes the trade once sendFunds has returned, at
which point the tx is committed to the wallet. That is consistent
with the trade completion screen, which calls onTradeCompleted
without any broadcast being involved and swaps the trade payout
address entry back to the available pool already when the screen
loads (BuyerStep4View), and with the api closeTrade call. It also
matches the TxBroadcaster policy comment that committing the tx to
the wallet and broadcasting it later is the least risky scenario.
The committed tx cannot be double spent by the wallet as its inputs
are marked as spent on commit, still pending txs are handed to the
broadcaster again at startup, and sendFunds additionally publishes
the tx via mempool nodes, so the broadcast does not depend on that
one future.

The broadcast callback is kept for logging and for surfacing a
broadcast failure via the fault handler. A failed broadcast no
longer blocks the trade close; the tx stays in the wallet as
pending.

The funds screen (WithdrawalView) completes trades inside its own
broadcast callback as well; that sibling case is left for a
follow-up to keep this change minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Trades now complete immediately after a withdrawal is committed, without waiting for network broadcast confirmation.
  - Failed withdrawals before commitment no longer mark trades as complete.
  - Broadcast failures after completion no longer incorrectly report the withdrawal as failed.
  - Improved handling ensures follow-up wallet steps continue independently.
  - Added warnings when funds remain pending and will be rebroadcast later.

- **Documentation**
  - Documented withdrawal completion and broadcast-failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->