### PR TITLE
Show update popup only once per session

### DIFF
--- a/core/src/main/java/bisq/core/app/BisqSetup.java
+++ b/core/src/main/java/bisq/core/app/BisqSetup.java
@@ -88,6 +88,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -217,6 +218,7 @@ public class BisqSetup {
     private MonadicBinding<Boolean> p2pNetworkAndWalletInitialized;
     private final List<BisqSetupListener> bisqSetupListeners = new ArrayList<>();
     boolean hasShownStorageWarning = false;
+    private final Set<String> shownUpdateAlertKeys = new HashSet<>();
 
     @Inject
     public BisqSetup(DomainInitialisation domainInitialisation,
@@ -285,7 +287,16 @@ public class BisqSetup {
                 user.setDisplayedAlert(alert);          // save context to compare later
                 newVersionAvailableProperty.set(true);  // shows link in footer bar
                 if ((alert.canShowPopup(preferences) || openNewVersionPopup) && displayUpdateHandler != null) {
-                    displayUpdateHandler.accept(alert, alert.showAgainKey());
+                    // The alert can be delivered again during a session, e.g. re-added
+                    // after its storage entry expired or was removed, or re-published
+                    // with an updated message. The alertMessageProperty listener then
+                    // fires again and would queue another popup for an update we have
+                    // already shown. We show the popup only once per session per
+                    // version, except when the user requests it via the footer link.
+                    boolean alreadyShown = !shownUpdateAlertKeys.add(alert.showAgainKey());
+                    if (openNewVersionPopup || !alreadyShown) {
+                        displayUpdateHandler.accept(alert, alert.showAgainKey());
+                    }
                 }
             }
         } else {

--- a/core/src/test/java/bisq/core/app/BisqSetupTest.java
+++ b/core/src/test/java/bisq/core/app/BisqSetupTest.java
@@ -1,13 +1,121 @@
 package bisq.core.app;
 
+import bisq.core.account.sign.SignedWitnessStorageService;
+import bisq.core.account.witness.AccountAgeWitnessService;
+import bisq.core.alert.Alert;
+import bisq.core.alert.AlertManager;
+import bisq.core.alert.PrivateNotificationManager;
+import bisq.core.btc.nodes.LocalBitcoinNode;
+import bisq.core.btc.setup.WalletsSetup;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.WalletsManager;
+import bisq.core.dao.state.unconfirmed.UnconfirmedBsqChangeOutputListService;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.support.dispute.arbitration.ArbitrationManager;
+import bisq.core.support.dispute.mediation.MediationManager;
+import bisq.core.support.dispute.refund.RefundManager;
+import bisq.core.trade.TradeManager;
+import bisq.core.user.Preferences;
+import bisq.core.user.User;
+import bisq.core.util.coin.CoinFormatter;
+
+import bisq.network.Socks5ProxyProvider;
+import bisq.network.p2p.P2PService;
+
+import bisq.common.config.Config;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BisqSetupTest {
 
     @Test
     void doesNotTreatUpgradeFrom1922AsDowngrade() {
         assertFalse(BisqSetup.hasDowngraded("1.9.22"));
+    }
+
+    @Test
+    void showsUpdatePopupOnlyOncePerSessionPerVersion() {
+        Preferences preferences = mock(Preferences.class);
+        when(preferences.showAgain(anyString())).thenReturn(true);
+        BisqSetup bisqSetup = createBisqSetup(preferences);
+        AtomicInteger popupCount = new AtomicInteger();
+        bisqSetup.setDisplayUpdateHandler((alert, key) -> popupCount.incrementAndGet());
+
+        Alert alert = new Alert("New version available", true, false, "99.99.98");
+
+        // The first automatic delivery shows the popup
+        bisqSetup.displayAlertIfPresent(alert, false);
+        assertEquals(1, popupCount.get());
+
+        // A re-delivery of an equal alert does not show it again
+        bisqSetup.displayAlertIfPresent(new Alert("New version available", true, false, "99.99.98"), false);
+        assertEquals(1, popupCount.get());
+
+        // A re-published alert for the same version does not show it again
+        bisqSetup.displayAlertIfPresent(new Alert("Reworded message", true, false, "99.99.98"), false);
+        assertEquals(1, popupCount.get());
+
+        // An explicit request via the footer link always shows it
+        bisqSetup.displayAlertIfPresent(alert, true);
+        assertEquals(2, popupCount.get());
+
+        // An alert for a newer version shows again
+        bisqSetup.displayAlertIfPresent(new Alert("Newer version available", true, false, "99.99.99"), false);
+        assertEquals(3, popupCount.get());
+    }
+
+    @Test
+    void footerLinkShowsPopupDespiteDontShowAgainPreference() {
+        Preferences preferences = mock(Preferences.class);
+        when(preferences.showAgain(anyString())).thenReturn(false);
+        BisqSetup bisqSetup = createBisqSetup(preferences);
+        AtomicInteger popupCount = new AtomicInteger();
+        bisqSetup.setDisplayUpdateHandler((alert, key) -> popupCount.incrementAndGet());
+
+        Alert alert = new Alert("New version available", true, false, "99.99.98");
+
+        // An automatic delivery respects the dont-show-again preference
+        bisqSetup.displayAlertIfPresent(alert, false);
+        assertEquals(0, popupCount.get());
+
+        // The footer link bypasses the stored preference
+        bisqSetup.displayAlertIfPresent(alert, true);
+        assertEquals(1, popupCount.get());
+    }
+
+    private static BisqSetup createBisqSetup(Preferences preferences) {
+        return new BisqSetup(
+                mock(DomainInitialisation.class),
+                mock(P2PNetworkSetup.class),
+                mock(WalletAppSetup.class),
+                mock(WalletsManager.class),
+                mock(WalletsSetup.class),
+                mock(BtcWalletService.class),
+                mock(P2PService.class),
+                mock(PrivateNotificationManager.class),
+                mock(SignedWitnessStorageService.class),
+                mock(TradeManager.class),
+                mock(OpenOfferManager.class),
+                preferences,
+                mock(User.class),
+                mock(AlertManager.class),
+                mock(UnconfirmedBsqChangeOutputListService.class),
+                mock(Config.class),
+                mock(AccountAgeWitnessService.class),
+                mock(CoinFormatter.class),
+                mock(LocalBitcoinNode.class),
+                mock(AppStartupState.class),
+                mock(Socks5ProxyProvider.class),
+                mock(MediationManager.class),
+                mock(RefundManager.class),
+                mock(ArbitrationManager.class));
     }
 }


### PR DESCRIPTION
Fixes #7936

The software update alert can be delivered to a running node more
than once. When its P2P storage entry expires or gets removed,
AlertManager clears alertMessageProperty or falls back to another
alert (onAlertRemoved), and a later re-receipt sets the property
again with an alert for an update that was already shown. The
alertMessageProperty listener in BisqSetup then fires again and
queues another update popup, so the user gets the same update
window again right after closing the first one, as described in
the report.

The normal message alert branch of displayAlertIfPresent already
guards against repeats by comparing user.getDisplayedAlert(). The
update branch has no such check, and the persisted displayedAlert
cannot serve as the guard there because the update popup should
show again in a new session as a reminder (canShowPopup already
handles the dont-show-again preference).

This change tracks the alert versions shown in the current session
and skips repeated popups for them, following the same approach as
the disk space warning fix in #7580. The session guard uses the
same version key as the persisted dont-show-again preference, so
it also covers a re-published alert for the same version. Opening
the popup via the footer link (openNewVersionPopup) is not
affected and an alert for a new version still shows.

Deduplicating inside AlertManager instead would change the
property semantics covered by AlertManagerTest; BisqSetup is the
only consumer and the message alert branch already handles repeats
there, so the guard lives next to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate update alerts from appearing repeatedly during the same session.
  * Update alerts can still be reopened manually through the footer link.
  * Newer software versions continue to display their update alerts.
  * Respected the “don’t show again” preference for automatically displayed alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->