### PR TITLE
Let the max heap scale with the machine RAM

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -7,8 +7,8 @@ plugins {
 
 application {
     mainClass = 'bisq.desktop.app.BisqAppMain'
-    applicationDefaultJvmArgs = ['-XX:MaxRAM=8g', '-Xss1280k', '-XX:+UseG1GC', '-XX:MaxHeapFreeRatio=10',
-                                 '-XX:MinHeapFreeRatio=5', '-XX:+UseStringDeduplication',
+    applicationDefaultJvmArgs = ['-XX:MaxRAMPercentage=50', '-XX:+UseCompressedOops', '-Xss1280k', '-XX:+UseG1GC',
+                                 '-XX:MaxHeapFreeRatio=10', '-XX:MinHeapFreeRatio=5', '-XX:+UseStringDeduplication',
                                  '-Djava.net.preferIPv4Stack=true',
                                  '--add-opens=javafx.controls/javafx.scene.control.skin=ALL-UNNAMED']
 }


### PR DESCRIPTION
The desktop ships -XX:MaxRAM=8g without an explicit -Xmx. HotSpot
ergonomics size the max heap at 25% of MaxRAM, and an explicit
MaxRAM replaces the detected physical RAM, so every installation
runs with a 2 GiB max heap regardless of the machine. This matches
the "Max memory: 2 GB" Profiler lines in the recent heap space
reports and explains why OutOfMemoryError reports became frequent:
the resident data set has grown close to that fixed cap, so any
larger allocation can tip it over.

Verified with -XX:+PrintFlagsFinal on JDK 21: with MaxRAM=8g the
ergonomic MaxHeapSize is 2 GiB regardless of the installed RAM,
with MaxRAMPercentage=50 it is half of the physical RAM.

With -XX:MaxRAMPercentage=50 the max heap scales with the machine:
2 GiB on a 4 GB machine as before, 4 GiB on 8 GB and so on.
Machines below 4 GB get a proportionally smaller max heap, which
matches what such machines can back with RAM; the old setting
promised them a heap larger than their physical RAM, which ends in
swapping or the OS OOM killer rather than useful headroom.
-XX:MaxHeapFreeRatio=10 keeps returning unused memory to the OS as
before.

The explicit -XX:+UseCompressedOops caps the ergonomic heap at the
compressed oops limit of about 30 GiB. Without it machines with
more than about 60 GB RAM would get a larger heap with compressed
oops silently disabled, which doubles the reference size. A power
user overriding the heap size with -Xmx above the limit gets a
startup warning, not a failure.

The packaging and app start plugins both read
applicationDefaultJvmArgs, so the installer and run-from-source
pick up the change alike. Seed nodes already run with a fixed
4 GiB heap and the apitest harness keeps its fixed MaxRAM settings
for regtest instances with tiny data sets, so both are not
affected.

Same approach as the MaxRAM bumps after the 2021 OOM wave (#5550,
#5609).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated desktop JVM memory settings to scale with available system RAM.
  * Enabled compressed object pointers to improve memory efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->